### PR TITLE
Activate APPSEC Xpass tests

### DIFF
--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -37,7 +37,7 @@ _released_java_blocking = {
     cpp="?",
     dotnet="2.27.0",
     php_appsec="0.7.0",
-    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "?"},
+    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "1.16.1"},
     nodejs="3.19.0",
     golang="1.51.0",
     ruby="1.0.0",
@@ -236,7 +236,7 @@ def _assert_custom_event_tag_absence():
     golang="1.51.0",
     nodejs="3.19.0",
     php_appsec="0.7.0",
-    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "?"},
+    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "1.16.1"},
     ruby="1.12.0",
     java=_released_java_blocking,
 )
@@ -287,7 +287,7 @@ class Test_Blocking_request_method:
     golang="1.51.0",
     nodejs="3.19.0",
     php_appsec="0.7.0",
-    python={"django-poc": "1.15", "flask-poc": "1.15", "*": "?"},
+    python={"django-poc": "1.15", "flask-poc": "1.15", "*": "1.16.1"},
     ruby="1.0.0",
     java=_released_java_blocking,
 )
@@ -349,7 +349,7 @@ class Test_Blocking_request_uri:
     java="1.15.0",
     nodejs="?",
     php_appsec="0.7.0",
-    python={"django-poc": "1.10", "flask-poc": "1.13", "*": "?"},
+    python={"django-poc": "1.10", "flask-poc": "1.13", "*": "1.16.1"},
     ruby="1.0.0",
 )
 @missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
@@ -403,7 +403,7 @@ class Test_Blocking_request_path_params:
     golang="1.51.0",
     nodejs="3.19.0",
     php_appsec="0.7.0",
-    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "?"},
+    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "1.16.1"},
     ruby="1.0.0",
     java=_released_java_blocking,
 )
@@ -460,7 +460,7 @@ class Test_Blocking_request_query:
     golang="1.51.0",
     nodejs="3.19.0",
     php_appsec="0.7.0",
-    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "?"},
+    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "1.16.1"},
     ruby="1.0.0",
     java=_released_java_blocking,
 )
@@ -517,7 +517,7 @@ class Test_Blocking_request_headers:
     golang="1.51.0",
     nodejs="?",
     php_appsec="0.7.0",
-    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "?"},
+    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "1.16.1"},
     ruby="1.0.0",
     java=_released_java_blocking,
 )
@@ -575,7 +575,7 @@ class Test_Blocking_request_cookies:
     java="1.15.0",
     nodejs="3.19.0",
     php_appsec="0.7.0",
-    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "?"},
+    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "1.16.1"},
     ruby="1.0.0",
 )
 @missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
@@ -647,7 +647,7 @@ class Test_Blocking_request_body:
     java="?",
     nodejs="?",
     php_appsec="0.7.0",
-    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "?"},
+    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "1.16.1"},
     ruby="1.10.0",
 )
 @missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
@@ -685,7 +685,7 @@ class Test_Blocking_response_status:
     java="?",
     nodejs="?",
     php_appsec="0.7.0",
-    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "?"},
+    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "1.16.1"},
     ruby="1.0.0",
 )
 @missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -175,7 +175,7 @@ class Test_Headers:
         "django-poc": "1.1.0rc2.dev",
         "flask-poc": PYTHON_RELEASE_PUBLIC_BETA,
         "uds-flask": PYTHON_RELEASE_PUBLIC_BETA,
-        "uwsgi-poc": "?",
+        "uwsgi-poc": "1.16.1",
         "pylons": "1.1.0rc2.dev",
     }
 )

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -56,7 +56,7 @@ JSON_CONTENT_TYPES = {
     golang="1.50.0-rc.1",
     nodejs="3.19.0",
     php_appsec="0.7.0",
-    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "?"},
+    python={"django-poc": "1.10", "flask-poc": "1.10", "*": "1.16.1"},
     ruby="1.11.0",
     java={
         "spring-boot": "0.112.0",
@@ -84,7 +84,7 @@ class Test_Blocking:
     @bug(context.library < "java@0.115.0" and context.weblog_variant == "spring-boot-undertow", reason="npe")
     @bug(context.library < "java@0.115.0" and context.weblog_variant == "spring-boot-wildfly", reason="npe")
     @bug(context.weblog_variant == "gin", reason="Block message is prepended")
-    @bug(context.library == "python", reason="Bug, minify and remove new line characters")
+    @bug(context.library < "python@1.16.1", reason="Bug, minify and remove new line characters")
     @bug(context.library < "ruby@1.12.1", reason="wrong default content-type")
     def test_no_accept(self):
         """Blocking without an accept header"""

--- a/tests/appsec/waf/test_custom_rules.py
+++ b/tests/appsec/waf/test_custom_rules.py
@@ -7,7 +7,7 @@ from utils import interfaces, released, scenarios, weblog
     golang="1.51.0",
     nodejs="4.1.0",
     php_appsec="0.8.1",
-    python={"django-poc": "1.12", "flask-poc": "1.12", "*": "?"},
+    python={"django-poc": "1.12", "flask-poc": "1.12", "*": "1.16.1"},
     ruby="1.12.0",
     cpp="?",
 )

--- a/tests/appsec/waf/test_exclusions.py
+++ b/tests/appsec/waf/test_exclusions.py
@@ -11,7 +11,7 @@ if context.weblog_variant == "akka-http":
     golang="1.53.0",
     nodejs="3.19.0",
     php_appsec="0.7.0",
-    python={"django-poc": "1.12", "flask-poc": "1.12", "*": "?"},
+    python={"django-poc": "1.12", "flask-poc": "1.12", "*": "1.16.1"},
     ruby="1.11.0",
     cpp="?",
 )


### PR DESCRIPTION
## Description

Activate those tests : 

* appsec-blocking_addresses-blocking_request_body
* appsec-blocking_addresses-blocking_request_cookies
* appsec-blocking_addresses-blocking_request_headers
* appsec-blocking_addresses-blocking_request_method
* appsec-blocking_addresses-blocking_request_path_params
* appsec-blocking_addresses-blocking_request_query
* appsec-blocking_addresses-blocking_request_uri
* appsec-blocking_addresses-blocking_response_headers
* appsec-blocking_addresses-blocking_response_status
* appsec-waf-custom_rules-customrules
* appsec-waf-exclusions-exclusio

They are all XPASS

I set the prod version of the tracer `1.16.1`, but they may be working prior to that version.


## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
