### PR TITLE
Add -p no:warnings for set of scenarios

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -83,26 +83,26 @@ ONBOARDING_SCENARIOS=(
 readonly SCENARIO=${1:-}
 
 if [[ $SCENARIO == "TRACER_RELEASE_SCENARIOS" ]]; then
-    for scenario in "${TRACER_RELEASE_SCENARIOS[@]}"; do pytest -S $scenario ${@:2}; done
+    for scenario in "${TRACER_RELEASE_SCENARIOS[@]}"; do pytest -p no:warnings -S $scenario ${@:2}; done
 
 elif [[ $SCENARIO == "TRACER_ESSENTIAL_SCENARIOS" ]]; then
-    for scenario in "${TRACER_ESSENTIAL_SCENARIOS[@]}"; do pytest -S $scenario ${@:2}; done
+    for scenario in "${TRACER_ESSENTIAL_SCENARIOS[@]}"; do pytest -p no:warnings -S $scenario ${@:2}; done
 
 elif [[ $SCENARIO == "APPSEC_SCENARIOS" ]]; then
-    for scenario in "${APPSEC_SCENARIOS[@]}"; do pytest -S $scenario ${@:2}; done
+    for scenario in "${APPSEC_SCENARIOS[@]}"; do pytest -p no:warnings -S $scenario ${@:2}; done
 
 elif [[ $SCENARIO == "REMOTE_CONFIG_SCENARIOS" ]]; then
-    for scenario in "${REMOTE_CONFIG_SCENARIOS[@]}"; do pytest -S $scenario ${@:2}; done
+    for scenario in "${REMOTE_CONFIG_SCENARIOS[@]}"; do pytest -p no:warnings -S $scenario ${@:2}; done
 
 elif [[ $SCENARIO == "TELEMETRY_SCENARIOS" ]]; then
-    for scenario in "${TELEMETRY_SCENARIOS[@]}"; do pytest -S $scenario ${@:2}; done
+    for scenario in "${TELEMETRY_SCENARIOS[@]}"; do pytest -p no:warnings -S $scenario ${@:2}; done
 
 elif [[ $SCENARIO == "ONBOARDING_SCENARIOS" ]]; then
-    for scenario in "${ONBOARDING_SCENARIOS[@]}"; do pytest -S $scenario ${@:2}; done
+    for scenario in "${ONBOARDING_SCENARIOS[@]}"; do pytest -p no:warnings -S $scenario ${@:2}; done
 
 elif [[ $SCENARIO == "APPSEC_IP_BLOCKING_MAXED" ]] || [[ $SCENARIO == "APPSEC_IP_BLOCKING" ]]; then
     # Those scenario has been renamed. Keep the compatibility, waiting for other CI to update.
-    pytest -S APPSEC_BLOCKING_FULL_DENYLIST ${@:2};
+    pytest -p no:warnings -S APPSEC_BLOCKING_FULL_DENYLIST ${@:2};
 
 elif [[ $SCENARIO =~ ^[A-Z0-9_]+$ ]]; then
     # If the first argument is a list of capital letters, then we consider it's a scenario name


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [ ] If this PR modify anything else than sctriclty the default scenario, then remove the `run-default-scenario` label
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Temove `run-default-scenario` label to run all scenarios ([more info](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions))

Once your PR is reviewed, you can merge it ! :heart:
