### PR TITLE
Use docker base images to get APM client library (java, php, dotnet)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,23 +209,8 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Load library binary
-      if: ${{ matrix.version == 'dev' && matrix.variant.library != 'php' }}
+      if: ${{ matrix.version == 'dev' }}
       run: ./utils/scripts/load-binary.sh ${{ matrix.variant.library }}
-    - name: Load PHP prod library binary
-      if: ${{ matrix.variant.library == 'php' }}
-      run: ./utils/scripts/load-binary.sh php prod
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Load library PHP appsec binary
-      if: ${{ matrix.variant.library == 'php' }}
-      run: ./utils/scripts/load-binary.sh php_appsec ${{matrix.version}}
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Load library dotNet prod binary
-      if: ${{ matrix.variant.library == 'dotNet' && matrix.version == 'prod' }}
-      run: ./utils/scripts/load-binary.sh ${{ matrix.variant.library }} prod
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Load agent binary
       if: ${{ matrix.version == 'dev' }}
       run: ./utils/scripts/load-binary.sh agent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Load library binary
-      if: ${{ matrix.version == 'dev' && (matrix.variant.library != 'php' && matrix.variant.library != 'java')}}
+      if: ${{ matrix.version == 'dev' && matrix.variant.library != 'php' }}
       run: ./utils/scripts/load-binary.sh ${{ matrix.variant.library }}
     - name: Load PHP prod library binary
       if: ${{ matrix.variant.library == 'php' }}
@@ -434,7 +434,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Load library binary
-      if: ${{ matrix.version == 'dev' && (matrix.variant.library != 'php' && matrix.variant.library != 'java')}}
+      if: ${{ matrix.version == 'dev' && matrix.variant.library != 'php' }}
       run: ./utils/scripts/load-binary.sh ${{ matrix.variant.library }}
     - name: Load PHP prod library binary
       if: ${{ matrix.variant.library == 'php' }}

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -175,7 +175,7 @@ build() {
             fi
             #By default if the binaries directory is empty, the latest release of the APM library will be loaded
             APM_LIBRARY_VERSION="latest"
-            if [ $(ls binaries/dd-java-agent*.jar | wc -l) = 1 ]; then
+            if [ $(ls binaries/ | wc -l) -gt 1 ]; then
                 echo "Using APM local library...."
                 APM_LIBRARY_VERSION="local"
             fi

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -173,6 +173,12 @@ build() {
                 cp -r $BINARY_PATH/* ./
                 cd ..
             fi
+            #By default if the binaries directory is empty, the latest release of the APM library will be loaded
+            APM_LIBRARY_VERSION="latest"
+            if [ $(ls binaries/dd-java-agent*.jar | wc -l) = 1 ]; then
+                echo "Using APM local library...."
+                APM_LIBRARY_VERSION="local"
+            fi
 
             DOCKERFILE=utils/build/docker/${TEST_LIBRARY}/${WEBLOG_VARIANT}.Dockerfile
 
@@ -181,6 +187,7 @@ build() {
                 ${DOCKER_PLATFORM_ARGS} \
                 -f ${DOCKERFILE} \
                 -t system_tests/weblog \
+                --build-arg APM_LIBRARY_IMAGE="apm_library_$APM_LIBRARY_VERSION" \
                 $CACHE_TO \
                 $CACHE_FROM \
                 $EXTRA_DOCKER_ARGS \

--- a/utils/build/docker/dotnet/install_ddtrace.sh
+++ b/utils/build/docker/dotnet/install_ddtrace.sh
@@ -1,35 +1,14 @@
 #!/bin/bash
 set -eu
 
-cd /binaries
-
-get_latest_release() {
-    curl "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/';
-}
-
 mkdir -p /opt/datadog
+tar xzf $(ls datadog-dotnet-apm-*.tar.gz) -C /opt/datadog
 
-if [ $(ls /binaries/Datadog.Trace.ClrProfiler.Native.so | wc -l) = 1 ]; then
-    echo "Install from local folder"
-    cp -r /binaries/* /opt/datadog/
-else
-    if [ $(ls datadog-dotnet-apm-*.tar.gz | wc -l) = 1 ]; then
-        echo "Install ddtrace from $(ls datadog-dotnet-apm-*.tar.gz)"
-    else
-        echo "Install ddtrace from github releases"
-        DDTRACE_VERSION="$(get_latest_release DataDog/dd-trace-dotnet)"
-        curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DDTRACE_VERSION}/datadog-dotnet-apm-${DDTRACE_VERSION}.tar.gz --output datadog-dotnet-apm-${DDTRACE_VERSION}.tar.gz
-    fi
-
-    tar xzf $(ls datadog-dotnet-apm-*.tar.gz) -C /opt/datadog
+if [ $(ls /LIBRARY_VERSION | wc -l) = 0 ]; then
+    ls datadog-dotnet-apm-*.tar.gz > /LIBRARY_VERSION
+    LD_LIBRARY_PATH=/opt/datadog dotnet fsi --langversion:preview /query-versions.fsx
 fi
 
-apt-get install -y binutils #we need 'strings' command to extract assembly version which is part of binutils package
-version=$(strings /opt/datadog/netstandard2.0/Datadog.Trace.dll | egrep '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$')
-echo "${version:0:-2}" > /app/SYSTEM_TESTS_LIBRARY_VERSION
-
-LD_LIBRARY_PATH=/opt/datadog dotnet fsi --langversion:preview /binaries/query-versions.fsx
-
-echo "dd-trace version: $(cat /app/SYSTEM_TESTS_LIBRARY_VERSION)"
-echo "libddwaf version: $(cat /app/SYSTEM_TESTS_LIBDDWAF_VERSION)"
-echo "appsec event rules version: $(cat /app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION)"
+echo "dd-trace version: $(cat /LIBRARY_VERSION)"
+echo "libddwaf version: $(cat /LIBDDWAF_VERSION)"
+echo "appsec event rules version: $(cat /APPSEC_EVENT_RULES_VERSION)"

--- a/utils/build/docker/dotnet/poc.Dockerfile
+++ b/utils/build/docker/dotnet/poc.Dockerfile
@@ -1,3 +1,14 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest as agent_latest
+
+FROM bash as apm_library_local
+COPY utils/build/docker/dotnet/install_ddtrace.sh utils/build/docker/dotnet/query-versions.fsx binaries* /
+RUN dos2unix /install_ddtrace.sh
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 
 RUN apt-get update && apt-get install dos2unix
@@ -12,11 +23,14 @@ COPY utils/build/docker/dotnet/Endpoints/*.cs ./Endpoints/
 COPY utils/build/docker/dotnet/Controllers/*.cs ./Controllers/
 COPY utils/build/docker/dotnet/Models/*.cs ./Models/
 
-COPY utils/build/docker/dotnet/install_ddtrace.sh utils/build/docker/dotnet/query-versions.fsx binaries* /binaries/
-RUN dos2unix /binaries/install_ddtrace.sh
-RUN /binaries/install_ddtrace.sh
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 
-RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") dotnet publish -c Release -o out
+COPY --from=apm_library /*.tar.gz /binaries/datadog-dotnet-apm.tar.gz
+RUN mkdir -p /opt/datadog && tar xzf $(ls /binaries/datadog-dotnet-apm.tar.gz) -C /opt/datadog
+
+RUN DDTRACE_VERSION=$(cat /binaries/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 
@@ -26,9 +40,9 @@ COPY --from=build /app/out .
 RUN mkdir /opt/datadog
 COPY --from=build /opt/datadog /opt/datadog
 
-COPY --from=build /app/SYSTEM_TESTS_LIBRARY_VERSION /app/SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /app/SYSTEM_TESTS_LIBDDWAF_VERSION /app/SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION /app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION /app/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION /app/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION /app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 
 COPY utils/build/docker/dotnet/app.sh app.sh
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'

--- a/utils/build/docker/dotnet/query-versions.fsx
+++ b/utils/build/docker/dotnet/query-versions.fsx
@@ -50,7 +50,7 @@ module QueryVersions =
                     unknownRulesDefault
                 else
                     ruleVersion.Value.ToString()
-        File.WriteAllText("/app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION", ruleVersion)
+        File.WriteAllText("/APPSEC_EVENT_RULES_VERSION", ruleVersion)
 
     let writeWafVersion () =
         let getOldWafVersion () =
@@ -67,7 +67,7 @@ module QueryVersions =
         let version = 
             if assem.GetName().Version.Major <= 2 && assem.GetName().Version.Minor <= 14 then getOldWafVersion()
             else getWafVersion()
-        File.WriteAllText("/app/SYSTEM_TESTS_LIBDDWAF_VERSION", version)
+        File.WriteAllText("/LIBDDWAF_VERSION", version)
 
     writeRulesVersion ()
     writeWafVersion ()

--- a/utils/build/docker/dotnet/uds.Dockerfile
+++ b/utils/build/docker/dotnet/uds.Dockerfile
@@ -1,3 +1,14 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest as agent_latest
+
+FROM bash as apm_library_local
+COPY utils/build/docker/dotnet/install_ddtrace.sh utils/build/docker/dotnet/query-versions.fsx binaries* /
+RUN dos2unix /install_ddtrace.sh
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 
 RUN apt-get update && apt-get install dos2unix
@@ -12,11 +23,14 @@ COPY utils/build/docker/dotnet/Endpoints/*.cs ./Endpoints/
 COPY utils/build/docker/dotnet/Controllers/*.cs ./Controllers/
 COPY utils/build/docker/dotnet/Models/*.cs ./Models/
 
-COPY utils/build/docker/dotnet/install_ddtrace.sh utils/build/docker/dotnet/query-versions.fsx binaries* /binaries/
-RUN dos2unix /binaries/install_ddtrace.sh
-RUN /binaries/install_ddtrace.sh
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 
-RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") dotnet publish -c Release -o out
+COPY --from=apm_library /*.tar.gz /binaries/datadog-dotnet-apm.tar.gz
+RUN mkdir -p /opt/datadog && tar xzf $(ls /binaries/datadog-dotnet-apm.tar.gz) -C /opt/datadog
+
+RUN DDTRACE_VERSION=$(cat /binaries/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 
@@ -26,9 +40,9 @@ COPY --from=build /app/out .
 RUN mkdir /opt/datadog
 COPY --from=build /opt/datadog /opt/datadog
 
-COPY --from=build /app/SYSTEM_TESTS_LIBRARY_VERSION /app/SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /app/SYSTEM_TESTS_LIBDDWAF_VERSION /app/SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION /app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION /app/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION /app/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION /app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 
 COPY utils/build/docker/dotnet/app.sh app.sh
 COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh

--- a/utils/build/docker/java/install_ddtrace.sh
+++ b/utils/build/docker/java/install_ddtrace.sh
@@ -2,39 +2,28 @@
 
 set -eu
 
-mkdir /dd-tracer
-
-if [ $(ls /binaries/dd-java-agent*.jar | wc -l) = 0 ]; then
-    BUILD_URL="https://github.com/DataDog/dd-trace-java/releases/latest/download/dd-java-agent.jar"
-    echo "install from Github release: $BUILD_URL"
-    curl  -Lf -o /dd-tracer/dd-java-agent.jar $BUILD_URL
-
-elif [ $(ls /binaries/dd-java-agent*.jar | wc -l) = 1 ]; then
-    echo "Install local file $(ls /binaries/dd-java-agent*.jar)"
-    cp $(ls /binaries/dd-java-agent*.jar) /dd-tracer/dd-java-agent.jar
-
+if [ $(ls /dd-java-agent*.jar | wc -l) = 1 ]; then
+    echo "Install local file $(ls /dd-java-agent*.jar)"
+    [ ! -f "dd-java-agent.jar"  ] && cp $(ls /dd-java-agent*.jar) /dd-java-agent.jar  
 else
     echo "Too many jar files in binaries"
     exit 1
 fi
 
-java -jar /dd-tracer/dd-java-agent.jar > /binaries/SYSTEM_TESTS_LIBRARY_VERSION
-
-echo "Installed $(cat /binaries/SYSTEM_TESTS_LIBRARY_VERSION) java library"
-
-touch /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
-
-SYSTEM_TESTS_LIBRARY_VERSION=$(cat /binaries/SYSTEM_TESTS_LIBRARY_VERSION)
-
-if [[ $SYSTEM_TESTS_LIBRARY_VERSION == 0.96* ]]; then
-  echo "1.2.5" > /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
-else
-  bsdtar -O - -xf /dd-tracer/dd-java-agent.jar appsec/default_config.json | \
-    grep rules_version | head -1 | awk -F'"' '{print $4;}' \
-    > /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+if [ $(ls /LIBRARY_VERSION | wc -l) = 0 ]; then
+  java -jar /dd-java-agent.jar > /LIBRARY_VERSION
+  touch /LIBDDWAF_VERSION
+  LIBRARY_VERSION=$(cat /LIBRARY_VERSION)
+  if [[ $LIBRARY_VERSION == 0.96* ]]; then
+    echo "1.2.5" > /APPSEC_EVENT_RULES_VERSION
+  else
+    bsdtar -O - -xf /dd-java-agent.jar appsec/default_config.json | \
+      grep rules_version | head -1 | awk -F'"' '{print $4;}' \
+      > /APPSEC_EVENT_RULES_VERSION
+  fi
 fi
 
-echo "dd-trace version: $(cat /binaries/SYSTEM_TESTS_LIBRARY_VERSION)"
-echo "libddwaf version: $(cat /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION)"
-echo "rules version: $(cat /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION)"
+echo "dd-trace version: $(cat /LIBRARY_VERSION)"
+echo "libddwaf version: $(cat /LIBDDWAF_VERSION)"
+echo "rules version: $(cat /APPSEC_EVENT_RULES_VERSION)"
 

--- a/utils/build/docker/java/jersey-grizzly2.Dockerfile
+++ b/utils/build/docker/java/jersey-grizzly2.Dockerfile
@@ -1,3 +1,19 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
+
+FROM eclipse-temurin:8 as apm_library_local
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM maven:3.6-jdk-11 as build
 
 RUN apt-get update && \
@@ -11,17 +27,14 @@ RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 COPY ./utils/build/docker/java/jersey-grizzly2/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app
-COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 COPY --from=build /app/target/jersey-grizzly2-1.0-SNAPSHOT.jar /app/app.jar
-COPY --from=build /dd-tracer/dd-java-agent.jar .
+COPY --from=apm_library /dd-java-agent.jar .
 
 COPY ./utils/build/docker/java/app.sh /app/app.sh
 RUN chmod +x /app/app.sh

--- a/utils/build/docker/java/ratpack.Dockerfile
+++ b/utils/build/docker/java/ratpack.Dockerfile
@@ -1,3 +1,19 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
+
+FROM eclipse-temurin:8 as apm_library_local
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM maven:3.6-jdk-11 as build
 
 RUN apt-get update && \
@@ -11,17 +27,14 @@ RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 COPY ./utils/build/docker/java/ratpack/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app
-COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 COPY --from=build /app/target/ratpack-1.0-SNAPSHOT.jar /app/app.jar
-COPY --from=build /dd-tracer/dd-java-agent.jar .
+COPY --from=apm_library /dd-java-agent.jar .
 
 COPY ./utils/build/docker/java/app.sh /app/app.sh
 RUN chmod +x /app/app.sh

--- a/utils/build/docker/java/resteasy-netty3.Dockerfile
+++ b/utils/build/docker/java/resteasy-netty3.Dockerfile
@@ -1,3 +1,19 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
+
+FROM eclipse-temurin:8 as apm_library_local
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM maven:3.6-jdk-11 as build
 
 RUN apt-get update && \
@@ -11,17 +27,14 @@ RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 COPY ./utils/build/docker/java/resteasy-netty3/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app
-COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 COPY --from=build /app/target/resteasy-netty3-1.0-SNAPSHOT.jar /app/app.jar
-COPY --from=build /dd-tracer/dd-java-agent.jar .
+COPY --from=apm_library /dd-java-agent.jar .
 
 COPY ./utils/build/docker/java/app.sh /app/app.sh
 RUN chmod +x /app/app.sh

--- a/utils/build/docker/java/spring-boot-3-native.Dockerfile
+++ b/utils/build/docker/java/spring-boot-3-native.Dockerfile
@@ -1,4 +1,20 @@
 
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
+
+FROM eclipse-temurin:8 as apm_library_local
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM eclipse-temurin:8 as agent
 
 # Install required bsdtar
@@ -24,7 +40,7 @@ RUN /opt/apache-maven-3.8.6/bin/mvn -P native -B dependency:go-offline
 COPY ./utils/build/docker/java/spring-boot-3-native/src ./src
 
 # Copy tracer
-COPY --from=agent /dd-tracer/dd-java-agent.jar .
+COPY --from=apm_library /dd-java-agent.jar .
 
 # Build native application
 RUN /opt/apache-maven-3.8.6/bin/mvn -Pnative native:compile
@@ -32,9 +48,9 @@ RUN /opt/apache-maven-3.8.6/bin/mvn -Pnative native:compile
 FROM ubuntu
 
 WORKDIR /app
-COPY --from=agent /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=agent /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=agent /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 COPY --from=build /app/target/myproject .
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'

--- a/utils/build/docker/java/spring-boot-jetty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-jetty.Dockerfile
@@ -1,3 +1,19 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
+
+FROM eclipse-temurin:8 as apm_library_local
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM maven:3.6-jdk-8 as build
 
 RUN apt-get update && \
@@ -11,17 +27,14 @@ RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Pjetty -B dependency:go-offli
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven -Pjetty package
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app
-COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 COPY --from=build /app/target/myproject-0.0.1-SNAPSHOT.jar /app/app.jar
-COPY --from=build /dd-tracer/dd-java-agent.jar .
+COPY --from=apm_library /dd-java-agent.jar .
 
 COPY ./utils/build/docker/java/app.sh /app/app.sh
 RUN chmod +x /app/app.sh

--- a/utils/build/docker/java/spring-boot-openliberty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-openliberty.Dockerfile
@@ -1,3 +1,19 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
+
+FROM eclipse-temurin:8 as apm_library_local
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM maven:3.8-jdk-8 as build
 
 RUN apt-get update && \
@@ -16,11 +32,11 @@ RUN /binaries/install_ddtrace.sh
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app
-COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 COPY --from=build /app/target/myproject-0.0.1-SNAPSHOT.jar /app/app.jar
-COPY --from=build /dd-tracer/dd-java-agent.jar .
+COPY --from=apm_library /dd-java-agent.jar .
 
 ENV DD_JMXFETCH_ENABLED=false
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'

--- a/utils/build/docker/java/spring-boot-openliberty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-openliberty.Dockerfile
@@ -26,9 +26,6 @@ COPY ./utils/build/docker/java/spring-boot/pom.xml .
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Popenliberty package
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app

--- a/utils/build/docker/java/spring-boot-undertow.Dockerfile
+++ b/utils/build/docker/java/spring-boot-undertow.Dockerfile
@@ -1,3 +1,19 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
+
+FROM eclipse-temurin:8 as apm_library_local
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM maven:3.6-jdk-8 as build
 
 RUN apt-get update && \
@@ -17,11 +33,11 @@ RUN /binaries/install_ddtrace.sh
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app
-COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 COPY --from=build /app/target/myproject-0.0.1-SNAPSHOT.jar /app/app.jar
-COPY --from=build /dd-tracer/dd-java-agent.jar .
+COPY --from=apm_library /dd-java-agent.jar .
 
 COPY ./utils/build/docker/java/app.sh /app/app.sh
 RUN chmod +x /app/app.sh

--- a/utils/build/docker/java/spring-boot-undertow.Dockerfile
+++ b/utils/build/docker/java/spring-boot-undertow.Dockerfile
@@ -27,9 +27,6 @@ RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Pundertow -B dependency:go-of
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven -Pundertow package
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app

--- a/utils/build/docker/java/spring-boot-wildfly.Dockerfile
+++ b/utils/build/docker/java/spring-boot-wildfly.Dockerfile
@@ -27,9 +27,6 @@ RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Pwildfly -B dependency:go-off
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven -Pwildfly package
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app

--- a/utils/build/docker/java/spring-boot-wildfly.Dockerfile
+++ b/utils/build/docker/java/spring-boot-wildfly.Dockerfile
@@ -1,3 +1,19 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
+
+FROM eclipse-temurin:8 as apm_library_local
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM maven:3.6-jdk-11 as build
 
 RUN apt-get update && \
@@ -17,11 +33,11 @@ RUN /binaries/install_ddtrace.sh
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app
-COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 COPY --from=build /app/target/myproject-0.0.1-SNAPSHOT-bootable.jar /app/app.jar
-COPY --from=build /dd-tracer/dd-java-agent.jar .
+COPY --from=apm_library /dd-java-agent.jar .
 
 COPY ./utils/build/docker/java/app.sh /app/app.sh
 RUN chmod +x /app/app.sh

--- a/utils/build/docker/java/spring-boot.Dockerfile
+++ b/utils/build/docker/java/spring-boot.Dockerfile
@@ -1,3 +1,19 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
+
+FROM eclipse-temurin:8 as apm_library_local
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM maven:3.8-jdk-8 as build
 
 RUN apt-get update && \
@@ -11,17 +27,14 @@ RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app
-COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 COPY --from=build /app/target/myproject-0.0.1-SNAPSHOT.jar /app/app.jar
-COPY --from=build /dd-tracer/dd-java-agent.jar .
+COPY --from=apm_library /dd-java-agent.jar .
 
 COPY ./utils/build/docker/java/app.sh /app/app.sh
 RUN chmod +x /app/app.sh

--- a/utils/build/docker/java/uds-spring-boot.Dockerfile
+++ b/utils/build/docker/java/uds-spring-boot.Dockerfile
@@ -1,3 +1,19 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
+
+FROM eclipse-temurin:8 as apm_library_local
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM maven:3.8-jdk-8 as build
 
 RUN apt-get update && \
@@ -17,11 +33,11 @@ RUN /binaries/install_ddtrace.sh
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app
-COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 COPY --from=build /app/target/myproject-0.0.1-SNAPSHOT.jar .
-COPY --from=build /dd-tracer/dd-java-agent.jar .
+COPY --from=apm_library /dd-java-agent.jar .
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 

--- a/utils/build/docker/java/uds-spring-boot.Dockerfile
+++ b/utils/build/docker/java/uds-spring-boot.Dockerfile
@@ -27,9 +27,6 @@ RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app

--- a/utils/build/docker/java/vertx3.Dockerfile
+++ b/utils/build/docker/java/vertx3.Dockerfile
@@ -27,9 +27,6 @@ RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 COPY ./utils/build/docker/java/vertx3/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
-RUN /binaries/install_ddtrace.sh
-
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app

--- a/utils/build/docker/java/vertx3.Dockerfile
+++ b/utils/build/docker/java/vertx3.Dockerfile
@@ -1,3 +1,19 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
+
+FROM eclipse-temurin:8 as apm_library_local
+
+# Install required bsdtar
+RUN apt-get update && \
+	apt-get install -y libarchive-tools
+
+# Install tracer
+COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /
+RUN /install_ddtrace.sh
+
+FROM $APM_LIBRARY_IMAGE as apm_library
+
 FROM maven:3.6-jdk-11 as build
 
 RUN apt-get update && \
@@ -17,11 +33,11 @@ RUN /binaries/install_ddtrace.sh
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app
-COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
-COPY --from=build /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 COPY --from=build /app/target/vertx3-1.0-SNAPSHOT.jar /app/app.jar
-COPY --from=build /dd-tracer/dd-java-agent.jar .
+COPY --from=apm_library /dd-java-agent.jar .
 
 COPY ./utils/build/docker/java/app.sh /app/app.sh
 RUN chmod +x /app/app.sh

--- a/utils/build/docker/php/apache-mod-7.0-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.0-zts.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=7.0
 ARG VARIANT=release-zts
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-7.0.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.0.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=7.0
 ARG VARIANT=release
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-7.1-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.1-zts.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=7.1
 ARG VARIANT=release-zts
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-7.1.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.1.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=7.1
 ARG VARIANT=release
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-7.2-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.2-zts.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=7.2
 ARG VARIANT=release-zts
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-7.2.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.2.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=7.2
 ARG VARIANT=release
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-7.3-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.3-zts.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=7.3
 ARG VARIANT=release-zts
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-7.3.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.3.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=7.3
 ARG VARIANT=release
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-7.4-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.4-zts.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=7.4
 ARG VARIANT=release-zts
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-7.4.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.4.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=7.4
 ARG VARIANT=release
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-8.0-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.0-zts.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=8.0
 ARG VARIANT=release-zts
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-8.0.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.0.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=8.0
 ARG VARIANT=release
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-8.1-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.1-zts.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=8.1
 ARG VARIANT=release-zts
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-8.1.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.1.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=8.1
 ARG VARIANT=release
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-8.2-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.2-zts.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=8.2
 ARG VARIANT=release-zts
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/apache-mod-8.2.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.2.Dockerfile
@@ -1,5 +1,18 @@
 ARG PHP_VERSION=8.2
 ARG VARIANT=release
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 
@@ -10,7 +23,13 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 EXPOSE 7777/tcp
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 RUN chmod +x /tmp/php/apache-mod/build.sh

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -44,17 +44,21 @@ else
     --php-bin all
 fi
 
-php -d error_reporting='' -d extension=ddtrace.so -d extension=ddappsec.so -r 'echo phpversion("ddtrace");' > \
-  ./SYSTEM_TESTS_LIBRARY_VERSION
-
-php -d error_reporting='' -d extension=ddtrace.so -d extension=ddappsec.so -r 'echo phpversion("ddappsec");' > \
-  ./SYSTEM_TESTS_PHP_APPSEC_VERSION
-
-touch SYSTEM_TESTS_LIBDDWAF_VERSION
-
-appsec_version=$(<./SYSTEM_TESTS_PHP_APPSEC_VERSION)
-rule_file="/opt/datadog/dd-library/appsec-${appsec_version}/etc/dd-appsec/recommended.json"
-jq -r '.metadata.rules_version // "1.2.5"' "${rule_file}" > SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+#Get library,appsec and app sec rules version (Check if we need to generate before)
+FILE_LIBRARY_VERSION=/binaries/SYSTEM_TESTS_LIBRARY_VERSION
+if  [ -s "$FILE_LIBRARY_VERSION" ]; then
+    echo "$FILE_LIBRARY_VERSION exists."
+    appsec_version=$(<./SYSTEM_TESTS_PHP_APPSEC_VERSION)
+else
+  php -d error_reporting='' -d extension=ddtrace.so -d extension=ddappsec.so -r 'echo phpversion("ddtrace");' > \
+    ./SYSTEM_TESTS_LIBRARY_VERSION
+  php -d error_reporting='' -d extension=ddtrace.so -d extension=ddappsec.so -r 'echo phpversion("ddappsec");' > \
+    ./SYSTEM_TESTS_PHP_APPSEC_VERSION
+  touch SYSTEM_TESTS_LIBDDWAF_VERSION
+  appsec_version=$(<./SYSTEM_TESTS_PHP_APPSEC_VERSION)
+  rule_file="/opt/datadog/dd-library/appsec-${appsec_version}/etc/dd-appsec/recommended.json"
+  jq -r '.metadata.rules_version // "1.2.5"' "${rule_file}" > SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+fi
 
 find /opt -name ddappsec-helper -exec ln -s '{}' /usr/local/bin/ \;
 mkdir -p /etc/dd-appsec

--- a/utils/build/docker/php/php-fpm-7.0.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.0.Dockerfile
@@ -1,8 +1,27 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM ubuntu:20.04
 ARG PHP_VERSION=7.0
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 ENV DD_TRACE_ENABLED=1

--- a/utils/build/docker/php/php-fpm-7.1.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.1.Dockerfile
@@ -1,8 +1,27 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM ubuntu:20.04
 ARG PHP_VERSION=7.1
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 ENV DD_TRACE_ENABLED=1

--- a/utils/build/docker/php/php-fpm-7.2.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.2.Dockerfile
@@ -1,8 +1,27 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM ubuntu:20.04
 ARG PHP_VERSION=7.2
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 ENV DD_TRACE_ENABLED=1

--- a/utils/build/docker/php/php-fpm-7.3.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.3.Dockerfile
@@ -1,8 +1,27 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM ubuntu:20.04
 ARG PHP_VERSION=7.3
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 ENV DD_TRACE_ENABLED=1

--- a/utils/build/docker/php/php-fpm-7.4.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.4.Dockerfile
@@ -1,8 +1,27 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM ubuntu:20.04
 ARG PHP_VERSION=7.4
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 ENV DD_TRACE_ENABLED=1

--- a/utils/build/docker/php/php-fpm-8.0.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.0.Dockerfile
@@ -1,8 +1,27 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM ubuntu:20.04
 ARG PHP_VERSION=8.0
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 ENV DD_TRACE_ENABLED=1

--- a/utils/build/docker/php/php-fpm-8.1.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.1.Dockerfile
@@ -1,8 +1,27 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM ubuntu:20.04
 ARG PHP_VERSION=8.1
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 ENV DD_TRACE_ENABLED=1

--- a/utils/build/docker/php/php-fpm-8.2.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.2.Dockerfile
@@ -1,8 +1,27 @@
+ARG APM_LIBRARY_IMAGE=apm_library_latest
+
+FROM ghcr.io/datadog/dd-trace-php/dd-trace-php:latest as apm_library_latest
+
+FROM bash as apm_library_local
+
+ADD binaries* /
+RUN touch /LIBRARY_VERSION
+RUN touch /LIBDDWAF_VERSION
+RUN touch /APPSEC_EVENT_RULES_VERSION
+RUN touch /PHP_APPSEC_VERSION
+
+FROM $APM_LIBRARY_IMAGE as apm_library
 
 FROM ubuntu:20.04
 ARG PHP_VERSION=8.2
 
-ADD binaries* /binaries/
+COPY --from=apm_library /LIBRARY_VERSION /binaries/SYSTEM_TESTS_LIBRARY_VERSION
+COPY --from=apm_library /LIBDDWAF_VERSION /binaries/SYSTEM_TESTS_LIBDDWAF_VERSION
+COPY --from=apm_library /APPSEC_EVENT_RULES_VERSION /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+COPY --from=apm_library /PHP_APPSEC_VERSION /binaries/SYSTEM_TESTS_PHP_APPSEC_VERSION
+
+COPY --from=apm_library /*.tar.gz /binaries/
+
 ADD utils/build/docker/php /tmp/php
 
 ENV DD_TRACE_ENABLED=1

--- a/utils/scripts/docker-deep-save.py
+++ b/utils/scripts/docker-deep-save.py
@@ -1,4 +1,3 @@
-
 from pathlib import Path
 from argparse import ArgumentParser, Namespace
 import tarfile
@@ -12,16 +11,10 @@ from subprocess import check_output, CalledProcessError
 def parse_args() -> Namespace:
     parser = ArgumentParser(Path(__file__).name)
     parser.add_argument(
-        "image",
-        type=str,
-        help="The docker image to save",
+        "image", type=str, help="The docker image to save",
     )
     parser.add_argument(
-        "-o",
-        "--output",
-        type=Path,
-        help="Where to save the extracted image",
-        default=Path("./deep-save-image"),
+        "-o", "--output", type=Path, help="Where to save the extracted image", default=Path("./deep-save-image"),
     )
 
     return parser.parse_args()
@@ -34,13 +27,7 @@ def create_output_directory(output: Path) -> None:
 def save_image(image: str, output: _TemporaryFileWrapper) -> None:
     print("saving docker image...")
     check_output(
-        [
-            "docker",
-            "save",
-            image,
-            "--output",
-            output.name,
-        ]
+        ["docker", "save", image, "--output", output.name,]
     )
 
 
@@ -58,6 +45,7 @@ def exctract_layer(layer_path: Path, output: Path) -> None:
         where = layer_path.parent
         print(f" - extracting {output}")
         t.extractall(str(output))
+
 
 def get_layers_from_manifest(output: Path) -> list[Path]:
     print("parsing manifest.json...")

--- a/utils/scripts/docker-deep-save.py
+++ b/utils/scripts/docker-deep-save.py
@@ -1,0 +1,105 @@
+
+from pathlib import Path
+from argparse import ArgumentParser, Namespace
+import tarfile
+import os
+import tempfile
+from tempfile import _TemporaryFileWrapper
+import json
+from subprocess import check_output, CalledProcessError
+
+
+def parse_args() -> Namespace:
+    parser = ArgumentParser(Path(__file__).name)
+    parser.add_argument(
+        "image",
+        type=str,
+        help="The docker image to save",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Where to save the extracted image",
+        default=Path("./deep-save-image"),
+    )
+
+    return parser.parse_args()
+
+
+def create_output_directory(output: Path) -> None:
+    output.mkdir(parents=True, exist_ok=True)
+
+
+def save_image(image: str, output: _TemporaryFileWrapper) -> None:
+    print("saving docker image...")
+    check_output(
+        [
+            "docker",
+            "save",
+            image,
+            "--output",
+            output.name,
+        ]
+    )
+
+
+def extract_tar(tar_file: _TemporaryFileWrapper, output: Path) -> None:
+    print("extracting tar file...")
+    with tarfile.open(tar_file.name) as t:
+        t.extractall(str(output))
+
+    tar_file.close()
+    os.unlink(tar_file.name)
+
+
+def exctract_layer(layer_path: Path, output: Path) -> None:
+    with tarfile.open(str(layer_path)) as t:
+        where = layer_path.parent
+        print(f" - extracting {output}")
+        t.extractall(str(output))
+
+def get_layers_from_manifest(output: Path) -> list[Path]:
+    print("parsing manifest.json...")
+    manifest_path = output / "manifest.json"
+    if not manifest_path.exists():
+        raise ValueError("no manifest file in the output directory")
+
+    with manifest_path.open("r") as f:
+        manifest_data = json.load(f)
+
+    layers: list[Path] = []
+
+    for image in manifest_data:
+        for layer in image.get("Layers"):
+            layer_path = output.joinpath(*layer.split(os.sep))
+            layers.append(layer_path)
+
+    return layers
+
+
+def main() -> None:
+    args = parse_args()
+
+    image: str = args.image
+    output: Path = args.output
+    temp_image_file = tempfile.NamedTemporaryFile(delete=False)
+
+    try:
+        save_image(image, temp_image_file)
+    except CalledProcessError:
+        exit(1)
+
+    create_output_directory(output)
+    extract_tar(temp_image_file, output)
+
+    print("extracting layers...")
+    for layer in get_layers_from_manifest(output):
+        exctract_layer(layer, output)
+        os.remove(str(layer))
+
+    print("done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -161,11 +161,8 @@ cd binaries/
 
 if [ "$TARGET" = "java" ]; then
     assert_version_is_dev
-    rm -rf *.jar
-    OWNER=DataDog
-    REPO=dd-trace-java
-
-    get_circleci_artifact "gh/DataDog/dd-trace-java" "nightly" "build_lib" "libs/dd-java-agent-.*(-SNAPSHOT)?.jar"
+    docker pull ghcr.io/datadog/dd-trace-java/dd-trace-java:latest_snapshot
+    python ../utils/scripts/docker-deep-save.py -o . ghcr.io/datadog/dd-trace-java/dd-trace-java:latest_snapshot
 
 elif [ "$TARGET" = "dotnet" ]; then
     rm -rf *.tar.gz

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -168,15 +168,11 @@ elif [ "$TARGET" = "dotnet" ]; then
     rm -rf *.tar.gz
 
     if [ $VERSION = 'dev' ]; then
-       SHA=$(curl --silent https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/sha.txt)
-       ARCHIVE=$(curl --silent https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/index.txt | grep '^datadog-dotnet-apm-[0-9.]*\.tar\.gz$')
-       URL=https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/$SHA/$ARCHIVE
-
-        echo "Load $URL"
-        curl -L --silent $URL --output $ARCHIVE
+        docker pull ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot
+        python ../utils/scripts/docker-deep-save.py -o . ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot
     elif [ $VERSION = 'prod' ]; then
-       DDTRACE_VERSION=$(curl -H "Authorization: token $GH_TOKEN" "https://api.github.com/repos/DataDog/dd-trace-dotnet/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-       curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DDTRACE_VERSION}/datadog-dotnet-apm-${DDTRACE_VERSION}.tar.gz --output datadog-dotnet-apm-${DDTRACE_VERSION}.tar.gz
+        docker pull ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest
+        python ../utils/scripts/docker-deep-save.py -o . ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest
     else
         echo "Don't know how to load version $VERSION for $TARGET"
     fi
@@ -194,9 +190,11 @@ elif [ "$TARGET" = "ruby" ]; then
 elif [ "$TARGET" = "php" ]; then
     rm -rf *.tar.gz
     if [ $VERSION = 'dev' ]; then
-        get_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "datadog-php-tracer-.*-nightly.x86_64.tar.gz"
+        docker pull ghcr.io/datadog/dd-trace-php/dd-trace-php:latest_snapshot
+        python ../utils/scripts/docker-deep-save.py -o . ghcr.io/datadog/dd-trace-php/dd-trace-php:latest_snapshot
     elif [ $VERSION = 'prod' ]; then
-        get_github_release_asset "DataDog/dd-trace-php" "datadog-php-tracer-.*.x86_64.tar.gz"
+        docker pull ghcr.io/datadog/dd-trace-php/dd-trace-php:latest
+        python ../utils/scripts/docker-deep-save.py -o . ghcr.io/datadog/dd-trace-php/dd-trace-php:latest
     else
         echo "Don't know how to load version $VERSION for $TARGET"
     fi
@@ -243,17 +241,6 @@ elif [ "$TARGET" = "waf_rule_set" ]; then
         -H "Accept: application/vnd.github.v3.raw" \
         --output "waf_rule_set.json" \
         https://api.github.com/repos/DataDog/appsec-event-rules/contents/build/recommended.json
-
-elif [ "$TARGET" = "php_appsec" ]; then
-
-    if [ $VERSION = 'dev' ]; then
-        get_github_action_artifact "DataDog/dd-appsec-php" "package.yml" "master" "dd-appsec-php-*-amd64.tar.gz"
-    elif [ $VERSION = 'prod' ]; then
-        get_github_release_asset "DataDog/dd-appsec-php" "dd-appsec-php-.*-amd64.tar.gz"
-    else
-        echo "Don't know how to load version $VERSION for $TARGET"
-    fi
-
 else
     echo "Unknown target: $1"
     exit 1


### PR DESCRIPTION
From dd-trace-java, dd-trace-php and dd-trace-php we are pushing docker images that contains the APM library. 
This PR adapt the script/pipeline to get APM library in this way. 
Docker base images, created from scrach, only contain the APM Library and files describing versions of the software (LIBRARY_VERSION, LIBDDWAF_VERSION, APPSEC_EVENT_RULES_VERSION)

[see doc:](https://docs.google.com/document/d/1HbMGgZFRnIYjfnXGJGyk0LCwWs2op12R0BE58wma448/edit#)
[see how we create docker images:]( https://github.com/DataDog/dd-trace-java/blob/eb7a0c6331262b861afded85211ea5aae534c2c5/.gitlab-ci.yml#L214)

## Description

*Please include a short summary of the change*

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
