### PR TITLE
Add ErrorDocument to PHP weblog

### DIFF
--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -239,7 +239,6 @@ class Test_ClientIP(BaseTestCase):
 
 @missing_feature(library="dotnet", reason="server.response.status not yet supported")
 @missing_feature(library="golang", reason="server.response.status not yet supported")
-@missing_feature(library="php", reason="???")
 @missing_feature(library="python", reason="server.response.status not yet supported")
 @missing_feature(context.library == "ruby" and context.libddwaf_version is None)
 @released(nodejs="2.0.0")

--- a/tests/appsec/waf/test_rules.py
+++ b/tests/appsec/waf/test_rules.py
@@ -336,7 +336,6 @@ class Test_SSRF(BaseTestCase):
 
 @missing_feature(library="dotnet", reason="server.response.status not yet supported")
 @missing_feature(library="golang", reason="server.response.status not yet supported")
-@missing_feature(library="php", reason="???")
 @missing_feature(library="python", reason="server.response.status not yet supported")
 @missing_feature(context.library == "ruby" and context.libddwaf_version is None)
 @released(nodejs="2.0.0")

--- a/utils/build/docker/php/php.conf
+++ b/utils/build/docker/php/php.conf
@@ -2,10 +2,10 @@
 <IfModule mod_php%PHP_MAJOR_VERSION.c>
     <VirtualHost *:7777>
         RewriteEngine on
-        RewriteRule "/path_that_doesn't_exists/" /404.php [L] # (sic)
         RewriteRule "^/waf$" "/waf/"
         RewriteCond /var/www/html/%{REQUEST_URI} !-f
         RewriteRule "^/([^/]+)/(.*)" "/$1.php/$2" [L]
+        ErrorDocument 404 /404.php
     </VirtualHost>
     AcceptPathInfo On
     <FilesMatch "\.php$">


### PR DESCRIPTION
This change makes it trivial to test 404 rules without having specific tests for PHP.