### PR TITLE
remote config: adjust type of hashes to be base16 encoded strings

### DIFF
--- a/scenarios/remote_config/rc_expected_requests_asm_dd.json
+++ b/scenarios/remote_config/rc_expected_requests_asm_dd.json
@@ -39,7 +39,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "Rgh1TeQMgt9l1rjV0WstcichyHvG+zf7JM7FiuLTALc="
+						"hash": "4608754de40c82df65d6b8d5d16b2d722721c87bc6fb37fb24cec58ae2d300b7"
 					}
 				]
 			}
@@ -67,7 +67,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "gJwK2asmsr413jlNWOtqI/9FM6dwCcu7HBxKUDr2k90="
+						"hash": "809c0ad9ab26b2be35de394d58eb6a23ff4533a77009cbbb1c1c4a503af693dd"
 					}
 				]
 			}
@@ -109,7 +109,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "Rgh1TeQMgt9l1rjV0WstcichyHvG+zf7JM7FiuLTALc="
+						"hash": "4608754de40c82df65d6b8d5d16b2d722721c87bc6fb37fb24cec58ae2d300b7"
 					}
 				]
 			},
@@ -119,7 +119,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kyBdHGqsL/HNBVnoEEMDCyyvdcP0YiZ0PJMsG1EDE18="
+						"hash": "93205d1c6aac2ff1cd0559e81043030b2caf75c3f46226743c932c1b5103135f"
 					}
 				]
 			}
@@ -152,7 +152,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "Rgh1TeQMgt9l1rjV0WstcichyHvG+zf7JM7FiuLTALc="
+						"hash": "4608754de40c82df65d6b8d5d16b2d722721c87bc6fb37fb24cec58ae2d300b7"
 					}
 				]
 			},
@@ -162,7 +162,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "QDVgAHybtbgvoi5Bp3YpLR9go7lrDnqs6zOMZ809v70="
+						"hash": "403560007c9bb5b82fa22e41a776292d1f60a3b96b0e7aaceb338c67cd3dbfbd"
 					}
 				]
 			}
@@ -175,13 +175,13 @@
 				"targets_version": 7,
 				"config_states": [
 					{
-						"id": "ASM_DD-third",
-						"version": 1,
+						"id": "ASM_DD-base",
+						"version": 2,
 						"product": "ASM_DD"
 					},
 					{
-						"id": "ASM_DD-base",
-						"version": 2,
+						"id": "ASM_DD-third",
+						"version": 1,
 						"product": "ASM_DD"
 					},
 					{
@@ -195,22 +195,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/ASM_DD/ASM_DD-third/config",
-				"length": 235229,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "QDVgAHybtbgvoi5Bp3YpLR9go7lrDnqs6zOMZ809v70="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/ASM_DD/ASM_DD-base/config",
 				"length": 235229,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "gJwK2asmsr413jlNWOtqI/9FM6dwCcu7HBxKUDr2k90="
+						"hash": "809c0ad9ab26b2be35de394d58eb6a23ff4533a77009cbbb1c1c4a503af693dd"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/ASM_DD/ASM_DD-third/config",
+				"length": 235229,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "403560007c9bb5b82fa22e41a776292d1f60a3b96b0e7aaceb338c67cd3dbfbd"
 					}
 				]
 			},
@@ -220,7 +220,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kyBdHGqsL/HNBVnoEEMDCyyvdcP0YiZ0PJMsG1EDE18="
+						"hash": "93205d1c6aac2ff1cd0559e81043030b2caf75c3f46226743c932c1b5103135f"
 					}
 				]
 			}
@@ -233,12 +233,12 @@
 				"targets_version": 8,
 				"config_states": [
 					{
-						"id": "ASM_DD-base",
+						"id": "ASM_DD-second",
 						"version": 1,
 						"product": "ASM_DD"
 					},
 					{
-						"id": "ASM_DD-second",
+						"id": "ASM_DD-base",
 						"version": 1,
 						"product": "ASM_DD"
 					}
@@ -248,22 +248,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/ASM_DD/ASM_DD-base/config",
-				"length": 235229,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "Rgh1TeQMgt9l1rjV0WstcichyHvG+zf7JM7FiuLTALc="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/ASM_DD/ASM_DD-second/config",
 				"length": 235229,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kyBdHGqsL/HNBVnoEEMDCyyvdcP0YiZ0PJMsG1EDE18="
+						"hash": "93205d1c6aac2ff1cd0559e81043030b2caf75c3f46226743c932c1b5103135f"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/ASM_DD/ASM_DD-base/config",
+				"length": 235229,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "4608754de40c82df65d6b8d5d16b2d722721c87bc6fb37fb24cec58ae2d300b7"
 					}
 				]
 			}
@@ -296,7 +296,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "Rgh1TeQMgt9l1rjV0WstcichyHvG+zf7JM7FiuLTALc="
+						"hash": "4608754de40c82df65d6b8d5d16b2d722721c87bc6fb37fb24cec58ae2d300b7"
 					}
 				]
 			},
@@ -306,7 +306,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kyBdHGqsL/HNBVnoEEMDCyyvdcP0YiZ0PJMsG1EDE18="
+						"hash": "93205d1c6aac2ff1cd0559e81043030b2caf75c3f46226743c932c1b5103135f"
 					}
 				]
 			}
@@ -319,12 +319,12 @@
 				"targets_version": 10,
 				"config_states": [
 					{
-						"id": "ASM_DD-second",
+						"id": "ASM_DD-base",
 						"version": 1,
 						"product": "ASM_DD"
 					},
 					{
-						"id": "ASM_DD-base",
+						"id": "ASM_DD-second",
 						"version": 1,
 						"product": "ASM_DD"
 					}
@@ -334,22 +334,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/ASM_DD/ASM_DD-second/config",
-				"length": 235229,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "kyBdHGqsL/HNBVnoEEMDCyyvdcP0YiZ0PJMsG1EDE18="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/ASM_DD/ASM_DD-base/config",
 				"length": 235229,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "Rgh1TeQMgt9l1rjV0WstcichyHvG+zf7JM7FiuLTALc="
+						"hash": "4608754de40c82df65d6b8d5d16b2d722721c87bc6fb37fb24cec58ae2d300b7"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/ASM_DD/ASM_DD-second/config",
+				"length": 235229,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "93205d1c6aac2ff1cd0559e81043030b2caf75c3f46226743c932c1b5103135f"
 					}
 				]
 			}
@@ -362,13 +362,13 @@
 				"targets_version": 11,
 				"config_states": [
 					{
-						"id": "ASM_DD-second",
-						"version": 1,
+						"id": "ASM_DD-base",
+						"version": 2,
 						"product": "ASM_DD"
 					},
 					{
-						"id": "ASM_DD-base",
-						"version": 2,
+						"id": "ASM_DD-second",
+						"version": 1,
 						"product": "ASM_DD"
 					}
 				],
@@ -377,22 +377,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/ASM_DD/ASM_DD-second/config",
-				"length": 235229,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "kyBdHGqsL/HNBVnoEEMDCyyvdcP0YiZ0PJMsG1EDE18="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/ASM_DD/ASM_DD-base/config",
 				"length": 235229,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "gJwK2asmsr413jlNWOtqI/9FM6dwCcu7HBxKUDr2k90="
+						"hash": "809c0ad9ab26b2be35de394d58eb6a23ff4533a77009cbbb1c1c4a503af693dd"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/ASM_DD/ASM_DD-second/config",
+				"length": 235229,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "93205d1c6aac2ff1cd0559e81043030b2caf75c3f46226743c932c1b5103135f"
 					}
 				]
 			}
@@ -405,13 +405,13 @@
 				"targets_version": 11,
 				"config_states": [
 					{
-						"id": "ASM_DD-second",
-						"version": 1,
+						"id": "ASM_DD-base",
+						"version": 2,
 						"product": "ASM_DD"
 					},
 					{
-						"id": "ASM_DD-base",
-						"version": 2,
+						"id": "ASM_DD-second",
+						"version": 1,
 						"product": "ASM_DD"
 					}
 				],
