### PR TITLE
Handle several version of .NET tracer

### DIFF
--- a/utils/build/docker/dotnet/Endpoints/IdentifyEndpoint.UserDetails.cs
+++ b/utils/build/docker/dotnet/Endpoints/IdentifyEndpoint.UserDetails.cs
@@ -1,0 +1,45 @@
+#if DDTRACE_2_7_0_OR_GREATER
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Datadog.Trace;
+
+namespace weblog
+{
+    public partial class IdentifyEndpoint : ISystemTestEndpoint
+    {
+        public void Register(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder routeBuilder)
+        {
+            routeBuilder.MapGet("/identify", async context =>
+            {
+                var userDetails = new UserDetails()
+                {
+                    Id = "usr.id",
+                    Email = "usr.email",
+                    Name = "usr.name",
+                    SessionId = "usr.session_id",
+                    Role = "usr.role",
+                    Scope = "usr.scope",
+                };
+                var scope = Tracer.Instance.ActiveScope;
+                scope?.Span.SetUser(userDetails);
+
+                await context.Response.WriteAsync("Hello world!\\n");
+            });
+
+            routeBuilder.MapGet("/identify-propagate", async context =>
+            {
+                var userDetails = new UserDetails()
+                {
+                    Id = "usr.id",
+                    // TODO Needs new SDK version merging before enabling this next line
+                    // PropagateId = true
+                };
+                var scope = Tracer.Instance.ActiveScope;
+                scope?.Span.SetUser(userDetails);
+
+                await context.Response.WriteAsync("Hello world!\\n");
+            });
+        }
+    }
+}
+#endif

--- a/utils/build/docker/dotnet/Endpoints/IdentifyEndpoint.cs
+++ b/utils/build/docker/dotnet/Endpoints/IdentifyEndpoint.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Datadog.Trace;
 
