### PR TITLE
go: revert "enforce init.service priority to be greater than 0 (#126)"

### DIFF
--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -8,7 +8,6 @@ from utils import context, BaseTestCase, interfaces, bug, irrelevant, missing_fe
 
 
 @irrelevant(context.sampling_rate is None, reason="Sampling rates should be set for this test to be meaningful")
-@flaky(library="golang", reason="investigation required")
 class Test_SamplingDecisions(BaseTestCase):
     """Sampling configuration"""
 

--- a/utils/build/docker/golang/app/common.go
+++ b/utils/build/docker/golang/app/common.go
@@ -1,16 +1,9 @@
 package main
 
-import (
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-)
+import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 func initDatadog() {
 	span := tracer.StartSpan("init.service")
 	defer span.Finish()
 	span.SetTag("whip", "done")
-	// avoid the default 0 priority not be removed by the sampler which removes
-	// every trace whose span priorities are <= 0 - this feature is configured
-	// by the agent and cannot be configured so far
-	span.SetTag(ext.SamplingPriority, ext.PriorityUserKeep)
 }


### PR DESCRIPTION
Reverts DataDog/system-tests#126

This test was failing for real. We want to re-enable it.