### PR TITLE
Add a way to force a test execution #913

### DIFF
--- a/docs/edit/egg-chicken-changes.md
+++ b/docs/edit/egg-chicken-changes.md
@@ -20,6 +20,18 @@ Totally acceptable, if you accept the risk to do another PR on your repo.
 
 You have to run system-tests locally. But you will reduces the risk of rework on your repo, and you keep your `main` branch clean.
 
+## The good way (when you don't need to modify the test)
+
+Use the [`-F` option](../execute/force-execute.md):
+
+1. Do your PR in your repo
+2. Modify your CI to include the test you want to activate:
+    * `./run.sh MY_SCENARIO -F tests/feature.py::Test_Feature`
+3. Iterate on your PR, merge it
+4. :warning: Add a PR in system-tests repo, otherwise we may change the test, and break your CI without noticing it.
+
+And so time to time, removes all the `-F` in your CI.
+
 ## The good way
 
 1. Do a PR in system-tests (it fails)

--- a/docs/execute/force-execute.md
+++ b/docs/execute/force-execute.md
@@ -1,0 +1,11 @@
+Test items are skipped (or not) based on declarations in tests class, using @released, @bug ... decorators.
+
+This fact implies an [egg-chicken issue](../edit/egg-chicken-changes.md) if you need to work on a feature. A way to handle it is to use the `-F` option : 
+
+1. in your PR, modify your CI to include the test you want to activate:
+    * `./run.sh MY_SCENARIO -F tests/feature.py::Test_Feature -F tests/feature.py::Test_FeatureEdgeCase` 
+2. iterate on your PR, merge it
+
+:warning: Do not forget to add a PR in system-tests repo, otherwise we may change the test, and break your CI without noticing it.
+
+And so time to time, removes all the `-F` in your CI.


### PR DESCRIPTION
## Description

See the documentation  

## Motivation

Ease the egg-chicken issue

## Reviewer checklist

* [ ] If this PR modify anything else than sctriclty the default scenario, then remove the `run-default-scenario` label
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Temove `run-default-scenario` label to run all scenarios ([more info](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions))

Once your PR is reviewed, you can merge it ! :heart:
