### PR TITLE
Bump Java Tracer to 1.7.0

### DIFF
--- a/parametric/apps/java/pom.xml
+++ b/parametric/apps/java/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <dd-trace.version>1.3.0</dd-trace.version>
+    <dd-trace.version>1.7.0</dd-trace.version>
     <opentracing.version>0.32.0</opentracing.version>
     <gprc.version>1.47.0</gprc.version>
   </properties>


### PR DESCRIPTION
## Description

Bump Java Tracer to 1.7.0. It includes fix for Single Span Sampling. See [this related PR](#848) with new test cases.

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
