### PR TITLE
Tests on old tracer failing because of some features werent implemented yet

### DIFF
--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -5,7 +5,7 @@
 import re
 from urllib.parse import urlparse
 
-from utils import context, interfaces, bug, released
+from utils import context, interfaces, bug, released, missing_feature
 
 RUNTIME_LANGUAGE_MAP = {
     "nodejs": "javascript",

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -225,6 +225,7 @@ class Test_Meta:
     @bug(library="cpp", reason="language tag not implemented")
     @bug(library="php", reason="language tag not implemented")
     @bug(library="java", reason="language tag implemented but not for all spans")
+    @missing_feature(context.library < "dotnet@2.6.0")
     def test_meta_language_tag(self):
         """Assert that all spans have required language tag."""
 
@@ -311,7 +312,7 @@ class Test_MetaDatadogTags:
         interfaces.library.validate_spans(validator=validator)
 
 
-@released(ruby="1.7.0", nodejs="3.13.1", java="1.6.0", php="0.83.1")
+@released(ruby="1.7.0", nodejs="3.13.1", java="1.6.0", php="0.83.1", dotnet="2.6.0")
 class Test_MetricsStandardTags:
     """metrics object in spans respect all conventions regarding basic tags"""
 


### PR DESCRIPTION
Two features were not yet implemented prior to 2.6:
- process_id tag
- language meta tag
which makkes CI on older version of tracers fail: 
![image](https://user-images.githubusercontent.com/8353486/218093917-770b99dd-fd28-4bb8-9e9e-30de68086eb5.png)

See 4th [attempt](https://github.com/DataDog/appsec-event-rules/actions/runs/4012188888/jobs/7163561116)
## Description

Please include a short summary of the change

## Check list

Your PR is not ready to be reviewed? Please save it as a draft :pray:

- [ ] Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
- [ ] CI is passing
- [ ] There is at least one approval from code owners

Yes to all? Feel free to merge it whenever you want :heart:
