### PR TITLE
Move  apt-get install socat to uds weblog

### DIFF
--- a/utils/build/docker/dotnet/uds.Dockerfile
+++ b/utils/build/docker/dotnet/uds.Dockerfile
@@ -31,6 +31,7 @@ COPY --from=build /app/SYSTEM_TESTS_LIBDDWAF_VERSION /app/SYSTEM_TESTS_LIBDDWAF_
 COPY --from=build /app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION /app/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 
 COPY utils/build/docker/dotnet/app.sh app.sh
+RUN apt-get update && apt-get install socat -y
 COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'

--- a/utils/build/docker/golang/uds-echo.Dockerfile
+++ b/utils/build/docker/golang/uds-echo.Dockerfile
@@ -10,7 +10,7 @@ COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh
 
 WORKDIR /app
 
-RUN apt-get update && apt-get -y install jq
+RUN apt-get update && apt-get -y install jq socat
 RUN /binaries/install_ddtrace.sh
 ENV DD_TRACE_HEADER_TAGS='user-agent'
 

--- a/utils/build/docker/java/uds-spring-boot.Dockerfile
+++ b/utils/build/docker/java/uds-spring-boot.Dockerfile
@@ -26,5 +26,6 @@ ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 
 COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh
 ENV DD_APM_RECEIVER_SOCKET=/var/run/datadog/apm.socket
+RUN apt-get update && apt-get install socat -y
 ENV UDS_WEBLOG=1
 COPY utils/build/docker/java/spring-boot/app.sh app.sh

--- a/utils/build/docker/python/uds-flask.Dockerfile
+++ b/utils/build/docker/python/uds-flask.Dockerfile
@@ -22,6 +22,7 @@ ENV DD_REMOTECONFIG_POLL_SECONDS=1
 ENV FLASK_APP=app.py
 
 ENV DD_APM_RECEIVER_SOCKET=/var/run/datadog/apm.socket
+RUN apt-get update && apt-get install socat -y
 ENV UDS_WEBLOG=1
 COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh
 

--- a/utils/build/docker/set-system-tests-weblog-env.Dockerfile
+++ b/utils/build/docker/set-system-tests-weblog-env.Dockerfile
@@ -1,7 +1,5 @@
 FROM system_tests/weblog
 
-RUN apt-get update
-
 # Datadog setup
 ENV DD_SERVICE=weblog
 ENV DD_VERSION=1.0.0
@@ -56,7 +54,6 @@ COPY tests/appsec/blocking_rule.json /appsec_blocking_rule.json
 # for remote configuration tests
 ENV DD_RC_TUF_ROOT='{"signed":{"_type":"root","spec_version":"1.0","version":1,"expires":"2032-05-29T12:49:41.030418-04:00","keys":{"ed7672c9a24abda78872ee32ee71c7cb1d5235e8db4ecbf1ca28b9c50eb75d9e":{"keytype":"ed25519","scheme":"ed25519","keyid_hash_algorithms":["sha256","sha512"],"keyval":{"public":"7d3102e39abe71044d207550bda239c71380d013ec5a115f79f51622630054e6"}}},"roles":{"root":{"keyids":["ed7672c9a24abda78872ee32ee71c7cb1d5235e8db4ecbf1ca28b9c50eb75d9e"],"threshold":1},"snapshot":{"keyids":["ed7672c9a24abda78872ee32ee71c7cb1d5235e8db4ecbf1ca28b9c50eb75d9e"],"threshold":1},"targets":{"keyids":["ed7672c9a24abda78872ee32ee71c7cb1d5235e8db4ecbf1ca28b9c50eb75d9e"],"threshold":1},"timestsmp":{"keyids":["ed7672c9a24abda78872ee32ee71c7cb1d5235e8db4ecbf1ca28b9c50eb75d9e"],"threshold":1}},"consistent_snapshot":true},"signatures":[{"keyid":"ed7672c9a24abda78872ee32ee71c7cb1d5235e8db4ecbf1ca28b9c50eb75d9e","sig":"d7e24828d1d3104e48911860a13dd6ad3f4f96d45a9ea28c4a0f04dbd3ca6c205ed406523c6c4cacfb7ebba68f7e122e42746d1c1a83ffa89c8bccb6f7af5e06"}]}'
 
-RUN apt-get install socat -y
 COPY ./utils/build/docker/weblog-cmd.sh ./weblog-cmd.sh
 RUN chmod +x app.sh
 RUN chmod +x weblog-cmd.sh


### PR DESCRIPTION
## Description

apt-get update executed on all weblog was breaking some of them. It was needed to install socat, which is usefull only for uds weblog -> moved it to only UDS weblogs
