### PR TITLE
Enable IP blocking tests for Java with Jetty and Undertow

### DIFF
--- a/scenarios/appsec/test_ip_blocking.py
+++ b/scenarios/appsec/test_ip_blocking.py
@@ -13,7 +13,7 @@ with open("scenarios/appsec/rc_expected_requests_asm_data.json", encoding="utf-8
 
 @rfc("https://docs.google.com/document/d/1GUd8p7HBp9gP0a6PZmDY26dpGrS1Ztef9OYdbK3Vq3M/edit")
 @released(cpp="?", dotnet="2.16.0", php="?", python="?", ruby="?", nodejs="?", golang="?")
-@released(java={"spring-boot": "0.110.0", "*": "?"})
+@released(java={"spring-boot": "0.110.0", "sprint-boot-jetty": "0.111.0", "spring-boot-undertow": "0.111.0", "*": "?"})
 @coverage.basic
 class Test_AppSecIPBlocking(BaseTestCase):
     """A library should block requests from blocked IP addresses."""

--- a/utils/build/docker/java/spring-boot-jetty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-jetty.Dockerfile
@@ -25,6 +25,6 @@ COPY --from=build /dd-tracer/dd-java-agent.jar .
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 
-RUN echo "#!/bin/bash\njava -Xmx362m -javaagent:/app/dd-java-agent.jar -jar /app/myproject-0.0.1-SNAPSHOT.jar --server.port=7777" > app.sh
+RUN echo "#!/bin/bash\njava -Xmx362m -javaagent:/app/dd-java-agent.jar -Ddd.remote_config.enabled=true -jar /app/myproject-0.0.1-SNAPSHOT.jar --server.port=7777" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/java/spring-boot-undertow.Dockerfile
+++ b/utils/build/docker/java/spring-boot-undertow.Dockerfile
@@ -25,6 +25,6 @@ COPY --from=build /dd-tracer/dd-java-agent.jar .
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 
-RUN echo "#!/bin/bash\njava -Xmx362m -javaagent:/app/dd-java-agent.jar -jar /app/myproject-0.0.1-SNAPSHOT.jar --server.port=7777" > app.sh
+RUN echo "#!/bin/bash\njava -Xmx362m -javaagent:/app/dd-java-agent.jar -Ddd.remote_config.enabled=true -jar /app/myproject-0.0.1-SNAPSHOT.jar --server.port=7777" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]


### PR DESCRIPTION
## Description

This requires enabling remote config for these two variants. These flags will be removed once remote config is enabled by default.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
