### PR TITLE
Add initial apmtelemetry-request schema

### DIFF
--- a/utils/interfaces/schemas/library/telemetry/proxy/api/v2/apmtelemetry-request.json
+++ b/utils/interfaces/schemas/library/telemetry/proxy/api/v2/apmtelemetry-request.json
@@ -1,0 +1,52 @@
+{
+  "$id": "/library/telemetry/proxy/api/v2/apmtelemetry-request.json",
+
+  "properties": {
+    "api_version": {
+      "type": "string"
+    },
+    "request_type": {
+      "type": "string"
+    },
+    "tracer_time": {
+      "type": "integer"
+    },
+    "runtime_id": {
+      "type": "string"
+    },
+    "seq_id": {
+      "type": "integer"
+    },
+    "payload": {
+      "anyOf": [{ "type": "object" }, { "type": "null" }]
+    },
+    "application": {
+      "type": "object",
+      "properties": {
+        "service_name": { "type": "string" },
+        "env": { "type": "string" },
+        "service_version": { "anyOf": [{ "type": "string" }, { "type": "null" }]  },
+        "tracer_version": { "type": "string" },
+        "language_name": { "type": "string" },
+        "language_version": { "type": "string" },
+        "runtime_name": { "anyOf": [{ "type": "string" }, { "type": "null" }]  },
+        "runtime_version": { "anyOf": [{ "type": "string" }, { "type": "null" }]  },
+        "runtime_patches": { "anyOf": [{ "type": "string" }, { "type": "null" }]  }
+        },
+      "required": ["service_name", "env", "tracer_version", "language_name", "language_version"]
+    },
+    "host": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "api_version",
+    "request_type",
+    "tracer_time",
+    "runtime_id",
+    "seq_id",
+    "application",
+    "host",
+    "payload"
+  ]
+}


### PR DESCRIPTION
This doesn't include the full schema, so is more of a placeholder to prevent errors for languages that implement the telemetry API.

For example, in .NET I'm [currently seeing an error](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=86072&view=logs&j=f9b5f215-18f7-5982-482b-42aaa98babdc&t=3f7875b6-f8c9-5740-4fc6-e671f428789e) in the system tests in my telemetry branch.

I'm not 100% sure I've defined the schema in the correct way (mostly around objects + potentially missing properties), so I've attached below an example from the logs generated in the above system tests for verification.

