### PR TITLE
Tuned schemas for Java code generator

### DIFF
--- a/utils/interfaces/schemas/miscs/appsec/contexts/actor/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/actor/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/actor/0.1.0.json",
+  "title": "Actor",
   "definitions": {
   },
   "type": "object",
@@ -34,7 +35,8 @@
         "^.+$": {
           "type": "string"
         }
-      }
+      },
+      "existingJavaType" : "java.util.Map<String, Object>"
     },
     "_id": {
       "type": ["string", "null"],

--- a/utils/interfaces/schemas/miscs/appsec/contexts/agent/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/agent/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/agent/0.1.0.json",
+  "title": "Agent",
   "type": "object",
   "properties": {
     "context_version": {

--- a/utils/interfaces/schemas/miscs/appsec/contexts/code_location/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/code_location/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/code_location/0.1.0.json",
+  "title": "Code Location",
   "definitions": {
     "StackTraceItem": {
       "in_app": {

--- a/utils/interfaces/schemas/miscs/appsec/contexts/host/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/host/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/host/0.1.0.json",
+  "title": "Host",
   "type": "object",
   "properties": {
     "context_version": {

--- a/utils/interfaces/schemas/miscs/appsec/contexts/http/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/http/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/http/0.1.0.json",
+  "title": "Http 0.1.0",
   "definitions": {
     "HttpHeaders": {
       "type": ["object", "null"],
@@ -8,9 +9,11 @@
         "^.*$": {
           "type": "string"
         }
-      }
+      },
+      "existingJavaType" : "java.lang.String"
     },
     "HttpRequest": {
+      "title": "HttpRequest 0.1.0",
       "type": "object",
       "properties": {
         "scheme": {
@@ -58,57 +61,7 @@
           "type": "integer"
         },
         "parameters": {
-          "description": "TODO Formalize this when more context.",
-          "type": ["object", "null"],
-          "properties": {
-            "form": {
-              "type": ["object", "null"],
-              "patternProperties": {
-                "^.+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "other": {
-              "type": ["object", "null"],
-              "$comment": "This is a dictionary and seems hard to describe consistently at the moment.",
-              "patternProperties": {
-                "^.+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "query": {
-              "type": ["object", "null"],
-              "$comment": "This is a dictionary and seems hard to describe consistently at the moment.",
-              "patternProperties": {
-                "^.+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "json": {
-              "type": ["object", "null"],
-              "$comment": "This is a dictionary and seems hard to describe consistently at the moment.",
-              "patternProperties": {
-                "^.+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
+          "$ref": "parameters.json"
         },
         "headers": {
           "$ref": "#/definitions/HttpHeaders"
@@ -145,6 +98,7 @@
       ]
     },
     "HttpResponse": {
+      "title": "HttpResponse 0.1.0",
       "type": "object",
       "$comments": "FIXME May not be complete",
       "properties": {

--- a/utils/interfaces/schemas/miscs/appsec/contexts/http/1.0.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/http/1.0.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/http/1.0.0.json",
+  "title": "Http 1.0.0",
   "definitions": {
     "HttpHeaders": {
       "type": ["object", "null"],
@@ -11,9 +12,11 @@
               "type": "string"
           }
         }
-      }
+      },
+      "existingJavaType" : "java.util.Map<String, ? extends java.util.Collection<String>>"
     },
     "HttpRequest": {
+      "title": "HttpRequest 1.0.0",
       "type": "object",
       "properties": {
         "method": {
@@ -52,57 +55,7 @@
           "type": ["string", "null"]
         },
         "parameters": {
-          "description": "TODO Formalize this when more context.",
-          "type": ["object", "null"],
-          "properties": {
-            "form": {
-              "type": ["object", "null"],
-              "patternProperties": {
-                "^.+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "other": {
-              "type": ["object", "null"],
-              "$comment": "This is a dictionary and seems hard to describe consistently at the moment.",
-              "patternProperties": {
-                "^.+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "query": {
-              "type": ["object", "null"],
-              "$comment": "This is a dictionary and seems hard to describe consistently at the moment.",
-              "patternProperties": {
-                "^.+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "json": {
-              "type": ["object", "null"],
-              "$comment": "This is a dictionary and seems hard to describe consistently at the moment.",
-              "patternProperties": {
-                "^.+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
+          "$ref": "parameters.json"
         }
       },
       "required": [
@@ -114,6 +67,7 @@
       ]
     },
     "HttpResponse": {
+      "title": "HttpResponse 1.0.0",
       "type": "object",
       "properties": {
         "status": {

--- a/utils/interfaces/schemas/miscs/appsec/contexts/http/parameters.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/http/parameters.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "/miscs/appsec/contexts/http/parameters.json",
+  "title": "Parameters",
+  "description": "TODO Formalize this when more context.",
+  "type": ["object", "null"],
+  "properties": {
+    "form": {
+      "type": ["object", "null"],
+      "patternProperties": {
+        "^.+$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "existingJavaType" : "java.util.Map<String, String>"
+    },
+    "other": {
+      "type": ["object", "null"],
+      "$comment": "This is a dictionary and seems hard to describe consistently at the moment.",
+      "patternProperties": {
+        "^.+$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "existingJavaType" : "java.util.Map<String, String>"
+    },
+    "query": {
+      "type": ["object", "null"],
+      "$comment": "This is a dictionary and seems hard to describe consistently at the moment.",
+      "patternProperties": {
+        "^.+$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "existingJavaType" : "java.util.Map<String, String>"
+    },
+    "json": {
+      "type": ["object", "null"],
+      "$comment": "This is a dictionary and seems hard to describe consistently at the moment.",
+      "patternProperties": {
+        "^.+$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "existingJavaType" : "java.util.Map<String, String>"
+    }
+  }
+}

--- a/utils/interfaces/schemas/miscs/appsec/contexts/library/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/library/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/library/0.1.0.json",
+  "title": "Library",
   "type": "object",
   "properties": {
     "context_version": {

--- a/utils/interfaces/schemas/miscs/appsec/contexts/service/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/service/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/service/0.1.0.json",
+  "title": "Service",
   "type": "object",
   "properties": {
     "context_version": {

--- a/utils/interfaces/schemas/miscs/appsec/contexts/service_entry_span/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/service_entry_span/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/service_entry_span/0.1.0.json",
+  "title": "Service Entry Span",
   "type": "object",
   "properties": {
     "context_version": {

--- a/utils/interfaces/schemas/miscs/appsec/contexts/span/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/span/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/span/0.1.0.json",
+  "title": "Span",
   "type": "object",
   "properties": {
     "context_version": {

--- a/utils/interfaces/schemas/miscs/appsec/contexts/sqreen/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/sqreen/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/sqreen/0.1.0.json",
+  "title": "Sqreen",
   "type": "object",
   "properties": {
     "context_version": {

--- a/utils/interfaces/schemas/miscs/appsec/contexts/tags/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/tags/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/tags/0.1.0.json",
+  "title": "Tags",
   "type": "object",
   "properties": {
     "context_version": {

--- a/utils/interfaces/schemas/miscs/appsec/contexts/trace/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/contexts/trace/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/contexts/trace/0.1.0.json",
+  "title": "Trace",
   "type": "object",
   "properties": {
     "context_version": {

--- a/utils/interfaces/schemas/miscs/appsec/events/_definitions/rule/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/events/_definitions/rule/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/events/_definitions/rule/0.1.0.json",
+  "title": "Rule 0.1.0",
   "type": "object",
   "properties": {
     "id": {

--- a/utils/interfaces/schemas/miscs/appsec/events/_definitions/rule/1.0.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/events/_definitions/rule/1.0.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/events/_definitions/rule/1.0.0.json",
+  "title": "Rule 1.0.0",
   "type": "object",
   "properties": {
     "id": {
@@ -16,7 +17,8 @@
       "description": "The tags associated to the rule in the event rules file.",
       "patternProperties": {
         "^.+$": { "type": "string" }
-      }
+      },
+      "existingJavaType" : "java.util.Map<String, String>"
     }
   },
   "required": [

--- a/utils/interfaces/schemas/miscs/appsec/events/_definitions/rule_match/0.1.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/events/_definitions/rule_match/0.1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/events/_definitions/rule_match/0.1.0.json",
+  "title": "Rule Match 0.1.0",
   "type": "object",
   "properties": {
     "operator": {
@@ -13,6 +14,7 @@
     "parameters": {
       "type": "array",
       "items": {
+        "title": "Parameter 0.1.0",
         "type": "object",
         "properties": {
           "name": {

--- a/utils/interfaces/schemas/miscs/appsec/events/_definitions/rule_match/1.0.0.json
+++ b/utils/interfaces/schemas/miscs/appsec/events/_definitions/rule_match/1.0.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "/miscs/appsec/events/_definitions/rule_match/1.0.0.json",
+  "title": "Rule Match 1.0.0",
   "type": "object",
   "properties": {
     "operator": {
@@ -14,6 +15,7 @@
     "parameters": {
       "type": "array",
       "items": {
+        "title": "Parameter 1.0.0",
         "type": "object",
         "properties": {
           "address": {
@@ -24,10 +26,10 @@
             "type": "array",
             "description": "The path of the value that triggered the rule. For example ``[\"query\", 0]`` to refer to the value in ``{\"query\": [\"triggering value\"]}``.",
             "items": {
-                "anyOf": [
-                   { "type": "string" },
-                   { "type": "number" }
-                ]
+              "anyOf": [
+                { "type": "string" },
+                { "type": "number" }
+              ]
             }
           },
           "value": {
@@ -36,7 +38,7 @@
           }
         },
         "required": [
-            "address"
+          "address"
         ]
       }
     },


### PR DESCRIPTION
In java, we have POJO generated automatically from JSON schemas. When class generated it use json-file name or title field for generated class name. Since, most of filenames are versions (e.g. `0.1.0.json`) it's generates ambiguous class names like `010`, `010_1`, `010_2` etc.
To bring better naming for generated class, I've added title field, which used for class names.

Another one problem, there is difficult consistently describe dictionary in json-schema and there is no suitable way to generate java classes which uses Map (i.e. dictionary).
The best workaround I found was to add java-specific tag `existingJavaType`, which used by java code generator to define Map. The `existingJavaType` tag is ignored by any other parsers, so should not be any problem.