### PR TITLE
appsec: better obfuscator tests

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -64,7 +64,7 @@ elif [ $SYSTEMTESTS_SCENARIO = "APPSEC_CORRUPTED_RULES" ]; then
     WEBLOG_ENV="DD_APPSEC_RULES=/appsec_corrupted_rules.yml"
 
 elif [ $SYSTEMTESTS_SCENARIO = "APPSEC_CUSTOM_RULES" ]; then
-    export RUNNER_ARGS="scenarios/appsec/test_customconf.py::Test_ConfRuleSet scenarios/appsec/test_customconf.py::Test_NoLimitOnWafRules scenarios/appsec/waf/test_addresses.py"
+    export RUNNER_ARGS="scenarios/appsec/test_customconf.py::Test_ConfRuleSet scenarios/appsec/test_customconf.py::Test_NoLimitOnWafRules scenarios/appsec/waf/test_addresses.py scenarios/appsec/test_rules.py"
     export SYSTEMTESTS_LOG_FOLDER=logs_custom_appsec_rules
     WEBLOG_ENV="DD_APPSEC_RULES=/appsec_custom_rules.json"
 

--- a/run.sh
+++ b/run.sh
@@ -64,7 +64,7 @@ elif [ $SYSTEMTESTS_SCENARIO = "APPSEC_CORRUPTED_RULES" ]; then
     WEBLOG_ENV="DD_APPSEC_RULES=/appsec_corrupted_rules.yml"
 
 elif [ $SYSTEMTESTS_SCENARIO = "APPSEC_CUSTOM_RULES" ]; then
-    export RUNNER_ARGS="scenarios/appsec/test_customconf.py::Test_ConfRuleSet scenarios/appsec/test_customconf.py::Test_NoLimitOnWafRules scenarios/appsec/waf/test_addresses.py scenarios/appsec/test_rules.py"
+    export RUNNER_ARGS="scenarios/appsec/test_customconf.py::Test_ConfRuleSet scenarios/appsec/test_customconf.py::Test_NoLimitOnWafRules scenarios/appsec/waf/test_addresses.py scenarios/appsec/test_traces.py"
     export SYSTEMTESTS_LOG_FOLDER=logs_custom_appsec_rules
     WEBLOG_ENV="DD_APPSEC_RULES=/appsec_custom_rules.json"
 

--- a/scenarios/appsec/test_traces.py
+++ b/scenarios/appsec/test_traces.py
@@ -55,6 +55,8 @@ class Test_AppSecObfuscator(BaseTestCase):
                 raise Exception("Could not find the non-sensitive cookie data")
             return True
 
-        r = self.weblog_get("/waf/", cookies={"Bearer": SECRET_VALUE_WITH_SENSITIVE_KEY, "Good": SECRET_VALUE_WITH_NON_SENSITIVE_KEY})
+        r = self.weblog_get(
+            "/waf/", cookies={"Bearer": SECRET_VALUE_WITH_SENSITIVE_KEY, "Good": SECRET_VALUE_WITH_NON_SENSITIVE_KEY}
+        )
         interfaces.library.assert_waf_attack(r)
         interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)

--- a/scenarios/appsec/test_traces.py
+++ b/scenarios/appsec/test_traces.py
@@ -29,10 +29,7 @@ class Test_AppSecObfuscator(BaseTestCase):
             return True
 
         r = self.weblog_get(
-            "/waf/",
-            headers={"DD_API_TOKEN": SECRET},
-            cookies={"Bearer": SECRET},
-            params={"pwd": SECRET},
+            "/waf/", headers={"DD_API_TOKEN": SECRET}, cookies={"Bearer": SECRET}, params={"pwd": SECRET},
         )
         interfaces.library.assert_waf_attack(r)
         interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)

--- a/scenarios/appsec/test_traces.py
+++ b/scenarios/appsec/test_traces.py
@@ -30,7 +30,7 @@ class Test_AppSecObfuscator(BaseTestCase):
 
         r = self.weblog_get(
             "/waf/",
-            headers={"User-Agent": f"Arachni/v1", "DD_API_TOKEN": SECRET},
+            headers={"DD_API_TOKEN": SECRET},
             cookies={"Bearer": SECRET},
             params={"pwd": SECRET},
         )
@@ -45,8 +45,8 @@ class Test_AppSecObfuscator(BaseTestCase):
         # Validate that the AppSec events do not contain the following secret value.
         # Note that this value must contain an attack pattern in order to be part of the security event data
         # that is expected to be obfuscated.
-        SECRET_VALUE_WITH_SENSITIVE_KEY = "this is a very sensitive cookie value having the appscan_fingerprint attack"
-        SECRET_VALUE_WITH_NON_SENSITIVE_KEY = "not a sensitive cookie value having an appscan_fingerprint attack"
+        SECRET_VALUE_WITH_SENSITIVE_KEY = "this is a very sensitive cookie value having the .htaccess attack"
+        SECRET_VALUE_WITH_NON_SENSITIVE_KEY = "not a sensitive cookie value having an .htaccess attack"
 
         def validate_appsec_span_tags(payload, chunk, span, appsec_data):
             if SECRET_VALUE_WITH_SENSITIVE_KEY in span["meta"]["_dd.appsec.json"]:

--- a/scenarios/appsec/test_traces.py
+++ b/scenarios/appsec/test_traces.py
@@ -1,0 +1,63 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+import pytest
+
+from utils import BaseTestCase, context, interfaces, released, bug, missing_feature, irrelevant, rfc
+
+
+if context.library == "cpp":
+    pytestmark = pytest.mark.skip("not relevant")
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2365948382/Sensitive+Data+Obfuscation")
+@missing_feature(reason="Not started yet in any lib")
+class Test_AppSecObfuscator(BaseTestCase):
+    """AppSec obfuscates sensitive data."""
+
+    def test_appsec_obfuscator(self):
+        """General obfuscation test of several attacks on several rule addresses."""
+        # Validate that the AppSec events do not contain the following secret value.
+        # Note that this value must contain an attack pattern in order to be part of the security event data
+        # that is expected to be obfuscated.
+        SECRET = "this is a very secret value having the appscan_fingerprint attack"
+
+        def validate_appsec_span_tags(payload, chunk, span, appsec_data):
+            if SECRET in span["meta"]["_dd.appsec.json"]:
+                raise Exception("The security events contain the secret value that should be obfuscated")
+            return True
+
+        r = self.weblog_get(
+            "/waf/",
+            headers={"User-Agent": f"Arachni/v1", "DD_API_TOKEN": SECRET},
+            cookies={"Bearer": SECRET},
+            params={"pwd": SECRET},
+        )
+        interfaces.library.assert_waf_attack(r)
+        interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)
+
+    def test_appsec_obfuscator_cookies(self):
+        """
+        Specific obfuscation test for the cookies which often contain sensitive data and are
+        expected to be properly obfuscated on sensitive cookies only.
+        """
+        # Validate that the AppSec events do not contain the following secret value.
+        # Note that this value must contain an attack pattern in order to be part of the security event data
+        # that is expected to be obfuscated.
+        SECRET_VALUE_WITH_SENSITIVE_KEY = "this is a very sensitive cookie value having the appscan_fingerprint attack"
+        SECRET_VALUE_WITH_NON_SENSITIVE_KEY = "not a sensitive cookie value having an appscan_fingerprint attack"
+
+        def validate_appsec_span_tags(payload, chunk, span, appsec_data):
+            if SECRET_VALUE_WITH_SENSITIVE_KEY in span["meta"]["_dd.appsec.json"]:
+                raise Exception("The security events contain the secret value that should be obfuscated")
+            if SECRET_VALUE_WITH_NON_SENSITIVE_KEY not in span["meta"]["_dd.appsec.json"]:
+                raise Exception("Could not find the non-sensitive cookie data")
+            return True
+
+        r = self.weblog_get(
+            "/waf/",
+            cookies={"Bearer": SECRET_VALUE_WITH_SENSITIVE_KEY, "Good": SECRET_VALUE_WITH_NON_SENSITIVE_KEY},
+        )
+        interfaces.library.assert_waf_attack(r)
+        interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)

--- a/scenarios/appsec/test_traces.py
+++ b/scenarios/appsec/test_traces.py
@@ -55,9 +55,6 @@ class Test_AppSecObfuscator(BaseTestCase):
                 raise Exception("Could not find the non-sensitive cookie data")
             return True
 
