### PR TITLE
Onboarding enable "prod" environment tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ variables:
 onboarding_nodejs:
   extends: .base_job_onboarding
   only:
-    - web
+    - schedules
   variables:
     TEST_LIBRARY: "nodejs"
   parallel:
@@ -67,7 +67,7 @@ onboarding_nodejs:
 onboarding_java:
   extends: .base_job_onboarding
   only:
-    - web
+    - schedules
   variables:
     TEST_LIBRARY: "java"
   parallel:
@@ -87,7 +87,7 @@ onboarding_java:
 onboarding_python:
   extends: .base_job_onboarding
   only:
-    - web
+    - schedules
   variables:
     TEST_LIBRARY: "python"
   parallel:
@@ -104,7 +104,7 @@ onboarding_python:
 onboarding_dotnet:
   extends: .base_job_onboarding
   only:
-    - web
+    - schedules
   variables:
     TEST_LIBRARY: "dotnet"
   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,12 +50,12 @@ variables:
 onboarding_nodejs:
   extends: .base_job_onboarding
   only:
-    - schedules
+    - web
   variables:
     TEST_LIBRARY: "nodejs"
   parallel:
       matrix:
-        - ONBOARDING_FILTER_ENV: [dev]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
           SCENARIO: [ONBOARDING_HOST,ONBOARDING_CONTAINER, ONBOARDING_HOST_AUTO_INSTALL, ONBOARDING_CONTAINER_AUTO_INSTALL] 
           ONBOARDING_FILTER_WEBLOG: [test-app-nodejs]
   script:
@@ -67,15 +67,15 @@ onboarding_nodejs:
 onboarding_java:
   extends: .base_job_onboarding
   only:
-    - schedules
+    - web
   variables:
     TEST_LIBRARY: "java"
   parallel:
       matrix:
-        - ONBOARDING_FILTER_ENV: [dev]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
           ONBOARDING_FILTER_WEBLOG: [test-app-java,wildfly]
           SCENARIO: [ONBOARDING_HOST, ONBOARDING_HOST_AUTO_INSTALL]
-        - ONBOARDING_FILTER_ENV: [dev]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
           ONBOARDING_FILTER_WEBLOG: [test-app-java,test-app-java-buildpack,test-app-java-alpine]
           SCENARIO: [ONBOARDING_CONTAINER, ONBOARDING_CONTAINER_AUTO_INSTALL]
   script:
@@ -87,12 +87,12 @@ onboarding_java:
 onboarding_python:
   extends: .base_job_onboarding
   only:
-    - schedules
+    - web
   variables:
     TEST_LIBRARY: "python"
   parallel:
       matrix:
-        - ONBOARDING_FILTER_ENV: [dev]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
           ONBOARDING_FILTER_WEBLOG: [test-app-python]
           SCENARIO: [ONBOARDING_HOST, ONBOARDING_CONTAINER, ONBOARDING_HOST_AUTO_INSTALL, ONBOARDING_CONTAINER_AUTO_INSTALL]
   script:
@@ -104,12 +104,12 @@ onboarding_python:
 onboarding_dotnet:
   extends: .base_job_onboarding
   only:
-    - schedules
+    - web
   variables:
     TEST_LIBRARY: "dotnet"
   parallel:
       matrix:
-        - ONBOARDING_FILTER_ENV: [dev]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
           ONBOARDING_FILTER_WEBLOG: [test-app-dotnet]     
           SCENARIO: [ONBOARDING_HOST,ONBOARDING_CONTAINER, ONBOARDING_HOST_AUTO_INSTALL,ONBOARDING_CONTAINER_AUTO_INSTALL]
 

--- a/tests/onboarding/infra_provision/provision_onboarding_container.yml
+++ b/tests/onboarding/infra_provision/provision_onboarding_container.yml
@@ -61,7 +61,7 @@ agent_auto_install:
             - name: copy-agent-docker-compose
               local_path: tests/onboarding/autoinjection/docker/docker-compose-agent-prod.yml
         command: |
-          DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_LIBRARIES=js DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+          DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_INSTRUMENTATION_LANGUAGES=js DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
           sudo cp docker_config.yaml /etc/datadog-agent/inject/docker_config.yaml
    
   - java: 
@@ -87,7 +87,7 @@ agent_auto_install:
             - name: copy-agent-docker-compose
               local_path: tests/onboarding/autoinjection/docker/docker-compose-agent-prod.yml
         command: |
-          DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_LIBRARIES=java DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+          DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_INSTRUMENTATION_LANGUAGES=java DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
           sudo cp docker_config.yaml /etc/datadog-agent/inject/docker_config.yaml
   - python: 
     - env: dev
@@ -112,7 +112,7 @@ agent_auto_install:
             - name: copy-agent-docker-compose
               local_path: tests/onboarding/autoinjection/docker/docker-compose-agent-prod.yml
         command: |
-          DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_LIBRARIES=python DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+          DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_INSTRUMENTATION_LANGUAGES=python DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
           sudo cp docker_config.yaml /etc/datadog-agent/inject/docker_config.yaml
   - dotnet: 
     - env: dev
@@ -137,7 +137,7 @@ agent_auto_install:
             - name: copy-agent-docker-compose
               local_path: tests/onboarding/autoinjection/docker/docker-compose-agent-prod.yml
         command: |
-          DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_LIBRARIES=dotnet DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+          DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_INSTRUMENTATION_LANGUAGES=dotnet DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
           sudo cp docker_config.yaml /etc/datadog-agent/inject/docker_config.yaml
         
 autoinjection: 

--- a/tests/onboarding/infra_provision/provision_onboarding_host.yml
+++ b/tests/onboarding/infra_provision/provision_onboarding_host.yml
@@ -51,7 +51,7 @@ agent_auto_install:
     - env: prod
       install:
       - os_type: linux
-        command:  DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_LIBRARIES=js DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+        command:  DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_INSTRUMENTATION_LANGUAGES=js DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
   - java: 
     - env: dev
       install:
@@ -64,7 +64,7 @@ agent_auto_install:
     - env: prod
       install:
       - os_type: linux
-        command:  DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_LIBRARIES=java DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+        command:  DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_INSTRUMENTATION_LANGUAGES=java DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
   - python: 
     - env: dev
@@ -77,7 +77,7 @@ agent_auto_install:
     - env: prod
       install:
       - os_type: linux
-        command:  DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_LIBRARIES=python DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+        command:  DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_INSTRUMENTATION_LANGUAGES=python DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
 
   - dotnet: 
@@ -91,7 +91,7 @@ agent_auto_install:
     - env: prod
       install:
       - os_type: linux
-        command:  DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_LIBRARIES=dotnet DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+        command:  DD_AGENT_DIST_CHANNEL=stable DD_AGENT_MAJOR_VERSION=7 DD_APM_INSTRUMENTATION_LANGUAGES=dotnet DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
 autoinjection:
 #Copy tests/onboarding/autoinjection/host_config.yaml to /etc/datadog-agent/inject/host_config.yaml to enable debug (Disabled for timing reasons)


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->
Enable stable version tests for onboarding
## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
