### PR TITLE
[dotnet library] activate headers tag config test

### DIFF
--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -16,7 +16,7 @@ class Test_HeaderTags:
         """ Test that http.request.headers.user-agent is in all web spans """
 
         for _, _, span in interfaces.library.get_spans():
-            if span.get("type") == "web":
+            if span.get("type") == "web" and span.get("parent_id") is None:
                 assert "http.request.headers.user-agent" in span.get("meta", {})
 
 

--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -7,7 +7,7 @@ from utils import coverage, weblog, interfaces, released, irrelevant, scenarios
 
 # basic / legacy tests, just tests user-agent can be received as a tag
 @irrelevant(library="cpp")
-@released(dotnet="?", golang="?", java="?", nodejs="?", php="0.68.2", python="0.53", ruby="?")
+@released(dotnet="2.27.0", golang="?", java="?", nodejs="?", php="0.68.2", python="0.53", ruby="?")
 @coverage.basic
 class Test_HeaderTags:
     """DD_TRACE_HEADER_TAGS env var support"""

--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -15,8 +15,8 @@ class Test_HeaderTags:
     def test_trace_header_tags_basic(self):
         """ Test that http.request.headers.user-agent is in all web spans """
 
-        for _, _, span in interfaces.library.get_spans():
-            if span.get("type") == "web" and span.get("parent_id") is None:
+        for _, span in interfaces.library.get_root_spans():
+            if span.get("type") == "web":
                 assert "http.request.headers.user-agent" in span.get("meta", {})
 
 


### PR DESCRIPTION
## Description

Test that checks that the tracer uses `DD_TRACE_HEADER_TAGS` to tag root spans.

This test was failing for dotnet, as the test checked all web spans, it should only check root entry spans. The test has been corrected.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
