### PR TITLE
Revert "parametric: use python3.9 binary if available (#1073)"

### DIFF
--- a/parametric/run.sh
+++ b/parametric/run.sh
@@ -1,14 +1,9 @@
 #!/usr/bin/env bash
 set -eu
 
+ARGS=$*
+
 # FIXME: have to ignore the root conftest as it does a bunch of initialization/teardown
 #        not required for the integration/shared tests.
-PARENT_DIR=$(dirname "$PWD")
-
-if python3.9 --version &> /dev/null; then
-  readonly PYTHON=python3.9
-else
-  readonly PYTHON=python
-fi
-
-exec "${PYTHON}" -m pytest -c "$PWD/conftest.py" "$@"
+PARENT_DIR=$(dirname $PWD)
+exec python -m pytest -c $PWD/conftest.py $ARGS


### PR DESCRIPTION


## Description

Revert "parametric: use python3.9 binary if available (#1073)"

This reverts commit 85e6f1a7b66f866550fa7bc27c8b231256db34f1.

It caused build issues in at least 1 local development environment. We have a workaround at dd-trace-java CI anyway.

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
