### PR TITLE
Successfully running a smoke test that exercises the full e2e APM tracing pipeline

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -122,6 +122,9 @@ elif [ $SYSTEMTESTS_SCENARIO = "INTEGRATIONS" ]; then
     WEBLOG_ENV+="DD_DBM_PROPAGATION_MODE=full"
     CONTAINERS+=(cassandra_db mongodb postgres)
 
+elif [ $SYSTEMTESTS_SCENARIO = "APM_TRACING_E2E" ]; then
+    export RUNNER_ARGS="tests/apm-tracing-e2e"
+
 else # Let user choose the target
     export SYSTEMTESTS_SCENARIO="CUSTOM"
     export RUNNER_ARGS=$@

--- a/tests/apm-tracing-e2e/test_smoke.py
+++ b/tests/apm-tracing-e2e/test_smoke.py
@@ -1,5 +1,6 @@
 from utils import weblog, interfaces, rfc, scenario
 
+
 @rfc("https://docs.google.com/document/d/1MtSlvPCKWM4x4amOYAvlKVbJjd0b0oUXxxlX-lo8KN8/edit#")
 @scenario("APM_TRACING_E2E")
 class Test_Backend:

--- a/tests/apm-tracing-e2e/test_smoke.py
+++ b/tests/apm-tracing-e2e/test_smoke.py
@@ -5,11 +5,11 @@ from utils import weblog, interfaces, rfc, scenario
 class Test_Backend:
     """This is a smoke test that exercises the full flow of APM Tracing.
     It includes trace submission, the trace flowing through the backend processing,
-    and then finally fetching the final trace from the API.
+    and then finally successfully fetching the final trace from the API.
     """
 
     def setup_main(self):
         self.r = weblog.get("/")
 
     def test_main(self):
-        interfaces.backend.assert_trace_exists(self.r)
+        trace = interfaces.backend.assert_trace_exists(self.r)

--- a/tests/apm-tracing-e2e/test_smoke.py
+++ b/tests/apm-tracing-e2e/test_smoke.py
@@ -1,0 +1,15 @@
+from utils import weblog, interfaces, rfc, scenario
+
+@rfc("https://docs.google.com/document/d/1MtSlvPCKWM4x4amOYAvlKVbJjd0b0oUXxxlX-lo8KN8/edit#")
+@scenario("APM_TRACING_E2E")
+class Test_Backend:
+    """This is a smoke test that exercises the full flow of APM Tracing.
+    It includes trace submission, the trace flowing through the backend processing,
+    and then finally fetching the final trace from the API.
+    """
+
+    def setup_main(self):
+        self.r = weblog.get("/")
+
+    def test_main(self):
+        interfaces.backend.assert_trace_exists(self.r)

--- a/utils/interfaces/_backend.py
+++ b/utils/interfaces/_backend.py
@@ -82,14 +82,16 @@ class _BackendInterfaceValidator(InterfaceValidator):
                 return data
 
             time.sleep(sleep_interval_s)
-            sleep_interval_s *= sleep_interval_multiplier # increase the sleep time with each retry
+            sleep_interval_s *= sleep_interval_multiplier  # increase the sleep time with each retry
 
-        raise Exception(f"Backend did not provide trace after {retries} retries: {data['path']}. Status is {status_code}.")
+        raise Exception(
+            f"Backend did not provide trace after {retries} retries: {data['path']}. Status is {status_code}."
+        )
 
     def _extract_trace_from_backend_response(self, response):
         content_parsed = json.loads(response["content"])
         trace = content_parsed.get("trace")
-        if not trace: 
+        if not trace:
             raise Exception(f"The response does not contain valid trace content: {response}")
         return trace
 

--- a/utils/interfaces/_backend.py
+++ b/utils/interfaces/_backend.py
@@ -4,11 +4,14 @@
 
 """ This files will validate data flow between agent and backend """
 
+import json
 import os
 import threading
 import requests
+import time
 
 from utils.interfaces._core import InterfaceValidator, get_rid_from_span, get_rid_from_request
+from utils.tools import logger
 
 
 class _BackendInterfaceValidator(InterfaceValidator):
@@ -22,6 +25,7 @@ class _BackendInterfaceValidator(InterfaceValidator):
 
         self.rid_to_trace_id = {}
 
+    # Called by the test setup to make sure the interface is ready.
     def wait(self):
         super().wait()
         from utils.interfaces import library
@@ -55,6 +59,46 @@ class _BackendInterfaceValidator(InterfaceValidator):
             "response": {"status_code": r.status_code, "content": r.text, "headers": dict(r.headers),},
         }
 
