### PR TITLE
[parametric] Fix remaining dotnet w3c tracecontext header tests

### DIFF
--- a/parametric/apps/dotnet/ApmTestClient.csproj
+++ b/parametric/apps/dotnet/ApmTestClient.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.22.0" />
+    <PackageReference Include="Datadog.Trace" Version="2.27.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
   </ItemGroup>

--- a/parametric/apps/dotnet/Program.cs
+++ b/parametric/apps/dotnet/Program.cs
@@ -18,7 +18,7 @@ builder.WebHost.ConfigureKestrel(options =>
     // NOTE: For now, we'll set this in code via the options.Listen call since this
     // seems to work with the Python tests (perhaps because this covers IPv4 and IPv6)
 
-    options.Listen(IPAddress.Any, Int32.Parse(Environment.GetEnvironmentVariable("APM_TEST_CLIENT_SERVER_PORT")), listenOptions =>
+    options.Listen(IPAddress.Any, Int32.Parse(Environment.GetEnvironmentVariable("APM_TEST_CLIENT_SERVER_PORT")!), listenOptions =>
     {
         listenOptions.Protocols = HttpProtocols.Http2;
     });

--- a/parametric/apps/dotnet/Services/ApmTestClientService.cs
+++ b/parametric/apps/dotnet/Services/ApmTestClientService.cs
@@ -74,8 +74,9 @@ namespace ApmTestClient.Services
 
             if (request.HttpHeaders?.HttpHeaders.Count > 0)
             {
+                // ASP.NET and ASP.NET Core HTTP headers are automatically lower-cased, simulate that here.
                 creationSettings.Parent = _spanContextExtractor.Extract(
-                    request.HttpHeaders.HttpHeaders,
+                    request.HttpHeaders?.HttpHeaders!,
                     getter: GetHeaderValues);
                 Console.WriteLine($"creationSettings.Parent?.SpanId={creationSettings.Parent?.SpanId}");
                 Console.WriteLine($"creationSettings.Parent?.TraceId={creationSettings.Parent?.TraceId}");

--- a/parametric/test_headers_tracecontext.py
+++ b/parametric/test_headers_tracecontext.py
@@ -368,7 +368,6 @@ def test_traceparent_parent_id_too_short(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
 def test_traceparent_trace_flags_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in trace_flags

--- a/parametric/test_headers_tracecontext.py
+++ b/parametric/test_headers_tracecontext.py
@@ -105,7 +105,6 @@ def test_traceparent_header_name(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("dotnet", "Bug: Header search is currently case-sensitive")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_traceparent_header_name_valid_casing(test_agent, test_library):
     """
@@ -508,7 +507,6 @@ def test_tracestate_header_name(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("dotnet", "Tracestate not implemented")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_tracestate_header_name_valid_casing(test_agent, test_library):
     """

--- a/parametric/test_headers_tracestate_dd.py
+++ b/parametric/test_headers_tracestate_dd.py
@@ -431,7 +431,6 @@ def test_headers_tracestate_dd_propagate_propagatedtags(test_agent, test_library
 
 
 @temporary_enable_propagationstyle_default()
-@pytest.mark.skip_library("dotnet", "Issue: Traceparent doesn't override sampling decision")
 @pytest.mark.skip_library("nodejs", "Issue: the decision maker is removed. Is that allowed behavior?")
 @pytest.mark.skip_library("php", "Issue: Does not drop dm")
 @pytest.mark.skip_library("python", "Issue: Does not drop dm")

--- a/parametric/test_headers_tracestate_dd.py
+++ b/parametric/test_headers_tracestate_dd.py
@@ -17,7 +17,6 @@ def temporary_enable_propagationstyle_default() -> Any:
 
 
 @temporary_enable_propagationstyle_default()
-@pytest.mark.skip_library("dotnet", "Issue: We need to prefer the traceparent sampled flag to fix headers4 test case")
 def test_headers_tracestate_dd_propagate_samplingpriority(test_agent, test_library):
     """
     harness sends a request with both tracestate and traceparent
@@ -189,7 +188,6 @@ def test_headers_tracestate_dd_propagate_samplingpriority(test_agent, test_libra
 
 
 @temporary_enable_propagationstyle_default()
-@pytest.mark.skip_library("dotnet", "The origin transformation has changed slightly")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_tracestate_dd_propagate_origin(test_agent, test_library):
     """


### PR DESCRIPTION
## Description

Combined with https://github.com/DataDog/system-tests/pull/954, this PR will allow the .NET Tracer to run (and pass) all the W3C tracecontext tests in the parametric test suite. Changes in this PR include:
- Run all of the tracestate tests for .NET (except for the newly added DecisionMaker resetting tests that will be covered in a follow-up PR)
- Make the header lookup case-insensitive for the .NET service
- Run the case-insensitive header tests for .NET

This PR cannot be merged until https://github.com/DataDog/dd-trace-dotnet/pull/3873 is merged and published.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
