### PR TITLE
Adapt tests and attributes

### DIFF
--- a/tests/appsec/test_logs.py
+++ b/tests/appsec/test_logs.py
@@ -85,6 +85,7 @@ class Test_Standardization(BaseTestCase):
         stdout.assert_presence(r"Detecting an attack from rule crs-921-160$", level="INFO")
         stdout.assert_presence(r"Detecting an attack from rule crs-913-110$", level="INFO")
 
+
 @released(golang="?", dotnet="?", java="?", nodejs="?", php="?", python="?", ruby="?")
 class Test_StandardizationBlockMode(BaseTestCase):
     """AppSec blocking logs should be standardized"""

--- a/tests/appsec/test_logs.py
+++ b/tests/appsec/test_logs.py
@@ -30,19 +30,19 @@ class Test_Standardization(BaseTestCase):
         """Log D1: names and adresses AppSec listen to"""
         stdout.assert_presence(r"Loaded rule:", level="DEBUG")  # TODO: should be more precise
 
-    @missing_feature(library="dotnet")
+    @missing_feature(library="dotnet", reason="APPSEC-983")
     @irrelevant(library="java", reason="IG doesn't push addresses in Java.")
     def test_d02(self):
         """Log D2: Address pushed to Instrumentation Gateway"""
         stdout.assert_presence(r"Pushing address .* to the Instrumentation Gateway.", level="DEBUG")
 
-    @missing_feature(library="dotnet")
+    @missing_feature(library="dotnet", reason="APPSEC-983, being discussed")
     @missing_feature(library="java")
     def test_d03(self):
         """Log D3: When an address matches a rule needs"""
         stdout.assert_presence(r"Available addresses .* match needs for rules", level="DEBUG")
 
-    @missing_feature(library="dotnet")
+    @missing_feature(library="dotnet", reason="APPSEC-983")
     @missing_feature(library="java")
     def test_d04(self):
         """Log D4: When calling the WAF, logs parameters"""
@@ -51,13 +51,13 @@ class Test_Standardization(BaseTestCase):
     @bug(context.library == "java@0.90.0", reason="APPSEC-2190")
     @bug(context.library == "java@0.91.0", reason="APPSEC-2190")
     @bug(context.library == "java@0.92.0", reason="APPSEC-2190")
-    @missing_feature(library="dotnet")
+    @missing_feature(library="dotnet", reason="APPSEC-983")
     def test_d05(self):
         """Log D5: WAF outputs"""
         stdout.assert_presence(r'AppSec In-App WAF returned:.*"rule":"crs-921-160"', level="DEBUG")
         stdout.assert_presence(r'AppSec In-App WAF returned:.*"rule":"crs-913-110"', level="DEBUG")
 
-    @missing_feature(library="dotnet")
+    @missing_feature(library="dotnet", reason="APPSEC-983")
     def test_d06(self):
         """Log D6: WAF rule detected an attack with details"""
         stdout.assert_presence(r"Detecting an attack from rule crs-921-160:.*", level="DEBUG")
@@ -68,53 +68,22 @@ class Test_Standardization(BaseTestCase):
         """Log D7: Exception in rule"""
         stdout.assert_presence(r"Rule .* failed. Error details: ", level="DEBUG")
 
-    @missing_feature(library="dotnet")
-    def test_d09(self):
-        """Log D9: WAF start of execution"""
-        stdout.assert_presence(r"Executing AppSec In-App WAF$", level="DEBUG")
-
-    @missing_feature(library="dotnet")
-    def test_d10(self):
-        """Log D10: WAF end of execution"""
-        stdout.assert_presence(r"Executing AppSec In-App WAF finished. Took \d+ ms\.$", level="DEBUG")
-
-    @missing_feature(library="dotnet")
+    @missing_feature(library="dotnet", reason="APPSEC-983, being discussed")
     def test_i01(self):
         """Log I1: AppSec initial configuration"""
         stdout.assert_presence(r"AppSec initial configuration from .*, libddwaf version: \d+\.\d+\.\d+", level="INFO")
 
-    @missing_feature(library="dotnet")
+    @missing_feature(library="dotnet", reason="APPSEC-983")
     def test_i02(self):
         """Log I2: AppSec rule source"""
         stdout.assert_presence(r"AppSec loaded \d+ rules from file .*$", level="INFO")
 
-    @missing_feature(library="dotnet")
+    @missing_feature(library="dotnet", reason="APPSEC-983")
     @missing_feature(context.library <= "java@0.88.0", reason="small typo")
     def test_i05(self):
         """Log I5: WAF detected an attack"""
         stdout.assert_presence(r"Detecting an attack from rule crs-921-160$", level="INFO")
         stdout.assert_presence(r"Detecting an attack from rule crs-913-110$", level="INFO")
-
-    @missing_feature(library="dotnet")
-    def test_i07(self):
-        """Log I7: Pushing AppSec events"""
-        stdout.assert_presence(r"Pushing new attack to AppSec events$", level="INFO")
-
-    @missing_feature(library="dotnet")
-    def test_i08(self):
-        """Log I8: Sending AppSec events"""
-        stdout.assert_presence(r"Sending \d+ AppSec events to the agent$", level="INFO")
-
-    @missing_feature(True, reason="not testable as now")
-    def test_i09(self):
-        """Log I9: Dropping events"""
-        stdout.assert_presence(r"Dropping \d+ AppSec events because ", level="INFO")
-
-    @missing_feature(True, reason="not testable as now")
-    def test_i10(self):
-        """Log I10: Flushing events before shutdown"""
-        stdout.assert_presence(r"Reporting AppSec event batch because of process shutdown.$", level="INFO")
-
 
 @released(golang="?", dotnet="?", java="?", nodejs="?", php="?", python="?", ruby="?")
 class Test_StandardizationBlockMode(BaseTestCase):

--- a/tests/appsec/test_reports.py
+++ b/tests/appsec/test_reports.py
@@ -115,8 +115,7 @@ class Test_ActorIP(BaseTestCase):
         interfaces.library.add_appsec_validation(r, validator=validator, legacy_validator=legacy_validator)
 
 
-@released(golang="?", java="0.87.0", nodejs="2.0.0-appsec-alpha.1", php="?", python="?", ruby="0.51.0")
-@bug(library="dotnet", reason="none is reported")
+@released(dotnet="2.0.0", golang="?", java="0.87.0", nodejs="2.0.0-appsec-alpha.1", php="?", python="?", ruby="0.51.0")
 class Test_Info(BaseTestCase):
     @bug(library="ruby", reason="name is sinatra io weblog")
     def test_service(self):
@@ -131,9 +130,9 @@ class Test_Info(BaseTestCase):
 
             return True
 
-        def _check_service(event):
-            name = event["request"]["content"]["service"]
-            environment = event["request"]["content"]["meta"]["env"]
+        def _check_service(span, appsec_data):
+            name = span.get("service")
+            environment = span.get("meta", {}).get("env")
             assert name == "weblog", f"weblog should have been reported, not {name}"
             assert environment == "system-tests", f"system-tests should have been reported, not {environment}"
 

--- a/tests/appsec/test_reports.py
+++ b/tests/appsec/test_reports.py
@@ -123,7 +123,7 @@ class Test_Info(BaseTestCase):
         """ Appsec reports the service information """
         r = self.weblog_get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
-        def _check_service(event):
+        def _check_service_legacy(event):
             name = event["context"]["service"]["name"]
             environment = event["context"]["service"]["environment"]
             assert name == "weblog", f"weblog should have been reported, not {name}"
@@ -131,4 +131,12 @@ class Test_Info(BaseTestCase):
 
             return True
 
