### PR TITLE
Updating dotnet attributes

### DIFF
--- a/scenarios/appsec/test_traces.py
+++ b/scenarios/appsec/test_traces.py
@@ -12,7 +12,7 @@ if context.library == "cpp":
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2365948382/Sensitive+Data+Obfuscation")
-@released(golang="1.38.0", dotnet="?", java="0.100.0", nodejs="?", php_appsec="0.3.0", python="?", ruby="?")
+@released(golang="1.38.0", dotnet="2.7.0", java="0.100.0", nodejs="?", php_appsec="0.3.0", python="?", ruby="?")
 class Test_AppSecObfuscator(BaseTestCase):
     """AppSec obfuscates sensitive data."""
 

--- a/scenarios/appsec/waf/test_reports.py
+++ b/scenarios/appsec/waf/test_reports.py
@@ -11,7 +11,7 @@ if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
 
 
-@released(golang="1.38.0", dotnet="?", java="?", nodejs="?", php_appsec="0.3.0", python="?", ruby="?")
+@released(golang="1.38.0", dotnet="2.7.0", java="?", nodejs="?", php_appsec="0.3.0", python="?", ruby="?")
 class Test_Monitoring(BaseTestCase):
     """ Support In-App WAF monitoring tags and metrics  """
 

--- a/tests/appsec/test_identify.py
+++ b/tests/appsec/test_identify.py
@@ -20,7 +20,7 @@ if context.library == "cpp":
 class Test_Basic(BaseTestCase):
     """ Basic tests for Identify SDK """
 
-    def test_indentify_tags(self):
+    def test_identify_tags(self):
         def assertTagInSpanMeta(span, tag):
             if tag not in span["meta"]:
                 raise Exception(f"Can't find {tag} in span's meta")

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -147,7 +147,7 @@ class Test_AppSecEventSpanTags(BaseTestCase):
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2365948382/Sensitive+Data+Obfuscation")
-@released(golang="1.38.0", dotnet="?", java="?", nodejs="?", php_appsec="0.3.0", python="?", ruby="?")
+@released(golang="1.38.0", dotnet="2.7.0", java="?", nodejs="?", php_appsec="0.3.0", python="?", ruby="?")
 class Test_AppSecObfuscator(BaseTestCase):
     """AppSec obfuscates sensitive data."""
 

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -12,7 +12,7 @@ if context.library == "cpp":
 
 
 # WAF/current ruleset don't support looking at keys at all
-@released(golang="?", dotnet="?", java="?", nodejs="2.6.0", php="?", python="1.1.0rc2.dev", ruby="?")
+@released(golang="?", dotnet="2.7.0", java="?", nodejs="2.6.0", php="?", python="1.1.0rc2.dev", ruby="?")
 class Test_UrlQueryKey(BaseTestCase):
     """Appsec supports keys on server.request.query"""
 

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -11,12 +11,12 @@ if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
 
 
-@released(golang="1.38.0", dotnet="?", java="0.100.0", nodejs="?", php_appsec="0.3.0", python="?", ruby="?")
+@released(golang="1.38.0", dotnet="2.7.0", java="0.100.0", nodejs="?", php_appsec="0.3.0", python="?", ruby="?")
 class Test_Monitoring(BaseTestCase):
     """ Support In-App WAF monitoring tags and metrics  """
 
     expected_version_regex = r"[0-9]+\.[0-9]+\.[0-9]+"
-
+    @missing_feature(library="dotnet", reason="_dd.appsec.event_rules.version reported only once for now")
     def test_waf_monitoring(self):
         """ WAF monitoring span tags and metrics are expected to be sent on each request """
 
@@ -56,6 +56,7 @@ class Test_Monitoring(BaseTestCase):
         interfaces.library.assert_waf_attack(r)
         interfaces.library.add_appsec_validation(r, validate_waf_monitoring_span_tags)
 
+    @missing_feature(library="dotnet", reason="_dd.appsec.event_rules.version reported only once for now")
     def test_waf_monitoring_once(self):
         """
         Some WAF monitoring span tags and metrics are expected to be sent at
@@ -114,7 +115,9 @@ class Test_Monitoring(BaseTestCase):
         interfaces.library.assert_waf_attack(r)
         interfaces.library.add_span_validation(validator=validate_rules_monitoring_span_tags)
 
-    @irrelevant(condition=context.library not in ["golang"], reason="optional tags")
+    @irrelevant(condition=context.library not in ["golang", "dotnet"], reason="optional tags")
+    @bug(library="dotnet", reason="we report them but have a regression that makes expected_bindings_duration_metric] < metrics[expected_waf_duration_metric")
+
     def test_waf_monitoring_optional(self):
         """ WAF monitoring span tags and metrics may send extra optional tags """
 

--- a/tests/appsec/waf/test_rules.py
+++ b/tests/appsec/waf/test_rules.py
@@ -290,7 +290,7 @@ class Test_NoSqli(BaseTestCase):
         interfaces.library.assert_waf_attack(r, rules.nosql_injection.sqr_000_007)
 
     @missing_feature(
-        context.library in ["dotnet", "golang", "nodejs", "php", "ruby"], reason="Need to use last WAF version"
+        context.library in ["golang", "nodejs", "php", "ruby"], reason="Need to use last WAF version"
     )
     @missing_feature(context.library < "java@0.96.0", reason="Was using a too old WAF version")
     @irrelevant(context.appsec_rules_version < "1.3.0", reason="before 1.3.0, keys was not supported")


### PR DESCRIPTION
Query keys should now work
Obfuscation is now working
Regression on waf metrics are bugs and were implemented, currently fixing, will open a subsequent PR