### PR TITLE
[ASM] Fix test_multiple_matching_substring test for dotnet

### DIFF
--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -85,14 +85,11 @@ class Test_StandardTagsUrl:
 
     def setup_multiple_matching_substring(self):
         self.request_multiple_matching_substring = weblog.get(
-            "/waf?token=03cb9f67dbbc4cb8b966329951e10934&key1=val1&key2=val2&pass=03cb9f67-dbbc-4cb8-b966-329951e10934&public_key=MDNjYjlmNjctZGJiYy00Y2I4LWI5NjYtMzI5OTUxZTEwOTM0&key3=val3&json=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D"  # pylint: disable=line-too-long
+            "/waf?token=03cb9f67dbbc4cb8b9&key1=val1&key2=val2&pass=03cb9f67-dbbc-4cb8-b966-329951e10934&public_key=MDNjYjlmNjctZGJiYy00Y2I4LWI5NjYtMzI5OTUxZTEwOTM0&key3=val3&json=%7B%20%22sign%22%3A%20%22%7D%7D%22%7D"  # pylint: disable=line-too-long
         )
 
     def test_multiple_matching_substring(self):
         tag = "http://weblog:7777/waf?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20%22<redacted>%7D"  # pylint: disable=line-too-long
-        if context.library == "dotnet":
-            # dotnet truncates querystring to 200 chars
-            tag = "http://weblog:7777/waf?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20%22sign%22%3A%20%"  # pylint: disable=line-too-long
         interfaces.library.add_span_tag_validation(self.request_multiple_matching_substring, tags={"http.url": tag})
 
 

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -88,9 +88,11 @@ class Test_StandardTagsUrl:
             "/waf?token=03cb9f67dbbc4cb8b966329951e10934&key1=val1&key2=val2&pass=03cb9f67-dbbc-4cb8-b966-329951e10934&public_key=MDNjYjlmNjctZGJiYy00Y2I4LWI5NjYtMzI5OTUxZTEwOTM0&key3=val3&json=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D"  # pylint: disable=line-too-long
         )
 
-    @bug(library="dotnet", reason="APPSEC-5773")
     def test_multiple_matching_substring(self):
         tag = "http://weblog:7777/waf?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20%22<redacted>%7D"  # pylint: disable=line-too-long
+        if context.library == "dotnet":
+            # dotnet truncates querystring to 200 chars
+            tag = "http://weblog:7777/waf?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20%22sign%22%3A%20%"  # pylint: disable=line-too-long
         interfaces.library.add_span_tag_validation(self.request_multiple_matching_substring, tags={"http.url": tag})
 
 


### PR DESCRIPTION
## Description

test_multiple_matching_substring was failing due to dotnet string truncation for performance reasons

