### PR TITLE
Test the test: Validate json report generation

### DIFF
--- a/tests/test_the_test/test_json_report.py
+++ b/tests/test_the_test/test_json_report.py
@@ -1,0 +1,135 @@
+import pytest
+from utils.tools import logger
+import os
+import json
+
+from utils import missing_feature, irrelevant, released, coverage, scenarios, rfc
+
+
+@scenarios.test_the_test
+class Test_Json_Report:
+    @classmethod
+    def setup_class(cls):
+        stream = os.popen("./run.sh MOCK_THE_TEST")
+        output = stream.read()
+        logger.info(output)
+
+        f = open("logs_mock_the_test/report.json")
+        cls.report_json = json.load(f)
+        f.close()
+
+    def test_missing_feature(self):
+        """Report is generated with correct outcome and skip reason nodes for missing features decorators"""
+
+        for test in self.report_json["tests"]:
+            if test["nodeid"] == "tests/test_the_test/test_json_report.py::Test_Mock::test_missing_feature":
+                assert test["outcome"] == "xfailed"
+                assert test["skip_reason"] == "missing feature: missing feature"
+                return
+        pytest.fail("Test method not found")
+
+    def test_irrelevant(self):
+        """Report is generated with correct outcome and skip reason nodes for irrelevant decorators"""
+
+        for test in self.report_json["tests"]:
+            if test["nodeid"] == "tests/test_the_test/test_json_report.py::Test_Mock::test_irrelevant":
+                assert test["outcome"] == "skipped"
+                assert test["skip_reason"] == "not relevant: irrelevant"
+                return
+        pytest.fail("Test method not found")
+
+    def test_pass(self):
+        """Report is generated with correct test data when a test is passed"""
+
+        for test in self.report_json["tests"]:
+            if test["nodeid"] == "tests/test_the_test/test_json_report.py::Test_Mock::test_mock":
+                assert test["outcome"] == "passed"
+                assert test["skip_reason"] is None
+                return
+        pytest.fail("Test method not found")
+
+    def test_clean_test_data(self):
+        """We are no adding more information that we need for each test"""
+
+        for test in self.report_json["tests"]:
+            assert len(test) == 3  # nodeid, outcome and skip_reason
+
+    def test_docs(self):
+        """Docs node is generating"""
+
+        assert "tests/test_the_test/test_json_report.py::Test_Mock::test_mock" in self.report_json["docs"]
+        assert (
+            self.report_json["docs"]["tests/test_the_test/test_json_report.py::Test_Mock::test_mock"] == "Mock test doc"
+        )
+
+    def test_rfcs(self):
+        """Rfcs node is generating"""
+
+        assert "tests/test_the_test/test_json_report.py::Test_Mock" in self.report_json["rfcs"]
+        assert self.report_json["rfcs"]["tests/test_the_test/test_json_report.py::Test_Mock"] == "https://mock"
+
+    def test_coverages(self):
+        """coverages node is generating"""
+
+        assert "tests/test_the_test/test_json_report.py::Test_Mock" in self.report_json["coverages"]
+        assert self.report_json["coverages"]["tests/test_the_test/test_json_report.py::Test_Mock"] == "good"
+
+    def test_release_versions(self):
+        """release_versions node is generating"""
+
+        assert "tests/test_the_test/test_json_report.py::Test_Mock" in self.report_json["release_versions"]
+        assert "java" in self.report_json["release_versions"]["tests/test_the_test/test_json_report.py::Test_Mock"]
+        assert (
+            self.report_json["release_versions"]["tests/test_the_test/test_json_report.py::Test_Mock"]["java"]
+            == "0.0.99"
+        )
+
+    def test_context_serialization(self):
+        """check context serialization node is generating"""
+
+        assert "context" in self.report_json
+        # Check agent node (version is set on TestTheTest scenario)
+        assert "agent" in self.report_json["context"]
+        assert self.report_json["context"]["agent"] == "0.77.0"
+        # Check library node (version is set on TestTheTest scenario)
+        assert "library" in self.report_json["context"]
+        assert "library" in self.report_json["context"]["library"]
+        assert self.report_json["context"]["library"]["library"] == "java"
+        assert "version" in self.report_json["context"]["library"]
+        assert self.report_json["context"]["library"]["version"] == "0.66.0"
+        # Check weblog node (version is set on TestTheTest scenario)
+        assert "weblog_variant" in self.report_json["context"]
+        assert self.report_json["context"]["weblog_variant"] == "spring"
+        # Check custom components ( set on TestTheTest scenario)
+        assert "mock_comp1" in self.report_json["context"]
+        assert self.report_json["context"]["mock_comp1"] == "mock_comp1_value"
+        # Check parametrized_tests_metadata ( set on TestTheTest scenario)
+        assert "parametrized_tests_metadata" in self.report_json["context"]
+        assert (
+            "tests/test_the_test/test_json_report.py::Test_Mock::test_mock"
+            in self.report_json["context"]["parametrized_tests_metadata"]
+        )
+        assert (
+            "meta1"
+            in self.report_json["context"]["parametrized_tests_metadata"][
+                "tests/test_the_test/test_json_report.py::Test_Mock::test_mock"
+            ]
+        )
+
+
+@scenarios.mock_the_test
+@released(java="0.0.99")
+@rfc("https://mock")
+@coverage.good
+class Test_Mock:
+    def test_mock(self):
+        """Mock test doc"""
+        assert 1 == 1
+
+    @missing_feature(True, reason="missing feature")
+    def test_missing_feature(self):
+        raise Exception("Should not be executed")
+
+    @irrelevant(True, reason="irrelevant")
+    def test_irrelevant(self):
+        raise Exception("Should not be executed")

