### PR TITLE
Merge parametric CI inside main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,13 @@ jobs:
       - run: ./run.sh TEST_THE_TEST
 
   scenarios:
-    uses: datadog/system-tests/.github/workflows/compute-scenarios.yml@main
+    uses: datadog/system-tests/.github/workflows/compute-scenarios.yml@${{ github.ref_name }}
+
+  parametric:
+    needs:
+    - lint
+    - test_the_test
+    uses: datadog/system-tests/.github/workflows/parametric.yml@${{ github.ref_name }}
 
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -1,33 +1,12 @@
 name: Parametric
 on:
-  workflow_dispatch: {}
-  schedule:
-  - cron: 00 02 * * 2-6
-  pull_request:
-    branches:
-    - '**'
-  push:
-    branches:
-    - main
+  workflow_call:
 
 env:
   REGISTRY: ghcr.io
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-jobs:
-  lints:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Run lints
-      uses: ./.github/actions/lint_code
-      
+jobs: 
   parametric:
         runs-on: ubuntu-latest
-        needs:
-        - lints
         strategy:
           matrix:
             client:
@@ -46,11 +25,8 @@ jobs:
         steps:
         - name: Checkout
           uses: actions/checkout@v3
-        - uses: actions/setup-python@v4
-          with:
-            python-version: '3.9'
-        - name: Build
-          run: ./build.sh -i runner
+        - name: Install runner
+          uses: ./.github/actions/install_runner
         - name: Run
           run: ./run.sh PARAMETRIC
         - name: Compress logs


### PR DESCRIPTION
## Description

As now, main CI and parametric CI are two separated workflow. 

Now, the main CI will call parametric tests once test_the_test and lint are ok

## Motivation

Simplify CI workflows, save some CI time

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] If this PR modifies anything else than strictly the default scenario, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/system-tests-ci.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
