### PR TITLE
[apm] manually index spans without manual retention filter

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -211,3 +211,18 @@ the possible values the WAF will return the proper action.
 Expected query parameters:
 - `user`: user id.
   - Possible values: `blockedUser`
+
+## GET /e2e_single_span
+
+This endpoint will create two spans, a parent span (which is a root-span), and a child span.
+The spans created are not sub-spans of the main root span automatically created by system-tests, but 
+they will have the same `user-agent` containing the request ID in order to allow assertions on them.
+
+The following query parameters are required:
+- `parentName`: The name of the parent span (root-span).
+- `childName`: The name of the child span (the parent of this span is the root-span identified by `parentName`).
+
+The following query parameters are optional:
+- `shouldIndex`: Valid values are `1` and `0`. When `shouldIndex=1` is provided, special tags are added in the spans that will force their indexation in the APM backend, without explicit retention filters needed.
+
+This endpoint is used for the Single Spans tests (`test_single_span.py`).

--- a/tests/apm_tracing_e2e/test_single_span.py
+++ b/tests/apm_tracing_e2e/test_single_span.py
@@ -26,7 +26,8 @@ class Test_SingleSpan:
 
     def setup_parent_span_is_single_span(self):
         self.req = weblog.get(
-            "/e2e_single_span?shouldIndex=1&parentName=parent.span.single_span_submitted&childName=child.span"
+            "/e2e_single_span",
+            {"shouldIndex": 1, "parentName": "parent.span.single_span_submitted", "childName": "child.span"},
         )
 
     def test_parent_span_is_single_span(self):
@@ -48,7 +49,8 @@ class Test_SingleSpan:
 
     def setup_child_span_is_single_span(self):
         self.req = weblog.get(
-            "/e2e_single_span?shouldIndex=1&parentName=parent.span&childName=child.span.single_span_submitted"
+            "/e2e_single_span",
+            {"shouldIndex": 1, "parentName": "parent.span", "childName": "child.span.single_span_submitted"},
         )
 
     def test_child_span_is_single_span(self):

--- a/tests/apm_tracing_e2e/test_single_span.py
+++ b/tests/apm_tracing_e2e/test_single_span.py
@@ -25,7 +25,9 @@ class Test_SingleSpan:
     """
 
     def setup_parent_span_is_single_span(self):
-        self.req = weblog.get("/e2e_single_span?parentName=parent.span.single_span_submitted&childName=child.span")
+        self.req = weblog.get(
+            "/e2e_single_span?shouldIndex=1&parentName=parent.span.single_span_submitted&childName=child.span"
+        )
 
     def test_parent_span_is_single_span(self):
         # Only the parent span should be submitted to the backend!
@@ -45,7 +47,9 @@ class Test_SingleSpan:
         _assert_single_span_event(spans[0], "parent.span.single_span_submitted", is_root=True)
 
     def setup_child_span_is_single_span(self):
-        self.req = weblog.get("/e2e_single_span?parentName=parent.span&childName=child.span.single_span_submitted")
+        self.req = weblog.get(
+            "/e2e_single_span?shouldIndex=1&parentName=parent.span&childName=child.span.single_span_submitted"
+        )
 
     def test_child_span_is_single_span(self):
         # Only the child should be submitted to the backend!

--- a/utils/build/docker/golang/app/chi.go
+++ b/utils/build/docker/golang/app/chi.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/appsec"
 	chitrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-chi/chi.v5"
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
@@ -128,16 +129,22 @@ func main() {
 		parentName := r.URL.Query().Get("parentName")
 		childName := r.URL.Query().Get("childName")
 
+		tags := []ddtrace.StartSpanOption{}
+
 		// We need to propagate the user agent header to retain the mapping between the system-tests/weblog request id
 		// and the traces/spans that will be generated below, so that we can reference to them in our tests.
 		// See https://github.com/DataDog/system-tests/blob/2d6ae4d5bf87d55855afd36abf36ee710e7d8b3c/utils/interfaces/_core.py#L156
 		userAgent := r.UserAgent()
-		userAgentTag := tracer.Tag("http.useragent", userAgent)
+		tags = append(tags, tracer.Tag("http.useragent", userAgent))
+
+		if r.URL.Query().Get("shouldIndex") == "1" {
+			tags = append(tags, forceSpanIndexingTags()...)
+		}
 
 		// Make a fresh root span!
 		duration, _ := time.ParseDuration("10s")
-		parentSpan, parentCtx := tracer.StartSpanFromContext(context.Background(), parentName, userAgentTag)
-		childSpan, _ := tracer.StartSpanFromContext(parentCtx, childName, userAgentTag)
+		parentSpan, parentCtx := tracer.StartSpanFromContext(context.Background(), parentName, tags...)
+		childSpan, _ := tracer.StartSpanFromContext(parentCtx, childName, tags...)
 		childSpan.Finish(tracer.FinishTime(time.Now().Add(duration)))
 		parentSpan.Finish(tracer.FinishTime(time.Now().Add(duration * 2)))
 

--- a/utils/build/docker/golang/app/common.go
+++ b/utils/build/docker/golang/app/common.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
@@ -38,4 +39,16 @@ func parseBody(r *http.Request) (interface{}, error) {
 	}
 	// Default to parsing body as URL encoded data
 	return url.ParseQuery(string(data))
+}
+
+func forceSpanIndexingTags() []ddtrace.StartSpanOption {
+	// These tags simulate a retention filter to index spans, otherwise
+	// they will only be available in live search of spans!
+	//
+	// Instead of adding these tags manually, we could also create a retention filter in each org/account
+	// that we want to run these e2e tests to retain single spans (to make them available in normal search).
+	return []ddtrace.StartSpanOption{
+		tracer.Tag("_dd.filter.kept", 1),
+		tracer.Tag("_dd.filter.id", "system_tests_e2e"),
+	}
 }

--- a/utils/interfaces/_backend.py
+++ b/utils/interfaces/_backend.py
@@ -107,7 +107,7 @@ class _BackendInterfaceValidator(InterfaceValidator):
         data = self._wait_for_event_platform_spans(query_filter, limit)
 
         result = data["response"]["contentJson"]["result"]
-        assert result["count"] >= min_spans_len
+        assert result["count"] >= min_spans_len, f"Did not have the expected number of spans ({min_spans_len}): {data}"
 
         return [item["event"] for item in result["events"]]
 


### PR DESCRIPTION
## Description

For the single spans tests, we need to either set a [retention filter](https://docs.datadoghq.com/tracing/trace_pipeline/trace_retention/#retention-filters) that will index the single spans submitted, or we need to use Driveline live search to fetch the spans for assertion.

Using the Live-search API is still not supported, and we don't know when it will be.

Also, since creating manual retention filters in every org/account we want to run these tests is cumbersome, this change manually adds the tags that will force the indexing of these spans, in a similar way to how retention filters work.

### Tests

The org I use with `DD_SITE=datadoghq.com` does NOT have a retention filter setup for the test spans, and with this change the tests still pass!

```sh
./build.sh -l golang -w chi

DD_SITE=datadoghq.com ./run.sh APM_TRACING_E2E
DD_SITE=datadoghq.com ./run.sh APM_TRACING_E2E_SINGLE_SPAN
```

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
