### PR TITLE
increase range for span sampling test to reduce flakiness

### DIFF
--- a/parametric/test_span_sampling.py
+++ b/parametric/test_span_sampling.py
@@ -186,8 +186,8 @@ def test_sampling_rate_not_absolute_value_sss009(test_agent, test_client: _TestT
         else:
             unsampled.append(trace)
 
-    assert len(sampled) in range(40, 60)
-    assert len(unsampled) in range(40, 60)
+    assert len(sampled) in range(30, 70)
+    assert len(unsampled) in range(30, 70)
 
 
 @pytest.mark.skip(


### PR DESCRIPTION
Despite never failing locally for me, it seems the range is a little more varied in CI, so expanding it to reduce flakiness.