### PR TITLE
Fix trace tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - run: pip install -r requirements.txt
-    - run: black --check .
+    - run: black --check --diff .
   test-the-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -2,9 +2,9 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import BaseTestCase, context, interfaces, released, bug, missing_feature
 import pytest
 
+from utils import BaseTestCase, context, interfaces, released, bug, missing_feature
 
 if context.weblog_variant == "echo-poc":
     pytestmark = pytest.mark.skip("not relevant: echo is not instrumented")
@@ -15,9 +15,14 @@ elif context.library == "cpp":
 @released(golang="v1.34.0-rc.4", dotnet="1.29.0", java="?", nodejs="?", php="?", python="?", ruby="?")
 class Test_AppSecEventSpanTags(BaseTestCase):
     def test_appsec_event_span_tags(self):
-        """Spans with AppSec events should have the general AppSec span tags, along with the appsec.event and _sampling_priority_v1 tags"""
+        """
+        Spans with AppSec events should have the general AppSec span tags, along with the appsec.event and
+        _sampling_priority_v1 tags
+        """
 
         @missing_feature(library="ruby", reason="can't report user agent with dd-trace-rb")
+        @missing_feature(library="dotnet",
+                         reason="still uses the appsec_keep priority and should move back to manual_keep")
         def validate_appsec_event_span_tags(span):
             if span.get("parent_id") not in (0, None):  # do nothing if not root span
                 return
@@ -53,7 +58,10 @@ class Test_AppSecEventSpanTags(BaseTestCase):
 
         interfaces.library.add_span_validation(validator=validate_custom_span_tags)
 
+
 RUNTIME_FAMILY = ["nodejs", "ruby", "jvm", "dotnet", "go", "php", "python"]
+
+
 def validate_appsec_span_tags(span):
     if span.get("parent_id") not in (0, None):  # do nothing if not root span
         return

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -19,8 +19,7 @@ class Test_AppSecEventSpanTags(BaseTestCase):
     """
 
     @missing_feature(library="ruby", reason="can't report user agent with dd-trace-rb")
-    @missing_feature(library="dotnet",
-                     reason="still uses the appsec_keep priority and should move back to manual_keep")
+    @missing_feature(library="dotnet", reason="still uses the appsec_keep priority and should move back to manual_keep")
     def test_appsec_event_span_tags(self):
         """
         Spans with AppSec events should have the general AppSec span tags, along with the appsec.event and

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -14,15 +14,19 @@ elif context.library == "cpp":
 
 @released(golang="v1.34.0-rc.4", dotnet="1.29.0", java="?", nodejs="?", php="?", python="?", ruby="?")
 class Test_AppSecEventSpanTags(BaseTestCase):
+    """
+    AppSec should had span tags.
+    """
+
+    @missing_feature(library="ruby", reason="can't report user agent with dd-trace-rb")
+    @missing_feature(library="dotnet",
+                     reason="still uses the appsec_keep priority and should move back to manual_keep")
     def test_appsec_event_span_tags(self):
         """
         Spans with AppSec events should have the general AppSec span tags, along with the appsec.event and
         _sampling_priority_v1 tags
         """
 
-        @missing_feature(library="ruby", reason="can't report user agent with dd-trace-rb")
-        @missing_feature(library="dotnet",
-                         reason="still uses the appsec_keep priority and should move back to manual_keep")
         def validate_appsec_event_span_tags(span):
             if span.get("parent_id") not in (0, None):  # do nothing if not root span
                 return

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -12,15 +12,13 @@ elif context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
 
 
-@released(golang="?", dotnet="1.29.0", java="?", nodejs="?", php="?", python="?")
-@missing_feature(library="ruby", reason="can't report user agent with dd-trace-rb")
-class Test_Retention(BaseTestCase):
-    def test_events_retain_traces(self):
-        """On traces with appsec event, meta.appsec-event and sampling prio are set"""
+@released(golang="v1.34.0-rc.4", dotnet="1.29.0", java="?", nodejs="?", php="?", python="?", ruby="?")
+class Test_AppSecEventSpanTags(BaseTestCase):
+    def test_appsec_event_span_tags(self):
+        """Spans with AppSec events should have the general AppSec span tags, along with the appsec.event and _sampling_priority_v1 tags"""
 
-        APPSEC_KEEP = 4
-
-        def validate_appsec_span(span):
+        @missing_feature(library="ruby", reason="can't report user agent with dd-trace-rb")
+        def validate_appsec_event_span_tags(span):
             if span.get("parent_id") not in (0, None):  # do nothing if not root span
                 return
 
@@ -33,42 +31,45 @@ class Test_Retention(BaseTestCase):
             if "_sampling_priority_v1" not in span["metrics"]:
                 raise Exception("Metric _sampling_priority_v1 should be set on traces that are manually kept")
 
-            if span["metrics"]["_sampling_priority_v1"] != APPSEC_KEEP:
-                raise Exception(f"Trace id {span['trace_id']} , sampling priority should be {APPSEC_KEEP}")
+            MANUAL_KEEP = 2
+            if span["metrics"]["_sampling_priority_v1"] != MANUAL_KEEP:
+                raise Exception(f"Trace id {span['trace_id']} , sampling priority should be {MANUAL_KEEP}")
 
-            return True
+            return validate_appsec_span_tags(span)
 
         r = self.weblog_get("/waf/", headers={"User-Agent": "Arachni/v1"})
-        interfaces.library.add_span_validation(r, validate_appsec_span)
+        interfaces.library.add_span_validation(r, validate_appsec_event_span_tags)
 
-
-@released(golang="?", dotnet="1.29.0", java="?", nodejs="2.0.0-appsec-alpha.1", php="?", python="?", ruby="0.51.0")
-class Test_AppSecMonitoring(BaseTestCase):
+    @missing_feature(library="golang", reason="appsec span tags are only applied to spans of instrumented frameworks")
     @bug(library="dotnet", reason="_dd.appsec.enabled is meta instead of metrics")
     @bug(library="ruby", reason="_dd.appsec.enabled is missing on user spans, maybe not a bug, TBC")
-    def test_events_retain_traces(self):
-        """ AppSec store in APM traces some data when enabled. """
+    def test_custom_span_tags(self):
+        """AppSec should store in APM spans some tags when enabled."""
 
-        RUNTIME_FAMILY = ["nodejs", "ruby", "jvm", "dotnet", "go", "php", "python"]
-
-        def validate_appsec_span(span):
-            if span.get("parent_id") not in (0, None):  # do nothing if not root span
+        def validate_custom_span_tags(span):
+            if span.get("name") != "init.service":
                 return
+            return validate_appsec_span_tags(span)
 
-            if "_dd.appsec.enabled" not in span["metrics"]:
-                raise Exception("Can't find _dd.appsec.enabled in span's metrics")
+        interfaces.library.add_span_validation(validator=validate_custom_span_tags)
 
-            if span["metrics"]["_dd.appsec.enabled"] != 1:
-                raise Exception(
-                    f'_dd.appsec.enabled in span\'s metrics should be 1 or 1.0, not {span["metrics"]["_dd.appsec.enabled"]}'
-                )
+RUNTIME_FAMILY = ["nodejs", "ruby", "jvm", "dotnet", "go", "php", "python"]
+def validate_appsec_span_tags(span):
+    if span.get("parent_id") not in (0, None):  # do nothing if not root span
+        return
 
-            if "_dd.runtime_family" not in span["meta"]:
-                raise Exception("Can't find _dd.runtime_family in span's meta")
+    if "_dd.appsec.enabled" not in span["metrics"]:
+        raise Exception("Can't find _dd.appsec.enabled in span's metrics")
 
-            if span["meta"]["_dd.runtime_family"] not in RUNTIME_FAMILY:
-                raise Exception(f"_dd.runtime_family {span['_dd.runtime_family']} , should be in {RUNTIME_FAMILY}")
+    if span["metrics"]["_dd.appsec.enabled"] != 1:
+        raise Exception(
+            f'_dd.appsec.enabled in span\'s metrics should be 1 or 1.0, not {span["metrics"]["_dd.appsec.enabled"]}'
+        )
 
-            return True
+    if "_dd.runtime_family" not in span["meta"]:
+        raise Exception("Can't find _dd.runtime_family in span's meta")
 
-        interfaces.library.add_span_validation(validator=validate_appsec_span)
+    if span["meta"]["_dd.runtime_family"] not in RUNTIME_FAMILY:
+        raise Exception(f"_dd.runtime_family {span['_dd.runtime_family']} , should be in {RUNTIME_FAMILY}")
+
+    return True

--- a/utils/build/docker/golang/net-http-poc.Dockerfile
+++ b/utils/build/docker/golang/net-http-poc.Dockerfile
@@ -19,6 +19,8 @@ func main() {\n\
     mux := httptrace.NewServeMux()\n\
     mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {\n\
 		w.Write([]byte("Hello, World!\\n"))\n\
+        span, _ := tracer.SpanFromContext(r.Context())\n\
+        span.SetTag("http.request.headers.user-agent", r.UserAgent())\n\
 	})\n\
     mux.HandleFunc("/sample_rate_route/:i", func(w http.ResponseWriter, r *http.Request) {\n\
 		w.Write([]byte("OK"))\n\


### PR DESCRIPTION
- APPSEC_KEEP didn't get approved so MANUAL_KEEP should be validated instead
- Check for every appsec span tags in case of an event, and not only the event-specific tags.
- Rework the test file.
- Add the missing user agent span tag in Go.