### PR TITLE
Avoid bsdtar in Java builds

### DIFF
--- a/utils/build/docker/java/install_ddtrace.sh
+++ b/utils/build/docker/java/install_ddtrace.sh
@@ -29,8 +29,8 @@ SYSTEM_TESTS_LIBRARY_VERSION=$(cat /binaries/SYSTEM_TESTS_LIBRARY_VERSION)
 if [[ $SYSTEM_TESTS_LIBRARY_VERSION == 0.96* ]]; then
   echo "1.2.5" > /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 else
-  bsdtar -O - -xf /dd-tracer/dd-java-agent.jar appsec/default_config.json | \
-    grep rules_version | head -1 | awk -F'"' '{print $4;}' \
+  jar xf /dd-tracer/dd-java-agent.jar appsec/default_config.json
+  grep rules_version appsec/default_config.json | head -n 1 | awk -F'"' '{print $4;}' \
     > /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 fi
 

--- a/utils/build/docker/java/jersey-grizzly2.Dockerfile
+++ b/utils/build/docker/java/jersey-grizzly2.Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3.6-jdk-11 as build
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 WORKDIR /app
 
 COPY ./utils/build/docker/java/jersey-grizzly2/pom.xml .

--- a/utils/build/docker/java/ratpack.Dockerfile
+++ b/utils/build/docker/java/ratpack.Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3.6-jdk-11 as build
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 WORKDIR /app
 
 COPY ./utils/build/docker/java/ratpack/pom.xml .

--- a/utils/build/docker/java/resteasy-netty3.Dockerfile
+++ b/utils/build/docker/java/resteasy-netty3.Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3.6-jdk-11 as build
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 WORKDIR /app
 
 COPY ./utils/build/docker/java/resteasy-netty3/pom.xml .

--- a/utils/build/docker/java/spring-boot-3-native.Dockerfile
+++ b/utils/build/docker/java/spring-boot-3-native.Dockerfile
@@ -1,13 +1,9 @@
 
 FROM eclipse-temurin:8 as agent
 
-# Install required bsdtar
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
 # Install tracer
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
-
 
 FROM ghcr.io/graalvm/graalvm-ce:ol7-java17-22.3.0 as build
 

--- a/utils/build/docker/java/spring-boot-jetty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-jetty.Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3.6-jdk-8 as build
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .

--- a/utils/build/docker/java/spring-boot-native.Dockerfile
+++ b/utils/build/docker/java/spring-boot-native.Dockerfile
@@ -1,10 +1,6 @@
 
 FROM eclipse-temurin:8 as agent
 
-# Install required bsdtar
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 # Install tracer
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
@@ -24,6 +20,7 @@ WORKDIR /app
 # Copy application sources
 COPY ./utils/build/docker/java/spring-boot/pom.xml .
 RUN mkdir /maven && /opt/apache-maven-3.8.6/bin/mvn -Dmaven.repo.local=/maven -B dependency:resolve-plugins dependency:go-offline -P spring-native
+
 #Force to download all pom from deps
 RUN /opt/apache-maven-3.8.6/bin/mvn -Dmaven.repo.local=/maven verify --fail-never
 

--- a/utils/build/docker/java/spring-boot-openliberty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-openliberty.Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3.8-jdk-8 as build
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .

--- a/utils/build/docker/java/spring-boot-undertow.Dockerfile
+++ b/utils/build/docker/java/spring-boot-undertow.Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3.6-jdk-8 as build
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .

--- a/utils/build/docker/java/spring-boot-wildfly.Dockerfile
+++ b/utils/build/docker/java/spring-boot-wildfly.Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3.6-jdk-11 as build
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .

--- a/utils/build/docker/java/spring-boot.Dockerfile
+++ b/utils/build/docker/java/spring-boot.Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3.8-jdk-8 as build
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .

--- a/utils/build/docker/java/uds-spring-boot.Dockerfile
+++ b/utils/build/docker/java/uds-spring-boot.Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3.8-jdk-8 as build
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .

--- a/utils/build/docker/java/vertx3.Dockerfile
+++ b/utils/build/docker/java/vertx3.Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3.6-jdk-11 as build
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 WORKDIR /app
 
 COPY ./utils/build/docker/java/vertx3/pom.xml .


### PR DESCRIPTION


## Description

Use jar instead of bsdtar to extract files from jars. This saves extra calls to apt-get update and install.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
