### PR TITLE
Add vscode conf to run and debug default scenario

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,40 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: Current File",
+            "name": "Run DEFAULT scenario",
             "type": "python",
             "request": "launch",
-            "program": "${file}",
+            "module": "pytest",
+            "args": ["-p", "no:warnings"],
             "console": "integratedTerminal",
-            "justMyCode": false
+            "justMyCode": true
+        },
+        {
+            "name": "Run INTEGRATIONS scenario",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["-S", "INTEGRATIONS", "-p", "no:warnings"],
+            "console": "integratedTerminal",
+            "justMyCode": true
+        },
+        {
+            "name": "Run LIBRARY_CONF_CUSTOM_HEADERS_LONG scenario",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["-S", "LIBRARY_CONF_CUSTOM_HEADERS_LONG", "-p", "no:warnings"],
+            "console": "integratedTerminal",
+            "justMyCode": true
+        },
+        {
+            "name": "Run PROFILING scenario",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["-S", "PROFILING", "-p", "no:warnings"],
+            "console": "integratedTerminal",
+            "justMyCode": true
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,10 @@
     "python.linting.enabled": true,
     "python.linting.pylintEnabled": true,
     "python.formatting.provider": "black",
-    "java.compile.nullAnalysis.mode": "disabled"
+    "java.compile.nullAnalysis.mode": "disabled",
+    "python.testing.pytestArgs": [
+        "tests",
+        "--replay"
+    ],
+    "python.testing.pytestEnabled": true
 }


### PR DESCRIPTION
## Description

Enable the VsCode testing integrations. #1084 

Two way to run them : 

1. threw the `run and debug` panel
    * works on normal mode
    * you can choose your scenario
    * it runs all tests
2.  threw the Testing panel. VsCode does not allow several confs for this panel, so, by default, it's DEFAULT scenario on replay mode:  
    * you need to manually edit `.vscode/settings.json` to change the scenario, or run on normal mode
    * but you can pick only one test

## Motivation

Easily run and debug a tests

![image](https://github.com/DataDog/system-tests/assets/11915659/3b27bb72-215f-4b8d-9e7a-dcb41f12f1ec)
![image](https://github.com/DataDog/system-tests/assets/11915659/54392ee2-21da-4512-9209-20a5802c0720)


## Reviewer checklist

* [ ] If this PR modify anything else than sctriclty the default scenario, then remove the `run-default-scenario` label
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
4. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
5. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
6. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Temove `run-default-scenario` label to run all scenarios ([more info](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions))

Once your PR is reviewed, you can merge it ! :heart:
