### PR TITLE
Update test for ruby ASM library

### DIFF
--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -300,7 +300,7 @@ class Test_BodyRaw:
         interfaces.library.assert_waf_attack(self.r, address="server.request.body")
 
 
-@released(golang="1.37.0", dotnet="2.7.0", nodejs="2.2.0", php_appsec="0.1.0", python="1.4.0rc1.dev", ruby="?")
+@released(golang="1.37.0", dotnet="2.7.0", nodejs="2.2.0", php_appsec="0.1.0", python="1.4.0rc1.dev", ruby="1.8.0")
 @released(java={"vertx3": "0.99.0", "ratpack": "0.99.0", "spring-boot-undertow": "0.98.0", "*": "0.95.1"})
 @coverage.basic
 @bug(context.library == "nodejs@2.8.0", reason="Capability to read body content is broken")
@@ -331,7 +331,7 @@ class Test_BodyUrlEncoded:
         interfaces.library.assert_waf_attack(self.r_value, value='<vmlframe src="xss">', address="server.request.body")
 
 
-@released(golang="1.37.0", dotnet="2.8.0", nodejs="2.2.0", php="?", python="1.4.0rc1.dev", ruby="?")
+@released(golang="1.37.0", dotnet="2.8.0", nodejs="2.2.0", php="?", python="1.4.0rc1.dev", ruby="1.8.0")
 @released(java={"vertx3": "0.99.0", "ratpack": "0.99.0", "*": "0.95.1"})
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -15,7 +15,7 @@ if context.library == "cpp":
 
 
 @released(golang="1.38.0", dotnet="2.9.0", java="0.100.0", nodejs="2.8.0")
-@released(php_appsec="0.3.0", python=PYTHON_RELEASE_GA_1_1, ruby="?")
+@released(php_appsec="0.3.0", python=PYTHON_RELEASE_GA_1_1, ruby="1.8.0")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @coverage.good

--- a/tests/appsec/waf/test_rules.py
+++ b/tests/appsec/waf/test_rules.py
@@ -294,7 +294,7 @@ class Test_SQLI:
 
 
 @released({"gin": "1.37.0", "*": "1.35.0"})
-@released(dotnet="2.12.0", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1")
+@released(dotnet="2.12.0", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.2.1", ruby="1.8.0")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @flaky(context.library <= "php@0.68.2")
@@ -316,7 +316,7 @@ class Test_NoSqli:
         self.r_3 = weblog.get("/waf/", params={"[$ne]": "value"})
         self.r_4 = weblog.get("/waf/", params={"$nin": "value"})
 
-    @missing_feature(context.library in ["golang", "php", "ruby"], reason="Need to use last WAF version")
+    @missing_feature(context.library in ["golang", "php"], reason="Need to use last WAF version")
     @missing_feature(context.library < "java@0.96.0", reason="Was using a too old WAF version")
     @irrelevant(context.appsec_rules_version < "1.3.0", reason="before 1.3.0, keys was not supported")
     @irrelevant(library="nodejs", reason="brackets are interpreted as arrays and thus truncated")

--- a/utils/build/docker/ruby/install_ddtrace.sh
+++ b/utils/build/docker/ruby/install_ddtrace.sh
@@ -8,8 +8,7 @@ if [ -e "/binaries/dd-trace-rb" ]; then
     echo "gem 'ddtrace', require: 'ddtrace/auto_instrument', path: '/binaries/dd-trace-rb'" >> Gemfile
 elif [ $(ls /binaries/ruby-load-from-bundle-add | wc -l) = 0 ]; then
     echo "Install prod version"
-    echo "1.8.0"
-    echo "gem 'ddtrace', '~> 1.8.0', require: 'ddtrace/auto_instrument'" >> Gemfile
+    echo "gem 'ddtrace', require: 'ddtrace/auto_instrument'" >> Gemfile
 else
     options=$(cat /binaries/ruby-load-from-bundle-add)
     echo "Install from $options"

--- a/utils/build/docker/ruby/install_ddtrace.sh
+++ b/utils/build/docker/ruby/install_ddtrace.sh
@@ -8,7 +8,8 @@ if [ -e "/binaries/dd-trace-rb" ]; then
     echo "gem 'ddtrace', require: 'ddtrace/auto_instrument', path: '/binaries/dd-trace-rb'" >> Gemfile
 elif [ $(ls /binaries/ruby-load-from-bundle-add | wc -l) = 0 ]; then
     echo "Install prod version"
-    echo "gem 'ddtrace', '~> 1.0.0.beta1', require: 'ddtrace/auto_instrument'" >> Gemfile
+    echo "1.8.0"
+    echo "gem 'ddtrace', '~> 1.8.0', require: 'ddtrace/auto_instrument'" >> Gemfile
 else
     options=$(cat /binaries/ruby-load-from-bundle-add)
     echo "Install from $options"


### PR DESCRIPTION
## Description

Some test where passing with XPASS, but they were enable for ruby.

The changes include:
- Updated test to acccount for the ruby library
- Make sure we are using the lastest version of dd-trace-rb for images

The PR doesn't enable all ruby test. 
There are some ruby tests that require a little bit of more work. I'm going to take the time to enable them in subsequent PRs

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
