### PR TITLE
appsec custom rules: use string for exclusion filter id

### DIFF
--- a/tests/appsec/custom_rules.json
+++ b/tests/appsec/custom_rules.json
@@ -5,7 +5,7 @@
   },
   "exclusions": [
     {
-      "id": 1,
+      "id": "1",
       "rules_target": [
         {
           "tags": {
@@ -35,7 +35,7 @@
       ]
     },
     {
-      "id": 2,
+      "id": "2",
       "rules_target": [
         {
           "rule_id": "easy-to-match-rule-bbbb",


### PR DESCRIPTION
## Description

This changes the ID fields of the exclusion filters in the custom rules to be strings instead of integers.
This follows the examples specified in the following [RFC](https://docs.google.com/document/d/1FIVKbvLxpZN6wr3CKqmElfbYvMiDlII1YlyiUb0Wwrk/edit#heading=h.o5gstqo08gu5).

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
