### PR TITLE
Enable some standard tags tests for PHP

### DIFF
--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -10,7 +10,7 @@ if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
 
 
-@released(dotnet="2.0.0", golang="?", java="?", nodejs="?", php="0.74.0", python="?", ruby="?")
+@released(dotnet="2.0.0", golang="?", java="?", nodejs="?", php="0.75.0", python="?", ruby="?")
 @coverage.good
 class Test_StandardTagsMethod(BaseTestCase):
     """Tests to verify that libraries annotate spans with correct http.method tags"""
@@ -62,7 +62,7 @@ class Test_StandardTagsUrl(BaseTestCase):
         interfaces.library.add_span_tag_validation(request=r, tags=tags)
 
 
-@released(dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="?")
+@released(dotnet="?", golang="?", java="?", nodejs="?", php="0.75.0", python="?", ruby="?")
 @coverage.basic
 class Test_StandardTagsUserAgent(BaseTestCase):
     """Tests to verify that libraries annotate spans with correct http.useragent tags"""
@@ -73,10 +73,10 @@ class Test_StandardTagsUserAgent(BaseTestCase):
         tags = {
             "http.useragent": "Mistake Not ...",
         }
-        interfaces.library.add_span_tag_validation(request=r, tags=tags)
+        interfaces.library.add_span_tag_validation(request=r, tags=tags, value_as_regular_expression=True)
 
 
-@released(dotnet="2.0.0", golang="?", java="?", nodejs="?", php="0.74.0", python="?", ruby="?")
+@released(dotnet="2.0.0", golang="?", java="?", nodejs="?", php="0.75.0", python="?", ruby="?")
 @coverage.good
 class Test_StandardTagsStatusCode(BaseTestCase):
     """Tests to verify that libraries annotate spans with correct http.status_code tags"""

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -33,7 +33,7 @@ class Test_StandardTagsMethod(BaseTestCase):
 
     @irrelevant(library="php", reason="Trace method does not reach php-land")
     def test_method_trace(self):
-        r = self._weblog_request("TRACE", "/waf", data=data)
+        r = self._weblog_request("TRACE", "/waf", data=None)
         tags = {
             "http.method": "TRACE",
         }

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -31,13 +31,13 @@ class Test_StandardTagsMethod(BaseTestCase):
             }
             interfaces.library.add_span_tag_validation(request=r, tags=tags)
 
-    @irrelevant(library="php", reason="Method does not reach php-land")
+    @irrelevant(library="php", reason="Trace method does not reach php-land")
     def test_method_trace(self):
-            r = self._weblog_request("TRACE", "/waf", data=data)
-            tags = {
-                "http.method": "TRACE",
-            }
-            interfaces.library.add_span_tag_validation(request=r, tags=tags)
+        r = self._weblog_request("TRACE", "/waf", data=data)
+        tags = {
+            "http.method": "TRACE",
+        }
+        interfaces.library.add_span_tag_validation(request=r, tags=tags)
 
 
 @released(dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="?")

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -17,7 +17,7 @@ class Test_StandardTagsMethod(BaseTestCase):
 
     def test_method(self):
 
-        verbs = ["GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "TRACE", "PATCH"]
+        verbs = ["GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"]
 
         for verb in verbs:
             data = None
@@ -31,8 +31,16 @@ class Test_StandardTagsMethod(BaseTestCase):
             }
             interfaces.library.add_span_tag_validation(request=r, tags=tags)
 
+    @irrelevant(library="php", reason="Method does not reach php-land")
+    def test_method_trace(self):
+            r = self._weblog_request("TRACE", "/waf", data=data)
+            tags = {
+                "http.method": "TRACE",
+            }
+            interfaces.library.add_span_tag_validation(request=r, tags=tags)
 
-@released(dotnet="?", golang="?", java="?", nodejs="?", php="0.74.0", python="?", ruby="?")
+
+@released(dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="?")
 @coverage.basic
 class Test_StandardTagsUrl(BaseTestCase):
     """Tests to verify that libraries annotate spans with correct http.url tags"""
@@ -54,7 +62,7 @@ class Test_StandardTagsUrl(BaseTestCase):
         interfaces.library.add_span_tag_validation(request=r, tags=tags)
 
 
-@released(dotnet="?", golang="?", java="?", nodejs="?", php_appsec="?", python="?", ruby="?")
+@released(dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="?")
 @coverage.basic
 class Test_StandardTagsUserAgent(BaseTestCase):
     """Tests to verify that libraries annotate spans with correct http.useragent tags"""
@@ -84,7 +92,7 @@ class Test_StandardTagsStatusCode(BaseTestCase):
             interfaces.library.add_span_tag_validation(request=r, tags=tags)
 
 
-@released(dotnet="?", golang="?", java="?", nodejs="?", php_appsec="?", python="?", ruby="?")
+@released(dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="?")
 @coverage.basic
 class Test_StandardTagsRoute(BaseTestCase):
     """Tests to verify that libraries annotate spans with correct http.route tags"""
@@ -98,7 +106,7 @@ class Test_StandardTagsRoute(BaseTestCase):
         interfaces.library.add_span_tag_validation(request=r, tags=tags)
 
 
-@released(dotnet="?", golang="?", java="?", nodejs="?", php_appsec="?", python="?", ruby="?")
+@released(dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="?")
 @coverage.basic
 class Test_StandardTagsClientIp(BaseTestCase):
     """Tests to verify that libraries annotate spans with correct http.client_ip tags"""

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -70,9 +70,8 @@ class Test_StandardTagsUserAgent(BaseTestCase):
     def test_useragent(self):
         r = self.weblog_get(f"/waf", headers={"user-agent": "Mistake Not ..."})
 
-        tags = {
-            "http.useragent": "Mistake Not ...",
-        }
+        # system tests uses user-agent to ad a request id => allow anything at the end
+        tags = {"http.useragent": r"Mistake Not \.\.\. .*"}
         interfaces.library.add_span_tag_validation(request=r, tags=tags, value_as_regular_expression=True)
 
 

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -10,7 +10,7 @@ if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
 
 
-@released(dotnet="2.0.0", golang="?", java="?", nodejs="?", php_appsec="?", python="?", ruby="?")
+@released(dotnet="2.0.0", golang="?", java="?", nodejs="?", php="0.74.0", python="?", ruby="?")
 @coverage.good
 class Test_StandardTagsMethod(BaseTestCase):
     """Tests to verify that libraries annotate spans with correct http.method tags"""
@@ -32,7 +32,7 @@ class Test_StandardTagsMethod(BaseTestCase):
             interfaces.library.add_span_tag_validation(request=r, tags=tags)
 
 
-@released(dotnet="?", golang="?", java="?", nodejs="?", php_appsec="?", python="?", ruby="?")
+@released(dotnet="?", golang="?", java="?", nodejs="?", php="0.74.0", python="?", ruby="?")
 @coverage.basic
 class Test_StandardTagsUrl(BaseTestCase):
     """Tests to verify that libraries annotate spans with correct http.url tags"""
@@ -68,7 +68,7 @@ class Test_StandardTagsUserAgent(BaseTestCase):
         interfaces.library.add_span_tag_validation(request=r, tags=tags)
 
 
-@released(dotnet="2.0.0", golang="?", java="?", nodejs="?", php_appsec="?", python="?", ruby="?")
+@released(dotnet="2.0.0", golang="?", java="?", nodejs="?", php="0.74.0", python="?", ruby="?")
 @coverage.good
 class Test_StandardTagsStatusCode(BaseTestCase):
     """Tests to verify that libraries annotate spans with correct http.status_code tags"""

--- a/utils/build/docker/php/apache-mod.Dockerfile
+++ b/utils/build/docker/php/apache-mod.Dockerfile
@@ -15,6 +15,7 @@ RUN echo '<?php phpinfo();' > /var/www/html/index.php
 RUN echo '<?php echo "OK";' > /var/www/html/sample_rate_route.php
 RUN echo '<?php echo "Hello, WAF!";' > /var/www/html/waf.php
 RUN echo '<?php http_response_code(404);' > /var/www/html/404.php
