### PR TITLE
Add OpenLiberty springboot app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,9 @@ jobs:
             weblog-variant: spring-boot-jetty
             version: prod
           - library: java
+            weblog-variant: spring-boot-openliberty
+            version: prod
+          - library: java
             weblog-variant: jersey-grizzly2
             version: prod
           - library: java

--- a/tests/appsec/iast/test_iast.py
+++ b/tests/appsec/iast/test_iast.py
@@ -9,7 +9,7 @@ from utils import BaseTestCase, interfaces, context, missing_feature, coverage, 
 @released(
     dotnet="?",
     golang="?",
-    java={"spring-boot": "0.108.0", "spring-boot-jetty": "0.108.0", "*": "?"},
+    java={"spring-boot": "0.108.0", "spring-boot-jetty": "0.108.0", "spring-boot-openliberty": "0.108.0", "*": "?"},
     nodejs={"express4": "3.6.0", "*": "?"},
     php_appsec="?",
     python="?",

--- a/tests/appsec/test_reports.py
+++ b/tests/appsec/test_reports.py
@@ -36,9 +36,14 @@ if context.library == "cpp":
 class Test_StatusCode(BaseTestCase):
     """ Appsec reports good status code """
 
+    @bug(
+        library="java",
+        weblog_variant="spring-boot-openliberty",
+        reason="https://datadoghq.atlassian.net/browse/APPSEC-6583",
+    )
     def test_basic(self):
         r = self.weblog_get("/path_that_doesn't_exists/", headers={"User-Agent": "Arachni/v1"})
-        assert r.status_code == 404
+        interfaces.library.add_assertion(r.status_code == 404)
         interfaces.library.assert_waf_attack(r)
 
         def check_http_code_legacy(event):

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -105,6 +105,11 @@ class Test_AppSecEventSpanTags(BaseTestCase):
 
     @bug(context.library < f"python@{PYTHON_RELEASE_GA_1_1}", reason="a PR was not included in the release")
     @irrelevant(context.library not in ["golang", "nodejs", "java", "dotnet"], reason="test")
+    @bug(
+        library="java",
+        weblog_variant="spring-boot-openliberty",
+        reason="https://datadoghq.atlassian.net/browse/APPSEC-6583",
+    )
     def test_header_collection(self):
         """
         AppSec should collect some headers for http.request and http.response and store them in span tags.

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -226,6 +226,11 @@ class Test_BodyUrlEncoded(BaseTestCase):
         r = self.weblog_post("/waf", data={'<vmlframe src="xss">': "value"})
         interfaces.library.assert_waf_attack(r, pattern="x", address="x")
 
+    @bug(
+        library="java",
+        weblog_variant="spring-boot-openliberty",
+        reason="https://datadoghq.atlassian.net/browse/APPSEC-6583",
+    )
     def test_body_value(self):
         """AppSec detects attacks in URL encoded body values"""
         r = self.weblog_post("/waf", data={"value": '<vmlframe src="xss">'})
@@ -318,6 +323,11 @@ class Test_ClientIP(BaseTestCase):
 class Test_ResponseStatus(BaseTestCase):
     """Appsec supports values on server.response.status"""
 
+    @bug(
+        library="java",
+        weblog_variant="spring-boot-openliberty",
+        reason="https://datadoghq.atlassian.net/browse/APPSEC-6583",
+    )
     def test_basic(self):
         """AppSec reports 404 responses"""
         r = self.weblog_get("/mysql")

--- a/tests/appsec/waf/test_miscs.py
+++ b/tests/appsec/waf/test_miscs.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from utils import context, BaseTestCase, interfaces, released, bug, coverage, missing_feature
+from utils import context, BaseTestCase, interfaces, released, bug, coverage, missing_feature, irrelevant
 from .utils import rules
 
 
@@ -19,11 +19,16 @@ if context.library == "cpp":
 class Test_404(BaseTestCase):
     """ Appsec WAF misc tests """
 
+    @bug(
+        library="java",
+        weblog_variant="spring-boot-openliberty",
+        reason="https://datadoghq.atlassian.net/browse/APPSEC-6583",
+    )
     def test_404(self):
         """ AppSec WAF catches attacks, even on 404"""
 
         r = self.weblog_get("/path_that_doesn't_exists/", headers={"User-Agent": "Arachni/v1"})
-        assert r.status_code == 404
+        interfaces.library.add_assertion(r.status_code == 404)
         interfaces.library.assert_waf_attack(
             r,
             rule=rules.security_scanner.ua0_600_12x,

--- a/tests/appsec/waf/test_rules.py
+++ b/tests/appsec/waf/test_rules.py
@@ -348,6 +348,11 @@ class Test_DiscoveryScan(BaseTestCase):
     """AppSec WAF Tests on Discovery Scan rules"""
 
     @bug(context.library < "java@0.98.0" and context.weblog_variant == "spring-boot-undertow")
+    @bug(
+        library="java",
+        weblog_variant="spring-boot-openliberty",
+        reason="https://datadoghq.atlassian.net/browse/APPSEC-6583",
+    )
     def test_security_scan(self):
         """AppSec WAF catches Discovery scan"""
         r = self.weblog_get("/etc/")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -48,6 +48,11 @@ class Test_Telemetry(BaseTestCase):
         )
 
     @missing_feature(library="python")
+    @bug(
+        library="java",
+        weblog_variant="spring-boot-openliberty",
+        reason="https://datadoghq.atlassian.net/browse/APPSEC-6583",
+    )
     def test_seq_id(self):
         """Test that messages are sent sequentially"""
         interfaces.library.assert_seq_ids_are_roughly_sequential()
@@ -63,6 +68,11 @@ class Test_Telemetry(BaseTestCase):
         interfaces.library.add_telemetry_validation(validator=validator)
 
     @missing_feature(library="python")
+    @bug(
+        library="java",
+        weblog_variant="spring-boot-openliberty",
+        reason="https://datadoghq.atlassian.net/browse/APPSEC-6583",
+    )
     def test_app_started_sent_only_once(self):
         """Request type app-started is not sent twice"""
 
@@ -95,6 +105,11 @@ class Test_Telemetry(BaseTestCase):
             Bug in the telemetry agent proxy, that can't reopen connections if they're closed by timeout
             https://github.com/DataDog/datadog-agent/pull/11880
         """,
+    )
+    @bug(
+        library="java",
+        weblog_variant="spring-boot-openliberty",
+        reason="https://datadoghq.atlassian.net/browse/APPSEC-6583",
     )
     def test_proxy_forwarding(self):
         """Test that all telemetry requests sent by library are forwarded correctly by the agent"""

