### PR TITLE
Mitigate agent failure on dev tests

### DIFF
--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -221,7 +221,7 @@ elif [ "$TARGET" = "cpp" ]; then
     # Not handled for now
 elif [ "$TARGET" = "agent" ]; then
     assert_version_is_dev
-    echo "datadog/agent-dev:master-py3" > agent-image
+    echo "datadog/agent-dev:master-py3@sha256:a50aee313c362a30429fc6948aeb1f63925fd43ba7c67fe9fb68a3a83c694040" > agent-image
     echo "Using $(cat agent-image) image"
 
 elif [ "$TARGET" = "nodejs" ]; then


### PR DESCRIPTION
## Description

Pin dev agent image while things get resolved

## Motivation

`dev` test cases [started failing tonight](https://github.com/DataDog/system-tests/actions/runs/5538435351):

- `docker.io/datadog/agent-dev:master-py3@sha256:a50aee313c362a30429fc6948aeb1f63925fd43ba7c67fe9fb68a3a83c694040` worked
- `docker.io/datadog/agent-dev:master-py3@sha256:ae0937801ae912dd13afa8411e2f7128846e1cbddda86811a3e979c84af38eb7` failed

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
