### PR TITLE
utils: fix sampling decision test for spans tagged with WAF ruleset info

### DIFF
--- a/utils/interfaces/_library/sampling.py
+++ b/utils/interfaces/_library/sampling.py
@@ -69,7 +69,7 @@ class _TracesSamplingDecision(BaseValidation):
         MANUAL_KEEP = 2
         MANUAL_REJECT = -1
 
-        if meta.get("appsec.event", None) == "true":
+        if meta.get("appsec.event", None) == "true" or meta.get("_dd.appsec.event_rules.loaded", None) is not None:
             return (MANUAL_KEEP,)
 
         if ((trace_id * KNUTH_FACTOR) % MAX_TRACE_ID) <= (sampling_rate * MAX_TRACE_ID):


### PR DESCRIPTION
get_sampling_decision now expects spans that hold WAF ruleset info tags to have ManualKeep priority