### PR TITLE
fix the APM_TRACING_E2E scenario missing after migration of run.sh

### DIFF
--- a/binaries/agent-image
+++ b/binaries/agent-image
@@ -1,0 +1,1 @@
+datadog/agent:7

--- a/binaries/agent-image
+++ b/binaries/agent-image
@@ -1,1 +1,0 @@
-datadog/agent:7

--- a/utils/_context/core.py
+++ b/utils/_context/core.py
@@ -218,6 +218,8 @@ class _Context:  # pylint: disable=too-many-instance-attributes
             self.weblog_env["DD_REMOTE_CONFIG_ENABLED"] = "true"
         elif self.scenario == "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE":
             self.proxy_state = '{"mock_remote_config_backend": "ASM_DD_NO_CACHE"}'
+        elif self.scenario == "APM_TRACING_E2E":
+            pass  # nothing to do
         elif self.scenario == "APM_TRACING_E2E_SINGLE_SPAN":
             self.weblog_env[
                 "DD_SPAN_SAMPLING_RULES"


### PR DESCRIPTION
## Description

```sh
./build.sh -l golang -w chi
DD_SITE=datadoghq.com ./run.sh APM_TRACING_E2E
```

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
