### PR TITLE
go: enable standard tag http.client_ip test

### DIFF
--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -157,7 +157,7 @@ class Test_StandardTagsRoute:
         interfaces.library.add_span_tag_validation(request=self.r, tags=tags)
 
 
-@released(dotnet="?", golang="?", java="0.114.0")
+@released(dotnet="?", golang="1.46.0", java="0.114.0")
 @released(nodejs="3.6.0", php_appsec="0.4.4", python="1.5.0", ruby="?")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")


### PR DESCRIPTION
## Description

Enable the `http.client_ip` standard tag test for Go.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
