### PR TITLE
fix(parametric-test): update test_otel_get_span_context

### DIFF
--- a/parametric/test_otel_span_methods.py
+++ b/parametric/test_otel_span_methods.py
@@ -233,7 +233,6 @@ def test_otel_get_span_context(test_agent, test_library):
             with test_library.otel_start_span(name="operation", parent_id=parent.span_id, new_root=False) as span:
                 span.end_span()
                 context = span.span_context()
-                assert len(context.get("trace_id")) == 32 and int(context.get("trace_id"), 16)
                 assert context.get("trace_id") == parent.span_context().get("trace_id")
                 assert context.get("span_id") == "{:016x}".format(span.span_id)
                 assert context.get("trace_flags") == "01"

--- a/parametric/test_otel_span_methods.py
+++ b/parametric/test_otel_span_methods.py
@@ -233,6 +233,7 @@ def test_otel_get_span_context(test_agent, test_library):
             with test_library.otel_start_span(name="operation", parent_id=parent.span_id, new_root=False) as span:
                 span.end_span()
                 context = span.span_context()
-                assert context.get("trace_id") == f"{parent.span_id:0x}".ljust(32, "0")
-                assert context.get("span_id") == f"{span.span_id:0x}".rjust(16, "0")
+                assert len(context.get("trace_id")) == 32 and int(context.get("trace_id"), 16)
+                assert context.get("trace_id") == parent.span_context().get("trace_id")
+                assert context.get("span_id") == "{:016x}".format(span.span_id)
                 assert context.get("trace_flags") == "01"


### PR DESCRIPTION
## Description

`test_otel_get_span_context` is currently broken. It asserts that `child_span.trace_id == parent_span.span_id`. Instead we should check if `child_span.trace_id == parent_span.trace_id`. 

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
