### PR TITLE
Revert skipped obfuscator tests on PHP

### DIFF
--- a/scenarios/appsec/test_traces.py
+++ b/scenarios/appsec/test_traces.py
@@ -5,7 +5,7 @@
 import pytest
 
 from tests.constants import PYTHON_RELEASE_GA_1_1
-from utils import BaseTestCase, context, interfaces, released, rfc, bug
+from utils import BaseTestCase, context, interfaces, released, rfc
 
 if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
@@ -17,7 +17,6 @@ if context.library == "cpp":
 class Test_AppSecObfuscator(BaseTestCase):
     """AppSec obfuscates sensitive data."""
 
-    @bug(context.php_appsec == "0.4.0")
     def test_appsec_obfuscator_key(self):
         """General obfuscation test of several attacks on several rule addresses."""
         # Validate that the AppSec events do not contain the following secret value.

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -167,7 +167,6 @@ class Test_AppSecEventSpanTags(BaseTestCase):
 class Test_AppSecObfuscator(BaseTestCase):
     """AppSec obfuscates sensitive data."""
 
-    @bug(context.php_appsec == "0.4.0")
     def test_appsec_obfuscator_key(self):
         """General obfuscation test of several attacks on several rule addresses."""
         # Validate that the AppSec events do not contain the following secret value.
@@ -216,7 +215,6 @@ class Test_AppSecObfuscator(BaseTestCase):
         interfaces.library.add_appsec_validation(r, validate_appsec_span_tags)
 
     @missing_feature(library="java")
-    @bug(context.php_appsec == "0.4.0")
     def test_appsec_obfuscator_value(self):
         """Obfuscation test of a matching rule parameter value containing a sensitive keyword."""
         # Validate that the AppSec event do not contain the following secret value.


### PR DESCRIPTION
## Description

Reenable obfuscator tests on PHP.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
