### PR TITLE
[GO] parametric: separated tracer initialisation for datadog and otel tests

### DIFF
--- a/utils/build/docker/golang/parametric/datadog.go
+++ b/utils/build/docker/golang/parametric/datadog.go
@@ -7,6 +7,10 @@ import (
 )
 
 func (s *apmClientServer) StartSpan(ctx context.Context, args *StartSpanArgs) (*StartSpanReturn, error) {
+	if !s.tracerStarted {
+		s.tracerStarted = true
+		tracer.Start()
+	}
 	var opts []tracer.StartSpanOption
 	if args.GetParentId() > 0 {
 		parent := s.spans[*args.ParentId]

--- a/utils/build/docker/golang/parametric/main.go
+++ b/utils/build/docker/golang/parametric/main.go
@@ -18,10 +18,11 @@ import (
 
 type apmClientServer struct {
 	UnimplementedAPMClientServer
-	spans     map[uint64]tracer.Span
-	otelSpans map[uint64]otel_trace.Span
-	tp        *ddotel.TracerProvider
-	tracer    otel_trace.Tracer
+	spans         map[uint64]tracer.Span
+	otelSpans     map[uint64]otel_trace.Span
+	tp            *ddotel.TracerProvider
+	tracer        otel_trace.Tracer
+	tracerStarted bool
 }
 
 func newServer() *apmClientServer {
@@ -31,7 +32,6 @@ func newServer() *apmClientServer {
 	}
 	s.tp = ddotel.NewTracerProvider()
 	otel.SetTracerProvider(s.tp)
-	s.tracer = s.tp.Tracer("")
 	return s
 }
 

--- a/utils/build/docker/golang/parametric/otel.go
+++ b/utils/build/docker/golang/parametric/otel.go
@@ -16,6 +16,9 @@ import (
 )
 
 func (s *apmClientServer) OtelStartSpan(ctx context.Context, args *OtelStartSpanArgs) (*OtelStartSpanReturn, error) {
+	if s.tracer == nil {
+		s.tracer = s.tp.Tracer("")
+	}
 	var pCtx = context.Background()
 	var ddOpts []tracer.StartSpanOption
 	if pid := args.GetParentId(); pid != 0 {


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation
This concerns only GO tracer. Fixes, an issue where setup for OTel tests causes test failures for non-otel tests
<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
