### PR TITLE
[dotnet library] Active some blocking tests

### DIFF
--- a/tests/appsec/blocking_rule.json
+++ b/tests/appsec/blocking_rule.json
@@ -342,6 +342,45 @@
       "on_match": [
         "block"
       ]
+    },
+    {
+      "id": "tst-037-010",
+      "name": "Test block on not found",
+      "tags": {
+        "type": "lfi",
+        "crs_id": "000005",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.status"
+              }
+            ],
+            "regex": "404"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "operator": "phrase_match",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.uri.raw"
+              }
+            ],
+            "list": [
+              "/finger_print"
+            ]
+          }
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "block"
+      ]
     }
   ],
   "actions": [

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -108,9 +108,8 @@ class Test_BlockingAddresses:
     def setup_not_found(self):
         self.rnf_req = weblog.get(path="/finger_print")
 
-    @missing_feature(context.library == "dotnet", reason="only support blocking on 404 status at the moment")
     @missing_feature(context.library == "java", reason="Happens on a subsequent WAF run")
-    @missing_feature(context.library < "ruby@1.10.0")
+    @missing_feature(context.library == "ruby", reason="Not working")
     def test_not_found(self):
         """can block on server.response.status"""
 

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -108,6 +108,9 @@ class Test_BlockingAddresses:
     def setup_not_found(self):
         self.rnf_req = weblog.get(path="/finger_print")
 
+    @missing_feature(context.library == "dotnet", reason="only support blocking on 404 status at the moment")
+    @missing_feature(context.library == "java", reason="Happens on a subsequent WAF run")
+    @missing_feature(context.library < "ruby@1.10.0")
     def test_not_found(self):
         """can block on server.response.status"""
 

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -110,7 +110,7 @@ HTML_DATA = """<!-- Sorry, you’ve been blocked -->
 """
 
 
-@released(dotnet="?", golang="?", nodejs="?", php_appsec="0.7.0", python="?", ruby="?")
+@released(dotnet="2.27.0", golang="?", nodejs="?", php_appsec="0.7.0", python="?", ruby="?")
 @released(
     java={
         "spring-boot": "0.112.0",
@@ -193,6 +193,7 @@ class Test_Blocking:
         )
 
     @missing_feature(context.library == "php", reason="Support for partial html not implemented")
+    @missing_feature(context.library == "dotnet", reason="Support for partial html not implemented")
     def test_accept_partial_html(self):
         """Blocking with Accept: text/*"""
         assert self.r_aph.status_code == 403
@@ -222,6 +223,7 @@ class Test_Blocking:
         )
 
     @missing_feature(context.library == "php", reason="Support for quality not implemented")
+    @missing_feature(context.library == "dotnet", reason="Support for quality not implemented")
     def test_accept_full_html(self):
         """Blocking with Accept: text/html"""
         assert self.r_afh.status_code == 403

--- a/utils/build/docker/dotnet/Models/Model.cs
+++ b/utils/build/docker/dotnet/Models/Model.cs
@@ -8,6 +8,7 @@ namespace weblog
 {
     public class Model
     {
+        public string? Foo { get; set; }
         public string? Value { get; set; }
         public string? Value2 { get; set; }
 


### PR DESCRIPTION
## Description

Activates the blocking tests that are currently working for the .NET library.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
