### PR TITLE
Restore support for arm64

### DIFF
--- a/utils/build/docker/agent.Dockerfile
+++ b/utils/build/docker/agent.Dockerfile
@@ -1,7 +1,6 @@
 ARG AGENT_IMAGE=datadog/agent:latest
 FROM $AGENT_IMAGE
 
-# We create mirrorlist.main to work with both old and new agent images.
 RUN set -eux;\
     apt-get update;\
     apt-get --no-install-recommends -y install ca-certificates --option=Dpkg::Options::=--force-confdef;\

--- a/utils/build/docker/agent.Dockerfile
+++ b/utils/build/docker/agent.Dockerfile
@@ -1,7 +1,6 @@
 ARG AGENT_IMAGE=datadog/agent:latest
 FROM $AGENT_IMAGE
 
-# Old agents (e.g. 7.43.0) have /etc/apt/mirrorlist rather than /etc/apt/mirrorlist.main.
 # We create mirrorlist.main to work with both old and new agent images.
 RUN set -eux;\
     apt-get update;\

--- a/utils/build/docker/agent.Dockerfile
+++ b/utils/build/docker/agent.Dockerfile
@@ -4,9 +4,6 @@ FROM $AGENT_IMAGE
 # Old agents (e.g. 7.43.0) have /etc/apt/mirrorlist rather than /etc/apt/mirrorlist.main.
 # We create mirrorlist.main to work with both old and new agent images.
 RUN set -eux;\
-    echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu	priority:1" > /etc/apt/mirrorlist.main;\
-    echo "http://archive.ubuntu.com/ubuntu" >> /etc/apt/mirrorlist.main;\
-    echo "deb mirror+file:/etc/apt/mirrorlist.main jammy main" > /etc/apt/sources.list;\
     apt-get update;\
     apt-get --no-install-recommends -y install ca-certificates --option=Dpkg::Options::=--force-confdef;\
     rm -rf /var/lib/apt/lists/*;


### PR DESCRIPTION
## Description

Revert some optimizations to agent build, too much trouble, see https://github.com/DataDog/system-tests/issues/1349

For further context, see:

* https://github.com/DataDog/system-tests/pull/1299
* https://github.com/DataDog/system-tests/pull/1340

## Motivation

<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:
