### PR TITLE
Update Docker images for Java to Temurin 11

### DIFF
--- a/utils/build/docker/java/jersey-grizzly2.Dockerfile
+++ b/utils/build/docker/java/jersey-grizzly2.Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -Dmaven.repo.local=/maven package
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/java/ratpack.Dockerfile
+++ b/utils/build/docker/java/ratpack.Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -Dmaven.repo.local=/maven package
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/java/resteasy-netty3.Dockerfile
+++ b/utils/build/docker/java/resteasy-netty3.Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -Dmaven.repo.local=/maven package
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/java/spring-boot-jetty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-jetty.Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -Dmaven.repo.local=/maven -Pjetty package
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/java/spring-boot-openliberty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-openliberty.Dockerfile
@@ -13,7 +13,7 @@ RUN mvn -Popenliberty package
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/java/spring-boot-undertow.Dockerfile
+++ b/utils/build/docker/java/spring-boot-undertow.Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -Dmaven.repo.local=/maven -Pundertow package
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/java/spring-boot-wildfly.Dockerfile
+++ b/utils/build/docker/java/spring-boot-wildfly.Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -Dmaven.repo.local=/maven -Pwildfly package
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/java/spring-boot.Dockerfile
+++ b/utils/build/docker/java/spring-boot.Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -Dmaven.repo.local=/maven package
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/java/uds-spring-boot.Dockerfile
+++ b/utils/build/docker/java/uds-spring-boot.Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -Dmaven.repo.local=/maven package
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/java/vertx3.Dockerfile
+++ b/utils/build/docker/java/vertx3.Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -Dmaven.repo.local=/maven package
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION


### PR DESCRIPTION
## Description

Update Docker images for Java to Temurin 11

AdoptOpenJDK images are deprecated and not updated anymore.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
