### PR TITLE
AppSec addresses don't have semi-colons

### DIFF
--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -74,24 +74,24 @@ class Test_Headers(BaseTestCase):
         """ Appsec WAF detects attacks in header value """
         r = self.weblog_get("/waf/", headers={"User-Agent": "Arachni/v1"})
         interfaces.library.assert_waf_attack(
-            r, pattern="Arachni/v", address="server.request.headers.no_cookies:user-agent"
+            r, pattern="Arachni/v", address="server.request.headers.no_cookies", key_path=["user-agent"]
         )
 
     def test_specific_key(self):
         """ Appsec WAF detects attacks on specific header x-file-name or referer, and report it """
         r = self.weblog_get("/waf/", headers={"x-file-name": "routing.yml"})
         interfaces.library.assert_waf_attack(
-            r, pattern="routing.yml", address="server.request.headers.no_cookies:x-file-name"
+            r, pattern="routing.yml", address="server.request.headers.no_cookies", key_path=["x-file-name"]
         )
 
         r = self.weblog_get("/waf/", headers={"X-File-Name": "routing.yml"})
         interfaces.library.assert_waf_attack(
-            r, pattern="routing.yml", address="server.request.headers.no_cookies:x-file-name"
+            r, pattern="routing.yml", address="server.request.headers.no_cookies", key_path=["x-file-name"]
         )
 
         r = self.weblog_get("/waf/", headers={"X-Filename": "routing.yml"})
         interfaces.library.assert_waf_attack(
-            r, pattern="routing.yml", address="server.request.headers.no_cookies:x-filename"
+            r, pattern="routing.yml", address="server.request.headers.no_cookies", key_path=["x-filename"]
         )
 
     @not_relevant(library="ruby", reason="Rack transforms undersocre to dashes")
@@ -99,7 +99,7 @@ class Test_Headers(BaseTestCase):
         """ attacks on specific header X_Filename, and report it """
         r = self.weblog_get("/waf/", headers={"X_Filename": "routing.yml"})
         interfaces.library.assert_waf_attack(
-            r, pattern="routing.yml", address="server.request.headers.no_cookies:x_filename"
+            r, pattern="routing.yml", address="server.request.headers.no_cookies", key_path=["x_filename"]
         )
 
     @not_relevant(library="nodejs", reason="Rules set 2.1 => libinjection does not report highlight")
@@ -108,22 +108,22 @@ class Test_Headers(BaseTestCase):
         """ When a specific header key is specified, other key are ignored """
         r = self.weblog_get("/waf/", headers={"referer": "<script >"})
         interfaces.library.assert_waf_attack(
-            r, pattern="<script >", address="server.request.headers.no_cookies:referer"
+            r, pattern="<script >", address="server.request.headers.no_cookies", key_path=["referer"]
         )
 
         r = self.weblog_get("/waf/", headers={"RefErEr": "<script >"})
         interfaces.library.assert_waf_attack(
-            r, pattern="<script >", address="server.request.headers.no_cookies:referer"
+            r, pattern="<script >", address="server.request.headers.no_cookies", key_path=["referer"]
         )
 
     @not_relevant(context.library != "nodejs", reason="Rules set 2.1 => libxss does not report highlight")
     def test_specific_key4(self):
         """ When a specific header key is specified, other key are ignored """
         r = self.weblog_get("/waf/", headers={"referer": "<script >"})
-        interfaces.library.assert_waf_attack(r, address="server.request.headers.no_cookies:referer")
+        interfaces.library.assert_waf_attack(r, address="server.request.headers.no_cookies", key_path=["referer"])
 
         r = self.weblog_get("/waf/", headers={"RefErEr": "<script >"})
-        interfaces.library.assert_waf_attack(r, address="server.request.headers.no_cookies:referer")
+        interfaces.library.assert_waf_attack(r, address="server.request.headers.no_cookies", key_path=["referer"])
 
     def test_specific_wrong_key(self):
         """ When a specific header key is specified in rules, other key are ignored """

--- a/tests/appsec/waf/test_miscs.py
+++ b/tests/appsec/waf/test_miscs.py
@@ -26,7 +26,8 @@ class Test_404(BaseTestCase):
             r,
             rule_id=rules.security_scanner.ua0_600_12x,
             pattern="Arachni/v",
