### PR TITLE
Edit dotnet weblog script : add param to waf creation 

### DIFF
--- a/utils/build/docker/dotnet/query-versions.fsx
+++ b/utils/build/docker/dotnet/query-versions.fsx
@@ -37,6 +37,7 @@ module QueryVersions =
             match createMethodParameters.Length with
             | 1 ->  createMethod.Invoke(null, [| null |])
             | 3 ->  createMethod.Invoke(null, [| String.Empty; String.Empty; null |])
+            | 4 ->  createMethod.Invoke(null, [| String.Empty; String.Empty; null; null |]) // from tracer 2.15 PR #3251
             | _ -> failwith "Unknown number of parameters"
         let version = versionProp.GetValue(waf)
         File.WriteAllText("/app/SYSTEM_TESTS_LIBDDWAF_VERSION", (version.ToString()))


### PR DESCRIPTION
From 1.15 we add unit tests to test specific versions of the waf with current tracer, and make sure it doesnt init with wrong waf version, so another param was added