### PR TITLE
container-id can be missing

### DIFF
--- a/utils/_context/core.py
+++ b/utils/_context/core.py
@@ -94,7 +94,7 @@ class _Context:
         with open(cgroup_file, mode="r") as fp:
             for line in fp:
                 info = CGroupInfo.from_line(line)
-                if info and info.container_id:
+                if info:
                     return info.container_id
 
         raise RuntimeError("Failed to get container id")

--- a/utils/interfaces/_library/trace_headers.py
+++ b/utils/interfaces/_library/trace_headers.py
@@ -32,18 +32,19 @@ class _TraceHeadersContainerTags(BaseValidation):
 
         request_headers = {h[0].lower(): h[1] for h in data["request"]["headers"]}
 
-        if "datadog-container-id" not in request_headers:
-            self.set_failure(f"Datadog-Container-ID header is missing in request {data['log_filename']}")
-            return
-
         expected_value = context.get_weblog_container_id()
 
-        if request_headers["datadog-container-id"] != expected_value:
-            self.set_failure(
-                f"Expected Datadog-Container-ID header to be {expected_value}, "
-                f"but got {request_headers['datadog-container-id']} "
-                f"in request number {data['log_filename']}"
-            )
+        if expected_value is not None:
+            if "datadog-container-id" not in request_headers:
+                self.set_failure(f"Datadog-Container-ID header is missing in request {data['log_filename']}")
+                return
+
+            if request_headers["datadog-container-id"] != expected_value:
+                self.set_failure(
+                    f"Expected Datadog-Container-ID header to be {expected_value}, "
+                    f"but got {request_headers['datadog-container-id']} "
+                    f"in request number {data['log_filename']}"
+                )
 
 
 class _TraceHeadersContainerTagsCpp(BaseValidation):


### PR DESCRIPTION
`/proc/self/cgroup` gives `0::/` on my laptop.

At least ruby tracer use the same method, and do not have the container id, so the header `datadog-container-id` is missing.