### PR TITLE
utils/interface/schemas: make 'products' optional for RC client schema

### DIFF
--- a/utils/interfaces/schemas/library/v0.7/config-request.json
+++ b/utils/interfaces/schemas/library/v0.7/config-request.json
@@ -4,7 +4,7 @@
   "required": ["client"],
   "properties": {
     "client": {
-      "required": ["id", "state", "is_tracer", "products", "client_tracer"],
+      "required": ["id", "state", "is_tracer", "client_tracer"],
       "properties": {
         "id": { "$ref": "#/definitions/non-empty-string" },
         "is_tracer": {


### PR DESCRIPTION
## Description

Make the products field optional for the remote configuration client interface validation.
Some clients may not subscribe to any product and can thus omit this field.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
