### PR TITLE
Reenable ip blocking tests on java

### DIFF
--- a/tests/appsec/test_ip_blocking.py
+++ b/tests/appsec/test_ip_blocking.py
@@ -19,11 +19,17 @@ with open("tests/appsec/rc_expected_requests_asm_data.json", encoding="utf-8") a
         "sprint-boot-jetty": "0.111.0",
         "spring-boot-undertow": "0.111.0",
         "spring-boot-openliberty": "0.115.0",
+        "ratpack": "1.7.0",
+        "jersey-grizzly2": "1.7.0",
+        "resteasy-netty3": "1.7.0",
+        "vertx3": "1.7.0",
         "*": "?",
     }
 )
-@irrelevant(context.appsec_rules_file == "")
-@bug(context.weblog_variant == "spring-boot-undertow" and context.appsec_rules_version >= "1.4.2")
+@irrelevant(
+    context.library == "java" and context.appsec_rules_file is not None,
+    reason="No Remote Config sub with custom rules file",
+)
 @bug(context.weblog_variant == "uds-echo")
 @coverage.basic
 @scenario("APPSEC_IP_BLOCKING")
@@ -33,8 +39,6 @@ class Test_AppSecIPBlocking:
     request_number = 0
     remote_config_is_sent = False
 
-    @bug(context.library >= "java@1.1.0" and context.weblog_variant == "spring-boot-openliberty")
-    @bug(context.library >= "java@1.1.0" and context.weblog_variant == "spring-boot")
     def test_rc_protocol(self):
         """test sequence of remote config messages"""
 
@@ -78,10 +82,19 @@ class Test_AppSecIPBlocking:
         self.not_blocked_request = weblog.get(headers={"X-Forwarded-For": NOT_BLOCKED_IP})
         self.blocked_requests = [weblog.get(headers={"X-Forwarded-For": ip}) for ip in BLOCKED_IPS]
 
-    @bug(context.library == "java@0.110.0", reason="default action not implemented")
-    @bug(context.library <= "java@0.114.0" and context.weblog_variant == "spring-boot-openliberty")
-    @bug(context.library >= "java@1.1.0" and context.weblog_variant == "spring-boot-openliberty")
-    @bug(context.library >= "java@1.1.0" and context.weblog_variant == "spring-boot")
+    @released(
+        java={
+            "spring-boot": "0.111.0",
+            "spring-boot-jetty": "0.111.0",
+            "spring-boot-undertow": "0.111.0",
+            "spring-boot-openliberty": "0.115.0",
+            "ratpack": "1.7.0",
+            "jersey-grizzly2": "1.7.0",
+            "resteasy-netty3": "1.7.0",
+            "vertx3": "1.7.0",
+            "*": "?",
+        }
+    )
     def test_blocked_ips(self):
         """test blocked ips are enforced"""
 

--- a/tests/appsec/test_runtime_activation.py
+++ b/tests/appsec/test_runtime_activation.py
@@ -12,9 +12,9 @@ from utils import weblog, context, coverage, interfaces, released, irrelevant, s
 
 @scenario("APPSEC_RUNTIME_ACTIVATION")
 @released(java="0.115.0", cpp="?", dotnet="2.16.0", php="?", python="?", ruby="?", nodejs="3.9.0", golang="?")
-@irrelevant(context.appsec_rules_file == "")
 @irrelevant(
-    context.library >= "java@1.1.0" and context.appsec_rules_file is not None, reason="Can't test with custom rule file"
+    context.library == "java" and context.appsec_rules_file is not None,
+    reason="No Remote Config sub with custom rules file",
 )
 @bug(context.library == "java@1.6.0", reason="https://github.com/DataDog/dd-trace-java/pull/4614")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -117,6 +117,10 @@ HTML_DATA = """<!-- Sorry, you’ve been blocked -->
         "sprint-boot-jetty": "0.112.0",
         "spring-boot-undertow": "0.112.0",
         "spring-boot-openliberty": "1.3.0",
+        "ratpack": "1.7.0",
+        "jersey-grizzly2": "1.7.0",
+        "resteasy-netty3": "1.7.0",
+        "vertx3": "1.7.0",
         "*": "?",
     }
 )


### PR DESCRIPTION
## Description

Some tests had been disabled, but they invariably pass locally. Opened PR to investigate further.

## Check list

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [ ] There is at least one approval from code owners

