### PR TITLE
[parametric/dotnet] prepare auto-instrumentation and other code clean-up, redux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ reportJunit.xml
 /utils/build/docker/dotnet/app.csproj.user
 
 # VSCode
+.vscode/
 .ionide/
 
 # Visual Studio

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -211,10 +211,10 @@ def dotnet_library_factory(env: Dict[str, str], container_id: str, port: str):
     server = APMLibraryTestServer(
         lang="dotnet",
         protocol="grpc",
-        container_name="dotnet-test-client-%s" % container_id,
-        container_tag="dotnet6_0-test-client",
-        container_img=f"""
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+        container_name=f"dotnet-test-client-{container_id}",
+        container_tag="dotnet7_0-test-client",
+        container_img="""
+FROM mcr.microsoft.com/dotnet/sdk:7.0
 WORKDIR /client
 COPY ["./ApmTestClient.csproj","./nuget.config","./*.nupkg", "./"]
 RUN dotnet restore "./ApmTestClient.csproj"

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -216,19 +216,37 @@ def dotnet_library_factory(env: Dict[str, str], container_id: str, port: str):
         container_img="""
 FROM mcr.microsoft.com/dotnet/sdk:7.0
 WORKDIR /client
-COPY ["./ApmTestClient.csproj","./nuget.config","./*.nupkg", "./"]
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+COPY ["./ApmTestClient.csproj", "./nuget.config", "./*.nupkg", "./"]
 RUN dotnet restore "./ApmTestClient.csproj"
-COPY . .
-WORKDIR "/client/."
+COPY . ./
+RUN dotnet publish --no-restore --configuration Release --output out
+WORKDIR /client/out
+
+# Opt-out of .NET SDK CLI telemetry (prevent unexpected http client spans)
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# Set up automatic instrumentation (required for OpenTelemetry tests),
+# but don't enable it globally
+ENV CORECLR_ENABLE_PROFILING=0
+ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+ENV CORECLR_PROFILER_PATH=/client/out/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so
+ENV DD_DOTNET_TRACER_HOME=/client/out/datadog
+
+# disable gRPC, ASP.NET Core, and other auto-instrumentations (to prevent unexpected spans)
+ENV DD_TRACE_Grpc_ENABLED=false
+ENV DD_TRACE_AspNetCore_ENABLED=false
+ENV DD_TRACE_Process_ENABLED=false
 """,
-        container_cmd=["dotnet", "run"],
+        container_cmd=["./ApmTestClient"],
         container_build_dir=dotnet_absolute_appdir,
         container_build_context=dotnet_absolute_appdir,
-        volumes=[(os.path.join(dotnet_absolute_appdir), "/client"),],
+        volumes=[],
         env=env,
         port=port,
     )
-    server.env["ASPNETCORE_URLS"] = "http://localhost:%s" % server.port
+
     return server
 
 

--- a/utils/build/docker/dotnet/parametric/.dockerignore
+++ b/utils/build/docker/dotnet/parametric/.dockerignore
@@ -1,0 +1,9 @@
+.idea/
+.vs/
+.vscode/
+bin/
+obj/
+packages/
+out/
+*.user
+*.suo

--- a/utils/build/docker/dotnet/parametric/.gitignore
+++ b/utils/build/docker/dotnet/parametric/.gitignore
@@ -1,0 +1,9 @@
+.idea/
+.vs/
+.vscode/
+bin/
+obj/
+packages/
+out/
+*.user
+*.suo

--- a/utils/build/docker/dotnet/parametric/ApmTestClient.csproj
+++ b/utils/build/docker/dotnet/parametric/ApmTestClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/utils/build/docker/dotnet/parametric/ApmTestClient.csproj
+++ b/utils/build/docker/dotnet/parametric/ApmTestClient.csproj
@@ -11,9 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.30.0" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.31.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.52.0" />
   </ItemGroup>
 
 </Project>

--- a/utils/build/docker/dotnet/parametric/Dockerfile
+++ b/utils/build/docker/dotnet/parametric/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:7.0
 WORKDIR /client
 COPY ["./ApmTestClient.csproj","./nuget.config","./*.nupkg", "./"]
 RUN dotnet restore "./ApmTestClient.csproj"

--- a/utils/build/docker/dotnet/parametric/Dockerfile
+++ b/utils/build/docker/dotnet/parametric/Dockerfile
@@ -1,7 +1,25 @@
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0
 WORKDIR /client
