### PR TITLE
fix query key rule

### DIFF
--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -12,10 +12,11 @@ if context.library == "cpp":
 
 
 # WAF/current ruleset don't support looking at keys at all
-@released(golang="?", dotnet="?", java="?", nodejs="?", php="?", python="?", ruby="1.0.0.beta1")
+@released(golang="?", dotnet="?", java="?", nodejs="2.6.0", php="?", python="?", ruby="1.0.0.beta1")
 class Test_UrlQueryKey(BaseTestCase):
     """Appsec supports keys on server.request.query"""
 
+    @irrelevant(reason="no non-encoded rule on query yet")
     def test_query_key(self):
         """AppSec catches attacks in URL query key"""
         r = self.weblog_get("/waf/", params={"appscan_fingerprint": "attack"})
@@ -24,8 +25,8 @@ class Test_UrlQueryKey(BaseTestCase):
     @missing_feature(library="ruby")
     def test_query_key_encoded(self):
         """AppSec catches attacks in URL query encoded key"""
-        r = self.weblog_get("/waf/", params={"<script>": "attack"})
-        interfaces.library.assert_waf_attack(r, pattern="<script>", address="server.request.query")
+        r = self.weblog_get("/waf/", params={"$eq": "attack"})
+        interfaces.library.assert_waf_attack(r, pattern="$eq", address="server.request.query")
 
 
 @released(golang="1.35.0")

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -12,7 +12,7 @@ if context.library == "cpp":
 
 
 # WAF/current ruleset don't support looking at keys at all
-@released(golang="?", dotnet="?", java="?", nodejs="2.6.0", php="?", python="?", ruby="1.0.0.beta1")
+@released(golang="?", dotnet="?", java="?", nodejs="2.6.0", php="?", python="?", ruby="?")
 class Test_UrlQueryKey(BaseTestCase):
     """Appsec supports keys on server.request.query"""
 
@@ -22,7 +22,6 @@ class Test_UrlQueryKey(BaseTestCase):
         r = self.weblog_get("/waf/", params={"appscan_fingerprint": "attack"})
         interfaces.library.assert_waf_attack(r, pattern="appscan_fingerprint", address="server.request.query")
 
-    @missing_feature(library="ruby")
     def test_query_key_encoded(self):
         """AppSec catches attacks in URL query encoded key"""
         r = self.weblog_get("/waf/", params={"$eq": "attack"})

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -16,14 +16,8 @@ if context.library == "cpp":
 class Test_UrlQueryKey(BaseTestCase):
     """Appsec supports keys on server.request.query"""
 
-    @irrelevant(reason="no non-encoded rule on query yet")
     def test_query_key(self):
         """AppSec catches attacks in URL query key"""
-        r = self.weblog_get("/waf/", params={"appscan_fingerprint": "attack"})
-        interfaces.library.assert_waf_attack(r, pattern="appscan_fingerprint", address="server.request.query")
-
-    def test_query_key_encoded(self):
-        """AppSec catches attacks in URL query encoded key"""
         r = self.weblog_get("/waf/", params={"$eq": "attack"})
         interfaces.library.assert_waf_attack(r, pattern="$eq", address="server.request.query")
 


### PR DESCRIPTION
This PR skips the non-encoded query key test because there is no rule for it yet, and modifies the encoded query key rule as it wasn't matching with any keys_only rule