### PR TITLE
Fix issue when running single test due to missing docs

### DIFF
--- a/utils/scripts/junit_report.py
+++ b/utils/scripts/junit_report.py
@@ -32,7 +32,9 @@ def junit_modifyreport(
         search_class = words[0] + "::" + words[1]
 
         # Get doc/description for the test
-        test_doc = _docs[nodeid]
+        test_doc = None
+        if nodeid in _docs:
+            test_doc = _docs[nodeid]
 
         # Get rfc for the test
         test_rfc = None


### PR DESCRIPTION
## Description

When running a single test it was failing due to a missing entry in the docs dictionary:

```
runner           |   File "/app/conftest.py", line 440, in _pytest_junit_modifyreport
runner           |     junit_modifyreport(
runner           |   File "/app/utils/scripts/junit_report.py", line 35, in junit_modifyreport
runner           |     test_doc = _docs[nodeid]
runner           | KeyError: 'tests/appsec/iast/test_iast_sql_injection.py::TestIastSqlInjection::test_secure_sql'
```

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
