### PR TITLE
Fix pycache clearing

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -102,7 +102,7 @@ function downcase() {
 }
 
 function clean_pycache() {
-    find utils tests -type d -name '__pycache__'  -prune -exec rm -rf {} +
+    find utils tests -type d -name '__pycache__' -exec rm -rf {} +
 }
 
 function is_using_nix() {

--- a/run.sh
+++ b/run.sh
@@ -101,10 +101,6 @@ function downcase() {
     tr '[:upper:]' '[:lower:]'
 }
 
-function clean_pycache() {
-    find utils tests -type d -name '__pycache__' -exec rm -rf {} +
-}
-
 function is_using_nix() {
     [[ -n "${IN_NIX_SHELL:-}" ]]
 }
@@ -298,9 +294,6 @@ function main() {
         run_mode='docker'
     else
         run_mode='direct'
-
-        # cleanups
-        clean_pycache
 
         # ensure environment
         if ! is_using_nix; then


### PR DESCRIPTION
## Description

Fix pycache clearing.

## Motivation

`-prune` appears to be useless, unless (or even if) someone expects a `__pycache__` folder to be nested.

@cbeauchesne reported that this occcured:

```
rm: cannot remove 'tests/parametric/__pycache__': Directory not empty
```

Possible causes:

- The `find` command attempted to delete things before the directory was entirely cleared out (but there's `-rf` on `rm`)
- Something regenerated pycache files while it was being recursively removed
- Something created nested files that could not be removed (e.g due to permissions):
  - A typical candidate would be a container with that path exposed as a volume, but the users within (root) and outside (regular user) are in mismatch, so the generated files and folders are not writable, thus not removable
  - `ProxyContainer` does that but exposes `ro` so probably not that. Also, it's happening in `tests/parametric`, and no container has that exposed as a volume by default.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
