### PR TITLE
Fix OTel collector healthcheck endpoint

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -534,14 +534,14 @@ class OpenTelemetryCollectorContainer(TestedContainer):
 
         for i in range(61):
             try:
-                r = requests.get("http://localhost:13133", timeout=1)
-                logger.debug(f"Healthcheck #{i} on localhost:13133: {r}")
+                r = requests.get("http://0.0.0.0:13133", timeout=1)
+                logger.debug(f"Healthcheck #{i} on 0.0.0.0:13133: {r}")
                 if r.status_code == 200:
                     return
             except Exception as e:
-                logger.debug(f"Healthcheck #{i} on localhost:13133: {e}")
+                logger.debug(f"Healthcheck #{i} on 0.0.0.0:13133: {e}")
             time.sleep(1)
-        pytest.exit("localhost:13133 never answered to healthcheck request", 1)
+        pytest.exit("0.0.0.0:13133 never answered to healthcheck request", 1)
 
     def start(self) -> Container:
         # _otel_config_host_path is mounted in the container, and depending on umask,


### PR DESCRIPTION
## Description

Previous OTel collector healthcheck endpoint is `localhost:13133`, that will introduce problems when running the tests in CI (in docker images). While `0.0.0.0:13133` works in both local tests and CI jobs.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
