### PR TITLE
go: enable custom blocking response test

### DIFF
--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -232,7 +232,7 @@ class Test_Blocking:
 @rfc(
     "https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2705464728/Blocking#Custom-Blocking-Response-via-Remote-Config"
 )
-@released(java="1.11.0", dotnet="?", golang="?", nodejs="?", php_appsec="0.7.0", python="?", ruby="?")
+@released(java="1.11.0", dotnet="?", golang="1.53.0", nodejs="?", php_appsec="0.7.0", python="?", ruby="?")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @coverage.basic
 @scenarios.appsec_blocking

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -234,6 +234,7 @@ class Test_Blocking:
 )
 @released(java="1.11.0", dotnet="?", golang="1.53.0", nodejs="?", php_appsec="0.7.0", python="?", ruby="?")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
+@bug(context.weblog_variant == "uds-echo")
 @coverage.basic
 @scenarios.appsec_blocking
 class Test_CustomBlockingResponse:


### PR DESCRIPTION
## Description

Enable custom blocking response test for Go.
## Motivation

<!-- What inspired you to submit this pull request? -->

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:
