### PR TITLE
[parametric] For dotnet, unskip the dotnet test case that tests the decision maker reset

### DIFF
--- a/parametric/apps/dotnet/ApmTestClient.csproj
+++ b/parametric/apps/dotnet/ApmTestClient.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.27.0" />
+    <PackageReference Include="Datadog.Trace" Version="2.28.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
   </ItemGroup>

--- a/parametric/test_headers_tracestate_dd.py
+++ b/parametric/test_headers_tracestate_dd.py
@@ -500,7 +500,6 @@ def test_headers_tracestate_dd_propagate_propagatedtags_change_sampling_same_dm(
 
 
 @temporary_enable_propagationstyle_default()
-@pytest.mark.skip_library("dotnet", "Issue: Does not reset dm to DEFAULT")
 @pytest.mark.skip_library("golang", "Issue: Does not reset dm to DEFAULT")
 @pytest.mark.skip_library("nodejs", "Issue: Does not reset dm to DEFAULT")
 @pytest.mark.skip_library("php", "Issue: Does not drop dm")


### PR DESCRIPTION
## Description
Unskip the dotnet test case that resets dm to DEFAULT. This requires a new release of Datadog.Trace, so the NuGet package update for the .NET Tracer is included in this commit as well. This means that dotnet will now pass all header tests in the parametric test suite 🎉 

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
