### PR TITLE
app dependency not sent test

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -19,10 +19,11 @@ fi
 FIRST_ARGUMENT=${1:-DEFAULT}
 if [[ $FIRST_ARGUMENT =~ ^[A-Z0-9_]+$ ]]; then
     export SYSTEMTESTS_SCENARIO=$FIRST_ARGUMENT
-    export RUNNER_ARGS="tests/"
+export RUNNER_ARGS="tests/"
+export SYSTEMTESTS_LOG_FOLDER="logs_$(echo $SYSTEMTESTS_SCENARIO | tr '[:upper:]' '[:lower:]')"
 
     if [ $SYSTEMTESTS_SCENARIO = "DEFAULT" ]; then
-        export SYSTEMTESTS_LOG_FOLDER=logs
+    export SYSTEMTESTS_LOG_FOLDER=logs
     else
         export SYSTEMTESTS_LOG_FOLDER="logs_$(echo $SYSTEMTESTS_SCENARIO | tr '[:upper:]' '[:lower:]')"
     fi
@@ -33,15 +34,12 @@ else
     export SYSTEMTESTS_LOG_FOLDER=logs
 fi
 
-export HOST_PWD=$(pwd)
-
 # clean any pycache folder
 find utils tests -type d -name '__pycache__'  -prune -exec rm -rf {} +
 
 # Clean logs/ folder
 rm -rf $SYSTEMTESTS_LOG_FOLDER
 
-interfaces=(agent library backend)
 for interface in ${interfaces[@]}
 do
     mkdir -p $SYSTEMTESTS_LOG_FOLDER/interfaces/$interface

--- a/utils/_context/core.py
+++ b/utils/_context/core.py
@@ -199,6 +199,8 @@ class _Context:  # pylint: disable=too-many-instance-attributes
             self.proxy_state = '{"mock_remote_config_backend": "ASM_FEATURES"}'
             del self.weblog_env["DD_APPSEC_ENABLED"]
             self.weblog_env["DD_REMOTE_CONFIGURATION_ENABLED"] = "true"
+        elif self.scenario == "APP_DEPENDENCY_LOADED_NOT_SENT":
+            self.weblog_env["DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED"] = "false"
         elif self.scenario == "REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING":
             self.proxy_state = '{"mock_remote_config_backend": "LIVE_DEBUGGING"}'
             self.weblog_env["DD_DYNAMIC_INSTRUMENTATION_ENABLED"] = "1"


### PR DESCRIPTION
## Description

Assert that app-dependencies loaded is not sent when this flag DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED is set to false

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
