### PR TITLE
feat(python): update RC gunicorn behavior

### DIFF
--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -190,6 +190,7 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
     """Tests that over a sequence of related updates, tracers follow the RFC for the Features product"""
 
     request_number = 0
+    python_request_number = 0
 
     @bug(context.weblog_variant == "spring-boot-openliberty", reason="APPSEC-6721")
     @bug(
@@ -207,7 +208,15 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
 
             rc_check_request(data, ASM_FEATURES_EXPECTED_REQUESTS[self.request_number], caching=True)
 
-            self.request_number += 1
+            # TODO(Python). Gunicorn creates 2 process (main gunicorn process + X child workers). It generates two payloads
+            #  for each request number. We're working to update this behavior in this propossal
+            #  https://docs.google.com/document/d/1zeh7g_c_4Oj9EUuf8kQEW_qbZl9PCH4hJHiVYnoLy6I/edit
+            self.python_request_number += 1
+            if context.library == "python" and context.weblog_variant != "uwsgi-poc":
+                if self.python_request_number % 2 == 0:
+                    self.request_number += 1
+            else:
+                self.request_number += 1
 
             return False
 


### PR DESCRIPTION
## Description
update RC gunicorn behavior. Gunicorn creates 2 process (main gunicorn process + X child workers). It generates two payloads for each request number

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
