### PR TITLE
cpp: pass more parametric tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,7 @@
 Tests scenario.
 
 * Each file tests a feature
-* Each class tests a feature declinaison
+* Each class tests a feature declension
 * Each method tests a use case
 
 Please use meaningful messages, and avoid any duplication

--- a/tests/parametric/README.md
+++ b/tests/parametric/README.md
@@ -40,7 +40,7 @@ The following dependencies are required to run the tests locally:
 - Docker
 - Python >= 3.7 (for Windows users, Python 3.9 seems to run best without issues)
 
-then, create a Python virtual environment and install the Python dependencies from the root directory:
+then, run the following command, which will create a Python virtual environment and install the Python dependencies from the root directory:
 
 ```sh
 ./build.sh -i runner
@@ -93,14 +93,14 @@ To test unmerged PRs locally, do the following:
 
 1. Build Java Tracer artifacts
 ```bash
-git clone git@github.com:DataDog/dd-trace-java.git 
+git clone git@github.com:DataDog/dd-trace-java.git
 cd dd-trace-java
 ./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar
 ```
 
 2. Copy both artifacts into the `system-tests/binaries/` folder:
   * The Java tracer agent artifact `dd-java-agent-*.jar` from `dd-java-agent/build/libs/`
-  * Its public API `dd-trace-api-*.jar` from `dd-trace-api/build/libs/` into 
+  * Its public API `dd-trace-api-*.jar` from `dd-trace-api/build/libs/` into
 
 3. Run Parametric tests from the `system-tests/parametric` folder:
 
@@ -133,7 +133,7 @@ PYTHON_DDTRACE_PACKAGE=git+https://github.com/Datadog/dd-trace-py@1.x ./run.sh .
 
 There is two ways for running the NodeJS tests with a custom tracer:
 - Place the ddtrace NPM package in the folder ``apps/nodejs/npm`` and then set the environment variable ``NODEJS_DDTRACE_MODULE``
-with the filename placed in the aforementioned folder. For example: 
+with the filename placed in the aforementioned folder. For example:
 ``CLIENTS_ENABLED=nodejs NODEJS_DDTRACE_MODULE="dd-trace-2.22.3.tgz" ./run.sh``
 - Set the environment variable ``NODEJS_DDTRACE_MODULE`` to hold a commit in a remote branch. The following example will run
 the tests with a specific commit: ``CLIENTS_ENABLED=nodejs NODEJS_DDTRACE_MODULE=datadog/dd-trace-js#687cb813289e19bfcc884a2f9f634470cf138143 ./run.sh``
@@ -145,6 +145,44 @@ To run the Ruby tests "locally" push your code GitHub and then specify `RUBY_DDT
 ```sh
 RUBY_DDTRACE_SHA=0552ebd49dc5b3bec4e739c2c74b214fb3102c2a ./run.sh ...
 ```
+
+#### C++
+
+The parametric shared tests can be run against the C++ library,
+[dd-trace-cpp][1], this way:
+```console
+$ TEST_LIBRARY=cpp ./run.sh PARAMETRIC
+```
+
+Use the `-k` command line argument, which is forwarded to [pytest][2], to
+specify a substring within a particular test file, class, or method. Then only
+matching tests will run, e.g.
+```console
+$ TEST_LIBRARY=cpp ./run.sh PARAMETRIC -k test_headers
+```
+
+It's convenient to have a pretty printer for the tests' XML output. I use
+[xunit-viewer][3].
+```console
+$ npm install junit-viewer -g
+```
+
+My development iterations then involve running the following at the top of the
+repository:
+```console
+$ TEST_LIBRARY=cpp ./run.sh PARAMETRIC -k test_headers; xunit-viewer -r logs_parametric/reportJunit.xml
+```
+
+This will create a file `index.html` at the top of the repository, which I then
+inspect with a web browser.
+
+The C++ build can be made to point to a different GitHub branch by modifying the
+`FetchContent_Declare` command's `GIT_TAG` argument in [CMakeLists.txt][4].
+
+In order to coerce Docker to rebuild the C++ gRPC server image, one of the build
+inputs must change, and so whenever I push changes to the target branch, I also
+modify a scratch comment in `CMakeLists.txt` to trigger a rebuild on the next
+test run.
 
 ### Debugging
 
