### PR TITLE
lib-injection/runner: update actions, pass test script as input

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -69,3 +69,4 @@ jobs:
           docker-registry: ghcr.io
           docker-registry-username: ${{ github.actor }}
           docker-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          test-script: ./lib-injection/run-lib-injection.sh

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -42,10 +42,10 @@ jobs:
           - uds
           - network
 
-        lib-injection-use-admission-controller: 
+        lib-injection-use-admission-controller:
           - use-admission-controller
           - ''
-        
+
         version: 
           - latest #Production tag
           - latest_snapshot
@@ -61,7 +61,7 @@ jobs:
       DOCKER_IMAGE_WEBLOG_TAG: ${{ github.sha }}
       BUILDX_PLATFORMS: linux/amd64
     steps:
-    
+
       - name: lib-injection test runner
         id: lib-injection-test-runner
         uses: DataDog/system-tests/lib-injection/runner@main

--- a/lib-injection/runner/action.yml
+++ b/lib-injection/runner/action.yml
@@ -15,16 +15,16 @@ runs:
   using: composite
   steps:
       - name: Checkout system tests
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # 3.3.0
         with:
           repository: 'DataDog/system-tests'
           path: './system-tests'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # 2.0.0
+        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8  # 2.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # 2.0.0
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # 2.2.1
         with: 
           install: true
           config-inline: |
@@ -32,7 +32,7 @@ runs:
               max-parallelism = 1
 
       - name: Log in to the Container registry
-        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # 2.0.0
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # 2.1.0
         with:
           registry: ${{ inputs.docker-registry }}
           username: ${{ inputs.docker-registry-username }}

--- a/lib-injection/runner/action.yml
+++ b/lib-injection/runner/action.yml
@@ -11,6 +11,9 @@ inputs:
   docker-registry-password:
     description: password for Docker registry
     required: true
+  test-script:
+    description: test script to run
+    required: true
 runs:
   using: composite
   steps:
@@ -25,7 +28,7 @@ runs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # 2.2.1
-        with: 
+        with:
           install: true
           config-inline: |
             [worker.oci]
@@ -37,19 +40,19 @@ runs:
           registry: ${{ inputs.docker-registry }}
           username: ${{ inputs.docker-registry-username }}
           password: ${{ inputs.docker-registry-password}}
-      
+
       - name: Build injection image
         shell: bash
         run: |
-          cd system-tests   
-          ./lib-injection/execFunction.sh build-and-push-test-app-image 
+          cd system-tests
+          ./lib-injection/execFunction.sh build-and-push-test-app-image
           ./lib-injection/build.sh
- 
+
       - name: Run lib injection tests
         shell: bash
         run: |
-          cd system-tests   
-          ./lib-injection/run-lib-injection.sh
+          cd system-tests
+          ${{ inputs.test-script }}
 
       - name: Compress lib injection logs
         shell: bash


### PR DESCRIPTION
## Description

Update the lib-injection runner action to use newer action versions to
avoid deprecation warnings like:

```
Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

To support running test scripts under the same environment the test
script can be passed as an argument.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
