### PR TITLE
Fix parametric python tests for v05

### DIFF
--- a/parametric/spec/trace.py
+++ b/parametric/spec/trace.py
@@ -225,3 +225,8 @@ def find_span_in_traces(traces: List[Trace], span: Span) -> Span:
             max_similarity_span = similar_span
             max_similarity = similarity
     return max_similarity_span
+
+
+def span_has_no_parent(span: Span) -> bool:
+    """Return if a span has a parent by checking the presence and value of the `parent_id`."""
+    return "parent_id" not in span or span.get("parent_id") == 0 or span.get("parent_id") is None

--- a/parametric/test_trace_distributed.py
+++ b/parametric/test_trace_distributed.py
@@ -2,6 +2,7 @@ import pytest
 
 from parametric.protos.apm_test_client_pb2 import DistributedHTTPHeaders
 from parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
+from parametric.spec.trace import span_has_no_parent
 
 
 @pytest.mark.skip_library("golang", "not implemented")
@@ -31,7 +32,6 @@ def test_distributed_headers_extract_datadog(test_agent, test_library):
     assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
 
 
-@pytest.mark.skip_library("python", "Needs to be adapted to traces v0.5")
 @pytest.mark.skip_library("golang", "not implemented")
 @pytest.mark.skip_library("nodejs", "not implemented")
 def test_distributed_headers_extract_datadog_invalid(test_agent, test_library):
@@ -53,7 +53,7 @@ def test_distributed_headers_extract_datadog_invalid(test_agent, test_library):
 
     span = test_agent.wait_for_num_traces(num=1)[0][0]
     assert span.get("trace_id") != 0
-    assert span.get("parent_id") != 0
+    assert span_has_no_parent(span)
     # assert span["meta"].get(ORIGIN) is None # TODO: Determine if we keep x-datadog-origin for an invalid trace-id/parent-id
     assert span["meta"].get("_dd.p.dm") != "-4"
     assert span["metrics"].get(SAMPLING_PRIORITY_KEY) != 2


### PR DESCRIPTION
## Description
The parametric tests failed with the recent update to the Python client to use the v0.5 agent endpoint by default instead of the v0.4 endpoint. Specifically, in situations with  invalid parent/span ids being provided with the v0.4 endpoint resulted in the parent id not being set at all. However with the v0.5 endpoint, the resulting span is now set with a parent id of 0, which is still fine (but fails the current test) since this denotes that the span does not have a parent. 

The test `test_distributed_headers_extract_datadog_invalid` was fixed to accept both results, as both are expected.

Please include a short summary of the change

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
