### PR TITLE
Fix /etc/otelcol-config.yml perms in Linux

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import json
 from pathlib import Path
 import time
@@ -515,12 +516,13 @@ class SqlServerContainer(TestedContainer):
 
 class OpenTelemetryCollectorContainer(TestedContainer):
     def __init__(self, host_log_folder) -> None:
+        self._otel_config_host_path = "./utils/build/docker/otelcol-config.yaml"
         super().__init__(
             image_name="otel/opentelemetry-collector-contrib:latest",
             name="collector",
             command="--config=/etc/otelcol-config.yml",
             environment={},
-            volumes={"./utils/build/docker/otelcol-config.yaml": {"bind": "/etc/otelcol-config.yml", "mode": "ro",}},
+            volumes={self._otel_config_host_path: {"bind": "/etc/otelcol-config.yml", "mode": "ro",}},
             host_log_folder=host_log_folder,
             ports={"13133/tcp": ("0.0.0.0", 13133)},
         )
@@ -539,3 +541,13 @@ class OpenTelemetryCollectorContainer(TestedContainer):
                 logger.debug(f"Healthcheck #{i} on localhost:13133: {e}")
             time.sleep(1)
         pytest.exit("localhost:13133 never answered to healthcheck request", 1)
+
+    def start(self) -> Container:
+        # _otel_config_host_path is mounted in the container, and depending on umask,
+        # it might have no read permissions for other users, which is required within
+        # the container. So set them here.
+        prev_mode = os.stat(self._otel_config_host_path).st_mode
+        new_mode = prev_mode | stat.S_IROTH
+        if prev_mode != new_mode:
+            os.chmod(self._otel_config_host_path, new_mode)
+        return super().start()


### PR DESCRIPTION

## Description

Depending on the umask settings (e.g. umask 0007), the otel conf path might be set without read permissions by other users. Since we bind mount this file into a Docker container, and the user within the container is different from the one in the host, the file requires permission to read by other users. Force it when needed before starting the container.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [x] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:
