### PR TITLE
Add custom binaries support for parametric tests

### DIFF
--- a/parametric/README.md
+++ b/parametric/README.md
@@ -44,7 +44,7 @@ then just create a Python virtual environment and install the dependencies:
 
 ```sh
 python -m venv venv
-source .venv/bin/activate
+source venv/bin/activate
 pip install -r requirements.txt
 ```
 

--- a/parametric/apps/dotnet/Dockerfile
+++ b/parametric/apps/dotnet/Dockerfile
@@ -1,7 +1,0 @@
-
-FROM mcr.microsoft.com/dotnet/sdk:6.0
-WORKDIR /client
-COPY ["ApmTestClient.csproj", "."]
-RUN dotnet restore "./ApmTestClient.csproj"
-COPY . .
-WORKDIR "/client/."

--- a/parametric/apps/golang/Dockerfile
+++ b/parametric/apps/golang/Dockerfile
@@ -1,9 +1,0 @@
-
-FROM golang:1.18
-WORKDIR /client
-COPY go.mod /client
-COPY go.sum /client
-RUN go mod download
-COPY . /client
-RUN go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
-RUN go install

--- a/parametric/apps/python/Dockerfile
+++ b/parametric/apps/python/Dockerfile
@@ -1,6 +1,0 @@
-
-FROM datadog/dd-trace-py:buster
-WORKDIR /client
-RUN pyenv global 3.9.11
-RUN python3.9 -m pip install grpcio==1.46.3 grpcio-tools==1.46.3
-RUN python3.9 -m pip install ddtrace

--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -102,18 +102,20 @@ RUN python3.9 -m pip install %s
 
 
 def golang_library_server_factory(env: Dict[str, str]):
-    go_dir = os.path.join(os.path.dirname(__file__), "apps", "golang")
+    go_appdir = os.path.join("apps", "golang")
+    go_dir = os.path.join(os.path.dirname(__file__), go_appdir)
+    go_reldir = os.path.join("parametric", go_appdir)
     return APMLibraryTestServer(
         lang="golang",
         container_name="go-test-library",
         container_tag="go118-test-library",
-        container_img="""
+        container_img=f"""
 FROM golang:1.18
 WORKDIR /client
-COPY go.mod /client
-COPY go.sum /client
+COPY {go_reldir}/go.mod /client
+COPY {go_reldir}/go.sum /client
 RUN go mod download
-COPY . /client
+COPY {go_reldir} /client
 RUN go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
 RUN go install
 """,
@@ -125,18 +127,20 @@ RUN go install
 
 
 def dotnet_library_server_factory(env: Dict[str, str]):
-    dotnet_dir = os.path.join(os.path.dirname(__file__), "apps", "dotnet")
+    dotnet_appdir = os.path.join("apps", "dotnet")
+    dotnet_dir = os.path.join(os.path.dirname(__file__), dotnet_appdir)
+    dotnet_reldir = os.path.join("parametric", dotnet_appdir)
     env["ASPNETCORE_URLS"] = "http://localhost:50051"
     return APMLibraryTestServer(
         lang="dotnet",
         container_name="dotnet-test-client",
         container_tag="dotnet6_0-test-client",
-        container_img="""
+        container_img=f"""
 FROM mcr.microsoft.com/dotnet/sdk:6.0
 WORKDIR /client
-COPY ["ApmTestClient.csproj", "."]
+COPY ["{dotnet_reldir}/ApmTestClient.csproj", "."]
 RUN dotnet restore "./ApmTestClient.csproj"
-COPY . .
+COPY {dotnet_reldir} .
 WORKDIR "/client/."
 """,
         container_cmd=["dotnet", "run"],
@@ -461,18 +465,21 @@ def test_server(
         dockf.write(apm_test_server.container_img)
     # Build the container
     docker = shutil.which("docker")
+    root_path = ".."
     cmd = [
         docker,
         "build",
         "-t",
         apm_test_server.container_tag,
+        "-f",
+        dockf_path,
         ".",
     ]
-    test_server_log_file.write("running %r in %r\n\n" % (" ".join(cmd), apm_test_server.container_build_dir))
+    test_server_log_file.write("running %r in %r\n\n" % (" ".join(cmd), root_path))
     test_server_log_file.flush()
     subprocess.run(
         cmd,
-        cwd=apm_test_server.container_build_dir,
+        cwd=root_path,
         stdout=test_server_log_file,
         stderr=test_server_log_file,
         check=True,
@@ -499,6 +506,9 @@ def test_server(
         network_name=docker_network,
     ):
         yield apm_test_server
+
+    # Clean up generated files
+    os.remove(dockf_path)
 
 
 class _TestSpan:


### PR DESCRIPTION
As requested per @Kyle-Verhoog, I created a dedicated PR from #504 to add the support for custom binaries for parametric tests.

- Build docker images from project root in order to access to /binaries.
- Update dockerfile copy paths.
- Clean up generated dockerfiles.