### PR TITLE
Expand WAF telemetry tests

### DIFF
--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -1,4 +1,4 @@
-from utils import interfaces, released, rfc, weblog, scenarios, context, bug, irrelevant, missing_feature
+from utils import interfaces, released, rfc, weblog, scenarios, context, bug, missing_feature
 from utils.tools import logger
 
 TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
@@ -81,7 +81,7 @@ class Test_TelemetryMetrics:
 
     setup_metric_waf_updates = _setup
 
-    @irrelevant(reason="Test not implemented")
+    @missing_feature(reason="Test not implemented")
     @bug(context.library < "java@1.13.0", reason="Missing tags")
     def test_metric_waf_updates(self):
         """Test waf.updates metric."""

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -43,7 +43,11 @@ class Test_TelemetryMetrics:
         }
         valid_tag_prefixes = mandatory_tag_prefixes
         series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
-        assert len(series) == 1
+        # TODO(Python). Gunicorn creates 2 process (main gunicorn process + X child workers). It generates two init
+        if context.library == "python":
+            assert len(series) == 2
+        else:
+            assert len(series) == 1
         s = series[0]
         assert s["_computed_namespace"] == "appsec"
         assert s["metric"] == expected_metric_name
@@ -95,7 +99,8 @@ class Test_TelemetryMetrics:
             "event_rules_version",
             "rule_triggered",
             "request_blocked",
-            "request_excluded," "waf_timeout",
+            "request_excluded",
+            "waf_timeout",
         }
         mandatory_tag_prefixes = {
             "waf_version",

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -1,5 +1,5 @@
 from utils import interfaces, released, rfc, weblog, scenarios, context, bug, irrelevant, missing_feature
-
+from utils.tools import logger
 
 TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
 TELEMETRY_REQUEST_TYPE_DISTRIBUTIONS = "distributions"
@@ -129,7 +129,7 @@ class Test_TelemetryMetrics:
             "request_blocked",
         }
         series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
-        print(series)
+        logger.debug(series)
         # Depending on the timing, there might be more than 3 series. For example, if a warmup
         # request goes first, we might have two series for rule_triggered:false,blocked_request:false
         assert len(series) >= 3

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -26,6 +26,8 @@ def _setup(self):
 
 @rfc("https://docs.google.com/document/d/1qBDsS_ZKeov226CPx2DneolxaARd66hUJJ5Lh9wjhlE")
 @released(python="?", cpp="?", golang="?", java="1.12.0", dotnet="?", nodejs="?", php="?", ruby="?")
+@missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
+@missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @scenarios.appsec_waf_telemetry
 class Test_TelemetryMetrics:
     """Test instrumentation telemetry metrics, type of metrics generate-metrics"""
@@ -40,8 +42,6 @@ class Test_TelemetryMetrics:
     setup_headers_are_correct = _setup
 
     @bug(context.library < "java@1.13.0", reason="Missing two headers")
-    @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
-    @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_headers_are_correct(self):
         """Tests that all telemetry requests have correct headers."""
         for data in interfaces.library.get_telemetry_data():
@@ -50,8 +50,6 @@ class Test_TelemetryMetrics:
 
     setup_metric_waf_init = _setup
 
-    @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
-    @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_metric_waf_init(self):
         """Test waf.init metric."""
         expected_metric_name = "waf.init"
@@ -85,8 +83,6 @@ class Test_TelemetryMetrics:
 
     @irrelevant(reason="Test not implemented")
     @bug(context.library < "java@1.13.0", reason="Missing tags")
-    @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
-    @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_metric_waf_updates(self):
         """Test waf.updates metric."""
         expected_metric_name = "waf.updates"
@@ -115,8 +111,6 @@ class Test_TelemetryMetrics:
     setup_metric_waf_requests = _setup
 
     @bug(context.library < "java@1.13.0", reason="Missing tags")
-    @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
-    @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_metric_waf_requests(self):
         """Test waf.requests metric."""
         expected_metric_name = "waf.requests"

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -28,12 +28,16 @@ class Test_TelemetryMetrics:
             assert data["response"]["status_code"] == 202
 
     @bug(context.library < "java@1.13.0", reason="Missing two headers")
+    @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
+    @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_headers_are_correct(self):
         """Tests that all telemetry requests have correct headers."""
         for data in interfaces.library.get_telemetry_data():
             request_type = data["request"]["content"].get("request_type")
             _validate_headers(data["request"]["headers"], request_type)
 
+    @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
+    @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_metric_waf_init(self):
         """Test waf.init metric."""
         expected_metric_name = "waf.init"
@@ -65,6 +69,8 @@ class Test_TelemetryMetrics:
 
     @irrelevant(reason="Test not implemented")
     @bug(context.library < "java@1.13.0", reason="Missing tags")
+    @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
+    @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_metric_waf_updates(self):
         """Test waf.updates metric."""
         expected_metric_name = "waf.updates"
@@ -91,6 +97,8 @@ class Test_TelemetryMetrics:
         assert p[1] == 1
 
     @bug(context.library < "java@1.13.0", reason="Missing tags")
+    @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
+    @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_metric_waf_requests(self):
         """Test waf.requests metric."""
         expected_metric_name = "waf.requests"

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -1,28 +1,193 @@
-from utils import interfaces, released, rfc, weblog, scenarios, context
+from utils import interfaces, released, rfc, weblog, scenarios, context, bug, irrelevant, missing_feature
 
 
 TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
 TELEMETRY_REQUEST_TYPE_DISTRIBUTIONS = "distributions"
 
 
+@rfc("https://docs.google.com/document/d/1qBDsS_ZKeov226CPx2DneolxaARd66hUJJ5Lh9wjhlE")
+@released(python="?", cpp="?", golang="?", java="1.12.0", dotnet="?", nodejs="?", php="?", ruby="?")
+@scenarios.appsec_waf_telemetry
+class Test_TelemetryMetrics:
+    """Test instrumentation telemetry metrics, type of metrics generate-metrics"""
+
+    # This setup is shared for all tests in the suite.
+    def setup_all_telemetry_requests_are_successful(self):
+        self.r_plain = weblog.get("/", headers={"x-forwarded-for": "80.80.80.80"})
+        self.r_triggered = weblog.get("/", headers={"x-forwarded-for": "80.80.80.80", "user-agent": "Arachni/v1"})
+        self.r_blocked = weblog.get(
+            "/",
+            headers={"x-forwarded-for": "80.80.80.80", "user-agent": "dd-test-scanner-log-block"},
+            # XXX: hack to prevent rid inhibiting the dd-test-scanner-log-block rule
+            rid_in_user_agent=False,
+        )
+
+    def test_all_telemetry_requests_are_successful(self):
+        """Tests that all telemetry requests succeed."""
+        for data in interfaces.library.get_telemetry_data():
+            assert data["response"]["status_code"] == 202
+
+    @bug(context.library < "java@1.13.0", reason="Missing two headers")
+    def test_headers_are_correct(self):
+        """Tests that all telemetry requests have correct headers."""
+        for data in interfaces.library.get_telemetry_data():
+            request_type = data["request"]["content"].get("request_type")
+            _validate_headers(data["request"]["headers"], request_type)
+
+    def test_metric_waf_init(self):
+        """Test waf.init metric."""
+        expected_metric_name = "waf.init"
+        mandatory_tag_prefixes = {
+            "waf_version",
+            "event_rules_version",
+        }
+        valid_tag_prefixes = mandatory_tag_prefixes
+        series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
+        assert len(series) == 1
+        s = series[0]
+        assert s["_computed_namespace"] == "appsec"
+        assert s["metric"] == expected_metric_name
+        assert s["common"] is True
+        assert s["type"] == "count"
+
+        full_tags = set(s["tags"])
+        self._assert_valid_tags(
+            full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes
+        )
+
+        assert len(s["points"]) == 1
+        p = s["points"][0]
+        assert p[1] == 1
+
+    @irrelevant(reason="Test not implemented")
+    @bug(context.library < "java@1.13.0", reason="Missing tags")
+    def test_metric_waf_updates(self):
+        """Test waf.updates metric."""
+        expected_metric_name = "waf.updates"
+        mandatory_tag_prefixes = {
+            "waf_version",
+            "event_rules_version",
+        }
+        valid_tag_prefixes = mandatory_tag_prefixes
+        series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
+        assert len(series) == 1
+        s = series[0]
+        assert s["_computed_namespace"] == "appsec"
+        assert s["metric"] == expected_metric_name
+        assert s["common"] is True
+        assert s["type"] == "count"
+
+        full_tags = set(s["tags"])
+        self._assert_valid_tags(
+            full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes
+        )
+
+        assert len(s["points"]) == 1
+        p = s["points"][0]
+        assert p[1] == 1
+
+    @bug(context.library < "java@1.13.0", reason="Missing tags")
+    def test_metric_waf_requests(self):
+        """Test waf.requests metric."""
+        expected_metric_name = "waf.requests"
+        valid_tag_prefixes = {
+            "waf_version",
+            "event_rules_version",
+            "rule_triggered",
+            "request_blocked",
+            "request_excluded," "waf_timeout",
+        }
+        mandatory_tag_prefixes = {
+            "waf_version",
+            "event_rules_version",
+            "rule_triggered",
+            "request_blocked",
+        }
+        series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
+        print(series)
+        # Depending on the timing, there might be more than 3 series. For example, if a warmup
+        # request goes first, we might have two series for rule_triggered:false,blocked_request:false
+        assert len(series) >= 3
+
+        matched_not_blocked = 0
+        matched_triggered = 0
+        matched_blocked = 0
+        for s in series:
+            assert s["_computed_namespace"] == "appsec"
+            assert s["metric"] == expected_metric_name
+            assert s["common"] is True
+            assert s["type"] == "count"
+            assert len(s["points"]) == 1
+            p = s["points"][0]
+
+            full_tags = set(s["tags"])
+            self._assert_valid_tags(
+                full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes
+            )
+
+            if len(full_tags & {"request_blocked:false", "rule_triggered:false"}) == 2:
+                matched_not_blocked += 1
+                assert p[1] >= 1
+            elif len(full_tags & {"request_blocked:false", "rule_triggered:true"}) == 2:
+                matched_triggered += 1
+                assert p[1] == 1
+            elif len(full_tags & {"request_blocked:true", "rule_triggered:true"}) == 2:
+                matched_blocked += 1
+                assert p[1] == 1
+
+        assert matched_not_blocked >= 1
+        assert matched_triggered == 1
+        assert matched_blocked == 1
+
+    def _find_series(self, request_type, namespace, metric):
+        series = []
+        for data in interfaces.library.get_telemetry_data():
+            content = data["request"]["content"]
+            if content.get("request_type") != request_type:
+                continue
+            fallback_namespace = content["payload"].get("namespace")
+            for serie in content["payload"]["series"]:
+                computed_namespace = serie.get("namespace", fallback_namespace)
+                # We inject here the computed namespace considering the fallback
+                serie["_computed_namespace"] = computed_namespace
+                if computed_namespace == namespace and serie["metric"] == metric:
+                    series.append(serie)
+        return series
+
+    def _assert_valid_tags(self, full_tags, valid_prefixes, mandatory_prefixes):
+        full_tags = set(full_tags)
+        tag_prefixes = {t.split(":")[0] for t in full_tags}
+
+        invalid_tags = tag_prefixes - valid_prefixes
+        assert not invalid_tags
+
+        missing_tags = mandatory_prefixes - tag_prefixes
+        assert not missing_tags
+
+
 def _validate_headers(headers, request_type):
-    """https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/how-to-use.md
-    """
+    """https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/how-to-use.md"""
+
+    expected_language = context.library.library
+    if expected_language == "java":
+        expected_language = "jvm"
+
     # empty value means we don't care about the content, but we want to check the key exists
+    # a set means "any of"
     expected_headers = {
-        "Content-Type": "application/json",
+        "Content-Type": {"application/json", "application/json; charset=utf-8"},
         "DD-Telemetry-API-Version": "v1",
         "DD-Telemetry-Request-Type": request_type,
-        "DD-Client-Library-Language": context.library,
+        "DD-Client-Library-Language": expected_language,
         "DD-Client-Library-Version": "",
-        "DD-Agent-Env": "system-tests",
-        "DD-Agent-Hostname": "",
     }
 
     for key, value in headers:
         if expected_headers.get(key) is not None:
             expected_value = expected_headers.pop(key)
-            if expected_value != "":
+            if isinstance(expected_value, set):
+                assert value in expected_value
+            elif expected_value != "":
                 assert value == expected_value
             else:
                 assert value is not None, f"Empty `{key}` header"
@@ -31,169 +196,3 @@ def _validate_headers(headers, request_type):
         raise AssertionError(
             "Headers %s not found in payload headers: %s" % ([header for header in expected_headers], headers)
         )
-
-
-def _validate_generate_metrics_headers(headers):
-    _validate_headers(headers, TELEMETRY_REQUEST_TYPE_GENERATE_METRICS)
-
-
-def _validate_distributions_headers(headers):
-    _validate_headers(headers, TELEMETRY_REQUEST_TYPE_DISTRIBUTIONS)
-
-
-def _validate_tags(payload_tags, expected_tags, metric_name):
-    for tag in payload_tags:
-        tag_key, tag_value = tag.split(":")
-
-        if expected_tags.get(tag_key) is not None:
-            expected_tag = expected_tags.pop(tag_key)
-            if expected_tag != "":
-                assert tag_value.lower() == expected_tag, "Metric %s Tag %s. Expected %s. get %s" % (
-                    metric_name,
-                    tag_key,
-                    expected_tag,
-                    tag_value,
-                )
-            else:
-                assert expected_tag is not None, f"Empty `{expected_tag}` tag"
-
-    if len(expected_tags) > 0:
-        raise AssertionError(f"Metric %s Tags %s not found" % (metric_name, [metric for metric in expected_tags]))
-
-
-def _validate_generate_metrics_metrics(payload):
-    """https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/metric_data.md
-    """
-    # CAVEAT: each library could have different metrics result. If you get an error ping in slack
-    expected_common_tags = [
-        {
-            "waf_version": "1.6.1",
-            "event_rules_version": context.appsec_rules_version,
-            "rule_triggered": "false",
-            "request_blocked": "false",
-        },
-        {
-            "waf_version": "1.6.1",
-            "event_rules_version": context.appsec_rules_version,
-            "rule_triggered": "true",
-            "request_blocked": "false",
-        },
-    ]
-    expected_metrics = {
-        "event_rules.loaded": {"type": "count", "num_points": 1, "point": 134.0, "tags": {}, "found": 0},
-        "waf.requests": {"type": "count", "num_points": 1, "point": 1.0, "tags": {}, "found": 0},
-    }
-    assert payload["namespace"] == "appsec"
-    assert len(payload["series"]) == 4
-
-    for serie in payload["series"]:
-        if expected_metrics.get(serie["metric"]):
-            expected_metric = expected_metrics.get(serie["metric"])
-            assert serie["common"] is True
-            assert serie["type"] == expected_metric["type"], "Metric %s. Expected %s. get %s" % (
-                serie["metric"],
-                expected_metric["type"],
-                serie["type"],
-            )
-            assert len(serie["points"]) == expected_metric["num_points"], "Metric %s. Expected %s point. get %s" % (
-                serie["metric"],
-                expected_metric["num_points"],
-                serie["points"],
-            )
-            assert serie["points"][0][1] >= expected_metric["point"], "Metric %s. Expected %s. get %s" % (
-                serie["metric"],
-                expected_metric["point"],
-                serie["points"],
-            )
-            _validate_tags(
-                serie["tags"],
-                dict(expected_common_tags[expected_metric["found"]], **expected_metric["tags"]),
-                serie["metric"],
-            )
-            expected_metric["found"] += 1
-    if not all(metric["found"] > 0 for _, metric in expected_metrics.items()):
-        raise AssertionError(
-            f"Metrics %s not found in payload"
-            % [(metric, value["found"]) for metric, value in expected_metrics.items()]
-        )
-
-
-def _validate_distributions_metrics(payload):
-    """https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/metric_data.md
-    """
-    # CAVEAT: each library could have different metrics result. If you get an error ping in slack
-    expected_common_tags = [
-        {
-            "waf_version": "",
-            "event_rules_version": context.appsec_rules_version,
-            "rule_triggered": "false",
-            "request_blocked": "false",
-        },
-        {
-            "waf_version": "",
-            "event_rules_version": context.appsec_rules_version,
-            "rule_triggered": "true",
-            "request_blocked": "false",
-        },
-    ]
-    expected_metrics = {
-        "waf.duration": {"num_points": 1, "point": 0.01, "tags": {}, "found": 0},
-        "waf.duration_ext": {"num_points": 1, "point": 0.01, "tags": {}, "found": 0},
-    }
-    assert payload["namespace"] == "appsec"
-    assert len(payload["series"]) == 4
-
-    for serie in payload["series"]:
-        if expected_metrics.get(serie["metric"]):
-            expected_metric = expected_metrics.get(serie["metric"])
-            assert len(serie["points"]) == expected_metric["num_points"], "Metric %s. Expected %s point. get %s" % (
-                serie["metric"],
-                expected_metric["num_points"],
-                serie["points"],
-            )
-            assert serie["points"][0] >= expected_metric["point"], "Metric %s. Expected %s. get %s" % (
-                serie["metric"],
-                expected_metric["point"],
-                serie["points"],
-            )
-            _validate_tags(
-                serie["tags"],
-                dict(expected_common_tags[expected_metric["found"]], **expected_metric["tags"]),
-                serie["metric"],
-            )
-            expected_metric["found"] += 1
-
-    if not all(metric["found"] > 0 for _, metric in expected_metrics.items()):
-        raise AssertionError(
-            f"Metrics %s not found in payload"
-            % [(metric, value["found"]) for metric, value in expected_metrics.items()]
-        )
-
-
-@rfc("https://docs.google.com/document/d/1qBDsS_ZKeov226CPx2DneolxaARd66hUJJ5Lh9wjhlE")
-@released(python="?", cpp="?", golang="?", java="?", dotnet="?", nodejs="?", php="?", ruby="?")
-@scenarios.appsec_waf_telemetry
-class Test_TelemetryMetricsTriggered:
-    """Test instrumentation telemetry metrics, type of metrics generate-metrics"""
-
-    generate_metrics_requests = False
-
-    def setup_telemetry_metrics_request_analyzed(self):
-        """AppSec catches attacks in URL query key"""
-        self.r = weblog.get("/myadmin")
-
-    def test_telemetry_metrics_request_analyzed(self):
-        """Test that telemetry requests are successful"""
-
-        def validator(data):
-            assert data["response"]["status_code"] == 202
-            if data["request"]["content"].get("request_type") == TELEMETRY_REQUEST_TYPE_DISTRIBUTIONS:
-                self.generate_metrics_requests = True
-                _validate_distributions_headers(data["request"]["headers"])
-                _validate_distributions_metrics(data["request"]["content"]["payload"])
-            if data["request"]["content"].get("request_type") == TELEMETRY_REQUEST_TYPE_GENERATE_METRICS:
-                self.generate_metrics_requests = True
-                _validate_generate_metrics_headers(data["request"]["headers"])
-                _validate_generate_metrics_metrics(data["request"]["content"]["payload"])
-
-        interfaces.library.validate_telemetry(validator, success_by_default=True)

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -723,7 +723,11 @@ class scenarios:
 
     appsec_waf_telemetry = EndToEndScenario(
         "APPSEC_WAF_TELEMETRY",
-        weblog_env={"DD_INSTRUMENTATION_TELEMETRY_ENABLED": "true", "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": "2.0"},
+        weblog_env={
+            "DD_INSTRUMENTATION_TELEMETRY_ENABLED": "true",
+            "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": "2.0",
+            "DD_APPSEC_RULES": None,
+        },
     )
     # The spec says that if  DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
     # In this scenario, we use remote config. By the spec, whem remote config is available, rules file embedded in the tracer will never be used (it will be the file defined in DD_APPSEC_RULES, or the data coming from remote config).

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -725,6 +725,7 @@ class scenarios:
         "APPSEC_WAF_TELEMETRY",
         weblog_env={
             "DD_INSTRUMENTATION_TELEMETRY_ENABLED": "true",
+            "DD_TELEMETRY_METRICS_ENABLED": "true",
             "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": "2.0",
             "DD_APPSEC_RULES": None,
         },

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -729,7 +729,6 @@ class scenarios:
             # Python lib has different env var until we enable Telemetry Metrics by default
             "_DD_TELEMETRY_METRICS_ENABLED": "true",
             "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": "2.0",
-            "DD_APPSEC_RULES": None,
         },
     )
     # The spec says that if  DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -726,6 +726,8 @@ class scenarios:
         weblog_env={
             "DD_INSTRUMENTATION_TELEMETRY_ENABLED": "true",
             "DD_TELEMETRY_METRICS_ENABLED": "true",
+            # Python lib has different env var until we enable Telemetry Metrics by default
+            "_DD_TELEMETRY_METRICS_ENABLED": "true",
             "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": "2.0",
             "DD_APPSEC_RULES": None,
         },

--- a/utils/_weblog.py
+++ b/utils/_weblog.py
@@ -77,6 +77,7 @@ class _Weblog:
         domain=None,
         port=7777,
         allow_redirects=True,
+        rid_in_user_agent=True,
         **kwargs,
     ):
         # rid = str(uuid.uuid4()) Do NOT use uuid, it sometimes can looks like credit card number
@@ -90,7 +91,10 @@ class _Weblog:
                 break
 
         user_agent = headers.get(user_agent_key, "system_tests")
-        headers[user_agent_key] = f"{user_agent} rid/{rid}"
+        # Inject a request id (rid) to be able to correlate traces generated from this request.
+        # This behavior can be disabled with rid_in_user_agent=False, which should be rarely needed.
+        if rid_in_user_agent:
+            headers[user_agent_key] = f"{user_agent} rid/{rid}"
 
         if method == "GET" and params:
             url = self._get_url(path, domain, port, params)


### PR DESCRIPTION
<!--

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.


Once your PR is reviewed, you can merge it ! :heart:

-->

## Description

Expand WAF telemetry tests:

* Test payload headers separately.
* Add a test for each metric.

## Motivation

* Previous tests did not test every WAF metric.
* They did not ensure that all metrics were present (e.g. the test would success with 0 metrics).

## Additional notes

<!-- Anything else we should know when reviewing? Context, references, considered alternatives, logs... are welcome!-->
Depends on:
* https://github.com/DataDog/dd-trace-java/pull/5105
* https://github.com/DataDog/dd-trace-java/pull/5111
* https://github.com/DataDog/dd-trace-java/pull/5113

Future work:
* Check that timestamps in metric points are correctly defined in seconds.
