### PR TITLE
Change timeout and add env var to make Java debugger system tests pass

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -137,7 +137,7 @@ elif [ $SYSTEMTESTS_SCENARIO = "REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING" ]; 
     export RUNNER_ARGS="scenarios/remote_config/test_remote_configuration.py::Test_RemoteConfigurationFields scenarios/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceLiveDebugging"
     export SYSTEMTESTS_LOG_FOLDER=logs_remote_config_mocked_backend_live_debugging
     export SYSTEMTESTS_LIBRARY_PROXY_STATE='{"mock_remote_config_backend": "LIVE_DEBUGGING"}'
-    WEBLOG_ENV="DD_DEBUGGER_ENABLED=1"
+    WEBLOG_ENV="DD_DEBUGGER_ENABLED=1\nDD_REMOTE_CONFIG_ENABLED=true"
 
 elif [ $SYSTEMTESTS_SCENARIO = "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD" ]; then
     export RUNNER_ARGS="scenarios/remote_config/test_remote_configuration.py::Test_RemoteConfigurationFields scenarios/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceASMDD"
@@ -153,7 +153,7 @@ elif [ $SYSTEMTESTS_SCENARIO = "REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING_NOCA
     export RUNNER_ARGS="scenarios/remote_config/test_remote_configuration.py::Test_RemoteConfigurationFields scenarios/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache"
     export SYSTEMTESTS_LOG_FOLDER=logs_remote_config_mocked_backend_live_debugging_nocache
     export SYSTEMTESTS_LIBRARY_PROXY_STATE='{"mock_remote_config_backend": "LIVE_DEBUGGING_NO_CACHE"}'
-    WEBLOG_ENV="DD_DEBUGGER_ENABLED=1"
+    WEBLOG_ENV="DD_DEBUGGER_ENABLED=1\nDD_REMOTE_CONFIG_ENABLED=true"
 
 elif [ $SYSTEMTESTS_SCENARIO = "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE" ]; then
     export RUNNER_ARGS="scenarios/remote_config/test_remote_configuration.py::Test_RemoteConfigurationFields scenarios/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceASMDDNoCache"

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -44,7 +44,7 @@ class LibraryInterfaceValidator(InterfaceValidator):
         self.uniqueness_exceptions = _TraceIdUniquenessExceptions()
 
         if context.library == "java":
-            self.expected_timeout = 30
+            self.expected_timeout = 80
         elif context.library.library in ("golang",):
             self.expected_timeout = 10
         elif context.library.library in ("nodejs",):


### PR DESCRIPTION
This PR makes the Live Debugger Remote Configuration system tests pass on the Java library,  after the change that makes the debugger use the new RC client (https://github.com/DataDog/dd-trace-java/pull/3720).

I've added a new environment variable (`DD_REMOTE_CONFIG_ENABLED`) which is required by the Java RC client and I've increased the timeout to 80s like we've had to do for .NET (see https://github.com/DataDog/system-tests/pull/455#discussion_r945618124). This should be a no-op for .NET, I don't know if the python RC client requires any configuration to enable.

In the future we should consider using a shorter polling interval for RC so we can decrease the timeout, but unfortunately it looks like the configuration options are currently different between runtimes: for .NET we have `DD_INTERNAL_RCM_POLL_INTERVAL` and for Java we have `DD_REMOTE_CONFIG_INITIAL_POLL_INTERVAL` (https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-api/src/main/java/datadog/trace/api/config/RemoteConfigConfig.java#L6-L7).