### PR TITLE
go: parse appsec rules version from rules.json

### DIFF
--- a/utils/build/docker/golang/install_ddtrace.sh
+++ b/utils/build/docker/golang/install_ddtrace.sh
@@ -25,7 +25,10 @@ echo $version > SYSTEM_TESTS_LIBRARY_VERSION
 touch SYSTEM_TESTS_LIBDDWAF_VERSION
 
 # Read the rule file version
-if [[ $(cat $mod_dir/internal/appsec/rule.go) =~ rules_version\\\":\\\"([[:digit:].-]+)\\\" ]]; then
+if [[ -f $mod_dir/internal/appsec/rules.json ]]; then
+    # Parse the appsec rules version string out of the inlined rules json
+    rules_version=$(jq -r .metadata.rules_version $mod_dir/internal/appsec/rules.json)
+elif [[ $(cat $mod_dir/internal/appsec/rule.go) =~ rules_version\\\":\\\"([[:digit:].-]+)\\\" ]]; then
     # Parse the appsec rules version string out of the inlined rules json
     rules_version="${BASH_REMATCH[1]}"
 else


### PR DESCRIPTION
## Description

Allow parsing the appsec rules version from dd-trace-go/internal/appsec/rules.json.
This will allow dd-trace-go to use go:embed to embed the default rule files, see https://github.com/DataDog/dd-trace-go/pull/1573. After https://github.com/DataDog/dd-trace-go/pull/1573 is merged we can do a follow-up PR to remove the old rules version parsing (we need to keep it as is for now to allow https://github.com/DataDog/dd-trace-go/pull/1573 to go in).

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
