### PR TITLE
Fix ruby install_ddtrace

### DIFF
--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -155,8 +155,7 @@ elif [ "$TARGET" = "python" ]; then
     echo "ddtrace @ git+https://github.com/DataDog/dd-trace-py.git" > python-load-from-pip
 
 elif [ "$TARGET" = "ruby" ]; then
-    # echo 'ddtrace --git "https://github.com/Datadog/dd-trace-rb" --branch "master"' > ruby-load-from-bundle-add
-    echo "gem 'ddtrace', require: 'ddtrace/auto_instrument', github: 'Datadog/dd-trace-rb', branch: 'master'" > ruby-load-from-bundle-add
+    echo "gem 'ddtrace', require: 'ddtrace/auto_instrument', git: 'https://github.com/Datadog/dd-trace-rb.git'" > ruby-load-from-bundle-add
     echo "Using $(cat ruby-load-from-bundle-add)"
 
 elif [ "$TARGET" = "php" ]; then


### PR DESCRIPTION
See https://github.com/DataDog/system-tests-dashboard/runs/5565042743?check_suite_focus=true

```
Install from gem 'ddtrace', require: 'ddtrace/auto_instrument', github: 'Datadog/dd-trace-rb', branch: 'master'
The git source `git://github.com/Datadog/dd-trace-rb.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
Fetching git://github.com/Datadog/dd-trace-rb.git
fatal: remote error: 
  The unauthenticated git protocol on port [94](https://github.com/DataDog/system-tests-dashboard/runs/5565042743?check_suite_focus=true#step:7:94)18 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

I changed from `github: 'Datadog/dd-trace-rb', branch: 'master'` to `git: 'https://github.com/Datadog/dd-trace-rb.git'` and it seems to be ok.

The strange thing is that the issue do not happen on all variant, and I have no idea why.