-        r = self.weblog_get(
-            "/waf/",
-            cookies={"Bearer": SECRET_VALUE_WITH_SENSITIVE_KEY, "Good": SECRET_VALUE_WITH_NON_SENSITIVE_KEY},
-        )
+        r = self.weblog_get("/waf/", cookies={"Bearer": SECRET_VALUE_WITH_SENSITIVE_KEY, "Good": SECRET_VALUE_WITH_NON_SENSITIVE_KEY})
         interfaces.library.assert_waf_attack(r)
         interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -194,10 +194,7 @@ class Test_AppSecObfuscator(BaseTestCase):
                 raise Exception("Could not find the non-sensitive cookie data")
             return True
 
-        r = self.weblog_get(
-            "/waf/",
-            cookies={"Bearer": SECRET_VALUE_WITH_SENSITIVE_KEY, "Good": SECRET_VALUE_WITH_NON_SENSITIVE_KEY},
-        )
+        r = self.weblog_get("/waf/", cookies={"Bearer": SECRET_VALUE_WITH_SENSITIVE_KEY, "Good": SECRET_VALUE_WITH_NON_SENSITIVE_KEY})
         interfaces.library.assert_waf_attack(r)
         interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)
 

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -167,10 +167,7 @@ class Test_AppSecObfuscator_ToBeRestoredOnceWeHaveRules(BaseTestCase):
             return True
 
         r = self.weblog_get(
-            "/waf/",
-            headers={"DD_API_TOKEN": SECRET},
-            cookies={"Bearer": SECRET},
-            params={"pwd": SECRET},
+            "/waf/", headers={"DD_API_TOKEN": SECRET}, cookies={"Bearer": SECRET}, params={"pwd": SECRET},
         )
         interfaces.library.assert_waf_attack(r)
         interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -151,7 +151,7 @@ class Test_AppSecEventSpanTags(BaseTestCase):
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2365948382/Sensitive+Data+Obfuscation")
 @missing_feature(reason="Not started yet in any lib")
-class Test_AppSecObfuscator(BaseTestCase):
+class Test_AppSecObfuscator_ToBeRestoredOnceWeHaveRules(BaseTestCase):
     """AppSec obfuscates sensitive data."""
 
     def test_appsec_obfuscator(self):
@@ -159,7 +159,7 @@ class Test_AppSecObfuscator(BaseTestCase):
         # Validate that the AppSec events do not contain the following secret value.
         # Note that this value must contain an attack pattern in order to be part of the security event data
         # that is expected to be obfuscated.
-        SECRET = "this is a very secret value having the appscan_fingerprint attack"
+        SECRET = "this is a very secret value having the .htaccess attack"
 
         def validate_appsec_span_tags(payload, chunk, span, appsec_data):
             if SECRET in span["meta"]["_dd.appsec.json"]:
@@ -168,7 +168,7 @@ class Test_AppSecObfuscator(BaseTestCase):
 
         r = self.weblog_get(
             "/waf/",
-            headers={"User-Agent": f"Arachni/v1", "DD_API_TOKEN": SECRET},
+            headers={"DD_API_TOKEN": SECRET},
             cookies={"Bearer": SECRET},
             params={"pwd": SECRET},
         )
@@ -184,8 +184,8 @@ class Test_AppSecObfuscator(BaseTestCase):
         # Validate that the AppSec events do not contain the following secret value.
         # Note that this value must contain an attack pattern in order to be part of the security event data
         # that is expected to be obfuscated.
-        SECRET_VALUE_WITH_SENSITIVE_KEY = "this is a very sensitive cookie value having the appscan_fingerprint attack"
-        SECRET_VALUE_WITH_NON_SENSITIVE_KEY = "not a sensitive cookie value having an appscan_fingerprint attack"
+        SECRET_VALUE_WITH_SENSITIVE_KEY = "this is a very sensitive cookie value having the .htaccess attack"
+        SECRET_VALUE_WITH_NON_SENSITIVE_KEY = "not a sensitive cookie value having an .htaccess attack"
 
         def validate_appsec_span_tags(payload, chunk, span, appsec_data):
             if SECRET_VALUE_WITH_SENSITIVE_KEY in span["meta"]["_dd.appsec.json"]:

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -155,22 +155,51 @@ class Test_AppSecObfuscator(BaseTestCase):
     """AppSec obfuscates sensitive data."""
 
     def test_appsec_obfuscator(self):
-        SECRET = "this is a very secret value"
+        """General obfuscation test of several attacks on several rule addresses."""
+        # Validate that the AppSec events do not contain the following secret value.
+        # Note that this value must contain an attack pattern in order to be part of the security event data
+        # that is expected to be obfuscated.
+        SECRET = "this is a very secret value having the appscan_fingerprint attack"
 
         def validate_appsec_span_tags(payload, chunk, span, appsec_data):
-
             if SECRET in span["meta"]["_dd.appsec.json"]:
-                raise Exception("The secret value should be obfuscated")
-
+                raise Exception("The security events contain the secret value that should be obfuscated")
             return True
 
         r = self.weblog_get(
             "/waf/",
-            headers={"User-Agent": "Arachni/v1", "DD_API_TOKEN": f"{SECRET} token {SECRET}"},
-            params={"pwd": f"{SECRET} appscan_fingerprint {SECRET}"},
+            headers={"User-Agent": f"Arachni/v1", "DD_API_TOKEN": SECRET},
+            cookies={"Bearer": SECRET},
+            params={"pwd": SECRET},
         )
         interfaces.library.assert_waf_attack(r)
-        interfaces.agent.add_appsec_validation(r, validate_appsec_span_tags)
+        interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)
+
+    @irrelevant(context.appsec_rules_version >= "1.2.7", reason="cookies were disabled for the time being")
+    def test_appsec_obfuscator_cookies(self):
+        """
+        Specific obfuscation test for the cookies which often contain sensitive data and are
+        expected to be properly obfuscated on sensitive cookies only.
+        """
+        # Validate that the AppSec events do not contain the following secret value.
+        # Note that this value must contain an attack pattern in order to be part of the security event data
+        # that is expected to be obfuscated.
+        SECRET_VALUE_WITH_SENSITIVE_KEY = "this is a very sensitive cookie value having the appscan_fingerprint attack"
+        SECRET_VALUE_WITH_NON_SENSITIVE_KEY = "not a sensitive cookie value having an appscan_fingerprint attack"
+
+        def validate_appsec_span_tags(payload, chunk, span, appsec_data):
+            if SECRET_VALUE_WITH_SENSITIVE_KEY in span["meta"]["_dd.appsec.json"]:
+                raise Exception("The security events contain the secret value that should be obfuscated")
+            if SECRET_VALUE_WITH_NON_SENSITIVE_KEY not in span["meta"]["_dd.appsec.json"]:
+                raise Exception("Could not find the non-sensitive cookie data")
+            return True
+
+        r = self.weblog_get(
+            "/waf/",
+            cookies={"Bearer": SECRET_VALUE_WITH_SENSITIVE_KEY, "Good": SECRET_VALUE_WITH_NON_SENSITIVE_KEY},
+        )
+        interfaces.library.assert_waf_attack(r)
+        interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2186870984/HTTP+header+collection")

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -194,7 +194,9 @@ class Test_AppSecObfuscator(BaseTestCase):
                 raise Exception("Could not find the non-sensitive cookie data")
             return True
 
-        r = self.weblog_get("/waf/", cookies={"Bearer": SECRET_VALUE_WITH_SENSITIVE_KEY, "Good": SECRET_VALUE_WITH_NON_SENSITIVE_KEY})
+        r = self.weblog_get(
+            "/waf/", cookies={"Bearer": SECRET_VALUE_WITH_SENSITIVE_KEY, "Good": SECRET_VALUE_WITH_NON_SENSITIVE_KEY}
+        )
         interfaces.library.assert_waf_attack(r)
         interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)
 


### PR DESCRIPTION
- Fix the existing test
- Check the obfuscation results on the library interface now that it is implemented by the WAF
- And most importantly, introduce a new test for `server.request.cookies` to check the behavior in case of several cookies having attacks so that we can validate only the one with sensitive data are getting obfuscated.