### PR TITLE
Ruby:Enable test for all supported telemetry features

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -414,7 +414,6 @@ class Test_Telemetry:
 @released(python="1.7.0", dotnet="2.12.0", java="0.108.1", nodejs="3.2.0", ruby="1.4.0")
 @bug(context.uds_mode and context.library < "nodejs@3.7.0")
 @missing_feature(library="cpp")
-@missing_feature(library="ruby")
 @missing_feature(library="php")
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
@@ -437,7 +436,7 @@ class Test_ProductsDisabled:
                 ), "Product information is present telemetry data on app-started event when all products are disabled"
 
 
-@released(cpp="?", dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="?")
+@released(cpp="?", dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="1.4.0")
 @scenarios.telemetry_dependency_loaded_test_for_dependency_collection_disabled
 class Test_DpendencyEnable:
     """ Tests on DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED flag """
@@ -454,6 +453,7 @@ class Test_DpendencyEnable:
 
 
 @released(cpp="?", dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="?")
+@missing_feature(library="ruby", reason="DD_FORCE_BATCHING_ENABLE not yet supported")
 @scenarios.telemetry_message_batch_event_order
 class Test_ForceBatchingEnabled:
     """ Tests on DD_FORCE_BATCHING_ENABLE environment variable """
@@ -477,7 +477,7 @@ class Test_ForceBatchingEnabled:
         ), "Events in message-batch are not in chronological order of event triggered"
 
 
-@released(cpp="?", dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="?")
+@released(cpp="?", dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="1.4.0")
 @scenarios.telemetry_log_generation_disabled
 class Test_Log_Generation:
     """Assert that logs are not reported when logs generation is disabled in telemetry"""
@@ -494,7 +494,7 @@ class Test_Log_Generation:
                 raise Exception(" Logs event is sent when log generation is disabled")
 
 
-@released(cpp="?", dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="?")
+@released(cpp="?", dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="1.4.0")
 @scenarios.telemetry_metric_generation_disabled
 class Test_Metric_Generation:
     """Assert that metrics are not reported when metric generation is disabled in telemetry"""


### PR DESCRIPTION
## Description

The only feature not supported is `DD_FORCE_BATCHING_ENABLE`, thus its test is disabled.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
