### PR TITLE
go: handle http.request.body address tests

### DIFF
--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -175,7 +175,7 @@ class Test_BodyRaw(BaseTestCase):
         interfaces.library.assert_waf_attack(r, address="server.request.body")
 
 
-@released(golang="?", dotnet="?", java="?", nodejs="2.2.0", php_appsec="0.1.0", python="?", ruby="?")
+@released(golang="1.37.0", dotnet="?", java="?", nodejs="2.2.0", php_appsec="0.1.0", python="?", ruby="?")
 class Test_BodyUrlEncoded(BaseTestCase):
     """Appsec supports <url encoded body>"""
 
@@ -192,7 +192,7 @@ class Test_BodyUrlEncoded(BaseTestCase):
         interfaces.library.assert_waf_attack(r, value='<vmlframe src="xss">', address="server.request.body")
 
 
-@released(golang="?", dotnet="?", java="?", nodejs="2.2.0", php="?", python="?", ruby="?")
+@released(golang="1.37.0", dotnet="?", java="?", nodejs="2.2.0", php="?", python="?", ruby="?")
 class Test_BodyJson(BaseTestCase):
     """Appsec supports <JSON encoded body>"""
 
@@ -213,7 +213,7 @@ class Test_BodyJson(BaseTestCase):
         interfaces.library.assert_waf_attack(r, value='<vmlframe src="xss">', address="server.request.body")
 
 
-@released(golang="?", dotnet="?", java="?", nodejs="2.2.0", php="?", python="?", ruby="?")
+@released(golang="1.37.0", dotnet="?", java="?", nodejs="2.2.0", php="?", python="?", ruby="?")
 class Test_BodyXml(BaseTestCase):
     """Appsec supports <XML encoded body>"""
 

--- a/utils/build/docker/golang/app/chi.go
+++ b/utils/build/docker/golang/app/chi.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec"
 	chitrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-chi/chi.v5"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -14,6 +15,14 @@ func main() {
 	defer tracer.Stop()
 
 	mux := chi.NewRouter().With(chitrace.Middleware())
+
+	mux.HandleFunc("/waf", func(w http.ResponseWriter, r *http.Request) {
+		body, err := parseBody(r)
+		if err == nil {
+			appsec.MonitorParsedHTTPBody(r.Context(), body)
+		}
+		w.Write([]byte("Hello, WAF!\n"))
+	})
 
 	mux.HandleFunc("/waf/*", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello, WAF!\n"))

--- a/utils/build/docker/golang/app/common.go
+++ b/utils/build/docker/golang/app/common.go
@@ -1,9 +1,40 @@
 package main
 
-import "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+import (
+	"encoding/json"
+	"encoding/xml"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
 
 func initDatadog() {
 	span := tracer.StartSpan("init.service")
 	defer span.Finish()
 	span.SetTag("whip", "done")
+}
+
+func parseBody(r *http.Request) (interface{}, error) {
+	var payload interface{}
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	// Try parsing body as JSON data
+	if err := json.Unmarshal(data, &payload); err == nil {
+		return payload, err
+	}
+
+	xmlPayload := struct {
+		XMLName xml.Name `xml:"a"`
+		Attr    string   `xml:"attack,attr"`
+		Content string   `xml:",chardata"`
+	}{}
+	// Try parsing body as XML data
+	if err := xml.Unmarshal(data, &xmlPayload); err == nil {
+		return xmlPayload, err
+	}
+	// Default to parsing body as URL encoded data
+	return url.ParseQuery(string(data))
 }

--- a/utils/build/docker/golang/app/echo.go
+++ b/utils/build/docker/golang/app/echo.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec"
 	echotrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/labstack/echo.v4"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -23,6 +24,15 @@ func main() {
 
 	r.Any("/*", func(c echo.Context) error {
 		return c.NoContent(http.StatusNotFound)
+	})
+
+	r.Any("/waf", func(c echo.Context) error {
+		req := c.Request()
+		body, err := parseBody(req)
+		if err == nil {
+			appsec.MonitorParsedHTTPBody(req.Context(), body)
+		}
+		return c.String(http.StatusOK, "Hello, WAF!\n")
 	})
 
 	r.Any("/waf/", func(c echo.Context) error {

--- a/utils/build/docker/golang/app/gin.go
+++ b/utils/build/docker/golang/app/gin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec"
 	gintrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gin-gonic/gin"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -18,6 +19,13 @@ func main() {
 
 	r.Any("/", func(ctx *gin.Context) {
 		ctx.Writer.WriteHeader(http.StatusOK)
+	})
+	r.Any("/waf", func(ctx *gin.Context) {
+		body, err := parseBody(ctx.Request)
+		if err == nil {
+			appsec.MonitorParsedHTTPBody(ctx.Request.Context(), body)
+		}
+		ctx.Writer.Write([]byte("Hello, WAF!\n"))
 	})
 	r.Any("/waf/*allpaths", func(ctx *gin.Context) {
 		ctx.Writer.Write([]byte("Hello, WAF!\n"))

--- a/utils/build/docker/golang/app/gorilla.go
+++ b/utils/build/docker/golang/app/gorilla.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec"
 	muxtrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -15,6 +16,14 @@ func main() {
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/waf", func(w http.ResponseWriter, r *http.Request) {
+		body, err := parseBody(r)
+		if err == nil {
+			appsec.MonitorParsedHTTPBody(r.Context(), body)
+		}
+		w.Write([]byte("Hello, WAF!\n"))
 	})
 
 	mux.HandleFunc("/waf/", func(w http.ResponseWriter, r *http.Request) {

--- a/utils/build/docker/golang/app/net-http.go
+++ b/utils/build/docker/golang/app/net-http.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/appsec"
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -21,6 +22,14 @@ func main() {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/waf", func(w http.ResponseWriter, r *http.Request) {
+		body, err := parseBody(r)
+		if err == nil {
+			appsec.MonitorParsedHTTPBody(r.Context(), body)
+		}
+		w.Write([]byte("Hello, WAF!\n"))
 	})
 
 	mux.HandleFunc("/waf/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
- `utils/build/docker/golang/app/`: use appsec SDK to monitor http request body
- `utils/build/docker/golang/app/common.go`: add http request body parser
- `tests/appsec/waf/test_addresses.py`: enable http.request.body related tests for go starting from v1.37.0