### PR TITLE
[Telemetry] Unskip tests that should no longer be flaky

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -54,7 +54,6 @@ class Test_Telemetry:
         self.validate_library_telemetry_data(validator)
         self.validate_agent_telemetry_data(validator)
 
-    @flaky(library="java", reason="Agent sometimes respond 502")
     def test_status_ok(self):
         """Test that telemetry requests are successful"""
 
@@ -170,13 +169,6 @@ class Test_Telemetry:
 
         self.validate_library_telemetry_data(validator)
 
-    @bug(
-        library="dotnet",
-        reason="""
-            Bug in the telemetry agent proxy, that can't reopen connections if they're closed by timeout
-            https://github.com/DataDog/datadog-agent/pull/11880
-        """,
-    )
     @bug(
         library="java",
         weblog_variant="spring-boot-openliberty",


### PR DESCRIPTION
## Description

The tests in this PR were skipped due to a bug in the agent that was fixed in version 7.41.
It should be safe to remove the skips.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
