### PR TITLE
cleanup old decorators

### DIFF
--- a/tests/appsec/test_reports.py
+++ b/tests/appsec/test_reports.py
@@ -68,10 +68,8 @@ class Test_StatusCode:
     else "1.34.0"
 )
 @released(dotnet="1.30.0", java="0.98.1", nodejs="2.0.0", php_appsec="0.3.0", python=PYTHON_RELEASE_GA_1_1)
-@missing_feature(context.library == "ruby" and context.libddwaf_version is None)
 @missing_feature(weblog_variant="akka-http", reason="No AppSec support")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
-@flaky(context.library == "ruby" and context.weblog_variant in ("rails32", "rails40"))
 @coverage.good
 @missing_feature(
     True, reason="Bug on system test: with the runner on the host, we do not have the real IP from weblog POV"


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

Remove old decorators for Ruby. The test doesn't work for any language at the moment, but having the flaky decorators makes the report think Ruby has a bug 🐛 
<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [ ] If this PR modify anything else than sctriclty the default scenario, then remove the `run-default-scenario` label
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Temove `run-default-scenario` label to run all scenarios ([more info](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions))

Once your PR is reviewed, you can merge it ! :heart:
