### PR TITLE
Reduce flakiness on span sampling tests.

### DIFF
--- a/tests/parametric/test_span_sampling.py
+++ b/tests/parametric/test_span_sampling.py
@@ -200,11 +200,11 @@ class Test_Span_Sampling:
         """Test span sampling tags are added until rate limit hit, then need to wait for tokens to reset"""
         # generate three traces before requesting them to avoid timing issues
         with test_library:
-            for i in range(3):
+            for i in range(6):
                 with test_library.start_span(name="web.request", service="webserver"):
                     pass
 
-        traces = test_agent.wait_for_num_traces(3, clear=True)
+        traces = test_agent.wait_for_num_traces(6, clear=True)
 
         # expect first and second traces sampled
         span = find_span_in_traces(traces[:1], Span(name="web.request", service="webserver"))
@@ -216,9 +216,11 @@ class Test_Span_Sampling:
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_RATE) == 1.0
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MECHANISM) == 8
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MAX_PER_SEC) == 2
-
-        # expect third trace unsampled because of rate limiters
-        span = find_span_in_traces(traces[2:], Span(name="web.request", service="webserver"))
+        # Some issues related with timming. It's difficult to be so accurate and it can cause flakiness
+        # For example code in the Java tracer starts the clock as soon as the limiter is created.
+        # This means that even though all traces happen within ~59 ms, they could straddle two token buckets and hence all be allowed to pass
+        # Given 6 traces, at least the last two traces are unsampled because of rate limiters
+        span = find_span_in_traces(traces[5:6], Span(name="web.request", service="webserver"))
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_RATE) is None
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MECHANISM) is None
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MAX_PER_SEC) is None
@@ -427,37 +429,38 @@ class Test_Span_Sampling:
         """
         # generate spans before requesting them to avoid timing issues
         with test_library:
-            for i in range(2):
+            for i in range(4):
                 with test_library.start_span(name="web.request", service="webserver"):
                     pass
-            for i in range(3):
+            for i in range(6):
                 with test_library.start_span(name="web.request2", service="webserver2"):
                     pass
 
-        traces = test_agent.wait_for_num_traces(5, clear=True)
-
+        traces = test_agent.wait_for_num_traces(10, clear=True)
+        # Some issues related with timming. It's difficult to be so accurate and it can cause flakiness
+        # We check at least last trace is unsampled
         span = find_span_in_traces(traces[:1], Span(name="web.request", service="webserver"))
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_RATE) == 1.0
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MECHANISM) == SINGLE_SPAN_SAMPLING_MECHANISM_VALUE
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MAX_PER_SEC) == 1
 
-        span = find_span_in_traces(traces[1:2], Span(name="web.request", service="webserver"))
+        span = find_span_in_traces(traces[3:4], Span(name="web.request", service="webserver"))
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_RATE) is None
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MECHANISM) is None
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MAX_PER_SEC) is None
 
-        # for trace in traces[2:4]:
-        span = find_span_in_traces(traces[2:3], Span(name="web.request2", service="webserver2"))
-        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_RATE) == 1.0
-        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MECHANISM) == SINGLE_SPAN_SAMPLING_MECHANISM_VALUE
-        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MAX_PER_SEC) == 2
-
-        span = find_span_in_traces(traces[3:4], Span(name="web.request2", service="webserver2"))
-        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_RATE) == 1.0
-        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MECHANISM) == SINGLE_SPAN_SAMPLING_MECHANISM_VALUE
-        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MAX_PER_SEC) == 2
-
+        # for trace in traces[4:10]:
         span = find_span_in_traces(traces[4:5], Span(name="web.request2", service="webserver2"))
+        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_RATE) == 1.0
+        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MECHANISM) == SINGLE_SPAN_SAMPLING_MECHANISM_VALUE
+        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MAX_PER_SEC) == 2
+
+        span = find_span_in_traces(traces[5:6], Span(name="web.request2", service="webserver2"))
+        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_RATE) == 1.0
+        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MECHANISM) == SINGLE_SPAN_SAMPLING_MECHANISM_VALUE
+        assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MAX_PER_SEC) == 2
+
+        span = find_span_in_traces(traces[8:9], Span(name="web.request2", service="webserver2"))
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_RATE) is None
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MECHANISM) is None
         assert span["metrics"].get(SINGLE_SPAN_SAMPLING_MAX_PER_SEC) is None


### PR DESCRIPTION
It is difficult to be very accurate when we specify one or two request per second span sampling rate limit

## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then remove the `run-default-scenario` label
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

> **_NOTE:_**  By default in PR only default scenario tests will be launched. Remove the `run-default-scenario` label to run all scenarios ([more info](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2866381467/CI+Workflow+Github+Actions))

Once your PR is reviewed, you can merge it! :heart:
