### PR TITLE
Late pulumi import: improve pytest performance

### DIFF
--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -4,13 +4,11 @@ from pathlib import Path
 import shutil
 import time
 
-from pulumi import automation as auto
 import pytest
 from watchdog.observers.polling import PollingObserver
 from watchdog.events import FileSystemEventHandler
 from utils._context.library_version import LibraryVersion, Version
 from utils.onboarding.provision_utils import ProvisionMatrix, ProvisionFilter
-from utils.onboarding.pulumi_ssh import PulumiSSH
 
 from utils._context.containers import (
     WeblogContainer,
@@ -705,6 +703,9 @@ class OnBoardingScenario(_Scenario):
         return LibraryVersion(os.getenv("TEST_LIBRARY"), "0.0")
 
     def _start_pulumi(self):
+        from pulumi import automation as auto
+        from utils.onboarding.pulumi_ssh import PulumiSSH
+
         def pulumi_start_program():
             # Static loading of keypairs for ec2 machines
             PulumiSSH.load()

--- a/utils/_context/virtual_machines.py
+++ b/utils/_context/virtual_machines.py
@@ -1,11 +1,5 @@
 import os
 from utils.tools import logger
-import pulumi
-import pulumi_aws as aws
-from pulumi import Output
-import pulumi_command as command
-from utils.onboarding.pulumi_utils import remote_install, pulumi_logger, remote_docker_login
-from utils.onboarding.pulumi_ssh import PulumiSSH
 
 
 class TestedVirtualMachine:
@@ -60,6 +54,13 @@ class TestedVirtualMachine:
         self.aws_infra_config = AWSInfraConfig()
 
     def start(self):
+        import pulumi
+        import pulumi_aws as aws
+        from pulumi import Output
+        import pulumi_command as command
+        from utils.onboarding.pulumi_ssh import PulumiSSH
+        from utils.onboarding.pulumi_utils import remote_install, pulumi_logger, remote_docker_login
+
         logger.info("start...")
         self.configure()
         # Startup VM and prepare connection


### PR DESCRIPTION


## Description

Import pulumi only when it's really needed.

## Motivation

First exception caught and formatted by pytest in a test triggers a bunch of pulumi initialization (presumably from their lazy import logic), dominating the execution time in replay mode.

On my machine, replaying the default scenario takes ~8s. After this change, <4s. The change is proportionally much bigger when running single tests  (e.g. from several seconds to sub-second).

Here's a flamegraph before this change, where ~62% of the samples are in pytest's `repr_traceback`, and whose breakdown goes almost entirely to initialization of various pulumi modules.

![image](https://github.com/DataDog/system-tests/assets/23248/8e90a1b3-526f-4b18-8f05-48be3dcdc206)


## Reviewer checklist

* [x] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [x] CI is green
   * [x] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:
