### PR TITLE
Enable Ruby Telemetry tests

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -5,10 +5,10 @@ from utils.tools import logger
 from utils.interfaces._misc_validators import HeadersPresenceValidator, HeadersMatchValidator
 
 
-@released(python="1.7.0", dotnet="2.12.0", java="0.108.1", nodejs="3.2.0")
+@released(python="1.7.0", dotnet="2.12.0", java="0.108.1", nodejs="3.2.0", ruby="1.4.0")
 @bug(context.uds_mode and context.library < "nodejs@3.7.0")
+@bug(context.library <= "ruby@1.10.1", reason="Mishandling DD_INSTRUMENTATION_TELEMETRY_ENABLED activation. Fixed in https://github.com/DataDog/dd-trace-rb/pull/2710.")
 @missing_feature(library="cpp")
-@missing_feature(library="ruby")
 @missing_feature(library="php")
 @missing_feature(library="golang", reason="Implemented but not merged in master")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
@@ -408,7 +408,7 @@ class Test_Telemetry:
             raise Exception("app-product-change is not emited when product change is enabled")
 
 
-@released(python="1.7.0", dotnet="2.12.0", java="0.108.1", nodejs="3.2.0")
+@released(python="1.7.0", dotnet="2.12.0", java="0.108.1", nodejs="3.2.0", ruby="1.4.0")
 @bug(context.uds_mode and context.library < "nodejs@3.7.0")
 @missing_feature(library="cpp")
 @missing_feature(library="ruby")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -7,7 +7,10 @@ from utils.interfaces._misc_validators import HeadersPresenceValidator, HeadersM
 
 @released(python="1.7.0", dotnet="2.12.0", java="0.108.1", nodejs="3.2.0", ruby="1.4.0")
 @bug(context.uds_mode and context.library < "nodejs@3.7.0")
-@bug(context.library <= "ruby@1.10.1", reason="Mishandling DD_INSTRUMENTATION_TELEMETRY_ENABLED activation. Fixed in https://github.com/DataDog/dd-trace-rb/pull/2710.")
+@bug(
+    context.library <= "ruby@1.10.1",
+    reason="Mishandling DD_INSTRUMENTATION_TELEMETRY_ENABLED activation. Fixed in https://github.com/DataDog/dd-trace-rb/pull/2710.",
+)
 @missing_feature(library="cpp")
 @missing_feature(library="php")
 @missing_feature(library="golang", reason="Implemented but not merged in master")


### PR DESCRIPTION
## Description

Enable Tracer Telemetry test for Ruby.
This support has been merged for a while, but Ruby didn't get parametric system tests until recently.
One fix was needed for the Ruby Tracer (https://github.com/DataDog/dd-trace-rb/pull/2710), but this PR can be merged as is with the `@bug` tag for that specific fix.
Tests will still run, but report as `XPASS` when succeeded. If failed, they won't break the build.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
