### PR TITLE
Fix failing Java Spring MVC Jetty test after the fix in Java Tracer

### DIFF
--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -45,6 +45,7 @@ VARIANT_COMPONENT_MAP = {
         "spring.handler": "spring-web-controller",
         "servlet.forward": "java-web-servlet-dispatcher",
         "servlet.response": "java-web-servlet-response",
+        "servlet.error": "java-web-servlet-dispatcher",
     },
     "spring-boot-3-native": {
         "servlet.request": "tomcat-server",


### PR DESCRIPTION
## Description

Fix for a failing Java Spring MVC Jetty test after the instrumentation fix in Java Tracer (https://github.com/DataDog/dd-trace-java/pull/4953)

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
