### PR TITLE
go: install jq in Docker envs

### DIFF
--- a/utils/build/docker/golang/chi.Dockerfile
+++ b/utils/build/docker/golang/chi.Dockerfile
@@ -8,6 +8,7 @@ COPY utils/build/docker/golang/app /app
 
 WORKDIR /app
 
+RUN apt-get update && apt-get -y install jq
 RUN /binaries/install_ddtrace.sh
 ENV DD_TRACE_HEADER_TAGS='user-agent'
 

--- a/utils/build/docker/golang/echo.Dockerfile
+++ b/utils/build/docker/golang/echo.Dockerfile
@@ -8,6 +8,7 @@ COPY utils/build/docker/golang/app /app
 
 WORKDIR /app
 
+RUN apt-get update && apt-get -y install jq
 RUN /binaries/install_ddtrace.sh
 ENV DD_TRACE_HEADER_TAGS='user-agent'
 

--- a/utils/build/docker/golang/gin.Dockerfile
+++ b/utils/build/docker/golang/gin.Dockerfile
@@ -8,6 +8,7 @@ COPY utils/build/docker/golang/app /app
 
 WORKDIR /app
 
+RUN apt-get update && apt-get -y install jq
 RUN /binaries/install_ddtrace.sh
 ENV DD_TRACE_HEADER_TAGS='user-agent'
 

--- a/utils/build/docker/golang/gorilla.Dockerfile
+++ b/utils/build/docker/golang/gorilla.Dockerfile
@@ -8,6 +8,7 @@ COPY utils/build/docker/golang/app /app
 
 WORKDIR /app
 
+RUN apt-get update && apt-get -y install jq
 RUN /binaries/install_ddtrace.sh
 ENV DD_TRACE_HEADER_TAGS='user-agent'
 

--- a/utils/build/docker/golang/net-http.Dockerfile
+++ b/utils/build/docker/golang/net-http.Dockerfile
@@ -8,6 +8,7 @@ COPY utils/build/docker/golang/app /app
 
 WORKDIR /app
 
+RUN apt-get update && apt-get -y install jq
 RUN /binaries/install_ddtrace.sh
 ENV DD_TRACE_HEADER_TAGS='user-agent'
 


### PR DESCRIPTION
## Description

Make sure jq is available in the Go weblog docker containers (needed for rules version parsing).

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
