### PR TITLE
fix: retrieve IP in a more reliable way for Python IP tests

### DIFF
--- a/tests/appsec/test_reports.py
+++ b/tests/appsec/test_reports.py
@@ -2,6 +2,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
+import socket
+
 import pytest
 
 from utils import (
@@ -78,7 +80,8 @@ class Test_HttpClientIP:
         headers = {"User-Agent": "Arachni/v1"}
         self.r = weblog.get("/waf/", headers=headers, stream=True)
         try:
-            self.actual_remote_ip = self.r.raw._connection.sock.getsockname()[0]  # pylint: disable=protected-access
+            s = socket.fromfd(self.r.raw.fileno(), socket.AF_INET, socket.SOCK_STREAM)
+            self.actual_remote_ip = s.getsockname()[0]
             self.r.close()
         except:
             self.actual_remote_ip = None


### PR DESCRIPTION
## Description

Currently and for some reasons (dependency changes?) `self.r.raw._connection.sock` on the IP Django system test was returning `None` which was breaking all Django system tests. 

This changes it so we don't use a private-ish struct but instead retrieve the IP by doing:

```
s = socket.fromfd(self.r.raw.fileno(), socket.AF_INET, socket.SOCK_STREAM)
self.actual_remote_ip = s.getsockname()[0]
```

which seems to fix the issue. 


## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
