### PR TITLE
Update Java client for parametric tests

### DIFF
--- a/parametric/apps/java/build.sh
+++ b/parametric/apps/java/build.sh
@@ -29,4 +29,4 @@ else
 fi
 
 echo Running Maven build with profiles \"$MAVEN_PROFILES\"
-mvn $MAVEN_PROFILES package
+mvn -q $MAVEN_PROFILES package

--- a/parametric/apps/java/build.sh
+++ b/parametric/apps/java/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+MAVEN_PROFILES=
+
+# Look for custom dd-trace-ot jar in custom binaries folder
+CUSTOM_DD_TRACE_OT_COUNT=$(ls /binaries/dd-trace-ot*.jar 2>/dev/null | wc -l)
+if [ $CUSTOM_DD_TRACE_OT_COUNT = 0 ]; then
+    echo "Using default dd-trace-ot"
+elif [ $CUSTOM_DD_TRACE_OT_COUNT = 1 ]; then
+    CUSTOM_DD_TRACE_OT=$(ls /binaries/dd-trace-ot*.jar)
+    echo "Using custom dd-trace-ot: ${CUSTOM_DD_TRACE_OT}"
+    MAVEN_PROFILES="$MAVEN_PROFILES -DcustomDdTraceOt=${CUSTOM_DD_TRACE_OT}"
+else
+    echo "Too many dd-trace-ot within binaries folder"
+    exit 1
+fi
+
+# Look for custom dd-trace-api jar in custom binaries folder
+CUSTOM_DD_TRACE_API_COUNT=$(ls /binaries/dd-trace-api*.jar 2>/dev/null | wc -l)
+if [ $CUSTOM_DD_TRACE_API_COUNT = 0 ]; then
+    echo "Using default dd-trace-api"
+elif [ $CUSTOM_DD_TRACE_API_COUNT = 1 ]; then
+    CUSTOM_DD_TRACE_API=$(ls /binaries/dd-trace-api*.jar)
+    echo "Using custom dd-trace-api: ${CUSTOM_DD_TRACE_API}"
+    MAVEN_PROFILES="$MAVEN_PROFILES -DcustomDdTraceApi=${CUSTOM_DD_TRACE_API}"
+else
+    echo "Too many dd-trace-api within binaries folder"
+    exit 1
+fi
+
+echo Running Maven build with profiles \"$MAVEN_PROFILES\"
+mvn $MAVEN_PROFILES package

--- a/parametric/apps/java/pom.xml
+++ b/parametric/apps/java/pom.xml
@@ -128,6 +128,9 @@
               <mainClass>com.datadoghq.App</mainClass>
               <classpathPrefix>lib/</classpathPrefix>
             </manifest>
+            <manifestEntries>
+              <Class-Path>lib/dd-trace-ot-dev.jar lib/dd-trace-ot-dev.jar</Class-Path>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/parametric/apps/java/pom.xml
+++ b/parametric/apps/java/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <dd-trace.version>1.0.0</dd-trace.version>
+    <dd-trace.version>1.1.4</dd-trace.version>
     <opentracing.version>0.32.0</opentracing.version>
     <gprc.version>1.47.0</gprc.version>
   </properties>

--- a/parametric/apps/java/pom.xml
+++ b/parametric/apps/java/pom.xml
@@ -14,6 +14,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <dd-trace.version>1.0.0</dd-trace.version>
+    <opentracing.version>0.32.0</opentracing.version>
     <gprc.version>1.47.0</gprc.version>
   </properties>
 
@@ -21,7 +23,7 @@
     <dependency>
       <groupId>com.datadoghq</groupId>
       <artifactId>dd-trace-ot</artifactId>
-      <version>[1.1,2)</version>
+      <version>${dd-trace.version}</version>
     </dependency>
     <!-- gRPC server -->
     <dependency>
@@ -114,6 +116,21 @@
           </execution>
         </executions>
       </plugin>
