### PR TITLE
Improve nix environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ rfc3339-validator==0.1.4
 matplotlib
 
 docker==6.0.0
+paramiko==3.1.0

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ fi
 # clean any pycache folder
 find utils tests -type d -name '__pycache__'  -prune -exec rm -rf {} +
 
-if [[ -z "$IN_NIX_SHELL" ]]; then
+if [[ -z "${IN_NIX_SHELL:-}" ]]; then
    source venv/bin/activate
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -19,5 +19,8 @@ fi
 # clean any pycache folder
 find utils tests -type d -name '__pycache__'  -prune -exec rm -rf {} +
 
-source venv/bin/activate
+if [[ -z "$IN_NIX_SHELL" ]]; then
+   source venv/bin/activate
+fi
+
 pytest $RUNNER_ARGS

--- a/shell.nix
+++ b/shell.nix
@@ -27,13 +27,13 @@ in llvm.stdenv.mkDerivation {
     # linters
     pinned.shellcheck
 
-    # have docker-compose at hand
-    pinned.docker-compose
-
     # for scripts
     pinned.bash
     pinned.fswatch
     pinned.rsync
+
+    # for c++ dependencies such as grpcio-tools
+    llvm.libcxx.dev
   ];
 
   shellHook = ''
@@ -46,6 +46,6 @@ in llvm.stdenv.mkDerivation {
     export PATH="$PIP_PREFIX/bin:$PATH"
 
     # for grpcio-tools, which is building from source but doesn't pick up the proper include
-    export CFLAGS="-I${llvm.libcxx}/include/c++/v1"
+    export CFLAGS="-I${llvm.libcxx.dev}/include/c++/v1"
   '';
 }

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -10,7 +10,7 @@ import requests
 from utils._context.library_version import LibraryVersion, Version
 from utils.tools import logger
 
-_client = docker.DockerClient()
+_client = docker.DockerClient.from_env()
 
 _NETWORK_NAME = "system-tests_default"
 

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -128,7 +128,7 @@ build() {
         echo "-----------------------"
         echo Build $IMAGE_NAME
         if [[ $IMAGE_NAME == runner ]]; then
-            if [[ -z "$IN_NIX_SHELL" ]]; then
+            if [[ -z "${IN_NIX_SHELL:-}" ]]; then
               if [ ! -d "venv/" ]
               then
                   echo "Build virtual env"

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -128,14 +128,16 @@ build() {
         echo "-----------------------"
         echo Build $IMAGE_NAME
         if [[ $IMAGE_NAME == runner ]]; then
-            if [ ! -d "venv/" ] 
-            then
-                echo "Build virtual env"
-                python3.9 -m venv venv
-            fi
+            if [[ -z "$IN_NIX_SHELL" ]]; then
+              if [ ! -d "venv/" ]
+              then
+                  echo "Build virtual env"
+                  python3.9 -m venv venv
+              fi
 
-            source venv/bin/activate
-            python -m pip install --upgrade pip
+              source venv/bin/activate
+              python -m pip install --upgrade pip
+            fi
             pip install -r requirements.txt
 
         elif [[ $IMAGE_NAME == agent ]]; then


### PR DESCRIPTION
## Description

- Improve nix environment
- Fix docker client connection when using `DOCKER_HOST` env var
- Allow docker connection over `DOCKER_HOST=ssh://`

## Additional notes

This DOES NOT fix reaching to the various docker services exposed ports, which need do be accessed using the external IP of where Docker is hosted (in my case a VM). This IP is the one present in `DOCKER_HOST`.

There are theoretically two cases:

- `runner` (outside VM) reaching to `agent` (inside VM) and `weblog` (inside VM), notably for health check
  
  This needs the VM IP. `DOCKER_HOST` contains it in my case.
 
- weblog (inside VM) reaching to runner's proxy (IIUC outside VM)

  This needs the host IP on the VM network. it should be the TCP client IP that a listening process running in the VM sees as a peer.

<details>

<summary>List of references to `localhost`</summary>

```
utils/interfaces/_backend.py
126:        # We use `localhost` as host since we run a proxy that forwards the requests to the right
129:        host = f"http://localhost:{BACKEND_LOCAL_PORT}"
221:        # We use `localhost` as host since we run a proxy that forwards the requests to the right
224:        host = f"http://localhost:{BACKEND_LOCAL_PORT}"

utils/interfaces/schemas/README.md
5:Then go to <http://localhost:7070>

utils/_context/containers.py
215:            healthcheck=_HealthCheck(f"http://localhost:{self.agent_port}/info", 60, start_period=1),
256:            healthcheck=_HealthCheck("http://localhost:7777", 60),

utils/_context/_scenarios.py
502:            requests.get("http://localhost:7777", timeout=10)

utils/build/docker/php/php-fpm/php-fpm.conf
25:            SetHandler "proxy:unix:/run/php/phpPHP_VERSION-fpm.sock|fcgi://localhost"

utils/build/docker/dotnet/Properties/launchSettings.json
6:      "applicationUrl": "http://localhost:61558/",
24:      "applicationUrl": "https://localhost:5001;http://localhost:5000"

utils/build/docker/dotnet/Endpoints/MakeDistantCallEndpoint.cs
43:                    // http://localhost:7777/make_distant_call?url=http%3A%2F%2Fweblog%3A7777
44:                    // https://localhost:44381/make_distant_call?url=https%3A%2F%2Flocalhost%3A44381
47:                    var example = "http://localhost:7777/make_distant_call?url=http%3A%2F%2Fweblog%3A7777";

utils/build/docker/python/django/django.app.urls.py
143:    # curl localhost:7777/make_distant_call?url=http%3A%2F%2Fweblog%3A7777 | jq

utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
154:                env.put(Context.PROVIDER_URL, "ldap://localhost:8389/dc=example");

utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
309:    // E.g. curl "http://localhost:8080/sqli?q=%271%27%20union%20select%20%2A%20from%20display_names"

utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/grpc/SynchronousWebLogGrpc.java
13:        this.channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build();

utils/build/docker/python/django-poc.Dockerfile
17:RUN sed -i "s/ALLOWED_HOSTS\s=\s\[\]/ALLOWED_HOSTS = \[\"0.0.0.0\",\"weblog\"\,\"localhost\"\]/g" django_app/settings.py

utils/build/docker/python/pylons/app/test.ini
10:smtp_server = localhost
11:error_email_from = paste@localhost

utils/build/docker/python/pylons/app/development.ini
10:smtp_server = localhost
11:error_email_from = paste@localhost

utils/build/docker/java/iast-common/src/main/java/com/datadoghq/system_tests/iast/infra/LdapServer.java
30:            final String url = String.format("ldap://localhost:%s/dc=example", server.getListenPort());

utils/_weblog.py
46:            self.domain = "localhost"

utils/proxy/core.py
109:        if flow.request.host in ("proxy", "localhost"):

utils/build/docker/python/pylons/app/app/config/deployment.ini_tmpl
9:smtp_server = localhost
10:error_email_from = paste@localhost
```

</details>

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.

Once your PR is reviewed, you can merge it ! :heart:
