### PR TITLE
utils: rework sampling decision for spans with WAF metrics

### DIFF
--- a/utils/interfaces/_library/sampling.py
+++ b/utils/interfaces/_library/sampling.py
@@ -69,7 +69,7 @@ class _TracesSamplingDecision(BaseValidation):
         MANUAL_KEEP = 2
         MANUAL_REJECT = -1
 
-        if meta.get("appsec.event", None) == "true" or meta.get("_dd.appsec.event_rules.version", None) is not None:
+        if meta.get("appsec.event", None) == "true" or meta.get("_dd.appsec.event_rules.errors", None) is not None:
             return (MANUAL_KEEP,)
 
         if ((trace_id * KNUTH_FACTOR) % MAX_TRACE_ID) <= (sampling_rate * MAX_TRACE_ID):


### PR DESCRIPTION
### Motivation
A decision has been made that the libraries would report the WAF rules version for every request rather than once.
The current check in system tests for sampling decision is made assuming that this happens once per WAF instantiation which will lead the tests to fail once the library change goes live. This change makes sure to do the check on a tag that gets reported only once, to make sure that the MANUAL_KEEP priority is not expected when it should not be.