### PR TITLE
Logs for experimental tests (lib-injection)

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: lib-injection test runner
         id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@main
+        uses: DataDog/system-tests/lib-injection/runner@robertomonteromiguel/test_lib_injection
         with:
           docker-registry: ghcr.io
           docker-registry-username: ${{ github.actor }}
@@ -98,9 +98,9 @@ jobs:
     steps:
       - name: lib-injection test runner
         id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@main
+        uses: DataDog/system-tests/lib-injection/runner@robertomonteromiguel/test_lib_injection
         with:
           docker-registry: ghcr.io
           docker-registry-username: ${{ github.actor }}
           docker-registry-password: ${{ secrets.GITHUB_TOKEN }}
-          test-script: ./lib-injection/run-auto-lib-injection.sh || ./lib-injection/execFunction.sh print-debug-info-auto
+          test-script: ./lib-injection/run-auto-lib-injection.sh

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -103,4 +103,4 @@ jobs:
           docker-registry: ghcr.io
           docker-registry-username: ${{ github.actor }}
           docker-registry-password: ${{ secrets.GITHUB_TOKEN }}
-          test-script: ./lib-injection/run-auto-lib-injection.sh
+          test-script: ./lib-injection/run-auto-lib-injection.sh || ./lib-injection/execFunction.sh print-debug-info-auto

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: lib-injection test runner
         id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@robertomonteromiguel/test_lib_injection
+        uses: DataDog/system-tests/lib-injection/runner@main
         with:
           docker-registry: ghcr.io
           docker-registry-username: ${{ github.actor }}

--- a/lib-injection/README.md
+++ b/lib-injection/README.md
@@ -94,6 +94,7 @@ We can find some environment variables that we need to define previously:
 * **deploy-operator:** Deploys Datadog operator in the case that we are using Admission Controller. It uses common/operator-helm-values.yaml or common/operator-helm-values-uds.yaml to configure Admission Controller.
 * **deploy-test-agent:** Deploys Datadog Agent in Kubernetes cluster, using configuration file: test/resources/dd-apm-test-agent-config.yaml.
 * **deploy-app:** Deploys sample application/weblog in Kubernetes cluster, using template file: lib-injection/build/docker/$TEST_LIBRARY/values-override.yaml.
+* **print-debug-info:** prints and log debug information for kubernertes cluster and library injection tests
 
 ## How to run the lib-injection tests in CI
 
@@ -159,8 +160,8 @@ When we have the environment ready, we have to execute this logic:
 * Create the Kubernetes cluster
 
 ```sh
-./lib-injection/run.sh build-and-push-init-image
-./lib-injection/run.sh build-and-push-test-app-image
+./lib-injection/execFunction.sh build-and-push-init-image
+./lib-injection/execFunction.sh build-and-push-test-app-image
 ./lib-injection/build.sh
 ```
 
@@ -175,6 +176,14 @@ When we have the environment ready, we have to execute this logic:
 ```sh
 TEST_CASE=<TestCaseN>  # define the test case
 ./lib-injection/run-auto-lib-injection.sh
+```
+
+## How to debug your kubernetes environment
+
+After running the tests you can always run the following command to export all the information from the kubernetes cluster to the logs folder:
+
+```sh
+./lib-injection/execFunction.sh print-debug-info
 ```
 
 ## How to create init images in your tracer repository

--- a/lib-injection/runner/action.yml
+++ b/lib-injection/runner/action.yml
@@ -54,6 +54,13 @@ runs:
           cd system-tests
           ${{ inputs.test-script }}
 
+      - name: Debug kubernetes cluster info
+        shell: bash
+        if: ${{ always() }}
+        run: |
+          cd system-tests
+          ./lib-injection/execFunction.sh print-debug-info
+
       - name: Compress lib injection logs
         shell: bash
         if: ${{ always() }}

