### PR TITLE
Fix nodejs system-test

### DIFF
--- a/utils/build/docker/nodejs/express4-typescript/auth.ts
+++ b/utils/build/docker/nodejs/express4-typescript/auth.ts
@@ -48,7 +48,10 @@ module.exports = function (app: Express, passport: any, tracer: Tracer) {
     const userMail = req.query.sdk_mail as  string || 'system_tests_user@system_tests_user.com'
     const exists = req.query.sdk_user_exists === 'true'
 
-    if (err) { return next(err)}
+    if (err) {
+      console.error('unexpected login error', err)
+      return next(err)
+    }
     if (!user) {
       if (event === 'failure') {
         tracer.appsec.trackUserLoginFailureEvent(userId, exists, { metadata0: "value0", metadata1: "value1" });

--- a/utils/build/docker/nodejs/express4/auth.js
+++ b/utils/build/docker/nodejs/express4/auth.js
@@ -68,9 +68,11 @@ module.exports = function (app, passport, tracer) {
             metadata1: "value1"
           }
         )
-      }
 
-      res.sendStatus(200)
+        res.sendStatus(200)
+      } else {
+        res.sendStatus(200)
+      }
   }
 
   function getStrategy (req, res, next) {

--- a/utils/build/docker/nodejs/express4/iast/index.js
+++ b/utils/build/docker/nodejs/express4/iast/index.js
@@ -5,7 +5,7 @@ const { readFileSync, statSync } = require('fs')
 const { join } = require('path')
 const crypto = require('crypto');
 const { execSync } = require('child_process');
-const https = require('http');
+const https = require('https');
 
 function initData () {
   const query = readFileSync(join(__dirname, '..', 'resources', 'iast-data.sql')).toString()
@@ -55,7 +55,6 @@ function init (app, tracer) {
     const span = tracer.scope().active();
     span.setTag('appsec.event"', true);
   
-    console.error('/iast/insecure_hashing/test_md5_algorithm')
     res.send(crypto.createHash('md5').update('insecure').digest('hex'));
   });
   
@@ -69,7 +68,12 @@ function init (app, tracer) {
   app.get('/iast/insecure_cipher/test_secure_algorithm', (req, res) => {
     const span = tracer.scope().active();
     span.setTag('appsec.event"', true);
-    const cipher = crypto.createCipheriv('sha256', '1111111111111111', 'abcdefgh')
+ 
+    const key = crypto.randomBytes(32);
+ 
+    const iv = crypto.randomBytes(16);
+ 
+    const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(key), iv);
     res.send(Buffer.concat([cipher.update('12345'), cipher.final()]))
   });
   


### PR DESCRIPTION
## Description
<!-- A brief description of the change being made with this pull request. -->
When authentication returns an error, the nodejs application is broken because `next` method is not in `handleAuthentication` methods, in this PR we are fixing it.
## Motivation
<!-- What inspired you to submit this pull request? -->
Some PR builds fails and release process is stopped. 

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [x] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
