### PR TITLE
appsec: check span attributes for the enabled metric

### DIFF
--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -80,6 +80,12 @@ class Test_AppSecEventSpanTags(BaseTestCase):
             if span["meta"]["_dd.runtime_family"] not in RUNTIME_FAMILIES:
                 raise Exception(f"_dd.runtime_family {span['_dd.runtime_family']}, should be in {RUNTIME_FAMILIES}")
 
+            if span.get("service") != "weblog":
+                raise Exception("Service name is not 'weblog'")
+
+            if span.get("meta", {}).get("env") != "system-tests":
+                raise Exception("Environment is not 'system-tests'")
+
             return True
 
         interfaces.library.add_span_validation(validator=validate_custom_span_tags)
@@ -98,6 +104,12 @@ class Test_AppSecEventSpanTags(BaseTestCase):
 
             if "_dd.runtime_family" in span["meta"]:
                 raise Exception("_dd.runtime_family should be present when span type is web")
+
+            if span.get("service") != "weblog":
+                raise Exception("Service name is not 'weblog'")
+
+            if span.get("meta", {}).get("env") != "system-tests":
+                raise Exception("Environment is not 'system-tests'")
 
             return True
 


### PR DESCRIPTION
The current tests for checking the `_dd.appsec.enabled` metric doesn't fully validate if the span contains the expected values. This PR adds two checks for the service name and environment.