```json
{
  "path": "/telemetry/proxy/api/v2/apmtelemetry",
  "query": "",
  "host": "agent",
  "port": 8126,
  "request": {
    "timestamp_start": "2022-01-05T17:54:43.576669",
    "content": "b'{\"api_version\":\"v1\",\"request_type\":\"app-started\",\"tracer_time\":1641405282,\"runtime_id\":\"12e0d8e3-b184-4ea6-9c11-ec540fe76514\",\"seq_id\":1,\"application\":{\"service_name\":\"weblog\",\"env\":\"system-tests\",\"tracer_version\":\"2.0.1.0\",\"language_name\":\"dotnet\",\"language_version\":\"3.1.22\",\"runtime_name\":\".NET Core\"},\"host\":{\"container_id\":\"a191430c089c44d88431e8d1ab74dedb36965c8cc144b2409d15c3f006df9937\",\"hostname\":\"a191430c089c\",\"os\":\"Linux\",\"os_version\":\"Unix 5.4.0.1064\",\"kernel_name\":\"Linux\",\"kernel_release\":\"5.4.0-1064-azure\",\"kernel_version\":\"#67~18.04.1-Ubuntu SMP Wed Nov 10 11:38:21 UTC 2021\\\\n\"},\"payload\":{\"integrations\":[{\"name\":\"HttpMessageHandler\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"HttpSocketsHandler\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"WinHttpHandler\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"CurlHandler\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"AspNetCore\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"AdoNet\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"AspNet\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"AspNetMvc\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"AspNetWebApi2\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"GraphQL\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"MongoDb\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"XUnit\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"NUnit\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"MsTestV2\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"Wcf\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"WebRequest\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"ElasticsearchNet\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"ServiceStackRedis\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"StackExchangeRedis\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"ServiceRemoting\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"RabbitMQ\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"Msmq\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"Kafka\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"CosmosDb\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"AwsSdk\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"AwsSqs\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"ILogger\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"Aerospike\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"AzureFunctions\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"Couchbase\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"MySql\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"Npgsql\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"Oracle\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"SqlClient\",\"enabled\":false,\"auto_enabled\":false},{\"name\":\"Sqlite\",\"enabled\":false,\"auto_enabled\":false}],\"dependencies\":[{\"name\":\"System.Net.Security\",\"version\":\"4.1.2.0\"},{\"name\":\"System.Net.Http\",\"version\":\"4.2.2.0\"},{\"name\":\"System.Threading.Thread\",\"version\":\"4.1.2.0\"},{\"name\":\"System.Text.Encoding.Extensions\",\"version\":\"4.1.2.0\"},{\"name\":\"System.Memory\",\"version\":\"4.2.1.0\"},{\"name\":\"System.Runtime.Loader\",\"version\":\"4.1.1.0\"},{\"name\":\"System.Text.RegularExpressions\",\"version\":\"4.2.2.0\"},{\"name\":\"System.Reflection.Primitives\",\"version\":\"4.1.2.0\"},{\"name\":\"System.ComponentModel.Primitives\",\"version\":\"4.2.2.0\"},{\"name\":\"System.Net.Primitives\",\"version\":\"4.1.2.0\"},{\"name\":\"System.Reflection.Emit.ILGeneration\",\"version\":\"4.1.1.0\"},{\"name\":\"System.Reflection.Emit.Lightweight\",\"version\":\"4.1.1.0\"},{\"name\":\"System.Collections\",\"version\":\"4.1.2.0\"},{\"name\":\"System.Runtime.Numerics\",\"version\":\"4.1.2.0\"},{\"name\":\"System.Private.Uri\",\"version\":\"4.0.6.0\"},{\"name\":\"System.ObjectModel\",\"version\":\"4.1.2.0\"},{\"name\":\"Microsoft.Extensions.Hosting.Abstractions\",\"version\":\"3.1.22.0\"},{\"name\":\"System.Private.CoreLib\",\"version\":\"4.0.0.0\"},{\"name\":\"System.Linq\",\"version\":\"4.2.2.0\"},{\"name\":\"System.Runtime.InteropServices\",\"version\":\"4.2.2.0\"},{\"name\":\"System.IO.Pipes\",\"version\":\"4.1.2.0\"},{\"name\":\"System.Diagnostics.Process\",\"version\":\"4.2.2.0\"},{\"name\":\"System.Runtime\",\"version\":\"4.2.2.0\"},{\"name\":\"System.Collections.Concurrent\",\"version\":\"4.0.15.0\"},{\"name\":\"System.Buffers\",\"version\":\"4.0.5.0\"},{\"name\":\"System.Threading.Tasks\",\"version\":\"4.1.2.0\"},{\"name\":\"Datadog.Trace.ClrProfiler.Managed.Loader\",\"version\":\"2.0.1.0\"},{\"name\":\"app\",\"version\":\"1.0.0.0\"},{\"name\":\"System.Security.Cryptography.X509Certificates\",\"version\":\"4.2.2.0\"},{\"name\":\"Datadog.Trace\",\"version\":\"2.0.1.0\"},{\"name\":\"System.Runtime.InteropServices.RuntimeInformation\",\"version\":\"4.0.4.0\"},{\"name\":\"System.Threading\",\"version\":\"4.1.2.0\"},{\"name\":\"System.Console\",\"version\":\"4.1.2.0\"},{\"name\":\"System.IO.FileSystem\",\"version\":\"4.1.2.0\"},{\"name\":\"System.Runtime.Extensions\",\"version\":\"4.2.2.0\"},{\"name\":\"System.Diagnostics.Tracing\",\"version\":\"4.2.2.0\"}],\"configuration\":{\"platform\":\"x64\",\"enabled\":true,\"agent_url\":\"http://library_proxy:8126/\",\"debug\":true,\"analytics_enabled\":false,\"sample_rate\":0.5,\"log_injection_enabled\":false,\"runtime_metrics_enabled\":false,\"routetemplate_resourcenames_enabled\":true,\"partialflush_enabled\":false,\"partialflush_minspans\":500,\"tracer_instance_count\":1,\"aas_configuration_error\":false},\"additional_payload\":{}}}'",
    "headers": [
      [
        "Host",
        "agent:8126"
      ],
      [
        "DD-Telemetry-API-Version",
        "v1"
      ],
      [
        "DD-Telemetry-Request-Type",
        "app-started"
      ],
      [
        "x-datadog-tracing-enabled",
        "false"
      ],
      [
        "Content-Type",
        "application/json; charset=utf-8"
      ],
      [
        "Content-Length",
        "5082"
      ]
    ],
    "length": 5082
  },
  "response": {
    "status_code": 404,
    "content": "b'404 page not found\\n'",
    "headers": [
      [
        "Content-Type",
        "text/plain; charset=utf-8"
      ],
      [
        "X-Content-Type-Options",
        "nosniff"
      ],
      [
        "Date",
        "Wed, 05 Jan 2022 17:54:43 GMT"
      ],
      [
        "Content-Length",
        "19"
      ]
    ],
    "length": 19
  },
  "log_filename": "logs/interfaces/library/002__telemetry_proxy_api_v2_apmtelemetry.json"
}
```


