### PR TITLE
ASM - Add a test for boolean options in WAF rules

### DIFF
--- a/tests/appsec/waf/test_miscs.py
+++ b/tests/appsec/waf/test_miscs.py
@@ -109,4 +109,4 @@ class Test_CorrectOptionProcessing:
     @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_main(self):
         attack = weblog.get("/waf/", params={"x-attack": "query_string"})
-        interfaces.library.assert_waf_attack(attack, rules.php_code_injection.crs_933_131)
+        interfaces.library.assert_no_appsec_event(attack)

--- a/tests/appsec/waf/test_miscs.py
+++ b/tests/appsec/waf/test_miscs.py
@@ -101,6 +101,7 @@ class Test_NoWafTimeout:
     def test_main(self):
         interfaces.library_stdout.assert_absence("Ran out of time while running flow")
 
+
 @coverage.basic
 class Test_CorrectOptionProcessing:
     """Check that the case sensitive option is properly processed"""

--- a/tests/appsec/waf/test_miscs.py
+++ b/tests/appsec/waf/test_miscs.py
@@ -92,6 +92,23 @@ class Test_MultipleAttacks:
         interfaces.library.assert_waf_attack(self.r_same_location, pattern="Arachni/v")
 
 
+@released(golang={"gin": "1.37.0", "echo": "1.36.0", "chi": "1.36.0", "*": "1.34.0"})
+@released(dotnet="1.28.6", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.1.0")
+@missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
+@missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
+@coverage.good
+class Test_CorrectOptionProcessing:
+    """Check that the case sensitive option is properly processed"""
+
+    def setup_main(self):
+        self.r_match = weblog.get("/waf/", params={"x-attack": "QUERY_STRING"})
+        self.r_no_match = weblog.get("/waf/", params={"x-attack": "query_string"})
+
+    def test_main(self):
+        interfaces.library.assert_waf_attack(self.r_match)
+        interfaces.library.assert_no_appsec_event(self.r_no_match)
+
+
 @coverage.basic
 class Test_NoWafTimeout:
     """With an high value of DD_APPSEC_WAF_TIMEOUT, there is no WAF timeout"""
@@ -100,14 +117,3 @@ class Test_NoWafTimeout:
     @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_main(self):
         interfaces.library_stdout.assert_absence("Ran out of time while running flow")
-
-
-@coverage.basic
-class Test_CorrectOptionProcessing:
-    """Check that the case sensitive option is properly processed"""
-
-    @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
-    @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
-    def test_main(self):
-        attack = weblog.get("/waf/", params={"x-attack": "query_string"})
-        interfaces.library.assert_no_appsec_event(attack)

--- a/tests/appsec/waf/test_miscs.py
+++ b/tests/appsec/waf/test_miscs.py
@@ -100,3 +100,13 @@ class Test_NoWafTimeout:
     @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_main(self):
         interfaces.library_stdout.assert_absence("Ran out of time while running flow")
+
+@coverage.basic
+class Test_CorrectOptionProcessing:
+    """Check that the case sensitive option is properly processed"""
+
+    @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
+    @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
+    def test_main(self):
+        attack = weblog.get("/waf/", params={"x-attack": "query_string"})
+        interfaces.library.assert_waf_attack(attack, rules.php_code_injection.crs_933_131)

--- a/tests/appsec/waf/test_miscs.py
+++ b/tests/appsec/waf/test_miscs.py
@@ -93,7 +93,8 @@ class Test_MultipleAttacks:
 
 
 @released(golang={"gin": "1.37.0", "echo": "1.36.0", "chi": "1.36.0", "*": "1.34.0"})
-@released(dotnet="1.28.6", java="0.87.0", nodejs="2.0.0", php_appsec="0.1.0", python="1.1.0")
+@released(dotnet="1.28.6", java="0.87.0", php_appsec="0.1.0", python="1.1.0")
+@bug(library="nodejs", reason="current releases are buggy")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @coverage.good


### PR DESCRIPTION
## Description

Add a test checking that the case_sensitive setting of crs-933-131 is properly parsed

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