@@ -244,9 +282,14 @@ other tooling to assist in development.
 
 - Shared tests are written in Python (pytest).
 - GRPC/HTTP servers for each language are built and run in docker containers.
-- [test agent](https://github.com/DataDog/dd-apm-test-agent/) is started in a container to collect the data from the GRPC servers. 
+- [test agent](https://github.com/DataDog/dd-apm-test-agent/) is started in a container to collect the data from the GRPC servers.
 
 Test cases are written in Python and target the shared GRPC interface. The tests use a GRPC client to query the servers and the servers generate the data which is submitted to the test agent. Test cases can then query the data from the test agent to perform assertions.
 
 
 <img width="869" alt="image" src="https://user-images.githubusercontent.com/6321485/182887064-e241d65c-5e29-451b-a8a8-e8d18328c083.png">
+
+[1]: https://github.com/DataDog/dd-trace-cpp
+[2]: https://docs.pytest.org/en/6.2.x/usage.html#specifying-tests-selecting-tests
+[3]: https://github.com/roydahan/xunit-viewer
+[4]: ../../utils/build/docker/cpp/parametric/CMakeLists.txt

--- a/tests/parametric/test_128_bit_traceids.py
+++ b/tests/parametric/test_128_bit_traceids.py
@@ -36,7 +36,6 @@ class Test_128_Bit_Traceids:
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid == "640cfd8d00000000"
 
-    @missing_feature(context.library == "cpp", reason="invalid tid treated as error instead of being discarded")
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "php", reason="Issue: Traces not available from test agent")
     @missing_feature(context.library == "python_http", reason="not implemented")
@@ -65,7 +64,6 @@ class Test_128_Bit_Traceids:
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
 
-    @missing_feature(context.library == "cpp", reason="not implemented")
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "php", reason="Issue: Traces not available from test agent")
     @missing_feature(context.library == "python_http", reason="not implemented")
@@ -94,7 +92,6 @@ class Test_128_Bit_Traceids:
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
 
-    @missing_feature(context.library == "cpp", reason="invalid tid treated as error instead of being discarded")
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "php", reason="Issue: Traces not available from test agent")
     @missing_feature(context.library == "python_http", reason="not implemented")
@@ -123,7 +120,6 @@ class Test_128_Bit_Traceids:
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
 
-    @missing_feature(context.library == "cpp", reason="invalid tid treated as error instead of being discarded")
     @missing_feature(context.library == "dotnet", reason="Optional feature not implemented")
     @missing_feature(context.library == "golang", reason="Optional feature not implemented")
     @missing_feature(context.library == "nodejs", reason="not implemented")
@@ -185,7 +181,6 @@ class Test_128_Bit_Traceids:
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
 
-    @missing_feature(context.library == "cpp", reason="timestamp in tid not supported")
     @missing_feature(context.library == "php", reason="Issue: Traces not available from test agent")
     @missing_feature(context.library == "python_http", reason="not implemented")
     @missing_feature(context.library == "ruby", reason="not implemented")
@@ -291,7 +286,6 @@ class Test_128_Bit_Traceids:
 
         check_128_bit_trace_id(fields[0], span.get("trace_id"), span["meta"].get("_dd.p.tid"))
 
