### PR TITLE
[RCM] Add RC to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 * @DataDog/system-tests-core
 /utils/build/docker/golang/* @DataDog/appsec-go
 /parametric/* @Kyle-Verhoog 
+/tests/remote_config/* @DataDog/system-tests-core @DataDog/remote-config


### PR DESCRIPTION
## Description

Add remote-config team as co-codeowners of the RC tests

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
