### PR TITLE
Use mitmproxy for the backend requests

### DIFF
--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -190,9 +190,9 @@ class EndToEndScenario(_Scenario):
         print_info(f"Scenario: {self.name}")
 
     def _get_warmups(self):
-        from utils.proxy.core import start_proxy  # prevent circular import
+        from utils.proxy.core import start_proxy, start_backend_proxy  # prevent circular import
 
-        warmups = [lambda: start_proxy(self.proxy_state)]
+        warmups = [lambda: start_proxy(self.proxy_state), lambda: start_backend_proxy()]
 
         for container in self._required_containers:
             warmups.append(container.start)

--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -40,9 +40,9 @@ class InterfaceValidator:
     def __str__(self):
         return f"{self.name} interface"
 
-    def wait(self, timeout):
+    def wait(self, timeout, stop_accepting_data=True):
         time.sleep(timeout)
-        self.accept_data = False
+        self.accept_data = not stop_accepting_data
 
     # data collector thread domain
     def append_data(self, data):

--- a/utils/proxy/core.py
+++ b/utils/proxy/core.py
@@ -208,7 +208,12 @@ def start_backend_proxy(state=None) -> None:
     thread.start()
 
     dd_site_url = get_dd_site_api_host()
-    opts = options.Options(mode=[f"reverse:{dd_site_url}"], listen_host="0.0.0.0", listen_port=BACKEND_LOCAL_PORT, confdir="utils/proxy/.mitmproxy")
+    opts = options.Options(
+        mode=[f"reverse:{dd_site_url}"],
+        listen_host="0.0.0.0",
+        listen_port=BACKEND_LOCAL_PORT,
+        confdir="utils/proxy/.mitmproxy",
+    )
     proxy = master.Master(opts, event_loop=loop)
     proxy.addons.add(*default_addons())
     proxy.addons.add(errorcheck.ErrorCheck())

--- a/utils/proxy/core.py
+++ b/utils/proxy/core.py
@@ -15,6 +15,9 @@ from utils.tools import logger
 SIMPLE_TYPES = (bool, int, float, type(None))
 
 
+BACKEND_LOCAL_PORT = 11111
+
+
 with open("utils/proxy/rc_mocked_responses_live_debugging.json", encoding="utf-8") as f:
     RC_MOCKED_RESPONSES_LIVE_DEBUGGING = json.load(f)
 
@@ -49,6 +52,8 @@ with open("utils/proxy/rc_mocked_responses_asm_nocache.json", encoding="utf-8") 
 class _RequestLogger:
     def __init__(self, state) -> None:
         self.dd_api_key = os.environ["DD_API_KEY"]
+        self.dd_application_key = os.environ.get("DD_APPLICATION_KEY")
+        self.dd_app_key = os.environ.get("DD_APP_KEY")
         self.state = state
 
         # for config backend mock
@@ -56,7 +61,12 @@ class _RequestLogger:
 
     def _scrub(self, content):
         if isinstance(content, str):
-            return content.replace(self.dd_api_key, "{redacted-by-system-tests-proxy}")
+            content = content.replace(self.dd_api_key, "{redacted-by-system-tests-proxy}")
+            if self.dd_app_key:
+                content = content.replace(self.dd_app_key, "{redacted-by-system-tests-proxy}")
+            if self.dd_application_key:
+                content = content.replace(self.dd_application_key, "{redacted-by-system-tests-proxy}")
+            return content
 
         if isinstance(content, (list, set, tuple)):
             return [self._scrub(item) for item in content]
@@ -108,8 +118,12 @@ class _RequestLogger:
         if flow.error and flow.error.msg == FlowError.KILLED_MESSAGE:
             payload["response"] = None
 
+        dd_site_url = get_dd_site_api_host()
+
         if flow.request.host == "agent":
             interface = interfaces.library
+        elif f"https://{flow.request.host}" == dd_site_url:
+            interface = interfaces.backend
         else:
             interface = interfaces.agent
 
@@ -185,6 +199,47 @@ def start_proxy(state) -> None:
     proxy.addons.add(_RequestLogger(state or {}))
 
     asyncio.run_coroutine_threadsafe(proxy.run(), loop)
+
+
+def start_backend_proxy(state=None) -> None:
+    loop = asyncio.new_event_loop()
+
+    thread = threading.Thread(target=_start_background_loop, args=(loop,), daemon=True)
+    thread.start()
+
+    dd_site_url = get_dd_site_api_host()
+    opts = options.Options(mode=[f"reverse:{dd_site_url}"], listen_host="0.0.0.0", listen_port=BACKEND_LOCAL_PORT, confdir="utils/proxy/.mitmproxy")
+    proxy = master.Master(opts, event_loop=loop)
+    proxy.addons.add(*default_addons())
+    proxy.addons.add(errorcheck.ErrorCheck())
+    proxy.addons.add(_RequestLogger(state or {}))
+
+    asyncio.run_coroutine_threadsafe(proxy.run(), loop)
+
+
+def get_dd_site_api_host():
+    # https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
+    # DD_SITE => API HOST
+    # datad0g.com       => dd.datad0g.com
+    # datadoghq.com     => app.datadoghq.com
+    # datadoghq.eu      => app.datadoghq.eu
+    # ddog-gov.com      => app.ddog-gov.com
+    # XYZ.datadoghq.com => XYZ.datadoghq.com
+
+    dd_site = os.environ["DD_SITE"]
+    dd_site_to_app = {
+        "datad0g.com": "https://dd.datad0g.com",
+        "datadoghq.com": "https://app.datadoghq.com",
+        "datadoghq.eu": "https://app.datadoghq.eu",
+        "ddog-gov.com": "https://app.ddog-gov.com",
+        "us3.datadoghq.com": "https://us3.datadoghq.com",
+        "us5.datadoghq.com": "https://us5.datadoghq.com",
+    }
+    dd_app_url = dd_site_to_app.get(dd_site)
+    assert dd_app_url is not None, f"We could not resolve a proper Datadog API URL given DD_SITE[{dd_site}]!"
+
+    logger.debug(f"Using Datadog API URL[{dd_app_url}] as resolved from DD_SITE[{dd_site}].")
+    return dd_app_url
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

In a similar way to how we log every tracer/agent request and response, this PR integrates `mitmproxy` with the requests we make to the backend API during tests (e.g. fetching traces/spans) in order to allow for easier debugging and troubleshooting.

It will also allow both `DD_APP_KEY` and `DD_APPLICATION_KEY`.

- ATI-2553

### Test

```
./build.sh -l golang -w chi
./run.sh APM_TRACING_E2E_SINGLE_SPAN
...
runner  | tests/apm_tracing_e2e/test_single_span.py ..                                                                     [100%]
runner  | 
runner  | ------------------------------------ generated xml file: /app/logs/reportJunit.xml -------------------------------------
runner  | ========================================== 2 passed, 304 deselected in 30.81s ==========================================
runner exited with code 0
```

Now check the log files:
```
ls logs_apm_tracing_e2e_single_span/interfaces/backend 
000__api_unstable_event-platform_analytics_list.json  001__api_unstable_event-platform_analytics_list.json  002__api_unstable_event-platform_analytics_list.json  003__api_unstable_event-platform_analytics_list.json
```

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
