### PR TITLE
Hotfix: Using an older version of dev agent

### DIFF
--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -222,7 +222,7 @@ elif [ "$TARGET" = "cpp" ]; then
 elif [ "$TARGET" = "agent" ]; then
     assert_version_is_dev
     # echo "datadog/agent-dev:master-py3" > agent-image
-    echo "datadog/agent-dev@sha256:a50aee313c362a30429fc6948aeb1f63925fd43ba7c67fe9fb68a3a83c694040" > agent-image
+    echo "datadog/agent:latest" > agent-image
     echo "Using $(cat agent-image) image"
 
 elif [ "$TARGET" = "nodejs" ]; then


### PR DESCRIPTION
## Description

The last dev version of the agent break all ASM blocking tests. Using the prod one, waiting for a fix 

## Motivation

Unblock everything

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
