### PR TITLE
[opentelemetry] Allow to configure which path to include

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,7 +590,7 @@ jobs:
 
   test-the-tests-open-telemetry:
     runs-on: ubuntu-latest
-    if: github.event.action != 'opened' && !contains(github.event.pull_request.labels.*.name, 'run-default-scenario')
+    if: github.event.action != 'opened' && contains(github.event.pull_request.labels.*.name, 'opentelemetry')
     needs:
     - lint_and_test
     steps:

--- a/tests/otel_tracing_e2e/_validator.py
+++ b/tests/otel_tracing_e2e/_validator.py
@@ -112,6 +112,7 @@ def validate_span_fields(span1: dict, span2: dict, name1: str, name2: str):
 
 KNOWN_UNMATCHED_METAS = [
     "otel.user_agent",
+    "otel.source",
     "span.kind",
     "_dd.agent_version",
     "_dd.span_links",  # TODO: remove once Agent supports span links

--- a/tests/otel_tracing_e2e/test_e2e.py
+++ b/tests/otel_tracing_e2e/test_e2e.py
@@ -9,7 +9,7 @@ from utils import context, weblog, interfaces, scenarios, irrelevant
 class Test_OTel_E2E:
     def setup_main(self):
         self.use_128_bits_trace_id = False
-        self.r = weblog.get(path="/basic")
+        self.r = weblog.get(path="/basic/trace")
 
     def test_main(self):
         otel_trace_ids = set(interfaces.open_telemetry.get_otel_trace_id(request=self.r))

--- a/utils/build/docker/java_otel/spring-boot-native/src/main/java/com/datadoghq/springbootnative/WebController.java
+++ b/utils/build/docker/java_otel/spring-boot-native/src/main/java/com/datadoghq/springbootnative/WebController.java
@@ -27,7 +27,7 @@ public class WebController {
   }
 
   // Basic test scenario that generates a server span with a span link to a fake message span.
-  @RequestMapping("/basic")
+  @RequestMapping("/basic/trace")
   private String basic(@RequestHeader HttpHeaders headers) throws InterruptedException {
     try (Scope scope = Context.current().makeCurrent()) {
       SpanContext spanContext = fakeAsyncWork(headers);


### PR DESCRIPTION
<!--

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.


Once your PR is reviewed, you can merge it ! :heart:

-->

## Description

Allow to choose which path to include (agent, collector or intake) in OTel E2E test instead of always running them all. Also some refactor on `java_otel` weblog container.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Additional notes

<!-- Anything else we should know when reviewing? Context, references, considered alternatives, logs... are welcome!-->

