### PR TITLE
feat(parametric): Enable Java client in parametric

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -762,6 +762,7 @@ jobs:
         - dotnet
         - golang
         - nodejs
+        - java
       fail-fast: false
     steps:
     - name: Checkout


### PR DESCRIPTION
## Description

As we just released (yesterday 🎉 ) a version with the missing parts from the Java tracer to work properly with the parametric tests, here is finally the change to enable the Java client in parametric system tests during CI.

I ignored two new tests about SSS until fixed. I will reach @ygree about them. 

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
