### PR TITLE
Enable telemetry XPASSED tests detected in java@0.113.0

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -16,7 +16,6 @@ class Test_Telemetry(BaseTestCase):
 
     app_started_count = 0
 
-    @missing_feature(library="java")
     def test_status_ok(self):
         """Test that telemetry requests are successful"""
 
@@ -50,7 +49,6 @@ class Test_Telemetry(BaseTestCase):
         )
 
     @missing_feature(library="python")
-    @missing_feature(library="java")
     def test_seq_id(self):
         """Test that messages are sent sequentially"""
         interfaces.library.assert_seq_ids_are_roughly_sequential()
@@ -66,7 +64,6 @@ class Test_Telemetry(BaseTestCase):
         interfaces.library.add_telemetry_validation(validator=validator)
 
     @missing_feature(library="python")
-    @missing_feature(library="java")
     def test_app_started_sent_only_once(self):
         """Request type app-started is not sent twice"""
 


### PR DESCRIPTION
## Description

We have detected some XPASSED test in java@0.113.0

Scenarios: Default, UDS
Weblog variant: spring-boot, spring-boot-jetty, jersey-grizzly2, resteasy-netty3, ratpack, vertx3
Tests:

- tests/test_telemetry.py::Test_Telemetry::test_status_ok
- tests/test_telemetry.py::Test_Telemetry::test_app_started_sent_only_once
- tests/test_telemetry.py::Test_Telemetry::test_seq_id

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
