### PR TITLE
Add binary path support

### DIFF
--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -56,7 +56,7 @@ print_usage() {
     echo -e "  ${CYAN}--list-weblogs${NC}             Lists all available weblogs for a library and exits."
     echo -e "  ${CYAN}--default-weblog${NC}           Prints the name of the default weblog for a given library and exits."
     echo -e "  ${CYAN}--binary-path${NC}              Optional. Path of a directory binaries will be copied from. Should be used for local development only."
-    echo -e "  ${CYAN}--binary-url${NC}              Optional. Url of the client library redistributable. Should be used for local development only."
+    echo -e "  ${CYAN}--binary-url${NC}               Optional. Url of the client library redistributable. Should be used for local development only."
     echo -e "  ${CYAN}--help${NC}                     Prints this message and exits."
     echo
     echo -e "${WHITE_BOLD}EXAMPLES${NC}"

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -55,6 +55,8 @@ print_usage() {
     echo -e "  ${CYAN}--list-libraries${NC}           Lists all available libraries and exits."
     echo -e "  ${CYAN}--list-weblogs${NC}             Lists all available weblogs for a library and exits."
     echo -e "  ${CYAN}--default-weblog${NC}           Prints the name of the default weblog for a given library and exits."
+    echo -e "  ${CYAN}--binary-path${NC}              Optional. Path of a directory binaries will be copied from. Should be used for local development only."
+    echo -e "  ${CYAN}--binary-url${NC}              Optional. Url of the client library redistributable. Should be used for local development only."
     echo -e "  ${CYAN}--help${NC}                     Prints this message and exits."
     echo
     echo -e "${WHITE_BOLD}EXAMPLES${NC}"
@@ -62,6 +64,10 @@ print_usage() {
     echo -e "    ${SCRIPT_NAME}"
     echo -e "  Build images for Java and Spring Boot:"
     echo -e "    ${SCRIPT_NAME} --library java --weblog-variant spring-boot"
+    echo -e "  Build default images for Dotnet with binary path:"
+    echo -e "    ${SCRIPT_NAME} dotnet --binary-path "/mnt/c/dev/dd-trace-dotnet-linux/tmp/linux-x64""    
+    echo -e "  Build default images for Dotnet with binary url:"
+    echo -e "    ${SCRIPT_NAME} ./build.sh dotnet --binary-url "https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.27.0/datadog-dotnet-apm-2.27.0.tar.gz""
     echo -e "  List libraries:"
     echo -e "    ${SCRIPT_NAME} --list-libraries"
     echo -e "  List weblogs for PHP:"
@@ -123,7 +129,7 @@ build() {
         echo Build $IMAGE_NAME
         if [[ $IMAGE_NAME == runner ]]; then
             docker build -f utils/build/docker/runner.Dockerfile -t system_tests/runner $EXTRA_DOCKER_ARGS .
-
+            
         elif [[ $IMAGE_NAME == agent ]]; then
             if [ -f ./binaries/agent-image ]; then
                 AGENT_BASE_IMAGE=$(cat ./binaries/agent-image)
@@ -150,6 +156,25 @@ build() {
                 .
 
         elif [[ $IMAGE_NAME == weblog ]]; then
+            clean-binaries() {
+                find . -mindepth 1 -type d -exec rm -rf {} +
+                find . ! -name 'README.md' -type f -exec rm -f {} +
+            }
+
+            if ! [[ -z "$BINARY_URL" ]]; then 
+                cd binaries
+                clean-binaries
+                curl -L -O $BINARY_URL
+                cd ..
+            fi
+
+            if ! [[ -z "$BINARY_PATH" ]]; then 
+                cd binaries
+                clean-binaries
+                cp -r $BINARY_PATH/* ./
+                cd ..
+            fi
+
             DOCKERFILE=utils/build/docker/${TEST_LIBRARY}/${WEBLOG_VARIANT}.Dockerfile
 
             docker buildx build \
@@ -220,6 +245,8 @@ while [[ "$#" -gt 0 ]]; do
         -e|--extra-docker-args) EXTRA_DOCKER_ARGS="$2"; shift ;;
         -c|--cache-mode) DOCKER_CACHE_MODE="$2"; shift ;;
         -p|--docker-platform) DOCKER_PLATFORM="--platform $2"; shift ;;
+        --binary-url) BINARY_URL="$2"; shift ;;
+        --binary-path) BINARY_PATH="$2"; shift ;;
         --list-libraries) COMMAND=list-libraries ;;
         --list-weblogs) COMMAND=list-weblogs ;;
         --default-weblog) COMMAND=default-weblog ;;
@@ -235,6 +262,8 @@ EXTRA_DOCKER_ARGS="${EXTRA_DOCKER_ARGS:-}"
 DOCKER_PLATFORM="${DOCKER_PLATFORM:-}"
 BUILD_IMAGES="${BUILD_IMAGES:-${DEFAULT_BUILD_IMAGES}}"
 TEST_LIBRARY="${TEST_LIBRARY:-${DEFAULT_TEST_LIBRARY}}"
+BINARY_PATH="${BINARY_PATH:-}"
+BINARY_URL="${BINARY_URL:-}"
 
 if [[ ! -d "${SCRIPT_DIR}/docker/${TEST_LIBRARY}" ]]; then
     echo "Library ${TEST_LIBRARY} not found"

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -129,7 +129,6 @@ build() {
         echo Build $IMAGE_NAME
         if [[ $IMAGE_NAME == runner ]]; then
             docker build -f utils/build/docker/runner.Dockerfile -t system_tests/runner $EXTRA_DOCKER_ARGS .
-            
         elif [[ $IMAGE_NAME == agent ]]; then
             if [ -f ./binaries/agent-image ]; then
                 AGENT_BASE_IMAGE=$(cat ./binaries/agent-image)

--- a/utils/build/docker/dotnet/install_ddtrace.sh
+++ b/utils/build/docker/dotnet/install_ddtrace.sh
@@ -7,18 +7,26 @@ get_latest_release() {
     curl "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/';
 }
 
-if [ $(ls datadog-dotnet-apm-*.tar.gz | wc -l) = 1 ]; then
-    echo "Install ddtrace from $(ls datadog-dotnet-apm-*.tar.gz)"
+mkdir -p /opt/datadog
+
+if [ $(ls /binaries/Datadog.Trace.ClrProfiler.Native.so | wc -l) = 1 ]; then
+    echo "Install from local folder"
+    cp -r /binaries/* /opt/datadog/
 else
-    echo "Install ddtrace from github releases"
-    DDTRACE_VERSION="$(get_latest_release DataDog/dd-trace-dotnet)"
-    curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DDTRACE_VERSION}/datadog-dotnet-apm-${DDTRACE_VERSION}.tar.gz --output datadog-dotnet-apm-${DDTRACE_VERSION}.tar.gz
+    if [ $(ls datadog-dotnet-apm-*.tar.gz | wc -l) = 1 ]; then
+        echo "Install ddtrace from $(ls datadog-dotnet-apm-*.tar.gz)"
+    else
+        echo "Install ddtrace from github releases"
+        DDTRACE_VERSION="$(get_latest_release DataDog/dd-trace-dotnet)"
+        curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DDTRACE_VERSION}/datadog-dotnet-apm-${DDTRACE_VERSION}.tar.gz --output datadog-dotnet-apm-${DDTRACE_VERSION}.tar.gz
+    fi
+
+    tar xzf $(ls datadog-dotnet-apm-*.tar.gz) -C /opt/datadog
 fi
 
-ls datadog-dotnet-apm-*.tar.gz > /app/SYSTEM_TESTS_LIBRARY_VERSION
-
-mkdir -p /opt/datadog
-tar xzf $(ls datadog-dotnet-apm-*.tar.gz) -C /opt/datadog
+apt-get install -y binutils #we need 'strings' command to extract assembly version which is part of binutils package
+version=$(strings /opt/datadog/netstandard2.0/Datadog.Trace.dll | egrep '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$')
+echo "${version:0:-2}" > /app/SYSTEM_TESTS_LIBRARY_VERSION
 
 LD_LIBRARY_PATH=/opt/datadog dotnet fsi --langversion:preview /binaries/query-versions.fsx
 


### PR DESCRIPTION
## Description

### 1. Addition of a binary path:

This change adds the ability to include a binary file in the binaries files. The binary file can be a URL (by using `--binary-url` parameter) or a path to a local directory (by using `--binary-path`). Once the binary file is included, it will be copied to the binaries directory. Both parameters are optional, and don't change default behaviour.

### 2. Modification of dotnet `install_ddtrace.sh` script:

This change modifies the install_ddtrace.sh shell script to accept not only an archived file but also a directory. 
Additionally, the script is modified to check `.dll` from the assembly version instead of relying solely on the filename. 