### PR TITLE
Remove library versions for Test_Basic

### DIFF
--- a/tests/test_miscs.py
+++ b/tests/test_miscs.py
@@ -5,7 +5,6 @@
 from utils import weblog, interfaces, released, irrelevant
 
 
-@released(golang="1.43.0", java="0.97.0", nodejs="3.1.0", php="0.74.0", python="0.59.1", ruby="1.8.0")
 @irrelevant(library="cpp")
 class Test_Basic:
     """ Make sure the spans endpoint is successful """


### PR DESCRIPTION
<!--

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.


Once your PR is reviewed, you can merge it ! :heart:

-->

## Description

This remove the library versions decorator for the Test_Basic class as it's testing the weblog app, not the library. Hence having a library version makes no sense.

