### PR TITLE
chore(python): enable http.url standard tags tests for 1.6.0

### DIFF
--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -41,7 +41,9 @@ class Test_StandardTagsMethod(BaseTestCase):
         interfaces.library.add_span_tag_validation(request=r, tags=tags)
 
 
-@released(dotnet="2.13.0", golang="1.40.0", java="0.107.1", nodejs="3.0.0", php="0.76.0", python="?", ruby="?")
+@released(
+    dotnet="2.13.0", golang="1.40.0", java="0.107.1", nodejs="3.0.0", php="0.76.0", python="1.6.0rc1.dev", ruby="?"
+)
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2490990623/QueryString+-+Sensitive+Data+Obfuscation")
 @coverage.basic
 class Test_StandardTagsUrl(BaseTestCase):


### PR DESCRIPTION
## Description

Enables http.url standard tag tests for Python library version 1.6.0

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
