### PR TITLE
Disable dns in parametric test

### DIFF
--- a/parametric/apps/nodejs/servicer.js
+++ b/parametric/apps/nodejs/servicer.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const tracer = require('dd-trace').init()
+tracer.use('dns', false)
 const SpanContext = require('dd-trace/packages/dd-trace/src/opentracing/span_context');
 
 class Servicer {


### PR DESCRIPTION
## Description
Disable dns plugin in parametric test, this is creating more spans than expected.

With some changes in dd-trace-js@2.x library, we have started to generate more spans related with dns. It generates extra `dns.lookup` span and causes the test fail, because it has 2 spans instead of expected one. 

With this change we are disabling `dns` plugin in the affected test to fix it, and be able to release 2.x version with success test results.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
