### PR TITLE
parametric: better log organization

### DIFF
--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -354,8 +354,6 @@ def docker() -> str:
 def docker_network_log_file(request) -> TextIO:
     with tempfile.NamedTemporaryFile(mode="w+") as f:
         yield f
-        f.seek(0)
-        request.node._report_sections.append(("teardown", f"Docker Network", "".join(f.readlines())))
 
 
 @pytest.fixture()

--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -4,13 +4,12 @@ import dataclasses
 import os
 import shutil
 import subprocess
-import sys
+import tempfile
 import time
 from typing import Callable, Dict, Generator, List, TextIO, Tuple, TypedDict
 import urllib.parse
 
 import grpc
-
 import requests
 import pytest
 
@@ -85,7 +84,7 @@ def python_library_factory(env: Dict[str, str]) -> APMLibraryTestServer:
     return APMLibraryTestServer(
         lang="python",
         container_name="python-test-library",
-        container_tag="py39-test-library",
+        container_tag="python-test-library",
         container_img="""
 FROM datadog/dd-trace-py:buster
 WORKDIR /client
@@ -201,11 +200,20 @@ def apm_test_server(request, library_env):
     yield apm_test_library(library_env)
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+
+
 @pytest.fixture
-def test_server_log_file(apm_test_server, tmp_path) -> TextIO:
-    # timestr = time.strftime("%Y%m%d-%H%M%S")
-    # yield tmp_path / ("%s_%s.out" % (apm_test_server.container_name, timestr))
-    return sys.stderr
+def test_server_log_file(apm_test_server, request) -> Generator[TextIO, None, None]:
+    with tempfile.NamedTemporaryFile(mode="w+") as f:
+        yield f
+        f.seek(0)
+        request.node._report_sections.append(
+            ("teardown", f"{apm_test_server.lang.capitalize()} Library Output", "".join(f.readlines()))
+        )
 
 
 class _TestAgentAPI:
@@ -297,7 +305,8 @@ def docker_run(
         _cmd.extend(["-p", "%s:%s" % (k, v)])
     _cmd += [image]
     _cmd.extend(cmd)
-    log_file.write("$ " + " ".join(_cmd) + "\n\n")
+
+    log_file.write("$ " + " ".join(_cmd) + "\n")
     log_file.flush()
     docker = shutil.which("docker")
 
@@ -322,15 +331,15 @@ def docker_run(
     finally:
         docker_logs.kill()
         _cmd = [docker, "kill", name]
-        log_file.write(" ".join(_cmd) + "\n\n")
+        log_file.write("\n\n\n$ %s\n" % " ".join(_cmd))
         log_file.flush()
         subprocess.run(
             _cmd, stdout=log_file, stderr=log_file, check=True,
         )
 
 
-@pytest.fixture
-def docker() -> None:
+@pytest.fixture()
+def docker() -> str:
     """Fixture to ensure docker is ready to use on the system."""
     # Redirect output to /dev/null since we just care if we get a successful response code.
     r = subprocess.run(["docker", "info"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -338,30 +347,34 @@ def docker() -> None:
         pytest.fail(
             "Docker is not running and is required to run the shared APM library tests. Start docker and try running the tests again."
         )
+    return shutil.which("docker")
 
 
-@pytest.fixture
-def docker_network_log_file() -> TextIO:
-    return sys.stderr
+@pytest.fixture()
+def docker_network_log_file(request) -> TextIO:
+    with tempfile.NamedTemporaryFile(mode="w+") as f:
+        yield f
+        f.seek(0)
+        request.node._report_sections.append(("teardown", f"Docker Network", "".join(f.readlines())))
 
 
-@pytest.fixture
+@pytest.fixture()
 def docker_network_name() -> str:
     return "apm_shared_tests_network"
 
 
-@pytest.fixture
-def docker_network(docker_network_log_file: TextIO, docker_network_name: str) -> str:
+@pytest.fixture()
+def docker_network(docker: str, docker_network_log_file: TextIO, docker_network_name: str) -> str:
     # Initial check to see if docker network already exists
     cmd = [
-        shutil.which("docker"),
+        docker,
         "network",
         "inspect",
         docker_network_name,
     ]
     docker_network_log_file.write("$ " + " ".join(cmd) + "\n\n")
     docker_network_log_file.flush()
-    r = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    r = subprocess.run(cmd, stderr=docker_network_log_file)
     if r.returncode not in (0, 1):  # 0 = network exists, 1 = network does not exist
         pytest.fail(
             "Could not check for docker network %r, error: %r" % (docker_network_name, r.stderr), pytrace=False,
@@ -407,8 +420,11 @@ def test_agent_port() -> str:
 
 
 @pytest.fixture
-def test_agent_log_file() -> TextIO:
-    return sys.stderr
+def test_agent_log_file(request) -> Generator[TextIO, None, None]:
+    with tempfile.NamedTemporaryFile(mode="w+") as f:
+        yield f
+        f.seek(0)
+        request.node._report_sections.append(("teardown", f"Test Agent Output", "".join(f.readlines())))
 
 
 @pytest.fixture
@@ -489,7 +505,6 @@ def test_server(
     # Note that this needs to be done as the context cannot be
     # specified if Dockerfiles are read from stdin.
     dockf_path = os.path.join(apm_test_server.container_build_dir, "Dockerfile")
-    test_server_log_file.write("writing dockerfile %r\n" % dockf_path)
     with open(dockf_path, "w") as dockf:
         dockf.write(apm_test_server.container_img)
     # Build the container
@@ -505,16 +520,17 @@ def test_server(
         dockf_path,
         ".",
     ]
-    test_server_log_file.write("running %r in %r\n\n" % (" ".join(cmd), root_path))
+    test_server_log_file.write("running %r in %r\n" % (" ".join(cmd), root_path))
     test_server_log_file.flush()
     subprocess.run(
         cmd,
         cwd=root_path,
-        stdout=test_server_log_file,
-        stderr=test_server_log_file,
         check=True,
         text=True,
         input=apm_test_server.container_img,
+        stdout=test_server_log_file,
+        stderr=test_server_log_file,
+        env={"DOCKER_SCAN_SUGGEST": "false",},  # Docker outputs an annoying synk message on every build
     )
 
     env = {

--- a/parametric/test_trace_distributed.py
+++ b/parametric/test_trace_distributed.py
@@ -1,6 +1,6 @@
 import pytest
 
-from parametric.protos.apm_test_library_pb2 import DistributedHTTPHeaders
+from parametric.protos.apm_test_client_pb2 import DistributedHTTPHeaders
 
 
 @pytest.mark.skip_library("dotnet", "not implemented")

--- a/parametric/test_trace_distributed.py
+++ b/parametric/test_trace_distributed.py
@@ -1,24 +1,24 @@
 import pytest
 
-from parametric.protos.apm_test_client_pb2 import DistributedHTTPHeaders
+from parametric.protos.apm_test_library_pb2 import DistributedHTTPHeaders
 
 
-@pytest.mark.skip_library("dotnet", "not impemented")
-@pytest.mark.skip_library("golang", "not impemented")
-@pytest.mark.skip_library("nodejs", "not impemented")
-def test_distributed_headers_extract_datadog(test_agent, test_client):
+@pytest.mark.skip_library("dotnet", "not implemented")
+@pytest.mark.skip_library("golang", "not implemented")
+@pytest.mark.skip_library("nodejs", "not implemented")
+def test_distributed_headers_extract_datadog(test_agent, test_library):
     """Ensure that Datadog distributed tracing headers are extracted
     and activated properly.
     """
 
-    with test_client:
+    with test_library:
         http_headers = DistributedHTTPHeaders()
         http_headers.x_datadog_trace_id_key = "x-datadog-trace-id"
         http_headers.x_datadog_trace_id_value = "12345"
         http_headers.x_datadog_parent_id_key = "x-datadog-parent-id"
         http_headers.x_datadog_parent_id_value = "123"
 
-        with test_client.start_span(name="name", http_headers=http_headers) as span:
+        with test_library.start_span(name="name", http_headers=http_headers) as span:
             span.set_meta(key="http.status_code", val="200")
 
     span = get_span(test_agent)
@@ -28,17 +28,17 @@ def test_distributed_headers_extract_datadog(test_agent, test_client):
 
 @pytest.mark.skip("needs to be implemented by tracers and test needs to adhere to RFC")
 @pytest.mark.parametrize("apm_test_server_env", [{"DD_TRACE_PROPAGATION_STYLE_EXTRACT": "W3C"}])
-def test_distributed_headers_extract_w3c001(apm_test_server_env, test_agent, test_client):
+def test_distributed_headers_extract_w3c001(apm_test_server_env, test_agent, test_library):
     """Ensure that W3C distributed tracing headers are extracted
     and activated properly.
     """
 
-    with test_client:
+    with test_library:
         http_headers = DistributedHTTPHeaders()
         http_headers.traceparent_key = "traceparent"
         http_headers.traceparent_value = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
 
-        with test_client.start_span(name="name", http_headers=http_headers) as span:
+        with test_library.start_span(name="name", http_headers=http_headers) as span:
             span.set_meta(key="http.status_code", val="200")
 
     span = get_span(test_agent)

--- a/parametric/test_tracer.py
+++ b/parametric/test_tracer.py
@@ -61,7 +61,7 @@ def test_tracer_service_name_environment_variable(
     assert span["service"] == library_env["DD_SERVICE"]
 
 
-@parametrize("library_env", [{"DD_ENV": "prod"}, {"DD_ENV": "dev"}])
+@parametrize("library_env", [{"DD_ENV": "prod"}])
 def test_tracer_env_environment_variable(
     library_env: Dict[str, str], test_library: APMLibrary, test_agent: _TestAgentAPI
 ) -> None:


### PR DESCRIPTION
## Description

Group the logs into sections of the pytest report:

```
======================================================================== test session starts =========================================================================
platform darwin -- Python 3.9.11, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/kverhoog/dev/system-tests/parametric, configfile: conftest.py
plugins: ddtrace-1.4.4, json-report-1.2.1, metadata-2.0.2
collected 3 items / 2 deselected / 1 selected                                                                                                                        

test_tracer.py F                                                                                                                                               [100%]

============================================================================== FAILURES ==============================================================================
_____________________________________________________ test_tracer_env_environment_variable[python-library_env0] ______________________________________________________

library_env = {'DD_ENV': 'prod'}, test_library = <parametric.conftest.APMLibrary object at 0x103335040>
test_agent = <parametric.conftest._TestAgentAPI object at 0x1032c66d0>

    @parametrize("library_env", [{"DD_ENV": "prod"}])
    def test_tracer_env_environment_variable(
        library_env: Dict[str, str], test_library: APMLibrary, test_agent: _TestAgentAPI
    ) -> None:
        """
        When DD_ENV is specified
            When a span is created
                The span should have the value of DD_ENV in meta.env
        """
        with test_library:
            with test_library.start_span("operation"):
                pass
    
        traces = test_agent.traces()
        trace = find_trace_by_root(traces, Span(name="operation"))
>       assert len(trace) == 2
E       AssertionError: assert 1 == 2
E        +  where 1 = len([{'duration': 9863583, 'meta': {'_dd.p.dm': '-0', 'env': 'prod', 'runtime-id': '873c8516914e466d88a95dbb716fe54a'}, 'm...agent_psr': 1.0, '_dd.top_level': 1, '_dd.tracer_kr': 1.0, '_sampling_priority_v1': 1, ...}, 'name': 'operation', ...}])

test_tracer.py:79: AssertionError
----------------------------------------------------------------------- Captured stdout setup ------------------------------------------------------------------------
[]
----------------------------------------------------------------------- Captured stderr setup ------------------------------------------------------------------------
E1005 15:07:06.157627000 4316038528 fork_posix.cc:76]                  Other threads are currently calling into gRPC, skipping fork() handlers
---------------------------------------------------------------- Captured Test Agent Output teardown -----------------------------------------------------------------
$ /usr/local/bin/docker run -d --rm --name=ddapm-test-agent --network=apm_shared_tests_network -e DISABLED_CHECKS=meta_tracer_version_header,trace_content_length -v /Users/kverhoog/dev/system-tests/parametric/snapshots:/snapshots -p 8126:8126 ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
dd8a9cfcccf5715e91b2d7845ada26d98a3d478373ab62a20b24a3b0f561375f
INFO:ddapm_test_agent.agent:Trace request stall seconds setting set to 0.0.
INFO:aiohttp.access:172.18.0.1 [05/Oct/2022:19:07:06 +0000] "GET /info HTTP/1.1" 200 320 "-" "python-requests/2.28.1"
INFO:ddapm_test_agent.agent:received trace for token None payload with 1 trace chunks
INFO:ddapm_test_agent.agent:Chunk 0
[operation]
INFO:ddapm_test_agent.agent:end of payload ----------------------------------------
INFO:aiohttp.access:172.18.0.2 [05/Oct/2022:19:07:06 +0000] "PUT /v0.4/traces HTTP/1.1" 200 180 "-" "-"
INFO:aiohttp.access:172.18.0.1 [05/Oct/2022:19:07:06 +0000] "GET /test/session/traces HTTP/1.1" 200 567 "-" "python-requests/2.28.1"



$ /usr/local/bin/docker kill ddapm-test-agent
ddapm-test-agent
-------------------------------------------------------------- Captured Python Library Output teardown ---------------------------------------------------------------
running '/usr/local/bin/docker build --progress=plain -t python-test-library -f /Users/kverhoog/dev/system-tests/parametric/apps/python/Dockerfile .' in '..'
#1 [internal] load build definition from Dockerfile
#1 sha256:37eff0402e22ad6468ee119bdba88793f1f1bae1e65b89f0e9e82576a80d1c14
#1 transferring dockerfile: 219B done
#1 DONE 0.0s

#2 [internal] load .dockerignore
#2 sha256:5df1bd2b7ef8551439517439675a9f9dd546e1a9d6a1dfa463b61d88b3f3aa64
#2 transferring context: 34B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/datadog/dd-trace-py:buster
#3 sha256:9b261832d94b8626c985b85cb899d81904df8d48e4c2bd1ad0ac7ecff069f45b
#3 DONE 0.9s

#4 [1/5] FROM docker.io/datadog/dd-trace-py:buster@sha256:914821cb1b53e78422f168cb21feb7c37182cbd0934bdc83eaf094ab9ebd52ec
#4 sha256:81278eec7821f565155c2cf91c1c56df94f7cf54cf0c07e1bcb019a4435de129
#4 DONE 0.0s

#5 [2/5] WORKDIR /client
#5 sha256:8359265f1a90812db8c347055ef8f4d0075af8602ed82e302b326b71b0a127c8
#5 CACHED

#6 [3/5] RUN pyenv global 3.9.11
#6 sha256:ed9e913dd200f2db1ccab629f90fb97fc1c66fb019fbeb223a69832430eb8491
#6 CACHED

#7 [4/5] RUN python3.9 -m pip install grpcio==1.46.3 grpcio-tools==1.46.3
#7 sha256:562719396e10408c4a92fe825f210b4e1be09c84579af8c78aa536b03667f497
#7 CACHED

#8 [5/5] RUN python3.9 -m pip install ddtrace
#8 sha256:1ea48f708dfa84a8a9dbcb3951772bf95bec068f45defb29c96bfe2e1301893d
#8 CACHED

#9 exporting to image
#9 sha256:e8c613e07b0b7ff33893b694f7759a10d42e180f2b4dc349fb57dc6b71dcab00
#9 exporting layers done
#9 writing image sha256:95b4c2166ddba89028846eafd0bd2e3768c807581656701475bfc1b5fc21d929 done
#9 naming to docker.io/library/python-test-library done
#9 DONE 0.0s
$ /usr/local/bin/docker run -d --rm --name=python-test-library --network=apm_shared_tests_network -e DD_TRACE_DEBUG=true -e DD_TRACE_AGENT_URL=http://ddapm-test-agent:8126 -e DD_AGENT_HOST=ddapm-test-agent -e DD_TRACE_AGENT_PORT=8126 -e DD_ENV=prod -v /Users/kverhoog/dev/system-tests/parametric/apps/python/apm_test_client:/client/apm_test_client -p 50051:50051 python-test-library python3.9 -m apm_test_client
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
0db8763f124d41fa4f56162b98f6a9aaf8dc2305c03fb3b8d2694a7423e2fc5b
DEBUG:ddtrace.tracer:finishing span name='operation' id=8060667689374339746 trace_id=13842595608873482240 parent_id=None service='' resource='operation' type='' start=1664996826.5830398 end=1664996826.5929034 duration=0.009863583 error=0 tags={'_dd.p.dm': '-0', 'env': 'prod', 'runtime-id': '873c8516914e466d88a95dbb716fe54a'} metrics={'_dd.agent_psr': 1.0, '_dd.top_level': 1, '_dd.tracer_kr': 1.0, '_sampling_priority_v1': 1, 'system.pid': 1} (enabled:True)
DEBUG:ddtrace.internal.writer:creating new agent connection to http://ddapm-test-agent:8126 with timeout 2
DEBUG:ddtrace.internal.writer:sent 293B in 0.02114s to http://ddapm-test-agent:8126/v0.4/traces



$ /usr/local/bin/docker kill python-test-library
python-test-library
====================================================================== short test summary info =======================================================================
FAILED test_tracer.py::test_tracer_env_environment_variable[python-library_env0] - AssertionError: assert 1 == 2
================================================================== 1 failed, 2 deselected in 6.94s ===================================================================          
```


## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
