### PR TITLE
Use docker base images to get snapshots(dev) of APM client libraries  (java, php, dotnet)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,23 +209,8 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Load library binary
-      if: ${{ matrix.version == 'dev' && (matrix.variant.library != 'php' && matrix.variant.library != 'java')}}
+      if: ${{ matrix.version == 'dev' }}
       run: ./utils/scripts/load-binary.sh ${{ matrix.variant.library }}
-    - name: Load PHP prod library binary
-      if: ${{ matrix.variant.library == 'php' }}
-      run: ./utils/scripts/load-binary.sh php prod
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Load library PHP appsec binary
-      if: ${{ matrix.variant.library == 'php' }}
-      run: ./utils/scripts/load-binary.sh php_appsec ${{matrix.version}}
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Load library dotNet prod binary
-      if: ${{ matrix.variant.library == 'dotNet' && matrix.version == 'prod' }}
-      run: ./utils/scripts/load-binary.sh ${{ matrix.variant.library }} prod
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Load agent binary
       if: ${{ matrix.version == 'dev' }}
       run: ./utils/scripts/load-binary.sh agent

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -161,25 +161,15 @@ cd binaries/
 
 if [ "$TARGET" = "java" ]; then
     assert_version_is_dev
-    rm -rf *.jar
-    OWNER=DataDog
-    REPO=dd-trace-java
-
-    get_circleci_artifact "gh/DataDog/dd-trace-java" "nightly" "build_lib" "libs/dd-java-agent-.*(-SNAPSHOT)?.jar"
+    ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-java/dd-trace-java:latest_snapshot .
 
 elif [ "$TARGET" = "dotnet" ]; then
     rm -rf *.tar.gz
 
     if [ $VERSION = 'dev' ]; then
-       SHA=$(curl --silent https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/sha.txt)
-       ARCHIVE=$(curl --silent https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/index.txt | grep '^datadog-dotnet-apm-[0-9.]*\.tar\.gz$')
-       URL=https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/$SHA/$ARCHIVE
-
-        echo "Load $URL"
-        curl -L --silent $URL --output $ARCHIVE
+        ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot .
     elif [ $VERSION = 'prod' ]; then
-       DDTRACE_VERSION=$(curl -H "Authorization: token $GH_TOKEN" "https://api.github.com/repos/DataDog/dd-trace-dotnet/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-       curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DDTRACE_VERSION}/datadog-dotnet-apm-${DDTRACE_VERSION}.tar.gz --output datadog-dotnet-apm-${DDTRACE_VERSION}.tar.gz
+        ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest .
     else
         echo "Don't know how to load version $VERSION for $TARGET"
     fi
@@ -197,9 +187,9 @@ elif [ "$TARGET" = "ruby" ]; then
 elif [ "$TARGET" = "php" ]; then
     rm -rf *.tar.gz
     if [ $VERSION = 'dev' ]; then
-        get_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "datadog-php-tracer-.*-nightly.x86_64.tar.gz"
+        ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-php/dd-trace-php:latest_snapshot .
     elif [ $VERSION = 'prod' ]; then
-        get_github_release_asset "DataDog/dd-trace-php" "datadog-php-tracer-.*.x86_64.tar.gz"
+        ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-php/dd-trace-php:latest .
     else
         echo "Don't know how to load version $VERSION for $TARGET"
     fi
@@ -246,16 +236,6 @@ elif [ "$TARGET" = "waf_rule_set" ]; then
         -H "Accept: application/vnd.github.v3.raw" \
         --output "waf_rule_set.json" \
         https://api.github.com/repos/DataDog/appsec-event-rules/contents/build/recommended.json
-
-elif [ "$TARGET" = "php_appsec" ]; then
-
-    if [ $VERSION = 'dev' ]; then
-        get_github_action_artifact "DataDog/dd-appsec-php" "package.yml" "master" "dd-appsec-php-*-amd64.tar.gz"
-    elif [ $VERSION = 'prod' ]; then
-        get_github_release_asset "DataDog/dd-appsec-php" "dd-appsec-php-.*-amd64.tar.gz"
-    else
-        echo "Don't know how to load version $VERSION for $TARGET"
-    fi
 
 else
     echo "Unknown target: $1"


### PR DESCRIPTION

## Description

From dd-trace-java, dd-trace-php and dd-trace-php we are pushing docker images that contains the APM library. 
This PR adapt the script/pipeline to get snapshot of APM library in this way. 
Docker base images, created from scrach, only contain the APM Library and files describing versions of the software (LIBRARY_VERSION, LIBDDWAF_VERSION, APPSEC_EVENT_RULES_VERSION)

*Please include a short summary of the change*

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
