### PR TITLE
Enable new IAST tests for java 1.1.0

### DIFF
--- a/tests/appsec/iast/test_iast_command_injection.py
+++ b/tests/appsec/iast/test_iast_command_injection.py
@@ -7,7 +7,14 @@ from utils import BaseTestCase, interfaces, context, missing_feature, coverage, 
 # Weblog are ok for nodejs/express4 and java/spring-boot
 @coverage.basic
 @released(
-    dotnet="?", golang="?", java="?", nodejs="?", php_appsec="?", python="?", ruby="?", cpp="?",
+    dotnet="?",
+    golang="?",
+    java={"spring-boot": "1.1.0", "spring-boot-jetty": "1.1.0", "spring-boot-openliberty": "1.1.0", "*": "?"},
+    nodejs="?",
+    php_appsec="?",
+    python="?",
+    ruby="?",
+    cpp="?",
 )
 class TestIastCommandInjection(BaseTestCase):
     """Verify IAST features"""
@@ -21,7 +28,6 @@ class TestIastCommandInjection(BaseTestCase):
         expected = self.EXPECTATIONS.get(context.library.library)
         return expected.get("LOCATION") if expected else None
 
-    @missing_feature(reason="Need to implement Command injection detection")
     def test_insecure_command_injection(self):
         """Insecure command executions are reported as insecure"""
         r = self.weblog_post("/iast/cmdi/test_insecure", data={"cmd": "ls"})

--- a/tests/appsec/iast/test_iast_path_traversal.py
+++ b/tests/appsec/iast/test_iast_path_traversal.py
@@ -7,7 +7,14 @@ from utils import BaseTestCase, interfaces, context, missing_feature, coverage, 
 # Weblog are ok for nodejs/express4 and java/spring-boot
 @coverage.basic
 @released(
-    dotnet="?", golang="?", java="?", nodejs="?", php_appsec="?", python="?", ruby="?", cpp="?",
+    dotnet="?",
+    golang="?",
+    java={"spring-boot": "1.1.0", "spring-boot-jetty": "1.1.0", "spring-boot-openliberty": "1.1.0", "*": "?"},
+    nodejs="?",
+    php_appsec="?",
+    python="?",
+    ruby="?",
+    cpp="?",
 )
 class TestIastPathTraversal(BaseTestCase):
     """Verify IAST features"""
@@ -21,7 +28,6 @@ class TestIastPathTraversal(BaseTestCase):
         expected = self.EXPECTATIONS.get(context.library.library)
         return expected.get("LOCATION") if expected else None
 
-    @missing_feature(reason="Need to implement Path traversal detection")
     def test_insecure_path_traversal(self):
         """Insecure path traversals are reported as insecure"""
         r = self.weblog_post("/iast/path_traversal/test_insecure", data={"path": "/var/log"})

--- a/tests/appsec/iast/test_iast_sql_injection.py
+++ b/tests/appsec/iast/test_iast_sql_injection.py
@@ -6,7 +6,16 @@ from utils import BaseTestCase, interfaces, context, missing_feature, coverage, 
 
 # Weblog are ok for nodejs/express4 and java/spring-boot
 @coverage.basic
-@released(dotnet="?", golang="?", java="?", nodejs="?", php_appsec="?", python="?", ruby="?", cpp="?")
+@released(
+    dotnet="?",
+    golang="?",
+    java={"spring-boot": "1.1.0", "spring-boot-jetty": "1.1.0", "spring-boot-openliberty": "1.1.0", "*": "?"},
+    nodejs="?",
+    php_appsec="?",
+    python="?",
+    ruby="?",
+    cpp="?",
+)
 class TestIastSqlInjection(BaseTestCase):
     """Verify IAST SQL INJECTION feature"""
 

--- a/tests/appsec/iast/test_iast_weak_hash.py
+++ b/tests/appsec/iast/test_iast_weak_hash.py
@@ -34,7 +34,7 @@ class TestIastWeakHash(BaseTestCase):
         return expected.get("WEAK_CIPHER_ALGORITHM") if expected else None
 
     @missing_feature(library="python", reason="Need to be implement duplicates vulnerability hashes")
-    @missing_feature(context.weblog_variant == "spring-boot-openliberty")
+    @bug(context.weblog_variant == "spring-boot-openliberty")
     def test_insecure_hash_remove_duplicates(self):
         """If one line is vulnerable and it is executed multiple times (for instance in a loop) in a request,
         we will report only one vulnerability"""
@@ -44,7 +44,7 @@ class TestIastWeakHash(BaseTestCase):
             r, vulnerability_count=1, vulnerability_type="WEAK_HASH", location_path=self.__expected_location(),
         )
 
-    @missing_feature(context.weblog_variant == "spring-boot-openliberty")
+    @bug(context.weblog_variant == "spring-boot-openliberty")
     def test_insecure_hash_multiple(self):
         """If a endpoint has multiple vulnerabilities (in diferent lines) we will report all of them"""
         r = self.weblog_get("/iast/insecure_hashing/multiple_hash")


### PR DESCRIPTION


## Description

java@1.1.0 supports SQL Injection, Command Injection, and Path Traversal. The enabled tests pass in master.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