-    @missing_feature(context.library == "cpp", reason="_dd.p.tid is not set for b3")
     @missing_feature(context.library == "python_http", reason="not implemented")
     @missing_feature(context.library == "ruby", reason="not implemented")
     @pytest.mark.parametrize(
@@ -353,7 +347,6 @@ class Test_128_Bit_Traceids:
 
         check_64_bit_trace_id(headers["x-b3-traceid"], span.get("trace_id"), span["meta"].get("_dd.p.tid"))
 
-    @missing_feature(context.library == "cpp", reason="generated 128 bit ids do not have some top bits zeroed")
     @missing_feature(context.library == "php", reason="Issue: Traces not available from test agent")
     @missing_feature(context.library == "python_http", reason="not implemented")
     @missing_feature(context.library == "ruby", reason="not implemented")
@@ -371,7 +364,6 @@ class Test_128_Bit_Traceids:
 
         check_128_bit_trace_id(headers["x-b3-traceid"], span.get("trace_id"), span["meta"].get("_dd.p.tid"))
 
-    @missing_feature(context.library == "cpp", reason="_dd.p.tid is not populated")
     @missing_feature(context.library == "php", reason="Issue: Traces not available from test agent")
     @missing_feature(context.library == "python_http", reason="not implemented")
     @missing_feature(context.library == "ruby", reason="not implemented")
@@ -396,7 +388,6 @@ class Test_128_Bit_Traceids:
         assert dd_p_tid == "640cfd8d00000000"
         check_128_bit_trace_id(fields[1], trace_id, dd_p_tid)
 
-    @missing_feature(context.library == "cpp", reason="_dd.p.tid is not populated")
     @missing_feature(context.library == "ruby", reason="not implemented")
     @pytest.mark.parametrize(
         "library_env",
@@ -454,7 +445,6 @@ class Test_128_Bit_Traceids:
         assert child_tid is None
         assert propagation_error is None
 
-    @missing_feature(context.library == "cpp", reason="_dd.p.tid is not populated")
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "php", reason="Issue: Traces not available from test agent")
     @missing_feature(context.library == "python_http", reason="not implemented")
@@ -482,7 +472,6 @@ class Test_128_Bit_Traceids:
         assert trace_id == int("abcdefab12345678", 16)
         assert dd_p_tid == "640cfd8d00000000"
 
-    @missing_feature(context.library == "cpp", reason="_dd.p.tid is not populated")
     @missing_feature(context.library == "dotnet", reason="Optional feature not implemented")
     @missing_feature(context.library == "golang", reason="Optional feature not implemented")
     @missing_feature(context.library == "nodejs", reason="not implemented")
@@ -508,7 +497,6 @@ class Test_128_Bit_Traceids:
             )
         assert get_span(test_agent)["meta"].get("_dd.propagation_error") == "inconsistent_tid 640cfd8d0000ffff"
 
-    @missing_feature(context.library == "cpp", reason="invalid tid treated as error instead of being discarded")
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "php", reason="Issue: Traces not available from test agent")
     @missing_feature(context.library == "python_http", reason="not implemented")
@@ -535,7 +523,6 @@ class Test_128_Bit_Traceids:
         assert trace_id == int("abcdefab12345678", 16)
         assert dd_p_tid == "640cfd8d00000000"
 
-    @missing_feature(context.library == "cpp", reason="invalid tid treated as error instead of being discarded")
     @missing_feature(context.library == "dotnet", reason="Optional feature not implemented")
     @missing_feature(context.library == "golang", reason="Optional feature not implemented")
     @missing_feature(context.library == "nodejs", reason="not implemented")
@@ -601,7 +588,6 @@ class Test_128_Bit_Traceids:
 
         check_64_bit_trace_id(fields[1], span.get("trace_id"), span["meta"].get("_dd.p.tid"))
 
-    @missing_feature(context.library == "cpp", reason="generated 128 bit ids do not have some top bits zeroed")
     @missing_feature(context.library == "php", reason="Issue: Traces not available from test agent")
     @missing_feature(context.library == "python_http", reason="not implemented")
     @missing_feature(context.library == "ruby", reason="not implemented")
@@ -651,5 +637,6 @@ def validate_dd_p_tid(dd_p_tid):
     assert len(dd_p_tid) == 16
     assert dd_p_tid != ZERO16
     assert dd_p_tid[8:16] == ZERO8
-    # check that dd_p_tid[0:8] is a timestamp
+    # check that dd_p_tid[0:8] is consistent with a  Unix timestamp from after
+    # 17:15:40 March 11, 2023.
     assert int(dd_p_tid[0:8], 16) > 0x640CFD8C

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -54,7 +54,6 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
-    @missing_feature(context.library == "cpp", reason="trace-id 0 not treated as invalid")
     def test_headers_b3multi_extract_invalid(self, test_agent, test_library):
         """Ensure that invalid b3multi distributed tracing headers are not extracted.
         """
@@ -116,7 +115,6 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
-    @missing_feature(context.library == "cpp", reason="trace-id 0 not treated as invalid")
     @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_b3multi_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3multi distributed tracing headers are not extracted

--- a/tests/parametric/test_headers_datadog.py
+++ b/tests/parametric/test_headers_datadog.py
@@ -34,7 +34,6 @@ class Test_Headers_Datadog:
         assert span["meta"].get("_dd.p.dm") == "-4"
         assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
 
-    @bug(context.library == "cpp", reason="trace-id 0 not treated as error")
     def test_distributed_headers_extract_datadog_invalid_D002(self, test_agent, test_library):
         """Ensure that invalid Datadog distributed tracing headers are not extracted.
         """
@@ -91,7 +90,6 @@ class Test_Headers_Datadog:
         assert headers["x-datadog-origin"] == "synthetics"
         assert "_dd.p.dm=-4" in headers["x-datadog-tags"]
 
-    @bug(context.library == "cpp", reason="trace-id 0 not treated as error")
     def test_distributed_headers_extractandinject_datadog_invalid_D005(self, test_agent, test_library):
         """Ensure that invalid Datadog distributed tracing headers are not extracted
         and the new span context is injected properly.

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -32,7 +32,6 @@ def enable_datadog_tracecontext() -> Any:
 
 @scenarios.parametric
 class Test_Headers_Precedence:
-    @missing_feature(context.library == "cpp", reason="traceparent is injected in headers1")
     @missing_feature(context.library == "dotnet", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "golang", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "nodejs", reason="New 'datadog' default hasn't been implemented yet")

--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -134,7 +134,6 @@ class Test_Headers_Tracecontext:
         assert traceparent3.trace_id == "12345678901234567890123456789012"
 
     @temporary_enable_optin_tracecontext()
-    @missing_feature(context.library == "cpp", reason="trace id is not regenerated for second case")
     def test_traceparent_version_0x00(self, test_agent, test_library):
         """
         harness sends an invalid traceparent with extra trailing characters

--- a/tests/parametric/test_headers_tracestate_dd.py
+++ b/tests/parametric/test_headers_tracestate_dd.py
@@ -321,7 +321,9 @@ class Test_Headers_Tracestate_DD:
         assert "o:tracing2.0" in dd_items6
 
     @temporary_enable_propagationstyle_default()
