### PR TITLE
Add more links to make it easier to navigate docs

### DIFF
--- a/docs/execute/README.md
+++ b/docs/execute/README.md
@@ -25,3 +25,7 @@ The summary in stdout contains a list of test, then a list of validations. Each 
 * A small red `x`: should not happen, sen a message to `#libraries-system-tests` slack channel
 
 If system tests fails, you'll need to dig into logs. Most of the time and with some experience, standard ouput will contains enough info to understand the issue. But sometimes, you'll need to have a look [inside logs/ folder](./logs.md).
+
+## Troubleshooting
+
+For troubleshooting check the troubleshooting [page](./troubleshooting.md)

--- a/docs/execute/troubleshooting.md
+++ b/docs/execute/troubleshooting.md
@@ -5,11 +5,11 @@ is printed, it means that you have previously ran tests outside docker, and pyth
 
 => Remove any `__pycache__` folder
 
-## `run.sh` fails at the very begning, saying `runner` is unhealthy
+## `run.sh` fails at the very beginning, saying `runner` is unhealthy
 
 You may have python errors, try `docker-compose up runner` to directly see them
 
-## `run.sh` fails at the very begning, saying `agent` is unhealthy
+## `run.sh` fails at the very beginning, saying `agent` is unhealthy
 
 Internet connection issue?
 


### PR DESCRIPTION
## Description
I ran into issues when trying to run the tests, I didn't immediately notice there was an additional file called troubleshooting.md (it solved the issue for me). So adding a link to this page to make it easier to find / navigate from the github interface.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
