### PR TITLE
parametric: run all libraries by default

### DIFF
--- a/parametric/README.md
+++ b/parametric/README.md
@@ -6,7 +6,6 @@ each of the libraries.
 Example:
 
 ```python
-@all_libs()
 @pytest.mark.parametrize("apm_test_server_env", [
     {
         "DD_SERVICE": "svc1",
@@ -25,10 +24,72 @@ def test_the_suite(apm_test_server_env: Dict[str, str], test_agent: TestAgentAPI
     assert traces[0][0]["service"] == apm_test_server_env["DD_SERVICE"]
 ```
 
-- This test case runs against all the APM libraries (`all_libs()`) and is parameterized with two different environments specifying two different values of the environment variable `DD_SERVICE`.
+- This test case runs against all the APM libraries and is parameterized with two different environments specifying two different values of the environment variable `DD_SERVICE`.
 - The test case creates a new root span and sets a tag on it using the shared GRPC interface.
 - Data is flushed to the test agent after the with test_client block closes.
 - Data is retrieved using the `test_agent` fixture and asserted on.
+
+
+## Usage
+
+
+### Installation
+
+The following are required to run the tests locally:
+
+- docker
+- Python >= 3.7
+
+then just create a Python virtual environment and install the dependencies:
+
+```sh
+python -m venv venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+
+### Running the tests
+
+Run all the tests:
+
+```sh
+./run.sh
+```
+
+Run a specific test (`test_metrics_msgpack_serialization_TS001`) against multiple libraries (`dotnet`, `golang`):
+
+```sh
+CLIENTS_ENABLED=dotnet,golang ./run.sh -k test_metrics_msgpack_serialization_TS001
+```
+
+
+Run all tests matching pattern
+
+```sh
+CLIENTS_ENABLED=dotnet,golang ./run.sh -k test_metrics_
+```
+
+
+
+Tests can be aborted using CTRL-C.
+
+
+### Debugging 
+
+The stdout and stderr logs of the test run will include the output from the library server and the test agent container.
+These can be used to debug the test case.
+
+The output also contains the commands used to build and run the containers which can be run manually to debug the issue
+further.
+
+
+## Troubleshooting
+
+- Ensure docker is running.
+- Exiting the tests abruptly maybe leave some docker containers running. Use `docker ps` to find and `docker kill` any
+  containers that may still be running.
+
 
 ## Implementation
 
@@ -62,20 +123,7 @@ Test cases are written in Python and target the shared GRPC interface. The tests
 ## Local Development
 
 ### Requirements
+
 - docker
 - protobuf
 - Python >= 3.7
-
-### Running the Tests
-
-In the root of the system-tests repo, run the following:
-
-(Note that `parametric/run.sh` explicitly ignores the root `conftest.py`, otherwise the root `conftest.py` will interfere with the parametric tests.)
-
-```bash
-cd parametric
-python -m venv venv
-source .venv/bin/activate
-pip install -r requirements.txt
-CLIENTS_ENABLED=<client_language> ./run.sh
-```

--- a/parametric/run.sh
+++ b/parametric/run.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+ARGS=$*
+
 # FIXME: have to use /dev/null to ignore root pytest.ini config
 # FIXME: have to ignore the root conftest as it does a bunch of initialization/teardown
 #        not required for the integration/shared tests.
 PARENT_DIR=$(dirname $PWD)
-pytest -rs -c /dev/null -p no:$(realpath $PARENT_DIR)/conftest.py .
+pytest -rs -c /dev/null -p no:$(realpath $PARENT_DIR)/conftest.py . $ARGS

--- a/parametric/test_span_sampling.py
+++ b/parametric/test_span_sampling.py
@@ -12,6 +12,8 @@ from .conftest import _TestTracer
 import json
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request"}])}]
 )
@@ -25,6 +27,8 @@ def test_single_rule_match_span_sampling_sss001(test_agent, test_client: _TestTr
     assert_sampling_decision_tags(span)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webse*", "name": "web.re?uest"}])}]
 )
@@ -50,6 +54,8 @@ def test_single_rule_no_match_span_sampling_sss003(test_agent, test_client: _Tes
     assert_sampling_decision_tags(span, sample_rate=None, mechanism=None)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
 @pytest.mark.parametrize("apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver"}])}])
 def test_single_rule_only_service_pattern_match_span_sampling_sss004(test_agent, test_client: _TestTracer):
     """Test span sampling tags are added when both:
@@ -62,6 +68,7 @@ def test_single_rule_only_service_pattern_match_span_sampling_sss004(test_agent,
     assert_sampling_decision_tags(span)
 
 
+@pytest.mark.skip_library("golang", "Not implemented")
 @pytest.mark.parametrize("apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"name": "no_match"}])}])
 def test_single_rule_only_name_pattern_no_match_span_sampling_sss005(test_agent, test_client: _TestTracer):
     """Test span sampling tags are not added when:
@@ -74,6 +81,8 @@ def test_single_rule_only_name_pattern_no_match_span_sampling_sss005(test_agent,
     assert_sampling_decision_tags(span, sample_rate=None, mechanism=None)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
     [
@@ -132,6 +141,8 @@ def test_multi_rule_drop_keep_span_sampling_sss007(test_agent, test_client: _Tes
     assert_sampling_decision_tags(span, sample_rate=None, mechanism=None)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
     [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "max_per_second": 2}])}],
@@ -162,6 +173,8 @@ def test_single_rule_rate_limiter_span_sampling_sss08(test_agent, test_client: _
     assert_sampling_decision_tags(span, limit=2)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
     [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 0.5}])}],
@@ -213,6 +226,8 @@ def test_keep_span_with_stats_computation_sss010(test_agent, test_client: _TestT
     assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == USER_KEEP
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
     [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 1.0}])}],
@@ -249,6 +264,8 @@ def test_single_rule_tracer_always_keep_span_sampling_sss012(test_agent, test_cl
     assert_sampling_decision_tags(span, sample_rate=None, mechanism=None, trace_sampling=True)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
     [


### PR DESCRIPTION
Before, all test cases needed to use an all_libs() decorator to specify running the test against all the libraries. Now the server factory fixture is parametrized out to run with all the libraries by default.