-        interfaces.library.add_appsec_validation(r, legacy_validator=_check_service)
+        def _check_service(event):
+            name = event["request"]["content"]["service"]
+            environment = event["request"]["content"]["meta"]["env"]
+            assert name == "weblog", f"weblog should have been reported, not {name}"
+            assert environment == "system-tests", f"system-tests should have been reported, not {environment}"
+
+            return True
+
+        interfaces.library.add_appsec_validation(r, legacy_validator=_check_service_legacy, validator=_check_service)

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -26,7 +26,6 @@ class Test_AppSecEventSpanTags(BaseTestCase):
         get("/waf", headers={"random-key": "acunetix-user-agreement"})  # rules.security_scanner.crs_913_110
 
     @missing_feature(library="ruby", reason="can't report user agent with dd-trace-rb")
-    @missing_feature(library="dotnet", reason="still uses the appsec_keep priority and should move back to manual_keep")
     def test_appsec_event_span_tags(self):
         """
         Spans with AppSec events should have the general AppSec span tags, along with the appsec.event and

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -154,13 +154,13 @@ class Test_Cookies(BaseTestCase):
         r = self.weblog_get("/waf", cookies={"key": ".cookie-%3Bdomain="})
         interfaces.library.assert_waf_attack(r, pattern=".cookie-;domain=", address="server.request.cookies")
 
-    @bug(library="dotnet", reason="APPSEC-1407 and APPSEC-1408")
+    @bug(library="dotnet", reason="APPSEC-2290")
     def test_cookies_with_spaces(self):
         """ Cookie with pattern containing a space """
         r = self.weblog_get("/waf/", cookies={"x-attack": "var_dump ()"})
         interfaces.library.assert_waf_attack(r, pattern="var_dump ()", address="server.request.cookies")
 
-    @bug(library="dotnet", reason="APPSEC-1407 and APPSEC-1408")
+    @bug(library="dotnet", reason="APPSEC-2290")
     @bug(library="java", reason="under Valentin's investigations")
     @bug(library="golang")
     def test_cookies_with_special_chars2(self):

--- a/tests/appsec/waf/test_rules.py
+++ b/tests/appsec/waf/test_rules.py
@@ -35,7 +35,7 @@ class Test_Scanners(BaseTestCase):
 class Test_HttpProtocol(BaseTestCase):
     """ Appsec WAF tests on HTTP protocol rules """
 
-    @bug(library="dotnet", reason="APPSEC-1407")
+    @bug(library="dotnet", reason="APPSEC-2290")
     @bug(library="java", reason="under Valentin's investigations")
     @bug(library="ruby", reason="? need to be investiged")
     def test_http_protocol(self):
@@ -72,7 +72,7 @@ class Test_LFI(BaseTestCase):
         r = self.weblog_get("/waf/", params={"attack": ".htaccess"})
         interfaces.library.assert_waf_attack(r, rules.lfi.crs_930_120)
 
-    @bug(library="dotnet", reason="APPSEC-1405")
+    @bug(library="dotnet", reason="APPSEC-2290")
     @bug(library="java", reason="under Valentin's investigations")
     @bug(library="golang", reason="? may be not supported by framework")
     @bug(library="ruby", reason="? may be not supported by framework")
@@ -148,7 +148,7 @@ class Test_PhpCodeInjection(BaseTestCase):
         r = self.weblog_get("/waf/", cookies={"x-attack": "rar://"})
         interfaces.library.assert_waf_attack(r, rules.php_code_injection.crs_933_200)
 
-    @bug(library="dotnet", reason="APPSEC-1407 and APPSEC-1408")
+    @bug(library="dotnet", reason="APPSEC-2290")
     @bug(library="golang")
     def test_php_code_injection_bug(self):
         """ Appsec WAF detects other php injection rules """
@@ -220,7 +220,7 @@ class Test_XSS(BaseTestCase):
         r = self.weblog_get("/waf/", cookies={"key": "+ADw->|<+AD$-"})
         interfaces.library.assert_waf_attack(r, rules.xss)
 
-    @bug(library="dotnet", reason="APPSEC-1407 and APPSEC-1408")
+    @bug(library="dotnet", reason="APPSEC-2290")
     def test_xss2(self):
         """Other XSS patterns, to be merged once issue are corrected"""
         r = self.weblog_get("/waf", cookies={"value": '<vmlframe src="xss">'})
@@ -250,7 +250,7 @@ class Test_SQLI(BaseTestCase):
         r = self.weblog_get("/waf", params={"value": "0000012345"})
         interfaces.library.assert_waf_attack(r, rules.sql_injection.crs_942_220)
 
-    @bug(library="dotnet", reason="APPSEC-1407 and APPSEC-1408")
+    @bug(library="dotnet", reason="APPSEC-2290")
     def test_sqli2(self):
         """Other SQLI patterns, to be merged once issue are corrected"""
         r = self.weblog_get("/waf", cookies={"value": "alter d char set f"})
@@ -259,13 +259,13 @@ class Test_SQLI(BaseTestCase):
         r = self.weblog_get("/waf", cookies={"value": "merge using("})
         interfaces.library.assert_waf_attack(r, rules.sql_injection.crs_942_250)
 
-    @bug(library="dotnet", reason="APPSEC-1407 and APPSEC-1408")
+    @bug(library="dotnet", reason="APPSEC-2290")
     @irrelevant(context.waf_rule_set >= "1.0", reason="crs-942-190 catch it")
     def test_sqli2_bis(self):
         r = self.weblog_get("/waf", cookies={"value": "union select from"})
         interfaces.library.assert_waf_attack(r, rules.sql_injection.crs_942_270)
 
-    @bug(library="dotnet", reason="APPSEC-1407 and APPSEC-1408")
+    @bug(library="dotnet", reason="APPSEC-2290")
     @bug(library="java", reason="under Valentin's investigations")
     @bug(library="ruby", reason="need to be investiged")
     def test_sqli3(self):

--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -8,7 +8,7 @@ from utils import context, BaseTestCase, interfaces, released, bug, irrelevant, 
 
 
 @irrelevant(library="cpp")
-@bug(library="dotnet", reason=".NET replaces dot by underscores: XXXXX")
+@bug(library="dotnet", reason=".NET replaces dot by underscores even in the mapping part : http.request.headers.user-agent>: http_request_headers_user-agent")
 @missing_feature(library="golang")
 @missing_feature(library="nodejs")
 @missing_feature(library="php", reason="partial support, can't set the key")

--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -9,7 +9,7 @@ from utils import context, BaseTestCase, interfaces, released, bug, irrelevant, 
 
 @irrelevant(library="cpp")
 @bug(
-    library="dotnet", 
+    library="dotnet",
     reason=".NET replaces dot by underscores even in the mapping part : http.request.headers.user-agent>: http_request_headers_user-agent",
 )
 @missing_feature(library="golang")

--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -8,7 +8,10 @@ from utils import context, BaseTestCase, interfaces, released, bug, irrelevant, 
 
 
 @irrelevant(library="cpp")
-@bug(library="dotnet", reason=".NET replaces dot by underscores even in the mapping part : http.request.headers.user-agent>: http_request_headers_user-agent")
+@bug(
+    library="dotnet", 
+    reason=".NET replaces dot by underscores even in the mapping part : http.request.headers.user-agent>: http_request_headers_user-agent"
+)
 @missing_feature(library="golang")
 @missing_feature(library="nodejs")
 @missing_feature(library="php", reason="partial support, can't set the key")

--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -10,7 +10,7 @@ from utils import context, BaseTestCase, interfaces, released, bug, irrelevant, 
 @irrelevant(library="cpp")
 @bug(
     library="dotnet", 
-    reason=".NET replaces dot by underscores even in the mapping part : http.request.headers.user-agent>: http_request_headers_user-agent"
+    reason=".NET replaces dot by underscores even in the mapping part : http.request.headers.user-agent>: http_request_headers_user-agent",
 )
 @missing_feature(library="golang")
 @missing_feature(library="nodejs")

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -120,9 +120,7 @@ class Test_MetaDatadogTags(BaseTestCase):
                 raise Exception(f'keyTag tag in span\'s meta should be "test", not {span["meta"]["env"]}')
 
             if span["meta"]["key2"] != "val2":
-                raise Exception(
-                    f'dKey tag in span\'s meta should be "key2:val2", not {span["meta"]["key2"]}'
-                )
+                raise Exception(f'dKey tag in span\'s meta should be "key2:val2", not {span["meta"]["key2"]}')
 
             return True
 

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -108,7 +108,7 @@ class Test_Meta(BaseTestCase):
 
 
 @bug(
-    context.library in ("java", "cpp", "python", "ruby"),
+    context.library in ("cpp", "python", "ruby"),
     reason="Inconsistent implementation across tracers; will need a dedicated testing scenario",
 )
 class Test_MetaDatadogTags(BaseTestCase):

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -108,7 +108,7 @@ class Test_Meta(BaseTestCase):
 
 
 @bug(
-    context.library in ("java", "cpp", "python", "ruby", "dotnet"),
+    context.library in ("java", "cpp", "python", "ruby"),
     reason="Inconsistent implementation across tracers; will need a dedicated testing scenario",
 )
 class Test_MetaDatadogTags(BaseTestCase):
@@ -119,9 +119,9 @@ class Test_MetaDatadogTags(BaseTestCase):
             if span["meta"]["key1"] != "val1":
                 raise Exception(f'keyTag tag in span\'s meta should be "test", not {span["meta"]["env"]}')
 
-            if span["meta"]["aKey"] != "aVal bKey:bVal cKey:":
+            if span["meta"]["key2"] != "val2":
                 raise Exception(
-                    f'dKey tag in span\'s meta should be "aVal bKey:bVal cKey:", not {span["meta"]["aKey"]}'
+                    f'dKey tag in span\'s meta should be "key2:val2", not {span["meta"]["key2"]}'
                 )
 
             return True

--- a/utils/build/docker/cpp/nginx.Dockerfile
+++ b/utils/build/docker/cpp/nginx.Dockerfile
@@ -41,4 +41,4 @@ RUN /builds/install_ddtrace.sh
 ENV DD_AGENT_HOST=agent_proxy
 ENV DD_SERVICE=weblog
 ENV DD_TRACE_SAMPLE_RATE=0.5
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '

--- a/utils/build/docker/dotnet/poc.Dockerfile
+++ b/utils/build/docker/dotnet/poc.Dockerfile
@@ -25,6 +25,6 @@ ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 ENV DD_INTEGRATIONS=/opt/datadog/integrations.json
 ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 ENV DD_TRACE_SAMPLE_RATE=0.5
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '
 
 CMD ["dotnet", "app.dll"]

--- a/utils/build/docker/golang/gorilla.Dockerfile
+++ b/utils/build/docker/golang/gorilla.Dockerfile
@@ -18,4 +18,4 @@ CMD ./weblog
 ENV DD_TRACE_SAMPLE_RATE=0
 ENV DD_TRACE_DEBUG=true
 ENV DD_LOGGING_RATE=0
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '

--- a/utils/build/docker/golang/net-http.Dockerfile
+++ b/utils/build/docker/golang/net-http.Dockerfile
@@ -18,4 +18,4 @@ CMD ./weblog
 ENV DD_TRACE_SAMPLE_RATE=0
 ENV DD_TRACE_DEBUG=true
 ENV DD_LOGGING_RATE=0
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '

--- a/utils/build/docker/java/spring-boot-poc.Dockerfile
+++ b/utils/build/docker/java/spring-boot-poc.Dockerfile
@@ -21,4 +21,4 @@ CMD [ "java", "-javaagent:/app/dd-java-agent.jar", "-jar", "/app/myproject-0.0.1
 
 # Datadog setup
 ENV DD_TRACE_SAMPLE_RATE=0.5
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '

--- a/utils/build/docker/nodejs/armv7.Dockerfile
+++ b/utils/build/docker/nodejs/armv7.Dockerfile
@@ -32,7 +32,7 @@ RUN /binaries/install_ddtrace.sh
 
 # Datadog setup
 ENV DD_TRACE_SAMPLE_RATE=0.5
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '
 
 # docker build -f utils/build/docker/nodejs.datadog.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test

--- a/utils/build/docker/nodejs/express-poc.Dockerfile
+++ b/utils/build/docker/nodejs/express-poc.Dockerfile
@@ -30,9 +30,9 @@ CMD ./app.sh
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-# Datadog setup
+# Datadog setupS
 ENV DD_TRACE_SAMPLE_RATE=0.5
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '
 
 # docker build -f utils/build/docker/nodejs.datadog.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test

--- a/utils/build/docker/php/vanilla-poc.Dockerfile
+++ b/utils/build/docker/php/vanilla-poc.Dockerfile
@@ -15,7 +15,7 @@ CMD ["php", "-f","index.php","-S","0.0.0.0:7777"]
 EXPOSE 7777
 
 ENV DD_TRACE_SAMPLE_RATE=0.5
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '
 
 COPY utils/build/docker/php/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh

--- a/utils/build/docker/python/armv7.Dockerfile
+++ b/utils/build/docker/python/armv7.Dockerfile
@@ -14,7 +14,7 @@ RUN /binaries/install_ddtrace.sh
 
 # Datadog setup
 ENV DD_TRACE_SAMPLE_RATE=0.5
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '
 
 # docker startup
 RUN echo '#!/bin/bash \n\

--- a/utils/build/docker/python/flask-poc.Dockerfile
+++ b/utils/build/docker/python/flask-poc.Dockerfile
@@ -14,7 +14,7 @@ RUN /binaries/install_ddtrace.sh
 
 # Datadog setup
 ENV DD_TRACE_SAMPLE_RATE=0.5
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '
 
 # docker startup
 RUN echo '#!/bin/bash \n\

--- a/utils/build/docker/python/uwsgi-poc.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.Dockerfile
@@ -14,7 +14,7 @@ RUN /binaries/install_ddtrace.sh
 
 # Datadog setup
 ENV DD_TRACE_SAMPLE_RATE=0.5
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '
 
 # docker startup
 # note, only thread mode is supported

--- a/utils/build/docker/ruby/armv7.Dockerfile
+++ b/utils/build/docker/ruby/armv7.Dockerfile
@@ -47,7 +47,7 @@ RUN /binaries/install_ddtrace.sh
 
 # Datadog setup
 ENV DD_TRACE_SAMPLE_RATE=0.5
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '
 
 # docker build -f utils/build/docker/ruby.sinatra-poc.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test

--- a/utils/build/docker/ruby/sinatra-poc.Dockerfile
+++ b/utils/build/docker/ruby/sinatra-poc.Dockerfile
@@ -52,7 +52,7 @@ RUN /binaries/install_ddtrace.sh
 
 # Datadog setup
 ENV DD_TRACE_SAMPLE_RATE=0.5
-ENV DD_TAGS='key1:val1, aKey : aVal bKey:bVal cKey:'
+ENV DD_TAGS='key1:val1, key2 : val2 '
 
 # docker build -f utils/build/docker/ruby.sinatra-poc.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test


### PR DESCRIPTION
- Remove older versions of log tests
- Annotations on .net tests attributes
- Change DD_TAGS to current implementation, tracers separate value by comma, agent and heroku separate by spaces (specs need to be reworked)