### PR TITLE
Add IAST unvalidated redirect vertx enpoints

### DIFF
--- a/tests/appsec/iast/sink/test_unvalidated_redirect.py
+++ b/tests/appsec/iast/sink/test_unvalidated_redirect.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import pytest
-from utils import context, coverage, released
+from utils import context, coverage, released, irrelevant
 from ..iast_fixtures import SinkFixture
 
 if context.library == "cpp":
@@ -18,6 +18,10 @@ def _expected_location():
             return "com.datadoghq.resteasy.IastSinkResource"
         if context.weblog_variant == "jersey-grizzly2":
             return "com.datadoghq.jersey.IastSinkResource"
+        if context.weblog_variant == "vertx3":
+            return "com.datadoghq.vertx3.iast.routes.IastSinkRouteProvider"
+        if context.weblog_variant == "vertx4":
+            return "com.datadoghq.vertx4.iast.routes.IastSinkRouteProvider"
     if context.library.library == "nodejs":
         return "iast/index.js"
 
@@ -26,13 +30,15 @@ def _expected_location():
 @released(dotnet="?", golang="?", php_appsec="?", ruby="?", python="?", nodejs="?")
 @released(
     java={
-        "spring-boot": "?",
-        "spring-boot-jetty": "?",
-        "spring-boot-openliberty": "?",
-        "spring-boot-wildfly": "?",
-        "spring-boot-undertow": "?",
-        "resteasy-netty3": "?",
-        "jersey-grizzly2": "?",
+        "spring-boot": "1.16.0",
+        "spring-boot-jetty": "1.17.0",
+        "spring-boot-openliberty": "1.16.0",
+        "spring-boot-wildfly": "1.16.0",
+        "spring-boot-undertow": "1.16.0",
+        "resteasy-netty3": "1.16.0",
+        "jersey-grizzly2": "1.16.0",
+        "vertx3": "1.16.0",
+        "vertx4": "1.17.0",
         "*": "?",
     }
 )
@@ -71,11 +77,13 @@ class TestUnvalidatedRedirect:
     def setup_insecure_redirect(self):
         self.sink_fixture_redirect.setup_insecure()
 
+    @irrelevant(library="java", weblog_variant="vertx3", reason="vertx3 redirects using location header")
     def test_insecure_redirect(self):
         self.sink_fixture_redirect.test_insecure()
 
     def setup_secure_redirect(self):
         self.sink_fixture_redirect.setup_secure()
 
+    @irrelevant(library="java", weblog_variant="vertx3", reason="vertx3 redirects using location header")
     def test_secure_redirect(self):
         self.sink_fixture_redirect.test_secure()

--- a/tests/appsec/iast/sink/test_unvalidated_redirect_forward.py
+++ b/tests/appsec/iast/sink/test_unvalidated_redirect_forward.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import pytest
-from utils import context, coverage, released
+from utils import context, coverage, released, missing_feature
 from ..iast_fixtures import SinkFixture
 
 if context.library == "cpp":
@@ -14,23 +14,25 @@ def _expected_location():
     if context.library.library == "java":
         if context.weblog_variant.startswith("spring-boot"):
             return "com.datadoghq.system_tests.springboot.AppSecIast"
-        if context.weblog_variant == "resteasy-netty3":
-            return "com.datadoghq.resteasy.IastSinkResource"
-        if context.weblog_variant == "jersey-grizzly2":
-            return "com.datadoghq.jersey.IastSinkResource"
+        if context.weblog_variant == "vertx3":
+            return "com.datadoghq.vertx3.iast.routes.IastSinkRouteProvider"
+        if context.weblog_variant == "vertx4":
+            return "com.datadoghq.vertx4.iast.routes.IastSinkRouteProvider"
 
 
 @coverage.basic
 @released(dotnet="?", golang="?", php_appsec="?", ruby="?", python="?", nodejs="?")
 @released(
     java={
-        "spring-boot": "?",
-        "spring-boot-jetty": "?",
-        "spring-boot-openliberty": "?",
-        "spring-boot-wildfly": "?",
-        "spring-boot-undertow": "?",
-        "resteasy-netty3": "?",
-        "jersey-grizzly2": "?",
+        "spring-boot": "1.16.0",
+        "spring-boot-jetty": "1.16.0",
+        "spring-boot-openliberty": "1.16.0",
+        "spring-boot-wildfly": "1.16.0",
+        "spring-boot-undertow": "1.16.0",
+        "resteasy-netty3": "1.16.0",
+        "jersey-grizzly2": "1.16.0",
+        "vertx3": "1.16.0",
+        "vertx4": "1.17.0",
         "*": "?",
     }
 )
@@ -49,11 +51,15 @@ class TestUnvalidatedForward:
     def setup_insecure_forward(self):
         self.sink_fixture_forward.setup_insecure()
 
+    @missing_feature(library="java", weblog_variant="resteasy-netty3")
+    @missing_feature(library="java", weblog_variant="jersey-grizzly2")
     def test_insecure_forward(self):
         self.sink_fixture_forward.test_insecure()
 
     def setup_secure_forward(self):
         self.sink_fixture_forward.setup_secure()
 
+    @missing_feature(library="java", weblog_variant="resteasy-netty3")
+    @missing_feature(library="java", weblog_variant="jersey-grizzly2")
     def test_secure_forward(self):
         self.sink_fixture_forward.test_secure()

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
@@ -89,5 +89,24 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         router.get("/iast/weak_randomness/test_secure").handler(ctx ->
                 ctx.response().end(weakRandomness.secureRandom())
         );
+        router.post("/iast/unvalidated_redirect/test_insecure_forward").handler(ctx ->{
+                    final HttpServerRequest request = ctx.request();
+                    final String location = request.getParam("location");
+                    ctx.reroute(location);
+        }
+        );
+        router.post("/iast/unvalidated_redirect/test_secure_forward").handler(ctx ->
+                ctx.reroute("http://dummy.location.com")
+        );
+        router.post("/iast/unvalidated_redirect/test_insecure_header").handler(ctx ->
+                {
+                    final HttpServerRequest request = ctx.request();
+                    final String location = request.getParam("location");
+                    ctx.response().putHeader("Location", location).end();
+                }
+        );
+        router.post("/iast/unvalidated_redirect/test_secure_header").handler(ctx ->
+                ctx.response().putHeader("Location", "http://dummy.location.com").end()
+        );
     }
 }

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
@@ -85,5 +85,34 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         router.get("/iast/weak_randomness/test_secure").handler(ctx ->
                 ctx.response().end(weakRandomness.secureRandom())
         );
+        router.post("/iast/unvalidated_redirect/test_insecure_forward").handler(ctx ->{
+                    final HttpServerRequest request = ctx.request();
+                    final String location = request.getParam("location");
+                    ctx.reroute(location);
+                }
+        );
+        router.post("/iast/unvalidated_redirect/test_secure_forward").handler(ctx ->
+                ctx.reroute("http://dummy.location.com")
+        );
+        router.post("/iast/unvalidated_redirect/test_insecure_header").handler(ctx ->
+                {
+                    final HttpServerRequest request = ctx.request();
+                    final String location = request.getParam("location");
+                    ctx.response().putHeader("Location", location).end();
+                }
+        );
+        router.post("/iast/unvalidated_redirect/test_secure_header").handler(ctx ->
+                ctx.response().putHeader("Location", "http://dummy.location.com").end()
+        );
+        router.post("/iast/unvalidated_redirect/test_insecure_redirect").handler(ctx ->
+                {
+                    final HttpServerRequest request = ctx.request();
+                    final String location = request.getParam("location");
+                    ctx.redirect(location);
+                }
+        );
+        router.post("/iast/unvalidated_redirect/test_secure_redirect").handler(ctx ->
+                ctx.redirect("http://dummy.location.com")
+        );
     }
 }


### PR DESCRIPTION
## Description

- Add vertx3 unvalidated redirect endpoints
- Add vertx4 unvalidated redirect endpoints
- Enable xpassed tests for java unvalidated redirect

## Motivation

Test unvalidated redirect vulnerability

## Additional Notes

Some test are enabled for next version (1.17.0) 
