### PR TITLE
parametric: use DD_TRACE_SAMPLE_RATE in span sampling tests

### DIFF
--- a/parametric/run.sh
+++ b/parametric/run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+ARGS=$*
+
 # FIXME: have to use /dev/null to ignore root pytest.ini config
 # FIXME: have to ignore the root conftest as it does a bunch of initialization/teardown
 #        not required for the integration/shared tests.
-pytest -rs -c /dev/null -p no:$(dirname $PWD)/conftest.py .
+PARENT_DIR=$(dirname $PWD)
+pytest -rs -c /dev/null -p no:$(realpath $PARENT_DIR)/conftest.py . $ARGS

--- a/parametric/test_span_sampling.py
+++ b/parametric/test_span_sampling.py
@@ -5,7 +5,6 @@ from parametric.spec.trace import SINGLE_SPAN_SAMPLING_MECHANISM_VALUE
 from parametric.spec.trace import SINGLE_SPAN_SAMPLING_RATE
 from parametric.spec.trace import SAMPLING_PRIORITY_KEY
 from parametric.spec.trace import MANUAL_DROP_KEY
-from parametric.spec.trace import MANUAL_KEEP_KEY
 from parametric.spec.trace import USER_KEEP
 import time
 from .conftest import APMLibrary

--- a/parametric/test_span_sampling.py
+++ b/parametric/test_span_sampling.py
@@ -14,7 +14,13 @@ import json
 
 @pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
-    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request"}]), "DD_TRACE_SAMPLE_RATE": 0}]
+    "apm_test_server_env",
+    [
+        {
+            "DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request"}]),
+            "DD_TRACE_SAMPLE_RATE": 0,
+        }
+    ],
 )
 def test_single_rule_match_span_sampling_sss001(test_agent, test_client: _TestTracer):
     """Test that span sampling tags are added when both:
@@ -22,16 +28,14 @@ def test_single_rule_match_span_sampling_sss001(test_agent, test_client: _TestTr
     2. tracer is set to drop the trace manually"""
     generate_span(test_client)
     span = get_span(test_agent)
-    print("lala span")
-    print(span)
-    assert 0
 
     assert_sampling_decision_tags(span)
 
 
 @pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
-    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webse*", "name": "web.re?uest"}]), "DD_TRACE_SAMPLE_RATE": 0}]
+    "apm_test_server_env",
+    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webse*", "name": "web.re?uest"}]), "DD_TRACE_SAMPLE_RATE": 0}],
 )
 def test_special_glob_characters_span_sampling_sss002(test_agent, test_client: _TestTracer):
     """Test span sampling tags are added when a rule with glob patterns with special characters * and ? match"""
@@ -42,7 +46,13 @@ def test_special_glob_characters_span_sampling_sss002(test_agent, test_client: _
 
 
 @pytest.mark.parametrize(
-    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "notmatching", "name": "notmatching"}]), "DD_TRACE_SAMPLE_RATE": 0}]
+    "apm_test_server_env",
+    [
+        {
+            "DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "notmatching", "name": "notmatching"}]),
+            "DD_TRACE_SAMPLE_RATE": 0,
+        }
+    ],
 )
 def test_single_rule_no_match_span_sampling_sss003(test_agent, test_client: _TestTracer):
     """Test span sampling tags are not added when both:
@@ -57,7 +67,8 @@ def test_single_rule_no_match_span_sampling_sss003(test_agent, test_client: _Tes
 
 @pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
-    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver"}]), "DD_TRACE_SAMPLE_RATE": 0}]
+    "apm_test_server_env",
+    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver"}]), "DD_TRACE_SAMPLE_RATE": 0}],
 )
 def test_single_rule_only_service_pattern_match_span_sampling_sss004(test_agent, test_client: _TestTracer):
     """Test span sampling tags are added when both:
@@ -70,8 +81,9 @@ def test_single_rule_only_service_pattern_match_span_sampling_sss004(test_agent,
     assert_sampling_decision_tags(span)
 
 
-
-@pytest.mark.parametrize("apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"name": "no_match"}]), "DD_TRACE_SAMPLE_RATE": 0}])
+@pytest.mark.parametrize(
+    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"name": "no_match"}]), "DD_TRACE_SAMPLE_RATE": 0}]
+)
 def test_single_rule_only_name_pattern_no_match_span_sampling_sss005(test_agent, test_client: _TestTracer):
     """Test span sampling tags are not added when:
     1. a span sampling rule that only has a name pattern does not match
@@ -93,7 +105,8 @@ def test_single_rule_only_name_pattern_no_match_span_sampling_sss005(test_agent,
                     {"service": "webserver", "name": "web.request"},
                     {"service": "webserver", "name": "web.request", "sample_rate": 0},
                 ]
-            )
+            ),
+            "DD_TRACE_SAMPLE_RATE": 0,
         }
     ],
 )
@@ -122,7 +135,8 @@ def test_multi_rule_keep_drop_span_sampling_sss006(test_agent, test_client: _Tes
                     {"service": "webserver", "name": "web.request", "sample_rate": 0},
                     {"service": "webserver", "name": "web.request"},
                 ]
-            )
+            ),
+            "DD_TRACE_SAMPLE_RATE": 0,
         }
     ],
 )
@@ -145,7 +159,14 @@ def test_multi_rule_drop_keep_span_sampling_sss007(test_agent, test_client: _Tes
 @pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
-    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "max_per_second": 2}]), "DD_TRACE_SAMPLE_RATE": 0}],
+    [
+        {
+            "DD_SPAN_SAMPLING_RULES": json.dumps(
+                [{"service": "webserver", "name": "web.request", "max_per_second": 2}]
+            ),
+            "DD_TRACE_SAMPLE_RATE": 0,
+        }
+    ],
 )
 def test_single_rule_rate_limiter_span_sampling_sss08(test_agent, test_client: _TestTracer):
     """Test span sampling tags are added until rate limit hit, then need to wait for tokens to reset"""
@@ -176,7 +197,12 @@ def test_single_rule_rate_limiter_span_sampling_sss08(test_agent, test_client: _
 @pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
-    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 0.5}]), "DD_TRACE_SAMPLE_RATE": 0}],
+    [
+        {
+            "DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 0.5}]),
+            "DD_TRACE_SAMPLE_RATE": 0,
+        }
+    ],
 )
 def test_sampling_rate_not_absolute_value_sss009(test_agent, test_client: _TestTracer):
     """Test sample rate comes close to expected number of spans sampled. We do this by setting the
@@ -209,7 +235,8 @@ def test_sampling_rate_not_absolute_value_sss009(test_agent, test_client: _TestT
     "apm_test_server_env",
     [
         {
-            "DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request"}]), "DD_TRACE_SAMPLE_RATE": 0,
+            "DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request"}]),
+            "DD_TRACE_SAMPLE_RATE": 0,
             "DD_TRACE_STATS_COMPUTATION_ENABLED": "True",
         }
     ],
@@ -224,31 +251,43 @@ def test_keep_span_with_stats_computation_sss010(test_agent, test_client: _TestT
     # the below does not apply to all agent APIs
     assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == USER_KEEP
 
-@pytest.mark.skip_library("golang", "The Go tracer does not have an easy way to modulate trace sampling")
+
+@pytest.mark.skip_library("golang", "The Go tracer does not have an easy way to modulate trace sampling once started")
 @pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
-    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 1.0}])}],
+    [
+        {
+            "DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 1.0}]),
+            "DD_TRACE_SAMPLE_RATE": 1.0,
+        }
+    ],
 )
 def test_single_rule_always_keep_span_sampling_sss011(test_agent, test_client: _TestTracer):
     """Test that spans are always kept when the sampling rule matches and has sample_rate:1.0 regardless of tracer decision.
 
     Basically, if we have a rule for spans with sample_rate:1.0 we should always keep those spans, either due to trace sampling or span sampling"""
-    generate_span(test_client)
+    # This span is set to be dropped by the tracer/user, however it is kept by span sampling
+    generate_span(test_client, manual_drop=True)
     span = get_span(test_agent)
 
     assert_sampling_decision_tags(span)
 
     # This span is sampled by the tracer, not span sampling.
     # Therefore it won't have the span sampling tags, but rather the trace sampling tags.
