### PR TITLE
go: update apps to use go1.19

### DIFF
--- a/utils/build/docker/golang/app/go.mod
+++ b/utils/build/docker/golang/app/go.mod
@@ -1,6 +1,6 @@
 module weblog
 
-go 1.17
+go 1.19
 
 require (
 	github.com/go-chi/chi/v5 v5.0.7


### PR DESCRIPTION
Attempt to fix https://github.com/DataDog/dd-trace-go/runs/7647831382?check_suite_focus=true#step:5:48