### PR TITLE
[APPSEC-7986] Use numeric user IDs in login event tests

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -180,6 +180,10 @@ The generated event has the following specification:
 - User ID: `123456` 
 - Metadata: `{metadata0: value0, metadata1: value1}`
 
+*NOTE*: The user id must be an integer because we want to cover
+the test case where it's reported as an integer (client side) but still reported
+as a string through meta to the backend.
+
 ## GET /user_login_failure_event
 
 This endpoint calls the appsec event tracking SDK function used for user login failure.
@@ -188,6 +192,10 @@ The generated event has the following specification:
 - User ID: `123456`
 - Exists: `true`
 - Metadata: `{metadata0: value0, metadata1: value1}`
+
+*NOTE*: The user id must be an integer because we want to cover
+the test case where it's reported as an integer (client side) but still reported
+as a string through meta to the backend.
 
 ## GET /custom_event
 

--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -177,7 +177,7 @@ Supported Libraries:
 This endpoint calls the appsec event tracking SDK function used for user login success.
 
 The generated event has the following specification:
-- User ID: `system_tests_user`
+- User ID: `123456` 
 - Metadata: `{metadata0: value0, metadata1: value1}`
 
 ## GET /user_login_failure_event
@@ -185,7 +185,7 @@ The generated event has the following specification:
 This endpoint calls the appsec event tracking SDK function used for user login failure.
 
 The generated event has the following specification:
-- User ID: `system_tests_user`
+- User ID: `123456`
 - Exists: `true`
 - Metadata: `{metadata0: value0, metadata1: value1}`
 

--- a/tests/appsec/test_event_tracking.py
+++ b/tests/appsec/test_event_tracking.py
@@ -28,7 +28,7 @@ class Test_UserLoginSuccessEvent:
         def validate_user_login_success_tags(span):
             expected_tags = {
                 "http.client_ip": "1.2.3.4",
-                "usr.id": "system_tests_user",
+                "usr.id": "123456",
                 "appsec.events.users.login.success.track": "true",
                 "appsec.events.users.login.success.metadata0": "value0",
                 "appsec.events.users.login.success.metadata1": "value1",
@@ -63,7 +63,7 @@ class Test_UserLoginFailureEvent:
         def validate_user_login_failure_tags(span):
             expected_tags = {
                 "http.client_ip": "1.2.3.4",
-                "appsec.events.users.login.failure.usr.id": "system_tests_user",
+                "appsec.events.users.login.failure.usr.id": "123456",
                 "appsec.events.users.login.failure.track": "true",
                 "appsec.events.users.login.failure.usr.exists": "true",
                 "appsec.events.users.login.failure.metadata0": "value0",

--- a/utils/build/docker/php/common/user_login_failure_event.php
+++ b/utils/build/docker/php/common/user_login_failure_event.php
@@ -1,5 +1,6 @@
 <?php
-\datadog\appsec\track_user_login_failure_event('system_tests_user', true,
+// pass user ID as integer to test that it ends up in meta not metrics
+\datadog\appsec\track_user_login_failure_event(123456, true,
 [
     'metadata0' => 'value0',
     'metadata1' => 'value1',

--- a/utils/build/docker/php/common/user_login_success_event.php
+++ b/utils/build/docker/php/common/user_login_success_event.php
@@ -1,5 +1,6 @@
 <?php
-\datadog\appsec\track_user_login_success_event('system_tests_user',
+// pass user ID as integer to test that it ends up in meta not metrics
+\datadog\appsec\track_user_login_success_event(123456,
 [
     'metadata0' => 'value0',
     'metadata1' => 'value1',


### PR DESCRIPTION
## Description

For handling custom events on the backend, the related user IDs need to be passed as strings.

Modifying the login success/failure tests to make sure this is covered.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
