### PR TITLE
parametric: use python3.9 binary if available

### DIFF
--- a/parametric/run.sh
+++ b/parametric/run.sh
@@ -1,8 +1,14 @@
-#!/bin/bash
-
-ARGS=$*
+#!/usr/bin/env bash
+set -eu
 
 # FIXME: have to ignore the root conftest as it does a bunch of initialization/teardown
 #        not required for the integration/shared tests.
-PARENT_DIR=$(dirname $PWD)
-python -m pytest -c $PWD/conftest.py $ARGS
+PARENT_DIR=$(dirname "$PWD")
+
+if python3.9 --version &> /dev/null; then
+  readonly PYTHON=python3.9
+else
+  readonly PYTHON=python
+fi
+
+exec "${PYTHON}" -m pytest -c "$PWD/conftest.py" "$@"


### PR DESCRIPTION
## Description

This should simplify setting the right python version in various scenarios, like having a system-wide Python 3.9 in Ubuntu, or having pyenv with multiple Python versions.

Related: https://github.com/DataDog/dd-trace-java/pull/5068

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
