### PR TITLE
Enable Java parametric tests in workflow

### DIFF
--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -34,6 +34,7 @@ jobs:
         - python_http
         - dotnet
         - golang
+        - java
         - nodejs
       fail-fast: false
     steps:

--- a/parametric/apps/java/pom.xml
+++ b/parametric/apps/java/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <dd-trace.version>1.8.0</dd-trace.version>
+    <dd-trace.version>1.9.0</dd-trace.version>
     <opentracing.version>0.32.0</opentracing.version>
     <gprc.version>1.47.0</gprc.version>
     <slf4j.version>1.7.30</slf4j.version>

--- a/parametric/test_headers_b3.py
+++ b/parametric/test_headers_b3.py
@@ -56,6 +56,7 @@ def test_headers_b3_extract_invalid(test_agent, test_library):
 @enable_b3()
 @pytest.mark.skip_library("python", "Issue: Python doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: Java doesn't pad the span-id to length of 16 lower-hex characters")
 def test_headers_b3_inject_valid(test_agent, test_library):
     """Ensure that b3 distributed tracing headers are injected properly.
     """
@@ -78,6 +79,7 @@ def test_headers_b3_inject_valid(test_agent, test_library):
 @enable_b3()
 @pytest.mark.skip_library("python", "Issue: Python doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: Java doesn't pad the span-id to length of 16 lower-hex characters")
 def test_headers_b3multi_propagate_valid(test_agent, test_library):
     """Ensure that b3 distributed tracing headers are extracted
     and injected properly.
@@ -103,6 +105,7 @@ def test_headers_b3multi_propagate_valid(test_agent, test_library):
 @enable_b3()
 @pytest.mark.skip_library("python", "Issue: Python doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: Java doesn't pad the span-id to length of 16 lower-hex characters")
 def test_headers_b3multi_propagate_invalid(test_agent, test_library):
     """Ensure that invalid b3 distributed tracing headers are not extracted
     and the new span context is injected properly.

