### PR TITLE
[dotnet] Support new package layout in system tests

### DIFF
--- a/utils/build/docker/dotnet/install_ddtrace.sh
+++ b/utils/build/docker/dotnet/install_ddtrace.sh
@@ -23,14 +23,20 @@ tar xzf $(ls datadog-dotnet-apm-*.tar.gz) -C /opt/datadog
 
 if [ -e /opt/datadog/tracer/Datadog.Tracer.Native.so ]
 then
+    # native tracer is in tracer subfolder
     cp /opt/datadog/tracer/Datadog.Tracer.Native.so /binaries/libDatadog.Trace.ClrProfiler.Native.so
+elif [ -e /opt/datadog/linux-x64/Datadog.Tracer.Native.so ]
+then
+    # native tracer is in arch folder - Waf expects Datadog.Tracer.Native for PInvoke
+    cp /opt/datadog/linux-x64/Datadog.Tracer.Native.so /binaries/Datadog.Tracer.Native.so
 else
     cp /opt/datadog/Datadog.Trace.ClrProfiler.Native.so /binaries/libDatadog.Trace.ClrProfiler.Native.so
 fi
 
 cp /opt/datadog/libddwaf.so /binaries
 dotnet fsi --langversion:preview /binaries/query-versions.fsx
-rm /binaries/libDatadog.Trace.ClrProfiler.Native.so
+rm -f /binaries/libDatadog.Trace.ClrProfiler.Native.so
+rm -f /binaries/Datadog.Tracer.Native.so
 rm /binaries/libddwaf.so
 
 echo "dd-trace version: $(cat /app/SYSTEM_TESTS_LIBRARY_VERSION)"


### PR DESCRIPTION
We are refactoring the package layout and as part of the change we need to update these system tests.

Package layout before:
![image](https://user-images.githubusercontent.com/18755388/183434010-9e35025b-ab12-47ef-a188-8a837767b2ad.png)

Package layout after:
![image](https://user-images.githubusercontent.com/18755388/183434066-6a465a71-1fbc-4c9d-8089-b94c3fa39857.png)


Note that the package layout should not be breaking, it's only because the `query-versions.fsx` script assumes certain things about the WAF/PInvokes that we need these changes