### PR TITLE
Process to update images on hub.docker.com

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,12 +6,6 @@
 
 <!-- What inspired you to submit this pull request? -->
 
-## Reviewer checklist
-
-* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
-* [ ] CI is green
-   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
-
 ## Workflow
 
 1. ⚠️⚠️ Create your PR as draft
@@ -20,3 +14,12 @@
 4. Mark it as ready for review
 
 Once your PR is reviewed, you can merge it! :heart:
+
+## Reviewer checklist
+
+* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
+* [ ] CI is green
+   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
+* if any of `build-some-image` label is present
+  1. is the image labl have been updated ? 
+  2. just before merging, locally build and push the image to hub.docker.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,15 @@ jobs:
       uses: ./.github/actions/pull_images
       with:
         pull-all: ${{ needs.scenarios.outputs.run_all == 'true' }}
+    - name: Build python's weblog base images
+      if: matrix.variant.library == 'python' && contains(github.event.pull_request.labels.*.name, 'build-python-base-images')
+      run: |
+        docker build --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v0 .
+        docker build --progress=plain -f utils/build/docker/python/flask-poc.base.Dockerfile -t datadog/system-tests:flask-poc.base-v0 .
+        docker build --progress=plain -f utils/build/docker/python/uwsgi-poc.base.Dockerfile -t datadog/system-tests:uwsgi-poc.base-v0 .
+    - name: Build proxy image
+      if: contains(github.event.pull_request.labels.*.name, 'build-proxy-image')
+      run: ./build.sh -i proxy
     - name: Load WAF rules
       if: ${{ matrix.version == 'dev' }}
       run: ./utils/scripts/load-binary.sh waf_rule_set

--- a/docs/edit/update-docker-images.md
+++ b/docs/edit/update-docker-images.md
@@ -1,0 +1,9 @@
+Some of images used in system-tests are prebuild and used threw [hub.docker.com/datadog/system-tests](https://hub.docker.com/repository/docker/datadog/system-tests/).
+
+If you need to update them, you will need to follow those
+
+1. update the version in the tag for the image you've just modified (there should be 3 or 4 occurences in the code)
+2. create your PR, and add the relevant label to rebuild the image in the CI
+  * `build-python-base-images` for python weblogs
+  * `build-proxy-image` for proxy image
+3. just before merging your PR, ping somebody from Reliability & Performance team to push your image to hub.docker.com (`#apm-shared-testing` on slack)


### PR DESCRIPTION
## Description

Recent performance improvement used some pre-build images on hub.docker.com

It lack a process to update those images. For reliability reason, we'll keep the push process manual (AFAIK, there is no way to protect an image from overwrite on docker.com, and we absolutely do not want a rogue PR overwrite an used image).

But appart from that very last manual push, this process will make the update possible during a PR.

## Motivation

Ease the process of updating pre-build images

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:
