### PR TITLE
Parametric tests wait for number of spans instead of traces

### DIFF
--- a/parametric/test_span_sampling.py
+++ b/parametric/test_span_sampling.py
@@ -458,7 +458,7 @@ def test_root_span_selected_by_sss014(test_agent, test_library):
             with test_library.start_span(name="child", service="webserver", parent_id=parent_span.span_id):
                 pass
 
-    traces = test_agent.wait_for_num_traces(1, clear=True)
+    traces = test_agent.wait_for_num_spans(2, clear=True)
 
     parent_span = find_span_in_traces(traces, Span(name="parent", service="webserver"))
     child_span = find_span_in_traces(traces, Span(name="child", service="webserver"))
@@ -502,7 +502,7 @@ def test_child_span_selected_by_sss015(test_agent, test_library):
             with test_library.start_span(name="child", service="webserver", parent_id=parent_span.span_id):
                 pass
 
-    traces = test_agent.wait_for_num_traces(1, clear=True)
+    traces = test_agent.wait_for_num_spans(2, clear=True)
 
     parent_span = find_span_in_traces(traces, Span(name="parent", service="webserver"))
     child_span = find_span_in_traces(traces, Span(name="child", service="webserver"))


### PR DESCRIPTION
## Description

Waits for a number of spans instead of a number of traces in some single span sampling scenarios.

## Motivation

In Java the single sampled spans are sent to a different queue than the rest of the trace spans, and depending on timing they might end up in the same or different trace chunks. This leads to intermittent failures if we only wait for a specific number of traces instead of spans. 

## Reviewer checklist

* [ ] If this PR modify anything else than sctriclty the default scenario, then remove the `run-default-scenario` label
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Temove `run-default-scenario` label to run all scenarios ([more info](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions))

Once your PR is reviewed, you can merge it ! :heart:
