### PR TITLE
remote_config: allow for has_error to be set to false

### DIFF
--- a/scenarios/remote_config/test_remote_configuration.py
+++ b/scenarios/remote_config/test_remote_configuration.py
@@ -57,7 +57,7 @@ class Test_RemoteConfigurationFields(BaseTestCase):
             content = data["request"]["content"]
             state = content.get("client", {}).get("state", {})
 
-            if "has_error" in state:
+            if "has_error" in state and state["has_error"] == True:
                 assert (
                     "error" in state and state["error"] != ""
                 ), f"'client.state.error' must be non-empty if a client reports an error with 'client.state.has_error'"


### PR DESCRIPTION
The RFC allows for has_error to be set to false, so we need to check
this before asserting that error be non-empty.