### PR TITLE
Skip a test one a flaky python behavior

### DIFF
--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 """Misc checks around data integrity during components' lifetime"""
-from utils import weblog, interfaces, context, bug, rfc, scenario
+from utils import weblog, interfaces, context, bug, rfc, scenario, flaky
 from utils.tools import logger
 from utils.cgroup_info import get_container_id
 
@@ -50,6 +50,7 @@ class Test_TraceHeaders:
 
         interfaces.library.add_traces_validation(validator=validator, success_by_default=True)
 
+    @flaky(library="python", reason="Header sometimes does not match the reported trace count")
     def test_trace_header_count_match(self):
         """X-Datadog-Trace-Count header value is right in all traces submitted to the agent"""
 


### PR DESCRIPTION
## Description

Sometimes (not often), the `X-Datadog-Trace-Count` headers reports an lower value than real trace count. Last exemple, I saw this trace (I supposed it's the xtra one, regarding the weird trace_id value):

```json
[
        {
          "trace_id": 1,
          "parent_id": 1,
          "span_id": 2084599785098134101,
          "service": "weblog",
          "resource": "GET waf",
          "name": "django.request",
          "start": 1670562528022254292,
          "duration": 7321197,
          "type": "web",
          "meta": {
            "runtime-id": "dcd188bc0191448780baa977eada7f94",
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0",
            "django.request.class": "django.core.handlers.wsgi.WSGIRequest",
            "django.user.is_authenticated": "False",
            "django.response.class": "django.http.response.HttpResponse",
            "http.route": "waf",
            "django.view": "app.urls.waf",
            "http.method": "GET",
            "http.url": "http://weblog:7777/waf",
            "http.status_code": "200",
            "http.useragent": "system_tests rid/DXRCPJDIBQBXHOUMORVDUKGBTOKHOGZSUYYT",
            "http.client_ip": "172.18.0.5",
            "network.client.ip": "172.18.0.5",
            "http.request.headers.user-agent": "system_tests rid/DXRCPJDIBQBXHOUMORVDUKGBTOKHOGZSUYYT",
            "_dd.runtime_family": "python",
            "_dd.appsec.event_rules.version": "1.3.1",
            "_dd.appsec.waf.version": "1.4.1",
            "_dd.p.usr.id": "dXNyLmlk"
          },
          "metrics": {
            "system.pid": 19,
            "_dd.measured": 1,
            "_dd.top_level": 1,
            "_dd.appsec.enabled": 1.0,
            "_dd.appsec.event_rules.loaded": 126,
            "_dd.appsec.event_rules.error_count": 0,
            "_dd.appsec.waf.duration": 152.002,
            "_dd.appsec.waf.duration_ext": 206.7089080810547,
            "_dd.iast.enabled": 1.0,
            "_dd.tracer_kr": 1.0
          }
        },
        {
          "trace_id": 1,
          "parent_id": 2084599785098134101,
          "span_id": 16358416987194971796,
          "service": "weblog",
          "resource": "django.middleware.security.SecurityMiddleware.__call__",
          "name": "django.middleware",
          "start": 1670562528022340493,
          "duration": 6674589,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 16358416987194971796,
          "span_id": 6991629820613727112,
          "service": "weblog",
          "resource": "django.middleware.security.SecurityMiddleware.process_request",
          "name": "django.middleware",
          "start": 1670562528022376594,
          "duration": 27800,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 16358416987194971796,
          "span_id": 16626258732309435611,
          "service": "weblog",
          "resource": "django.contrib.sessions.middleware.SessionMiddleware.__call__",
          "name": "django.middleware",
          "start": 1670562528022598397,
          "duration": 6094780,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 16626258732309435611,
          "span_id": 2726714353194239660,
          "service": "weblog",
          "resource": "django.contrib.sessions.middleware.SessionMiddleware.process_request",
          "name": "django.middleware",
          "start": 1670562528022633997,
          "duration": 39501,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 16626258732309435611,
          "span_id": 4035354950225257317,
          "service": "weblog",
          "resource": "django.middleware.common.CommonMiddleware.__call__",
          "name": "django.middleware",
          "start": 1670562528022836100,
          "duration": 5543073,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 4035354950225257317,
          "span_id": 11487216273595274794,
          "service": "weblog",
          "resource": "django.middleware.common.CommonMiddleware.process_request",
          "name": "django.middleware",
          "start": 1670562528022870500,
          "duration": 127202,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 4035354950225257317,
          "span_id": 12162809323285270205,
          "service": "weblog",
          "resource": "django.middleware.csrf.CsrfViewMiddleware.__call__",
          "name": "django.middleware",
          "start": 1670562528023173304,
          "duration": 4874465,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 12162809323285270205,
          "span_id": 17429847583974019447,
          "service": "weblog",
          "resource": "django.middleware.csrf.CsrfViewMiddleware.process_request",
          "name": "django.middleware",
          "start": 1670562528023210005,
          "duration": 25400,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 12162809323285270205,
          "span_id": 3474848788542233839,
          "service": "weblog",
          "resource": "django.contrib.auth.middleware.AuthenticationMiddleware.__call__",
          "name": "django.middleware",
          "start": 1670562528023389607,
          "duration": 4304457,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 3474848788542233839,
          "span_id": 7194735801474907038,
          "service": "weblog",
          "resource": "django.contrib.auth.middleware.AuthenticationMiddleware.process_request",
          "name": "django.middleware",
          "start": 1670562528023423407,
          "duration": 26301,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 3474848788542233839,
          "span_id": 407625525857912096,
          "service": "weblog",
          "resource": "django.contrib.messages.middleware.MessageMiddleware.__call__",
          "name": "django.middleware",
          "start": 1670562528023643210,
          "duration": 1995927,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 407625525857912096,
          "span_id": 7293943852235372507,
          "service": "weblog",
          "resource": "django.contrib.messages.middleware.MessageMiddleware.process_request",
          "name": "django.middleware",
          "start": 1670562528023679811,
          "duration": 61001,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 407625525857912096,
          "span_id": 8050919361034758663,
          "service": "weblog",
          "resource": "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__",
          "name": "django.middleware",
          "start": 1670562528023905614,
          "duration": 1385918,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 8050919361034758663,
          "span_id": 10965041881460505055,
          "service": "weblog",
          "resource": "django.middleware.csrf.CsrfViewMiddleware.process_view",
          "name": "django.middleware",
          "start": 1670562528024002315,
          "duration": 28300,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 8050919361034758663,
          "span_id": 11285410432937196670,
          "service": "weblog",
          "resource": "app.urls.waf",
          "name": "django.view",
          "start": 1670562528024217318,
          "duration": 61701,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 8050919361034758663,
          "span_id": 16940933920760395069,
          "service": "weblog",
          "resource": "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response",
          "name": "django.middleware",
          "start": 1670562528024442921,
          "duration": 34600,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 407625525857912096,
          "span_id": 13184938939882566460,
          "service": "weblog",
          "resource": "django.contrib.messages.middleware.MessageMiddleware.process_response",
          "name": "django.middleware",
          "start": 1670562528025467135,
          "duration": 32700,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 12162809323285270205,
          "span_id": 6735603159771026003,
          "service": "weblog",
          "resource": "django.middleware.csrf.CsrfViewMiddleware.process_response",
          "name": "django.middleware",
          "start": 1670562528027873766,
          "duration": 32401,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 4035354950225257317,
          "span_id": 7990858219898280037,
          "service": "weblog",
          "resource": "django.middleware.common.CommonMiddleware.process_response",
          "name": "django.middleware",
          "start": 1670562528028197671,
          "duration": 38500,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 16626258732309435611,
          "span_id": 13401853061533716896,
          "service": "weblog",
          "resource": "django.contrib.sessions.middleware.SessionMiddleware.process_response",
          "name": "django.middleware",
          "start": 1670562528028525275,
          "duration": 34401,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        },
        {
          "trace_id": 1,
          "parent_id": 16358416987194971796,
          "span_id": 16719102284058632160,
          "service": "weblog",
          "resource": "django.middleware.security.SecurityMiddleware.process_response",
          "name": "django.middleware",
          "start": 1670562528028836879,
          "duration": 42201,
          "meta": {
            "key1": "val1",
            " key2 ": " val2",
            "env": "system-tests",
            "version": "1.0.0"
          }
        }
      ]
```

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
