### PR TITLE
telemetry(python): skip irrelevant app-dependencies-loaded validation

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -235,6 +235,7 @@ class Test_Telemetry:
     @irrelevant(library="nodejs")
     @irrelevant(library="dotnet")
     @irrelevant(library="golang")
+    @irrelevant(library="python")
     def test_app_dependencies_loaded_not_sent(self):
         """app-dependencies-loaded request should not be sent"""
         # Request type app-dependencies-loaded is never sent from certain language tracers


### PR DESCRIPTION
Skips an irrelevant test. Sending application dependencies is supported for the python client.

Currently dependencies are only submitted in the `app-started` event. Moving forward dependencies will not be sent in `app-started`. This data will only be sent in the `app-dependencies-loaded`  event. This change was made to support telemetry v2.

Unblocks: https://github.com/DataDog/dd-trace-py/pull/5740