### PR TITLE
Remove iast conf from node test application to use env vars

### DIFF
--- a/utils/build/docker/nodejs/express4/app.js
+++ b/utils/build/docker/nodejs/express4/app.js
@@ -1,15 +1,7 @@
 "use strict";
 
 const tracer = require("dd-trace").init({
-  debug: true,
-  experimental: {
-    iast: {
-      enabled: true,
-      requestSampling: 100,
-      maxConcurrentRequests: 4,
-      maxContextOperations: 30,
-    },
-  },
+  debug: true
 });
 
 const app = require("express")();


### PR DESCRIPTION
<!--

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.


Once your PR is reviewed, you can merge it ! :heart:

-->

## Description

<!-- A brief description of the change being made with this pull request. -->
This PR removes the hardcoded IAST configuration to be able to use the environment variables to configure it.

## Motivation

<!-- What inspired you to submit this pull request? -->
People is using this application to do other test, and it is easier to activate/deactivate it if we can just change the environment var value.

## Additional notes

<!-- Anything else we should know when reviewing? Context, references, considered alternatives, logs... are welcome!-->