-            address="server.request.headers.no_cookies:user-agent",
+            address="server.request.headers.no_cookies",
+            key_path=["user-agent"],
         )
 
 

--- a/utils/interfaces/_library/appsec.py
+++ b/utils/interfaces/_library/appsec.py
@@ -104,7 +104,9 @@ class _WafAttack(_BaseAppSecValidation):
         self.rule_id = rule_id
         self.pattern = pattern
 
-        self.address = address
+        # addresses should never have semi-colon
+        self.address = address.split(":", 1)[0]
+        self.key_path = key_path
 
         if patterns:
             raise NotImplementedError
@@ -115,18 +117,14 @@ class _WafAttack(_BaseAppSecValidation):
 
         for parameter in event["rule_match"]["parameters"]:
             # don't care about event version, it's the schemas' job
-            if "name" in parameter:
-                address = parameter["name"]
-            elif "address" in parameter:
+            if "address" in parameter:
                 address = parameter["address"]
+            elif "name" in parameter:
+                address = parameter["name"].split(":", 1)[0]
             else:
                 continue
 
-            if "key_path" in parameter:
-                for key_path in parameter["key_path"]:
-                    result.append(f"{address}:{key_path}")
-            else:
-                result.append(address)
+            result.append(address)
 
         return result
 

--- a/utils/interfaces/_library/appsec.py
+++ b/utils/interfaces/_library/appsec.py
@@ -105,7 +105,7 @@ class _WafAttack(_BaseAppSecValidation):
         self.pattern = pattern
 
         # addresses should never have semi-colon
-        self.address = address.split(":", 1)[0]
+        self.address = address.split(":", 1)[0] if address is not None else None
 
         if patterns:
             raise NotImplementedError

--- a/utils/interfaces/_library/appsec.py
+++ b/utils/interfaces/_library/appsec.py
@@ -106,7 +106,6 @@ class _WafAttack(_BaseAppSecValidation):
 
         # addresses should never have semi-colon
         self.address = address.split(":", 1)[0]
-        self.key_path = key_path
 
         if patterns:
             raise NotImplementedError

--- a/utils/interfaces/_library/appsec.py
+++ b/utils/interfaces/_library/appsec.py
@@ -122,16 +122,18 @@ class _WafAttack(_BaseAppSecValidation):
         result = []
 
         for parameter in event.get("rule_match", {}).get("parameters", []):
-            key_path = parameter.get("key_path", [])
+            key_path = parameter.get("key_path")
             # don't care about event version, it's the schemas' job
             if "address" in parameter:
                 address = parameter["address"]
             elif "name" in parameter:
-                address = parameter["name"].split(":", 1)[0]
+                address, raw_key_path = parameter["name"].split(":", 1)
+                if key_path is None:
+                    key_path = raw_key_path.split(".")
             else:
                 continue
 
-            result.append((address, key_path))
+            result.append((address, key_path or []))
 
         return result
 

--- a/utils/interfaces/_library/appsec.py
+++ b/utils/interfaces/_library/appsec.py
@@ -127,9 +127,10 @@ class _WafAttack(_BaseAppSecValidation):
             if "address" in parameter:
                 address = parameter["address"]
             elif "name" in parameter:
-                address, raw_key_path = parameter["name"].split(":", 1)
-                if key_path is None:
-                    key_path = raw_key_path.split(".")
+                parts = parameter["name"].split(":", 1)
+                address = parts[0]
+                if key_path is None and len(parts) > 1:
+                    key_path = parts[1].split(".")
             else:
                 continue
 

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -76,9 +76,9 @@ class LibraryInterfaceValidator(InterfaceValidator):
     def assert_no_appsec_event(self, request):
         self.append_validation(_NoAppsecEvent(request))
 
-    def assert_waf_attack(self, request, rule_id=None, pattern=None, address=None, patterns=None):
+    def assert_waf_attack(self, request, rule_id=None, pattern=None, address=None, patterns=None, key_path=None):
         self.append_validation(
-            _WafAttack(request, rule_id=rule_id, pattern=pattern, address=address, patterns=patterns)
+            _WafAttack(request, rule_id=rule_id, pattern=pattern, address=address, patterns=patterns, key_path=key_path)
         )
 
     def assert_metric_existence(self, metric_name):


### PR DESCRIPTION
This PR changes the WAF attack assertion to check for the address and the key path separately.