### PR TITLE
parametric: don't `go get` the latest tagged version in the docker build

### DIFF
--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -147,9 +147,7 @@ FROM golang:1.18
 WORKDIR /client
 COPY {go_reldir}/go.mod /client
 COPY {go_reldir}/go.sum /client
-RUN go mod download
 COPY {go_reldir} /client
-RUN go get gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
 RUN go install
 """,
         container_cmd=["main"],


### PR DESCRIPTION
## Description

Calling `go get` in the docker build is going to get the latest tagged version and use it, which is why tests were failing locally. This won't be a problem once the latest tagged version includes the bug fix, but it currently doesn't.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
