### PR TITLE
add suspicious requests tests

### DIFF
--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, coverage, interfaces, irrelevant, missing_feature, released, scenarios, weblog
+from utils import context, coverage, interfaces, irrelevant, missing_feature, released, rfc, scenarios, weblog
 
 
 @released(cpp="?", dotnet="2.27.0", php_appsec="0.7.0", python="?", nodejs="?", golang="?", ruby="1.0.0")
@@ -300,8 +300,8 @@ class Test_Blocking_response_headers:
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
 @coverage.not_implement
 @released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
-class Test_Blocking:
-    """Test if blocking on multiple addresses is supported"""
+class Test_Suspicious_Request_Blocking:
+    """Test if blocking on multiple addresses with multiple rules is supported"""
 
     def test_blocking(self):
         """Test if requests that should be blocked are blocked"""

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import weblog, context, coverage, interfaces, released, scenarios, missing_feature, irrelevant
+from utils import context, coverage, interfaces, irrelevant, missing_feature, released, scenarios, weblog
 
 
 @released(cpp="?", dotnet="2.27.0", php_appsec="0.7.0", python="?", nodejs="?", golang="?", ruby="1.0.0")
@@ -132,3 +132,185 @@ class Test_BlockingAddresses:
     @missing_feature(reason="No endpoint defined yet")
     def test_response_cookies(self):
         assert False
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
+@coverage.not_implement
+@released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
+class Test_Blocking_request_method:
+    """Test if blocking is supported on server.request.method address"""
+
+    def test_blocking(self):
+        """Test if requests that should be blocked are blocked"""
+        # TODO
+
+    def test_non_blocking(self):
+        """Test if requests that should not be blocked are not blocked"""
+        # TODO
+
+    def test_blocking_before(self):
+        """Test that blocked requests are blocked before being processed"""
+        # TODO
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
+@coverage.not_implement
+@released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
+class Test_Blocking_request_uri:
+    """Test if blocking is supported on server.request.uri.raw address"""
+
+    def test_blocking(self):
+        """Test if requests that should be blocked are blocked"""
+        # TODO
+
+    def test_non_blocking(self):
+        """Test if requests that should not be blocked are not blocked"""
+        # TODO
+
+    def test_blocking_before(self):
+        """Test that blocked requests are blocked before being processed"""
+        # TODO
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
+@coverage.not_implement
+@released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
+class Test_Blocking_request_path_params:
+    """Test if blocking is supported on server.request.path_params address"""
+
+    def test_blocking(self):
+        """Test if requests that should be blocked are blocked"""
+        # TODO
+
+    def test_non_blocking(self):
+        """Test if requests that should not be blocked are not blocked"""
+        # TODO
+
+    def test_blocking_before(self):
+        """Test that blocked requests are blocked before being processed"""
+        # TODO
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
+@coverage.not_implement
+@released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
+class Test_Blocking_request_query:
+    """Test if blocking is supported on server.request.query address"""
+
+    def test_blocking(self):
+        """Test if requests that should be blocked are blocked"""
+        # TODO
+
+    def test_non_blocking(self):
+        """Test if requests that should not be blocked are not blocked"""
+        # TODO
+
+    def test_blocking_before(self):
+        """Test that blocked requests are blocked before being processed"""
+        # TODO
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
+@coverage.not_implement
+@released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
+class Test_Blocking_request_headers:
+    """Test if blocking is supported on server.request.headers.no_cookies address"""
+
+    def test_blocking(self):
+        """Test if requests that should be blocked are blocked"""
+        # TODO
+
+    def test_non_blocking(self):
+        """Test if requests that should not be blocked are not blocked"""
+        # TODO
+
+    def test_blocking_before(self):
+        """Test that blocked requests are blocked before being processed"""
+        # TODO
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
+@coverage.not_implement
+@released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
+class Test_Blocking_request_cookies:
+    """Test if blocking is supported on server.request.cookies address"""
+
+    def test_blocking(self):
+        """Test if requests that should be blocked are blocked"""
+        # TODO
+
+    def test_non_blocking(self):
+        """Test if requests that should not be blocked are not blocked"""
+        # TODO
+
+    def test_blocking_before(self):
+        """Test that blocked requests are blocked before being processed"""
+        # TODO
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
+@coverage.not_implement
+@released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
+class Test_Blocking_request_body:
+    """Test if blocking is supported on server.request.headers.body address"""
+
+    def test_blocking(self):
+        """Test if requests that should be blocked are blocked"""
+        # TODO
+
+    def test_non_blocking(self):
+        """Test if requests that should not be blocked are not blocked"""
+        # TODO
+
+    def test_blocking_before(self):
+        """Test that blocked requests are blocked before being processed"""
+        # TODO
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
+@coverage.not_implement
+@released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
+class Test_Blocking_response_status:
+    """Test if blocking is supported on server.response.status address"""
+
+    def test_blocking(self):
+        """Test if requests that should be blocked are blocked"""
+        # TODO
+
+    def test_non_blocking(self):
+        """Test if requests that should not be blocked are not blocked"""
+        # TODO
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
+@coverage.not_implement
+@released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
+class Test_Blocking_response_headers:
+    """Test if blocking is supported on server.response.headers.no_cookies address"""
+
+    def test_blocking(self):
+        """Test if requests that should be blocked are blocked"""
+        # TODO
+
+    def test_non_blocking(self):
+        """Test if requests that should not be blocked are not blocked"""
+        # TODO
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
+@coverage.not_implement
+@released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
+class Test_Blocking:
+    """Test if blocking on multiple addresses is supported"""
+
+    def test_blocking(self):
+        """Test if requests that should be blocked are blocked"""
+        # TODO
+
+    def test_non_blocking(self):
+        """Test if requests that should not be blocked are not blocked"""
+        # TODO
+
+    def test_blocking_before(self):
+        """Test that blocked requests are blocked before being processed"""
+        # TODO

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -135,7 +135,7 @@ class Test_BlockingAddresses:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
-@coverage.not_implement
+@coverage.not_implemented
 @released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
 class Test_Blocking_request_method:
     """Test if blocking is supported on server.request.method address"""
@@ -154,7 +154,7 @@ class Test_Blocking_request_method:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
-@coverage.not_implement
+@coverage.not_implemented
 @released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
 class Test_Blocking_request_uri:
     """Test if blocking is supported on server.request.uri.raw address"""
@@ -173,7 +173,7 @@ class Test_Blocking_request_uri:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
-@coverage.not_implement
+@coverage.not_implemented
 @released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
 class Test_Blocking_request_path_params:
     """Test if blocking is supported on server.request.path_params address"""
@@ -192,7 +192,7 @@ class Test_Blocking_request_path_params:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
-@coverage.not_implement
+@coverage.not_implemented
 @released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
 class Test_Blocking_request_query:
     """Test if blocking is supported on server.request.query address"""
@@ -211,7 +211,7 @@ class Test_Blocking_request_query:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
-@coverage.not_implement
+@coverage.not_implemented
 @released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
 class Test_Blocking_request_headers:
     """Test if blocking is supported on server.request.headers.no_cookies address"""
@@ -230,7 +230,7 @@ class Test_Blocking_request_headers:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
-@coverage.not_implement
+@coverage.not_implemented
 @released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
 class Test_Blocking_request_cookies:
     """Test if blocking is supported on server.request.cookies address"""
@@ -249,7 +249,7 @@ class Test_Blocking_request_cookies:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
-@coverage.not_implement
+@coverage.not_implemented
 @released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
 class Test_Blocking_request_body:
     """Test if blocking is supported on server.request.headers.body address"""
@@ -268,7 +268,7 @@ class Test_Blocking_request_body:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
-@coverage.not_implement
+@coverage.not_implemented
 @released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
 class Test_Blocking_response_status:
     """Test if blocking is supported on server.response.status address"""
@@ -283,7 +283,7 @@ class Test_Blocking_response_status:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
-@coverage.not_implement
+@coverage.not_implemented
 @released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
 class Test_Blocking_response_headers:
     """Test if blocking is supported on server.response.headers.no_cookies address"""
@@ -298,7 +298,7 @@ class Test_Blocking_response_headers:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
-@coverage.not_implement
+@coverage.not_implemented
 @released(cpp="?", dotnet="?", php_appsec="?", python="?", nodejs="?", golang="?", ruby="?")
 class Test_Suspicious_Request_Blocking:
     """Test if blocking on multiple addresses with multiple rules is supported"""


### PR DESCRIPTION
## Description

Add 10 test classes for suspicious request blocking for automatic detection of features in the appsec library dashboard.

- 7 test classes for each request address
- 2 test classes for each response address
-  1 test class for combinations and corner cases

All tests are currently empty

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
