### PR TITLE
Prevent finding rid in non-service entry spans

### DIFF
--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -170,6 +170,7 @@ def get_rid_from_span(span):
         return None
 
     meta = span.get("meta", {})
+    metrics = span.get("metrics", {})
 
     user_agent = None
 
@@ -177,7 +178,7 @@ def get_rid_from_span(span):
         user_agent = meta.get("grpc.metadata.user-agent")
         # java does not fill this tag; it uses the normal http tags
 
-    if not user_agent:
+    if not user_agent and metrics.get("_dd.top_level") == 1.0:
         # code version
         user_agent = meta.get("http.request.headers.user-agent")
 

--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -179,7 +179,7 @@ def get_rid_from_span(span):
         # java does not fill this tag; it uses the normal http tags
 
     if not user_agent and metrics.get("_dd.top_level") == 1.0:
-        # code version
+        # The top level span (aka root span) is mark via the _dd.top_level tag by the tracers
         user_agent = meta.get("http.request.headers.user-agent")
 
     if not user_agent:  # try something for .NET


### PR DESCRIPTION
## Description

We are introducing proper `DD_TRACE_HEADER_TAGS` support in `dd-trace-rb` (https://github.com/DataDog/dd-trace-rb/pull/2935) and it trips a few appsec system-tests.

The issue happens because we tag non-service entry spans with `DD_TRACE_HEADER_TAGS`, but those tags are used to find the request id (`rid`) by system-tests to perform assertions.

It is likely very uncommon to set HTTP serve `DD_TRACE_HEADER_TAGS` tags in non-service entry spans, but it's the current state of the Ruby tracer. We should likely change this, and stop tagging Sinatra spans with `DD_TRACE_HEADER_TAGS`, but that's a breaking change for our clients and won't happen in the short term.
Disabling test until this change happens in the Ruby tracer is also not a great approach, because that would mean disabling a large set of appsec tests that we want to keep.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
