### PR TITLE
Fix parametric Java client docker build

### DIFF
--- a/parametric/apps/java/build.sh
+++ b/parametric/apps/java/build.sh
@@ -29,4 +29,4 @@ else
 fi
 
 echo Running Maven build with profiles \"$MAVEN_PROFILES\"
-mvn -q $MAVEN_PROFILES package
+mvn -q $MAVEN_PROFILES -Dclient.protobuf.path=src/main/proto/ package

--- a/parametric/apps/java/pom.xml
+++ b/parametric/apps/java/pom.xml
@@ -17,6 +17,7 @@
     <dd-trace.version>1.8.0</dd-trace.version>
     <opentracing.version>0.32.0</opentracing.version>
     <gprc.version>1.47.0</gprc.version>
+    <client.protobuf.path>../../protos</client.protobuf.path>
   </properties>
 
   <dependencies>
@@ -106,7 +107,7 @@
           <protocArtifact>com.google.protobuf:protoc:3.21.1:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${gprc.version}:exe:${os.detected.classifier}</pluginArtifact>
-          <protoSourceRoot>../../protos</protoSourceRoot>
+          <protoSourceRoot>${client.protobuf.path}</protoSourceRoot>
         </configuration>
         <executions>
           <execution>

--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -218,6 +218,7 @@ def java_library_factory(env: Dict[str, str]):
     java_appdir = os.path.join("apps", "java")
     java_dir = os.path.join(os.path.dirname(__file__), java_appdir)
     java_reldir = os.path.join("parametric", java_appdir)
+    protofile = os.path.join("parametric", "protos", "apm_test_client.proto")
     return APMLibraryTestServer(
         lang="java",
         protocol="grpc",
@@ -230,6 +231,7 @@ COPY {java_reldir}/src src
 COPY {java_reldir}/build.sh .
 COPY {java_reldir}/pom.xml .
 COPY {java_reldir}/run.sh .
+COPY {protofile} src/main/proto/
 COPY binaries /binaries
 RUN bash build.sh
 """,


### PR DESCRIPTION
## Description

Fix regression introduced by #899 where protobuf file is not included within docker image during build.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
