### PR TITLE
Fix remote config tests involving mocked rc backend responses

### DIFF
--- a/utils/proxy/core.py
+++ b/utils/proxy/core.py
@@ -187,7 +187,7 @@ class _RequestLogger:
             c = json.loads(flow.response.content)
             c["endpoints"].append("/v0.7/config")
             flow.response.content = json.dumps(c).encode()
-        elif flow.request.path == "/v0.7/config" and str(flow.response.status_code) == "404":
+        elif flow.request.path == "/v0.7/config":
             request_content = json.loads(flow.request.content)
 
             runtime_id = request_content["client"]["client_tracer"]["runtime_id"]


### PR DESCRIPTION
Remote configuration is a tricky beast to test live in the system-tests framework as it's a timing issue trying to add configuartions to the RC backend in time to make sure all the recorded responses are suitable for validation. As a result, we have a setup in place to allow developers to "pre-load" responses that should be sent to tracer libraries and have the MITM proxy sitting between the tracers and agents use those mocked responses instead of actually trying to contact the agent/rc-backend. At this point in time, all RC tests rely on this functionality.

Recently, the remote configuration team enabled RC by default in agents when it was previously explicitly disabled by default. This caused in issue in the proxy as it was set to only return mocked RC responses if the response from the agent was a 404. Now that RC is enabled by default, which causes that endpoint to exist and serve requests, that response will never be 404 and our mocked responses won't be used, breaking the tests.

To resolve this, we just drop the status code check. There's a top level flag that has to be set for the proxy to attempt the Remote Config response modification behavior, and that's sufficient enough. If that flag is set that's us explicitly saying we want this behavior and it doesn't matter if the agent is actually serving remote config or not.

## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