--- a/lib-injection/src/test/shell/functions.sh
+++ b/lib-injection/src/test/shell/functions.sh
@@ -315,10 +315,8 @@ function check-for-no-pod-metadata() {
     has_enabled_key=$(kubectl get ${pod} -ojson | jq .metadata.labels | jq 'has("admission.datadoghq.com/enabled")')
     if [[ $has_enabled_key != "false" ]]; then
         echo "[Test] label 'admission.datadoghq.com/enabled' was unexpectedly applied to the pod!"
-        print-debug-info || true
         exit 1
     fi
-    print-debug-info || true
 }
 
 # check-for-no-pod-metadata ensures that admission is disabled on the targeted pod.
@@ -359,13 +357,11 @@ function test-for-traces() {
     echo "[Test] ${traces}"
     if [[ ${#traces} -lt 3 ]] ; then
         echoerr "No traces reported - ${traces}"
-        print-debug-info || true
         exit 1
     else
         count=`jq '. | length' <<< "${traces}"`
         echo "Received ${count} traces so far"
     fi
-    print-debug-info || true
     echo "[Test] test-for-traces completed successfully"
 }
 

--- a/lib-injection/src/test/shell/functions.sh
+++ b/lib-injection/src/test/shell/functions.sh
@@ -401,7 +401,7 @@ function print-debug-info-manual() {
     echo "[debug] Generating debug log files (manual lib injection)... (${log_dir})"
     echo "[debug] Export: Current cluster status"
     kubectl get pods > "${log_dir}/cluster_pods.log"
-    kubectl get deployments datadog-cluster-agent > "${log_dir}/cluster_deployments.log"
+    kubectl get deployments datadog-cluster-agent > "${log_dir}/cluster_deployments.log" || true
 
     echo "[debug] Export: Describe my-app status"
     kubectl describe pod my-app > "${log_dir}/my-app_describe.log"

--- a/lib-injection/src/test/shell/functions.sh
+++ b/lib-injection/src/test/shell/functions.sh
@@ -367,14 +367,14 @@ function test-for-traces() {
 
 # print-debug-info prints and zip debug information
 function print-debug-info() {
-    if [[ $MODE == "manual" ]]; then print-debug-info-manual; else print-debug-info-auto; fi
+    if [[ $MODE == manual* ]]; then print-debug-info-manual; else print-debug-info-auto; fi
 }
 
 # print-debug-info-auto prints and zip debug information for auto library injection tests
 function print-debug-info-auto() {
     log_dir=${BASE_DIR}/../logs_lib-injection
     mkdir -p ${log_dir}/pod
-    echo "[debug] Generating debug log files... (${log_dir})"
+    echo "[debug] Generating debug log files (auto lib injection)... (${log_dir})"
     echo "[debug] Export: Current cluster status"
     kubectl get pods > "${log_dir}/cluster_pods.log"
     kubectl get deployments datadog-cluster-agent > "${log_dir}/cluster_deployments.log"
@@ -398,7 +398,7 @@ function print-debug-info-auto() {
 function print-debug-info-manual() {
     log_dir=${BASE_DIR}/../logs_lib-injection
     mkdir -p ${log_dir}/pod
-    echo "[debug] Generating debug log files... (${log_dir})"
+    echo "[debug] Generating debug log files (manual lib injection)... (${log_dir})"
     echo "[debug] Export: Current cluster status"
     kubectl get pods > "${log_dir}/cluster_pods.log"
     kubectl get deployments datadog-cluster-agent > "${log_dir}/cluster_deployments.log"


### PR DESCRIPTION
## Description

Log outputs for experimental tests.
Currently the "auto lib-injection" tests are failing, but we can't access to the logs.

I removed the calls to the "print-debug-info" from inside the scripts.
I think we don't need to call this method from other functions:
- When something fails, in most cases we do not get to execute the "print-debug-info" function, because the execution of the script is aborted.
- Multiple calls from different locations messes up the code a bit.

Added the existence of this method to the documentation.
Added the call to this method "always" after launch the tests

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->
Currently the "auto lib-injection" tests are failing, but we can't access to the logs.

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:
