### PR TITLE
go: fix server.request.cookies tests

### DIFF
--- a/scenarios/appsec/waf/test_addresses.py
+++ b/scenarios/appsec/waf/test_addresses.py
@@ -28,7 +28,7 @@ class Test_Cookies(BaseTestCase):
         interfaces.library.assert_waf_attack(r, pattern=".htaccess", address="server.request.cookies")
 
     @missing_feature(library="java", reason="cookie is rejected by Coyote")
-    @missing_feature(library="golang", reason="cookies are not url-decoded")
+    @irrelevant(library="golang", reason="not handled by the Go standard cookie parser")
     def test_cookies_with_semicolon(self):
         """ Cookie with pattern containing a semicolon """
         r = self.weblog_get("/waf", cookies={"value": "%3Bshutdown--"})
@@ -40,7 +40,7 @@ class Test_Cookies(BaseTestCase):
         r = self.weblog_get("/waf/", cookies={"x-attack": "var_dump ()"})
         interfaces.library.assert_waf_attack(r, pattern="var_dump ()", address="server.request.cookies")
 
-    @missing_feature(context.library < "golang@1.36.0")
+    @irrelevant(library="golang", reason="not handled by the Go standard cookie parser")
     @bug(library="dotnet", reason="APPSEC-2290")
     @bug(context.library < "java@0.96.0")
     def test_cookies_with_special_chars2(self):

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -150,7 +150,7 @@ class Test_Cookies_ToBeRestoredOnceWeHaveRules(BaseTestCase):
         interfaces.library.assert_waf_attack(r, pattern=".htaccess", address="server.request.cookies")
 
     @missing_feature(library="java", reason="cookie is rejected by Coyote")
-    @missing_feature(library="golang", reason="cookies are not url-decoded")
+    @irrelevant(library="golang", reason="not handled by the Go standard cookie parser")
     def test_cookies_with_semicolon(self):
         """ Cookie with pattern containing a semicolon """
         r = self.weblog_get("/waf", cookies={"value": "%3Bshutdown--"})
@@ -165,7 +165,7 @@ class Test_Cookies_ToBeRestoredOnceWeHaveRules(BaseTestCase):
         r = self.weblog_get("/waf/", cookies={"x-attack": "var_dump ()"})
         interfaces.library.assert_waf_attack(r, pattern="var_dump ()", address="server.request.cookies")
 
-    @missing_feature(context.library < "golang@1.36.0")
+    @irrelevant(library="golang", reason="not handled by the Go standard cookie parser")
     @bug(library="dotnet", reason="APPSEC-2290")
     @bug(context.library < "java@0.96.0")
     def test_cookies_with_special_chars2(self):


### PR DESCRIPTION
Make two `missing_feature` tests `irrelevant` as we rely on the standard Go parser and it doesn't handle those corner cases properly. We don't plan to do anything about it, even in the long term when we will have dynamic instrumentation. 