### PR TITLE
Fix typo in Java build file for adding external binaries to class path

### DIFF
--- a/parametric/apps/java/pom.xml
+++ b/parametric/apps/java/pom.xml
@@ -129,7 +129,7 @@
               <classpathPrefix>lib/</classpathPrefix>
             </manifest>
             <manifestEntries>
-              <Class-Path>lib/dd-trace-ot-dev.jar lib/dd-trace-ot-dev.jar</Class-Path>
+              <Class-Path>lib/dd-trace-ot-dev.jar lib/dd-trace-api-dev.jar</Class-Path>
             </manifestEntries>
           </archive>
         </configuration>


### PR DESCRIPTION
## Description

If one changed the java binaries for the parametric tests, by adding an `dd-trace-api` jar file to the `binaries` folder, the app could no longer find all classes, due to the typo, and would fail to start with the following exception:

```
Exception in thread "main" java.lang.NoClassDefFoundError: datadog/trace/api/Tracer
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at datadog.opentracing.DDTracer$DDTracerBuilder.build(DDTracer.java:169)
	at com.datadoghq.App.createTracer(App.java:64)
	at com.datadoghq.App.<init>(App.java:20)
	at com.datadoghq.App.main(App.java:26)
Caused by: java.lang.ClassNotFoundException: datadog.trace.api.Tracer
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 16 more
```