--- a/tests/test_the_test/test_stdout_reader.py
+++ b/tests/test_the_test/test_stdout_reader.py
@@ -10,8 +10,8 @@ class Test_Main:
     def test_stdout_reader(self):
         """Test stdout reader"""
 
-        os.makedirs("logs/docker/weblog", exist_ok=True)
-        with open("logs/docker/weblog/stdout.log", "w", encoding="utf-8") as f:
+        os.makedirs("logs_test_the_test/docker/weblog", exist_ok=True)
+        with open("logs_test_the_test/docker/weblog/stdout.log", "w", encoding="utf-8") as f:
             f.write("[dd.trace 2021-11-29 17:10:22:203 +0000] [main] DEBUG com.klass - some file\n")
             f.write("[dd.trace 2021-11-29 17:10:22:203 +0000] [main] INFO com.klass - AppSec initial 1.0.14\n")
 

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -183,8 +183,16 @@ class _Scenario:
 
 class TestTheTestScenario(_Scenario):
     @property
-    def host_log_folder(self):
-        return "logs"
+    def agent_version(self):
+        return "0.77.0"
+
+    @property
+    def components(self):
+        return {"mock_comp1": "mock_comp1_value"}
+
+    @property
+    def parametrized_tests_metadata(self):
+        return {"tests/test_the_test/test_json_report.py::Test_Mock::test_mock": {"meta1": "meta1"}}
 
     @property
     def library(self):
@@ -827,6 +835,7 @@ class ParametricScenario(_Scenario):
 class scenarios:
     todo = _Scenario("TODO", doc="scenario that skips tests not yet executed")
     test_the_test = TestTheTestScenario("TEST_THE_TEST", doc="Small scenario that check system-tests internals")
+    mock_the_test = TestTheTestScenario("MOCK_THE_TEST", doc="Mock scenario that check system-tests internals")
 
     default = EndToEndScenario(
         "DEFAULT",


### PR DESCRIPTION


## Description

Incorrect generation of json report could cause problems in system-tests-dashboard due to we are parsing the report. This PR adds a new test to validate it.
To generate the report we have to launch a new scenario "mock_the_test".This scenario is launched programatically executing ./run.sh MOCK_THE_TEST

## Motivation

Incorrect generation of json report could cause problems in system-tests-dashboard due to we are parsing the report.

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:
