### PR TITLE
Skip PHP on newly added span sampling tests

### DIFF
--- a/parametric/test_span_sampling.py
+++ b/parametric/test_span_sampling.py
@@ -309,6 +309,7 @@ def test_keep_span_with_stats_computation_sss010(test_agent, test_library):
 
 @pytest.mark.skip_library("dotnet", "Not implemented")
 @pytest.mark.skip_library("golang", "The Go tracer does not have a way to modulate trace sampling once started")
+@pytest.mark.skip_library("php", "manual.drop and manual.keep span tags are not implemented.")
 @pytest.mark.skip_library("ruby", "Issue: does not respect manual.drop or manual.keep span tags")
 @pytest.mark.parametrize(
     "library_env",

--- a/parametric/test_span_sampling.py
+++ b/parametric/test_span_sampling.py
@@ -531,6 +531,7 @@ def test_child_span_selected_by_sss015(test_agent, test_library):
 
 @pytest.mark.skip_library("dotnet", "The .NET tracer sends the full trace to the agent anyways.")
 @pytest.mark.skip_library("nodejs", "Not implemented")
+@pytest.mark.skip_library("php", "The PHP tracer always sends the full trace to the agent.")
 @pytest.mark.skip_library("python", "RPC issue causing test to hang")
 @pytest.mark.skip_library("ruby", "Issue: sending the complete trace when only the root span is expected")
 @pytest.mark.parametrize(
@@ -583,6 +584,7 @@ def test_root_span_selected_and_child_dropped_by_sss_when_dropping_policy_is_act
 
 @pytest.mark.skip_library("dotnet", "The .NET tracer sends the full trace to the agent anyways.")
 @pytest.mark.skip_library("nodejs", "Not implemented")
+@pytest.mark.skip_library("php", "The PHP tracer always sends the full trace to the agent.")
 @pytest.mark.skip_library("python", "RPC issue causing test to hang")
 @pytest.mark.skip_library("ruby", "Issue: sending the complete trace when only the root span is expected")
 @pytest.mark.parametrize(
@@ -636,6 +638,7 @@ def test_child_span_selected_and_root_dropped_by_sss_when_dropping_policy_is_act
 
 @pytest.mark.skip_library("dotnet", "The .NET tracer sends the full trace to the agent anyways.")
 @pytest.mark.skip_library("nodejs", "Not implemented")
+@pytest.mark.skip_library("php", "The PHP tracer always sends the full trace to the agent.")
 @pytest.mark.skip_library("python", "RPC issue causing test to hang")
 @pytest.mark.skip_library("ruby", "Issue: sending the complete trace when only the root span is expected")
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

These got added after PHP tests were merged and are failing PHP now.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
