### PR TITLE
PHP reenable tests affected by duplicate traces

### DIFF
--- a/tests/appsec/test_identify.py
+++ b/tests/appsec/test_identify.py
@@ -18,7 +18,6 @@ if context.library == "cpp":
 class Test_Basic(BaseTestCase):
     """Basic tests for Identify SDK for AppSec"""
 
-    @bug(context.library >= "php@1.0.0", reason="Duplicated root span, october 8th 2022")
     def test_identify_tags_with_attack(self):
         # Send a random attack on the identify endpoint - should not affect the usr.id tag
 

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -28,7 +28,6 @@ class Test_RetainTraces(BaseTestCase):
         get("/waf", params={"key": "\n :"})  # rules.http_protocol_violation.crs_921_160
         get("/waf", headers={"random-key": "acunetix-user-agreement"})  # rules.security_scanner.crs_913_110
 
-    @bug(context.library >= "php@1.0.0", reason="Duplicated root span, october 8th 2022")
     def test_appsec_event_span_tags(self):
         """
         Spans with AppSec events should have the general AppSec span tags, along with the appsec.event and
@@ -73,7 +72,6 @@ class Test_AppSecEventSpanTags(BaseTestCase):
         get("/waf", params={"key": "\n :"})  # rules.http_protocol_violation.crs_921_160
         get("/waf", headers={"random-key": "acunetix-user-agreement"})  # rules.security_scanner.crs_913_110
 
-    @bug(context.library >= "php@1.0.0", reason="Duplicated root span, october 8th 2022")
     def test_custom_span_tags(self):
         """AppSec should store in all APM spans some tags when enabled."""
 
@@ -270,7 +268,6 @@ class Test_AppSecObfuscator(BaseTestCase):
 class Test_CollectRespondHeaders(BaseTestCase):
     """AppSec should collect some headers for http.response and store them in span tags."""
 
-    @bug(context.library >= "php@1.0.0", reason="Duplicated root span, october 8th 2022")
     def test_header_collection(self):
         def assertHeaderInSpanMeta(span, header):
             if header not in span["meta"]:

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -29,7 +29,6 @@ class Test_Monitoring(BaseTestCase):
 
     expected_version_regex = r"[0-9]+\.[0-9]+\.[0-9]+"
 
-    @bug(context.library >= "php@1.0.0", reason="Duplicated root span, october 8th 2022")
     def test_waf_monitoring(self):
         """WAF monitoring span tags and metrics are expected to be sent on each request"""
 

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -49,7 +49,6 @@ class Test_Basic(BaseTestCase):
         reason="DD_TRACE_HEADER_TAGS is not working properly, can't correlate request to trace",
     )
     @bug(library="ruby", reason="DD_TRACE_HEADER_TAGS is not working properly, can't correlate request to trace")
-    @bug(context.library >= "php@1.0.0", reason="Duplicated root span, october 8th 2022")
     def test_identify_tags(self):
         # Send a request to the identify endpoint
         r = self.weblog_get("/identify")
@@ -57,8 +56,6 @@ class Test_Basic(BaseTestCase):
             r, validate_identify_tags(["id", "name", "email", "session_id", "role", "scope"])
         )
 
-    @bug(context.library >= "php@1.0.0", reason="Under investigation")
-    @bug(context.library >= "php@1.0.0", reason="Duplicated root span, october 8th 2022")
     def test_identify_tags_with_attack(self):
         # Send a random attack on the identify endpoint - should not affect the usr.id tag
         r = self.weblog_get("/identify", headers={"User-Agent": "Arachni/v1"})
@@ -73,7 +70,6 @@ class Test_Basic(BaseTestCase):
 class Test_Propagate(BaseTestCase):
     """Propagation tests for Identify SDK"""
 
-    @bug(context.library >= "php@1.0.0", reason="Duplicated root span, october 8th 2022")
     def test_identify_tags_outgoing(self):
         tagTable = {"_dd.p.usr.id": "dXNyLmlk"}
 


### PR DESCRIPTION
## Description

Reenable PHP tests disabled due to duplicate traces.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
