### PR TITLE
Unskip default propagation parametric test for .NET

### DIFF
--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -33,7 +33,6 @@ def enable_datadog_tracecontext() -> Any:
 @scenarios.parametric
 class Test_Headers_Precedence:
     @missing_feature(context.library == "cpp", reason="traceparent is injected in headers1")
-    @missing_feature(context.library == "dotnet", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "golang", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "nodejs", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "php", reason="New 'datadog' default hasn't been implemented yet")


### PR DESCRIPTION
## Description

Unskips the parametric test for the default propagation style.

> Note stacked ontop of my otel branch as this will also require the next release of the .NET Tracer 2.34.0

## Motivation

Default propagation is being changed from `tracecontext,Datadog` to just `Datadog`

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
