### PR TITLE
Make find_span in parametric tests stricter

### DIFF
--- a/utils/parametric/spec/trace.py
+++ b/utils/parametric/spec/trace.py
@@ -181,7 +181,7 @@ def _span_similarity(s1: Span, s2: Span) -> int:
     return score
 
 
-def find_trace_by_root(traces: List[Trace], span: Span) -> Trace:
+def find_similar_trace_by_root(traces: List[Trace], span: Span) -> Trace:
     """Return the trace from `traces` with root span most similar to `span`."""
     assert len(traces) > 0
 
@@ -196,7 +196,14 @@ def find_trace_by_root(traces: List[Trace], span: Span) -> Trace:
     return max_score_trace
 
 
-def find_span(trace: Trace, span: Span) -> Span:
+def find_trace_by_root(traces: List[Trace], span: Span) -> Trace:
+    """Return the trace from `traces` with root span matching all fields of `span`."""
+    trace = find_similar_trace_by_root(traces, span)
+    _assert_span_match(span, root_span(trace))
+    return trace
+
+
+def find_similar_span(trace: Trace, span: Span) -> Span:
     """Return a span from the trace which most closely matches `span`."""
     assert len(trace) > 0
 
@@ -210,14 +217,19 @@ def find_span(trace: Trace, span: Span) -> Span:
     return max_similarity_span
 
 
-def find_span_in_traces(traces: List[Trace], span: Span) -> Span:
+def find_span(trace: Trace, span: Span) -> Span:
+    """Return a span from the trace matches all fields in `span`."""
+    return _assert_span_match(span, find_similar_span(trace, span))
+
+
+def find_similar_span_in_traces(traces: List[Trace], span: Span) -> Span:
     """Return a span from the traces which most closely matches `span`."""
     assert len(traces) > 0
 
     max_similarity = -math.inf
     max_similarity_span = None
     for trace in traces:
-        similar_span = find_span(trace, span)
+        similar_span = find_similar_span(trace, span)
         if max_similarity_span is None:
             max_similarity_span = similar_span
         similarity = _span_similarity(span, max_similarity_span)
@@ -225,6 +237,29 @@ def find_span_in_traces(traces: List[Trace], span: Span) -> Span:
             max_similarity_span = similar_span
             max_similarity = similarity
     return max_similarity_span
+
+
+def find_span_in_traces(traces: List[Trace], span: Span) -> Span:
+    """Return a span from the traces that matches all fields in `span`."""
+    return _assert_span_match(span, find_similar_span_in_traces(traces, span))
+
+
+def _assert_span_match(span: Span, similar: Span) -> Span:
+    for var in Span.__annotations__:
+        if not var.startswith("__"):
+            val = span.get(var)
+            s_val = similar.get(var)
+            if val != None and val != s_val:
+                # TODO remove this special handling once nodejs sets service in the same way.
+                # Right now, nodejs sets a tag named "service" in meta with the correct value.
+                if var == "service":
+                    meta = similar.get("meta")
+                    if meta != None:
+                        s_val = meta.get(var)
+                assert val == s_val, "Span field '{}' mismatch '{}' != '{}'\nSpan   : {}\nSimilar: {}".format(
+                    var, val, s_val, span, similar,
+                )
+    return similar
 
 
 def span_has_no_parent(span: Span) -> bool:


### PR DESCRIPTION
## Description

Makes the checks on the spans returned from `find_span` stricter.

## Motivation

The `find_*` methods are to loose and can return unexpected Spans/Traces.

Some tests failed intermittently on Java on non helpful asserts, and when debugging this, it was discovered that some traces where split into two chunks, and the `child` span we thought we got back was actually the `parent` span once more. None of the tests seem to expect anything other than a _strict_ match, but the original methods are available as `find_similar*`.

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:
