### PR TITLE
feat(java): Add new weblog variant for native image

### DIFF
--- a/tests/appsec/iast/test_iast_ldap_injection.py
+++ b/tests/appsec/iast/test_iast_ldap_injection.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import pytest
-from utils import weblog, interfaces, context, coverage, released
+from utils import weblog, interfaces, context, coverage, released, missing_feature
 
 if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
@@ -12,6 +12,7 @@ if context.library == "cpp":
 # Weblog are ok for nodejs/express4 and java/spring-boot
 @coverage.basic
 @released(dotnet="?", golang="?", java="?", nodejs="?", php_appsec="?", python="?", ruby="?")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 class TestIastLDAPInjection:
     """Verify IAST LDAP Injection"""
 

--- a/tests/appsec/test_alpha.py
+++ b/tests/appsec/test_alpha.py
@@ -14,6 +14,7 @@ if context.library == "cpp":
 @released(golang={"gin": "1.37.0", "echo": "1.36.0", "chi": "1.36.0", "*": "1.34.0"})
 @released(dotnet="1.28.6", java="0.87.0", nodejs="2.0.0", php_appsec="0.2.1", python="1.1.0rc2.dev")
 @missing_feature(context.library == "ruby" and context.libddwaf_version is None)
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 class Test_Basic:
     """ Detect attacks on raw URI and headers with default rules """

--- a/tests/appsec/test_client_ip.py
+++ b/tests/appsec/test_client_ip.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from utils import weblog, context, coverage, interfaces, released, scenario
+from utils import weblog, context, coverage, interfaces, released, scenario, missing_feature
 
 if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
@@ -12,6 +12,7 @@ if context.library == "cpp":
 
 @released(dotnet="?", golang="?", java="0.114.0")
 @released(nodejs="3.6.0", php="0.81.0", python="1.5.0", ruby="?")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 @scenario("APPSEC_DISABLED")
 class Test_StandardTagsClientIp:

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -18,6 +18,7 @@ class Test_OneVariableInstallation:
 
 
 @released(dotnet="1.29.0", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="?", ruby="?")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 class Test_StaticRuleSet:
     """Appsec loads rules from a static rules file"""
@@ -56,6 +57,7 @@ class Test_RuleSet_1_2_5:
 
 @released(dotnet="2.7.0", golang="1.38.0", java="0.99.0", nodejs="2.5.0")
 @released(php_appsec="0.3.0", python="1.2.1", ruby="1.0.0")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_RuleSet_1_3_1:
     """ AppSec uses rule set 1.3.1 or higher """
@@ -84,6 +86,7 @@ class Test_RuleSet_1_3_1:
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2355333252/Environment+Variables")
 @coverage.basic
 @released(java="0.100.0", nodejs="2.7.0", python="1.1.2")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 class Test_ConfigurationVariables:
     """ Configuration environment variables """
 

--- a/tests/appsec/test_customconf.py
+++ b/tests/appsec/test_customconf.py
@@ -14,6 +14,7 @@ stdout = interfaces.library_stdout if context.library != "dotnet" else interface
 
 
 @released(java="0.93.0", php_appsec="0.3.0", ruby="?")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 @scenario("APPSEC_CORRUPTED_RULES")
 class Test_CorruptedRules:
@@ -39,6 +40,7 @@ class Test_CorruptedRules:
 
 
 @released(java="0.93.0", nodejs="?", php_appsec="0.3.0", ruby="?")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 @scenario("APPSEC_MISSING_RULES")
 class Test_MissingRules:
@@ -71,6 +73,7 @@ class Test_MissingRules:
 # Basically the same test as Test_MissingRules, and will be called by the same scenario (save CI time)
 @released(java="0.93.0", nodejs="2.0.0", php_appsec="0.3.0", python="1.1.0rc2.dev")
 @missing_feature(context.library <= "ruby@1.0.0.beta1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 @scenario("APPSEC_CUSTOM_RULES")
 class Test_ConfRuleSet:
@@ -94,6 +97,7 @@ class Test_ConfRuleSet:
 
 @released(dotnet="2.4.4", golang="1.37.0", java="0.97.0", nodejs="2.4.0", php_appsec="0.3.0", python="1.1.0rc2.dev")
 @missing_feature(context.library <= "ruby@1.0.0.beta1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 @scenario("APPSEC_CUSTOM_RULES")
 class Test_NoLimitOnWafRules:

--- a/tests/appsec/test_endpoint_ognl.py
+++ b/tests/appsec/test_endpoint_ognl.py
@@ -9,6 +9,7 @@ from utils import weblog, interfaces, context, missing_feature
 @missing_feature(weblog_variant="jersey-grizzly2", reason="Need to build endpoint on weblog")
 @missing_feature(weblog_variant="resteasy-netty3", reason="Need to build endpoint on weblog")
 @missing_feature(weblog_variant="ratpack", reason="Need to build endpoint on weblog")
+@missing_feature(weblog_variant="spring-boot-native", reason="Need to build endpoint on weblog")
 @missing_feature(weblog_variant="vertx3", reason="Need to build endpoint on weblog")
 class Test_Ognl:
     """ Verify the /trace/ognl endpoint is setup """

--- a/tests/appsec/test_endpoint_sqli.py
+++ b/tests/appsec/test_endpoint_sqli.py
@@ -9,6 +9,7 @@ from utils import weblog, interfaces, context, missing_feature
 @missing_feature(weblog_variant="jersey-grizzly2", reason="Need to build endpoint on weblog")
 @missing_feature(weblog_variant="resteasy-netty3", reason="Need to build endpoint on weblog")
 @missing_feature(weblog_variant="ratpack", reason="Need to build endpoint on weblog")
+@missing_feature(weblog_variant="spring-boot-native", reason="Need to build endpoint on weblog")
 @missing_feature(weblog_variant="vertx3", reason="Need to build endpoint on weblog")
 class Test_Sqli:
     """ Verify the /rasp/sqli endpoint is setup """

--- a/tests/appsec/test_identify.py
+++ b/tests/appsec/test_identify.py
@@ -5,7 +5,7 @@
 import pytest
 
 from tests.constants import PYTHON_RELEASE_GA_1_1
-from utils import weblog, context, coverage, interfaces, released
+from utils import weblog, context, coverage, interfaces, released, missing_feature
 
 if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
@@ -13,6 +13,7 @@ if context.library == "cpp":
 
 @released(dotnet="2.7.0", golang="1.37.0", java="?", nodejs="2.4.0")
 @released(php="0.72.0", python=PYTHON_RELEASE_GA_1_1, ruby="1.0.0")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 class Test_Basic:
     """Basic tests for Identify SDK for AppSec"""

--- a/tests/appsec/test_logs.py
+++ b/tests/appsec/test_logs.py
@@ -53,6 +53,7 @@ class Test_Standardization:
     @bug(context.library == "java@0.90.0", reason="APPSEC-2190")
     @bug(context.library == "java@0.91.0", reason="APPSEC-2190")
     @missing_feature(context.library < "dotnet@2.1.0")
+    @missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
     def test_d05(self):
         """Log D5: WAF outputs"""
         stdout.assert_presence(r'AppSec In-App WAF returned:.*crs-921-160"', level="DEBUG")
@@ -60,6 +61,7 @@ class Test_Standardization:
 
     @missing_feature(library="php", reason="Would require parsing the WAF result")
     @missing_feature(library="dotnet", reason="APPSEC-983")
+    @missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
     def test_d06(self):
         """Log D6: WAF rule detected an attack with details"""
         stdout.assert_presence(r"Detecting an attack from rule crs-921-160:.*", level="DEBUG")
@@ -72,12 +74,14 @@ class Test_Standardization:
 
     @missing_feature(library="php")
     @missing_feature(library="dotnet", reason="APPSEC-983, being discussed")
+    @missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
     def test_i01(self):
         """Log I1: AppSec initial configuration"""
         stdout.assert_presence(r"AppSec initial configuration from .*, libddwaf version: \d+\.\d+\.\d+", level="INFO")
 
     @missing_feature(library="php", reason="rules are not analyzed, only converted to PWArgs")
     @missing_feature(library="dotnet", reason="APPSEC-983")
+    @missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
     def test_i02(self):
         """Log I2: AppSec rule source"""
         stdout.assert_presence(r"AppSec loaded \d+ rules from file .*$", level="INFO")
@@ -85,6 +89,7 @@ class Test_Standardization:
     @missing_feature(library="dotnet", reason="APPSEC-983")
     @missing_feature(context.library <= "java@0.88.0", reason="small typo")
     @missing_feature(library="php")
+    @missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
     def test_i05(self):
         """Log I5: WAF detected an attack"""
         stdout.assert_presence(r"Detecting an attack from rule crs-921-160$", level="INFO")
@@ -92,6 +97,7 @@ class Test_Standardization:
 
 
 @released(golang="?", dotnet="?", java="?", nodejs="?", php="?", python="?", ruby="?")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 class Test_StandardizationBlockMode:
     """AppSec blocking logs should be standardized"""
 

--- a/tests/appsec/test_reports.py
+++ b/tests/appsec/test_reports.py
@@ -24,6 +24,7 @@ if context.library == "cpp":
 
 @released(dotnet="1.28.6", java="0.92.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.1.0rc2.dev")
 @released(golang={"gin": "1.37.0", "echo": "1.36.0", "*": "1.34.0"})
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @bug(library="python@1.1.0", reason="a PR was not included in the release")
 @coverage.basic
 class Test_StatusCode:
@@ -65,6 +66,7 @@ class Test_StatusCode:
 )
 @released(dotnet="1.30.0", java="0.98.1", nodejs="2.0.0", php_appsec="0.3.0", python=PYTHON_RELEASE_GA_1_1)
 @missing_feature(context.library == "ruby" and context.libddwaf_version is None)
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_HttpClientIP:
     """ AppSec reports good http client IP"""
@@ -104,6 +106,7 @@ class Test_HttpClientIP:
     else "1.34.0"
 )
 @released(dotnet="2.0.0", java="0.87.0", nodejs="2.0.0", php="0.68.2", python="1.1.0rc2.dev")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @flaky(context.library <= "php@0.68.2")
 @bug(library="python@1.1.0", reason="a PR was not included in the release")
 @coverage.good
@@ -138,6 +141,7 @@ class Test_Info:
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2186870984/HTTP+header+collection")
 @released(golang={"gin": "1.37.0", "echo": "1.36.0", "*": "1.34.0"})
 @released(dotnet="1.30.0", nodejs="2.0.0", php_appsec="0.2.0", python="1.1.0rc2.dev")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @missing_feature(context.library == "ruby" and context.libddwaf_version is None)
 @bug(library="python@1.1.0", reason="a PR was not included in the release")
 @coverage.good

--- a/tests/appsec/test_runtime_activation.py
+++ b/tests/appsec/test_runtime_activation.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import weblog, context, coverage, interfaces, released, irrelevant, scenario
+from utils import weblog, context, coverage, interfaces, released, irrelevant, scenario, missing_feature
 
 # dd.rc.targets.key.id=TEST_KEY_ID
 # dd.rc.targets.key=1def0961206a759b09ccdf2e622be20edf6e27141070e7b164b7e16e96cf402c
@@ -15,6 +15,7 @@ from utils import weblog, context, coverage, interfaces, released, irrelevant, s
 @irrelevant(
     context.library >= "java@1.1.0" and context.appsec_rules_file is not None, reason="Can't test with cutom rule file"
 )
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 class Test_RuntimeActivation:
     """A library should block requests after AppSec is activated via remote config."""

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -26,6 +26,7 @@ RUNTIME_FAMILIES = ["nodejs", "ruby", "jvm", "dotnet", "go", "php", "python"]
 @released(golang="1.37.0" if context.weblog_variant == "gin" else "1.36.0")
 @released(dotnet="1.29.0", java="0.92.0", python="1.1.0rc2.dev")
 @released(nodejs="2.0.0", php_appsec="0.1.0", ruby="0.54.2")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @bug(library="python@1.1.0", reason="a PR was not included in the release")
 @coverage.good
 class Test_RetainTraces:
@@ -70,6 +71,7 @@ class Test_RetainTraces:
 @released(golang="1.37.0" if context.weblog_variant == "gin" else "1.36.0")
 @released(dotnet="1.29.0", java="0.104.0", nodejs="2.0.0")
 @released(php_appsec="0.1.0", python="0.58.5", ruby="0.54.2")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_AppSecEventSpanTags:
     """AppSec correctly fill span tags."""
@@ -163,6 +165,7 @@ class Test_AppSecEventSpanTags:
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2365948382/Sensitive+Data+Obfuscation")
 @released(golang="1.38.0", dotnet="2.7.0", java="0.113.0", nodejs="2.6.0")
 @released(php_appsec="0.3.0", python=PYTHON_RELEASE_GA_1_1, ruby="?")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_AppSecObfuscator:
     """AppSec obfuscates sensitive data."""
@@ -325,6 +328,7 @@ class Test_AppSecObfuscator:
 @released(dotnet="2.5.1", php_appsec="0.2.2", python=PYTHON_RELEASE_PUBLIC_BETA, ruby="1.0.0.beta1")
 @released(golang="1.37.0" if context.weblog_variant == "gin" else "1.36.2")
 @released(nodejs="2.0.0", java="0.102.0")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_CollectRespondHeaders:
     """AppSec should collect some headers for http.response and store them in span tags."""

--- a/tests/appsec/test_versions.py
+++ b/tests/appsec/test_versions.py
@@ -8,6 +8,7 @@ from utils import context, interfaces, released, coverage, irrelevant, missing_f
 @irrelevant(library="cpp")
 @released(java="0.90.0", nodejs="2.0.0", python="0.58.5", ruby="0.54.2")
 @released(golang="1.37.0" if context.weblog_variant == "gin" else "1.36.0")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 class Test_Events:
     """AppSec events uses events in span"""

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -26,6 +26,7 @@ if context.library == "cpp":
 
 @released(golang="1.38.1", dotnet="2.7.0", java="0.100.0", nodejs="2.6.0")
 @released(php_appsec="0.3.2", python="1.2.1", ruby="1.0.0")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 class Test_UrlQueryKey:
     """Appsec supports keys on server.request.query"""
@@ -41,6 +42,7 @@ class Test_UrlQueryKey:
 
 @released(golang="1.37.0" if context.weblog_variant == "gin" else "1.35.0")
 @released(dotnet="1.28.6", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1", ruby="0.54.2")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_UrlQuery:
     """Appsec supports values on server.request.query"""
@@ -75,6 +77,7 @@ class Test_UrlQuery:
 @released(golang={"gin": "1.37.0", "chi": "1.36.0", "echo": "1.36.0", "*": "1.34.0"})
 @released(dotnet="1.28.6", java="0.87.0")
 @released(nodejs="2.0.0", php_appsec="0.1.0", python="0.58.5")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @flaky(context.library <= "php@0.68.2")
 @coverage.basic
 class Test_UrlRaw:
@@ -92,6 +95,7 @@ class Test_UrlRaw:
 @released(dotnet="1.28.6", java="0.87.0")
 @released(nodejs="2.0.0", php_appsec="0.1.0")
 @released(python="1.1.0rc2.dev")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @flaky(context.library <= "php@0.68.2")
 @bug(library="python@1.1.0", reason="a PR was not included in the release")
 @coverage.good
@@ -286,6 +290,7 @@ class Test_BodyRaw:
 
 @released(golang="1.37.0", dotnet="2.7.0", nodejs="2.2.0", php_appsec="0.1.0", python="1.4.0rc1.dev", ruby="?")
 @released(java={"vertx3": "0.99.0", "ratpack": "0.99.0", "spring-boot-undertow": "0.98.0", "*": "0.95.1"})
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 @bug(context.library == "nodejs@2.8.0", reason="Capability to read body content is broken")
 class Test_BodyUrlEncoded:
@@ -315,6 +320,7 @@ class Test_BodyUrlEncoded:
 
 @released(golang="1.37.0", dotnet="2.8.0", nodejs="2.2.0", php="?", python="1.4.0rc1.dev", ruby="?")
 @released(java={"vertx3": "0.99.0", "ratpack": "0.99.0", "*": "0.95.1"})
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 @bug(context.library == "nodejs@2.8.0", reason="Capability to read body content is broken")
 class Test_BodyJson:
@@ -352,6 +358,7 @@ class Test_BodyJson:
 
 @released(golang="1.37.0", dotnet="2.8.0", nodejs="2.2.0", php="?", python=PYTHON_RELEASE_GA_1_1, ruby="?")
 @released(java={"vertx3": "?", "ratpack": "0.99.0", "*": "0.95.1"})
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @bug(context.library == "nodejs@2.8.0", reason="Capability to read body content is broken")
 @coverage.basic
 class Test_BodyXml:
@@ -398,6 +405,7 @@ class Test_ClientIP:
 
 
 @missing_feature(context.library == "ruby" and context.libddwaf_version is None)
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @released(golang="1.37.0" if context.weblog_variant == "gin" else "1.36.0")
 @released(dotnet="2.3.0", java="0.88.0", nodejs="2.0.0", python="0.58.5")
 @coverage.good
@@ -429,6 +437,7 @@ class Test_ResponseStatus:
         "pylons": "1.1.0rc2.dev",
     }
 )
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @irrelevant(
     context.library == "golang" and context.weblog_variant == "net-http", reason="net-http doesn't handle path params"
 )

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from utils import released, coverage, interfaces, bug, scenario, weblog
+from utils import released, coverage, interfaces, bug, scenario, weblog, missing_feature
 from utils._context.core import context
 
 if context.library == "cpp":
@@ -120,6 +120,7 @@ HTML_DATA = """<!-- Sorry, you’ve been blocked -->
         "*": "?",
     }
 )
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 @scenario("APPSEC_BLOCKING")
 class Test_Blocking:

--- a/tests/appsec/waf/test_miscs.py
+++ b/tests/appsec/waf/test_miscs.py
@@ -14,6 +14,7 @@ if context.library == "cpp":
 
 @released(golang={"gin": "1.37.0", "echo": "1.36.0", "chi": "1.36.0", "*": "1.34.0"})
 @released(dotnet="1.28.6", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.1.0rc2.dev")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @bug(library="python@1.1.0", reason="a PR was not included in the release")
 @coverage.basic
 class Test_404:
@@ -39,6 +40,7 @@ class Test_404:
 @released(golang="1.37.0" if context.weblog_variant == "gin" else "1.36.0")
 @released(dotnet="2.3.0", java="0.95.0", nodejs="2.0.0")
 @released(php_appsec="0.2.0", python="1.2.1", ruby="1.0.0.beta1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 class Test_MultipleHighlight:
     """ Appsec reports multiple attacks on same request """
@@ -55,6 +57,7 @@ class Test_MultipleHighlight:
 
 @released(golang="1.37.0" if context.weblog_variant == "gin" else "1.35.0")
 @released(dotnet="2.1.0", java="0.92.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1", ruby="0.54.2")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_MultipleAttacks:
     """If several attacks are sent threw one requests, all of them are reported"""
@@ -87,6 +90,7 @@ class Test_MultipleAttacks:
 
 
 @missing_feature(library="php")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 class Test_NoWafTimeout:
     """ With an high value of DD_APPSEC_WAF_TIMEOUT, there is no WAF timeout"""

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -7,7 +7,7 @@ import json
 import pytest
 
 from tests.constants import PYTHON_RELEASE_GA_1_1
-from utils import weblog, context, interfaces, released, irrelevant, coverage, scenario
+from utils import weblog, context, interfaces, released, irrelevant, coverage, scenario, missing_feature
 
 
 if context.library == "cpp":
@@ -16,6 +16,7 @@ if context.library == "cpp":
 
 @released(golang="1.38.0", dotnet="2.9.0", java="0.100.0", nodejs="2.8.0")
 @released(php_appsec="0.3.0", python=PYTHON_RELEASE_GA_1_1, ruby="?")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_Monitoring:
     """Support In-App WAF monitoring tags and metrics"""

--- a/tests/appsec/waf/test_rules.py
+++ b/tests/appsec/waf/test_rules.py
@@ -16,6 +16,7 @@ if context.library == "cpp":
 
 @released({"gin": "1.37.0", "*": "1.35.0"})
 @released(dotnet="1.28.6", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_Scanners:
     """ Appsec WAF tests on scanners rules """
@@ -34,6 +35,7 @@ class Test_Scanners:
 
 @released({"gin": "1.37.0", "*": "1.36.1"})
 @released(nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_HttpProtocol:
     """ Appsec WAF tests on HTTP protocol rules """
@@ -60,6 +62,7 @@ class Test_HttpProtocol:
 @released({"gin": "1.37.0", "*": "1.35.0"})
 @released(python={"flask-poc": "1.5.2", "uds-flask": "1.5.2", "*": "?"})
 @released(nodejs="2.0.0", php_appsec="0.1.0")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_LFI:
     """ Appsec WAF tests on LFI rules """
@@ -99,6 +102,7 @@ class Test_LFI:
 
 @released({"gin": "1.37.0", "*": "1.35.0"})
 @released(dotnet="1.28.6", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_RFI:
     """ Appsec WAF tests on RFI rules """
@@ -115,6 +119,7 @@ class Test_RFI:
 
 @released({"gin": "1.37.0", "*": "1.35.0"})
 @released(dotnet="1.28.6", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @flaky(context.library <= "php@0.68.2")
 @coverage.good
 class Test_CommandInjection:
@@ -140,6 +145,7 @@ class Test_CommandInjection:
 
 @released({"gin": "1.37.0", "*": "1.35.0"})
 @released(java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_PhpCodeInjection:
     """ Appsec WAF tests on PHP injection rules """
@@ -174,6 +180,7 @@ class Test_PhpCodeInjection:
 
 @released({"gin": "1.37.0", "*": "1.35.0"})
 @released(dotnet="1.28.6", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_JsInjection:
     """ Appsec WAF tests on Js Injection rules """
@@ -190,6 +197,7 @@ class Test_JsInjection:
 
 @released({"gin": "1.37.0", "echo": "1.36.0", "*": "1.35.0"})
 @released(java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.3.0")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_XSS:
     """ Appsec WAF tests on XSS rules """
@@ -226,6 +234,7 @@ class Test_XSS:
 
 @released({"gin": "1.37.0", "*": "1.35.0"})
 @released(nodejs="2.0.0", php_appsec="0.1.0", python="1.3.0")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @flaky(context.library <= "php@0.68.2")
 @coverage.good
 class Test_SQLI:
@@ -277,6 +286,7 @@ class Test_SQLI:
 
 @released({"gin": "1.37.0", "*": "1.35.0"})
 @released(dotnet="2.12.0", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @flaky(context.library <= "php@0.68.2")
 @coverage.good
 class Test_NoSqli:
@@ -308,6 +318,7 @@ class Test_NoSqli:
 
 @released({"gin": "1.37.0", "*": "1.35.0"})
 @released(dotnet="1.28.6", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_JavaCodeInjection:
     """ Appsec WAF tests on Java code injection rules """
@@ -326,6 +337,7 @@ class Test_JavaCodeInjection:
 
 @released({"gin": "1.37.0", "*": "1.35.0"})
 @released(dotnet="1.28.6", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.good
 class Test_SSRF:
     """ Appsec WAF tests on SSRF rules """
@@ -339,6 +351,7 @@ class Test_SSRF:
 
 
 @missing_feature(context.library == "ruby" and context.libddwaf_version is None)
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @released({"gin": "1.37.0", "*": "1.36.0"})
 @released(dotnet="2.3.0", nodejs="2.0.0", python="0.58.5")
 @coverage.good

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -4,7 +4,7 @@
 
 import pytest
 from tests.constants import PYTHON_RELEASE_GA_1_1, PYTHON_RELEASE_PUBLIC_BETA
-from utils import bug, context, coverage, interfaces, irrelevant, released, rfc, weblog
+from utils import bug, context, coverage, interfaces, irrelevant, released, rfc, weblog, missing_feature
 
 if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
@@ -159,6 +159,7 @@ class Test_StandardTagsRoute:
 
 @released(dotnet="?", golang="?", java="0.114.0")
 @released(nodejs="3.6.0", php_appsec="0.4.4", python="1.5.0", ruby="?")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 @coverage.basic
 class Test_StandardTagsClientIp:
     """Tests to verify that libraries annotate spans with correct http.client_ip tags"""

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -10,6 +10,7 @@ from utils.tools import logger
 @missing_feature(library="ruby")
 @missing_feature(library="php")
 @missing_feature(library="golang", reason="Implemented but not merged in master")
+@missing_feature(weblog_variant="spring-boot-native", reason="Tracing support only")
 class Test_Telemetry:
     """Test that instrumentation telemetry is sent"""
 

--- a/utils/build/docker/java/spring-boot-native.Dockerfile
+++ b/utils/build/docker/java/spring-boot-native.Dockerfile
@@ -1,0 +1,40 @@
+FROM eclipse-temurin:8 as agent
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh
+
+
+FROM ghcr.io/graalvm/graalvm-ce:ol8-java11-22 as build
+
+# Install maven
+RUN curl https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz --output /opt/maven.tar.gz && \
+	tar xzvf /opt/maven.tar.gz --directory /opt && \
+	rm /opt/maven.tar.gz
+
+WORKDIR /app
+
+# Copy application sources
+COPY ./utils/build/docker/java/spring-boot-native/src ./src
+COPY ./utils/build/docker/java/spring-boot-native/pom.xml .
+# Copy tracer
+COPY --from=agent /dd-tracer/dd-java-agent.jar .
+# Build native application
+RUN --mount=type=cache,target=/root/.m2 /opt/apache-maven-3.8.6/bin/mvn -Pnative package
+
+
+FROM ubuntu
+
+WORKDIR /app
+COPY --from=agent /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=agent /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=agent /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=build /app/target/myproject .
+COPY ./utils/build/docker/java/spring-boot-native/app.sh .
+
+ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
+
+CMD [ "./myproject" ]

--- a/utils/build/docker/java/spring-boot-native/app.sh
+++ b/utils/build/docker/java/spring-boot-native/app.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "${UDS_WEBLOG:-}" = "1" ]; then
+    ./set-uds-transport.sh
+fi
+
+./myproject --server.port=7777

--- a/utils/build/docker/java/spring-boot-native/pom.xml
+++ b/utils/build/docker/java/spring-boot-native/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>myproject</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.1</version>
+    </parent>
+
+    <properties>
+         <agent.path>/app/dd-java-agent.jar</agent.path>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.experimental</groupId>
+            <artifactId>spring-native</artifactId>
+            <version>0.12.1</version>
+        </dependency>
+
+         <dependency>
+            <groupId>com.datadoghq</groupId>
+            <artifactId>dd-trace-api</artifactId>
+            <version>LATEST</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>LATEST</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+            <version>LATEST</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.4.3</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.springframework.experimental</groupId>
+                <artifactId>spring-aot-maven-plugin</artifactId>
+                <version>0.12.1</version>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.datadoghq.springbootnative.App</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>spring-release</id>
+            <name>Spring release</name>
+            <url>https://repo.spring.io/release</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-release</id>
+            <name>Spring release</name>
+            <url>https://repo.spring.io/release</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>0.9.13</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <buildArgs>
+                                <arg>-J-javaagent:${agent.path}</arg>
+                            </buildArgs>
+                        </configuration>
+                    </plugin>
+                    <!-- Avoid a clash between Spring Boot repackaging and native-maven-plugin -->
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <configuration>
+                            <classifier>exec</classifier>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/utils/build/docker/java/spring-boot-native/src/main/java/com/datadoghq/springbootnative/App.java
+++ b/utils/build/docker/java/spring-boot-native/src/main/java/com/datadoghq/springbootnative/App.java
@@ -1,0 +1,12 @@
+package com.datadoghq.springbootnative;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class App {
+
+  public static void main(final String[] args) {
+    SpringApplication.run(App.class, args);
+  }
+}

--- a/utils/build/docker/java/spring-boot-native/src/main/java/com/datadoghq/springbootnative/controller/IntegrationController.java
+++ b/utils/build/docker/java/spring-boot-native/src/main/java/com/datadoghq/springbootnative/controller/IntegrationController.java
@@ -1,0 +1,64 @@
+package com.datadoghq.springbootnative.controller;
+
+import io.opentracing.Span;
+import io.opentracing.util.GlobalTracer;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+@RestController
+public class IntegrationController {
+    @RequestMapping("/trace/sql")
+    String traceSQL() {
+        final Span span = GlobalTracer.get().activeSpan();
+        if (span != null) {
+            span.setTag("appsec.event", true);
+        }
+
+        // NOTE: see README.md for setting up the docker image to quickly test this
+
+        String url = "jdbc:postgresql://postgres_db/sportsdb?user=postgres&password=postgres";
+        try (Connection pgConn = DriverManager.getConnection(url)) {
+
+            Statement st = pgConn.createStatement();
+            ResultSet rs = st.executeQuery("SELECT * FROM display_names LIMIT 10");
+            while (rs.next())
+            {
+                System.out.print("Column 2 returned ");
+                System.out.println(rs.getString(2));
+            }
+            rs.close();
+            st.close();
+        } catch (SQLException e) {
+            e.printStackTrace(System.err);
+            return "pgsql exception :(";
+        }
+
+        return "hi SQL";
+    }
+
+    @RequestMapping("/trace/http")
+    String traceHTTP() {
+        final Span span = GlobalTracer.get().activeSpan();
+        if (span != null) {
+            span.setTag("appsec.event", true);
+        }
+
+        try {
+            URL server = new URL("http://example.com");
+            HttpURLConnection connection = (HttpURLConnection)server.openConnection();
+            connection.connect();
+            System.out.println("Response code:" + connection.getResponseCode());
+        } catch (Exception e) {
+            e.printStackTrace(System.err);
+            return "ssrf exception :(";
+        }
+        return "hi HTTP";
+    }
+}

--- a/utils/build/docker/java/spring-boot-native/src/main/java/com/datadoghq/springbootnative/controller/WebController.java
+++ b/utils/build/docker/java/spring-boot-native/src/main/java/com/datadoghq/springbootnative/controller/WebController.java
@@ -1,0 +1,45 @@
+package com.datadoghq.springbootnative.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+
+@RestController
+public class WebController {
+  @RequestMapping("/")
+  String home() {
+    return "Hello World!";
+  }
+
+  @GetMapping("/headers")
+  String headers(HttpServletResponse response) {
+    response.setHeader("content-language", "en-US");
+    return "012345678901234567890123456789012345678901";
+  }
+
+  @RequestMapping("/status")
+  ResponseEntity<String> status(@RequestParam Integer code) {
+    return new ResponseEntity<>(HttpStatus.valueOf(code));
+  }
+
+  @RequestMapping("/hello")
+  public String hello() {
+    return "Hello world";
+  }
+
+  @RequestMapping("/sample_rate_route/{i}")
+  String sample_route(@PathVariable("i") String i) {
+    return "OK";
+  }
+
+  @RequestMapping("/params/{str}")
+  String params_route(@PathVariable("str") String str) {
+    return "OK";
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a new weblog variant for `native-image`.
It's based on Spring 2.7 but build with native-image. For now, only tracing feature is supported from Java tracer so most of the tests like appsec are disabled.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