+
 namespace weblog
 {
     public class IdentifyEndpoint : ISystemTestEndpoint
@@ -10,6 +11,8 @@ namespace weblog
         {
             routeBuilder.MapGet("/identify", async context =>
             {
+
+#if DDTRACE_HAS_USERDETAILS
                 var userDetails = new UserDetails()
                 {
                     Id = "usr.id",
@@ -21,12 +24,15 @@ namespace weblog
                 };
                 var scope = Tracer.Instance.ActiveScope;
                 scope?.Span.SetUser(userDetails);
-
+#endif
+ 
                 await context.Response.WriteAsync("Hello world!\\n");
             });
 
             routeBuilder.MapGet("/identify-propagate", async context =>
             {
+
+#if DDTRACE_HAS_USERDETAILS
                 var userDetails = new UserDetails()
                 {
                     Id = "usr.id",
@@ -35,6 +41,7 @@ namespace weblog
                 };
                 var scope = Tracer.Instance.ActiveScope;
                 scope?.Span.SetUser(userDetails);
+#endif
 
                 await context.Response.WriteAsync("Hello world!\\n");
             });

--- a/utils/build/docker/dotnet/Endpoints/IdentifyEndpoint.cs
+++ b/utils/build/docker/dotnet/Endpoints/IdentifyEndpoint.cs
@@ -1,3 +1,4 @@
+#if !DDTRACE_2_7_0_OR_GREATER
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Datadog.Trace;
@@ -5,46 +6,20 @@ using Datadog.Trace;
 
 namespace weblog
 {
-    public class IdentifyEndpoint : ISystemTestEndpoint
+    public partial class IdentifyEndpoint : ISystemTestEndpoint
     {
         public void Register(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder routeBuilder)
         {
             routeBuilder.MapGet("/identify", async context =>
             {
-
-#if DDTRACE_HAS_USERDETAILS
-                var userDetails = new UserDetails()
-                {
-                    Id = "usr.id",
-                    Email = "usr.email",
-                    Name = "usr.name",
-                    SessionId = "usr.session_id",
-                    Role = "usr.role",
-                    Scope = "usr.scope",
-                };
-                var scope = Tracer.Instance.ActiveScope;
-                scope?.Span.SetUser(userDetails);
-#endif
- 
-                await context.Response.WriteAsync("Hello world!\\n");
+                await context.Response.WriteAsync("Not implemented before 2.7.0\\n");
             });
 
             routeBuilder.MapGet("/identify-propagate", async context =>
             {
-
-#if DDTRACE_HAS_USERDETAILS
-                var userDetails = new UserDetails()
-                {
-                    Id = "usr.id",
-                    // TODO Needs new SDK version merging before enabling this next line
-                    // PropagateId = true
-                };
-                var scope = Tracer.Instance.ActiveScope;
-                scope?.Span.SetUser(userDetails);
-#endif
-
-                await context.Response.WriteAsync("Hello world!\\n");
+                await context.Response.WriteAsync("Not implemented yet\\n");
             });
         }
     }
 }
+#endif

--- a/utils/build/docker/dotnet/app.csproj
+++ b/utils/build/docker/dotnet/app.csproj
@@ -6,7 +6,7 @@
 		<GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(DDTRACE_VERSION)' != '' AND '$(DDTRACE_VERSION)' >= '2.7.0'">
+	<PropertyGroup Condition="'$(DDTRACE_VERSION)' != '' OR '$(DDTRACE_VERSION)' >= '2.7.0'">
 		<DefineConstants>$(DefineConstants);DDTRACE_2_7_0_OR_GREATER</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>

--- a/utils/build/docker/dotnet/app.csproj
+++ b/utils/build/docker/dotnet/app.csproj
@@ -1,10 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<RootNamespace>weblog</RootNamespace>
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 		<GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(DDTRACE_VERSION)' != '' AND '$(DDTRACE_VERSION)' >= '2.7.0'">
+		<DefineConstants>$(DefineConstants);DDTRACE_2_7_0_OR_GREATER</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.Data.SqlClient" />

--- a/utils/build/docker/dotnet/app.csproj
+++ b/utils/build/docker/dotnet/app.csproj
@@ -6,7 +6,7 @@
 		<GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(DDTRACE_VERSION)' != '' OR '$(DDTRACE_VERSION)' >= '2.7.0'">
+	<PropertyGroup Condition="'$(DDTRACE_VERSION)' >= '2.7.0'">
 		<DefineConstants>$(DefineConstants);DDTRACE_2_7_0_OR_GREATER</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>

--- a/utils/build/docker/dotnet/poc.Dockerfile
+++ b/utils/build/docker/dotnet/poc.Dockerfile
@@ -6,8 +6,6 @@ WORKDIR /app
 
 COPY utils/build/docker/dotnet/app.csproj app.csproj
 
-RUN dotnet restore
-
 COPY utils/build/docker/dotnet/*.cs ./
 COPY utils/build/docker/dotnet/Dependencies/*.cs ./Dependencies/
 COPY utils/build/docker/dotnet/Endpoints/*.cs ./Endpoints/
@@ -18,7 +16,8 @@ COPY utils/build/docker/dotnet/install_ddtrace.sh utils/build/docker/dotnet/quer
 RUN dos2unix /binaries/install_ddtrace.sh
 RUN /binaries/install_ddtrace.sh
 
-RUN dotnet publish -c Release -o out
+RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") dotnet restore
+RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
 WORKDIR /app

--- a/utils/build/docker/dotnet/poc.Dockerfile
+++ b/utils/build/docker/dotnet/poc.Dockerfile
@@ -16,7 +16,6 @@ COPY utils/build/docker/dotnet/install_ddtrace.sh utils/build/docker/dotnet/quer
 RUN dos2unix /binaries/install_ddtrace.sh
 RUN /binaries/install_ddtrace.sh
 
-RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") dotnet restore
 RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime


### PR DESCRIPTION
extract ddtrace_version from the loaded binary with regex
read env variable DDTRACE_VERSION from msbuild 
define constants dependin on the tracer version and different partial class executed depending on it
