### PR TITLE
Revert "Send custom span tags in dotnet container (#700)"

### DIFF
--- a/utils/build/docker/dotnet/Helper.cs
+++ b/utils/build/docker/dotnet/Helper.cs
@@ -20,17 +20,6 @@ namespace weblog
                 {
                     childScope.Span.SetTag("garbage" + i, RandomString(50));
                 }
-
-                // Send custom span tags
-                string customSpanTags = Environment.GetEnvironmentVariable("TEST_SPAN_CUSTOM_TAGS");
-                if (!String.IsNullOrEmpty(customSpanTags)) {
-                    string[] customSpanTagsArr = customSpanTags.Split(',');
-                    foreach (var tag in customSpanTagsArr)
-                    {
-                        string[] arr = tag.Split(':');
-                        childScope.Span.SetTag(arr[0], arr[1]);
-                    }                    
-                }
             }
         }
 


### PR DESCRIPTION
This reverts commit 58f4ff7330103f3bfec0cda2f2cb0c638156c7df.

It's not needed since we can make use of [DD_TAGS](https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=noncontainerizedenvironments#environment-variables)
## Description

Please include a short summary of the change

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
