### PR TITLE
Fix bugs on incorrect LibraryVersion comparison

### DIFF
--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -44,7 +44,7 @@ class _Scenario:
         return "logs" if self.name == "DEFAULT" else f"logs_{self.name.lower()}"
 
     @property
-    def library(self):
+    def library_version(self):
         return None
 
     @property
@@ -68,7 +68,7 @@ class _Scenario:
 
 class TestTheTestScenario(_Scenario):
     @property
-    def library(self):
+    def library_version(self):
         return LibraryVersion("java", "0.66.0")
 
     @property
@@ -148,16 +148,16 @@ class EndToEndScenario(_Scenario):
         if library_interface_timeout is not None:
             self.library_interface_timeout = library_interface_timeout
         else:
-            if self.weblog_container.library == "java":
+            if self.weblog_container.library_version.library == "java":
                 self.library_interface_timeout = 80
-            elif self.weblog_container.library.library in ("golang",):
+            elif self.weblog_container.library_version.library in ("golang",):
                 self.library_interface_timeout = 10
-            elif self.weblog_container.library.library in ("nodejs",):
+            elif self.weblog_container.library_version.library in ("nodejs",):
                 self.library_interface_timeout = 5
-            elif self.weblog_container.library.library in ("php",):
+            elif self.weblog_container.library_version.library in ("php",):
                 # possibly something weird on obfuscator, let increase the delay for now
                 self.library_interface_timeout = 10
-            elif self.weblog_container.library.library in ("python",):
+            elif self.weblog_container.library_version.library in ("python",):
                 self.library_interface_timeout = 25
             else:
                 self.library_interface_timeout = 40
@@ -171,9 +171,9 @@ class EndToEndScenario(_Scenario):
             terminal.write_line(info)
 
         terminal.write_sep("=", "Tested components", bold=True)
-        print_info(f"Library: {self.library}")
+        print_info(f"Library: {self.library_version}")
         print_info(f"Agent: {self.agent_version}")
-        if self.library == "php":
+        if self.library_version.library == "php":
             print_info(f"AppSec: {self.weblog_container.php_appsec}")
 
         if self.weblog_container.libddwaf_version:
@@ -234,8 +234,8 @@ class EndToEndScenario(_Scenario):
             container.remove()
 
     @property
-    def library(self):
-        return self.weblog_container.library
+    def library_version(self):
+        return self.weblog_container.library_version
 
     @property
     def agent_version(self):
@@ -253,8 +253,8 @@ class EndToEndScenario(_Scenario):
         result = super().get_junit_properties()
 
         result["dd_tags[systest.suite.context.agent]"] = self.agent_version
-        result["dd_tags[systest.suite.context.library.name]"] = self.library.library
-        result["dd_tags[systest.suite.context.library.version]"] = self.library.version
+        result["dd_tags[systest.suite.context.library.name]"] = self.library_version.library
+        result["dd_tags[systest.suite.context.library.version]"] = self.library_version.version
         result["dd_tags[systest.suite.context.weblog_variant]"] = self.weblog_variant
         result["dd_tags[systest.suite.context.sampling_rate]"] = self.weblog_container.tracer_sampling_rate
         result["dd_tags[systest.suite.context.libddwaf_version]"] = self.weblog_container.libddwaf_version

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -207,14 +207,14 @@ class WeblogContainer(TestedContainer):
 
         self.uds_socket = self.image_info.env.get("DD_APM_RECEIVER_SOCKET", None)
 
-        self.library = LibraryVersion(
+        self.library_version = LibraryVersion(
             self.image_info.env.get("SYSTEM_TESTS_LIBRARY", None),
             self.image_info.env.get("SYSTEM_TESTS_LIBRARY_VERSION", None),
         )
 
         self.weblog_variant = self.image_info.env.get("SYSTEM_TESTS_WEBLOG_VARIANT", None)
 
-        if self.library == "php":
+        if self.library_version.library == "php":
             self.php_appsec = Version(self.image_info.env.get("SYSTEM_TESTS_PHP_APPSEC_VERSION"), "php_appsec")
         else:
             self.php_appsec = None
@@ -237,9 +237,9 @@ class WeblogContainer(TestedContainer):
         if appsec_enabled:
             base_environment["DD_APPSEC_ENABLED"] = "true"
 
-        if self.library in ("cpp", "dotnet", "java", "python"):
+        if self.library_version.library in ("cpp", "dotnet", "java", "python"):
             base_environment["DD_TRACE_HEADER_TAGS"] = "user-agent:http.request.headers.user-agent"
-        elif self.library in ("golang", "nodejs", "php", "ruby"):
+        elif self.library_version.library in ("golang", "nodejs", "php", "ruby"):
             base_environment["DD_TRACE_HEADER_TAGS"] = "user-agent"
         else:
             base_environment["DD_TRACE_HEADER_TAGS"] = ""

--- a/utils/_context/core.py
+++ b/utils/_context/core.py
@@ -33,8 +33,8 @@ class _Context:
         return current_scenario.weblog_container.uds_socket
 
     @property
-    def library(self):
-        return current_scenario.library
+    def library_version(self):
+        return current_scenario.library_version
 
     @property
     def weblog_variant(self):
@@ -67,7 +67,7 @@ class _Context:
     def serialize(self):
         result = {
             "agent": str(self.agent_version),
-            "library": self.library.serialize(),
+            "library": self.library_version.serialize(),
             "weblog_variant": self.weblog_variant,
             "dd_site": self.dd_site,
             "sampling_rate": self.tracer_sampling_rate,
@@ -77,7 +77,7 @@ class _Context:
             "scenario": self.scenario,
         }
 
-        if self.library == "php":
+        if self.library_version.library == "php":
             result["php_appsec"] = self.php_appsec
 
         return result


### PR DESCRIPTION
## Description

In `utils/_context` package, there are several places that compare the [LibraryVersion](https://github.com/DataDog/system-tests/blob/2435e1cf4c07b7d84fbc8b284567fb226691f971/utils/_context/library_version.py#L163) class against a string while it should really be comparing `LibraryVersion.library` against the string. E.g. https://github.com/DataDog/system-tests/blob/2435e1cf4c07b7d84fbc8b284567fb226691f971/utils/_context/core.py#L80

This PR fixes the incorrect comparisons and renames LibraryVersion properties to `library_version`.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