-    @missing_feature(context.library == "cpp", reason="_dd.p.dm is reset to DEFAULT because we made the sampling decision")
+    @missing_feature(
+        context.library == "cpp", reason="_dd.p.dm is reset to DEFAULT because we made the sampling decision"
+    )
     @missing_feature(
         context.library == "golang",
         reason="False Bug: header[3,6]: can't guarantee the order of strings in the tracestate since they came from the map. BUG: header[4,5]: w3cTraceID shouldn't be present",

--- a/tests/parametric/test_headers_tracestate_dd.py
+++ b/tests/parametric/test_headers_tracestate_dd.py
@@ -190,9 +190,6 @@ class Test_Headers_Tracestate_DD:
         assert "s:0" in dd_items8 or not any(item.startswith("s:") for item in dd_items8)
 
     @temporary_enable_propagationstyle_default()
-    @missing_feature(
-        context.library == "cpp", reason="origin 'synthetics~;=web,z' does not match expected values for dd_items3"
-    )
     @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_tracestate_dd_propagate_origin(self, test_agent, test_library):
         """
@@ -324,7 +321,7 @@ class Test_Headers_Tracestate_DD:
         assert "o:tracing2.0" in dd_items6
 
     @temporary_enable_propagationstyle_default()
-    @missing_feature(context.library == "cpp", reason="_dd.p.dm=-4 in headers1")
+    @missing_feature(context.library == "cpp", reason="_dd.p.dm is reset to DEFAULT because we made the sampling decision")
     @missing_feature(
         context.library == "golang",
         reason="False Bug: header[3,6]: can't guarantee the order of strings in the tracestate since they came from the map. BUG: header[4,5]: w3cTraceID shouldn't be present",
@@ -439,7 +436,7 @@ class Test_Headers_Tracestate_DD:
                 )
 
     @temporary_enable_propagationstyle_default()
-    @missing_feature(context.library == "cpp", reason="t.dm is still in dd_items2")
+    @missing_feature(context.library == "cpp", reason="_dd.p.dm is never dropped")
     @missing_feature(
         context.library == "nodejs", reason="Issue: the decision maker is removed. Is that allowed behavior?"
     )
@@ -510,7 +507,7 @@ class Test_Headers_Tracestate_DD:
         assert "t.url:http://localhost" in dd_items2
 
     @temporary_enable_propagationstyle_default()
-    @missing_feature(context.library == "cpp", reason="_dd.p.dm=-4 in dd_tags1")
+    @missing_feature(context.library == "cpp", reason="_dd.p.dm does not change when a sampling priority was extracted")
     @missing_feature(context.library == "nodejs", reason="Issue: Does not reset dm to DEFAULT")
     @missing_feature(context.library == "php", reason="Issue: Does not drop dm")
     @missing_feature(context.library == "python", reason="Issue: Does not reset dm to DEFAULT")

--- a/tests/parametric/test_span_sampling.py
+++ b/tests/parametric/test_span_sampling.py
@@ -273,7 +273,7 @@ class Test_Span_Sampling:
         assert len(sampled) in range(30, 70)
         assert len(unsampled) in range(30, 70)
 
-    @missing_feature(context.library == "cpp", reason="span is marked -1 / drop")
+    @missing_feature(context.library == "cpp", reason="cpp has not implemented stats computation yet")
     @missing_feature(
         context.library == "*",
         reason="this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert",
@@ -490,7 +490,7 @@ class Test_Span_Sampling:
     )
     def test_root_span_selected_by_sss014(self, test_agent, test_library):
         """Single spans selected by SSS must be kept and shouldn't affect child span sampling priority.
-        
+
         We're essentially testing to make sure that the span sampling rule keeps selected spans regardless of the trace sampling decision
         and doesn't affect child spans that are dropped by the tracer sampling mechanism.
         """
@@ -533,7 +533,7 @@ class Test_Span_Sampling:
     )
     def test_child_span_selected_by_sss015(self, test_agent, test_library):
         """Single spans selected by SSS must be kept even if its parent has been dropped.
-        
+
         We're essentially testing to make sure that the span sampling rule keeps selected spans despite of the trace sampling decision
         and doesn't affect parent spans that are dropped by the tracer sampling mechanism.
         """


### PR DESCRIPTION
## Description
Recent changes to [dd-trace-cpp][1] have made it more compatible with some of the parametric tests in this repository. Specifically, tests involving:

- 128-bit trace IDs
- trace propagation, with the exception of the "B3 single header" style.

This revision removes "cpp" exemptions from many tests, which now pass. Some of the tests for which "cpp" is still exempt now have updated descriptions. For example, it is still an open question (at least until Zach Montoya returns) how `_dd.p.dm` propagation should be handled in certain cases. Also, whether dd-trace-cpp should support the B3 single header propagation style, which has not been requested by any users of the C++ tracer and which is largely superseded by the similar W3C propagation style. Those questions we can address later.

See the commits for a breakdown of all that is proposed here.

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
 
[1]: https://github.com/DataDog/dd-trace-cpp
