### PR TITLE
Fix: Missing feature for GraalVm on WAF tests

### DIFF
--- a/tests/appsec/waf/test_exclusions.py
+++ b/tests/appsec/waf/test_exclusions.py
@@ -1,7 +1,9 @@
-from utils import scenario, released, weblog, interfaces
+from utils import scenario, released, weblog, interfaces, missing_feature, context
 
 
 @released(java="1.6.0", dotnet="?", golang="?", nodejs="?", php_appsec="?", python="?", ruby="?", cpp="?")
+@missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
+@missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @scenario("APPSEC_CUSTOM_RULES")
 class Test_Exclusions:
     """Includes a version of the WAF supporting rule exclusion"""


### PR DESCRIPTION
Graalvm only supports tracing. Exclude from WAF tests

## Description

Please include a short summary of the change

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