-COPY ["./ApmTestClient.csproj","./nuget.config","./*.nupkg", "./"]
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+COPY ["./ApmTestClient.csproj", "./nuget.config", "./*.nupkg", "./"]
 RUN dotnet restore "./ApmTestClient.csproj"
-COPY . .
-WORKDIR "/client/."
+COPY . ./
+RUN dotnet publish --no-restore --configuration Release --output out
+WORKDIR /client/out
+
+# Opt-out of .NET SDK CLI telemetry (prevent unexpected http client spans)
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# Set up automatic instrumentation (required for OpenTelemetry tests),
+# but don't enable it globally
+ENV CORECLR_ENABLE_PROFILING=0
+ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+ENV CORECLR_PROFILER_PATH=/client/out/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so
+ENV DD_DOTNET_TRACER_HOME=/client/out/datadog
+
+# disable gRPC, ASP.NET Core, and other auto-instrumentations (to prevent unexpected spans)
+ENV DD_TRACE_Grpc_ENABLED=false
+ENV DD_TRACE_AspNetCore_ENABLED=false
+ENV DD_TRACE_Process_ENABLED=false

--- a/utils/build/docker/dotnet/parametric/Program.cs
+++ b/utils/build/docker/dotnet/parametric/Program.cs
@@ -10,19 +10,18 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddGrpc();
-builder.WebHost.ConfigureKestrel(options =>
-{
-    // If we're using http, then _must_ listen on Http2 only, as the TLS
-    // negotiation is where we would typically negotiate between Http1.1/Http2
-    // Without this, you'll get a PROTOCOL_ERROR
-    // NOTE: For now, we'll set this in code via the options.Listen call since this
-    // seems to work with the Python tests (perhaps because this covers IPv4 and IPv6)
 
-    options.Listen(IPAddress.Any, Int32.Parse(Environment.GetEnvironmentVariable("APM_TEST_CLIENT_SERVER_PORT")!), listenOptions =>
-    {
-        listenOptions.Protocols = HttpProtocols.Http2;
-    });
-});
+// If we're using http, then _must_ listen on Http2 only, as the TLS
+// negotiation is where we would typically negotiate between Http1.1/Http2
+// Without this, you'll get a PROTOCOL_ERROR
+// NOTE: For now, we'll set this in code via the options.Listen call since this
+// seems to work with the Python tests (perhaps because this covers IPv4 and IPv6)
+if (int.TryParse(Environment.GetEnvironmentVariable("APM_TEST_CLIENT_SERVER_PORT"), out var port))
+{
+    builder.WebHost.ConfigureKestrel(
+        options =>
+            options.Listen(IPAddress.Any, port, listenOptions => { listenOptions.Protocols = HttpProtocols.Http2; }));
+}
 
 var app = builder.Build();
 

--- a/utils/build/docker/dotnet/parametric/Protos/apm_test_client.proto
+++ b/utils/build/docker/dotnet/parametric/Protos/apm_test_client.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option java_package = "com.datadoghq.client";
+option csharp_namespace = "ApmTestClient";
 
 // Interface of APM clients to be used for shared testing.
 service APMClient {


### PR DESCRIPTION
This PR is a redo of #1144 after files related to parametric tests were moved around. What follows is a copy of that PR's description:

<!--

## Workflow

1. ⚠️⚠️ Create your PR as draft (we're receiving lot of PR, it saves us lot of time) ⚠️⚠️
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Please refer to the [documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions) to run all scenarios in your PR if needed.


Once your PR is reviewed, you can merge it ! :heart:

-->

## Description

This PR makes some updates to the .NET app used for parametrics tests:
~https://github.com/DataDog/system-tests/tree/main/parametric/apps/dotnet~
https://github.com/DataDog/system-tests/tree/main/utils/build/docker/dotnet/parametric/

- update nuget package references to latest versions
- enable automatic instrumentation (not used yet, but required for OTel test endpoints coming soon)
  - change `Datadog.Trace` nuget package to `Datadog.Trace.Bundle`
  - add required environment variables
- allow running app without env var `APM_TEST_CLIENT_SERVER_PORT` (easier to run as a stand-alone app)
- misc code clean-up
- added `.gitignore` and `.dockerignore` files

## Motivation

Automatic instrumentation in required for the .NET tracer to support the OpenTelemetry API. The rest are bonus changes :) 

## Additional notes

<!-- Anything else we should know when reviewing? Context, references, considered alternatives, logs... are welcome!-->
none