@@ -420,22 +420,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/ASM_DD/ASM_DD-second/config",
-				"length": 235229,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "kyBdHGqsL/HNBVnoEEMDCyyvdcP0YiZ0PJMsG1EDE18="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/ASM_DD/ASM_DD-base/config",
 				"length": 235229,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "gJwK2asmsr413jlNWOtqI/9FM6dwCcu7HBxKUDr2k90="
+						"hash": "809c0ad9ab26b2be35de394d58eb6a23ff4533a77009cbbb1c1c4a503af693dd"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/ASM_DD/ASM_DD-second/config",
+				"length": 235229,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "93205d1c6aac2ff1cd0559e81043030b2caf75c3f46226743c932c1b5103135f"
 					}
 				]
 			}

--- a/scenarios/remote_config/rc_expected_requests_features.json
+++ b/scenarios/remote_config/rc_expected_requests_features.json
@@ -39,7 +39,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
 					}
 				]
 			}
@@ -67,7 +67,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "o46/n6JWBx+YI6X1EqhOinhsjaKwcZRS3utdwofsmQ8="
+						"hash": "a38ebf9fa256071f9823a5f512a84e8a786c8da2b0719452deeb5dc287ec990f"
 					}
 				]
 			}
@@ -104,22 +104,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/FEATURES/FEATURES-second/config",
-				"length": 47,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/FEATURES/FEATURES-base/config",
 				"length": 47,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/FEATURES/FEATURES-second/config",
+				"length": 47,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
 					}
 				]
 			}
@@ -132,12 +132,12 @@
 				"targets_version": 6,
 				"config_states": [
 					{
-						"id": "FEATURES-base",
+						"id": "FEATURES-third",
 						"version": 1,
 						"product": "FEATURES"
 					},
 					{
-						"id": "FEATURES-third",
+						"id": "FEATURES-base",
 						"version": 1,
 						"product": "FEATURES"
 					}
@@ -152,7 +152,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
 					}
 				]
 			},
@@ -162,7 +162,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
 					}
 				]
 			}
@@ -195,12 +195,22 @@
 		},
 		"cached_target_files": [
 			{
+				"path": "datadog/2/FEATURES/FEATURES-base/config",
+				"length": 48,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "a38ebf9fa256071f9823a5f512a84e8a786c8da2b0719452deeb5dc287ec990f"
+					}
+				]
+			},
+			{
 				"path": "datadog/2/FEATURES/FEATURES-third/config",
 				"length": 47,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
 					}
 				]
 			},
@@ -210,17 +220,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
-					}
-				]
-			},
-			{
-				"path": "datadog/2/FEATURES/FEATURES-base/config",
-				"length": 48,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "o46/n6JWBx+YI6X1EqhOinhsjaKwcZRS3utdwofsmQ8="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
 					}
 				]
 			}
@@ -233,12 +233,12 @@
 				"targets_version": 8,
 				"config_states": [
 					{
-						"id": "FEATURES-second",
+						"id": "FEATURES-base",
 						"version": 1,
 						"product": "FEATURES"
 					},
 					{
-						"id": "FEATURES-base",
+						"id": "FEATURES-second",
 						"version": 1,
 						"product": "FEATURES"
 					}
@@ -253,7 +253,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
 					}
 				]
 			},
@@ -263,7 +263,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
 					}
 				]
 			}
@@ -276,12 +276,12 @@
 				"targets_version": 9,
 				"config_states": [
 					{
-						"id": "FEATURES-base",
+						"id": "FEATURES-second",
 						"version": 1,
 						"product": "FEATURES"
 					},
 					{
-						"id": "FEATURES-second",
+						"id": "FEATURES-base",
 						"version": 1,
 						"product": "FEATURES"
 					}
@@ -291,22 +291,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/FEATURES/FEATURES-base/config",
-				"length": 47,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/FEATURES/FEATURES-second/config",
 				"length": 47,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/FEATURES/FEATURES-base/config",
+				"length": 47,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
 					}
 				]
 			}
