### PR TITLE
[APPSEC-9344] Enable user blocking tests for ruby

### DIFF
--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -10,7 +10,7 @@ from utils import context, released, coverage, interfaces, scenarios, weblog, bu
     php="0.86.3",
     php_appsec="0.7.2",
     python={"django-poc": "1.10", "flask-poc": "1.10", "*": "?"},
-    ruby="?",
+    ruby="1.11.0",
 )
 @missing_feature(library="java", reason="/users endpoint is not implemented on java weblog")
 @coverage.basic
@@ -59,6 +59,7 @@ class Test_UserBlocking_FullDenylist:
 
         self.r_blocked_requests = [weblog.get("/users", params={"user": i}) for i in range(1250)]
 
+    @bug(context.library < "ruby@1.12.1", reason="not setting the tags on the service entry span")
     def test_blocking_test(self):
         """Test with a denylisted user"""
 

--- a/utils/build/docker/ruby/rack/config.ru
+++ b/utils/build/docker/ruby/rack/config.ru
@@ -138,6 +138,12 @@ app = proc do |env|
     end
 
     [ status_code, headers, ['Value tagged'] ]
+  elsif request.path.include?('/users')
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    [ 200, {'Content-Type' => 'text/plain'}, ['Hello, user!'] ]
   else
     [ 404, {'Content-Type' => 'text/plain'}, ['not found'] ]
   end

--- a/utils/build/docker/ruby/rails32/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails32/app/controllers/system_test_controller.rb
@@ -94,4 +94,12 @@ class SystemTestController < ApplicationController
 
     render text: 'Value tagged', status: status_code
   end
+
+  def users
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    render text: 'Hello, user!'
+  end
 end

--- a/utils/build/docker/ruby/rails32/config/routes.rb
+++ b/utils/build/docker/ruby/rails32/config/routes.rb
@@ -79,4 +79,5 @@ Rails32::Application.routes.draw do
     send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
   end
   match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  get '/users' => 'system_test#users'
 end

--- a/utils/build/docker/ruby/rails40/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails40/app/controllers/system_test_controller.rb
@@ -94,4 +94,12 @@ class SystemTestController < ApplicationController
 
     render text: 'Value tagged', status: status_code
   end
+
+  def users
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    render text: 'Hello, user!'
+  end
 end

--- a/utils/build/docker/ruby/rails40/config/routes.rb
+++ b/utils/build/docker/ruby/rails40/config/routes.rb
@@ -23,4 +23,5 @@ Rails40::Application.routes.draw do
     send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
   end
   match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  get '/users' => 'system_test#users'
 end

--- a/utils/build/docker/ruby/rails41/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails41/app/controllers/system_test_controller.rb
@@ -117,4 +117,12 @@ class SystemTestController < ApplicationController
 
     render plain: 'Value tagged', status: status_code
   end
+
+  def users
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    render plain: 'Hello, user!'
+  end
 end

--- a/utils/build/docker/ruby/rails41/config/routes.rb
+++ b/utils/build/docker/ruby/rails41/config/routes.rb
@@ -23,4 +23,5 @@ Rails.application.routes.draw do
     send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
   end
   match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  get '/users' => 'system_test#users'
 end

--- a/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
@@ -117,4 +117,12 @@ class SystemTestController < ApplicationController
 
     render plain: 'Value tagged', status: status_code
   end
+
+  def users
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    render plain: 'Hello, user!'
+  end
 end

--- a/utils/build/docker/ruby/rails42/config/routes.rb
+++ b/utils/build/docker/ruby/rails42/config/routes.rb
@@ -22,4 +22,5 @@ Rails.application.routes.draw do
     send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
   end
   match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  get '/users' => 'system_test#users'
 end

--- a/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
@@ -117,4 +117,12 @@ class SystemTestController < ApplicationController
 
     render plain: 'Value tagged', status: status_code
   end
+
+  def users
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    render plain: 'Hello, user!'
+  end
 end

--- a/utils/build/docker/ruby/rails50/config/routes.rb
+++ b/utils/build/docker/ruby/rails50/config/routes.rb
@@ -25,4 +25,5 @@ Rails.application.routes.draw do
     send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
   end
   match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  get '/users' => 'system_test#users'
 end

