### PR TITLE
go: automated rule file version

### DIFF
--- a/utils/build/docker/golang/install_ddtrace.sh
+++ b/utils/build/docker/golang/install_ddtrace.sh
@@ -7,9 +7,9 @@ if [ -e "/binaries/dd-trace-go" ]; then
     go mod edit -replace gopkg.in/DataDog/dd-trace-go.v1=/binaries/dd-trace-go
     # Read from the version file directly because go list cannot know the local
     # directory version
-    version_file=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)/internal/version/version.go
-    # Parse and print the version string content "v.*"
-    version=$(sed -nrE 's#.*"v(.*)".*#\1#p' $version_file)
+    mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)
+    # Parse the version string content "v.*"
+    version=$(sed -nrE 's#.*"v(.*)".*#\1#p' $mod_dir/internal/version/version.go)
 
 elif [ -e "/binaries/golang-load-from-go-get" ]; then
     echo "Install from go get -d $(cat /binaries/golang-load-from-go-get)"
@@ -24,14 +24,14 @@ fi
 
 go mod tidy
 
-echo $version > /app/SYSTEM_TESTS_LIBRARY_VERSION
+#echo $version > /app/SYSTEM_TESTS_LIBRARY_VERSION
 touch SYSTEM_TESTS_LIBDDWAF_VERSION
-if [[ $version >= "1.37.0" ]]; then
+if [[ $version =~ v1.36 ]]; then
+    echo "1.2.5" > SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+else
     # Parse the appsec rules version string out of the inlined rules json
     mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)
     rules_version=$(sed -nrE 's#.*rules_version\\\\":\\\\"([[:digit:]\.-]+)\\\\".*#\1#p' $mod_dir/internal/appsec/rule.go)
-else
-    echo "1.2.5" > SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 fi
 
 echo "dd-trace-go version: $(cat /app/SYSTEM_TESTS_LIBRARY_VERSION)"

--- a/utils/build/docker/golang/install_ddtrace.sh
+++ b/utils/build/docker/golang/install_ddtrace.sh
@@ -20,17 +20,18 @@ go mod tidy
 # Read the library version out of the version.go file
 mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)
 version=$(sed -nrE 's#.*"v(.*)".*#\1#p' $mod_dir/internal/version/version.go) # Parse the version string content "v.*"
-echo $version > /app/SYSTEM_TESTS_LIBRARY_VERSION
+echo $version > SYSTEM_TESTS_LIBRARY_VERSION
 
 touch SYSTEM_TESTS_LIBDDWAF_VERSION
 
 # Read the rule file version
 if [[ $version =~ v1.36 ]]; then
-    echo "1.2.5" > SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+    rules_version="1.2.5"
 else
     # Parse the appsec rules version string out of the inlined rules json
     rules_version=$(sed -nrE 's#.*rules_version\\\\":\\\\"([[:digit:]\.-]+)\\\\".*#\1#p' $mod_dir/internal/appsec/rule.go)
 fi
+echo $rules_version > SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 
 echo "dd-trace-go version: $(cat /app/SYSTEM_TESTS_LIBRARY_VERSION)"
 echo "rules version: $(cat /app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION)"

--- a/utils/build/docker/golang/install_ddtrace.sh
+++ b/utils/build/docker/golang/install_ddtrace.sh
@@ -25,7 +25,7 @@ echo $version > SYSTEM_TESTS_LIBRARY_VERSION
 touch SYSTEM_TESTS_LIBDDWAF_VERSION
 
 # Read the rule file version
-if [[ $version =~ v1.36 ]]; then
+if [[ "$version" =~ "1.36" ]]; then
     rules_version="1.2.5"
 else
     # Parse the appsec rules version string out of the inlined rules json

--- a/utils/build/docker/golang/install_ddtrace.sh
+++ b/utils/build/docker/golang/install_ddtrace.sh
@@ -26,6 +26,13 @@ go mod tidy
 
 echo $version > /app/SYSTEM_TESTS_LIBRARY_VERSION
 touch SYSTEM_TESTS_LIBDDWAF_VERSION
-echo "1.2.5" > SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+if [[ $version >= "1.37.0" ]]; then
+    # Parse the appsec rules version string out of the inlined rules json
+    mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)
+    rules_version=$(sed -nrE 's#.*rules_version\\\\":\\\\"([[:digit:]\.-]+)\\\\".*#\1#p' $mod_dir/internal/appsec/rule.go)
+else
+    echo "1.2.5" > SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+fi
 
-echo "dd-trace version: $(cat /app/SYSTEM_TESTS_LIBRARY_VERSION)"
+echo "dd-trace-go version: $(cat /app/SYSTEM_TESTS_LIBRARY_VERSION)"
+echo "rules version: $(cat /app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION)"

--- a/utils/build/docker/golang/install_ddtrace.sh
+++ b/utils/build/docker/golang/install_ddtrace.sh
@@ -5,32 +5,30 @@ set -eux
 if [ -e "/binaries/dd-trace-go" ]; then
     echo "Install from folder /binaries/dd-trace-go"
     go mod edit -replace gopkg.in/DataDog/dd-trace-go.v1=/binaries/dd-trace-go
-    # Read from the version file directly because go list cannot know the local
-    # directory version
-    mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)
-    # Parse the version string content "v.*"
-    version=$(sed -nrE 's#.*"v(.*)".*#\1#p' $mod_dir/internal/version/version.go)
 
 elif [ -e "/binaries/golang-load-from-go-get" ]; then
     echo "Install from go get -d $(cat /binaries/golang-load-from-go-get)"
     go get -v -d "$(cat /binaries/golang-load-from-go-get)"
-    version=$(go list -f '{{.Version}}' -m gopkg.in/DataDog/dd-trace-go.v1)
 
 else
     echo "Installing production dd-trace-version"
     go get -v -d -u gopkg.in/DataDog/dd-trace-go.v1
-    version=$(go list -f '{{.Version}}' -m gopkg.in/DataDog/dd-trace-go.v1)
 fi
 
 go mod tidy
 
-#echo $version > /app/SYSTEM_TESTS_LIBRARY_VERSION
+# Read the library version out of the version.go file
+mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)
+version=$(sed -nrE 's#.*"v(.*)".*#\1#p' $mod_dir/internal/version/version.go) # Parse the version string content "v.*"
+echo $version > /app/SYSTEM_TESTS_LIBRARY_VERSION
+
 touch SYSTEM_TESTS_LIBDDWAF_VERSION
+
+# Read the rule file version
 if [[ $version =~ v1.36 ]]; then
     echo "1.2.5" > SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 else
     # Parse the appsec rules version string out of the inlined rules json
-    mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)
     rules_version=$(sed -nrE 's#.*rules_version\\\\":\\\\"([[:digit:]\.-]+)\\\\".*#\1#p' $mod_dir/internal/appsec/rule.go)
 fi
 


### PR DESCRIPTION
Get the rule file version out of the inlined rule json in the Go library.