### PR TITLE
go: enable IP blocking test

### DIFF
--- a/tests/appsec/test_ip_blocking.py
+++ b/tests/appsec/test_ip_blocking.py
@@ -12,7 +12,7 @@ with open("tests/appsec/rc_expected_requests_asm_data.json", encoding="utf-8") a
 
 
 @rfc("https://docs.google.com/document/d/1GUd8p7HBp9gP0a6PZmDY26dpGrS1Ztef9OYdbK3Vq3M/edit")
-@released(cpp="?", dotnet="2.16.0", php="?", python="?", ruby="?", nodejs="?", golang="?")
+@released(cpp="?", dotnet="2.16.0", php="?", python="?", ruby="?", nodejs="?", golang="1.47.0")
 @released(
     java={
         "spring-boot": "0.110.0",

--- a/tests/appsec/test_ip_blocking.py
+++ b/tests/appsec/test_ip_blocking.py
@@ -24,6 +24,7 @@ with open("tests/appsec/rc_expected_requests_asm_data.json", encoding="utf-8") a
 )
 @irrelevant(context.appsec_rules_file == "")
 @bug(context.weblog_variant == "spring-boot-undertow" and context.appsec_rules_version == "1.4.2")
+@bug(context.weblog_variant == "uds-echo")
 @coverage.basic
 @scenario("APPSEC_IP_BLOCKING")
 class Test_AppSecIPBlocking:


### PR DESCRIPTION
## Description

- Enable ip blocking test for Go (except for uds-echo)

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
