### PR TITLE
Add dotnet lib-injection test app

### DIFF
--- a/lib-injection/build/docker/dotnet/config-1.yaml
+++ b/lib-injection/build/docker/dotnet/config-1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auto-instru
+data:
+  auto-instru.json: |
+    [{
+      "id": "11777398274940883092",
+      "revision": 1,
+      "schema_version": "v1.0.0",
+      "action": "enable",
+      "lib_config": {
+        "library_language": "dotnet",
+        "library_version": "v2.23.0",
+        "service_name": "test-dotnet-service",
+        "env": "dev",
+        "tracing_enabled": true,
+        "tracing_sampling_rate": 0.50
+      },
+      "k8s_target": {
+        "cluster": "lib-injection-testing",
+        "kind": "deployment",
+        "name": "test-dotnet-deployment",
+        "namespace": "default"
+      }
+    }]

--- a/lib-injection/build/docker/dotnet/config-disabled.yaml
+++ b/lib-injection/build/docker/dotnet/config-disabled.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auto-instru
+data:
+  auto-instru.json: |
+    [{
+      "id": "11777398274940883092",
+      "revision": 2,
+      "schema_version": "v1.0.0",
+      "action": "disable",
+      "lib_config": {
+        "library_language": "dotnet",
+        "library_version": "v2.23.0",
+        "service_name": "test-dotnet-service",
+        "env": "dev",
+        "tracing_enabled": true,
+        "tracing_sampling_rate": 0.90
+      },
+      "k8s_target": {
+        "cluster": "lib-injection-testing",
+        "kind": "deployment",
+        "name": "test-dotnet-deployment",
+        "namespace": "default"
+      }
+    }]

--- a/lib-injection/build/docker/dotnet/config-mismatch-clustername.yaml
+++ b/lib-injection/build/docker/dotnet/config-mismatch-clustername.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auto-instru
+data:
+  auto-instru.json: |
+    [{
+      "id": "11777398274940883092",
+      "revision": 0,
+      "schema_version": "v1.0.0",
+      "action": "enable",
+      "lib_config": {
+        "library_language": "dotnet",
+        "library_version": "v2.23.0",
+        "service_name": "test-dotnet-service",
+        "env": "dev",
+        "tracing_enabled": true,
+        "tracing_sampling_rate": 0.90
+      },
+      "k8s_target": {
+        "cluster": "lib-injection-testing-no-match",
+        "kind": "deployment",
+        "name": "test-dotnet-deployment",
+        "namespace": "default"
+      }
+    }]

--- a/lib-injection/build/docker/dotnet/config.yaml
+++ b/lib-injection/build/docker/dotnet/config.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auto-instru
+data:
+  auto-instru.json: |
+    [{
+      "id": "11777398274940883092",
+      "revision": 0,
+      "schema_version": "v1.0.0",
+      "action": "enable",
+      "lib_config": {
+        "library_language": "dotnet",
+        "library_version": "v2.23.0",
+        "service_name": "test-dotnet-service",
+        "env": "dev",
+        "tracing_enabled": true,
+        "tracing_sampling_rate": 0.90
+      },
+      "k8s_target": {
+        "cluster": "lib-injection-testing",
+        "kind": "deployment",
+        "name": "test-dotnet-deployment",
+        "namespace": "default"
+      }
+    }]

--- a/lib-injection/build/docker/dotnet/dd-lib-dotnet-init-test-app/Dockerfile
+++ b/lib-injection/build/docker/dotnet/dd-lib-dotnet-init-test-app/Dockerfile
@@ -1,0 +1,24 @@
+ARG RUNTIME
+
+# We only ship the published app in the image
+# so we only use ASPNET runtime as the base-image
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-$RUNTIME AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/sdk:7.0.100-preview.2 AS build
+WORKDIR /app
+COPY MinimalWebApp.csproj .
+RUN dotnet restore
+COPY . .
+RUN dotnet build -c Release
+
+FROM build AS publish
+RUN dotnet publish -c Release -o /publish
+
+FROM base AS final
+WORKDIR /app
+EXPOSE 18080
+ENV ASPNETCORE_URLS=http://+:18080
+COPY --from=publish /publish .
+
+ENTRYPOINT ["dotnet", "MinimalWebApp.dll"]

--- a/lib-injection/build/docker/dotnet/dd-lib-dotnet-init-test-app/MinimalWebApp.csproj
+++ b/lib-injection/build/docker/dotnet/dd-lib-dotnet-init-test-app/MinimalWebApp.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>MinimalWebApp</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/lib-injection/build/docker/dotnet/dd-lib-dotnet-init-test-app/Program.cs
+++ b/lib-injection/build/docker/dotnet/dd-lib-dotnet-init-test-app/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/lib-injection/build/docker/dotnet/dd-lib-dotnet-init-test-app/appsettings.json
+++ b/lib-injection/build/docker/dotnet/dd-lib-dotnet-init-test-app/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/lib-injection/build/docker/dotnet/dd-lib-dotnet-init-test-app/build.sh
+++ b/lib-injection/build/docker/dotnet/dd-lib-dotnet-init-test-app/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -z "${BUILDX_PLATFORMS}" ] ; then
+    BUILDX_PLATFORMS="linux/amd64"
+fi
+if [ -z "${RUNTIME}" ] ; then
+    RUNTIME="bullseye-slim"
+fi
+docker buildx build --build-arg RUNTIME=${RUNTIME} --platform ${BUILDX_PLATFORMS} --tag ${LIBRARY_INJECTION_TEST_APP_IMAGE} --push .

--- a/lib-injection/build/docker/dotnet/install_ddtrace.sh
+++ b/lib-injection/build/docker/dotnet/install_ddtrace.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+BINARIES_DIR=$1 #/binaries
+
+current_dir=$(pwd)
+cd $BINARIES_DIR
+
+if [ -e "dd-trace-dotnet" ]; then
+    echo "Install from local folder ${BINARIES_DIR}/dd-trace-dotnet"
+fi
+
+cd $current_dir

--- a/lib-injection/build/docker/dotnet/values-override.yaml
+++ b/lib-injection/build/docker/dotnet/values-override.yaml
@@ -1,0 +1,11 @@
+app_env_no_admission_controller:
+  - name: CORECLR_ENABLE_PROFILING
+    value: "1"
+  - name: CORECLR_PROFILER
+    value: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+  - name: CORECLR_PROFILER_PATH
+    value: "/datadog-lib/Datadog.Trace.ClrProfiler.Native.so"
+  - name: DD_DOTNET_TRACER_HOME
+    value: "/datadog-lib"
+  - name: LD_PRELOAD
+    value: "/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so"


### PR DESCRIPTION
## Description

Adds a test application and setup so we can test the .NET Tracer in the lib-injection test suite. I've tested this dev branch by invoking it from a dev branch of `dd-trace-dotnet` and the tests are up and running correctly

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it ! :heart:
