### PR TITLE
Add cpp parametric test

### DIFF
--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -38,6 +38,7 @@ jobs:
         - java
         - nodejs
         - ruby
+        - cpp
       fail-fast: false
     defaults:
       run:
@@ -76,6 +77,7 @@ jobs:
             - java
             - nodejs
             - ruby
+            - cpp
           fail-fast: false
         env:
           TEST_LIBRARY: ${{ matrix.client }}

--- a/parametric/conftest.py
+++ b/parametric/conftest.py
@@ -34,6 +34,7 @@ from tests.parametric.conftest import (
     java_library_factory,
     php_library_factory,
     ruby_library_factory,
+    cpp_library_factory,
     get_open_port,
     pytest_runtest_makereport,
     test_server_log_file,
@@ -79,6 +80,7 @@ def pytest_configure(config):
 ClientLibraryServerFactory = Callable[[Dict[str, str]], APMLibraryTestServer]
 
 _libs = {
+    "cpp": cpp_library_factory,
     "dotnet": dotnet_library_factory,
     "golang": golang_library_factory,
     "java": java_library_factory,
@@ -89,7 +91,7 @@ _libs = {
     "ruby": ruby_library_factory,
 }
 _enabled_libs: List[Tuple[str, ClientLibraryServerFactory]] = []
-for _lang in os.getenv("CLIENTS_ENABLED", "dotnet,golang,java,nodejs,php,python,python_http,ruby").split(","):
+for _lang in os.getenv("CLIENTS_ENABLED", "cpp,dotnet,golang,java,nodejs,php,python,python_http,ruby").split(","):
     if _lang not in _libs:
         raise ValueError("Incorrect client %r specified, must be one of %r" % (_lang, ",".join(_libs.keys())))
     _enabled_libs.append((_lang, _libs[_lang]))

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -359,6 +359,39 @@ def ruby_library_factory(env: Dict[str, str], container_id: str, port: str) -> A
     )
 
 
+def cpp_library_factory(env: Dict[str, str], container_id: str, port: str) -> APMLibraryTestServer:
+    cpp_appdir = os.path.join("utils", "build", "docker", "cpp", "parametric")
+    cpp_absolute_appdir = os.path.join(_get_base_directory(), cpp_appdir)
+
+    shutil.copyfile(
+        os.path.join(_get_base_directory(), "utils", "parametric", "protos", "apm_test_client.proto"),
+        os.path.join(cpp_absolute_appdir, "apm_test_client.proto"),
+    )
+    return APMLibraryTestServer(
+        lang="cpp",
+        protocol="grpc",
+        container_name="cpp-test-client-%s" % container_id,
+        container_tag="cpp-test-client",
+        container_img=f"""
+FROM datadog/docker-library:dd-trace-cpp-ci AS build
+RUN apt-get update && apt-get -y install pkg-config protobuf-compiler-grpc libgrpc++-dev libabsl-dev
+WORKDIR /cpp-parametric-test
+ADD CMakeLists.txt distributed_headers_dicts.h main.cpp scheduler.h tracing_service.cpp tracing_service.h /cpp-parametric-test/
+ADD apm_test_client.proto /cpp-parametric-test/test_proto3_optional/
+RUN mkdir .build && cd .build && cmake .. && cmake --build . -j $(nproc) && cmake --install .
+
+FROM ubuntu:22.04
+RUN apt-get update && apt-get -y install libgrpc++1 libprotobuf23
+COPY --from=build /usr/local/bin/cpp-parametric-test /usr/local/bin/cpp-parametric-test
+            """,
+        container_cmd=["cpp-parametric-test"],
+        container_build_dir=cpp_absolute_appdir,
+        container_build_context=cpp_absolute_appdir,
+        env=env,
+        port=port,
+    )
+
+
 _libs = {
     "dotnet": dotnet_library_factory,
     "golang": golang_library_factory,

--- a/utils/build/docker/cpp/parametric/.clang-format
+++ b/utils/build/docker/cpp/parametric/.clang-format
@@ -1,0 +1,6 @@
+---
+Language: Cpp
+ColumnLimit: 180
+DerivePointerAlignment: false
+PointerAlignment: Left
+---

--- a/utils/build/docker/cpp/parametric/CMakeLists.txt
+++ b/utils/build/docker/cpp/parametric/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.24)
+
+project(cpp-parametric-test)
+
+set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(FetchContent)
+set(FETCHCONTENT_QUIET OFF)
+
+FetchContent_Declare(
+  dd-trace-cpp
+  GIT_REPOSITORY https://github.com/DataDog/dd-trace-cpp
+  GIT_TAG        main
+  GIT_SHALLOW    ON
+  GIT_PROGRESS   ON
+)
+FetchContent_MakeAvailable(dd-trace-cpp)
+
+include(FindProtobuf)
+
+# Project-level compile options
+add_compile_options(-Wall -Wextra -Werror)
+if (BUILD_COVERAGE)
+  add_compile_options(-g -O0 -fprofile-arcs -ftest-coverage)
+endif()
+
+# grpc client library
+add_library(grpc_apm_test_client)
+target_sources(grpc_apm_test_client PRIVATE test_proto3_optional/apm_test_client.proto)
+
+protobuf_generate(TARGET grpc_apm_test_client)
+protobuf_generate(TARGET grpc_apm_test_client LANGUAGE grpc GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc PLUGIN "protoc-gen-grpc=/usr/bin/grpc_cpp_plugin")
+target_include_directories(grpc_apm_test_client PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(grpc_apm_test_client PUBLIC protobuf::libprotobuf grpc grpc++)
+
+# paramegtric test executable
+add_executable(cpp-parametric-test)
+target_sources(cpp-parametric-test PRIVATE tracing_service.cpp main.cpp)
+target_include_directories(cpp-parametric-test PRIVATE ${dd-trace-cpp_SOURCE_DIR}/src)
+target_link_libraries(cpp-parametric-test PRIVATE dd_trace_cpp-static grpc_apm_test_client)
+
+install(TARGETS cpp-parametric-test RUNTIME DESTINATION bin)

--- a/utils/build/docker/cpp/parametric/distributed_headers_dicts.h
+++ b/utils/build/docker/cpp/parametric/distributed_headers_dicts.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <datadog/dict_reader.h>
+#include <datadog/dict_writer.h>
+
+#include "test_proto3_optional/apm_test_client.pb.h"
+
+class DistributedHTTPHeadersReader : public datadog::tracing::DictReader {
+  const DistributedHTTPHeaders& headers_;
+
+public:
+  DistributedHTTPHeadersReader(const DistributedHTTPHeaders& headers) : headers_(headers) {}
+
+  datadog::tracing::Optional<datadog::tracing::StringView> lookup(datadog::tracing::StringView key) const override {
+    for (int i = 0; i < headers_.http_headers_size(); i++) {
+      if (headers_.http_headers(i).key() == key) {
+        return headers_.http_headers(i).value();
+      }
+    }
+    return datadog::tracing::nullopt;
+  }
+
+  void visit(const std::function<void(datadog::tracing::StringView key, datadog::tracing::StringView value)>& visitor) const override {
+    for (int i = 0; i < headers_.http_headers_size(); i++) {
+      const auto& tuple = headers_.http_headers(i);
+      visitor(tuple.key(), tuple.value());
+    }
+  }
+};
+
+class DistributedHTTPHeadersWriter : public datadog::tracing::DictWriter {
+  DistributedHTTPHeaders* headers_;
+
+public:
+  explicit DistributedHTTPHeadersWriter(DistributedHTTPHeaders* headers) : headers_(headers) {}
+
+  void set(std::string_view key, std::string_view value) override {
+    auto tuple = headers_->add_http_headers();
+    tuple->set_key(std::string(key));
+    tuple->set_value(std::string(value));
+  }
+};

--- a/utils/build/docker/cpp/parametric/main.cpp
+++ b/utils/build/docker/cpp/parametric/main.cpp
@@ -1,0 +1,57 @@
+#include <datadog/cerr_logger.h>
+#include <datadog/tracer.h>
+#include <datadog/tracer_config.h>
+
+#include <grpc/grpc.h>
+#include <grpcpp/server_builder.h>
+
+#include <cstdlib>
+
+#include "scheduler.h"
+#include "tracing_service.h"
+
+int main() {
+  // Might as well use a CerrLogger here, since we don't have our own logging library to adapt to the tracer with.
+  auto logger = std::make_shared<datadog::tracing::CerrLogger>();
+
+  // An event scheduler needs to be shared between the TracingService and the tracer.
+  auto event_scheduler = std::make_shared<ManualScheduler>();
+
+  // Populate tracer configuration with our objects and values.
+  datadog::tracing::TracerConfig config;
+  config.logger = logger;
+  config.agent.event_scheduler = event_scheduler;
+  config.defaults.service = "cpp-parametric-test";
+  config.defaults.environment = "staging";
+  config.defaults.name = "grpc.request";
+
+  // Finalize configuration so we can create a tracer.
+  auto finalized_config = datadog::tracing::finalize_config(config);
+  if (!finalized_config) {
+    logger->log_error("unable to initialize tracer:");
+    logger->log_error(finalized_config.error());
+    return 1;
+  }
+
+  auto tracer = std::make_unique<datadog::tracing::Tracer>(*finalized_config);
+
+  TracingService tracing_service(logger, std::move(tracer), event_scheduler);
+
+  // TODO: check if the port is valid and all.
+  auto grpc_port_env = std::getenv("APM_TEST_CLIENT_SERVER_PORT");
+  if (grpc_port_env == nullptr) {
+    logger->log_error("environment variable APM_TEST_CLIENT_SERVER_PORT is not set");
+    return 1;
+  }
+  std::string grpc_port_str(grpc_port_env);
+
+  // Initialize GRPC service with the provided port number
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort("0.0.0.0:" + grpc_port_str, grpc::InsecureServerCredentials());
+  builder.RegisterService(&tracing_service);
+
+  // Launch things and block until finished.
+  std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
+  server->Wait();
+  return 0;
+}

--- a/utils/build/docker/cpp/parametric/scheduler.h
+++ b/utils/build/docker/cpp/parametric/scheduler.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <datadog/event_scheduler.h>
+#include <datadog/json.hpp>
+
+struct ManualScheduler : public datadog::tracing::EventScheduler {
+  std::function<void()> manual_flush;
+
+  Cancel schedule_recurring_event(std::chrono::steady_clock::duration /* interval */, std::function<void()> callback) override {
+    assert(callback != nullptr);
+    manual_flush = callback;
+    return []() {};
+  }
+
+  nlohmann::json config_json() const override { return nlohmann::json::object({{"type", "ManuaalScheduler"}}); }
+};

--- a/utils/build/docker/cpp/parametric/tracing_service.cpp
+++ b/utils/build/docker/cpp/parametric/tracing_service.cpp
@@ -1,0 +1,127 @@
+#include "tracing_service.h"
+
+#include <datadog/span_config.h>
+
+#include "distributed_headers_dicts.h"
+
+TracingService::TracingService(std::shared_ptr<datadog::tracing::CerrLogger> logger, std::unique_ptr<datadog::tracing::Tracer> tracer,
+                               std::shared_ptr<ManualScheduler> event_scheduler)
+    : logger_(logger), tracer_(std::move(tracer)), event_scheduler_(event_scheduler) {}
+
+TracingService::~TracingService() {}
+
+::grpc::Status TracingService::StartSpan(::grpc::ServerContext* /* context */, const ::StartSpanArgs* request, ::StartSpanReturn* response) {
+  datadog::tracing::SpanConfig config;
+  config.name = request->name();
+  if (request->has_service()) {
+    config.service = request->service();
+  }
+  if (request->has_resource()) {
+    config.resource = request->resource();
+  }
+  if (request->has_type()) {
+    config.service_type = request->type();
+  }
+  // Origin can't be set directly, only via extraction
+  if (request->has_origin()) {
+    logger_->log_error("StartSpanArgs origin, but this can only be set via the 'x-datadog-origin' header");
+  }
+
+  auto span = tracer_->extract_or_create_span(DistributedHTTPHeadersReader(request->http_headers()), config);
+  if (!span) {
+    logger_->log_error("could not extract span from http_headers");
+    logger_->log_error(span.error());
+    return ::grpc::Status(::grpc::StatusCode::INTERNAL, "could not extract span from http_headers");
+  }
+
+  active_spans_.insert({span->id(), std::move(*span)});
+  response->set_trace_id(span->trace_id().low);
+  response->set_span_id(span->id());
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::FinishSpan(::grpc::ServerContext* /* context */, const ::FinishSpanArgs* request, ::FinishSpanReturn* /* response */) {
+  auto span_id = request->id();
+  auto found = active_spans_.find(span_id);
+  if (found == active_spans_.end()) {
+    logger_->log_error("TracingService::FinishSpan: span not found for id " + std::to_string(span_id));
+    return ::grpc::Status(::grpc::StatusCode::INTERNAL, std::string() + "no active span for id " + std::to_string(span_id));
+  }
+
+  // spans finish when they are destroyed
+  active_spans_.erase(found);
+
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::SpanSetMeta(::grpc::ServerContext* /* context */, const ::SpanSetMetaArgs* request, ::SpanSetMetaReturn* /* response */) {
+  auto span_id = request->span_id();
+  auto found = active_spans_.find(span_id);
+  if (found == active_spans_.end()) {
+    logger_->log_error("TracingService::SpanSetMeta: span not found for id " + std::to_string(span_id));
+    return ::grpc::Status(::grpc::StatusCode::INTERNAL, std::string() + "no active span for id " + std::to_string(span_id));
+  }
+  auto& span = found->second;
+
+  span.set_tag(request->key(), request->value());
+
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::SpanSetMetric(::grpc::ServerContext* /* context */, const ::SpanSetMetricArgs* /* request */, ::SpanSetMetricReturn* /* response */) {
+  // No method available for directly setting a span metric.
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status TracingService::SpanSetError(::grpc::ServerContext* /* context */, const ::SpanSetErrorArgs* request, ::SpanSetErrorReturn* /* response */) {
+  auto span_id = request->span_id();
+  auto found = active_spans_.find(span_id);
+  if (found == active_spans_.end()) {
+    logger_->log_error("TracingService::SpanSetError: span not found for id " + std::to_string(span_id));
+    return ::grpc::Status(::grpc::StatusCode::INTERNAL, std::string() + "no active span for id " + std::to_string(span_id));
+  }
+  auto& span = found->second;
+
+  if (request->has_type()) {
+    span.set_error_type(request->type());
+  }
+  if (request->has_message()) {
+    span.set_error_message(request->message());
+  }
+  if (request->has_stack()) {
+    span.set_error_stack(request->stack());
+  }
+
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::InjectHeaders(::grpc::ServerContext* /* context */, const ::InjectHeadersArgs* request, ::InjectHeadersReturn* response) {
+  std::cout << "InjectHeaders" << std::endl;
+  auto span_id = request->span_id();
+  auto found = active_spans_.find(span_id);
+  if (found == active_spans_.end()) {
+    logger_->log_error("TracingService::InjectHeaders: span not found for id " + std::to_string(span_id));
+    return ::grpc::Status(::grpc::StatusCode::INTERNAL, std::string() + "no active span for id " + std::to_string(span_id));
+  }
+  const auto& span = found->second;
+
+  auto headers_writer = DistributedHTTPHeadersWriter(response->mutable_http_headers());
+  span.inject(headers_writer);
+
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::FlushSpans(::grpc::ServerContext* /* context */, const ::FlushSpansArgs* /* request */, ::FlushSpansReturn* /* response */) {
+  event_scheduler_->manual_flush();
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::FlushTraceStats(::grpc::ServerContext* /* context */, const ::FlushTraceStatsArgs* /* request */, ::FlushTraceStatsReturn* /* response */) {
+  // This is a lie to allow a basic test to complete.
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::StopTracer(::grpc::ServerContext* /* context */, const ::StopTracerArgs* /* request */, ::StopTracerReturn* /* response */) {
+  // This is a lie that seems to have no consequence for basic tests.
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}

--- a/utils/build/docker/cpp/parametric/tracing_service.h
+++ b/utils/build/docker/cpp/parametric/tracing_service.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <datadog/cerr_logger.h>
+#include <datadog/span.h>
+#include <datadog/tracer.h>
+
+#include "scheduler.h"
+#include "test_proto3_optional/apm_test_client.grpc.pb.h"
+
+class TracingService final : public APMClient::Service {
+public:
+  TracingService(std::shared_ptr<datadog::tracing::CerrLogger> logger, std::unique_ptr<datadog::tracing::Tracer> tracer, std::shared_ptr<ManualScheduler> event_scheduler);
+  virtual ~TracingService();
+  virtual ::grpc::Status StartSpan(::grpc::ServerContext* /* context */, const ::StartSpanArgs* request, ::StartSpanReturn* response);
+  virtual ::grpc::Status FinishSpan(::grpc::ServerContext* /* context */, const ::FinishSpanArgs* request, ::FinishSpanReturn* response);
+  virtual ::grpc::Status SpanSetMeta(::grpc::ServerContext* /* context */, const ::SpanSetMetaArgs* request, ::SpanSetMetaReturn* response);
+  virtual ::grpc::Status SpanSetMetric(::grpc::ServerContext* /* context */, const ::SpanSetMetricArgs* request, ::SpanSetMetricReturn* response);
+  virtual ::grpc::Status SpanSetError(::grpc::ServerContext* /* context */, const ::SpanSetErrorArgs* request, ::SpanSetErrorReturn* response);
+  virtual ::grpc::Status InjectHeaders(::grpc::ServerContext* /* context */, const ::InjectHeadersArgs* request, ::InjectHeadersReturn* response);
+  virtual ::grpc::Status FlushSpans(::grpc::ServerContext* /* context */, const ::FlushSpansArgs* request, ::FlushSpansReturn* response);
+  virtual ::grpc::Status FlushTraceStats(::grpc::ServerContext* /* context */, const ::FlushTraceStatsArgs* request, ::FlushTraceStatsReturn* response);
+  virtual ::grpc::Status StopTracer(::grpc::ServerContext* /* context */, const ::StopTracerArgs* request, ::StopTracerReturn* response);
+
+private:
+  std::shared_ptr<datadog::tracing::CerrLogger> logger_;
+  std::unique_ptr<datadog::tracing::Tracer> tracer_;
+  std::shared_ptr<ManualScheduler> event_scheduler_;
+  std::unordered_map<uint64_t, datadog::tracing::Span> active_spans_;
+};

--- a/utils/build/docker/cpp/parametric/working-main.cpp
+++ b/utils/build/docker/cpp/parametric/working-main.cpp
@@ -1,0 +1,244 @@
+#include <datadog/dict_reader.h>
+#include <datadog/dict_writer.h>
+#include <datadog/event_scheduler.h>
+#include <datadog/span_config.h>
+#include <datadog/tracer.h>
+#include <datadog/tracer_config.h>
+#include <grpc/grpc.h>
+#include <grpcpp/server_builder.h>
+#include <test_proto3_optional/apm_test_client.grpc.pb.h>
+#include <test_proto3_optional/apm_test_client.pb.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <datadog/json.hpp>
+#include <iostream>
+#include <thread>
+
+class DistributedHTTPHeadersReader : public datadog::tracing::DictReader {
+  const DistributedHTTPHeaders& headers_;
+
+public:
+  DistributedHTTPHeadersReader(const DistributedHTTPHeaders& headers) : headers_(headers) {}
+
+  datadog::tracing::Optional<datadog::tracing::StringView> lookup(datadog::tracing::StringView key) const override {
+    for (int i = 0; i < headers_.http_headers_size(); i++) {
+      if (headers_.http_headers(i).key() == key) {
+        return headers_.http_headers(i).value();
+      }
+    }
+    return datadog::tracing::nullopt;
+  }
+
+  void visit(const std::function<void(datadog::tracing::StringView key, datadog::tracing::StringView value)>& visitor) const override {
+    for (int i = 0; i < headers_.http_headers_size(); i++) {
+      const auto& tuple = headers_.http_headers(i);
+      visitor(tuple.key(), tuple.value());
+    }
+  }
+};
+
+class DistributedHTTPHeadersWriter : public datadog::tracing::DictWriter {
+  DistributedHTTPHeaders* headers_;
+
+public:
+  explicit DistributedHTTPHeadersWriter(DistributedHTTPHeaders* headers) : headers_(headers) {}
+
+  void set(std::string_view key, std::string_view value) override {
+    auto tuple = headers_->add_http_headers();
+    tuple->set_key(std::string(key));
+    tuple->set_value(std::string(value));
+  }
+};
+
+struct ManualScheduler : public datadog::tracing::EventScheduler {
+  std::function<void()> callback;
+
+  Cancel schedule_recurring_event(std::chrono::steady_clock::duration /* interval */, std::function<void()> callback) override {
+    assert(callback != nullptr);
+    callback = callback;
+    return []() {};
+  }
+
+  nlohmann::json config_json() const override { return nlohmann::json::object({{"type", "ManuaalScheduler"}}); }
+};
+
+class TracingService final : public APMClient::Service {
+public:
+  TracingService(std::unique_ptr<datadog::tracing::Tracer> tracer, std::shared_ptr<ManualScheduler> event_scheduler);
+  virtual ~TracingService();
+  virtual ::grpc::Status StartSpan(::grpc::ServerContext* /* context */, const ::StartSpanArgs* request, ::StartSpanReturn* response);
+  virtual ::grpc::Status FinishSpan(::grpc::ServerContext* /* context */, const ::FinishSpanArgs* request, ::FinishSpanReturn* response);
+  virtual ::grpc::Status SpanSetMeta(::grpc::ServerContext* /* context */, const ::SpanSetMetaArgs* request, ::SpanSetMetaReturn* response);
+  virtual ::grpc::Status SpanSetMetric(::grpc::ServerContext* /* context */, const ::SpanSetMetricArgs* request, ::SpanSetMetricReturn* response);
+  virtual ::grpc::Status SpanSetError(::grpc::ServerContext* /* context */, const ::SpanSetErrorArgs* request, ::SpanSetErrorReturn* response);
+  virtual ::grpc::Status InjectHeaders(::grpc::ServerContext* /* context */, const ::InjectHeadersArgs* request, ::InjectHeadersReturn* response);
+  virtual ::grpc::Status FlushSpans(::grpc::ServerContext* /* context */, const ::FlushSpansArgs* request, ::FlushSpansReturn* response);
+  virtual ::grpc::Status FlushTraceStats(::grpc::ServerContext* /* context */, const ::FlushTraceStatsArgs* request, ::FlushTraceStatsReturn* response);
+  virtual ::grpc::Status StopTracer(::grpc::ServerContext* /* context */, const ::StopTracerArgs* request, ::StopTracerReturn* response);
+
+private:
+  std::unique_ptr<datadog::tracing::Tracer> tracer_;
+  std::shared_ptr<ManualScheduler> event_scheduler_;
+  std::unordered_map<int, datadog::tracing::Span> active_spans_;
+};
+
+TracingService::TracingService(std::unique_ptr<datadog::tracing::Tracer> tracer, std::shared_ptr<ManualScheduler> event_scheduler)
+    : tracer_(std::move(tracer)), event_scheduler_(event_scheduler) {}
+
+TracingService::~TracingService() {}
+
+::grpc::Status TracingService::StartSpan(::grpc::ServerContext* /* context */, const ::StartSpanArgs* request, ::StartSpanReturn* response) {
+  std::cout << "StartSpan" << std::endl;
+  datadog::tracing::SpanConfig config;
+  config.name = request->name();
+  if (request->has_service()) {
+    config.service = request->service();
+  }
+  if (request->has_resource()) {
+    config.resource = request->resource();
+  }
+  if (request->has_type()) {
+    config.service_type = request->type();
+  }
+  // Origin can't be set directly, only via extraction
+  if (request->has_origin()) {
+    std::cerr << "unable to set origin." << std::endl;
+  }
+
+  auto span = tracer_->extract_or_create_span(DistributedHTTPHeadersReader(request->http_headers()), config);
+  if (!span) {
+    std::cerr << "could not extract span from http_headers" << std::endl;
+    return ::grpc::Status(::grpc::StatusCode::INTERNAL, "could not extract span from http_headers");
+  }
+
+  active_spans_.insert({span->id(), std::move(*span)});
+  response->set_trace_id(span->trace_id().low);
+  response->set_span_id(span->id());
+  std::cout << "StartSpan returning ok with trace_id " << response->trace_id() << " span_id " << response->span_id() << std::endl;
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::FinishSpan(::grpc::ServerContext* /* context */, const ::FinishSpanArgs* request, ::FinishSpanReturn* response) {
+  (void)request;
+  (void)response;
+  std::cout << "FinishSpan" << std::endl;
+
+  auto span_id = request->id();
+  auto found = active_spans_.find(span_id);
+  if (found == active_spans_.end()) {
+    std::cout << "span not found for id " << span_id << std::endl;
+    return ::grpc::Status(::grpc::StatusCode::INTERNAL, std::string() + "no active span for id " + std::to_string(span_id));
+  }
+  // spans finish when they are destroyed
+  active_spans_.erase(found);
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::SpanSetMeta(::grpc::ServerContext* /* context */, const ::SpanSetMetaArgs* request, ::SpanSetMetaReturn* /* response */) {
+  auto span_id = request->span_id();
+  auto found = active_spans_.find(span_id);
+  if (found == active_spans_.end()) {
+    std::cout << "span not found for id " << span_id << std::endl;
+    return ::grpc::Status(::grpc::StatusCode::INTERNAL, std::string() + "no active span for id " + std::to_string(span_id));
+  }
+  auto& span = found->second;
+  span.set_tag(request->key(), request->value());
+
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::SpanSetMetric(::grpc::ServerContext* /* context */, const ::SpanSetMetricArgs* /* request */, ::SpanSetMetricReturn* /* response */) {
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status TracingService::SpanSetError(::grpc::ServerContext* /* context */, const ::SpanSetErrorArgs* request, ::SpanSetErrorReturn* /* response */) {
+  auto span_id = request->span_id();
+  auto found = active_spans_.find(span_id);
+  if (found == active_spans_.end()) {
+    std::cout << "span not found for id " << span_id << std::endl;
+    return ::grpc::Status(::grpc::StatusCode::INTERNAL, std::string() + "no active span for id " + std::to_string(span_id));
+  }
+  auto& span = found->second;
+
+  if (request->has_type()) {
+    span.set_error_type(request->type());
+  }
+  if (request->has_message()) {
+    span.set_error_message(request->message());
+  }
+  if (request->has_stack()) {
+    span.set_error_stack(request->stack());
+  }
+
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status TracingService::InjectHeaders(::grpc::ServerContext* /* context */, const ::InjectHeadersArgs* request, ::InjectHeadersReturn* response) {
+  std::cout << "InjectHeaders" << std::endl;
+  (void)request;
+  auto span_id = request->span_id();
+  auto found = active_spans_.find(span_id);
+  if (found == active_spans_.end()) {
+    std::cout << "span not found for id " << span_id << std::endl;
+    return ::grpc::Status(::grpc::StatusCode::INTERNAL, std::string() + "no active span for id " + std::to_string(span_id));
+  }
+  const auto& span = found->second;
+  auto headers_writer = DistributedHTTPHeadersWriter(response->mutable_http_headers());
+  span.inject(headers_writer);
+
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::FlushSpans(::grpc::ServerContext* /* context */, const ::FlushSpansArgs* request, ::FlushSpansReturn* response) {
+  std::cout << "FlushSpans" << std::endl;
+  (void)request;
+  (void)response;
+  event_scheduler_->callback();
+
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::FlushTraceStats(::grpc::ServerContext* /* context */, const ::FlushTraceStatsArgs* request, ::FlushTraceStatsReturn* response) {
+  std::cout << "FlushTraceStats" << std::endl;
+  (void)request;
+  (void)response;
+  return ::grpc::Status(::grpc::StatusCode::OK, "");
+}
+
+::grpc::Status TracingService::StopTracer(::grpc::ServerContext* /* context */, const ::StopTracerArgs* request, ::StopTracerReturn* response) {
+  std::cout << "StopTracer" << std::endl;
+  (void)request;
+  (void)response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+int main() {
+  // get grpc port from environment variable
+  // TODO: add some error checking
+  int grpc_port = std::stoi(std::getenv("APM_TEST_CLIENT_SERVER_PORT"));
+
+  auto event_scheduler = std::make_shared<ManualScheduler>();
+
+  datadog::tracing::TracerConfig config;
+  config.defaults.service = "cpp-parametric-test";
+  config.defaults.environment = "staging";
+  config.defaults.name = "grpc.request";
+  config.agent.event_scheduler = event_scheduler;
+
+  auto finalized_config = datadog::tracing::finalize_config(config);
+  if (!finalized_config) {
+    std::cerr << "error initializing dd-trace-cpp: " << finalized_config.error() << std::endl;
+    return 1;
+  }
+
+  TracingService tracing_service(std::make_unique<datadog::tracing::Tracer>(*finalized_config), event_scheduler);
+
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort("0.0.0.0:" + std::to_string(grpc_port), grpc::InsecureServerCredentials());
+  builder.RegisterService(&tracing_service);
+
+  std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
+  server->Wait();
+  return 0;
+}


### PR DESCRIPTION
This adds a basic implementation of the gRPC tracing components but not including OTel workflows.
Failures are expected until some changes are made to dd-trace-cpp to satisfy the tests.

## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [ ] If this PR modify anything else than sctriclty the default scenario, then remove the `run-default-scenario` label
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follows the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Temove `run-default-scenario` label to run all scenarios ([more info](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions))

Once your PR is reviewed, you can merge it ! :heart:
