### PR TITLE
CI Upload failure tolerance

### DIFF
--- a/utils/scripts/upload_results_CI_visibility.sh
+++ b/utils/scripts/upload_results_CI_visibility.sh
@@ -23,5 +23,9 @@ export DD_SITE=datadoghq.com
 #Download tool
 curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "$(pwd)/datadog-ci" && chmod +x $(pwd)/datadog-ci
 for folder in $(find . -name "logs*" -type d -maxdepth 1); do 
-    ./datadog-ci junit upload --service ci-$SYS_ORIGIN_REPO --env env-system-test-$SYS_TEST_ENV --tags "ci.pipeline.run_id:$SYS_ORIGIN_REPO-$SYS_TEST_RUN_ID" $folder/reportJunit.xml 
+  if [[ -f "datadog-ci" ]]; then
+      ./datadog-ci junit upload --service ci-$SYS_ORIGIN_REPO --env env-system-test-$SYS_TEST_ENV --tags "ci.pipeline.run_id:$SYS_ORIGIN_REPO-$SYS_TEST_RUN_ID" $folder/reportJunit.xml 
+  else
+    echo "Skipping CI upload: datadog-ci not found"
+  fi
 done


### PR DESCRIPTION
## Description

Failure tolerance for CI results upload.
Sometimes when we try to download de CI Visibility script from github, service is not active and returns http 503. When this case happens, we won't upload results and we won't throw the failure, pipeline will continued....

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
