### PR TITLE
[parametric] fix test, don't require "t.tid" in "tracestate" W3C header

### DIFF
--- a/parametric/test_headers_tracestate_dd.py
+++ b/parametric/test_headers_tracestate_dd.py
@@ -427,7 +427,12 @@ def test_headers_tracestate_dd_propagate_propagatedtags(test_agent, test_library
             val = tag[index:]
 
             assert key.startswith("_dd.p.")
-            assert "t." + key[6:] + val.replace("=", ":") in dd_items4
+
+            # adding "t.tid" to "tracestate" header is redundant and optional,
+            # but if it is present, assert the value matches "_dd.p.tid".
+            assert (key == "_dd.p.tid" and "t.tid" not in dd_items4) or (
+                "t." + key[6:] + val.replace("=", ":") in dd_items4
+            )
 
 
 @temporary_enable_propagationstyle_default()

--- a/parametric/test_headers_tracestate_dd.py
+++ b/parametric/test_headers_tracestate_dd.py
@@ -428,7 +428,7 @@ def test_headers_tracestate_dd_propagate_propagatedtags(test_agent, test_library
 
             assert key.startswith("_dd.p.")
 
-            # adding "t.tid" to "tracestate" header is redundant and optional,
+            # adding "t.tid" to "tracestate" header is redundant,
             # but if it is present, assert the value matches "_dd.p.tid".
             assert (key == "_dd.p.tid" and "t.tid" not in dd_items4) or (
                 "t." + key[6:] + val.replace("=", ":") in dd_items4


### PR DESCRIPTION
<!--

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.


Once your PR is reviewed, you can merge it ! :heart:

-->

## Description

Fix a parametric test for propagation headers. When both Datadog and W3C headers are enabled, the test compares the propagated tags in `x-datadog-tags` and `tracestate` and expects them to be the same. However, the `_dd.p.tid` tag used for 128-bit trace ids is not added to `tracestate`, since `traceparent` already contains the full 128-bit trace id.


## Motivation

The test started failing for .NET when we updated to tracer 2.30 in #1101 which added support for 128-bit trace ids. 

## Additional notes

It is still not clear if adding `t.tid` to `tracestate` is optional or if we should require that it is never added. For now the test allows for either no `t.tid`, or that its value matches `_dd.p.tid`.