-    generate_span(test_client, trace_sampling=True)
+    generate_span(test_client)
     span = get_span(test_agent)
     assert_sampling_decision_tags(span, sample_rate=None, mechanism=None, trace_sampling=True)
 
 
 @pytest.mark.parametrize(
     "apm_test_server_env",
-    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 0}]), "DD_TRACE_SAMPLE_RATE": 1.0}],
+    [
+        {
+            "DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 0}]),
+            "DD_TRACE_SAMPLE_RATE": 1.0,
+        }
+    ],
 )
 def test_single_rule_tracer_always_keep_span_sampling_sss012(test_agent, test_client: _TestTracer):
     """Test spans are always kept when tracer keeps, regardless of span sampling rule set to drop.
@@ -272,7 +311,8 @@ def test_single_rule_tracer_always_keep_span_sampling_sss012(test_agent, test_cl
                     {"service": "webserver", "name": "web.request", "max_per_second": 1},
                     {"service": "webserver2", "name": "web.request2", "max_per_second": 5},
                 ]
-            )
+            ),
+            "DD_TRACE_SAMPLE_RATE": 0,
         }
     ],
 )
@@ -326,14 +366,12 @@ def assert_sampling_decision_tags(
         assert span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0
 
 
-def generate_span(test_client, name="web.request", service="webserver", trace_sampling=False):
+def generate_span(test_client, name="web.request", service="webserver", manual_drop=False):
     with test_client.start_span(name=name, service=service) as span:
-        pass
-    #     if trace_sampling:
-    #         span.set_meta(MANUAL_KEEP_KEY, "1")
-    #     else:
-    #         span.set_meta(MANUAL_DROP_KEY, "1")
+        if manual_drop:
+            span.set_meta(MANUAL_DROP_KEY, "1")
     test_client.flush()
+
 
 def get_span(test_agent):
     traces = test_agent.traces()

--- a/parametric/test_span_sampling.py
+++ b/parametric/test_span_sampling.py
@@ -49,6 +49,9 @@ def test_special_glob_characters_span_sampling_sss002(test_agent, test_client: _
     assert_sampling_decision_tags(span)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
+@pytest.mark.skip_library("nodejs", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
     [
@@ -70,13 +73,12 @@ def test_single_rule_no_match_span_sampling_sss003(test_agent, test_client: _Tes
 
 
 @pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
+@pytest.mark.skip_library("nodejs", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
     [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver"}]), "DD_TRACE_SAMPLE_RATE": 0}],
 )
-@pytest.mark.skip_library("golang", "Not implemented")
-@pytest.mark.skip_library("nodejs", "Not implemented")
-@pytest.mark.parametrize("apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver"}])}])
 def test_single_rule_only_service_pattern_match_span_sampling_sss004(test_agent, test_client: _TestTracer):
     """Test span sampling tags are added when both:
     1. a span sampling rule that only has a service pattern matches
@@ -88,12 +90,12 @@ def test_single_rule_only_service_pattern_match_span_sampling_sss004(test_agent,
     assert_sampling_decision_tags(span)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
+@pytest.mark.skip_library("nodejs", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"name": "no_match"}]), "DD_TRACE_SAMPLE_RATE": 0}]
 )
