### PR TITLE
Add Java library later in the Docker build process

### DIFF
--- a/utils/build/docker/java/jersey-grizzly2.Dockerfile
+++ b/utils/build/docker/java/jersey-grizzly2.Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 COPY ./utils/build/docker/java/jersey-grizzly2/pom.xml .
 RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 
 COPY ./utils/build/docker/java/jersey-grizzly2/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
+
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh
 
 FROM adoptopenjdk:11-jre-hotspot
 

--- a/utils/build/docker/java/ratpack.Dockerfile
+++ b/utils/build/docker/java/ratpack.Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 COPY ./utils/build/docker/java/ratpack/pom.xml .
 RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 
 COPY ./utils/build/docker/java/ratpack/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
+
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh
 
 FROM adoptopenjdk:11-jre-hotspot
 

--- a/utils/build/docker/java/resteasy-netty3.Dockerfile
+++ b/utils/build/docker/java/resteasy-netty3.Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 COPY ./utils/build/docker/java/resteasy-netty3/pom.xml .
 RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 
 COPY ./utils/build/docker/java/resteasy-netty3/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
+
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh
 
 FROM adoptopenjdk:11-jre-hotspot
 

--- a/utils/build/docker/java/spring-boot-jetty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-jetty.Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 COPY ./utils/build/docker/java/spring-boot/pom.xml .
 RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Pjetty -B dependency:go-offline
 
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven -Pjetty package
+
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh
 
 FROM adoptopenjdk:11-jre-hotspot
 

--- a/utils/build/docker/java/spring-boot-undertow.Dockerfile
+++ b/utils/build/docker/java/spring-boot-undertow.Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 COPY ./utils/build/docker/java/spring-boot/pom.xml .
 RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Pundertow -B dependency:go-offline
 
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven -Pundertow package
+
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh
 
 FROM adoptopenjdk:11-jre-hotspot
 

--- a/utils/build/docker/java/spring-boot.Dockerfile
+++ b/utils/build/docker/java/spring-boot.Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 COPY ./utils/build/docker/java/spring-boot/pom.xml .
 RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
+
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh
 
 FROM adoptopenjdk:11-jre-hotspot
 

--- a/utils/build/docker/java/vertx3.Dockerfile
+++ b/utils/build/docker/java/vertx3.Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 COPY ./utils/build/docker/java/vertx3/pom.xml .
 RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 
 COPY ./utils/build/docker/java/vertx3/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
+
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh
 
 FROM adoptopenjdk:11-jre-hotspot
 


### PR DESCRIPTION
## Description

Building a Java application is slow (fetching dependencies, compiling), while adding the library jar to the Docker image is fast, and possibly more frequent.

By moving the step of adding the library jar later in the process, we can still reuse most of the Docker build cache after changing to a different library jar, which is particularly useful for local testing.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
