### PR TITLE
Fix system-tests due to a packaging change

### DIFF
--- a/utils/build/docker/dotnet/install_ddtrace.sh
+++ b/utils/build/docker/dotnet/install_ddtrace.sh
@@ -21,7 +21,7 @@ ls datadog-dotnet-apm-*.tar.gz > /app/SYSTEM_TESTS_LIBRARY_VERSION
 mkdir -p /opt/datadog
 tar xzf $(ls datadog-dotnet-apm-*.tar.gz) -C /opt/datadog
 
-cp /opt/datadog/Datadog.Trace.ClrProfiler.Native.so /binaries/libDatadog.Trace.ClrProfiler.Native.so
+cp /opt/datadog/tracer/Datadog.Trace.ClrProfiler.Native.so /binaries/libDatadog.Trace.ClrProfiler.Native.so
 cp /opt/datadog/libddwaf.so /binaries
 dotnet fsi --langversion:preview /binaries/query-versions.fsx
 rm /binaries/libDatadog.Trace.ClrProfiler.Native.so


### PR DESCRIPTION
In this [PR ](https://github.com/DataDog/dd-trace-dotnet/pull/2777), we change the `dotnet-apm-XX.tar.gz` content. This currently break the dotnet system-tests.

Fix: point to the tracer so file
