### PR TITLE
Add missing types for metrics

### DIFF
--- a/utils/interfaces/schemas/library/telemetry/proxy/api/v2/apmtelemetry-request.json
+++ b/utils/interfaces/schemas/library/telemetry/proxy/api/v2/apmtelemetry-request.json
@@ -256,11 +256,16 @@
             "type": {
               "description": "Metric type variant",
               "type": "string",
-              "enum": ["gauge"],
+              "enum": ["gauge", "count", "rate"],
               "example": "gauge"
+            },
+            "interval": {
+              "description": "Set for gauge and rate metric types",
+              "type": "number",
+              "format": "double"
             }
           },
-          "required": ["metric", "points", "tags", "common", "type"]
+          "required": ["metric", "points"]
         },
         {
           "type": "object",


### PR DESCRIPTION
## Description

Add missing types to the Telemetry API JSON schema according to: [generate-metrics](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v1/producing-telemetry.md#generate-metrics)

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [x] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
