### PR TITLE
Decouple proxy ingestion and interface waiting

### DIFF
--- a/utils/interfaces/_backend.py
+++ b/utils/interfaces/_backend.py
@@ -58,7 +58,7 @@ class _BackendInterfaceValidator(InterfaceValidator):
 
     # Called by the test setup to make sure the interface is ready.
     def wait(self, timeout):
-        super().wait(timeout, stop_accepting_data=False)
+        super().wait(timeout)
 
         from utils.interfaces import library
 

--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -29,8 +29,6 @@ class InterfaceValidator:
         self._data_list = []
         self._ingested_files = set()
 
-        self.accept_data = True
-
     def configure(self):
         pass
 
@@ -40,14 +38,10 @@ class InterfaceValidator:
     def __str__(self):
         return f"{self.name} interface"
 
-    def wait(self, timeout, stop_accepting_data=True):
+    def wait(self, timeout):
         time.sleep(timeout)
-        self.accept_data = not stop_accepting_data
 
     def ingest_file(self, src_path):
-        if not self.accept_data:
-            return
-
         with self._lock:
             if src_path in self._ingested_files:
                 return


### PR DESCRIPTION


<!--

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.


Once your PR is reviewed, you can merge it ! :heart:

-->

## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

Rather than stopping ingestion on each interface after each wait, we can separate both concerns by waiting for all conditions, then stop all watchdog events at once.

## Additional notes

<!-- Anything else we should know when reviewing? Context, references, considered alternatives, logs... are welcome!-->

