### PR TITLE
Check request headers instead of response

### DIFF
--- a/tests/appsec/test_reports.py
+++ b/tests/appsec/test_reports.py
@@ -60,6 +60,7 @@ class Test_ActorIP(BaseTestCase):
 
         interfaces.library.add_appsec_validation(r, validator=validator, legacy_validator=legacy_validator)
 
+    @bug(library="dotnet", reason="headers are in the response, fix to come")
     def test_http_request_headers(self):
         """ AppSec reports the HTTP headers used for actor IP detection."""
         r = self.weblog_get(

--- a/utils/interfaces/_library/appsec.py
+++ b/utils/interfaces/_library/appsec.py
@@ -281,7 +281,7 @@ class _ReportedHeader(_BaseAppSecValidation):
         return True
 
     def validate(self, span, appsec_data):
-        headers = [n.lower() for n in span["meta"].keys() if n.startswith("http.response.headers.")]
-        assert f"http.response.headers.{self.header_name}" in headers, f"header {self.header_name} not reported"
+        headers = [n.lower() for n in span["meta"].keys() if n.startswith("http.request.headers.")]
+        assert f"http.request.headers.{self.header_name}" in headers, f"header {self.header_name} not reported"
 
         return True


### PR DESCRIPTION
Fix of checking response instead of request headers