### PR TITLE
Enable http.client_ip test on ASM disabled

### DIFF
--- a/scenarios/appsec/test_client_ip.py
+++ b/scenarios/appsec/test_client_ip.py
@@ -11,7 +11,7 @@ if context.library == "cpp":
 
 
 @released(dotnet="?", golang="?", java="0.114.0")
-@released(nodejs="3.6.0", php="?", python="?", ruby="?")
+@released(nodejs="3.6.0", php="0.81.0", python="?", ruby="?")
 @coverage.basic
 class Test_StandardTagsClientIp(BaseTestCase):
     """Tests to verify that libraries annotate spans with correct http.client_ip tags"""


### PR DESCRIPTION
## Description

Enable http.client_ip test when ASM is disabled on the release version of the tracer.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
