### PR TITLE
Fix check on telemetry app started only once

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -148,9 +148,18 @@ class Test_Telemetry:
     @bug(library="ruby", reason="app-started not sent")
     def test_app_started_sent_exactly_once(self):
         """Request type app-started is sent exactly once"""
-        telemetry_data = list(interfaces.library.get_telemetry_data())
-        app_started = [d for d in telemetry_data if d["request"]["content"].get("request_type") == "app-started"]
-        assert len(app_started) == 1
+
+        count = 0
+
+        for data in interfaces.library.get_telemetry_data():
+            if data["request"]["content"].get("request_type") == "app-started":
+                logger.debug(
+                    f"Found app-started in {data['log_filename']}. Response from agent: {data['response']['status_code']}"
+                )
+                if data["response"]["status_code"] == 202:
+                    count += 1
+
+        assert count == 1
 
     @bug(library="ruby", reason="app-started not sent")
     @bug(library="python", reason="app-started not sent first")


### PR DESCRIPTION
## Description

app started should be sent only once, but if answer is 503 (lot of unstability on telemetry backend those days), it should be resent.

## Motivation

Fix flakyness

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
