### PR TITLE
Add format.sh for easy black formatting

### DIFF
--- a/docs/edit/lint.md
+++ b/docs/edit/lint.md
@@ -1,6 +1,20 @@
 System tests code is in python, and is linted using [black](https://black.readthedocs.io/en/stable/).
 
-As the framework use `docker`, you may not have the setup to run it, and it can be painful to pass the CI. So here here the easy step to a quick setup:
+As the framework uses `docker`, you may not have the setup to run it, and it can be painful to pass the CI. So here here the easy step to a quick setup:
+
+## Using Docker
+
+There is a script `format.sh` in the root of the repository which will package the right `black` version in a Docker image and will run it:
+
+```bash
+# format everything
+./format.sh
+
+# format a directory or file
+./format.sh tests
+```
+
+## Using a virtualenv
 
 * [install python 3](https://www.python.org/downloads/). You may have it by default:
   * run `python --version`. As long as the version is 3, it's ok

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+
+readonly BLACK_VERSION=19.10b0
+readonly IMAGE=black:${BLACK_VERSION}
+
+if [[ -z "$(docker images -q "${IMAGE}")" ]]; then
+  echo "Building ${IMAGE}"
+  docker build -t "${IMAGE}" - <<EOF
+FROM python:3.10
+RUN pip install click==7.1.2 black==${BLACK_VERSION}
+EOF
+fi
+
+if [[ -z ${1:-} ]]; then
+	set -- .
+fi
+exec docker run -it --rm --user="$(id -u):$(id -g)" --workdir "$(pwd)" -v "$(pwd):$(pwd)" "${IMAGE}" black "$@"


### PR DESCRIPTION
## Description

Since setting up a virtualenv might be a hassle for some, and some users
have reported diffulties to get it installed correctly in their systems,
the script `format.sh` adds a simple way to run a dockerized black. The
only requisite is having Docker installed, and a Unix-like host (macOS
or Linux).

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
