### PR TITLE
remove log level to debug in flask application

### DIFF
--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -6,7 +6,6 @@ from utils import (
     bug,
     context,
     coverage,
-    flaky,
     interfaces,
     irrelevant,
     missing_feature,
@@ -14,6 +13,7 @@ from utils import (
     rfc,
     scenarios,
     weblog,
+    flaky,
 )
 
 # Compatibility matrix for blocking across Java variants, to be reused for multiple test suites.
@@ -658,10 +658,7 @@ class Test_Blocking_response_status:
     """Test if blocking is supported on server.response.status address"""
 
     def setup_blocking(self):
-        self.rm_req_block = {
-            (i, status): weblog.get(f"/tag_value/anything/{status}")
-            for i, status in enumerate((415, 416, 417, 418) * 1000)
-        }
+        self.rm_req_block = {status: weblog.get(f"/tag_value/anything/{status}") for status in (415, 416, 417, 418)}
 
     def test_blocking(self):
         """Test if requests that should be blocked are blocked"""

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -6,6 +6,7 @@ from utils import (
     bug,
     context,
     coverage,
+    flaky,
     interfaces,
     irrelevant,
     missing_feature,
@@ -13,7 +14,6 @@ from utils import (
     rfc,
     scenarios,
     weblog,
-    flaky,
 )
 
 # Compatibility matrix for blocking across Java variants, to be reused for multiple test suites.
@@ -658,7 +658,10 @@ class Test_Blocking_response_status:
     """Test if blocking is supported on server.response.status address"""
 
     def setup_blocking(self):
-        self.rm_req_block = {status: weblog.get(f"/tag_value/anything/{status}") for status in (415, 416, 417, 418)}
+        self.rm_req_block = {
+            (i, status): weblog.get(f"/tag_value/anything/{status}")
+            for i, status in enumerate((415, 416, 417, 418) * 1000)
+        }
 
     def test_blocking(self):
         """Test if requests that should be blocked are blocked"""

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -1,5 +1,3 @@
-import logging
-
 import psycopg2
 import requests
 from ddtrace import tracer
@@ -23,8 +21,6 @@ except ImportError:
 POSTGRES_CONFIG = dict(
     host="postgres", port="5433", user="system_tests_user", password="system_tests", dbname="system_tests",
 )
-
-logging.basicConfig(level=logging.DEBUG)
 
 app = Flask(__name__)
 


### PR DESCRIPTION

## Description

Remove default log level to DEBUG in flask application

## Motivation

Since merge of https://github.com/DataDog/system-tests/pull/1426 some tests using python tracer with flask-poc were failing non deterministically. It seems that default log level to debug can generate too much data and prevent some requests to have their responses caught by the tests.

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
