### PR TITLE
[ASM] Custom blocking response

### DIFF
--- a/tests/appsec/blocking_rule.json
+++ b/tests/appsec/blocking_rule.json
@@ -27,16 +27,74 @@
           "operator": "match_regex"
         }
       ],
-      "on_match": ["block_request"]
+      "on_match": ["block"]
+    },
+    {
+      "id": "canary_rule1",
+      "name": "Canary 1",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "^Canary\\/v1"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "on_match": ["block1"]
+    },
+    {
+      "id": "canary_rule2",
+      "name": "Canary 2",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "^Canary\\/v2"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "on_match": ["block2"]
     }
   ],
   "actions": [
     {
-      "id": "block_request",
+      "id": "block1",
       "type": "block_request",
       "parameters": {
-        "status_code": 403,
+        "status_code": 401,
         "type": "auto"
+      }
+    },
+    {
+      "id": "block2",
+      "type": "redirect_request",
+      "parameters": {
+        "status_code": 301,
+        "location": "/you-have-been-blocked"
       }
     }
   ]

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -221,6 +221,7 @@ class Test_Blocking:
         assert re.match("^text/html", self.r_afh.headers.get("content-type", "")) is not None
 
 
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2705464728/Blocking#Custom-Blocking-Response-via-Remote-Config")
 @released(java="?", dotnet="?", golang="?", nodejs="?", php_appsec="?", python="?", ruby="?")
 @coverage.basic
 @scenario("APPSEC_BLOCKING")

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from utils import released, coverage, interfaces, bug, scenario, weblog
+from utils import released, coverage, interfaces, bug, scenario, weblog, rfc
 from utils._context.core import context
 
 if context.library == "cpp":
@@ -221,7 +221,9 @@ class Test_Blocking:
         assert re.match("^text/html", self.r_afh.headers.get("content-type", "")) is not None
 
 
-@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2705464728/Blocking#Custom-Blocking-Response-via-Remote-Config")
+@rfc(
+    "https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2705464728/Blocking#Custom-Blocking-Response-via-Remote-Config"
+)
 @released(java="?", dotnet="?", golang="?", nodejs="?", php_appsec="?", python="?", ruby="?")
 @coverage.basic
 @scenario("APPSEC_BLOCKING")

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -123,7 +123,7 @@ HTML_DATA = """<!-- Sorry, you’ve been blocked -->
 @coverage.basic
 @scenario("APPSEC_BLOCKING")
 class Test_Blocking:
-    """Blocking response is obtained when triggering a blocking rule"""
+    """Blocking response is obtained when triggering a blocking rule, test the default blocking response"""
 
     def setup_no_accept(self):
         self.r_na = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
@@ -219,3 +219,25 @@ class Test_Blocking:
         """Blocking with Accept: text/html"""
         assert self.r_afh.status_code == 403
         assert re.match("^text/html", self.r_afh.headers.get("content-type", "")) is not None
+
+
+@released(java="?", dotnet="?", golang="?", nodejs="?", php_appsec="?", python="?", ruby="?")
+@coverage.basic
+@scenario("APPSEC_BLOCKING")
+class Test_CustomBlockingResponse:
+    """Custom Blocking response"""
+
+    def setup_custom_status_code(self):
+        self.r_cst = weblog.get("/waf/", headers={"User-Agent": "Canary/v1"})
+
+    def test_custom_status_code(self):
+        """Block with a custom HTTP status code"""
+        assert self.r_cst.status_code == 401
+
+    def setup_custom_redirect(self):
+        self.r_cr = weblog.get("/waf/", headers={"User-Agent": "Canary/v2"}, allow_redirects=False)
+
+    def test_custom_redirect(self):
+        """Block with an HTTP redirection"""
+        assert self.r_cr.status_code == 301
+        assert self.r_cr.headers.get("location", "") == "/you-have-been-blocked"

--- a/utils/_weblog.py
+++ b/utils/_weblog.py
@@ -46,7 +46,7 @@ class _Weblog:
         return self.request("TRACE", path, params=params, data=data, headers=headers, **kwargs)
 
     def request(
-        self, method, path="/", params=None, data=None, headers=None, stream=None, domain="weblog", port=7777, **kwargs,
+        self, method, path="/", params=None, data=None, headers=None, stream=None, domain="weblog", port=7777, allow_redirects=True, **kwargs,
     ):
         # rid = str(uuid.uuid4()) Do NOT use uuid, it sometimes can looks like credit card number
         rid = "".join(random.choices(string.ascii_uppercase, k=36))
@@ -72,7 +72,7 @@ class _Weblog:
             r.url = url
             logger.debug(f"Sending request {rid}: {method} {url}")
 
-            r = requests.Session().send(r, timeout=5, stream=stream)
+            r = requests.Session().send(r, timeout=5, stream=stream, allow_redirects=allow_redirects)
         except Exception as e:
             logger.error(f"Request {rid} raise an error: {e}")
             return _FailedQuery(request=r)

--- a/utils/_weblog.py
+++ b/utils/_weblog.py
@@ -46,7 +46,17 @@ class _Weblog:
         return self.request("TRACE", path, params=params, data=data, headers=headers, **kwargs)
 
     def request(
-        self, method, path="/", params=None, data=None, headers=None, stream=None, domain="weblog", port=7777, allow_redirects=True, **kwargs,
+        self,
+        method,
+        path="/",
+        params=None,
+        data=None,
+        headers=None,
+        stream=None,
+        domain="weblog",
+        port=7777,
+        allow_redirects=True,
+        **kwargs,
     ):
         # rid = str(uuid.uuid4()) Do NOT use uuid, it sometimes can looks like credit card number
         rid = "".join(random.choices(string.ascii_uppercase, k=36))


### PR DESCRIPTION
## Description

This PR specifies custom actions as a result of a WAF trigger.

All tracers with support for blocking requests include a builtin action `block`. The `block` action interrupts an HTTP request and returns an HTTP response with status code `403` and a body corresponding to the request `accept` header.

A tracer may be instructed to trigger a custom action, to block using a different HTTP status code or redirect to a given URL for instance. Two tests are introduced in this PR to test those cases.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [X] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