+      <!-- JAR configuration -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.2</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <mainClass>com.datadoghq.App</mainClass>
+              <classpathPrefix>lib/</classpathPrefix>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
       <!-- Dependency copy -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -134,4 +151,68 @@
       </plugin>
     </plugins>
   </build>
+
+  <!-- Profiles are enabled from build.sh script by custom properties, defining custom jar (from binaries) to use -->
+  <profiles>
+    <profile>
+      <id>custom-dd-trace-ot</id>
+      <activation>
+        <property>
+          <name>customDdTraceOt</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.datadoghq</groupId>
+          <artifactId>dd-trace-ot</artifactId>
+          <version>${dd-trace.version}</version>
+          <scope>system</scope>
+          <systemPath>${customDdTraceOt}</systemPath>
+        </dependency>
+        <!-- Declare immediate child dependencies as there will be no more POM resolution -->
+        <dependency>
+          <groupId>com.datadoghq</groupId>
+          <artifactId>dd-trace-api</artifactId>
+          <version>${dd-trace.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-api</artifactId>
+          <version>${opentracing.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-noop</artifactId>
+          <version>${opentracing.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-util</artifactId>
+          <version>${opentracing.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>1.7.30</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>custom-dd-trace-api</id>
+      <activation>
+        <property>
+          <name>customDdTraceApi</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.datadoghq</groupId>
+          <artifactId>dd-trace-api</artifactId>
+          <version>${dd-trace.version}</version>
+          <scope>system</scope>
+          <systemPath>${customDdTraceApi}</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/parametric/apps/java/pom.xml
+++ b/parametric/apps/java/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.datadoghq</groupId>
       <artifactId>dd-trace-ot</artifactId>
-      <version>0.113.0</version>
+      <version>[1.1,2)</version>
     </dependency>
     <!-- gRPC server -->
     <dependency>

--- a/parametric/apps/java/pom.xml
+++ b/parametric/apps/java/pom.xml
@@ -165,7 +165,7 @@
         <dependency>
           <groupId>com.datadoghq</groupId>
           <artifactId>dd-trace-ot</artifactId>
-          <version>${dd-trace.version}</version>
+          <version>dev</version>
           <scope>system</scope>
           <systemPath>${customDdTraceOt}</systemPath>
         </dependency>
@@ -208,7 +208,7 @@
         <dependency>
           <groupId>com.datadoghq</groupId>
           <artifactId>dd-trace-api</artifactId>
-          <version>${dd-trace.version}</version>
+          <version>dev</version>
           <scope>system</scope>
           <systemPath>${customDdTraceApi}</systemPath>
         </dependency>

--- a/parametric/apps/java/run.sh
+++ b/parametric/apps/java/run.sh
@@ -1,13 +1,2 @@
 #!/bin/bash
-
-AGENT_COUNT=$(ls /binaries/dd-java-agent*.jar 2>/dev/null | wc -l)
-if [ $AGENT_COUNT = 0 ]; then
-    echo "Running default build"
-    java -cp "target/*:target/lib/*" com.datadoghq.App
-elif [ $AGENT_COUNT = 1 ]; then
-    echo "Running custom binaries"
-    java -cp "target/*:/binaries/*:target/lib/*" com.datadoghq.App
-else
-    echo "Too many jar files in binaries"
-    exit 1
-fi
+java -jar target/dd-trace-java-client-1.0.0.jar

--- a/parametric/apps/java/src/main/java/com/datadoghq/ApmClientImpl.java
+++ b/parametric/apps/java/src/main/java/com/datadoghq/ApmClientImpl.java
@@ -1,19 +1,40 @@
 package com.datadoghq;
 
 import static com.datadoghq.App.LOGGER;
+import static com.datadoghq.client.ApmTestClient.DistributedHTTPHeaders;
+import static com.datadoghq.client.ApmTestClient.FinishSpanArgs;
+import static com.datadoghq.client.ApmTestClient.FinishSpanReturn;
+import static com.datadoghq.client.ApmTestClient.FlushSpansArgs;
+import static com.datadoghq.client.ApmTestClient.FlushSpansReturn;
+import static com.datadoghq.client.ApmTestClient.FlushTraceStatsArgs;
+import static com.datadoghq.client.ApmTestClient.FlushTraceStatsReturn;
+import static com.datadoghq.client.ApmTestClient.InjectHeadersArgs;
+import static com.datadoghq.client.ApmTestClient.InjectHeadersReturn;
+import static com.datadoghq.client.ApmTestClient.SpanSetErrorArgs;
+import static com.datadoghq.client.ApmTestClient.SpanSetErrorReturn;
+import static com.datadoghq.client.ApmTestClient.SpanSetMetaArgs;
+import static com.datadoghq.client.ApmTestClient.SpanSetMetaReturn;
+import static com.datadoghq.client.ApmTestClient.SpanSetMetricArgs;
+import static com.datadoghq.client.ApmTestClient.SpanSetMetricReturn;
+import static com.datadoghq.client.ApmTestClient.StartSpanArgs;
+import static com.datadoghq.client.ApmTestClient.StartSpanReturn;
+import static com.datadoghq.client.ApmTestClient.StopTracerArgs;
+import static com.datadoghq.client.ApmTestClient.StopTracerReturn;
+import static io.opentracing.propagation.Format.Builtin.TEXT_MAP;
 
 import com.datadoghq.client.APMClientGrpc;
-import com.datadoghq.client.ApmTestClient;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.internal.InternalTracer;
 import io.grpc.stub.StreamObserver;
 import io.opentracing.Span;
+import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+import io.opentracing.propagation.TextMap;
 import io.opentracing.tag.Tags;
-
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 public class ApmClientImpl extends APMClientGrpc.APMClientImplBase {
@@ -26,8 +47,9 @@ public class ApmClientImpl extends APMClientGrpc.APMClientImplBase {
     }
 
     @Override
-    public void startSpan(ApmTestClient.StartSpanArgs request, StreamObserver<ApmTestClient.StartSpanReturn> responseObserver) {
+    public void startSpan(StartSpanArgs request, StreamObserver<StartSpanReturn> responseObserver) {
         LOGGER.info("Creating span: " + request.toString());
+        // Build span from request
         Tracer.SpanBuilder builder = this.tracer.buildSpan(request.getName());
         if (request.hasService()) {
             builder.withTag(DDTags.SERVICE_NAME, request.getService());
@@ -48,13 +70,18 @@ public class ApmClientImpl extends APMClientGrpc.APMClientImplBase {
         if (request.hasOrigin()) {
             builder.withTag(DDTags.ORIGIN_KEY, request.getOrigin());
         }
-
+        // Extract headers from request to add them to span.
+        if (request.hasHttpHeaders()) {
+            SpanContext context = tracer.extract(TEXT_MAP, TextMapAdapter.fromRequest(request.getHttpHeaders()));
+            builder.asChildOf(context);
+        }
         Span span = builder.start();
+        // Store span
         long spanId = DDSpanId.from(span.context().toSpanId());
         long traceId = DDTraceId.from(span.context().toTraceId()).toLong();
         this.spans.put(spanId, span);
-
-        responseObserver.onNext(ApmTestClient.StartSpanReturn.newBuilder()
+        // Complete request
+        responseObserver.onNext(StartSpanReturn.newBuilder()
                 .setSpanId(spanId)
                 .setTraceId(traceId)
                 .build()
@@ -63,46 +90,63 @@ public class ApmClientImpl extends APMClientGrpc.APMClientImplBase {
     }
 
     @Override
-    public void injectHeaders(ApmTestClient.InjectHeadersArgs request, StreamObserver<ApmTestClient.InjectHeadersReturn> responseObserver) {
-        // TODO IMPLEMENT. FALLBACK TO UNIMPLEMENTED MEANWHILE
-        super.injectHeaders(request, responseObserver);
+    public void injectHeaders(InjectHeadersArgs request, StreamObserver<InjectHeadersReturn> responseObserver) {
+        LOGGER.info("Inject headers: " + request.toString());
+        Span span = getSpan(request.getSpanId(), responseObserver);
+        if (span != null) {
+            // Get context from span and inject it to carrier
+            SpanContext context = span.context();
+            TextMapAdapter carrier = TextMapAdapter.empty();
+            this.tracer.inject(context, TEXT_MAP, carrier);
+            // Copy carrier content to protobuf response
+            DistributedHTTPHeaders.Builder headerBuilder = DistributedHTTPHeaders.newBuilder();
+            for (Map.Entry<String, String> header : carrier) {
+                headerBuilder.putHttpHeaders(header.getKey(), header.getValue());
+            }
+            // Complete request
+            responseObserver.onNext(InjectHeadersReturn.newBuilder()
+                    .setHttpHeaders(headerBuilder.build())
+                    .build()
+            );
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
-    public void finishSpan(ApmTestClient.FinishSpanArgs request, StreamObserver<ApmTestClient.FinishSpanReturn> responseObserver) {
+    public void finishSpan(FinishSpanArgs request, StreamObserver<FinishSpanReturn> responseObserver) {
         LOGGER.info("Finishing span: " + request.toString());
         Span span = getSpan(request.getId(), responseObserver);
         if (span != null) {
             span.finish();
-            responseObserver.onNext(ApmTestClient.FinishSpanReturn.newBuilder().build());
+            responseObserver.onNext(FinishSpanReturn.newBuilder().build());
             responseObserver.onCompleted();
         }
     }
 
     @Override
-    public void spanSetMeta(ApmTestClient.SpanSetMetaArgs request, StreamObserver<ApmTestClient.SpanSetMetaReturn> responseObserver) {
+    public void spanSetMeta(SpanSetMetaArgs request, StreamObserver<SpanSetMetaReturn> responseObserver) {
         LOGGER.info("Setting meta span: " + request.toString());
         Span span = getSpan(request.getSpanId(), responseObserver);
         if (span != null) {
             span.setTag(request.getKey(), request.getValue());
-            responseObserver.onNext(ApmTestClient.SpanSetMetaReturn.newBuilder().build());
+            responseObserver.onNext(SpanSetMetaReturn.newBuilder().build());
             responseObserver.onCompleted();
         }
     }
 
     @Override
-    public void spanSetMetric(ApmTestClient.SpanSetMetricArgs request, StreamObserver<ApmTestClient.SpanSetMetricReturn> responseObserver) {
+    public void spanSetMetric(SpanSetMetricArgs request, StreamObserver<SpanSetMetricReturn> responseObserver) {
         LOGGER.info("Setting span metric: " + request.toString());
         Span span = getSpan(request.getSpanId(), responseObserver);
         if (span != null) {
             span.setTag(request.getKey(), request.getValue());
-            responseObserver.onNext(ApmTestClient.SpanSetMetricReturn.newBuilder().build());
+            responseObserver.onNext(SpanSetMetricReturn.newBuilder().build());
             responseObserver.onCompleted();
         }
     }
 
     @Override
-    public void spanSetError(ApmTestClient.SpanSetErrorArgs request, StreamObserver<ApmTestClient.SpanSetErrorReturn> responseObserver) {
+    public void spanSetError(SpanSetErrorArgs request, StreamObserver<SpanSetErrorReturn> responseObserver) {
         LOGGER.info("Setting span error: " + request.toString());
         Span span = getSpan(request.getSpanId(), responseObserver);
         if (span != null) {
@@ -116,32 +160,32 @@ public class ApmClientImpl extends APMClientGrpc.APMClientImplBase {
             if (request.hasMessage()) {
                 span.setTag(DDTags.ERROR_STACK, request.getStack());
             }
-            responseObserver.onNext(ApmTestClient.SpanSetErrorReturn.newBuilder().build());
+            responseObserver.onNext(SpanSetErrorReturn.newBuilder().build());
             responseObserver.onCompleted();
         }
     }
 
     @Override
-    public void flushSpans(ApmTestClient.FlushSpansArgs request, StreamObserver<ApmTestClient.FlushSpansReturn> responseObserver) {
+    public void flushSpans(FlushSpansArgs request, StreamObserver<FlushSpansReturn> responseObserver) {
         LOGGER.info("Flushing span: " + request.toString());
         ((InternalTracer) this.tracer).flush();
         this.spans.clear();
-        responseObserver.onNext(ApmTestClient.FlushSpansReturn.newBuilder().build());
+        responseObserver.onNext(FlushSpansReturn.newBuilder().build());
         responseObserver.onCompleted();
     }
 
     @Override
-    public void flushTraceStats(ApmTestClient.FlushTraceStatsArgs request, StreamObserver<ApmTestClient.FlushTraceStatsReturn> responseObserver) {
+    public void flushTraceStats(FlushTraceStatsArgs request, StreamObserver<FlushTraceStatsReturn> responseObserver) {
         LOGGER.info("Flushing trace stats: " + request.toString());
         ((InternalTracer) this.tracer).flushMetrics();
-        responseObserver.onNext(ApmTestClient.FlushTraceStatsReturn.newBuilder().build());
+        responseObserver.onNext(FlushTraceStatsReturn.newBuilder().build());
         responseObserver.onCompleted();
     }
 
     @Override
-    public void stopTracer(ApmTestClient.StopTracerArgs request, StreamObserver<ApmTestClient.StopTracerReturn> responseObserver) {
+    public void stopTracer(StopTracerArgs request, StreamObserver<StopTracerReturn> responseObserver) {
         this.tracer.close();
-        responseObserver.onNext(ApmTestClient.StopTracerReturn.newBuilder().build());
+        responseObserver.onNext(StopTracerReturn.newBuilder().build());
         responseObserver.onCompleted();
     }
 
@@ -154,5 +198,31 @@ public class ApmClientImpl extends APMClientGrpc.APMClientImplBase {
             return null;
         }
         return span;
+    }
+
+    private static class TextMapAdapter implements TextMap {
+        private final Map<String, String> map;
+
+        private static TextMapAdapter empty() {
+            return new TextMapAdapter(new HashMap<>());
+        }
+
+        private static TextMapAdapter fromRequest(DistributedHTTPHeaders headers) {
+            return new TextMapAdapter(headers.getHttpHeadersMap());
+        }
+
+        private TextMapAdapter(Map<String, String> map) {
+            this.map = map;
+        }
+
+        @Override
+        public Iterator<Map.Entry<String, String>> iterator() {
+            return map.entrySet().iterator();
+        }
+
+        @Override
+        public void put(String key, String value) {
+            map.put(key, value);
+        }
     }
 }

--- a/parametric/apps/java/src/main/java/com/datadoghq/ApmClientImpl.java
+++ b/parametric/apps/java/src/main/java/com/datadoghq/ApmClientImpl.java
@@ -63,6 +63,12 @@ public class ApmClientImpl extends APMClientGrpc.APMClientImplBase {
     }
 
     @Override
+    public void injectHeaders(ApmTestClient.InjectHeadersArgs request, StreamObserver<ApmTestClient.InjectHeadersReturn> responseObserver) {
+        // TODO IMPLEMENT. FALLBACK TO UNIMPLEMENTED MEANWHILE
+        super.injectHeaders(request, responseObserver);
+    }
+
+    @Override
     public void finishSpan(ApmTestClient.FinishSpanArgs request, StreamObserver<ApmTestClient.FinishSpanReturn> responseObserver) {
         LOGGER.info("Finishing span: " + request.toString());
         Span span = getSpan(request.getId(), responseObserver);
@@ -129,6 +135,13 @@ public class ApmClientImpl extends APMClientGrpc.APMClientImplBase {
         LOGGER.info("Flushing trace stats: " + request.toString());
         ((InternalTracer) this.tracer).flushMetrics();
         responseObserver.onNext(ApmTestClient.FlushTraceStatsReturn.newBuilder().build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void stopTracer(ApmTestClient.StopTracerArgs request, StreamObserver<ApmTestClient.StopTracerReturn> responseObserver) {
+        this.tracer.close();
+        responseObserver.onNext(ApmTestClient.StopTracerReturn.newBuilder().build());
         responseObserver.onCompleted();
     }
 

--- a/parametric/apps/java/src/main/java/com/datadoghq/App.java
+++ b/parametric/apps/java/src/main/java/com/datadoghq/App.java
@@ -5,26 +5,19 @@ import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
 
 import datadog.opentracing.DDTracer;
-import datadog.trace.common.metrics.MetricsAggregator;
-import datadog.trace.core.CoreTracer;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.opentracing.util.GlobalTracer;
-
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.logging.Logger;
 
 public class App {
     static final Logger LOGGER = Logger.getLogger(App.class.getName());
     private static final int CLIENT_SERVER_PORT = 50051;
     private final DDTracer tracer;
-    private Runnable flushTraceRunnable;
-    private Runnable flushStatsRunnable;
 
     public App() throws ReflectiveOperationException, IOException {
         this.tracer = createTracer();
-        extractFlushRunnable();
         startServer(CLIENT_SERVER_PORT);
     }
 
@@ -40,11 +33,7 @@ public class App {
 
     private void startServer(int port) throws IOException {
         Server server = ServerBuilder.forPort(port)
-                .addService(new ApmClientImpl(
-                        this.tracer,
-                        this.flushTraceRunnable,
-                        this.flushStatsRunnable
-                ))
+                .addService(new ApmClientImpl(this.tracer))
                 .build()
                 .start();
         LOGGER.info("Server started at port " + port + ".");
@@ -75,45 +64,5 @@ public class App {
         DDTracer tracer = new DDTracer.DDTracerBuilder().build();
         GlobalTracer.registerIfAbsent(tracer);
         return tracer;
-    }
-
-    private void extractFlushRunnable() throws ReflectiveOperationException {
-        for (Field field : DDTracer.class.getDeclaredFields()) {
-            if ("tracer".equals(field.getName())) {
-                field.setAccessible(true);
-                CoreTracer tracerApi = (CoreTracer) field.get(this.tracer);
-//              this.flushTraceRunnable = tracerApi::flush;
-                // TODO How to ensure trace flush? Is closing a solution in Java library?
-                this.flushTraceRunnable = () -> {
-                        tracerApi.flush();
-//                        tracer.close();
-                };
-                extractFlushStatsRunnable(tracerApi);
-                return;
-            }
-        }
-        throw new NoSuchFieldException("tracer");
-    }
-
-    private void extractFlushStatsRunnable(CoreTracer tracerApi) throws ReflectiveOperationException {
-        for (Field field : CoreTracer.class.getDeclaredFields()) {
-           if ("metricsAggregator".equals(field.getName())) {
-               field.setAccessible(true);
-                MetricsAggregator aggregator = (MetricsAggregator) field.get(tracerApi);
-//              this.flushStatsRunnable = aggregator::report;
-                // TODO How to ensure to flush metrics? Wait long enough to be sure to flush (every 10s by default)
-                this.flushStatsRunnable = () -> {
-                    aggregator.report();
-//                  tracer.close();
-                    try {
-                        Thread.sleep(15_000);
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                };
-                return;
-            }
-        }
-        throw new NoSuchFieldException("metricsAggregator");
     }
 }

--- a/parametric/apps/java/src/main/proto/apm_test_client.proto
+++ b/parametric/apps/java/src/main/proto/apm_test_client.proto
@@ -8,8 +8,10 @@ service APMClient {
   rpc SpanSetMeta(SpanSetMetaArgs) returns (SpanSetMetaReturn) {}
   rpc SpanSetMetric(SpanSetMetricArgs) returns (SpanSetMetricReturn) {}
   rpc SpanSetError(SpanSetErrorArgs) returns (SpanSetErrorReturn) {}
+  rpc InjectHeaders(InjectHeadersArgs) returns (InjectHeadersReturn) {}
   rpc FlushSpans(FlushSpansArgs) returns (FlushSpansReturn) {}
   rpc FlushTraceStats(FlushTraceStatsArgs) returns (FlushTraceStatsReturn) {}
+  rpc StopTracer(StopTracerArgs) returns (StopTracerReturn) {}
 }
 
 message StartSpanArgs {
@@ -19,10 +21,24 @@ message StartSpanArgs {
   optional string resource = 4;
   optional string type = 5;
   optional string origin = 6;
+  optional DistributedHTTPHeaders http_headers = 7;
 }
+
+message DistributedHTTPHeaders {
+    map<string, string> http_headers = 9;
+}
+
 message StartSpanReturn {
   uint64 span_id = 1;
   uint64 trace_id = 2;
+}
+
+message InjectHeadersArgs {
+  uint64 span_id = 1;
+}
+
+message InjectHeadersReturn {
+    optional DistributedHTTPHeaders http_headers = 1;
 }
 
 message FinishSpanArgs {
@@ -60,3 +76,6 @@ message FlushSpansReturn {}
 
 message FlushTraceStatsArgs {}
 message FlushTraceStatsReturn {}
+
+message StopTracerArgs {}
+message StopTracerReturn {}

--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -197,6 +197,7 @@ COPY {java_reldir}/src src
 COPY {java_reldir}/build.sh .
 COPY {java_reldir}/pom.xml .
 COPY {java_reldir}/run.sh .
+COPY binaries /binaries
 RUN bash build.sh
 """,
         container_cmd=["./run.sh"],

--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -194,10 +194,10 @@ def java_library_factory(env: Dict[str, str]):
 FROM maven:3-jdk-8
 WORKDIR /client
 COPY {java_reldir}/src src
+COPY {java_reldir}/build.sh .
 COPY {java_reldir}/pom.xml .
 COPY {java_reldir}/run.sh .
-COPY binaries* /binaries/
-RUN mvn package
+RUN bash build.sh
 """,
         container_cmd=["./run.sh"],
         container_build_dir=java_dir,

--- a/parametric/test_library_tracestats.py
+++ b/parametric/test_library_tracestats.py
@@ -322,6 +322,7 @@ def test_successes_errors_recorded_separately_TS006(library_env, test_agent, tes
 
 
 @pytest.mark.skip_library("dotnet", "FIXME: No traces should be emitted with the sample rate set to 0")
+@pytest.mark.skip_library("java", "FIXME: Undefined behavior according the java tracer core team")
 @pytest.mark.skip_library("nodejs", "nodejs has not implemented stats computation yet")
 @enable_tracestats(sample_rate=0.0)
 def test_sample_rate_0_TS007(library_env, test_agent, test_library, test_server):

--- a/parametric/test_trace_distributed.py
+++ b/parametric/test_trace_distributed.py
@@ -7,7 +7,7 @@ from parametric.spec.trace import span_has_no_parent
 
 @pytest.mark.skip_library("golang", "not implemented")
 @pytest.mark.skip_library("nodejs", "not implemented")
-def test_distributed_headers_extract_datadog(test_agent, test_library):
+def test_distributed_headers_extract_datadog_D001(test_agent, test_library):
     """Ensure that Datadog distributed tracing headers are extracted
     and activated properly.
     """
@@ -34,7 +34,7 @@ def test_distributed_headers_extract_datadog(test_agent, test_library):
 
 @pytest.mark.skip_library("golang", "not implemented")
 @pytest.mark.skip_library("nodejs", "not implemented")
-def test_distributed_headers_extract_datadog_invalid(test_agent, test_library):
+def test_distributed_headers_extract_datadog_invalid_D002(test_agent, test_library):
     """Ensure that Datadog distributed tracing headers are extracted
     and activated properly.
     """
@@ -61,7 +61,7 @@ def test_distributed_headers_extract_datadog_invalid(test_agent, test_library):
 
 @pytest.mark.skip_library("golang", "not implemented")
 @pytest.mark.skip_library("nodejs", "not implemented")
-def test_distributed_headers_inject_datadog(test_agent, test_library):
+def test_distributed_headers_inject_datadog_D003(test_agent, test_library):
     """Ensure that Datadog distributed tracing headers are injected properly.
     """
     with test_library:
@@ -75,7 +75,7 @@ def test_distributed_headers_inject_datadog(test_agent, test_library):
 
 @pytest.mark.skip_library("golang", "not implemented")
 @pytest.mark.skip_library("nodejs", "not implemented")
-def test_distributed_headers_extractandinject_datadog(test_agent, test_library):
+def test_distributed_headers_extractandinject_datadog_D004(test_agent, test_library):
     """Ensure that Datadog distributed tracing headers are extracted
     and activated properly.
     """
@@ -102,7 +102,7 @@ def test_distributed_headers_extractandinject_datadog(test_agent, test_library):
 
 @pytest.mark.skip_library("golang", "not implemented")
 @pytest.mark.skip_library("nodejs", "not implemented")
-def test_distributed_headers_extractandinject_datadog_invalid(test_agent, test_library):
+def test_distributed_headers_extractandinject_datadog_invalid_D005(test_agent, test_library):
     """Ensure that Datadog distributed tracing headers are extracted
     and activated properly.
     """
@@ -129,7 +129,7 @@ def test_distributed_headers_extractandinject_datadog_invalid(test_agent, test_l
 
 @pytest.mark.skip("needs to be implemented by tracers and test needs to adhere to RFC")
 @pytest.mark.parametrize("apm_test_server_env", [{"DD_TRACE_PROPAGATION_STYLE_EXTRACT": "W3C"}])
-def test_distributed_headers_extract_w3c001(apm_test_server_env, test_agent, test_library):
+def test_distributed_headers_extract_w3c001_D006(apm_test_server_env, test_agent, test_library):
     """Ensure that W3C distributed tracing headers are extracted
     and activated properly.
     """

--- a/parametric/test_tracer.py
+++ b/parametric/test_tracer.py
@@ -14,7 +14,7 @@ parametrize = pytest.mark.parametrize
 
 
 @pytest.mark.skip_library("nodejs", "nodejs overrides the manually set service name")
-def test_tracer_span_top_level_attributes(test_library: APMLibrary, test_agent: _TestAgentAPI) -> None:
+def test_tracer_span_top_level_attributes(test_agent: _TestAgentAPI, test_library: APMLibrary) -> None:
     """Do a simple trace to ensure that the test client is working properly."""
     with test_library:
         with test_library.start_span(
@@ -42,7 +42,7 @@ def test_tracer_span_top_level_attributes(test_library: APMLibrary, test_agent: 
 @pytest.mark.skip(reason="Libraries use empty string for service")
 @parametrize("library_env", [{"DD_SERVICE": "service1"}])
 def test_tracer_service_name_environment_variable(
-    library_env: Dict[str, str], test_library: APMLibrary, test_agent: _TestAgentAPI
+    library_env: Dict[str, str], test_agent: _TestAgentAPI, test_library: APMLibrary
 ) -> None:
     """
     When DD_SERVICE is specified
@@ -63,7 +63,7 @@ def test_tracer_service_name_environment_variable(
 
 @parametrize("library_env", [{"DD_ENV": "prod"}])
 def test_tracer_env_environment_variable(
-    library_env: Dict[str, str], test_library: APMLibrary, test_agent: _TestAgentAPI
+    library_env: Dict[str, str], test_agent: _TestAgentAPI, test_library: APMLibrary
 ) -> None:
     """
     When DD_ENV is specified


### PR DESCRIPTION
## Description

Update Java client for `parametric tests`:

* Upgrade to new Trace/Span ID
* Use new flush traces/metrics API
* Update client protobuf (inject header not supported yet)
* Update java client test coverage (disable tests not supported yet)
* Add support for `dd-trace-ot` and `dd-trace-api` artifact from the custom `binaries` folder

Update tracer test to start agent before client (see f3ff519)

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
