### PR TITLE
Fix ARM node

### DIFF
--- a/utils/build/docker/nodejs/armv7.Dockerfile
+++ b/utils/build/docker/nodejs/armv7.Dockerfile
@@ -16,8 +16,7 @@ RUN npm install
 EXPOSE 7777
 
 # docker startup
-RUN echo '#!/bin/sh' > app.sh
-RUN echo 'node app.js' >> app.sh
+RUN echo '#!/bin/sh\nnode app.js\n' > app.sh
 RUN chmod +x app.sh
 CMD ./app.sh
 

--- a/utils/build/docker/weblog-cmd.sh
+++ b/utils/build/docker/weblog-cmd.sh
@@ -18,11 +18,6 @@ echo "Configuration script executed from: ${PWD}"
 BASEDIR=$(dirname $0)
 echo "Configuration script location: ${BASEDIR}"
 
-if ! grep -q "#!/bin/bash" "./app.sh"; then
-    echo "Please ensure you add #!/bin/bash to your ./app.sh file"
-    exit 1
-fi
-
 if [ ${SYSTEMTESTS_SCENARIO:-DEFAULT} = "UDS" ]; then
 
     export EXPECTED_APM_SOCKET=${DD_APM_RECEIVER_SOCKET:-/var/run/datadog/apm.socket}


### PR DESCRIPTION
Several things here : 

* Remove the check on hashbang : it can be `bash`, or `sh`, ot anything else (reduce requirements is always good)
* use `--force-recreate` on docker-compose up, it removes the need of `docker-compose down` at the begining of `run.sh`, and reduce noise in output
* `cgroup` command:  ignore if it fails (check will be done after)
* Add a check on each container, and display stdout if one has been unexpectably stopped 