### PR TITLE
Add test for no HttpOnly cookie and no SameSite cookie

### DIFF
--- a/tests/appsec/iast/sink/test_no_httponly_cookie.py
+++ b/tests/appsec/iast/sink/test_no_httponly_cookie.py
@@ -11,25 +11,24 @@ if context.library == "cpp":
 
 
 @coverage.basic
-@released(dotnet="?", java="?", golang="?", php_appsec="?", python="?", ruby="?")
-@released(nodejs={"express4": "4.1.0", "*": "?"})
-class TestInsecureCookie:
-    """Test insecure cookie detection."""
+@released(dotnet="?", java="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?")
+class TestNoHttponlyCookie:
+    """Test no HttpOnly cookie detection."""
 
     sink_fixture = SinkFixture(
-        vulnerability_type="INSECURE_COOKIE",
+        vulnerability_type="NO_HTTPONLY_COOKIE",
         http_method="GET",
-        insecure_endpoint="/iast/insecure-cookie/test_insecure",
-        secure_endpoint="/iast/insecure-cookie/test_secure",
+        insecure_endpoint="/iast/no-httponly-cookie/test_insecure",
+        secure_endpoint="/iast/no-httponly-cookie/test_secure",
         data={},
         location_map={"nodejs": "iast/index.js",},
     )
 
     sink_fixture_empty_cookie = SinkFixture(
-        vulnerability_type="INSECURE_COOKIE",
+        vulnerability_type="NO_HTTPONLY_COOKIE",
         http_method="GET",
         insecure_endpoint="",
-        secure_endpoint="/iast/insecure-cookie/test_empty_cookie",
+        secure_endpoint="/iast/no-httponly-cookie/test_empty_cookie",
         data={},
         location_map={"nodejs": "iast/index.js",},
     )

--- a/tests/appsec/iast/sink/test_no_samesite_cookie.py
+++ b/tests/appsec/iast/sink/test_no_samesite_cookie.py
@@ -11,25 +11,24 @@ if context.library == "cpp":
 
 
 @coverage.basic
-@released(dotnet="?", java="?", golang="?", php_appsec="?", python="?", ruby="?")
-@released(nodejs={"express4": "4.1.0", "*": "?"})
-class TestInsecureCookie:
-    """Test insecure cookie detection."""
+@released(dotnet="?", java="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?")
+class TestNoSamesiteCookie:
+    """Test No SameSite cookie detection."""
 
     sink_fixture = SinkFixture(
-        vulnerability_type="INSECURE_COOKIE",
+        vulnerability_type="NO_SAMESITE_COOKIE",
         http_method="GET",
-        insecure_endpoint="/iast/insecure-cookie/test_insecure",
-        secure_endpoint="/iast/insecure-cookie/test_secure",
+        insecure_endpoint="/iast/no-samesite-cookie/test_insecure",
+        secure_endpoint="/iast/no-samesite-cookie/test_secure",
         data={},
         location_map={"nodejs": "iast/index.js",},
     )
 
     sink_fixture_empty_cookie = SinkFixture(
-        vulnerability_type="INSECURE_COOKIE",
+        vulnerability_type="NO_HTTPONLY_COOKIE",
         http_method="GET",
         insecure_endpoint="",
-        secure_endpoint="/iast/insecure-cookie/test_empty_cookie",
+        secure_endpoint="/iast/no-samesite-cookie/test_empty_cookie",
         data={},
         location_map={"nodejs": "iast/index.js",},
     )

--- a/utils/build/docker/nodejs/express4/iast/index.js
+++ b/utils/build/docker/nodejs/express4/iast/index.js
@@ -127,15 +127,53 @@ function init (app, tracer) {
   });
 
   app.get('/iast/insecure-cookie/test_secure', (req, res) => {
-    res.setHeader('set-cookie', 'secure=cookie; Secure')
-    res.cookie('secure2', 'value', { secure: true })
+    res.setHeader('set-cookie', 'secure=cookie; Secure; HttpOnly; SameSite=Strict')
+    res.cookie('secure2', 'value', { secure: true, httpOnly: true, sameSite: true })
     res.send('OK')
   });
 
   app.get('/iast/insecure-cookie/test_empty_cookie', (req, res) => {
     res.clearCookie('insecure')
     res.setHeader('set-cookie', 'empty=')
-    res.cookie('secure2', '')
+    res.cookie('secure3', '')
+    res.send('OK')
+  });
+
+
+  app.get('/iast/no-httponly-cookie/test_insecure', (req, res) => {
+    res.cookie('no-httponly', 'cookie')
+    res.send('OK')
+  });
+
+  app.get('/iast/no-httponly-cookie/test_secure', (req, res) => {
+    res.setHeader('set-cookie', 'httponly=cookie; Secure;HttpOnly;SameSite=Strict;')
+    res.cookie('httponly2', 'value', { secure: true, httpOnly: true, sameSite: true })
+    res.send('OK')
+  });
+
+  app.get('/iast/no-httponly-cookie/test_empty_cookie', (req, res) => {
+    res.clearCookie('insecure')
+    res.setHeader('set-cookie', 'httponlyempty=')
+    res.cookie('httponlyempty2', '')
+    res.send('OK')
+  });
+
+
+  app.get('/iast/no-samesite-cookie/test_insecure', (req, res) => {
+    res.cookie('nosamesite', 'cookie')
+    res.send('OK')
+  });
+
+  app.get('/iast/no-samesite-cookie/test_secure', (req, res) => {
+    res.setHeader('set-cookie', 'samesite=cookie; Secure; HttpOnly; SameSite=Strict')
+    res.cookie('samesite2', 'value', { secure: true, httpOnly: true, sameSite: true })
+    res.send('OK')
+  });
+
+  app.get('/iast/no-samesite-cookie/test_empty_cookie', (req, res) => {
+    res.clearCookie('insecure')
+    res.setHeader('set-cookie', 'samesiteempty=')
+    res.cookie('samesiteempty2', '')
     res.send('OK')
   });
 


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->
This PR adds test to cookies related vulnerability detections that the libraries are working on. 

As insecure-cookie is in production already in node, it is also activated with the correct version number.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [ ] If this PR modify anything else than sctriclty the default scenario, then remove the `run-default-scenario` label
* [x] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Temove `run-default-scenario` label to run all scenarios ([more info](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions))

Once your PR is reviewed, you can merge it ! :heart:
