### PR TITLE
Adapt test for dont report error tag if errors 0

### DIFF
--- a/scenarios/appsec/waf/test_reports.py
+++ b/scenarios/appsec/waf/test_reports.py
@@ -11,7 +11,7 @@ if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
 
 
-@released(golang="1.38.0", dotnet="?", java="?", nodejs="?", php_appsec="0.3.0", python="?", ruby="?")
+@released(golang="1.38.0", dotnet="2.7.0", java="?", nodejs="?", php_appsec="0.3.0", python="?", ruby="?")
 class Test_Monitoring(BaseTestCase):
     """ Support In-App WAF monitoring tags and metrics  """
 

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -106,11 +106,10 @@ class Test_Monitoring(BaseTestCase):
             ):
                 raise Exception(f"the number of rule errors should be 0")
 
-            if (
-                expected_rules_errors_meta_tag in meta
-                and meta[expected_rules_errors_meta_tag] != "{{}}"
-            ):
-                raise Exception(f"if there's no rule errors and if there are rule errors detail, then `{expected_rules_errors_meta_tag}` should be {{}}")
+            if expected_rules_errors_meta_tag in meta and meta[expected_rules_errors_meta_tag] != "{{}}":
+                raise Exception(
+                    f"if there's no rule errors and if there are rule errors detail, then `{expected_rules_errors_meta_tag}` should be {{}}"
+                )
 
             return True
 

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -106,7 +106,9 @@ class Test_Monitoring(BaseTestCase):
             ):
                 raise Exception(f"the number of rule errors should be 0")
 
-            if expected_rules_errors_meta_tag in meta and meta[expected_rules_errors_meta_tag] != "{{}}":
+            if expected_rules_errors_meta_tag in meta and (
+                meta[expected_rules_errors_meta_tag] != "{{}}" or meta[expected_rules_errors_meta_tag] != "null"
+            ):
                 raise Exception(
                     f"if there's no rule errors and if there are rule errors detail, then `{expected_rules_errors_meta_tag}` should be {{}}"
                 )

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -106,11 +106,13 @@ class Test_Monitoring(BaseTestCase):
             ):
                 raise Exception(f"the number of rule errors should be 0")
 
-            if expected_rules_errors_meta_tag in meta and (
-                meta[expected_rules_errors_meta_tag] != "{{}}" or meta[expected_rules_errors_meta_tag] != "null"
+            possible_errors_tag_values = ["null", "{}"]
+            if (
+                expected_rules_errors_meta_tag in meta
+                and meta[expected_rules_errors_meta_tag] not in possible_errors_tag_values
             ):
                 raise Exception(
-                    f"if there's no rule errors and if there are rule errors detail, then `{expected_rules_errors_meta_tag}` should be {{}}"
+                    f"if there's no rule errors and if there are rule errors detail, then `{expected_rules_errors_meta_tag}` should be {{}} or null but was `{meta[expected_rules_errors_meta_tag]}`"
                 )
 
             return True

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -66,7 +66,7 @@ class Test_Monitoring(BaseTestCase):
 
         # Tags that are expected to be reported at least once at some point
         expected_waf_version_tag = "_dd.appsec.waf.version"
-        expected_rules_monitoring_meta_tags = [expected_waf_version_tag, "_dd.appsec.event_rules.errors"]
+        expected_rules_errors_meta_tag = "_dd.appsec.event_rules.errors"
         expected_rules_monitoring_nb_loaded_tag = "_dd.appsec.event_rules.loaded"
         expected_rules_monitoring_nb_errors_tag = "_dd.appsec.event_rules.error_count"
         expected_rules_monitoring_metrics_tags = [
@@ -81,9 +81,8 @@ class Test_Monitoring(BaseTestCase):
             """
 
             meta = span["meta"]
-            for m in expected_rules_monitoring_meta_tags:
-                if m not in meta:
-                    return None  # Skip this span
+            if expected_waf_version_tag not in meta:
+                return None  # Skip this span
 
             metrics = span["metrics"]
             for m in expected_rules_monitoring_metrics_tags:
@@ -106,6 +105,12 @@ class Test_Monitoring(BaseTestCase):
                 and metrics[expected_rules_monitoring_nb_errors_tag] != 0
             ):
                 raise Exception(f"the number of rule errors should be 0")
+
+            if (
+                expected_rules_errors_meta_tag in meta
+                and meta[expected_rules_errors_meta_tag] != "{{}}"
+            ):
+                raise Exception(f"if there's no rule errors and if there are rule errors detail, then `{expected_rules_errors_meta_tag}` should be {{}}")
 
             return True
 


### PR DESCRIPTION
Some libraries dont report the error tags object if there's no errors at waf loading. So test the object's value only if it's present