--- a/parametric/test_headers_b3multi.py
+++ b/parametric/test_headers_b3multi.py
@@ -75,6 +75,7 @@ def test_headers_b3multi_extract_invalid(test_agent, test_library):
 @enable_b3multi()
 @pytest.mark.skip_library("python", "Issue: Python doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: Java doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 def test_headers_b3multi_inject_valid(test_agent, test_library):
     """Ensure that b3multi distributed tracing headers are injected properly.
     """
@@ -96,6 +97,7 @@ def test_headers_b3multi_inject_valid(test_agent, test_library):
 @enable_b3multi()
 @pytest.mark.skip_library("python", "Issue: Python doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: Java doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 def test_headers_b3multi_propagate_valid(test_agent, test_library):
     """Ensure that b3multi distributed tracing headers are extracted
     and injected properly.
@@ -125,6 +127,7 @@ def test_headers_b3multi_propagate_valid(test_agent, test_library):
 @enable_b3multi()
 @pytest.mark.skip_library("python", "Issue: Python doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: Java doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 def test_headers_b3multi_propagate_invalid(test_agent, test_library):
     """Ensure that invalid b3multi distributed tracing headers are not extracted
     and the new span context is injected properly.

--- a/parametric/test_headers_datadog.py
+++ b/parametric/test_headers_datadog.py
@@ -7,6 +7,7 @@ from parametric.utils.test_agent import get_span
 
 
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: java splits origin at the first ,")
 def test_distributed_headers_extract_datadog_D001(test_agent, test_library):
     """Ensure that Datadog distributed tracing headers are extracted
     and activated properly.

--- a/parametric/test_headers_precedence.py
+++ b/parametric/test_headers_precedence.py
@@ -30,6 +30,7 @@ def enable_datadog_tracecontext() -> Any:
 
 
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_headers_precedence_propagationstyle_default(test_agent, test_library):
     with test_library:
         # 1) No headers
@@ -173,6 +174,7 @@ def test_headers_precedence_propagationstyle_default(test_agent, test_library):
 
 @enable_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_headers_precedence_propagationstyle_tracecontext(test_agent, test_library):
     with test_library:
         # 1) No headers
@@ -295,6 +297,7 @@ def test_headers_precedence_propagationstyle_tracecontext(test_agent, test_libra
 
 @enable_datadog()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: only sampling priority -1 to 2 allowed")
 def test_headers_precedence_propagationstyle_datadog(test_agent, test_library):
     with test_library:
         # 1) No headers
@@ -404,6 +407,7 @@ def test_headers_precedence_propagationstyle_datadog(test_agent, test_library):
     "run, thus not retrieving / overwriting the headers",
 )
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_headers_precedence_propagationstyle_datadog_tracecontext(test_agent, test_library):
     with test_library:
         # 1) No headers

--- a/parametric/test_headers_tracecontext.py
+++ b/parametric/test_headers_tracecontext.py
@@ -27,6 +27,7 @@ def temporary_enable_optin_tracecontext() -> Any:
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_both_traceparent_and_tracestate_missing(test_agent, test_library):
     """
     harness sends a request without traceparent or tracestate
@@ -38,6 +39,7 @@ def test_both_traceparent_and_tracestate_missing(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_included_tracestate_missing(test_agent, test_library):
     """
     harness sends a request with traceparent but without tracestate
@@ -68,6 +70,7 @@ def test_traceparent_included_tracestate_missing(test_agent, test_library):
     "golang",
     "golang does not reconcile duplicate http headers, if duplicate headers received the propagator will not be used",
 )
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_duplicated(test_agent, test_library):
     """
     harness sends a request with two traceparent headers
@@ -88,6 +91,7 @@ def test_traceparent_duplicated(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_header_name(test_agent, test_library):
     """
     harness sends an invalid traceparent using wrong names
@@ -109,6 +113,7 @@ def test_traceparent_header_name(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Bug: Header search is currently case-sensitive")
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_header_name_valid_casing(test_agent, test_library):
     """
     harness sends a valid traceparent using different combination of casing
@@ -134,6 +139,7 @@ def test_traceparent_header_name_valid_casing(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_version_0x00(test_agent, test_library):
     """
     harness sends an invalid traceparent with extra trailing characters
@@ -159,6 +165,7 @@ def test_traceparent_version_0x00(test_agent, test_library):
     "golang",
     "Bug: See https://www.w3.org/TR/trace-context/#versioning-of-traceparent for corrections . 1) We currently assert that version must be two valid hex digits, except for 'ff' 2) We assert the length of the traceparent is exactly equal to 55",
 )
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_version_0xcc(test_agent, test_library):
     """
     harness sends an valid traceparent with future version 204 (0xcc)
@@ -186,6 +193,7 @@ def test_traceparent_version_0xcc(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_version_0xff(test_agent, test_library):
     """
     harness sends an invalid traceparent with version 255 (0xff)
@@ -201,6 +209,7 @@ def test_traceparent_version_0xff(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_version_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in version
@@ -221,6 +230,7 @@ def test_traceparent_version_illegal_characters(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_version_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with version more than 2 HEXDIG
@@ -241,6 +251,7 @@ def test_traceparent_version_too_long(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_version_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with version less than 2 HEXDIG
@@ -256,6 +267,7 @@ def test_traceparent_version_too_short(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_id_all_zero(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_id = 00000000000000000000000000000000
@@ -271,6 +283,7 @@ def test_traceparent_trace_id_all_zero(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_id_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in trace_id
@@ -291,6 +304,7 @@ def test_traceparent_trace_id_illegal_characters(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_id_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_id more than 32 HEXDIG
@@ -308,6 +322,7 @@ def test_traceparent_trace_id_too_long(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_id_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_id less than 32 HEXDIG
@@ -323,6 +338,7 @@ def test_traceparent_trace_id_too_short(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_parent_id_all_zero(test_agent, test_library):
     """
     harness sends an invalid traceparent with parent_id = 0000000000000000
@@ -338,6 +354,7 @@ def test_traceparent_parent_id_all_zero(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_parent_id_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in parent_id
@@ -358,6 +375,7 @@ def test_traceparent_parent_id_illegal_characters(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_parent_id_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with parent_id more than 16 HEXDIG
@@ -373,6 +391,7 @@ def test_traceparent_parent_id_too_long(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_parent_id_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with parent_id less than 16 HEXDIG
@@ -389,6 +408,7 @@ def test_traceparent_parent_id_too_short(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_flags_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in trace_flags
@@ -409,6 +429,7 @@ def test_traceparent_trace_flags_illegal_characters(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_flags_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_flags more than 2 HEXDIG
@@ -424,6 +445,7 @@ def test_traceparent_trace_flags_too_long(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_flags_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_flags less than 2 HEXDIG
@@ -439,6 +461,7 @@ def test_traceparent_trace_flags_too_short(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_ows_handling(test_agent, test_library):
     """
     harness sends an valid traceparent with heading and trailing OWS
@@ -474,6 +497,7 @@ def test_traceparent_ows_handling(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_tracestate_included_traceparent_missing(test_agent, test_library):
     """
     harness sends a request with tracestate but without traceparent
@@ -491,6 +515,7 @@ def test_tracestate_included_traceparent_missing(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_tracestate_included_traceparent_included(test_agent, test_library):
     """
     harness sends a request with both tracestate and traceparent
@@ -513,6 +538,7 @@ def test_tracestate_included_traceparent_included(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_tracestate_header_name(test_agent, test_library):
     """
     harness sends an invalid tracestate using wrong names
@@ -536,6 +562,7 @@ def test_tracestate_header_name(test_agent, test_library):
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_tracestate_header_name_valid_casing(test_agent, test_library):
     """
     harness sends a valid tracestate using different combination of casing
@@ -576,6 +603,7 @@ def test_tracestate_header_name_valid_casing(test_agent, test_library):
     "python",
     "python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
 )
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_tracestate_empty_header(test_agent, test_library):
     """
     harness sends a request with empty tracestate header
@@ -629,6 +657,7 @@ def test_tracestate_empty_header(test_agent, test_library):
     "python",
     "python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
 )
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_tracestate_multiple_headers_different_keys(test_agent, test_library):
     """
     harness sends a request with multiple tracestate headers, each contains different set of keys
@@ -659,6 +688,7 @@ def test_tracestate_multiple_headers_different_keys(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_tracestate_duplicated_keys(test_agent, test_library):
     """
     harness sends a request with an invalid tracestate header with duplicated keys
@@ -715,6 +745,7 @@ def test_tracestate_duplicated_keys(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_tracestate_all_allowed_characters(test_agent, test_library):
     """
     harness sends a request with a valid tracestate header with all legal characters
@@ -762,6 +793,7 @@ def test_tracestate_all_allowed_characters(test_agent, test_library):
     "python",
     "\t is an invalid character and is not supported in tracestate. We should update this test use spaces instead",
 )
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_tracestate_ows_handling(test_agent, test_library):
     """
     harness sends a request with a valid tracestate header with OWS

--- a/parametric/test_headers_tracestate_dd.py
+++ b/parametric/test_headers_tracestate_dd.py
@@ -10,8 +10,8 @@ parametrize = pytest.mark.parametrize
 
 def temporary_enable_propagationstyle_default() -> Any:
     env = {
-        "DD_PROPAGATION_STYLE_EXTRACT": "tracecontext,Datadog",
-        "DD_PROPAGATION_STYLE_INJECT": "tracecontext,Datadog",
+        "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "tracecontext,Datadog",
+        "DD_TRACE_PROPAGATION_STYLE_INJECT": "tracecontext,Datadog",
     }
     return parametrize("library_env", [env])
 
@@ -19,6 +19,7 @@ def temporary_enable_propagationstyle_default() -> Any:
 @temporary_enable_propagationstyle_default()
 @pytest.mark.skip_library("dotnet", "Issue: We need to prefer the traceparent sampled flag to fix headers4 test case")
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not available yet")
 def test_headers_tracestate_dd_propagate_samplingpriority(test_agent, test_library):
     """
     harness sends a request with both tracestate and traceparent
@@ -192,6 +193,7 @@ def test_headers_tracestate_dd_propagate_samplingpriority(test_agent, test_libra
 @temporary_enable_propagationstyle_default()
 @pytest.mark.skip_library("dotnet", "The origin transformation has changed slightly")
 @pytest.mark.skip_library("nodejs", "TODO: remove when https://github.com/DataDog/dd-trace-js/pull/2477 lands")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not available yet")
 def test_headers_tracestate_dd_propagate_origin(test_agent, test_library):
     """
     harness sends a request with both tracestate and traceparent
@@ -327,6 +329,7 @@ def test_headers_tracestate_dd_propagate_origin(test_agent, test_library):
     "False Bug: header[3,6]: can't guarantee the order of strings in the tracestate since they came from the map"
     "BUG: header[4,5]: w3cTraceID shouldn't be present",
 )
+@pytest.mark.skip_library("java", "Issue: tracecontext is not merged  yet, dm is reset on priority override")
 def test_headers_tracestate_dd_propagate_propagatedtags(test_agent, test_library):
     """
     harness sends a request with both tracestate and traceparent
@@ -446,7 +449,7 @@ def test_headers_tracestate_dd_propagate_propagatedtags(test_agent, test_library
             val = tag[index:]
 
             assert key.startswith("_dd.p.")
-            assert "t." + key[6:] + ":" + val.replace("=", ":") in dd_items4
+            assert "t." + key[6:] + val.replace("=", ":") in dd_items4
 
     # 5) tracestate[dd] is populated with well-known propagated tags
     # Result: Tags are placed into the tracestate where "_dd.p." is replaced with "t."

--- a/parametric/utils/headers.py
+++ b/parametric/utils/headers.py
@@ -1,4 +1,4 @@
 def make_single_request_and_get_inject_headers(test_library, headers):
     with test_library.start_span(name="name", service="service", resource="resource", http_headers=headers,) as span:
         headers = test_library.inject_headers(span.span_id)
-        return {k: v for k, v in headers}
+        return {k.lower(): v for k, v in headers}

--- a/utils/scripts/generate-github-action-file.py
+++ b/utils/scripts/generate-github-action-file.py
@@ -335,7 +335,7 @@ def add_parametric_job(workflow, needs):
     job = Job("parametric", needs=[job.name for job in needs])
 
     job.data["strategy"] = {
-        "matrix": {"client": ["python", "python_http", "dotnet", "golang", "nodejs"]},
+        "matrix": {"client": ["python", "python_http", "dotnet", "golang", "java", "nodejs"]},
         "fail-fast": False,
     }
 


### PR DESCRIPTION
## Description

Fix some bugs in the Java parametric test server and mark all unsupported tests as skipped. Enable java in the parametric GitHub workflow.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
