### PR TITLE
parametric: add env var to configure Node.js dd-trace module version

### DIFF
--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -104,6 +104,7 @@ def node_library_factory(env: Dict[str, str]) -> APMLibraryTestServer:
     nodejs_appdir = os.path.join("apps", "nodejs")
     nodejs_dir = os.path.join(os.path.dirname(__file__), nodejs_appdir)
     nodejs_reldir = os.path.join("parametric", nodejs_appdir)
+    node_module = os.getenv("NODEJS_DDTRACE_MODULE", "dd-trace")
     return APMLibraryTestServer(
         lang="nodejs",
         container_name="node-test-client",
@@ -115,6 +116,7 @@ COPY {nodejs_reldir}/package.json /client/
 COPY {nodejs_reldir}/package-lock.json /client/
 COPY {nodejs_reldir}/*.js /client/
 RUN npm install
+RUN npm install {node_module}
 """,
         container_cmd=["node", "server.js"],
         container_build_dir=nodejs_dir,


### PR DESCRIPTION
## Description

Adds the `NODEJS_DDTRACE_MODULE` env var to configure parametric tests from Node.js with a given package identifier. This corrersponds to: https://github.com/DataDog/dd-trace-js/pull/2442/files#diff-3f74be22ab2d868e3d9812082a1635cdf9938e2f1eb18bb3abf4a899fd7837f1R88.

## Check list

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
