### PR TITLE
Add IAST XPath injection system test

### DIFF
--- a/tests/appsec/iast/sink/test_xpath_injection.py
+++ b/tests/appsec/iast/sink/test_xpath_injection.py
@@ -11,22 +11,9 @@ if context.library == "cpp":
 
 
 @coverage.basic
-@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?")
-@released(
-    java={
-        "spring-boot": "1.18.0",
-        "spring-boot-jetty": "1.18.0",
-        "spring-boot-openliberty": "1.18.0",
-        "spring-boot-payara": "1.18.0",
-        "spring-boot-wildfly": "1.18.0",
-        "spring-boot-undertow": "1.18.0",
-        "resteasy-netty3": "1.18.0",
-        "jersey-grizzly2": "1.18.0",
-        "vertx3": "1.18.0",
-        "akka-http": "1.18.0",
-        "*": "?",
-    }
-)
+@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?", java="?")
+@missing_feature(weblog_variant="ratpatck", reason="Sources not supported yet")
+@missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
 class TestXPathInjection:
     """Test xpath injection detection."""
 

--- a/tests/appsec/iast/sink/test_xpath_injection.py
+++ b/tests/appsec/iast/sink/test_xpath_injection.py
@@ -11,7 +11,22 @@ if context.library == "cpp":
 
 
 @coverage.basic
-@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?", java="1.18.0")
+@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?")
+@released(
+    java={
+        "spring-boot": "1.18.0",
+        "spring-boot-jetty": "1.18.0",
+        "spring-boot-openliberty": "1.18.0",
+        "spring-boot-payara": "1.18.0",
+        "spring-boot-wildfly": "1.18.0",
+        "spring-boot-undertow": "1.18.0",
+        "resteasy-netty3": "1.18.0",
+        "jersey-grizzly2": "1.18.0",
+        "vertx3": "1.18.0",
+        "akka-http": "1.18.0",
+        "*": "?",
+    }
+)
 class TestXPathInjection:
     """Test xpath injection detection."""
 

--- a/tests/appsec/iast/sink/test_xpath_injection.py
+++ b/tests/appsec/iast/sink/test_xpath_injection.py
@@ -11,7 +11,7 @@ if context.library == "cpp":
 
 
 @coverage.basic
-@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?", java="?")
+@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?")
 @released(java={"ratpack": "?", "spring-boot-3-native": "?", "*": "1.18.0"})
 class TestXPathInjection:
     """Test xpath injection detection."""

--- a/tests/appsec/iast/sink/test_xpath_injection.py
+++ b/tests/appsec/iast/sink/test_xpath_injection.py
@@ -12,8 +12,7 @@ if context.library == "cpp":
 
 @coverage.basic
 @released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?", java="?")
-@missing_feature(weblog_variant="ratpatck", reason="Sources not supported yet")
-@missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
+@released(java={"ratpack": "?", "spring-boot-3-native":"?", "*": "1.18.0"})
 class TestXPathInjection:
     """Test xpath injection detection."""
 

--- a/tests/appsec/iast/sink/test_xpath_injection.py
+++ b/tests/appsec/iast/sink/test_xpath_injection.py
@@ -6,11 +6,14 @@ import pytest
 from utils import context, coverage, released, missing_feature
 from ..iast_fixtures import SinkFixture
 
+if context.library == "cpp":
+    pytestmark = pytest.mark.skip("not relevant")
+
 
 @coverage.basic
 @released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", java="?")
 class TestXPathInjection:
-    """Test command injection detection."""
+    """Test xpath injection detection."""
 
     sink_fixture = SinkFixture(
         vulnerability_type="XPATH_INJECTION",

--- a/tests/appsec/iast/sink/test_xpath_injection.py
+++ b/tests/appsec/iast/sink/test_xpath_injection.py
@@ -1,0 +1,34 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+import pytest
+from utils import context, coverage, released, missing_feature
+from ..iast_fixtures import SinkFixture
+
+
+@coverage.basic
+@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", java="?")
+class TestXPathInjection:
+    """Test command injection detection."""
+
+    sink_fixture = SinkFixture(
+        vulnerability_type="XPATH_INJECTION",
+        http_method="POST",
+        insecure_endpoint="/iast/xpathi/test_insecure",
+        secure_endpoint="/iast/xpathi/test_secure",
+        data={"expression": "expression"},
+        location_map={"java": "com.datadoghq.system_tests.iast.utils.XPathExamples"},
+    )
+
+    def setup_insecure(self):
+        self.sink_fixture.setup_insecure()
+
+    def test_insecure(self):
+        self.sink_fixture.test_insecure()
+
+    def setup_secure(self):
+        self.sink_fixture.setup_secure()
+
+    def test_secure(self):
+        self.sink_fixture.test_secure()

--- a/tests/appsec/iast/sink/test_xpath_injection.py
+++ b/tests/appsec/iast/sink/test_xpath_injection.py
@@ -11,7 +11,7 @@ if context.library == "cpp":
 
 
 @coverage.basic
-@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", java="?")
+@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?", java="?")
 class TestXPathInjection:
     """Test xpath injection detection."""
 

--- a/tests/appsec/iast/sink/test_xpath_injection.py
+++ b/tests/appsec/iast/sink/test_xpath_injection.py
@@ -12,7 +12,7 @@ if context.library == "cpp":
 
 @coverage.basic
 @released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?", java="?")
-@released(java={"ratpack": "?", "spring-boot-3-native":"?", "*": "1.18.0"})
+@released(java={"ratpack": "?", "spring-boot-3-native": "?", "*": "1.18.0"})
 class TestXPathInjection:
     """Test xpath injection detection."""
 

--- a/tests/appsec/iast/sink/test_xpath_injection.py
+++ b/tests/appsec/iast/sink/test_xpath_injection.py
@@ -11,7 +11,7 @@ if context.library == "cpp":
 
 
 @coverage.basic
-@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?", java="?")
+@released(dotnet="?", golang="?", php_appsec="?", python="?", ruby="?", nodejs="?", java="1.18.0")
 class TestXPathInjection:
     """Test xpath injection detection."""
 

--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/IastRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/IastRoutes.scala
@@ -21,6 +21,7 @@ object IastRoutes {
   private val ldap = new LDAPExamples(ldapContext)
   private val path_ = new PathExamples()
   private val sql = new SqlExamples(dataSource)
+  private val xpath = new XPathExamples()
 
   val route: Route = pathPrefix("iast") {
     pathPrefix("insecure_hashing") {
@@ -82,6 +83,20 @@ object IastRoutes {
           }
         }
       } ~
+      pathPrefix("xpathi") {
+              post {
+                path("test_insecure") {
+                  paramOrFormField("expression") { expression =>
+                    xpath.insecureXPath(expression)
+                    complete(StatusCodes.OK, "Insecure")
+                  }
+                } ~
+                  path("test_secure") {
+                    xpath.secureXPath()
+                    complete(StatusCodes.OK, "Secure")
+                  }
+              }
+            } ~
       path("path_traversal" / "test_insecure") {
         post {
           paramOrFormField("path") { pathParam =>

--- a/utils/build/docker/java/iast-common/src/main/java/com/datadoghq/system_tests/iast/utils/XPathExamples.java
+++ b/utils/build/docker/java/iast-common/src/main/java/com/datadoghq/system_tests/iast/utils/XPathExamples.java
@@ -1,0 +1,24 @@
+package com.datadoghq.system_tests.iast.utils;
+
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.lang.reflect.UndeclaredThrowableException;
+
+public class XPathExamples {
+
+    public void insecureXPath(final String expression) {
+        try {
+            XPathFactory.newInstance().newXPath().compile(expression);
+        } catch (XPathExpressionException e) {
+            throw new UndeclaredThrowableException(e);
+        }
+    }
+
+    public void secureXPath() {
+        try {
+            XPathFactory.newInstance().newXPath().compile("expression");
+        } catch (XPathExpressionException e) {
+            throw new UndeclaredThrowableException(e);
+        }
+    }
+}

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/IastSinkResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/IastSinkResource.java
@@ -1,12 +1,6 @@
 package com.datadoghq.jersey;
 
-import com.datadoghq.system_tests.iast.utils.CmdExamples;
-import com.datadoghq.system_tests.iast.utils.CryptoExamples;
-import com.datadoghq.system_tests.iast.utils.LDAPExamples;
-import com.datadoghq.system_tests.iast.utils.PathExamples;
-import com.datadoghq.system_tests.iast.utils.SqlExamples;
-import com.datadoghq.system_tests.iast.utils.SsrfExamples;
-import com.datadoghq.system_tests.iast.utils.WeakRandomnessExamples;
+import com.datadoghq.system_tests.iast.utils.*;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
 
@@ -33,6 +27,8 @@ public class IastSinkResource {
     private final PathExamples path = new PathExamples();
     private final SsrfExamples ssrf = new SsrfExamples();
     private final WeakRandomnessExamples weakRandomness = new WeakRandomnessExamples();
+
+    private final XPathExamples xPathExamples = new XPathExamples();
 
     @GET
     @Path("/insecure_hashing/deduplicate")
@@ -187,6 +183,20 @@ public class IastSinkResource {
     @Path("/unvalidated_redirect/test_insecure_redirect")
     public Response insecureUnvalidatedRedirect(@FormParam("location") final String location) throws URISyntaxException {
         return Response.status(Response.Status.TEMPORARY_REDIRECT).location(new URI(location)).build();
+    }
+
+    @POST
+    @Path("/xpathi/test_secure")
+    public String secureXPath() {
+        xPathExamples.secureXPath();
+        return "Secure";
+    }
+
+    @POST
+    @Path("/xpathi/test_insecure")
+    public String insecureXPath(@FormParam("expression") final String expression) {
+        xPathExamples.insecureXPath(expression);
+        return "Insecure";
     }
 
     @GET

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/IastSinkResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/IastSinkResource.java
@@ -29,6 +29,8 @@ public class IastSinkResource {
     private final SsrfExamples ssrf = new SsrfExamples();
     private final WeakRandomnessExamples weakRandomness = new WeakRandomnessExamples();
 
+    private final XPathExamples xPathExamples = new XPathExamples();
+
     @GET
     @Path("/insecure_hashing/deduplicate")
     public String removeDuplicates() {
@@ -182,6 +184,20 @@ public class IastSinkResource {
     @Path("/unvalidated_redirect/test_insecure_redirect")
     public Response insecureUnvalidatedRedirect(@FormParam("location") final String location) throws URISyntaxException {
         return Response.status(Response.Status.TEMPORARY_REDIRECT).location(new URI(location)).build();
+    }
+
+    @POST
+    @Path("/xpathi/test_secure")
+    public String secureXPath() {
+        xPathExamples.secureXPath();
+        return "Secure";
+    }
+
+    @POST
+    @Path("/xpathi/test_insecure")
+    public String insecureXPath(@FormParam("expression") final String expression) {
+        xPathExamples.insecureXPath(expression);
+        return "Insecure";
     }
 
     @GET

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
@@ -32,6 +32,8 @@ public class AppSecIast {
     private final SsrfExamples ssrfExamples;
     private final WeakRandomnessExamples weakRandomnessExamples;
 
+    private final XPathExamples xPathExamples;
+
 
     public AppSecIast(final DataSource dataSource) {
         this.sqlExamples = new SqlExamples(dataSource);
@@ -40,6 +42,7 @@ public class AppSecIast {
         this.cryptoExamples = new CryptoExamples();
         this.ssrfExamples = new SsrfExamples();
         this.weakRandomnessExamples = new WeakRandomnessExamples();
+        this.xPathExamples = new XPathExamples();
     }
 
     @RequestMapping("/insecure_hashing/deduplicate")
@@ -256,6 +259,19 @@ public class AppSecIast {
     String noHttpOnlyCookieSecure(final HttpServletResponse response) {
         response.addHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict");
         return "ok";
+    }
+
+    @PostMapping("/xpathi/test_insecure")
+    String insecureXPath(final ServletRequest request) {
+        final String expression = request.getParameter("expression");
+        xPathExamples.insecureXPath(expression);
+        return "XPath insecure";
+    }
+
+    @PostMapping("/xpathi/test_secure")
+    String secureXPath(final ServletRequest request) {
+        xPathExamples.secureXPath();
+        return "XPath secure";
     }
 
     /**

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
@@ -30,6 +30,7 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         final SqlExamples sql = new SqlExamples(dataSource);
         final SsrfExamples ssrf = new SsrfExamples();
         final WeakRandomnessExamples weakRandomness = new WeakRandomnessExamples();
+        final XPathExamples xpath = new XPathExamples();
 
         router.route("/iast/*").handler(BodyHandler.create());
 
@@ -136,5 +137,15 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         router.get("/iast/no-httponly-cookie/test_secure").handler(ctx ->
                 ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").end()
         );
+        router.post("/iast/xpathi/test_insecure").handler(ctx -> {
+            final HttpServerRequest request = ctx.request();
+            final String expression = request.getParam("expression");
+            xpath.insecureXPath(expression);
+            ctx.response().end("Insecure");
+        });
+        router.post("/iast/xpathi/test_secure").handler(ctx -> {
+            xpath.secureXPath();
+            ctx.response().end("Secure");
+        });
     }
 }

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
@@ -29,6 +29,7 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         final PathExamples path = new PathExamples();
         final SqlExamples sql = new SqlExamples(dataSource);
         final WeakRandomnessExamples weakRandomness = new WeakRandomnessExamples();
+        final XPathExamples xpath = new XPathExamples();
 
         router.route("/iast/*").handler(BodyHandler.create());
 
@@ -114,6 +115,16 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         router.post("/iast/unvalidated_redirect/test_secure_redirect").handler(ctx ->
                 ctx.redirect("http://dummy.location.com")
         );
+        router.post("/iast/xpathi/test_insecure").handler(ctx -> {
+            final HttpServerRequest request = ctx.request();
+            final String expression = request.getParam("expression");
+            xpath.insecureXPath(expression);
+            ctx.response().end("Insecure");
+        });
+        router.post("/iast/xpathi/test_secure").handler(ctx -> {
+            xpath.secureXPath();
+            ctx.response().end("Secure");
+        });
         router.get("/iast/insecure-cookie/test_empty_cookie").handler(ctx ->
                 ctx.response().putHeader("Set-Cookie", "").end()
         );


### PR DESCRIPTION
## Description
- Add XPath injection tests 
- Add Java XPath injection enpoints in:
   - spring-boot
   - resteasy-netty3
   - jersey-grizzly2
   - vertx3
   - vertx4
   - akka

## Motivation
Test XPath vulnerability

## Additional Notes
Some test are enabled for next dd-java-agent version (1.17.0) 
