### PR TITLE
parametric: parameterize, change default grpc server port

### DIFF
--- a/parametric/README.md
+++ b/parametric/README.md
@@ -155,6 +155,31 @@ further.
   containers that may still be running.
 
 
+### Port conflict on 50052
+
+If there is a port conflict with an existing process on the local machine then the default port `50052` can be
+overridden using `APM_GRPC_SERVER_PORT=... ./run.sh`.
+
+
+### Disable build kit
+
+If logs like
+
+```
+Failed to fire hook: while creating logrus local file hook: user: Current requires cgo or $USER, $HOME set in environment
+[2023-01-04T21:44:49.583965000Z][docker-credential-desktop][F] get system info: exec: "sw_vers": executable file not found in $PATH
+[goroutine 1 [running, locked to thread]:
+[common/pkg/system.init.0()
+[	common/pkg/system/os_info.go:32 +0x1bc
+#3 ERROR: rpc error: code = Unknown desc = error getting credentials - err: exit status 1, out: ``
+```
+
+are being produced then likely build kit has to be disabled.
+
+To do that open the Docker UI > Docker Engine. Change `buildkit: true` to `buildkit: false` and restart Docker.
+
+
+
 ## Implementation
 
 ### Shared Interface

--- a/parametric/apps/dotnet/Program.cs
+++ b/parametric/apps/dotnet/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using ApmTestClient.Services;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -17,7 +18,7 @@ builder.WebHost.ConfigureKestrel(options =>
     // NOTE: For now, we'll set this in code via the options.Listen call since this
     // seems to work with the Python tests (perhaps because this covers IPv4 and IPv6)
 
-    options.Listen(IPAddress.Any, 50051, listenOptions =>
+    options.Listen(IPAddress.Any, Int32.Parse(Environment.GetEnvironmentVariable("APM_TEST_CLIENT_SERVER_PORT")), listenOptions =>
     {
         listenOptions.Protocols = HttpProtocols.Http2;
     });

--- a/parametric/apps/golang/main.go
+++ b/parametric/apps/golang/main.go
@@ -6,13 +6,11 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
+	"strconv"
 
 	"google.golang.org/grpc"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-)
-
-var (
-	port = flag.Int("port", 50051, "The server port")
 )
 
 type apmClientServer struct {
@@ -102,7 +100,11 @@ func main() {
 	tracer.Start()
 	defer tracer.Stop()
 	flag.Parse()
-	lis, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", *port))
+	port, err := strconv.Atoi(os.Getenv("APM_TEST_CLIENT_SERVER_PORT"))
+	if err != nil {
+		log.Fatalf("failed to convert port to integer: %v", err)
+	}
+	lis, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/parametric/apps/java/src/main/java/com/datadoghq/App.java
+++ b/parametric/apps/java/src/main/java/com/datadoghq/App.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 
 public class App {
     static final Logger LOGGER = Logger.getLogger(App.class.getName());
-    private static final int CLIENT_SERVER_PORT = 50051;
+    private static final int CLIENT_SERVER_PORT = Integer.parseInt(System.getenv("APM_TEST_CLIENT_SERVER_PORT"));
     private final DDTracer tracer;
 
     public App() throws ReflectiveOperationException, IOException {

--- a/parametric/apps/nodejs/server.js
+++ b/parametric/apps/nodejs/server.js
@@ -5,7 +5,7 @@ const protoLoader = require('@grpc/proto-loader');
 const Servicer = require('./servicer')
 
 const PROTO_PATH = 'apm_test_client.proto';
-const PORT = process.env.APM_TEST_CLIENT_SERVER_PORT || 50051;
+const PORT = process.env.APM_TEST_CLIENT_SERVER_PORT;
 
 const options = {
     keepCase: true,

--- a/parametric/apps/python/apm_test_client/__main__.py
+++ b/parametric/apps/python/apm_test_client/__main__.py
@@ -5,4 +5,4 @@ from .server import serve
 
 
 logging.basicConfig(level=logging.DEBUG)
-serve(port=os.getenv("APM_TEST_CLIENT_SERVER_PORT") or "50051")
+serve(port=os.getenv("APM_TEST_CLIENT_SERVER_PORT"))


### PR DESCRIPTION
Prior, the port 50051 was hardcoded in the Java and .NET servers.

The port 50051 can also conflict with multipass so the default is changed to 50052.

The port can also now be configured using the APM_GRPC_SERVER_PORT environment variable.

Thanks @Qard for finding out the issue with buildkit the hard-way.


## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
