### PR TITLE
Enable parametric w3c trace context tests for Node.js

### DIFF
--- a/parametric/apps/nodejs/server.js
+++ b/parametric/apps/nodejs/server.js
@@ -24,12 +24,14 @@ const servicer = new Servicer();
 
 server.addService(grpcObj.APMClient.service, {
     StartSpan: servicer.StartSpan,
+    InjectHeaders: servicer.InjectHeaders,
     SpanSetMeta: servicer.SetTag,
     SpanSetMetric: servicer.SetTag, // dd-trace-js has support for numeric values in tags
     SpanSetError: servicer.SpanSetError,
     FinishSpan: servicer.FinishSpan,
     FlushSpans: servicer.FlushSpans,
-    FlushTraceStats: servicer.FlushTraceStats
+    FlushTraceStats: servicer.FlushTraceStats,
+    StopTracer: servicer.StopTracer
 });
 
 server.bindAsync(

--- a/parametric/test_headers_b3.py
+++ b/parametric/test_headers_b3.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 
 from parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
+from parametric.spec.trace import span_has_no_parent
 from parametric.utils.headers import make_single_request_and_get_inject_headers
 from parametric.utils.test_agent import get_span
 
@@ -23,7 +24,7 @@ def enable_b3() -> Any:
 @enable_b3()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_b3_extract_valid(test_agent, test_library):
     """Ensure that b3 distributed tracing headers are extracted
     and activated properly.
@@ -42,7 +43,7 @@ def test_headers_b3_extract_valid(test_agent, test_library):
 
 @enable_b3()
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_b3_extract_invalid(test_agent, test_library):
     """Ensure that invalid b3 distributed tracing headers are not extracted.
     """
@@ -51,14 +52,14 @@ def test_headers_b3_extract_invalid(test_agent, test_library):
 
     span = get_span(test_agent)
     assert span.get("trace_id") != 0
-    assert span.get("parent_id") != 0
+    assert span_has_no_parent(span)
     assert span["meta"].get(ORIGIN) is None
 
 
 @enable_b3()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not impemented")
-@pytest.mark.skip_library("nodejs", "not impemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_b3_inject_valid(test_agent, test_library):
     """Ensure that b3 distributed tracing headers are injected properly.
     """
@@ -81,7 +82,7 @@ def test_headers_b3_inject_valid(test_agent, test_library):
 @enable_b3()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_b3multi_propagate_valid(test_agent, test_library):
     """Ensure that b3 distributed tracing headers are extracted
     and injected properly.
@@ -107,7 +108,7 @@ def test_headers_b3multi_propagate_valid(test_agent, test_library):
 @enable_b3()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_b3multi_propagate_invalid(test_agent, test_library):
     """Ensure that invalid b3 distributed tracing headers are not extracted
     and the new span context is injected properly.

--- a/parametric/test_headers_b3multi.py
+++ b/parametric/test_headers_b3multi.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 
 from parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
+from parametric.spec.trace import span_has_no_parent
 from parametric.utils.headers import make_single_request_and_get_inject_headers
 from parametric.utils.test_agent import get_span
 
@@ -30,7 +31,7 @@ def enable_b3multi() -> Any:
 @enable_b3multi()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_b3multi_extract_valid(test_agent, test_library):
     """Ensure that b3multi distributed tracing headers are extracted
     and activated properly.
@@ -54,7 +55,7 @@ def test_headers_b3multi_extract_valid(test_agent, test_library):
 
 @enable_b3multi()
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_b3multi_extract_invalid(test_agent, test_library):
     """Ensure that invalid b3multi distributed tracing headers are not extracted.
     """
@@ -65,14 +66,14 @@ def test_headers_b3multi_extract_invalid(test_agent, test_library):
 
     span = get_span(test_agent)
     assert span.get("trace_id") != 0
-    assert span.get("parent_id") != 0
+    assert span_has_no_parent(span)
     assert span["meta"].get(ORIGIN) is None
 
 
 @enable_b3multi()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not impemented")
-@pytest.mark.skip_library("nodejs", "not impemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_b3multi_inject_valid(test_agent, test_library):
     """Ensure that b3multi distributed tracing headers are injected properly.
     """
@@ -94,7 +95,7 @@ def test_headers_b3multi_inject_valid(test_agent, test_library):
 @enable_b3multi()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_b3multi_propagate_valid(test_agent, test_library):
     """Ensure that b3multi distributed tracing headers are extracted
     and injected properly.
@@ -124,7 +125,7 @@ def test_headers_b3multi_propagate_valid(test_agent, test_library):
 @enable_b3multi()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_b3multi_propagate_invalid(test_agent, test_library):
     """Ensure that invalid b3multi distributed tracing headers are not extracted
     and the new span context is injected properly.

--- a/parametric/test_headers_datadog.py
+++ b/parametric/test_headers_datadog.py
@@ -7,7 +7,7 @@ from parametric.utils.test_agent import get_span
 
 
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_distributed_headers_extract_datadog_D001(test_agent, test_library):
     """Ensure that Datadog distributed tracing headers are extracted
     and activated properly.
@@ -33,7 +33,7 @@ def test_distributed_headers_extract_datadog_D001(test_agent, test_library):
 
 
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_distributed_headers_extract_datadog_invalid_D002(test_agent, test_library):
     """Ensure that invalid Datadog distributed tracing headers are not extracted.
     """
@@ -58,7 +58,7 @@ def test_distributed_headers_extract_datadog_invalid_D002(test_agent, test_libra
 
 
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_distributed_headers_inject_datadog_D003(test_agent, test_library):
     """Ensure that Datadog distributed tracing headers are injected properly.
     """
@@ -72,7 +72,7 @@ def test_distributed_headers_inject_datadog_D003(test_agent, test_library):
 
 
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_distributed_headers_propagate_datadog_D004(test_agent, test_library):
     """Ensure that Datadog distributed tracing headers are extracted
     and injected properly.
@@ -98,7 +98,7 @@ def test_distributed_headers_propagate_datadog_D004(test_agent, test_library):
 
 
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_distributed_headers_extractandinject_datadog_invalid_D005(test_agent, test_library):
     """Ensure that invalid Datadog distributed tracing headers are not extracted
     and the new span context is injected properly.

--- a/parametric/test_headers_none.py
+++ b/parametric/test_headers_none.py
@@ -34,7 +34,7 @@ def enable_none_invalid() -> Any:
 @enable_none()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_none_extract(test_agent, test_library):
     """Ensure that no distributed tracing headers are extracted.
     """
@@ -60,7 +60,7 @@ def test_headers_none_extract(test_agent, test_library):
 
 @enable_none_invalid()
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_none_extract_with_other_propagators(test_agent, test_library):
     """Ensure that the 'none' propagator is ignored when other propagators are present.
     In this case, ensure that the Datadog distributed tracing headers are extracted
@@ -89,7 +89,7 @@ def test_headers_none_extract_with_other_propagators(test_agent, test_library):
 @enable_none()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not impemented")
-@pytest.mark.skip_library("nodejs", "not impemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_none_inject(test_agent, test_library):
     """Ensure that the 'none' propagator is used and
     no Datadog distributed tracing headers are injected.
@@ -108,7 +108,7 @@ def test_headers_none_inject(test_agent, test_library):
 
 @enable_none_invalid()
 @pytest.mark.skip_library("golang", "not impemented")
-@pytest.mark.skip_library("nodejs", "not impemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_none_inject_with_other_propagators(test_agent, test_library):
     """Ensure that the 'none' propagator is ignored when other propagators are present.
     In this case, ensure that the Datadog distributed tracing headers are injected properly.
@@ -125,7 +125,7 @@ def test_headers_none_inject_with_other_propagators(test_agent, test_library):
 @enable_none()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_none_propagate(test_agent, test_library):
     """Ensure that the 'none' propagator is used and
     no Datadog distributed tracing headers are extracted or injected.

--- a/parametric/test_headers_precedence.py
+++ b/parametric/test_headers_precedence.py
@@ -31,7 +31,7 @@ def enable_datadog_tracecontext() -> Any:
 
 @pytest.mark.skip_library("dotnet", "tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 @pytest.mark.skip_library("python", "BUG: w3c propagation is disabled by default")
 def test_headers_precedence_propagationstyle_default(test_agent, test_library):
     with test_library:
@@ -177,7 +177,7 @@ def test_headers_precedence_propagationstyle_default(test_agent, test_library):
 @enable_tracecontext()
 @pytest.mark.skip_library("dotnet", "tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_precedence_propagationstyle_tracecontext(test_agent, test_library):
     with test_library:
         # 1) No headers
@@ -300,7 +300,7 @@ def test_headers_precedence_propagationstyle_tracecontext(test_agent, test_libra
 
 @enable_datadog()
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_precedence_propagationstyle_datadog(test_agent, test_library):
     with test_library:
         # 1) No headers
@@ -406,7 +406,7 @@ def test_headers_precedence_propagationstyle_datadog(test_agent, test_library):
 @enable_datadog_tracecontext()
 @pytest.mark.skip_library("dotnet", "tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_precedence_propagationstyle_datadog_tracecontext(test_agent, test_library):
     with test_library:
         # 1) No headers

--- a/parametric/test_headers_tracecontext.py
+++ b/parametric/test_headers_tracecontext.py
@@ -28,7 +28,7 @@ def temporary_enable_optin_tracecontext() -> Any:
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_both_traceparent_and_tracestate_missing(test_agent, test_library):
     """
     harness sends a request without traceparent or tracestate
@@ -41,7 +41,7 @@ def test_both_traceparent_and_tracestate_missing(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_included_tracestate_missing(test_agent, test_library):
     """
     harness sends a request with traceparent but without tracestate
@@ -61,7 +61,10 @@ def test_traceparent_included_tracestate_missing(test_agent, test_library):
     "dotnet", "Bug: The .NET Tracer accepts one of the traceparent headers instead of discarding the headers",
 )
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library(
+    "nodejs",
+    "nodejs does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
+)
 @pytest.mark.skip_library(
     "python",
     "python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
@@ -87,7 +90,7 @@ def test_traceparent_duplicated(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_header_name(test_agent, test_library):
     """
     harness sends an invalid traceparent using wrong names
@@ -109,7 +112,7 @@ def test_traceparent_header_name(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Bug: Header search is currently case-sensitive")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_header_name_valid_casing(test_agent, test_library):
     """
     harness sends a valid traceparent using different combination of casing
@@ -136,7 +139,7 @@ def test_traceparent_header_name_valid_casing(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_version_0x00(test_agent, test_library):
     """
     harness sends an invalid traceparent with extra trailing characters
@@ -162,7 +165,7 @@ def test_traceparent_version_0x00(test_agent, test_library):
     "Bug: See https://www.w3.org/TR/trace-context/#versioning-of-traceparent for corrections . 1) We currently assert that version must be 00 2) We assert the length of the traceparent is exactly equal to 55",
 )
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_version_0xcc(test_agent, test_library):
     """
     harness sends an valid traceparent with future version 204 (0xcc)
@@ -191,7 +194,7 @@ def test_traceparent_version_0xcc(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Bug: Version string ff should be considered invalid")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_version_0xff(test_agent, test_library):
     """
     harness sends an invalid traceparent with version 255 (0xff)
@@ -210,7 +213,7 @@ def test_traceparent_version_0xff(test_agent, test_library):
     "dotnet", "Bug: Version string has invalid characters and should be considered invalid",
 )
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_version_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in version
@@ -232,7 +235,7 @@ def test_traceparent_version_illegal_characters(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_version_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with version more than 2 HEXDIG
@@ -254,7 +257,7 @@ def test_traceparent_version_too_long(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_version_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with version less than 2 HEXDIG
@@ -271,7 +274,7 @@ def test_traceparent_version_too_short(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_trace_id_all_zero(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_id = 00000000000000000000000000000000
@@ -290,7 +293,7 @@ def test_traceparent_trace_id_all_zero(test_agent, test_library):
     "dotnet", "Bug: trace-id string has invalid characters and should be considered invalid",
 )
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_trace_id_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in trace_id
@@ -312,7 +315,7 @@ def test_traceparent_trace_id_illegal_characters(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_trace_id_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_id more than 32 HEXDIG
@@ -331,7 +334,7 @@ def test_traceparent_trace_id_too_long(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_trace_id_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_id less than 32 HEXDIG
@@ -348,7 +351,7 @@ def test_traceparent_trace_id_too_short(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Bug: Parent-id of all zeroes should be considered invalid")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_parent_id_all_zero(test_agent, test_library):
     """
     harness sends an invalid traceparent with parent_id = 0000000000000000
@@ -367,7 +370,7 @@ def test_traceparent_parent_id_all_zero(test_agent, test_library):
     "dotnet", "Bug: trace-id string has invalid characters and should be considered invalid",
 )
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_parent_id_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in parent_id
@@ -389,7 +392,7 @@ def test_traceparent_parent_id_illegal_characters(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_parent_id_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with parent_id more than 16 HEXDIG
@@ -406,7 +409,7 @@ def test_traceparent_parent_id_too_long(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_parent_id_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with parent_id less than 16 HEXDIG
@@ -423,7 +426,7 @@ def test_traceparent_parent_id_too_short(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_trace_flags_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in trace_flags
@@ -445,7 +448,7 @@ def test_traceparent_trace_flags_illegal_characters(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_trace_flags_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_flags more than 2 HEXDIG
@@ -462,7 +465,7 @@ def test_traceparent_trace_flags_too_long(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_trace_flags_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_flags less than 2 HEXDIG
@@ -479,7 +482,7 @@ def test_traceparent_trace_flags_too_short(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_traceparent_ows_handling(test_agent, test_library):
     """
     harness sends an valid traceparent with heading and trailing OWS
@@ -516,7 +519,7 @@ def test_traceparent_ows_handling(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_tracestate_included_traceparent_missing(test_agent, test_library):
     """
     harness sends a request with tracestate but without traceparent
@@ -535,7 +538,7 @@ def test_tracestate_included_traceparent_missing(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_tracestate_included_traceparent_included(test_agent, test_library):
     """
     harness sends a request with both tracestate and traceparent
@@ -559,7 +562,7 @@ def test_tracestate_included_traceparent_included(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_tracestate_header_name(test_agent, test_library):
     """
     harness sends an invalid tracestate using wrong names
@@ -583,7 +586,7 @@ def test_tracestate_header_name(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_tracestate_header_name_valid_casing(test_agent, test_library):
     """
     harness sends a valid tracestate using different combination of casing
@@ -613,7 +616,10 @@ def test_tracestate_header_name_valid_casing(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library(
+    "nodejs",
+    "nodejs does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
+)
 @pytest.mark.skip_library(
     "python",
     "python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
@@ -660,7 +666,10 @@ def test_tracestate_empty_header(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library(
+    "nodejs",
+    "nodejs does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
+)
 @pytest.mark.skip_library(
     "python",
     "python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
@@ -696,7 +705,7 @@ def test_tracestate_multiple_headers_different_keys(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_tracestate_duplicated_keys(test_agent, test_library):
     """
     harness sends a request with an invalid tracestate header with duplicated keys
@@ -754,7 +763,7 @@ def test_tracestate_duplicated_keys(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_tracestate_all_allowed_characters(test_agent, test_library):
     """
     harness sends a request with a valid tracestate header with all legal characters
@@ -799,7 +808,7 @@ def test_tracestate_all_allowed_characters(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 @pytest.mark.skip_library(
     "python",
     "\t is an invalid character and is not supported in tracestate. We should update this test use spaces instead",

--- a/parametric/test_headers_tracestate_dd.py
+++ b/parametric/test_headers_tracestate_dd.py
@@ -19,7 +19,7 @@ def temporary_enable_propagationstyle_default() -> Any:
 @temporary_enable_propagationstyle_default()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_tracestate_dd_propagate_samplingpriority(test_agent, test_library):
     """
     harness sends a request with both tracestate and traceparent
@@ -193,7 +193,7 @@ def test_headers_tracestate_dd_propagate_samplingpriority(test_agent, test_libra
 @temporary_enable_propagationstyle_default()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 def test_headers_tracestate_dd_propagate_origin(test_agent, test_library):
     """
     harness sends a request with both tracestate and traceparent
@@ -322,7 +322,7 @@ def test_headers_tracestate_dd_propagate_origin(test_agent, test_library):
 @temporary_enable_propagationstyle_default()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("golang", "not implemented")
-@pytest.mark.skip_library("nodejs", "not implemented")
+@pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
 @pytest.mark.skip_library("python", "not implemented")
 def test_headers_tracestate_dd_propagate_propagatedtags(test_agent, test_library):
     """
@@ -433,7 +433,7 @@ def test_headers_tracestate_dd_propagate_propagatedtags(test_agent, test_library
     dd_items4 = tracestate4["dd"].split(";")
     assert "traceparent" in headers4
 
-    if headers4["x-datadog-tags"] is None:
+    if headers4["x-datadog-tags"] is None or headers4["x-datadog-tags"] == "":
         assert not any(item.startswith("t:") for item in dd_items4)
     else:
         assert "tracestate" in headers4
@@ -448,7 +448,9 @@ def test_headers_tracestate_dd_propagate_propagatedtags(test_agent, test_library
     # 5) tracestate[dd] is populated with well-known propagated tags
     # Result: Tags are placed into the tracestate where "_dd.p." is replaced with "t."
     #         and "=" is replaced with ":"
-    assert headers5["x-datadog-tags"] == "_dd.p.dm=-4,_dd.p.usr.id=baz64=="
+    dd_tags5 = headers5["x-datadog-tags"].split(",")
+    assert "_dd.p.dm=-4" in dd_tags5
+    assert "_dd.p.usr.id=baz64==" in dd_tags5
 
     traceparent5, tracestate5 = get_tracecontext(headers5)
     dd_items5 = tracestate5["dd"].split(";")
@@ -460,12 +462,15 @@ def test_headers_tracestate_dd_propagate_propagatedtags(test_agent, test_library
     # 6) tracestate[dd][o] is populated with both well-known tags and unrecognized propagated tags
     # Result: Tags are placed into the tracestate where "_dd.p." is replaced with "t."
     #         and "=" is replaced with ":"
-    assert headers6["x-datadog-tags"] == "_dd.p.dm=-4,_dd.p.usr.id=baz64==,_dd.p.url=http://localhost"
+    dd_tags6 = headers6["x-datadog-tags"].split(",")
+    assert "_dd.p.dm=-4" in dd_tags6
+    assert "_dd.p.usr.id=baz64==" in dd_tags6
+    assert "_dd.p.url=http://localhost" in dd_tags6
 
     traceparent6, tracestate6 = get_tracecontext(headers6)
     dd_items6 = tracestate6["dd"].split(";")
     assert "traceparent" in headers6
     assert "tracestate" in headers6
     assert "t.dm:-4" in dd_items6
-    assert "t.usr.id:baz64::" in dd_items6
+    assert "t.usr.id:baz64~~" in dd_items6
     assert "t.url:http://localhost" in dd_items6


### PR DESCRIPTION
## Description

Enables the w3c trace context parametric tests started in #691. A bunch of them are not working yet, so I've only enabled the ones passing currently. I'll continue work on the PR to Node.js to get the last few things passing.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