--- a/utils/build/docker/java/spring-boot-openliberty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-openliberty.Dockerfile
@@ -1,0 +1,31 @@
+FROM maven:3.8-jdk-8 as build
+
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+WORKDIR /app
+
+COPY ./utils/build/docker/java/spring-boot/pom.xml .
+
+COPY ./utils/build/docker/java/spring-boot/src ./src
+RUN mvn -Popenliberty package
+
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh
+
+FROM adoptopenjdk:11-jre-hotspot
+
+WORKDIR /app
+COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=build /app/target/myproject-0.0.1-SNAPSHOT.jar .
+COPY --from=build /dd-tracer/dd-java-agent.jar .
+
+ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
+
+ENV JAVA_TOOL_OPTIONS='-javaagent:/app/dd-java-agent.jar -Ddd.remote_config.enabled=true -Ddd.jmxfetch.enabled=false'
+
+RUN echo "#!/bin/bash\njava -Xmx362m -jar /app/myproject-0.0.1-SNAPSHOT.jar" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/java/spring-boot/pom.xml
+++ b/utils/build/docker/java/spring-boot/pom.xml
@@ -155,6 +155,42 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>openliberty</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.openliberty.tools</groupId>
+                        <artifactId>liberty-maven-plugin</artifactId>
+                        <version>3.5.1</version>
+                        <configuration>
+                            <appsDirectory>apps</appsDirectory>
+                            <installAppPackages>spring-boot-project</installAppPackages>
+                            <include>minify,runnable</include>
+                            <packageName>myproject-0.0.1-SNAPSHOT</packageName>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>package-server</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>create</goal>
+                                    <goal>install-feature</goal>
+                                    <goal>deploy</goal>
+                                    <goal>package</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/iast/utils/CryptoExamples.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/iast/utils/CryptoExamples.java
@@ -5,8 +5,9 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
-import javax.crypto.spec.SecretKeySpec;
+import javax.crypto.SecretKey;
 import javax.xml.bind.DatatypeConverter;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
@@ -69,11 +70,10 @@ public class CryptoExamples {
     }
 
     private static String doCipher(final String password, final String algorithm) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
-        String Key = "key";
-        byte[] KeyData = Key.getBytes();
-        SecretKeySpec KS = new SecretKeySpec(KeyData, algorithm);
+        KeyGenerator keygenerator = KeyGenerator.getInstance(algorithm);
+        SecretKey key = keygenerator.generateKey();
         Cipher cipher = Cipher.getInstance(algorithm);
-        cipher.init(Cipher.ENCRYPT_MODE, KS);
+        cipher.init(Cipher.ENCRYPT_MODE, key);
         return new String(cipher.doFinal(password.getBytes()));
     }
 

--- a/utils/build/docker/java/spring-boot/src/main/liberty/config/server.xml
+++ b/utils/build/docker/java/spring-boot/src/main/liberty/config/server.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="demo-server">
+
+  <featureManager>
+    <feature>servlet-4.0</feature>
+    <feature>springBoot-2.0</feature>
+  </featureManager>
+
+  <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="7777" httpsPort="9443" />
+  <springBootApplication id="myproject"
+                         location="thin-myproject-0.0.1-SNAPSHOT.jar"
+                         name="myproject" />
+</server>


### PR DESCRIPTION
## Description

 - Add weblog-variant: spring-boot-openliberty
 - Fix CryptoExamples doCypher method
 - Marked as bug:
 
> tests/test_telemetry.py::Test_Telemetry::test_app_started_sent_only_once
> tests/test_telemetry.py::Test_Telemetry::test_seq_id
> tests/appsec/test_traces.py::Test_AppSecEventSpanTags::test_header_collection
> tests/appsec/waf/test_addresses.py::Test_BodyUrlEncoded::test_body_value
> tests/appsec/waf/test_addresses.py::Test_ResponseStatus::test_basic
> tests/appsec/waf/test_rules.py::Test_DiscoveryScan::test_security_scan
>tests.appsec.waf.test_miscs.Test_404.test_404
>tests.appsec.test_reports.Test_StatusCode.test_basic

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