+RUN echo '<?php http_response_code(intval($_GET["code"]));' > /var/www/html/status.php
 ADD utils/build/docker/php/common/*.php /var/www/html/
 RUN a2enmod rewrite
 

--- a/utils/build/docker/php/apache-mod/php.conf
+++ b/utils/build/docker/php/apache-mod/php.conf
@@ -5,6 +5,7 @@
         RewriteRule "^/waf$" "/waf/"
         RewriteRule "^/identify$" "/identify/"
         RewriteRule "^/headers$" "/headers/"
+        RewriteRule "^/status$" "/status/"
         RewriteCond /var/www/html/%{REQUEST_URI} !-f
         RewriteRule "^/([^/]+)/(.*)" "/$1.php/$2" [L]
         ErrorDocument 404 /404.php

--- a/utils/build/docker/php/php-fpm.Dockerfile
+++ b/utils/build/docker/php/php-fpm.Dockerfile
@@ -20,6 +20,7 @@ RUN echo '<?php phpinfo();' > /var/www/html/index.php
 RUN echo '<?php echo "OK";' > /var/www/html/sample_rate_route.php
 RUN echo '<?php echo "Hello, WAF!";' > /var/www/html/waf.php
 RUN echo '<?php http_response_code(404);' > /var/www/html/404.php
+RUN echo '<?php http_response_code(intval($_GET["code"]));' > /var/www/html/status.php
 ADD utils/build/docker/php/common/*.php /var/www/html/
 RUN a2enmod rewrite
 

--- a/utils/build/docker/php/php-fpm.Dockerfile
+++ b/utils/build/docker/php/php-fpm.Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata publicsuffix
 
 RUN printf '#!/bin/sh\n\nexit 101\n' > /usr/sbin/policy-rc.d && \
 	chmod +x /usr/sbin/policy-rc.d && \
@@ -10,7 +10,8 @@ RUN printf '#!/bin/sh\n\nexit 101\n' > /usr/sbin/policy-rc.d && \
 	&& rm -rf /var/lib/apt/lists/* && \
 	rm -rf /usr/sbin/policy-rc.d
 
-RUN add-apt-repository ppa:ondrej/php -y && apt-get update
+RUN add-apt-repository ppa:ondrej/php -y
+RUN apt-get update
 
 ARG PHP_VERSION=8.0
 RUN apt-get install -y php8.0-fpm

--- a/utils/build/docker/php/php-fpm/php8.0-fpm.conf
+++ b/utils/build/docker/php/php-fpm/php8.0-fpm.conf
@@ -10,6 +10,7 @@
         RewriteRule "^/waf$" "/waf/"
         RewriteRule "^/identify$" "/identify/"
         RewriteRule "^/headers$" "/headers/"
+        RewriteRule "^/status$" "/status/"
         RewriteCond /var/www/html/%{REQUEST_URI} !-f
         RewriteRule "^/([^/]+)/(.*)" "/$1.php/$2" [L]
         ErrorDocument 404 /404.php

--- a/utils/build/docker/set-system-tests-weblog-env.Dockerfile
+++ b/utils/build/docker/set-system-tests-weblog-env.Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update
 
 # Datadog setup
 ENV DD_SERVICE=weblog
-ENV DD_TRACE_HEADER_TAGS='user-agent'
+ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TAGS='key1:val1, key2 : val2 '
 ENV DD_PROFILING_ENABLED=true
 ENV DD_ENV=system-tests

--- a/utils/build/docker/set-system-tests-weblog-env.Dockerfile
+++ b/utils/build/docker/set-system-tests-weblog-env.Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update
 
 # Datadog setup
 ENV DD_SERVICE=weblog
-ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
+ENV DD_TRACE_HEADER_TAGS='user-agent'
 ENV DD_TAGS='key1:val1, key2 : val2 '
 ENV DD_PROFILING_ENABLED=true
 ENV DD_ENV=system-tests

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -100,7 +100,9 @@ class LibraryInterfaceValidator(InterfaceValidator):
         self.append_validation(_SpanValidation(request=request, validator=validator))
 
     def add_span_tag_validation(self, request=None, tags={}, value_as_regular_expression=False):
-        self.append_validation(_SpanTagValidation(request=request, tags=tags, value_as_regular_expression=value_as_regular_expression))
+        self.append_validation(
+            _SpanTagValidation(request=request, tags=tags, value_as_regular_expression=value_as_regular_expression)
+        )
 
     def add_appsec_validation(self, request=None, validator=None, legacy_validator=None, is_success_on_expiry=False):
         self.append_validation(

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -99,8 +99,8 @@ class LibraryInterfaceValidator(InterfaceValidator):
     def add_span_validation(self, request=None, validator=None):
         self.append_validation(_SpanValidation(request=request, validator=validator))
 
-    def add_span_tag_validation(self, request=None, tags={}):
-        self.append_validation(_SpanTagValidation(request=request, tags=tags))
+    def add_span_tag_validation(self, request=None, tags={}, value_as_regular_expression=False):
+        self.append_validation(_SpanTagValidation(request=request, tags=tags, value_as_regular_expression=value_as_regular_expression))
 
     def add_appsec_validation(self, request=None, validator=None, legacy_validator=None, is_success_on_expiry=False):
         self.append_validation(

--- a/utils/interfaces/_library/miscs.py
+++ b/utils/interfaces/_library/miscs.py
@@ -157,19 +157,16 @@ class _SpanTagValidation(BaseValidation):
                         expectValue = self.tags[tagKey]
                         actualValue = span["meta"][tagKey]
 
-                        match = False
                         if self.value_as_regular_expression:
-                            expectRE = re.compile(expectValue)
-                            if expectRE.match(actualValue):
-                                match = True
+                            if not re.compile(expectValue).fullmatch(actualValue):
+                                raise Exception(
+                                    f'{tagKey} tag value is "{actualValue}", and should match regex "{expectValue}"'
+                                )
                         else:
-                            if expectValue == actualValue:
-                                match = True
-
-                        if not match:
-                            raise Exception(
-                                f'{tagKey} tag in span\'s meta should be "{expectValue}", not "{actualValue}"'
-                            )
+                            if expectValue != actualValue:
+                                raise Exception(
+                                    f'{tagKey} tag in span\'s meta should be "{expectValue}", not "{actualValue}"'
+                                )
 
                     self.log_debug(f"Trace in {data['log_filename']} validates {m(self.message)}")
                     self.is_success_on_expiry = True

--- a/utils/interfaces/_library/miscs.py
+++ b/utils/interfaces/_library/miscs.py
@@ -156,7 +156,6 @@ class _SpanTagValidation(BaseValidation):
                         expectValue = self.tags[tagKey]
                         actualValue = span["meta"][tagKey]
 
-
                         match = False
                         if self.value_as_regular_expression:
                             expectRE = re.compile(expectValue)


### PR DESCRIPTION
Enabling the tests currently doesn't work, even though the tags are provided, because the validator itself requires the user-agent to be available in order to find the relevant spans. 