### PR TITLE
go: add a new weblog framework variant for echo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,15 @@ jobs:
             version: prod
           - library: golang
             weblog-variant: gorilla
+            version: prod
+          - library: golang
+            weblog-variant: gorilla
+            version: dev
+          - library: golang
+            weblog-variant: echo
+            version: prod
+          - library: golang
+            weblog-variant: echo
             version: dev
           - library: java
             weblog-variant: spring-boot-poc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,6 @@ jobs:
             version: dev
           - library: golang
             weblog-variant: echo
-            version: prod
-          - library: golang
-            weblog-variant: echo
             version: dev
           - library: java
             weblog-variant: spring-boot-poc

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -13,8 +13,9 @@ if context.library == "cpp":
 RUNTIME_FAMILIES = ["nodejs", "ruby", "jvm", "dotnet", "go", "php", "python"]
 
 
-@released(golang="v1.34.0-rc.4", dotnet="1.29.0", java="0.92.0")
+@released(golang="v1.34.0", dotnet="1.29.0", java="0.92.0")
 @released(nodejs="2.0.0-appsec-beta.2", php_appsec="?", python="?", ruby="?")
+@missing_feature(context.weblog_variant == "echo" and context.library < "golang@v1.35.0")
 class Test_AppSecEventSpanTags(BaseTestCase):
     """ AppSec correctly fill span tags. """
 

--- a/utils/build/docker/golang/echo.Dockerfile
+++ b/utils/build/docker/golang/echo.Dockerfile
@@ -18,4 +18,4 @@ CMD ./weblog
 ENV DD_TRACE_SAMPLE_RATE=0
 ENV DD_TRACE_DEBUG=true
 ENV DD_LOGGING_RATE=0
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '

--- a/utils/build/docker/golang/echo.Dockerfile
+++ b/utils/build/docker/golang/echo.Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1
+
+# print versions
+RUN go version && curl --version
+
+COPY utils/build/docker/golang/install_ddtrace.sh binaries* /binaries/
+COPY utils/build/docker/golang/app /app
+
+WORKDIR /app
+
+RUN /binaries/install_ddtrace.sh
+
+RUN go build -v -tags appsec -o weblog ./echo.go ./common.go
+
+CMD ./weblog
+
+# Datadog setup
+ENV DD_TRACE_SAMPLE_RATE=0
+ENV DD_TRACE_DEBUG=true
+ENV DD_LOGGING_RATE=0
+ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'


### PR DESCRIPTION
Add a new weblog variant for the HTTP framework called echo.