### PR TITLE
Fix parametric test run script

### DIFF
--- a/parametric/run.sh
+++ b/parametric/run.sh
@@ -3,4 +3,5 @@
 # FIXME: have to use /dev/null to ignore root pytest.ini config
 # FIXME: have to ignore the root conftest as it does a bunch of initialization/teardown
 #        not required for the integration/shared tests.
-pytest -rs -c /dev/null -p no:$(dirname $PWD)/conftest.py .
+PARENT_DIR=$(dirname $PWD)
+pytest -rs -c /dev/null -p no:$(realpath $PARENT_DIR)/conftest.py .


### PR DESCRIPTION
I got issue running the parametric tests on my laptop.

There is a parameter from the `run.sh` script to exclude the parent `conftest.py` but its path must be absolute.
When using symbolic link in its project path (like when cloning the project into the `~/dd` folder), the absolute file path is wrong, leading to the following error:

```INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/bruce.bujon/go/src/github.com/DataDog/system-tests-main/parametric/.venv/lib/python3.9/site-packages/_pytest/main.py", line 268, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/Users/bruce.bujon/go/src/github.com/DataDog/system-tests-main/parametric/.venv/lib/python3.9/site-packages/_pytest/main.py", line 321, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/Users/bruce.bujon/go/src/github.com/DataDog/system-tests-main/parametric/.venv/lib/python3.9/site-packages/pluggy/_hooks.py", line 265, in __call__
INTERNALERROR>     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
INTERNALERROR>   File "/Users/bruce.bujon/go/src/github.com/DataDog/system-tests-main/parametric/.venv/lib/python3.9/site-packages/pluggy/_manager.py", line 80, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>   File "/Users/bruce.bujon/go/src/github.com/DataDog/system-tests-main/parametric/.venv/lib/python3.9/site-packages/pluggy/_callers.py", line 60, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/Users/bruce.bujon/go/src/github.com/DataDog/system-tests-main/parametric/.venv/lib/python3.9/site-packages/pluggy/_result.py", line 60, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/Users/bruce.bujon/go/src/github.com/DataDog/system-tests-main/parametric/.venv/lib/python3.9/site-packages/pluggy/_callers.py", line 39, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/Users/bruce.bujon/go/src/github.com/DataDog/system-tests-main/parametric/.venv/lib/python3.9/site-packages/_pytest/main.py", line 332, in pytest_collection
INTERNALERROR>     session.perform_collect()
INTERNALERROR>   File "/Users/bruce.bujon/go/src/github.com/DataDog/system-tests-main/parametric/.venv/lib/python3.9/site-packages/_pytest/main.py", line 659, in perform_collect
INTERNALERROR>     self.config.pluginmanager.check_pending()
INTERNALERROR>   File "/Users/bruce.bujon/go/src/github.com/DataDog/system-tests-main/parametric/.venv/lib/python3.9/site-packages/pluggy/_manager.py", line 262, in check_pending
INTERNALERROR>     raise PluginValidationError(
INTERNALERROR> pluggy._manager.PluginValidationError: unknown hook 'pytest_json_modifyreport' in plugin <module 'conftest' from '/Users/bruce.bujon/go/src/github.com/DataDog/system-tests-main/conftest.py'>
```

This PR fixes the path read from current shell environment.