### PR TITLE
Fix v2 instrumentation telemetry json schema

### DIFF
--- a/utils/interfaces/schemas/miscs/telemetry/v2/telemetry_request.json
+++ b/utils/interfaces/schemas/miscs/telemetry/v2/telemetry_request.json
@@ -90,22 +90,34 @@
       }
     },
     {
-      "properties": {
-        "request_type": {
-          "const": "app-client-configuration-change"
-        },
-        "payload": {
-          "$ref": "/miscs/telemetry/v2/events/client-configuration-change.json"
+      "if": {
+        "properties": {
+          "request_type": {
+            "const": "app-client-configuration-change"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "/miscs/telemetry/v2/events/client-configuration-change.json"
+          }
         }
       }
     },
     {
-      "properties": {
-        "request_type": {
-          "const": "app-product-change"
-        },
-        "payload": {
-          "$ref": "/miscs/telemetry/v2/events/product-change.json"
+      "if": {
+        "properties": {
+          "request_type": {
+            "const": "app-product-change"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "/miscs/telemetry/v2/events/product-change.json"
+          }
         }
       }
     },


### PR DESCRIPTION
## Description

The json schema for v2 instrumentation telemetry expected every request to have `request_type` equal to `app-client-configuration-change` and `app-product-change` because of missing `if...then...` logic, causing schema validation to fail. This PR adds the `if...then...` logic for these two request types into the schema. 

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
