### PR TITLE
Enable XPASSED tests detected in java@0.113.0

### DIFF
--- a/scenarios/appsec/test_conf.py
+++ b/scenarios/appsec/test_conf.py
@@ -35,7 +35,7 @@ class Test_ConfigurationVariables(BaseTestCase):
         r = self.weblog_get("/waf", headers={"attack": "dedicated-value-for-testing-purpose"})
         interfaces.library.assert_waf_attack(r, pattern="dedicated-value-for-testing-purpose")
 
-    @missing_feature(library="java", reason="request is reported")
+    @missing_feature(context.library < "java@0.113.0", reason="request is reported")
     def test_waf_timeout(self):
         """ test DD_APPSEC_WAF_TIMEOUT = low value """
         long_payload = "?" + "&".join(f"{k}={v}" for k, v in ((f"key_{i}", f"value{i}") for i in range(1000)))

--- a/tests/appsec/iast/test_iast.py
+++ b/tests/appsec/iast/test_iast.py
@@ -9,7 +9,7 @@ from utils import BaseTestCase, interfaces, context, missing_feature, coverage, 
 @released(
     dotnet="?",
     golang="?",
-    java={"spring-boot": "0.108.0", "spring-boot-jetty": "0.109.0", "*": "?"},
+    java={"spring-boot": "0.108.0", "spring-boot-jetty": "0.108.0", "*": "?"},
     nodejs={"express4": "4.0.0pre0", "*": "?"},
     php_appsec="?",
     python="?",
@@ -26,9 +26,6 @@ class Test_Iast(BaseTestCase):
     else:
         EXPECTED_LOCATION = ""  # (TBD)
 
-    @missing_feature(
-        library="java", reason="Need to be implement deduplicate vulnerability hashes and sha1 algorithm detection"
-    )
     def test_insecure_hash_remove_duplicates(self):
         """If one line is vulnerable and it is executed multiple times (for instance in a loop) in a request,
         we will report only one vulnerability"""

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -4,7 +4,7 @@
 
 import pytest
 from tests.constants import PYTHON_RELEASE_PUBLIC_BETA, PYTHON_RELEASE_GA_1_1
-from utils import BaseTestCase, bug, context, coverage, interfaces, irrelevant, released, rfc
+from utils import BaseTestCase, bug, context, coverage, interfaces, irrelevant, released, rfc, missing_feature
 
 if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
@@ -157,7 +157,7 @@ class Test_AppSecEventSpanTags(BaseTestCase):
 @released(
     golang="1.38.0",
     dotnet="2.7.0",
-    java="?",
+    java="0.113.0",
     nodejs="2.6.0",
     php_appsec="0.3.0",
     python=PYTHON_RELEASE_GA_1_1,
@@ -188,6 +188,7 @@ class Test_AppSecObfuscator(BaseTestCase):
         interfaces.library.assert_waf_attack(r, address="server.request.query")
         interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)
 
+    @missing_feature(library="java")
     @irrelevant(context.appsec_rules_version >= "1.2.7", reason="cookies were disabled for the time being")
     def test_appsec_obfuscator_cookies(self):
         """
@@ -213,6 +214,7 @@ class Test_AppSecObfuscator(BaseTestCase):
         interfaces.library.assert_waf_attack(r, address="server.request.cookies")
         interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)
 
+    @missing_feature(library="java")
     def test_appsec_obfuscator_value(self):
         """Obfuscation test of a matching rule parameter value containing a sensitive keyword."""
         # Validate that the AppSec event do not contain the following secret value.

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -355,7 +355,7 @@ class Test_PathParams(BaseTestCase):
 
 @released(golang="1.36.0", dotnet="?", java="0.96.0", nodejs="?", php_appsec="?", python="?", ruby="?")
 @irrelevant(context.library == "java" and context.weblog_variant != "spring-boot")
-@bug(weblog_variant="spring-boot", reason="APPSEC-5426")
+@bug(context.library < "java@0.109.0", weblog_variant="spring-boot", reason="APPSEC-5426")
 @coverage.basic
 class Test_gRPC(BaseTestCase):
     """Appsec supports address grpc.server.request.message"""

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -3,7 +3,6 @@ from utils import context, BaseTestCase, interfaces, missing_feature, bug, relea
 
 @released(dotnet="2.12.0", java="0.108.1")
 @missing_feature(library="cpp")
-@missing_feature(library="java")
 @missing_feature(library="ruby")
 @missing_feature(library="php")
 @missing_feature(library="golang", reason="Implemented but not merged in master")
@@ -17,6 +16,7 @@ class Test_Telemetry(BaseTestCase):
 
     app_started_count = 0
 
+    @missing_feature(library="java")
     def test_status_ok(self):
         """Test that telemetry requests are successful"""
 
@@ -50,6 +50,7 @@ class Test_Telemetry(BaseTestCase):
         )
 
     @missing_feature(library="python")
+    @missing_feature(library="java")
     def test_seq_id(self):
         """Test that messages are sent sequentially"""
         interfaces.library.assert_seq_ids_are_roughly_sequential()
@@ -65,6 +66,7 @@ class Test_Telemetry(BaseTestCase):
         interfaces.library.add_telemetry_validation(validator=validator)
 
     @missing_feature(library="python")
+    @missing_feature(library="java")
     def test_app_started_sent_only_once(self):
         """Request type app-started is not sent twice"""
 


### PR DESCRIPTION
## Description

We have detected some XPASSED test in java@0.113.0

**Scenarios:** Default, UDS
**Weblog variant:** spring-boot, spring-boot-jetty
**Test:** tests/appsec/iast/test_iast.py::Test_Iast::test_insecure_hash_remove_duplicates

**Scenarios:** Default, UDS
**Weblog variant:** spring-boot, spring-boot-jetty, jersey-grizzly2, resteasy-netty3, ratpack, vertx3
**Tests:** 

- tests/test_telemetry.py::Test_Telemetry::test_app_started
- tests/test_telemetry.py::Test_Telemetry::test_proxy_forwarding 
- tests/test_telemetry.py::Test_Telemetry::test_telemetry_messages_valid
- tests/test_telemetry.py::Test_Telemetry::test_telemetry_proxy_enrichment
- tests/appsec/test_traces.py::Test_AppSecObfuscator::test_appsec_obfuscator_key

**Scenarios:** Default, UDS
**Weblog variant:** spring-boot
**Test:** tests/appsec/waf/test_addresses.py::Test_gRPC::test_basic

**Scenarios:** APPSEC_LOW_WAF_TIMEOUT
**Weblog variant:** spring-boot, spring-boot-jetty, jersey-grizzly2, resteasy-netty3, ratpack, vertx3
**Test:** scenarios/appsec/test_conf.py::Test_ConfigurationVariables::test_waf_timeout



## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
