### PR TITLE
Simplfiy dotnet WAF version detection

### DIFF
--- a/utils/build/docker/dotnet/install_ddtrace.sh
+++ b/utils/build/docker/dotnet/install_ddtrace.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -eu
 
 cd /binaries
@@ -21,31 +20,7 @@ ls datadog-dotnet-apm-*.tar.gz > /app/SYSTEM_TESTS_LIBRARY_VERSION
 mkdir -p /opt/datadog
 tar xzf $(ls datadog-dotnet-apm-*.tar.gz) -C /opt/datadog
 
-ARCH=$(uname -m | sed 's/x86_//;s/i[3-6]86/32/')
-ARTIFACT_NAME="linux-x64"
-
-if [ "$ARCH" = "arm64" ]; then
-    ARTIFACT_NAME="linux-arm64"
-fi
-
-if [ -e /opt/datadog/tracer/Datadog.Tracer.Native.so ]
-then
-    # native tracer is in tracer subfolder
-    cp /opt/datadog/tracer/Datadog.Tracer.Native.so /binaries/libDatadog.Trace.ClrProfiler.Native.so
-elif [ -e /opt/datadog/$ARTIFACT_NAME/Datadog.Tracer.Native.so ]
-then
-    # native tracer is in arch folder - Waf expects Datadog.Tracer.Native for PInvoke
-    echo "Using /opt/datadog/$ARTIFACT_NAME/Datadog.Tracer.Native.so"
-    cp /opt/datadog/$ARTIFACT_NAME/Datadog.Tracer.Native.so /binaries/Datadog.Tracer.Native.so
-else
-    cp /opt/datadog/Datadog.Trace.ClrProfiler.Native.so /binaries/libDatadog.Trace.ClrProfiler.Native.so
-fi
-
-cp /opt/datadog/libddwaf.so /binaries
-dotnet fsi --langversion:preview /binaries/query-versions.fsx
-rm -f /binaries/libDatadog.Trace.ClrProfiler.Native.so
-rm -f /binaries/Datadog.Tracer.Native.so
-rm /binaries/libddwaf.so
+LD_LIBRARY_PATH=/opt/datadog dotnet fsi --langversion:preview /binaries/query-versions.fsx
 
 echo "dd-trace version: $(cat /app/SYSTEM_TESTS_LIBRARY_VERSION)"
 echo "libddwaf version: $(cat /app/SYSTEM_TESTS_LIBDDWAF_VERSION)"


### PR DESCRIPTION
Previously we relied on the C# library Datadog.Trace.dll for the version detection, this kept breaking as the library internals changed. To avoid these issues we now directly call the native waf library.

## Description

Please include a short summary of the change

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
