### PR TITLE
parametric: output docker build logs if command fails

### DIFF
--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -526,16 +526,18 @@ def test_server(
     ]
     test_server_log_file.write("running %r in %r\n" % (" ".join(cmd), root_path))
     test_server_log_file.flush()
-    subprocess.run(
+    p = subprocess.run(
         cmd,
         cwd=root_path,
-        check=True,
         text=True,
         input=apm_test_server.container_img,
         stdout=test_server_log_file,
         stderr=test_server_log_file,
         env={"DOCKER_SCAN_SUGGEST": "false",},  # Docker outputs an annoying synk message on every build
     )
+    if p.returncode != 0:
+        test_server_log_file.seek(0)
+        pytest.fail("".join(test_server_log_file.readlines()), pytrace=False)
 
     env = {
         "DD_TRACE_DEBUG": "true",


### PR DESCRIPTION
Before, no output would be displayed if the docker build command failed for a container

![image](https://user-images.githubusercontent.com/6321485/197057383-a026b5bc-01a5-4673-8922-24305f2327c8.png)

this is fixed by outputting the output so far 

<img width="1917" alt="image" src="https://user-images.githubusercontent.com/6321485/197057610-cfd29e49-c43d-4172-b9ab-5e7b6db6121f.png">
