### PR TITLE
Allow an error with last dev agent on python

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -18,6 +18,12 @@ class Test_Library:
     @bug(context.library < "java@0.93.0")
     @bug(context.library >= "dotnet@2.24.0")
     @bug(context.library >= "nodejs@2.27.1")
+    @bug(
+        context.library >= "python@1.16.0rc2.dev37"
+        and context.agent_version >= "7.47.0rc2"
+        and context.appsec_rules_file is not None,
+        reason="on /v0.7/config, client.products is an empty array",
+    )
     def test_full(self):
         interfaces.library.assert_schemas()
 
@@ -50,6 +56,8 @@ class Test_Library:
                 # value is missing in configuration object in telemetry payloads
                 r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
             )
+        elif context.library == "python":
+            allowed_errors = (r"\[\] is too short on instance \['client'\]\['products'\]",)
 
         interfaces.library.assert_schemas(allowed_errors=allowed_errors)
 


### PR DESCRIPTION
## Description

With last dev agent (image on `docker.io/datadog/agent-dev:master-py3`), `DD_APPSEC_RULESET` set on the tracer, and the last dev tracer on python, an error happen on schema validation : https://github.com/DataDog/system-tests/actions/runs/5534817039/jobs/10100298061#step:14:186 

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
