### PR TITLE
Disable ip blocking tests with custom ruleset

### DIFF
--- a/scenarios/appsec/test_ip_blocking.py
+++ b/scenarios/appsec/test_ip_blocking.py
@@ -4,7 +4,7 @@
 import json
 
 from scenarios.remote_config.test_remote_configuration import rc_check_request
-from utils import BaseTestCase, context, coverage, interfaces, released, rfc, bug
+from utils import BaseTestCase, context, coverage, interfaces, released, rfc, bug, irrelevant
 from utils.tools import logger
 
 with open("scenarios/appsec/rc_expected_requests_asm_data.json", encoding="utf-8") as f:
@@ -14,7 +14,7 @@ with open("scenarios/appsec/rc_expected_requests_asm_data.json", encoding="utf-8
 @rfc("https://docs.google.com/document/d/1GUd8p7HBp9gP0a6PZmDY26dpGrS1Ztef9OYdbK3Vq3M/edit")
 @released(cpp="?", dotnet="2.16.0", php="?", python="?", ruby="?", nodejs="?", golang="?")
 @released(java={"spring-boot": "0.110.0", "sprint-boot-jetty": "0.111.0", "spring-boot-undertow": "0.111.0", "*": "?"})
-@bug(context.library >= "java@0.114.0" and context.appsec_rules_version >= "1.4.2")
+@irrelevant(context.appsec_rules_file == "")
 @coverage.basic
 class Test_AppSecIPBlocking(BaseTestCase):
     """A library should block requests from blocked IP addresses."""
@@ -36,6 +36,7 @@ class Test_AppSecIPBlocking(BaseTestCase):
 
         interfaces.library.add_remote_configuration_validation(validator=validate)
 
+    @bug(context.library == "java@0.110.0", reason="default action not implemented")
     def test_blocked_ips(self):
         """test blocked ips are enforced"""
 


### PR DESCRIPTION
## Description

If DD_APPSEC_RULES is set, remote config subscriptions from appsec should not be made.

## Check list

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

