### PR TITLE
[ASM] Make a config test slightly less restrictive about the triggering rule

### DIFF
--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -66,7 +66,7 @@ class Test_RuleSet_1_3_1(BaseTestCase):
     def test_nosqli_keys(self):
         """Test a rule defined on this rules version: nosql on keys"""
         r = self.weblog_get("/waf/", params={"$nin": "value"})
-        interfaces.library.assert_waf_attack(r, rules.nosql_injection.sqr_000_007)
+        interfaces.library.assert_waf_attack(r, rules.nosql_injection)
 
     @irrelevant(library="php", reason="The PHP runtime interprets brackets as arrays, so this is considered malformed")
     @irrelevant(library="nodejs", reason="Node interprets brackets as arrays, so they're truncated")


### PR DESCRIPTION
With release 1.4.0 of the event rules, a different rule trigger this test case