@@ -319,12 +319,12 @@
 				"targets_version": 10,
 				"config_states": [
 					{
-						"id": "FEATURES-base",
+						"id": "FEATURES-second",
 						"version": 1,
 						"product": "FEATURES"
 					},
 					{
-						"id": "FEATURES-second",
+						"id": "FEATURES-base",
 						"version": 1,
 						"product": "FEATURES"
 					}
@@ -334,22 +334,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/FEATURES/FEATURES-base/config",
-				"length": 47,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/FEATURES/FEATURES-second/config",
 				"length": 47,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/FEATURES/FEATURES-base/config",
+				"length": 47,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
 					}
 				]
 			}
@@ -362,13 +362,13 @@
 				"targets_version": 11,
 				"config_states": [
 					{
-						"id": "FEATURES-base",
-						"version": 2,
+						"id": "FEATURES-second",
+						"version": 1,
 						"product": "FEATURES"
 					},
 					{
-						"id": "FEATURES-second",
-						"version": 1,
+						"id": "FEATURES-base",
+						"version": 2,
 						"product": "FEATURES"
 					}
 				],
@@ -377,22 +377,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/FEATURES/FEATURES-base/config",
-				"length": 48,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "o46/n6JWBx+YI6X1EqhOinhsjaKwcZRS3utdwofsmQ8="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/FEATURES/FEATURES-second/config",
 				"length": 47,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/FEATURES/FEATURES-base/config",
+				"length": 48,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "a38ebf9fa256071f9823a5f512a84e8a786c8da2b0719452deeb5dc287ec990f"
 					}
 				]
 			}
@@ -405,13 +405,13 @@
 				"targets_version": 11,
 				"config_states": [
 					{
-						"id": "FEATURES-base",
-						"version": 2,
+						"id": "FEATURES-second",
+						"version": 1,
 						"product": "FEATURES"
 					},
 					{
-						"id": "FEATURES-second",
-						"version": 1,
+						"id": "FEATURES-base",
+						"version": 2,
 						"product": "FEATURES"
 					}
 				],
@@ -420,22 +420,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/FEATURES/FEATURES-base/config",
-				"length": 48,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "o46/n6JWBx+YI6X1EqhOinhsjaKwcZRS3utdwofsmQ8="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/FEATURES/FEATURES-second/config",
 				"length": 47,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "kiHf2fYIQVExPj5JIBIa6ENhTDKORjDqNxumbi8VoKY="
+						"hash": "9221dfd9f6084151313e3e4920121ae843614c328e4630ea371ba66e2f15a0a6"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/FEATURES/FEATURES-base/config",
+				"length": 48,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "a38ebf9fa256071f9823a5f512a84e8a786c8da2b0719452deeb5dc287ec990f"
 					}
 				]
 			}

--- a/scenarios/remote_config/rc_expected_requests_live_debugging.json
+++ b/scenarios/remote_config/rc_expected_requests_live_debugging.json
@@ -39,7 +39,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "3D6ly9bo7kMa58H1LD6gjdkeNuHhwLFzKWunafKEtkk="
+						"hash": "dc3ea5cbd6e8ee431ae7c1f52c3ea08dd91e36e1e1c0b173296ba769f284b649"
 					}
 				]
 			}
@@ -67,7 +67,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "lYb0IH7Y7ykCgILLK7LXD6ocTdLokLJg0MaLJ19lp8A="
+						"hash": "9586f4207ed8ef29028082cb2bb2d70faa1c4dd2e890b260d0c68b275f65a7c0"
 					}
 				]
 			}
@@ -109,7 +109,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "3D6ly9bo7kMa58H1LD6gjdkeNuHhwLFzKWunafKEtkk="
+						"hash": "dc3ea5cbd6e8ee431ae7c1f52c3ea08dd91e36e1e1c0b173296ba769f284b649"
 					}
 				]
 			},
@@ -119,7 +119,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "uq0J6grWRF91xRxZ/hPAjgFXHBcWTTU23lQPGlH8rPw="
+						"hash": "baad09ea0ad6445f75c51c59fe13c08e01571c17164d3536de540f1a51fcacfc"
 					}
 				]
 			}
@@ -132,12 +132,12 @@
 				"targets_version": 6,
 				"config_states": [
 					{
-						"id": "LIVE_DEBUGGING-third",
+						"id": "LIVE_DEBUGGING-base",
 						"version": 1,
 						"product": "LIVE_DEBUGGING"
 					},
 					{
-						"id": "LIVE_DEBUGGING-base",
+						"id": "LIVE_DEBUGGING-third",
 						"version": 1,
 						"product": "LIVE_DEBUGGING"
 					}
@@ -152,7 +152,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "3D6ly9bo7kMa58H1LD6gjdkeNuHhwLFzKWunafKEtkk="
+						"hash": "dc3ea5cbd6e8ee431ae7c1f52c3ea08dd91e36e1e1c0b173296ba769f284b649"
 					}
 				]
 			},
@@ -162,7 +162,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "hQ3axxLWFTbTlv6aUPDWM56DDXgyYuAXL+mQlXgZpjw="
+						"hash": "850ddac712d61536d396fe9a50f0d6339e830d783262e0172fe990957819a63c"
 					}
 				]
 			}
@@ -195,22 +195,12 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-third/config",
-				"length": 1500,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "hQ3axxLWFTbTlv6aUPDWM56DDXgyYuAXL+mQlXgZpjw="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-second/config",
 				"length": 1501,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "uq0J6grWRF91xRxZ/hPAjgFXHBcWTTU23lQPGlH8rPw="
+						"hash": "baad09ea0ad6445f75c51c59fe13c08e01571c17164d3536de540f1a51fcacfc"
 					}
 				]
 			},
@@ -220,7 +210,17 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "lYb0IH7Y7ykCgILLK7LXD6ocTdLokLJg0MaLJ19lp8A="
+						"hash": "9586f4207ed8ef29028082cb2bb2d70faa1c4dd2e890b260d0c68b275f65a7c0"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-third/config",
+				"length": 1500,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "850ddac712d61536d396fe9a50f0d6339e830d783262e0172fe990957819a63c"
 					}
 				]
 			}
@@ -233,12 +233,12 @@
 				"targets_version": 8,
 				"config_states": [
 					{
-						"id": "LIVE_DEBUGGING-base",
+						"id": "LIVE_DEBUGGING-second",
 						"version": 1,
 						"product": "LIVE_DEBUGGING"
 					},
 					{
-						"id": "LIVE_DEBUGGING-second",
+						"id": "LIVE_DEBUGGING-base",
 						"version": 1,
 						"product": "LIVE_DEBUGGING"
 					}
@@ -248,22 +248,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config",
-				"length": 1493,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "3D6ly9bo7kMa58H1LD6gjdkeNuHhwLFzKWunafKEtkk="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-second/config",
 				"length": 1501,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "uq0J6grWRF91xRxZ/hPAjgFXHBcWTTU23lQPGlH8rPw="
+						"hash": "baad09ea0ad6445f75c51c59fe13c08e01571c17164d3536de540f1a51fcacfc"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config",
+				"length": 1493,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "dc3ea5cbd6e8ee431ae7c1f52c3ea08dd91e36e1e1c0b173296ba769f284b649"
 					}
 				]
 			}
@@ -276,12 +276,12 @@
 				"targets_version": 9,
 				"config_states": [
 					{
-						"id": "LIVE_DEBUGGING-base",
+						"id": "LIVE_DEBUGGING-second",
 						"version": 1,
 						"product": "LIVE_DEBUGGING"
 					},
 					{
-						"id": "LIVE_DEBUGGING-second",
+						"id": "LIVE_DEBUGGING-base",
 						"version": 1,
 						"product": "LIVE_DEBUGGING"
 					}
@@ -291,22 +291,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config",
-				"length": 1493,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "3D6ly9bo7kMa58H1LD6gjdkeNuHhwLFzKWunafKEtkk="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-second/config",
 				"length": 1501,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "uq0J6grWRF91xRxZ/hPAjgFXHBcWTTU23lQPGlH8rPw="
+						"hash": "baad09ea0ad6445f75c51c59fe13c08e01571c17164d3536de540f1a51fcacfc"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config",
+				"length": 1493,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "dc3ea5cbd6e8ee431ae7c1f52c3ea08dd91e36e1e1c0b173296ba769f284b649"
 					}
 				]
 			}
@@ -339,7 +339,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "uq0J6grWRF91xRxZ/hPAjgFXHBcWTTU23lQPGlH8rPw="
+						"hash": "baad09ea0ad6445f75c51c59fe13c08e01571c17164d3536de540f1a51fcacfc"
 					}
 				]
 			},
@@ -349,7 +349,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "3D6ly9bo7kMa58H1LD6gjdkeNuHhwLFzKWunafKEtkk="
+						"hash": "dc3ea5cbd6e8ee431ae7c1f52c3ea08dd91e36e1e1c0b173296ba769f284b649"
 					}
 				]
 			}
@@ -362,13 +362,13 @@
 				"targets_version": 11,
 				"config_states": [
 					{
-						"id": "LIVE_DEBUGGING-base",
-						"version": 2,
+						"id": "LIVE_DEBUGGING-second",
+						"version": 1,
 						"product": "LIVE_DEBUGGING"
 					},
 					{
-						"id": "LIVE_DEBUGGING-second",
-						"version": 1,
+						"id": "LIVE_DEBUGGING-base",
+						"version": 2,
 						"product": "LIVE_DEBUGGING"
 					}
 				],
@@ -382,7 +382,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "lYb0IH7Y7ykCgILLK7LXD6ocTdLokLJg0MaLJ19lp8A="
+						"hash": "9586f4207ed8ef29028082cb2bb2d70faa1c4dd2e890b260d0c68b275f65a7c0"
 					}
 				]
 			},
@@ -392,7 +392,7 @@
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "uq0J6grWRF91xRxZ/hPAjgFXHBcWTTU23lQPGlH8rPw="
+						"hash": "baad09ea0ad6445f75c51c59fe13c08e01571c17164d3536de540f1a51fcacfc"
 					}
 				]
 			}
@@ -405,13 +405,13 @@
 				"targets_version": 11,
 				"config_states": [
 					{
-						"id": "LIVE_DEBUGGING-base",
-						"version": 2,
+						"id": "LIVE_DEBUGGING-second",
+						"version": 1,
 						"product": "LIVE_DEBUGGING"
 					},
 					{
-						"id": "LIVE_DEBUGGING-second",
-						"version": 1,
+						"id": "LIVE_DEBUGGING-base",
+						"version": 2,
 						"product": "LIVE_DEBUGGING"
 					}
 				],
@@ -420,22 +420,22 @@
 		},
 		"cached_target_files": [
 			{
-				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config",
-				"length": 1503,
-				"hashes": [
-					{
-						"algorithm": "sha256",
-						"hash": "lYb0IH7Y7ykCgILLK7LXD6ocTdLokLJg0MaLJ19lp8A="
-					}
-				]
-			},
-			{
 				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-second/config",
 				"length": 1501,
 				"hashes": [
 					{
 						"algorithm": "sha256",
-						"hash": "uq0J6grWRF91xRxZ/hPAjgFXHBcWTTU23lQPGlH8rPw="
+						"hash": "baad09ea0ad6445f75c51c59fe13c08e01571c17164d3536de540f1a51fcacfc"
+					}
+				]
+			},
+			{
+				"path": "datadog/2/LIVE_DEBUGGING/LIVE_DEBUGGING-base/config",
+				"length": 1503,
+				"hashes": [
+					{
+						"algorithm": "sha256",
+						"hash": "9586f4207ed8ef29028082cb2bb2d70faa1c4dd2e890b260d0c68b275f65a7c0"
 					}
 				]
 			}


### PR DESCRIPTION
We accidentally opted into Go's behavior of encoding byte slices as
base64 encoded strings when we really wanted to preserve how TUF encodes
them as base16 encoded strings in JSON