### PR TITLE
go/net-http: fix root route

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @cbeauchesne
+/utils/build/docker/golang/* @appsec-go

--- a/utils/build/docker/golang/app/net-http.go
+++ b/utils/build/docker/golang/app/net-http.go
@@ -15,7 +15,7 @@ func main() {
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// "/" is the default route when the others don't match
 		// cf. documentation at https://pkg.go.dev/net/http#ServeMux
-		// Therefore, we need to check the URL path to only handler the `/` case
+		// Therefore, we need to check the URL path to only handle the `/` case
 		if r.URL.Path != "/" {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/utils/build/docker/golang/app/net-http.go
+++ b/utils/build/docker/golang/app/net-http.go
@@ -13,6 +13,13 @@ func main() {
 	mux := httptrace.NewServeMux()
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// "/" is the default route when the others don't match
+		// cf. documentation at https://pkg.go.dev/net/http#ServeMux
+		// Therefore, we need to check the URL path to only handler the `/` case
+		if r.URL.Path != "/" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 


### PR DESCRIPTION
Fix the `net/http` variant of weblog so that:
- An access to `/` returns the status code 200 Ok
- Accesses to anything else such as `/i-dont-exist` returns the status 404 Not Found.

This is due to the way the `net/http.ServeMux` works and matches its pattern: `/` will match anything starting with `/`. This problem doesn't exist the two other variants gorilla and echo whose matching works differently.