+    def _wait_for_request_trace(self, request, retries=5, sleep_interval_multiplier=2.0):
+        if retries < 1:
+            retries = 1
+
+        rid = get_rid_from_request(request)
+        logger.info(f"Waiting for a trace to become available from request {rid} with {retries} retries...")
+
+        sleep_interval_s = 1
+        current_retry = 1
+        while current_retry <= retries:
+            logger.info(f"Retry {current_retry}")
+            current_retry += 1
+
+            data = self._get_backend_data(request)
+
+            # We should retry fetching from the backend as long as the response is 404.
+            status_code = data["response"]["status_code"]
+            if status_code != 404 and status_code != 200:
+                raise Exception(f"Backend did not provide trace: {data['path']}. Status is {status_code}.")
+            if status_code != 404:
+                return data
+
+            time.sleep(sleep_interval_s)
+            sleep_interval_s *= sleep_interval_multiplier # increase the sleep time with each retry
+
+        raise Exception(f"Backend did not provide trace after {retries} retries: {data['path']}. Status is {status_code}.")
+
+    def _extract_trace_from_backend_response(self, response):
+        content_parsed = json.loads(response["content"])
+        trace = content_parsed.get("trace")
+        if not trace: 
+            raise Exception(f"The response does not contain valid trace content: {response}")
+        return trace
+
+    def assert_trace_exists(self, request):
+        data = self._wait_for_request_trace(request)
+        trace = self._extract_trace_from_backend_response(data["response"])
+        return trace
+
+    # The following is not used!
     def assert_waf_attack(self, request):
         data = self._get_backend_data(request)
 


### PR DESCRIPTION
## Description

This change fixes the `backend` interface and adds a smoke test that verifies that we can submit traces, and fetch them from the backend.

I added some useful helpers to wait until the trace is ready as well, to keep the actual tests' code simple.

During a discussion with Charles last week, we decided to introduce a new scenario (`APM_TRACING_E2E`), until the fully end-to-end (e2e) tests are ready for adoption. And since these tests will take longer to run due to querying the actual backend, we don't want to run them in any other scenario unexpectedly.

### Example of running the test

```
lambros.petrou@COMP-F371T7QC44 system-tests % ./run.sh APM_TRACING_E2E
============ Run APM_TRACING_E2E tests ===================
ℹ️  Log folder is ./logs_apm_tracing_e2e
Starting containers in background
[+] Running 5/5
 ⠿ Network system-tests_default  Created                                                                                                                                                                   0.0s
 ⠿ Container postgres            Healthy                                                                                                                                                                  10.8s
 ⠿ Container runner              Started                                                                                                                                                                   0.5s
 ⠿ Container agent               Healthy                                                                                                                                                                   3.2s
 ⠿ Container weblog              Started                                                                                                                                                                  10.9s
Containers started
Outputting runner logs.
runner  | ================================================== Tested components ===================================================
runner  | Library: nodejs@3.13.2
runner  | Agent: 7.39.0
runner  | libddwaf: 1.5.1
runner  | Weblog variant: express4
runner  | Backend: datad0g.com
runner  | Scenario: APM_TRACING_E2E
runner  | ================================================= test session starts ==================================================
runner  | collected 1 item
runner  | Executing weblog warmup...
runner  | ----------------------------------------------------- Tests setup ------------------------------------------------------
runner  |
runner  | tests/apm-tracing-e2e/test_smoke.py .
runner  |
runner  | ------------------------------------------- Wait for library interface (5s) --------------------------------------------
runner  | ---------------------------------------- Wait for Weblog stdout interface (0s) -----------------------------------------
runner  | ----------------------------------- Wait for .Net tracer-managed logs interface (0s) -----------------------------------
runner  | -------------------------------------------- Wait for agent interface (5s) ---------------------------------------------
runner  | ----------------------------------------- Wait for Agent stdout interface (0s) -----------------------------------------
runner  | ------------------------------------------- Wait for backend interface (5s) --------------------------------------------
runner  |
runner  | tests/apm-tracing-e2e/test_smoke.py .                                                                            [100%]
runner  |
runner  | ------------------------------------ generated xml file: /app/logs/reportJunit.xml -------------------------------------
runner  | ================================================== 1 passed in 30.99s ==================================================
runner exited with code 0
[+] Running 5/3
 ⠿ Container weblog              Removed                                                                                                                                                                  10.2s
 ⠿ Container agent               Removed                                                                                                                                                                   3.7s
 ⠿ Container postgres            Removed                                                                                                                                                                   0.1s
 ⠿ Container runner              Removed                                                                                                                                                                   0.0s
 ⠿ Network system-tests_default  Removed                                                                                                                                                                   0.0s
Exiting with
```

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
