### PR TITLE
Enable ASM_FEATURES w/ custom rules for java 1.8.0

### DIFF
--- a/tests/appsec/test_runtime_activation.py
+++ b/tests/appsec/test_runtime_activation.py
@@ -12,9 +12,9 @@ from utils import weblog, context, coverage, interfaces, released, irrelevant, s
 
 @scenario("APPSEC_RUNTIME_ACTIVATION")
 @released(java="0.115.0", cpp="?", dotnet="2.16.0", php="?", python="?", ruby="?", nodejs="3.9.0", golang="?")
-@irrelevant(
-    context.library == "java" and context.appsec_rules_file is not None,
-    reason="No Remote Config sub with custom rules file",
+@bug(
+    context.library == "java" and context.agent_version < "1.8.0" and context.appsec_rules_file is not None,
+    reason="ASM_FEATURES was not subscribed when a custom rules file was present",
 )
 @bug(context.library == "java@1.6.0", reason="https://github.com/DataDog/dd-trace-java/pull/4614")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -156,7 +156,10 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
     request_number = 0
 
     @bug(context.weblog_variant == "spring-boot-openliberty", reason="APPSEC-6721")
-    @bug(context.library >= "java@1.4.0" and context.appsec_rules_file is not None, reason="APPSEC-7877")
+    @bug(
+        context.library >= "java@1.4.0" and context.agent_version < "1.8.0" and context.appsec_rules_file is not None,
+        reason="ASM_FEATURES was not subscribed when a custom rules file was present",
+    )
     def test_tracer_update_sequence(self):
         """ test update sequence, based on a scenario mocked in the proxy """
 
@@ -218,7 +221,10 @@ class Test_RemoteConfigurationUpdateSequenceASMDD(RemoteConfigurationFieldsBasic
 
     request_number = 0
 
-    @bug(context.library >= "java@1.4.0" and context.appsec_rules_file is not None, reason="APPSEC-7877")
+    @irrelevant(
+        context.library >= "java@1.4.0" and context.appsec_rules_file is not None,
+        reason="ASM_DD not subscribed with custom rules. This is the compliant behavior",
+    )
     @bug(context.weblog_variant == "spring-boot-openliberty", reason="APPSEC-6721")
     def test_tracer_update_sequence(self):
         """ test update sequence, based on a scenario mocked in the proxy """


### PR DESCRIPTION
## Description

Version 1.8.0 of the agent should subscribe ASM_FEATURES even with a custom rules file present. This enables two tests that were disabled because of the previous behavior.

## Check list

- [x] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [x] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
