### PR TITLE
enable header precedence test for python

### DIFF
--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -36,8 +36,6 @@ class Test_Headers_Precedence:
     @missing_feature(context.library == "golang", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "nodejs", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "php", reason="New 'datadog' default hasn't been implemented yet")
-    @missing_feature(context.library == "python", reason="New 'datadog' default hasn't been implemented yet")
-    @missing_feature(context.library == "python_http", reason="New 'datadog' default hasn't been implemented yet")
     def test_headers_precedence_propagationstyle_default(self, test_agent, test_library):
         with test_library:
             # 1) No headers


### PR DESCRIPTION
## Description

Enable header precedence test for python tracer, to be merged once https://github.com/DataDog/dd-trace-py/pull/6256 is merged into tracer.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:
