### PR TITLE
Fix codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @DataDog/system-tests-core
-/utils/build/docker/golang/* @DataDog/tracing-go @DataDog/system-tests-core
-/parametric/* @Kyle-Verhoog @DataDog/system-tests-core
-/tests/remote_config/* @DataDog/system-tests-core @DataDog/remote-config @DataDog/system-tests-core
-/tests/appsec/* @DataDog/appsec-libraries @DataDog/system-tests-core
+/utils/build/docker/golang/ @DataDog/tracing-go @DataDog/system-tests-core
+/parametric/ @Kyle-Verhoog @DataDog/system-tests-core
+/tests/remote_config/ @DataDog/system-tests-core @DataDog/remote-config @DataDog/system-tests-core
+/tests/appsec/ @DataDog/appsec-libraries @DataDog/system-tests-core


### PR DESCRIPTION
The `*` make the ownership not applied on sub-directories. See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners