### PR TITLE
chore(python): remove misleading trailing slash from vulnerability path

### DIFF
--- a/tests/appsec/iast/sink/test_iast_sql_injection.py
+++ b/tests/appsec/iast/sink/test_iast_sql_injection.py
@@ -33,7 +33,7 @@ class TestIastSqlInjection:
     EXPECTATIONS = {
         "java": {"LOCATION": "com.datadoghq.system_tests.springboot.iast.utils.SqlExamples"},
         "nodejs": {"LOCATION": "iast.js"},
-        "python": {"flask-poc": {"LOCATION": "/app.py"}, "django-poc": {"LOCATION": "/app/urls.py"},},
+        "python": {"flask-poc": {"LOCATION": "app.py"}, "django-poc": {"LOCATION": "app/urls.py"},},
     }
 
     def __expected_location(self):

--- a/tests/appsec/iast/sink/test_iast_weak_hash.py
+++ b/tests/appsec/iast/sink/test_iast_weak_hash.py
@@ -41,9 +41,9 @@ class TestIastWeakHash:
             if context.library.version >= "1.12.0" or is_dev_version:
                 # new value: relative path (but yes, the leading slash is misleading)
                 if context.weblog_variant == "uwsgi-poc":
-                    return "/./iast.py"
+                    return "./iast.py"
                 else:
-                    return "/iast.py"
+                    return "iast.py"
             else:
                 # old value: absolute path
                 if context.weblog_variant == "uwsgi-poc":


### PR DESCRIPTION
## Description
Removes misleading trailing slash from IAST vulnerability reports

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
