### PR TITLE
Send custom span tags in dotnet container

### DIFF
--- a/utils/build/docker/dotnet/Helper.cs
+++ b/utils/build/docker/dotnet/Helper.cs
@@ -22,7 +22,7 @@ namespace weblog
                 }
 
                 // Send custom span tags
-                string customSpanTags = Environment.GetEnvironmentVariable("DD_SPAN_CUSTOM_TAGS");
+                string customSpanTags = Environment.GetEnvironmentVariable("TEST_SPAN_CUSTOM_TAGS");
                 if (!String.IsNullOrEmpty(customSpanTags)) {
                     string[] customSpanTagsArr = customSpanTags.Split(',');
                     foreach (var tag in customSpanTagsArr)

--- a/utils/build/docker/dotnet/Helper.cs
+++ b/utils/build/docker/dotnet/Helper.cs
@@ -20,6 +20,17 @@ namespace weblog
                 {
                     childScope.Span.SetTag("garbage" + i, RandomString(50));
                 }
+
+                // Send custom span tags
+                string customSpanTags = Environment.GetEnvironmentVariable("DD_SPAN_CUSTOM_TAGS");
+                if (!String.IsNullOrEmpty(customSpanTags)) {
+                    string[] customSpanTagsArr = customSpanTags.Split(',');
+                    foreach (var tag in customSpanTagsArr)
+                    {
+                        string[] arr = tag.Split(':');
+                        childScope.Span.SetTag(arr[0], arr[1]);
+                    }                    
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Adding support for sending custom tags when calling the `/spans` URL in the dotnet container.

[Related PR](https://github.com/DataDog/k9-appsec-testing-env/pull/23)

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
