### PR TITLE
[parametric/dotnet] enable auto-instrumentation and minor code clean-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ dist/
 /utils/build/docker/dotnet/app.csproj.user
 
 # VSCode
+.vscode/
 .ionide/
 
 # Visual Studio

--- a/parametric/apps/dotnet/.dockerignore
+++ b/parametric/apps/dotnet/.dockerignore
@@ -1,0 +1,9 @@
+.idea/
+.vs/
+.vscode/
+bin/
+obj/
+packages/
+out/
+*.user
+*.suo

--- a/parametric/apps/dotnet/.gitignore
+++ b/parametric/apps/dotnet/.gitignore
@@ -1,0 +1,9 @@
+.idea/
+.vs/
+.vscode/
+bin/
+obj/
+packages/
+out/
+*.user
+*.suo

--- a/parametric/apps/dotnet/ApmTestClient.csproj
+++ b/parametric/apps/dotnet/ApmTestClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/parametric/apps/dotnet/ApmTestClient.csproj
+++ b/parametric/apps/dotnet/ApmTestClient.csproj
@@ -12,8 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Datadog.Trace" Version="2.30.0" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.52.0" />
   </ItemGroup>
 
 </Project>

--- a/parametric/apps/dotnet/ApmTestClient.csproj
+++ b/parametric/apps/dotnet/ApmTestClient.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.30.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.30.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.52.0" />
   </ItemGroup>
 

--- a/parametric/apps/dotnet/Program.cs
+++ b/parametric/apps/dotnet/Program.cs
@@ -10,19 +10,18 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddGrpc();
-builder.WebHost.ConfigureKestrel(options =>
-{
-    // If we're using http, then _must_ listen on Http2 only, as the TLS
-    // negotiation is where we would typically negotiate between Http1.1/Http2
-    // Without this, you'll get a PROTOCOL_ERROR
-    // NOTE: For now, we'll set this in code via the options.Listen call since this
-    // seems to work with the Python tests (perhaps because this covers IPv4 and IPv6)
 
-    options.Listen(IPAddress.Any, Int32.Parse(Environment.GetEnvironmentVariable("APM_TEST_CLIENT_SERVER_PORT")!), listenOptions =>
-    {
-        listenOptions.Protocols = HttpProtocols.Http2;
-    });
-});
+// If we're using http, then _must_ listen on Http2 only, as the TLS
+// negotiation is where we would typically negotiate between Http1.1/Http2
+// Without this, you'll get a PROTOCOL_ERROR
+// NOTE: For now, we'll set this in code via the options.Listen call since this
+// seems to work with the Python tests (perhaps because this covers IPv4 and IPv6)
+if (int.TryParse(Environment.GetEnvironmentVariable("APM_TEST_CLIENT_SERVER_PORT"), out var port))
+{
+    builder.WebHost.ConfigureKestrel(
+        options =>
+            options.Listen(IPAddress.Any, port, listenOptions => { listenOptions.Protocols = HttpProtocols.Http2; }));
+}
 
 var app = builder.Build();
 

--- a/parametric/apps/dotnet/Protos/apm_test_client.proto
+++ b/parametric/apps/dotnet/Protos/apm_test_client.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option java_package = "com.datadoghq.client";
+option csharp_namespace = "ApmTestClient";
 
 // Interface of APM clients to be used for shared testing.
 service APMClient {

--- a/parametric/apps/dotnet/Services/ApmTestClientService.cs
+++ b/parametric/apps/dotnet/Services/ApmTestClientService.cs
@@ -68,9 +68,9 @@ namespace ApmTestClient.Services
         public override Task<StartSpanReturn> StartSpan(StartSpanArgs request, ServerCallContext context)
         {
             var creationSettings = new SpanCreationSettings()
-            {
-                FinishOnClose = false,
-            };
+                                   {
+                                       FinishOnClose = false,
+                                   };
 
             if (request.HttpHeaders?.HttpHeaders.Count > 0)
             {
@@ -114,11 +114,12 @@ namespace ApmTestClient.Services
 
             Spans[span.SpanId] = span;
 
-            return Task.FromResult(new StartSpanReturn
-            {
-                SpanId = span.SpanId,
-                TraceId = span.TraceId,
-            });
+            return Task.FromResult(
+                new StartSpanReturn
+                {
+                    SpanId = span.SpanId,
+                    TraceId = span.TraceId,
+                });
         }
 
         public override Task<SpanSetMetaReturn> SpanSetMeta(SpanSetMetaArgs request, ServerCallContext context)
@@ -131,7 +132,7 @@ namespace ApmTestClient.Services
         public override Task<SpanSetMetricReturn> SpanSetMetric(SpanSetMetricArgs request, ServerCallContext context)
         {
             var span = Spans[request.SpanId];
-            SetMetric.Invoke(span, new object[] { request.Key, (double) request.Value});
+            SetMetric.Invoke(span, new object[] { request.Key, (double)request.Value });
             return Task.FromResult(new SpanSetMetricReturn());
         }
 
@@ -252,11 +253,11 @@ namespace ApmTestClient.Services
                 var parameters = method.GetParameters();
                 var genericArgs = method.GetGenericArguments();
 
-                if (parameters.Length == 3
-                    && genericArgs.Length == 1
-                    && parameters[0].ParameterType == typeof(SpanContext)
-                    && parameters[1].ParameterType == genericArgs[0]
-                    && parameters[2].ParameterType.Name == "Action`3")
+                if (parameters.Length == 3 &&
+                    genericArgs.Length == 1 &&
+                    parameters[0].ParameterType == typeof(SpanContext) &&
+                    parameters[1].ParameterType == genericArgs[0] &&
+                    parameters[2].ParameterType.Name == "Action`3")
                 {
                     var carrierType = typeof(RepeatedField<HeaderTuple>);
                     var actionType = typeof(Action<,,>);

--- a/parametric/apps/dotnet/Services/ApmTestClientService.cs
+++ b/parametric/apps/dotnet/Services/ApmTestClientService.cs
@@ -67,7 +67,7 @@ namespace ApmTestClient.Services
 
         public override Task<StartSpanReturn> StartSpan(StartSpanArgs request, ServerCallContext context)
         {
-            var creationSettings = new SpanCreationSettings()
+            var creationSettings = new SpanCreationSettings
                                    {
                                        FinishOnClose = false,
                                    };
@@ -78,8 +78,6 @@ namespace ApmTestClient.Services
                 creationSettings.Parent = _spanContextExtractor.Extract(
                     request.HttpHeaders?.HttpHeaders!,
                     getter: GetHeaderValues);
-                Console.WriteLine($"creationSettings.Parent?.SpanId={creationSettings.Parent?.SpanId}");
-                Console.WriteLine($"creationSettings.Parent?.TraceId={creationSettings.Parent?.TraceId}");
             }
 
             if (creationSettings.Parent is null && request is { HasParentId: true, ParentId: > 0 })
@@ -260,9 +258,6 @@ namespace ApmTestClient.Services
                     parameters[2].ParameterType.Name == "Action`3")
                 {
                     var carrierType = typeof(RepeatedField<HeaderTuple>);
-                    var actionType = typeof(Action<,,>);
-
-                    var closedActionType = actionType.MakeGenericType(carrierType, typeof(string), typeof(string));
                     return method.MakeGenericMethod(carrierType);
                 }
             }

--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -214,7 +214,7 @@ def dotnet_library_factory(env: Dict[str, str], container_id: str, port: str):
         container_name="dotnet-test-client-%s" % container_id,
         container_tag="dotnet6_0-test-client",
         container_img=f"""
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:7.0
 WORKDIR /client
 COPY ["./ApmTestClient.csproj","./nuget.config","./*.nupkg", "./"]
 RUN dotnet restore "./ApmTestClient.csproj"

--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -237,9 +237,6 @@ ENV DD_DOTNET_TRACER_HOME=/client/out/datadog
 ENV DD_TRACE_Grpc_ENABLED=false
 ENV DD_TRACE_AspNetCore_ENABLED=false
 ENV DD_TRACE_Process_ENABLED=false
-
-# enable OpenTelemetry support (required for OpenTelemetry tests)
-ENV DD_TRACE_OTEL_ENABLED=true
 """,
         container_cmd=["./ApmTestClient"],
         container_build_dir=dotnet_dir,

--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -244,7 +244,7 @@ ENV DD_TRACE_OTEL_ENABLED=true
         container_cmd=["./ApmTestClient"],
         container_build_dir=dotnet_dir,
         container_build_context=dotnet_dir,
-        volumes=[(os.path.join(dotnet_dir), "/client"),],
+        volumes=[],
         env=env,
         port=port,
     )


### PR DESCRIPTION
<!--

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.


Once your PR is reviewed, you can merge it ! :heart:

-->

## Description

This PR makes some updates to the .NET app used for parametrics tests:
https://github.com/DataDog/system-tests/tree/main/parametric/apps/dotnet

- update nuget package references to latest versions
- enable automatic instrumentation (not used yet, but required for OTel test endpoints coming soon)
  - change `Datadog.Trace` nuget package to `Datadog.Trace.Bundle`
  - add required environment variables
- allow running app without env var `APM_TEST_CLIENT_SERVER_PORT` (easier to run as a stand-alone app)
- misc code clean-up
- added `.gitignore` and `.dockerignore` files in `parametric/apps/dotnet`

## Motivation

Automatic instrumentation in required for the .NET tracer to support the OpenTelemetry API. The rest is bonus :) 

## Additional notes

<!-- Anything else we should know when reviewing? Context, references, considered alternatives, logs... are welcome!-->
none