--- a/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
@@ -116,4 +116,12 @@ class SystemTestController < ApplicationController
 
     render plain: 'Value tagged', status: status_code
   end
+
+  def users
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    render plain: 'Hello, user!'
+  end
 end

--- a/utils/build/docker/ruby/rails51/config/routes.rb
+++ b/utils/build/docker/ruby/rails51/config/routes.rb
@@ -25,4 +25,5 @@ Rails.application.routes.draw do
     send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
   end
   match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  get '/users' => 'system_test#users'
 end

--- a/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
@@ -117,4 +117,12 @@ class SystemTestController < ApplicationController
 
     render plain: 'Value tagged', status: status_code
   end
+
+  def users
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    render plain: 'Hello, user!'
+  end
 end

--- a/utils/build/docker/ruby/rails52/config/routes.rb
+++ b/utils/build/docker/ruby/rails52/config/routes.rb
@@ -25,4 +25,5 @@ Rails.application.routes.draw do
     send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
   end
   match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  get '/users' => 'system_test#users'
 end

--- a/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
@@ -137,4 +137,12 @@ class SystemTestController < ApplicationController
 
     render plain: 'Value tagged', status: status_code
   end
+
+  def users
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    render plain: 'Hello, user!'
+  end
 end

--- a/utils/build/docker/ruby/rails60/config/routes.rb
+++ b/utils/build/docker/ruby/rails60/config/routes.rb
@@ -25,4 +25,5 @@ Rails.application.routes.draw do
     send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
   end
   match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  get '/users' => 'system_test#users'
 end

--- a/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
@@ -117,4 +117,12 @@ class SystemTestController < ApplicationController
 
     render plain: 'Value tagged', status: status_code
   end
+
+  def users
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    render plain: 'Hello, user!'
+  end
 end

--- a/utils/build/docker/ruby/rails61/config/routes.rb
+++ b/utils/build/docker/ruby/rails61/config/routes.rb
@@ -25,4 +25,5 @@ Rails.application.routes.draw do
     send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
   end
   match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  get '/users' => 'system_test#users'
 end

--- a/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
@@ -120,4 +120,12 @@ class SystemTestController < ApplicationController
 
     render plain: 'Value tagged', status: status_code
   end
+
+  def users
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    render plain: 'Hello, user!'
+  end
 end

--- a/utils/build/docker/ruby/rails70/config/routes.rb
+++ b/utils/build/docker/ruby/rails70/config/routes.rb
@@ -29,4 +29,5 @@ Rails.application.routes.draw do
     send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
   end
   match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  get '/users' => 'system_test#users'
 end

--- a/utils/build/docker/ruby/sinatra14/app.rb
+++ b/utils/build/docker/ruby/sinatra14/app.rb
@@ -163,4 +163,12 @@ end
 
     'Value tagged'
   end
+
+  get '/users' do
+    user_id = request.params["user"]
+
+    Datadog::Kit::Identity.set_user(id: user_id)
+
+    'Hello, user!'
+  end
 end

--- a/utils/build/docker/ruby/sinatra20/app.rb
+++ b/utils/build/docker/ruby/sinatra20/app.rb
@@ -163,3 +163,11 @@ end
     'Value tagged'
   end
 end
+
+get '/users' do
+  user_id = request.params["user"]
+
+  Datadog::Kit::Identity.set_user(id: user_id)
+
+  'Hello, user!'
+end

--- a/utils/build/docker/ruby/sinatra21/app.rb
+++ b/utils/build/docker/ruby/sinatra21/app.rb
@@ -163,3 +163,11 @@ end
     'Value tagged'
   end
 end
+
+get '/users' do
+  user_id = request.params["user"]
+
+  Datadog::Kit::Identity.set_user(id: user_id)
+
+  'Hello, user!'
+end


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

Enable user blocking ruby specs

## Motivation

<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [ ] If this PR modify anything else than sctriclty the default scenario, then remove the `run-default-scenario` label
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Temove `run-default-scenario` label to run all scenarios ([more info](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions))

Once your PR is reviewed, you can merge it ! :heart:
