### PR TITLE
Disabling cookie name test for resteasy

### DIFF
--- a/tests/appsec/iast/source/test_iast_request_cookie_name.py
+++ b/tests/appsec/iast/source/test_iast_request_cookie_name.py
@@ -14,13 +14,7 @@ if context.library == "cpp":
 @coverage.basic
 @released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?")
 @released(
-    java={
-        "spring-boot": "1.5.0",
-        "spring-boot-jetty": "1.5.0",
-        "spring-boot-openliberty": "1.5.0",
-        "resteasy-netty3": "1.11.0",
-        "*": "?",
-    }
+    java={"spring-boot": "1.5.0", "spring-boot-jetty": "1.5.0", "spring-boot-openliberty": "1.5.0", "*": "?",}
 )
 @released(nodejs="?")
 class TestRequestCookieName:


### PR DESCRIPTION
## Description

Disable the Cookie name test for resteasy. It was enabled by mistake