-@pytest.mark.skip_library("golang", "Not implemented")
-@pytest.mark.skip_library("nodejs", "Not implemented")
-@pytest.mark.parametrize("apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"name": "no_match"}])}])
 def test_single_rule_only_name_pattern_no_match_span_sampling_sss005(test_agent, test_client: _TestTracer):
     """Test span sampling tags are not added when:
     1. a span sampling rule that only has a name pattern does not match
@@ -138,6 +140,9 @@ def test_multi_rule_keep_drop_span_sampling_sss006(test_agent, test_client: _Tes
     assert_sampling_decision_tags(span)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.skip_library("golang", "Not implemented")
+@pytest.mark.skip_library("nodejs", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
     [
@@ -182,7 +187,7 @@ def test_multi_rule_drop_keep_span_sampling_sss007(test_agent, test_client: _Tes
         }
     ],
 )
-def test_single_rule_rate_limiter_span_sampling_sss08(test_agent, test_client: _TestTracer):
+def test_single_rule_rate_limiter_span_sampling_sss008(test_agent, test_client: _TestTracer):
     """Test span sampling tags are added until rate limit hit, then need to wait for tokens to reset"""
     # generate spans until we hit the rate limit
     while True:

--- a/parametric/test_span_sampling.py
+++ b/parametric/test_span_sampling.py
@@ -274,7 +274,7 @@ def test_keep_span_with_stats_computation_sss010(test_agent, test_client: _TestT
 
 
 @pytest.mark.skip_library("dotnet", "Not implemented")
-@pytest.mark.skip_library("golang", "The Go tracer does not have an easy way to modulate trace sampling once started")
+@pytest.mark.skip_library("golang", "The Go tracer does not have a way to modulate trace sampling once started")
 @pytest.mark.skip_library("nodejs", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",

--- a/parametric/test_span_sampling.py
+++ b/parametric/test_span_sampling.py
@@ -12,8 +12,9 @@ from .conftest import _TestTracer
 import json
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
-    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request"}])}]
+    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request"}]), "DD_TRACE_SAMPLE_RATE": 0}]
 )
 def test_single_rule_match_span_sampling_sss001(test_agent, test_client: _TestTracer):
     """Test that span sampling tags are added when both:
@@ -21,12 +22,16 @@ def test_single_rule_match_span_sampling_sss001(test_agent, test_client: _TestTr
     2. tracer is set to drop the trace manually"""
     generate_span(test_client)
     span = get_span(test_agent)
+    print("lala span")
+    print(span)
+    assert 0
 
     assert_sampling_decision_tags(span)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
-    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webse*", "name": "web.re?uest"}])}]
+    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webse*", "name": "web.re?uest"}]), "DD_TRACE_SAMPLE_RATE": 0}]
 )
 def test_special_glob_characters_span_sampling_sss002(test_agent, test_client: _TestTracer):
     """Test span sampling tags are added when a rule with glob patterns with special characters * and ? match"""
@@ -37,7 +42,7 @@ def test_special_glob_characters_span_sampling_sss002(test_agent, test_client: _
 
 
 @pytest.mark.parametrize(
-    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "notmatching", "name": "notmatching"}])}]
+    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "notmatching", "name": "notmatching"}]), "DD_TRACE_SAMPLE_RATE": 0}]
 )
 def test_single_rule_no_match_span_sampling_sss003(test_agent, test_client: _TestTracer):
     """Test span sampling tags are not added when both:
@@ -50,7 +55,10 @@ def test_single_rule_no_match_span_sampling_sss003(test_agent, test_client: _Tes
     assert_sampling_decision_tags(span, sample_rate=None, mechanism=None)
 
 
-@pytest.mark.parametrize("apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver"}])}])
+@pytest.mark.skip_library("dotnet", "Not implemented")
+@pytest.mark.parametrize(
+    "apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver"}]), "DD_TRACE_SAMPLE_RATE": 0}]
+)
 def test_single_rule_only_service_pattern_match_span_sampling_sss004(test_agent, test_client: _TestTracer):
     """Test span sampling tags are added when both:
     1. a span sampling rule that only has a service pattern matches
@@ -62,7 +70,8 @@ def test_single_rule_only_service_pattern_match_span_sampling_sss004(test_agent,
     assert_sampling_decision_tags(span)
 
 
-@pytest.mark.parametrize("apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"name": "no_match"}])}])
+
+@pytest.mark.parametrize("apm_test_server_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"name": "no_match"}]), "DD_TRACE_SAMPLE_RATE": 0}])
 def test_single_rule_only_name_pattern_no_match_span_sampling_sss005(test_agent, test_client: _TestTracer):
     """Test span sampling tags are not added when:
     1. a span sampling rule that only has a name pattern does not match
@@ -74,6 +83,7 @@ def test_single_rule_only_name_pattern_no_match_span_sampling_sss005(test_agent,
     assert_sampling_decision_tags(span, sample_rate=None, mechanism=None)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
     [
@@ -132,9 +142,10 @@ def test_multi_rule_drop_keep_span_sampling_sss007(test_agent, test_client: _Tes
     assert_sampling_decision_tags(span, sample_rate=None, mechanism=None)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
-    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "max_per_second": 2}])}],
+    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "max_per_second": 2}]), "DD_TRACE_SAMPLE_RATE": 0}],
 )
 def test_single_rule_rate_limiter_span_sampling_sss08(test_agent, test_client: _TestTracer):
     """Test span sampling tags are added until rate limit hit, then need to wait for tokens to reset"""
@@ -162,9 +173,10 @@ def test_single_rule_rate_limiter_span_sampling_sss08(test_agent, test_client: _
     assert_sampling_decision_tags(span, limit=2)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
-    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 0.5}])}],
+    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 0.5}]), "DD_TRACE_SAMPLE_RATE": 0}],
 )
 def test_sampling_rate_not_absolute_value_sss009(test_agent, test_client: _TestTracer):
     """Test sample rate comes close to expected number of spans sampled. We do this by setting the
@@ -197,7 +209,7 @@ def test_sampling_rate_not_absolute_value_sss009(test_agent, test_client: _TestT
     "apm_test_server_env",
     [
         {
-            "DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request"}]),
+            "DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request"}]), "DD_TRACE_SAMPLE_RATE": 0,
             "DD_TRACE_STATS_COMPUTATION_ENABLED": "True",
         }
     ],
@@ -212,7 +224,8 @@ def test_keep_span_with_stats_computation_sss010(test_agent, test_client: _TestT
     # the below does not apply to all agent APIs
     assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == USER_KEEP
 
-
+@pytest.mark.skip_library("golang", "The Go tracer does not have an easy way to modulate trace sampling")
+@pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
     [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 1.0}])}],
@@ -235,7 +248,7 @@ def test_single_rule_always_keep_span_sampling_sss011(test_agent, test_client: _
 
 @pytest.mark.parametrize(
     "apm_test_server_env",
-    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 0}])}],
+    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver", "name": "web.request", "sample_rate": 0}]), "DD_TRACE_SAMPLE_RATE": 1.0}],
 )
 def test_single_rule_tracer_always_keep_span_sampling_sss012(test_agent, test_client: _TestTracer):
     """Test spans are always kept when tracer keeps, regardless of span sampling rule set to drop.
@@ -244,11 +257,12 @@ def test_single_rule_tracer_always_keep_span_sampling_sss012(test_agent, test_cl
     """
     # This span is sampled by the tracer, not span sampling, which would try to drop the span, so it's still kept because "_sampling_priority_v1" > 0
     # When the trace is kept by trace sampling, span rules are not applied
-    generate_span(test_client, trace_sampling=True)
+    generate_span(test_client)
     span = get_span(test_agent)
     assert_sampling_decision_tags(span, sample_rate=None, mechanism=None, trace_sampling=True)
 
 
+@pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.parametrize(
     "apm_test_server_env",
     [
@@ -314,12 +328,12 @@ def assert_sampling_decision_tags(
 
 def generate_span(test_client, name="web.request", service="webserver", trace_sampling=False):
     with test_client.start_span(name=name, service=service) as span:
-        if trace_sampling:
-            span.set_meta(MANUAL_KEEP_KEY, "1")
-        else:
-            span.set_meta(MANUAL_DROP_KEY, "1")
+        pass
+    #     if trace_sampling:
+    #         span.set_meta(MANUAL_KEEP_KEY, "1")
+    #     else:
+    #         span.set_meta(MANUAL_DROP_KEY, "1")
     test_client.flush()
-
 
 def get_span(test_agent):
     traces = test_agent.traces()

--- a/parametric/test_span_sampling.py
+++ b/parametric/test_span_sampling.py
@@ -76,8 +76,7 @@ def test_single_rule_no_match_span_sampling_sss003(test_agent, test_library):
 @pytest.mark.skip_library("golang", "Not implemented")
 @pytest.mark.skip_library("nodejs", "Not implemented")
 @pytest.mark.parametrize(
-    "library_env",
-    [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver"}]), "DD_TRACE_SAMPLE_RATE": 0}],
+    "library_env", [{"DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "webserver"}]), "DD_TRACE_SAMPLE_RATE": 0}],
 )
 def test_single_rule_only_service_pattern_match_span_sampling_sss004(test_agent, test_library):
     """Test span sampling tags are added when both:


### PR DESCRIPTION
## Description

Before we used the setting of manual_drop to 1 in order to modulate the tracer's decision to keep or drop the span. However changing manual_drop doesn't effect the Go tracer (and possibly other tracer's) decision when setting the tag `_sampling_priority_v1` which is what  matters when making the decision to try single span sampling or not. Using `DD_TRACE_SAMPLE_RATE` to modulate the tracer's decision is more consistent across tracers and easier to understand.

I did keep the option to add manual_drop in the generate_span method, as it was the only option I know of to modulate trace sampling for Python during runtime which is necessary for sss011.

## Check list

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
