### PR TITLE
Activate again nodejs iast system test

### DIFF
--- a/tests/appsec/iast/test_iast_command_injection.py
+++ b/tests/appsec/iast/test_iast_command_injection.py
@@ -12,8 +12,9 @@ if context.library == "cpp":
 
 # Weblog are ok for nodejs/express4 and java/spring-boot
 @coverage.basic
-@released(dotnet="?", golang="?", nodejs="?", php_appsec="?", python="?", ruby="?")
+@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?")
 @released(java={"spring-boot": "1.1.0", "spring-boot-jetty": "1.1.0", "spring-boot-openliberty": "1.1.0", "*": "?"})
+@released(nodejs={"express4": "3.11.0", "*": "?"})
 class TestIastCommandInjection:
     """Verify IAST features"""
 

--- a/tests/appsec/iast/test_iast_sql_injection.py
+++ b/tests/appsec/iast/test_iast_sql_injection.py
@@ -12,8 +12,9 @@ if context.library == "cpp":
 
 # Weblog are ok for nodejs/express4 and java/spring-boot
 @coverage.basic
-@released(dotnet="?", golang="?", nodejs="?", php_appsec="?", python="?", ruby="?")
+@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?")
 @released(java={"spring-boot": "1.1.0", "spring-boot-jetty": "1.1.0", "spring-boot-openliberty": "1.1.0", "*": "?"})
+@released(nodejs={"express4": "3.11.0", "*": "?"})
 class TestIastSqlInjection:
     """Verify IAST SQL INJECTION feature"""
 

--- a/tests/appsec/iast/test_iast_weak_hash.py
+++ b/tests/appsec/iast/test_iast_weak_hash.py
@@ -12,7 +12,7 @@ if context.library == "cpp":
 # Weblog are ok for nodejs/express4 and java/spring-boot
 @coverage.basic
 @released(dotnet="?", golang="?", php_appsec="?", python="1.6.0", ruby="?")
-@released(nodejs={"express4": "3.6.0", "*": "?"})
+@released(nodejs={"express4": "3.11.0", "*": "?"})
 @released(
     java={"spring-boot": "0.108.0", "spring-boot-jetty": "0.108.0", "spring-boot-openliberty": "0.108.0", "*": "?"}
 )
@@ -40,7 +40,6 @@ class TestIastWeakHash:
 
     @missing_feature(context.weblog_variant == "spring-boot-openliberty")
     @missing_feature(library="python", reason="Need to be implement duplicates vulnerability hashes")
-    @missing_feature(library="nodejs", reason="Changing from absolute path to relative path")
     def test_insecure_hash_remove_duplicates(self):
         """If one line is vulnerable and it is executed multiple times (for instance in a loop) in a request,
         we will report only one vulnerability"""
@@ -56,7 +55,6 @@ class TestIastWeakHash:
         self.r_insecure_hash_multiple = weblog.get("/iast/insecure_hashing/multiple_hash")
 
     @bug(context.weblog_variant == "spring-boot-openliberty")
-    @missing_feature(library="nodejs", reason="Changing from absolute path to relative path")
     def test_insecure_hash_multiple(self):
         """If a endpoint has multiple vulnerabilities (in diferent lines) we will report all of them"""
 
@@ -70,7 +68,6 @@ class TestIastWeakHash:
     def setup_secure_hash(self):
         self.r_secure_hash = weblog.get("/iast/insecure_hashing/test_secure_algorithm")
 
-    @missing_feature(context.library < "nodejs@3.3.1", reason="Need to be implement global vulnerability deduplication")
     def test_secure_hash(self):
         """Strong hash algorithm is not reported as insecure"""
         interfaces.library.expect_no_vulnerabilities(self.r_secure_hash)


### PR DESCRIPTION
## Description

I disabled some test when we did some changes in the tracer related with the paths of the vulnerability.
In the last release dd-trace-js release, we have included that fixes and and activate included also others vulnerabilities detection. 
In that PR I am just updating the nodejs versions to production versions.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
