### PR TITLE
Enable ruby test for already released features

### DIFF
--- a/tests/appsec/test_client_ip.py
+++ b/tests/appsec/test_client_ip.py
@@ -11,7 +11,7 @@ if context.library == "cpp":
 
 
 @released(dotnet="2.20.0", golang="1.44.1", java="0.114.0")
-@released(nodejs="3.6.0", php="0.81.0", python="1.5.0", ruby="?")
+@released(nodejs="3.6.0", php="0.81.0", python="1.5.0", ruby="1.8.0")
 @coverage.basic
 @scenario("APPSEC_DISABLED")
 class Test_StandardTagsClientIp:

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -166,7 +166,7 @@ class Test_AppSecEventSpanTags:
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2365948382/Sensitive+Data+Obfuscation")
 @released(golang="1.38.0", dotnet="2.7.0", java="0.113.0", nodejs="2.6.0")
-@released(php_appsec="0.3.0", python=PYTHON_RELEASE_GA_1_1, ruby="?")
+@released(php_appsec="0.3.0", python=PYTHON_RELEASE_GA_1_1, ruby="1.0.0")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @coverage.good

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -441,7 +441,7 @@ class Test_ResponseStatus:
         interfaces.library.assert_waf_attack(self.r, pattern="404", address="server.response.status")
 
 
-@released(dotnet="2.5.1", nodejs="2.0.0", php_appsec="0.2.1", ruby="?")
+@released(dotnet="2.5.1", nodejs="2.0.0", php_appsec="0.2.1", ruby="1.8.0")
 @released(java={"vertx3": "0.99.0", "ratpack": "0.99.0", "resteasy-netty3": "?", "jersey-grizzly2": "?", "*": "0.95.1"})
 @released(golang={"gin": "1.37.0", "*": "1.36.0"})
 @released(
@@ -456,6 +456,7 @@ class Test_ResponseStatus:
 @irrelevant(
     context.library == "golang" and context.weblog_variant == "net-http", reason="net-http doesn't handle path params"
 )
+@irrelevant(context.library == "ruby" and context.weblog_variant == "rack")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @coverage.basic

--- a/tests/test_miscs.py
+++ b/tests/test_miscs.py
@@ -5,7 +5,7 @@
 from utils import weblog, interfaces, released, irrelevant
 
 
-@released(golang="1.43.0", java="0.97.0", nodejs="3.1.0", php="0.74.0", python="0.59.1", ruby="?")
+@released(golang="1.43.0", java="0.97.0", nodejs="3.1.0", php="0.74.0", python="0.59.1", ruby="1.8.0")
 @irrelevant(library="cpp")
 class Test_Basic:
     """ Make sure the spans endpoint is successful """

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -10,7 +10,7 @@ if context.library == "cpp":
     pytestmark = pytest.mark.skip("not relevant")
 
 
-@released(dotnet="2.0.0", golang="1.39.0", java="0.102.0", nodejs="2.11.0", php="0.75.0", python="1.2.1", ruby="?")
+@released(dotnet="2.0.0", golang="1.39.0", java="0.102.0", nodejs="2.11.0", php="0.75.0", python="1.2.1", ruby="1.8.0")
 @coverage.good
 class Test_StandardTagsMethod:
     """Tests to verify that libraries annotate spans with correct http.method tags"""
@@ -109,7 +109,7 @@ class Test_StandardTagsUserAgent:
 
 
 @released(dotnet="2.0.0", golang="1.39.0", java="0.102.0", nodejs="2.11.0")
-@released(php="0.75.0", python=PYTHON_RELEASE_PUBLIC_BETA, ruby="?")
+@released(php="0.75.0", python=PYTHON_RELEASE_PUBLIC_BETA, ruby="1.8.0")
 @coverage.good
 class Test_StandardTagsStatusCode:
     """Tests to verify that libraries annotate spans with correct http.status_code tags"""
@@ -125,6 +125,14 @@ class Test_StandardTagsStatusCode:
 
 @released(dotnet="2.13.0", golang="1.39.0", nodejs="2.11.0", php="?", python="1.6.0", ruby="?")
 @released(java={"spring-boot": "0.102.0", "spring-boot-jetty": "0.102.0", "*": "?"})
+@irrelevant(
+    (context.library, context.weblog_variant) == ("golang", "net-http"),
+    reason="net-http does not handle route parameters",
+)
+@irrelevant(library="ruby", weblog_variant="rack", reason="rack can not access route pattern")
+@missing_feature(
+    context.library == "ruby" and context.weblog_variant in ("rails", "sinatra14", "sinatra20", "sinatra21")
+)
 @coverage.basic
 class Test_StandardTagsRoute:
     """Tests to verify that libraries annotate spans with correct http.route tags"""
@@ -132,10 +140,6 @@ class Test_StandardTagsRoute:
     def setup_route(self):
         self.r = weblog.get("/sample_rate_route/1")
 
-    @irrelevant(
-        (context.library, context.weblog_variant) == ("golang", "net-http"),
-        reason="net-http does not handle route parameters",
-    )
     def test_route(self):
 
         tags = {"http.route": "/sample_rate_route/{i}"}
@@ -156,8 +160,10 @@ class Test_StandardTagsRoute:
         interfaces.library.add_span_tag_validation(request=self.r, tags=tags)
 
 
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution")
 @released(dotnet="?", golang="1.46.0", java="0.114.0")
 @released(nodejs="3.6.0", php_appsec="0.4.4", python="1.5.0", ruby="?")
+@bug(library="ruby", reason="APPSEC-7946")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @coverage.basic


### PR DESCRIPTION
## Description

Enable ruby tests for already released features.

This change goes in coordination with the addition of new endpoint to the ruby tests apps https://github.com/DataDog/system-tests-apps-ruby/pull/6

A part from enabling new tests I also added some test metadata on certain standard tags tests. 

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
