### PR TITLE
Enable exclusion and no waf timeout tests

### DIFF
--- a/tests/appsec/waf/test_exclusions.py
+++ b/tests/appsec/waf/test_exclusions.py
@@ -1,7 +1,7 @@
 from utils import scenarios, released, weblog, interfaces, missing_feature, context
 
 
-@released(java="1.6.0", dotnet="?", golang="?", nodejs="?", php_appsec="?", python="?", ruby="?", cpp="?")
+@released(java="1.6.0", dotnet="?", golang="?", nodejs="?", php_appsec="0.7.0", python="?", ruby="?", cpp="?")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @scenarios.appsec_custom_rules

--- a/tests/appsec/waf/test_miscs.py
+++ b/tests/appsec/waf/test_miscs.py
@@ -92,7 +92,6 @@ class Test_MultipleAttacks:
         interfaces.library.assert_waf_attack(self.r_same_location, pattern="Arachni/v")
 
 
-@missing_feature(library="php")
 @coverage.basic
 class Test_NoWafTimeout:
     """With an high value of DD_APPSEC_WAF_TIMEOUT, there is no WAF timeout"""


### PR DESCRIPTION
## Description

Enabling some more tests on PHP, specifically exclusion filter tests and a no-timeout WAF test.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
