### PR TITLE
Enable W3C tests for released Java Library v1.11.0

### DIFF
--- a/parametric/apps/java/pom.xml
+++ b/parametric/apps/java/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <dd-trace.version>1.9.0</dd-trace.version>
+    <dd-trace.version>1.11.0</dd-trace.version>
     <opentracing.version>0.32.0</opentracing.version>
     <gprc.version>1.47.0</gprc.version>
     <slf4j.version>1.7.30</slf4j.version>

--- a/parametric/test_headers_b3.py
+++ b/parametric/test_headers_b3.py
@@ -53,7 +53,6 @@ def test_headers_b3_extract_invalid(test_agent, test_library):
 
 
 @enable_b3()
-@pytest.mark.skip_library("java", "Issue: Java doesn't pad the span-id to length of 16 lower-hex characters")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_b3_inject_valid(test_agent, test_library):
     """Ensure that b3 distributed tracing headers are injected properly.
@@ -75,7 +74,6 @@ def test_headers_b3_inject_valid(test_agent, test_library):
 
 
 @enable_b3()
-@pytest.mark.skip_library("java", "Issue: Java doesn't pad the span-id to length of 16 lower-hex characters")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_b3multi_propagate_valid(test_agent, test_library):
     """Ensure that b3 distributed tracing headers are extracted
@@ -100,7 +98,6 @@ def test_headers_b3multi_propagate_valid(test_agent, test_library):
 
 
 @enable_b3()
-@pytest.mark.skip_library("java", "Issue: Java doesn't pad the span-id to length of 16 lower-hex characters")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_b3multi_propagate_invalid(test_agent, test_library):
     """Ensure that invalid b3 distributed tracing headers are not extracted

--- a/parametric/test_headers_b3multi.py
+++ b/parametric/test_headers_b3multi.py
@@ -67,7 +67,6 @@ def test_headers_b3multi_extract_invalid(test_agent, test_library):
 
 
 @enable_b3multi()
-@pytest.mark.skip_library("java", "Issue: Java doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_b3multi_inject_valid(test_agent, test_library):
     """Ensure that b3multi distributed tracing headers are injected properly.
@@ -88,7 +87,6 @@ def test_headers_b3multi_inject_valid(test_agent, test_library):
 
 
 @enable_b3multi()
-@pytest.mark.skip_library("java", "Issue: Java doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_b3multi_propagate_valid(test_agent, test_library):
     """Ensure that b3multi distributed tracing headers are extracted
@@ -118,7 +116,6 @@ def test_headers_b3multi_propagate_valid(test_agent, test_library):
 
 
 @enable_b3multi()
-@pytest.mark.skip_library("java", "Issue: Java doesn't pad the trace-id to length of 16 or 32 lower-hex characters")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_b3multi_propagate_invalid(test_agent, test_library):
     """Ensure that invalid b3multi distributed tracing headers are not extracted

--- a/parametric/test_headers_datadog.py
+++ b/parametric/test_headers_datadog.py
@@ -6,7 +6,6 @@ from parametric.utils.headers import make_single_request_and_get_inject_headers
 from parametric.utils.test_agent import get_span
 
 
-@pytest.mark.skip_library("java", "Issue: java splits origin at the first ,")
 def test_distributed_headers_extract_datadog_D001(test_agent, test_library):
     """Ensure that Datadog distributed tracing headers are extracted
     and activated properly.

--- a/parametric/test_headers_precedence.py
+++ b/parametric/test_headers_precedence.py
@@ -29,7 +29,7 @@ def enable_datadog_tracecontext() -> Any:
     return parametrize("library_env", [env])
 
 
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
+@pytest.mark.skip_library("java", "Issue: tracecontext is not enabled by default")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_precedence_propagationstyle_default(test_agent, test_library):
     with test_library:
@@ -173,7 +173,6 @@ def test_headers_precedence_propagationstyle_default(test_agent, test_library):
 
 
 @enable_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_precedence_propagationstyle_tracecontext(test_agent, test_library):
     with test_library:
@@ -296,7 +295,6 @@ def test_headers_precedence_propagationstyle_tracecontext(test_agent, test_libra
 
 
 @enable_datadog()
-@pytest.mark.skip_library("java", "Issue: only sampling priority -1 to 2 allowed")
 def test_headers_precedence_propagationstyle_datadog(test_agent, test_library):
     with test_library:
         # 1) No headers
@@ -406,7 +404,6 @@ def test_headers_precedence_propagationstyle_datadog(test_agent, test_library):
     "BUG: suite #4 is failing - if context is successfully retrieved from W3C propagator, datadog propagator is NOT "
     "run, thus not retrieving / overwriting the headers",
 )
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_precedence_propagationstyle_datadog_tracecontext(test_agent, test_library):
     with test_library:

--- a/parametric/test_headers_tracecontext.py
+++ b/parametric/test_headers_tracecontext.py
@@ -26,7 +26,6 @@ def temporary_enable_optin_tracecontext() -> Any:
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_both_traceparent_and_tracestate_missing(test_agent, test_library):
     """
     harness sends a request without traceparent or tracestate
@@ -37,7 +36,6 @@ def test_both_traceparent_and_tracestate_missing(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_included_tracestate_missing(test_agent, test_library):
     """
     harness sends a request with traceparent but without tracestate
@@ -68,7 +66,6 @@ def test_traceparent_included_tracestate_missing(test_agent, test_library):
     "golang",
     "golang does not reconcile duplicate http headers, if duplicate headers received the propagator will not be used",
 )
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_traceparent_duplicated(test_agent, test_library):
     """
@@ -89,7 +86,6 @@ def test_traceparent_duplicated(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_header_name(test_agent, test_library):
     """
     harness sends an invalid traceparent using wrong names
@@ -110,7 +106,6 @@ def test_traceparent_header_name(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Bug: Header search is currently case-sensitive")
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_traceparent_header_name_valid_casing(test_agent, test_library):
     """
@@ -136,7 +131,6 @@ def test_traceparent_header_name_valid_casing(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_version_0x00(test_agent, test_library):
     """
     harness sends an invalid traceparent with extra trailing characters
@@ -157,7 +151,6 @@ def test_traceparent_version_0x00(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_version_0xcc(test_agent, test_library):
     """
     harness sends an valid traceparent with future version 204 (0xcc)
@@ -184,7 +177,6 @@ def test_traceparent_version_0xcc(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_version_0xff(test_agent, test_library):
     """
     harness sends an invalid traceparent with version 255 (0xff)
@@ -199,7 +191,6 @@ def test_traceparent_version_0xff(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_traceparent_version_illegal_characters(test_agent, test_library):
     """
@@ -220,7 +211,6 @@ def test_traceparent_version_illegal_characters(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_version_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with version more than 2 HEXDIG
@@ -240,7 +230,6 @@ def test_traceparent_version_too_long(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_version_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with version less than 2 HEXDIG
@@ -255,7 +244,6 @@ def test_traceparent_version_too_short(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_id_all_zero(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_id = 00000000000000000000000000000000
@@ -270,7 +258,6 @@ def test_traceparent_trace_id_all_zero(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_id_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in trace_id
@@ -290,7 +277,6 @@ def test_traceparent_trace_id_illegal_characters(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_id_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_id more than 32 HEXDIG
@@ -307,7 +293,6 @@ def test_traceparent_trace_id_too_long(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_id_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_id less than 32 HEXDIG
@@ -322,7 +307,6 @@ def test_traceparent_trace_id_too_short(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_parent_id_all_zero(test_agent, test_library):
     """
     harness sends an invalid traceparent with parent_id = 0000000000000000
@@ -337,7 +321,6 @@ def test_traceparent_parent_id_all_zero(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_parent_id_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in parent_id
@@ -357,7 +340,6 @@ def test_traceparent_parent_id_illegal_characters(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_parent_id_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with parent_id more than 16 HEXDIG
@@ -372,7 +354,6 @@ def test_traceparent_parent_id_too_long(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_parent_id_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with parent_id less than 16 HEXDIG
@@ -388,7 +369,6 @@ def test_traceparent_parent_id_too_short(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Latest release does not implement new configuration")
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_flags_illegal_characters(test_agent, test_library):
     """
     harness sends an invalid traceparent with illegal characters in trace_flags
@@ -408,7 +388,6 @@ def test_traceparent_trace_flags_illegal_characters(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_flags_too_long(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_flags more than 2 HEXDIG
@@ -423,7 +402,6 @@ def test_traceparent_trace_flags_too_long(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_trace_flags_too_short(test_agent, test_library):
     """
     harness sends an invalid traceparent with trace_flags less than 2 HEXDIG
@@ -438,7 +416,6 @@ def test_traceparent_trace_flags_too_short(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_traceparent_ows_handling(test_agent, test_library):
     """
     harness sends an valid traceparent with heading and trailing OWS
@@ -473,7 +450,6 @@ def test_traceparent_ows_handling(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_tracestate_included_traceparent_missing(test_agent, test_library):
     """
     harness sends a request with tracestate but without traceparent
@@ -490,7 +466,6 @@ def test_tracestate_included_traceparent_missing(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_tracestate_included_traceparent_included(test_agent, test_library):
     """
@@ -513,7 +488,6 @@ def test_tracestate_included_traceparent_included(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 def test_tracestate_header_name(test_agent, test_library):
     """
     harness sends an invalid tracestate using wrong names
@@ -536,7 +510,6 @@ def test_tracestate_header_name(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("dotnet", "Tracestate not implemented")
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_tracestate_header_name_valid_casing(test_agent, test_library):
     """
@@ -580,7 +553,6 @@ def test_tracestate_header_name_valid_casing(test_agent, test_library):
     "python",
     "python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
 )
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_tracestate_empty_header(test_agent, test_library):
     """
@@ -637,7 +609,6 @@ def test_tracestate_empty_header(test_agent, test_library):
     "python",
     "python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
 )
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_tracestate_multiple_headers_different_keys(test_agent, test_library):
     """
@@ -668,7 +639,6 @@ def test_tracestate_multiple_headers_different_keys(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_tracestate_duplicated_keys(test_agent, test_library):
     """
@@ -725,7 +695,6 @@ def test_tracestate_duplicated_keys(test_agent, test_library):
 
 
 @temporary_enable_optin_tracecontext()
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_tracestate_all_allowed_characters(test_agent, test_library):
     """
@@ -770,7 +739,6 @@ def test_tracestate_all_allowed_characters(test_agent, test_library):
 
 @temporary_enable_optin_tracecontext()
 @pytest.mark.skip_library("php", "PHP may preserve whitespace of foreign vendors trracestate (allowed per spec)")
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_tracestate_ows_handling(test_agent, test_library):
     """

--- a/parametric/test_headers_tracestate_dd.py
+++ b/parametric/test_headers_tracestate_dd.py
@@ -18,7 +18,6 @@ def temporary_enable_propagationstyle_default() -> Any:
 
 @temporary_enable_propagationstyle_default()
 @pytest.mark.skip_library("dotnet", "Issue: We need to prefer the traceparent sampled flag to fix headers4 test case")
-@pytest.mark.skip_library("java", "Issue: tracecontext is not available yet")
 def test_headers_tracestate_dd_propagate_samplingpriority(test_agent, test_library):
     """
     harness sends a request with both tracestate and traceparent
@@ -191,7 +190,6 @@ def test_headers_tracestate_dd_propagate_samplingpriority(test_agent, test_libra
 
 @temporary_enable_propagationstyle_default()
 @pytest.mark.skip_library("dotnet", "The origin transformation has changed slightly")
-@pytest.mark.skip_library("java", "Issue: tracecontext is not available yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_tracestate_dd_propagate_origin(test_agent, test_library):
     """
@@ -329,7 +327,6 @@ def test_headers_tracestate_dd_propagate_origin(test_agent, test_library):
     "False Bug: header[3,6]: can't guarantee the order of strings in the tracestate since they came from the map"
     "BUG: header[4,5]: w3cTraceID shouldn't be present",
 )
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("ruby", "Ruby doesn't support case-insensitive distributed headers")
 def test_headers_tracestate_dd_propagate_propagatedtags(test_agent, test_library):
     """
@@ -437,7 +434,6 @@ def test_headers_tracestate_dd_propagate_propagatedtags(test_agent, test_library
 
 @temporary_enable_propagationstyle_default()
 @pytest.mark.skip_library("dotnet", "Issue: Traceparent doesn't override sampling decision")
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("nodejs", "Issue: the decision maker is removed. Is that allowed behavior?")
 @pytest.mark.skip_library("php", "Issue: Does not drop dm")
 @pytest.mark.skip_library("python", "Issue: Does not drop dm")
@@ -509,7 +505,6 @@ def test_headers_tracestate_dd_propagate_propagatedtags_change_sampling_same_dm(
 @temporary_enable_propagationstyle_default()
 @pytest.mark.skip_library("dotnet", "Issue: Does not reset dm to DEFAULT")
 @pytest.mark.skip_library("golang", "Issue: Does not reset dm to DEFAULT")
-@pytest.mark.skip_library("java", "Issue: tracecontext is not merged yet")
 @pytest.mark.skip_library("nodejs", "Issue: Does not reset dm to DEFAULT")
 @pytest.mark.skip_library("php", "Issue: Does not drop dm")
 @pytest.mark.skip_library("python", "Issue: Does not reset dm to DEFAULT")


### PR DESCRIPTION
## Description

Enable W3C tests for released Java Library v1.11.0

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
