### PR TITLE
Extend telemetry app-started tests

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -13,15 +13,13 @@ from utils.interfaces._misc_validators import HeadersPresenceValidator, HeadersM
 )
 @missing_feature(library="cpp")
 @missing_feature(library="php")
-@missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
+@missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
 class Test_Telemetry:
     """Test that instrumentation telemetry is sent"""
 
     # containers for telemetry request to check consistency between library payloads and agent payloads
     library_requests = {}
     agent_requests = {}
-
-    app_started_count = 0
 
     def validate_library_telemetry_data(self, validator, success_by_default=False):
         telemetry_data = list(interfaces.library.get_telemetry_data())
@@ -148,24 +146,22 @@ class Test_Telemetry:
             if diff > 1:
                 raise Exception(f"Detected non consecutive seq_ids between {seq_ids[i + 1][1]} and {seq_ids[i][1]}")
 
-    @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
-    def test_app_started(self):
-        """Request type app-started is sent on startup at least once"""
+    @bug(library="ruby", reason="app-started not sent")
+    def test_app_started_sent_exactly_once(self):
+        """Request type app-started is sent exactly once"""
+        telemetry_data = list(interfaces.library.get_telemetry_data())
+        app_started = [d for d in telemetry_data if d["request"]["content"].get("request_type") == "app-started"]
+        assert len(app_started) == 1
 
-        def validator(data):
-            return data["request"]["content"].get("request_type") == "app-started"
-
-        self.validate_library_telemetry_data(validator)
-
-    def test_app_started_sent_only_once(self):
-        """Request type app-started is not sent twice"""
-
-        def validator(data):
-            if data["request"]["content"].get("request_type") == "app-started":
-                self.app_started_count += 1
-                assert self.app_started_count < 2, "request_type/app-started has been sent too many times"
-
-        self.validate_library_telemetry_data(validator)
+    @bug(library="ruby", reason="app-started not sent")
+    @bug(library="python", reason="app-started not sent first")
+    def test_app_started_is_first_message(self):
+        """Request type app-started is the first telemetry message"""
+        telemetry_data = list(interfaces.library.get_telemetry_data())
+        assert len(telemetry_data) > 0, "No telemetry messages"
+        assert (
+            telemetry_data[0]["request"]["content"].get("request_type") == "app-started"
+        ), "app-started was not the first message"
 
     @bug(
         library="java",
@@ -472,7 +468,7 @@ class Test_Telemetry:
 @bug(context.uds_mode and context.library < "nodejs@3.7.0")
 @missing_feature(library="cpp")
 @missing_feature(library="php")
-@missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
+@missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
 @irrelevant(library="golang", reason="products info is always in app-started for golang")
 class Test_ProductsDisabled:
     """Assert that product information are not reported when products are disabled in telemetry"""


### PR DESCRIPTION
## Description

Fix tests so that they test:

* app-started is sent at least once (not properly checked before if there were telemetry messages but not app-started messages).
* app-started is sent exactly once.
* app-started is the first telemetry message.
    
Mark Ruby and Python as bugged in some cases.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [x] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [x] CI is green
   * [x] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:
