### PR TITLE
activate more tests for custom rules on python

### DIFF
--- a/tests/appsec/waf/test_custom_rules.py
+++ b/tests/appsec/waf/test_custom_rules.py
@@ -1,7 +1,16 @@
-from utils import scenarios, released, interfaces, weblog
+from utils import interfaces, released, scenarios, weblog
 
 
-@released(java="?", dotnet="2.30.0", golang="1.51.0", nodejs="?", php_appsec="?", python="?", ruby="?", cpp="?")
+@released(
+    java="?",
+    dotnet="2.30.0",
+    golang="1.51.0",
+    nodejs="?",
+    php_appsec="?",
+    python={"django-poc": "1.12", "flask-poc": "1.12", "*": "?"},
+    ruby="?",
+    cpp="?",
+)
 @scenarios.appsec_custom_rules
 class Test_CustomRules:
     """Includes a version of the WAF supporting custom rules"""

--- a/tests/appsec/waf/test_exclusions.py
+++ b/tests/appsec/waf/test_exclusions.py
@@ -1,11 +1,20 @@
-from utils import scenarios, released, weblog, interfaces, missing_feature, context
 import pytest
+from utils import context, interfaces, missing_feature, released, scenarios, weblog
 
 if context.weblog_variant == "akka-http":
     pytestmark = pytest.mark.skip("missing feature: No AppSec support")
 
 
-@released(java="1.6.0", dotnet="2.26.0", golang="?", nodejs="?", php_appsec="0.7.0", python="?", ruby="?", cpp="?")
+@released(
+    java="1.6.0",
+    dotnet="2.26.0",
+    golang="?",
+    nodejs="?",
+    php_appsec="0.7.0",
+    python={"django-poc": "1.12", "flask-poc": "1.12", "*": "?"},
+    ruby="?",
+    cpp="?",
+)
 @missing_feature(context.weblog_variant == "spring-boot-native", reason="GraalVM. Tracing support only")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @scenarios.appsec_custom_rules


### PR DESCRIPTION
## Description

activate two more tests for python tracer for custom rules testing:

- Test_CustomRules
- Test_Exclusions

## Motivation

<!-- What inspired you to submit this pull request? -->

## Additional notes

<!-- Anything else we should know when reviewing? Context, references, considered alternatives, logs... are welcome!-->

