### PR TITLE
Upgrade java version for parametric tests

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -247,7 +247,7 @@ def java_library_factory(env: Dict[str, str], container_id: str, port: str):
         container_tag="java8-test-client",
         container_img=f"""
 # FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
-FROM maven:3-jdk-8
+FROM maven:3.9.2-eclipse-temurin-17
 WORKDIR /client
 # COPY --from=apm_library_latest /dd-java-agent.jar ./tracer/
 # COPY --from=apm_library_latest /LIBRARY_VERSION ./tracer/
@@ -255,10 +255,10 @@ RUN mkdir ./tracer/ && wget -O ./tracer/dd-java-agent.jar https://github.com/Dat
 COPY {java_reldir}/src src
 COPY {java_reldir}/build.sh .
 COPY {java_reldir}/pom.xml .
-COPY {java_reldir}/run.sh .
 COPY {protofile} src/main/proto/
 COPY binaries /binaries
 RUN bash build.sh
+COPY {java_reldir}/run.sh .
 """,
         container_cmd=["./run.sh"],
         container_build_dir=java_absolute_appdir,

--- a/utils/build/docker/java/parametric/Dockerfile
+++ b/utils/build/docker/java/parametric/Dockerfile
@@ -1,6 +1,6 @@
 
 # FROM ghcr.io/datadog/dd-trace-java/dd-trace-java:latest as apm_library_latest
-FROM maven:3-jdk-8
+FROM maven:3.9.2-eclipse-temurin-17
 WORKDIR /client
 # COPY --from=apm_library_latest /dd-java-agent.jar ./tracer/
 # COPY --from=apm_library_latest /LIBRARY_VERSION ./tracer/
@@ -8,7 +8,7 @@ RUN mkdir ./tracer/ && wget -O ./tracer/dd-java-agent.jar https://github.com/Dat
 COPY utils/build/docker/java/parametric/src src
 COPY utils/build/docker/java/parametric/build.sh .
 COPY utils/build/docker/java/parametric/pom.xml .
-COPY utils/build/docker/java/parametric/run.sh .
 COPY utils/parametric/protos/apm_test_client.proto src/main/proto/
 COPY binaries /binaries
 RUN bash build.sh
+COPY utils/build/docker/java/parametric/run.sh .

--- a/utils/build/docker/java/parametric/run.sh
+++ b/utils/build/docker/java/parametric/run.sh
@@ -19,6 +19,9 @@ case $(echo "${DD_TRACE_DEBUG:-false}" | tr '[:upper:]' '[:lower:]') in
   *);;
 esac
 
-java -javaagent:"${CUSTOM_DD_JAVA_AGENT:-$DD_JAVA_AGENT}" \
+java -Xmx128M -javaagent:"${CUSTOM_DD_JAVA_AGENT:-$DD_JAVA_AGENT}" \
+  -XX:TieredStopAtLevel=1 \
+  -Ddd.jmxfetch.enabled=false \
+  -Ddd.telemetry.dependency-collection.enabled=false \
   -Ddd.integration.opentelemetry.experimental.enabled=true \
   -jar target/dd-trace-java-client-1.0.0.jar


### PR DESCRIPTION
## Description

Upgrades the JVM version that runs the parametric tests for better container support (and hopefully faster startup). Also adds some startup flags that disable unnecessary components.

## Motivation

Slow startup is slow, and parametric tests starts a new JVM for every test.

## Reviewer checklist

* [ ] If this PR modify anything else than sctriclty the default scenario, then remove the `run-default-scenario` label
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Temove `run-default-scenario` label to run all scenarios ([more info](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions))

Once your PR is reviewed, you can merge it ! :heart:
