### PR TITLE
Bump go mod tidy to compat with 1.17

### DIFF
--- a/utils/build/docker/golang/install_ddtrace.sh
+++ b/utils/build/docker/golang/install_ddtrace.sh
@@ -15,7 +15,7 @@ else
     go get -v -d -u gopkg.in/DataDog/dd-trace-go.v1
 fi
 
-go mod tidy
+go mod tidy -compat=1.17
 
 # Read the library version out of the version.go file
 mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)


### PR DESCRIPTION
System tests are failing for the PR that will increase dd-trace-go go support version policy. I believe it's due to this line not specifying compatibility with 1.17 now that 1.19 is out.
Here's a link to a failing test: https://github.com/DataDog/dd-trace-go/runs/7660149337?check_suite_focus=true