### PR TITLE
Increase heartbeat interval check delta

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -263,7 +263,7 @@ class Test_Telemetry:
                 assert delta <= timedelta(
                     seconds=ALLOWED_INTERVALS * TELEMETRY_HEARTBEAT_INTERVAL
                 ), f"No heartbeat or message sent in {ALLOWED_INTERVALS} hearbeat intervals: {TELEMETRY_HEARTBEAT_INTERVAL}\nLast message was sent {str(delta)} seconds ago."
-                assert delta >= timedelta(seconds=TELEMETRY_HEARTBEAT_INTERVAL * 0.9), "Heartbeat sent too fast"
+                assert delta >= timedelta(seconds=TELEMETRY_HEARTBEAT_INTERVAL * 0.75), "Heartbeat sent too fast"
             prev_message_time = curr_message_time
 
     def setup_app_dependencies_loaded(self):


### PR DESCRIPTION
## Description
<!-- A brief description of the change being made with this pull request. -->
Increase the delta when the test is checking that heartbeat interval is not executed too fast. 

## Motivation
<!-- What inspired you to submit this pull request? -->
This line added few days ago has become a source of a flakyness in dd-trace-js. If the first request needs a bit more time than second to send the heartbeat, the test will fail. 


## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:
