### PR TITLE
Tracer does not support latest version of flask

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 import time
 import docker
+from docker.errors import APIError
 from docker.models.containers import Container
 import pytest
 
@@ -124,6 +125,11 @@ class TestedContainer:
 
                 if result.exit_code == 0:
                     return
+
+            except APIError as e:
+                logger.exception(f"Healthcheck #{i} failed")
+                pytest.exit(f"Healthcheck {cmd} failed for {self._container.name}: {e.explanation}", 1)
+
             except Exception as e:
                 logger.debug(f"Healthcheck #{i}: {e}")
 

--- a/utils/build/docker/python/flask-poc.Dockerfile
+++ b/utils/build/docker/python/flask-poc.Dockerfile
@@ -4,7 +4,8 @@ FROM python:3.9
 RUN python --version && curl --version
 
 # install hello world app
-RUN pip install flask gunicorn gevent requests pycryptodome psycopg2
+# Tracer does not support flask 2.3.0 or higher, pin the flask version for now
+RUN pip install flask==2.2.4 gunicorn gevent requests pycryptodome psycopg2
 
 COPY utils/build/docker/python/flask /app
 COPY utils/build/docker/python/iast.py /app/iast.py

--- a/utils/build/docker/python/uds-flask.Dockerfile
+++ b/utils/build/docker/python/uds-flask.Dockerfile
@@ -4,7 +4,8 @@ FROM python:3.9
 RUN python --version && curl --version
 
 # install hello world app
-RUN pip install flask gunicorn gevent requests pycryptodome psycopg2
+# Tracer does not support flask 2.3.0 or higher, pin the flask version for now
+RUN pip install flask==2.2.4 gunicorn gevent requests pycryptodome psycopg2
 
 COPY utils/build/docker/python/flask /app
 COPY utils/build/docker/python/iast.py /app/iast.py

--- a/utils/build/docker/python/uwsgi-poc.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.Dockerfile
@@ -4,7 +4,8 @@ FROM python:3.9
 RUN python --version && curl --version
 
 # install hello world app
-RUN pip install flask uwsgi requests pycryptodome psycopg2
+# Tracer does not support flask 2.3.0 or higher, pin the flask version for now
+RUN pip install flask==2.2.4 uwsgi requests pycryptodome psycopg2
 
 COPY utils/build/docker/python/flask /app
 COPY utils/build/docker/python/iast.py /app/iast.py


### PR DESCRIPTION


## Description

The latest version of flask released yesterday removed some decorators. see https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-3-0: 

> The app.before_first_request and bp.before_app_first_request decorators are removed.

It make the tracer break the app : 

```
File "/usr/local/lib/python3.9/site-packages/ddtrace/vendor/wrapt/wrappers.py", line 804, in lookup_attribute
    return getattr(parent, attribute)
AttributeError: type object 'Flask' has no attribute 'before_first_request'
```

Pin the flask version for now, waiting a fix from the tracer.