### PR TITLE
Update parametric tests gitignore

### DIFF
--- a/parametric/.gitignore
+++ b/parametric/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/parametric/README.md
+++ b/parametric/README.md
@@ -74,7 +74,7 @@ In the root of the system-tests repo, run the following:
 
 ```bash
 cd parametric
-python -m venv .venv
+python -m venv venv
 source .venv/bin/activate
 pip install -r requirements.txt
 CLIENTS_ENABLED=<client_language> ./run.sh


### PR DESCRIPTION
- Ignore the generated dockerfiles
- Rename the venv to match the name used by system-tests
