### PR TITLE
[APPSEC-9344] Enable specs for released features for Ruby

### DIFF
--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -2,7 +2,7 @@ import os.path
 
 import pytest
 
-from utils import released, coverage, interfaces, bug, scenarios, weblog, rfc, missing_feature
+from utils import released, coverage, interfaces, bug, scenarios, weblog, rfc, missing_feature, bug
 from utils._context.core import context
 
 if context.library == "cpp":
@@ -56,7 +56,7 @@ JSON_CONTENT_TYPES = {
     nodejs="3.19.0",
     php_appsec="0.7.0",
     python={"django-poc": "1.10", "flask-poc": "1.10", "*": "?"},
-    ruby="?",
+    ruby="1.11.0",
 )
 @released(
     java={
@@ -87,6 +87,7 @@ class Test_Blocking:
     @bug(context.library < "java@0.115.0" and context.weblog_variant == "spring-boot-wildfly", reason="npe")
     @bug(context.weblog_variant == "gin", reason="Block message is prepended")
     @bug(context.library == "python", reason="Bug, minify and remove new line characters")
+    @bug(context.library < "ruby@1.12.1", reason="wrong default content-type")
     def test_no_accept(self):
         """Blocking without an accept header"""
         assert self.r_na.status_code == 403
@@ -122,6 +123,7 @@ class Test_Blocking:
         self.r_aa = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1", "Accept": "*/*"})
 
     @bug(context.weblog_variant == "gin", reason="Block message is prepended")
+    @bug(context.library < "ruby@1.12.1", reason="wrong default content-type")
     def test_accept_all(self):
         """Blocking with Accept: */*"""
         assert self.r_aa.status_code == 403
@@ -135,6 +137,7 @@ class Test_Blocking:
         )
 
     @bug(context.weblog_variant == "gin", reason="Block message is prepended")
+    @bug(context.library < "ruby@1.12.1", reason="wrong default content-type")
     def test_accept_partial_json(self):
         """Blocking with Accept: application/*"""
         assert self.r_apj.status_code == 403
@@ -151,6 +154,7 @@ class Test_Blocking:
     @missing_feature(context.library == "golang", reason="Support for partial html not implemented")
     @missing_feature(context.library == "nodejs", reason="Support for partial html not implemented")
     @missing_feature(context.library == "python", reason="Support for partial html not implemented")
+    @missing_feature(context.library == "ruby", reason="Support for partial html not implemented")
     def test_accept_partial_html(self):
         """Blocking with Accept: text/*"""
         assert self.r_aph.status_code == 403
@@ -167,6 +171,7 @@ class Test_Blocking:
         )
 
     @bug(context.weblog_variant == "gin", reason="Block message is prepended")
+    @bug(context.library < "ruby@1.12.1", reason="wrong default content-type")
     def test_accept_full_json(self):
         """Blocking with Accept: application/json"""
         assert self.r_afj.status_code == 403
@@ -185,6 +190,7 @@ class Test_Blocking:
     @missing_feature(context.library == "php", reason="Support for quality not implemented")
     @missing_feature(context.library == "dotnet", reason="Support for quality not implemented")
     @missing_feature(context.library == "nodejs", reason="Support for quality not implemented")
+    @missing_feature(context.library == "ruby", reason="Support for quality not implemented")
     @bug(context.weblog_variant == "gin", reason="Block message is prepended")
     def test_accept_full_html(self):
         """Blocking with Accept: text/html"""

--- a/tests/appsec/waf/test_custom_rules.py
+++ b/tests/appsec/waf/test_custom_rules.py
@@ -8,7 +8,7 @@ from utils import interfaces, released, scenarios, weblog
     nodejs="4.1.0",
     php_appsec="0.8.1",
     python={"django-poc": "1.12", "flask-poc": "1.12", "*": "?"},
-    ruby="?",
+    ruby="1.12.0",
     cpp="?",
 )
 @scenarios.appsec_custom_rules

--- a/tests/appsec/waf/test_exclusions.py
+++ b/tests/appsec/waf/test_exclusions.py
@@ -1,5 +1,5 @@
 import pytest
-from utils import context, interfaces, missing_feature, released, scenarios, weblog
+from utils import context, interfaces, missing_feature, released, scenarios, weblog, bug
 
 if context.weblog_variant == "akka-http":
     pytestmark = pytest.mark.skip("missing feature: No AppSec support")
@@ -12,7 +12,7 @@ if context.weblog_variant == "akka-http":
     nodejs="3.19.0",
     php_appsec="0.7.0",
     python={"django-poc": "1.12", "flask-poc": "1.12", "*": "?"},
-    ruby="?",
+    ruby="1.11.0",
     cpp="?",
 )
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
@@ -24,6 +24,7 @@ class Test_Exclusions:
         self.r_iexnt1 = weblog.get("/waf/", params={"excluded_key": "true"})
         self.r_iexnt2 = weblog.get("/waf/", params={"excluded_key": "true", "activate_exclusion": "false"})
 
+    @bug(context.library <= "ruby@1.12.1")
     def test_input_exclusion_negative_test(self):
         interfaces.library.assert_waf_attack(self.r_iexnt1, pattern="true", address="server.request.query")
         interfaces.library.assert_waf_attack(self.r_iexnt2, pattern="true", address="server.request.query")
@@ -45,5 +46,6 @@ class Test_Exclusions:
     def setup_rule_exclusion_positive_test(self):
         self.r_rept = weblog.get("/waf/", params={"foo": "bbbb", "activate_exclusion": "true"})
 
+    @bug(context.library <= "ruby@1.12.1")
     def test_rule_exclusion_positive_test(self):
         interfaces.library.assert_no_appsec_event(self.r_rept)


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [ ] If this PR modify anything else than sctriclty the default scenario, then remove the `run-default-scenario` label
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Temove `run-default-scenario` label to run all scenarios ([more info](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions))

Once your PR is reviewed, you can merge it ! :heart:
