### PR TITLE
Adding an endpoint to generate multiple spans

### DIFF
--- a/tests/test_miscs.py
+++ b/tests/test_miscs.py
@@ -17,5 +17,4 @@ class Test_Basic(BaseTestCase):
 
     def test_spans_generation(self):
         r = self.weblog_get("/spans")
-        assert r.status_code == 200
         interfaces.library.assert_trace_exists(r)

--- a/tests/test_miscs.py
+++ b/tests/test_miscs.py
@@ -1,0 +1,21 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2022 Datadog, Inc.
+
+from utils import BaseTestCase, interfaces, missing_feature
+
+
+@missing_feature(library="cpp")
+@missing_feature(library="golang")
+@missing_feature(library="nodejs")
+@missing_feature(library="java")
+@missing_feature(library="php")
+@missing_feature(library="python")
+@missing_feature(library="ruby")
+class Test_Basic(BaseTestCase):
+    """ Make sure the spans endpoint is successful """
+
+    def test_spans_generation(self):
+        r = self.weblog_get("/spans")
+        assert r.status_code == 200
+        interfaces.library.assert_trace_exists(r)

--- a/utils/build/docker/dotnet/Helper.cs
+++ b/utils/build/docker/dotnet/Helper.cs
@@ -1,0 +1,32 @@
+using Datadog.Trace;
+using System;
+using System.Linq;
+using System.Threading;
+
+
+namespace weblog
+{
+    public class Helper
+    {
+        private static Random random = new Random();
+        private const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+        public void GenerateSpan(int garbageTags)
+        {
+            using (var childScope = Tracer.Instance.StartActive("spans.child"))
+            {
+                childScope.Span.ResourceName = "span_" + System.Guid.NewGuid().ToString();
+                for (int i = 0; i < garbageTags; i++)
+                {
+                    childScope.Span.SetTag("garbage" + i, RandomString(50));
+                }
+            }
+        }
+
+        private static string RandomString(int length)
+        {
+            return new string(Enumerable.Repeat(chars, length)
+                .Select(s => s[random.Next(s.Length)]).ToArray());
+        }
+    }
+}

--- a/utils/build/docker/dotnet/Helper.cs
+++ b/utils/build/docker/dotnet/Helper.cs
@@ -25,8 +25,11 @@ namespace weblog
 
         private static string RandomString(int length)
         {
-            return new string(Enumerable.Repeat(chars, length)
-                .Select(s => s[random.Next(s.Length)]).ToArray());
+            return new string(
+                Enumerable
+                    .Range(1, length)
+                    .Select(_ => chars[random.Next(chars.Length)])
+                    .ToArray());
         }
     }
 }

--- a/utils/build/docker/dotnet/Startup.cs
+++ b/utils/build/docker/dotnet/Startup.cs
@@ -12,6 +12,8 @@ namespace weblog
 {
     public class Startup
     {
+        private static Helper helper = new Helper();
+
         private static void SetupDatabase()
         {
             string script = @"
@@ -96,6 +98,29 @@ END
                         var value = reader["Value"]?.ToString();
                         await context.Response.WriteAsync(value + Environment.NewLine);
                     }
+                });
+
+                endpoints.MapGet("/spans", async context =>
+                {
+                    int repeats = 1;
+                    var repeatsStr = context.Request.Query["repeats"];
+                    if (!String.IsNullOrEmpty(repeatsStr)) {
+                        repeats = Int32.Parse(repeatsStr);
+                    }
+
+                    int garbageTags = 1;
+                    var garbageStr = context.Request.Query["garbage"];
+                    if (!String.IsNullOrEmpty(garbageStr)) {
+                        garbageTags = Int32.Parse(garbageStr);
+                    }
+
+                    for (int i = 0; i < repeats; i++)
+                    {
+                        helper.GenerateSpan(garbageTags);
+                    }
+                                        
+                    await context.Response.WriteAsync(
+                        String.Format("Generated {0} spans with {1} garbage tags\n", repeats, garbageTags));
                 });
 
 


### PR DESCRIPTION
We want to have an endpoint that generates a lot of load in APM to test our services. This new endpoint takes URL parameters to generate a number of spans and tags with random data (to increase the size of the payload)

We're using this in our load tests through https://github.com/DataDog/k9-appsec-testing-env
