### PR TITLE
Fix yaml parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
       # force /bin/bash in order to test against bash 3.2 on macOS
       - name: Test the test (direct)
         run: /bin/bash run.sh TEST_THE_TEST
+      - name: Test the test (docker)
+        run: |
+          /bin/bash build.sh -i runner -d
+          /bin/bash run.sh +d TEST_THE_TEST
       - name: Test group parsing
         run: |
           /bin/bash run.sh ++dry APPSEC_SCENARIOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,13 @@ jobs:
         uses: actions/checkout@v3
       - name: Install runner
         uses: ./.github/actions/install_runner
+      # force /bin/bash in order to test against bash 3.2 on macOS
       - name: Test the test (direct)
-        run: ./run.sh TEST_THE_TEST
+        run: /bin/bash run.sh TEST_THE_TEST
       - name: Test group parsing
         run: |
-          ./run.sh ++dry APPSEC_SCENARIOS
-          ./run.sh ++dry TRACER_RELEASE_SCENARIOS
+          /bin/bash run.sh ++dry APPSEC_SCENARIOS
+          /bin/bash run.sh ++dry TRACER_RELEASE_SCENARIOS
 
   scenarios:
     uses: datadog/system-tests/.github/workflows/compute-scenarios.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,6 @@ jobs:
       # force /bin/bash in order to test against bash 3.2 on macOS
       - name: Test the test (direct)
         run: /bin/bash run.sh TEST_THE_TEST
-      - name: Test the test (docker)
-        run: |
-          /bin/bash build.sh -i runner -d
-          /bin/bash run.sh +d TEST_THE_TEST
       - name: Test group parsing
         run: |
           /bin/bash run.sh ++dry APPSEC_SCENARIOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,24 @@ jobs:
       uses: ./.github/actions/lint_code
 
   test_the_test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    name: Test the test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install runner
         uses: ./.github/actions/install_runner
-      - run: ./run.sh TEST_THE_TEST
+      - name: Test the test (direct)
+        run: ./run.sh TEST_THE_TEST
+      - name: Test group parsing
+        run: |
+          ./run.sh ++dry APPSEC_SCENARIOS
+          ./run.sh ++dry TRACER_RELEASE_SCENARIOS
 
   scenarios:
     uses: datadog/system-tests/.github/workflows/compute-scenarios.yml@main

--- a/run.sh
+++ b/run.sh
@@ -221,7 +221,8 @@ function main() {
                   exit 64
                 fi
                 # upcase via ${2^^} is unsupported on bash 3.x
-                mapfile -t group <<< "$(lookup_scenario_group "$(echo "$2" | upcase)")"
+                # bash 3.x does not support mapfile, dance around with tr and IFS
+                IFS=',' read -r -a group <<< "$(lookup_scenario_group "$(echo "$2" | upcase)" | tr '\n' ',')"
                 scenarios+=("${group[@]}")
                 shift
                 ;;
@@ -260,7 +261,8 @@ function main() {
             *)
                 # handle positional arguments
                 if [[ "$1" =~ [A-Z0-9_]+_SCENARIOS$ ]]; then
-                    mapfile -t group <<< "$(lookup_scenario_group "$1")"
+                    # bash 3.x does not support mapfile, dance around with tr and IFS
+                    IFS=',' read -r -a group <<< "$(lookup_scenario_group "$1" | tr '\n' ',')"
                     scenarios+=("${group[@]}")
                 elif [[ "$1" =~ ^[A-Z0-9_]+$ ]]; then
                     scenarios+=("$1")

--- a/run.sh
+++ b/run.sh
@@ -93,8 +93,41 @@ function die() {
 function lookup_scenario_group() {
     local group="$1"
 
-    activate_venv
-    cat < scenario_groups.yml | python -c 'import yaml; import sys; key = sys.argv[1]; data = sys.stdin.read(); g = yaml.safe_load(data)[key]; [[print(t) for t in s] if isinstance(s, list) else print(s) for s in g]' "${group}"
+    # formatted perl code with -e for readabiliy
+    # shellcheck disable=SC2016
+    cat < scenario_groups.yml \
+        | env GROUP="${group}" perl -0777 \
+               -e '    use v5.30;                                          ' \
+               -e '    use YAML qw[ Load ];                                ' \
+               -e '                                                        ' \
+               -e '    # get group                                         ' \
+               -e '    my $group = $ENV{"GROUP"};                          ' \
+               -e '                                                        ' \
+               -e '    # parse yaml by surlping (0777) from stdin          ' \
+               -e '    my $yaml = Load(<>);                                ' \
+               -e '                                                        ' \
+               -e '    # dereference ref to hash                           ' \
+               -e '    my %groups = %{ $yaml };                            ' \
+               -e '                                                        ' \
+               -e '    # test if key exists                                ' \
+               -e '    if (! exists $groups{$group}) {                     ' \
+               -e '      print STDERR "error: group ${group} not found\n"; ' \
+               -e '      exit 1                                            ' \
+               -e '    }                                                   ' \
+               -e '                                                        ' \
+               -e '    # get list, dereference ref to array                ' \
+               -e '    my @scenarios = @{ %groups{$group} };               ' \
+               -e '                                                        ' \
+               -e '    foreach my $e (@scenarios) {                        ' \
+               -e '      if (ref $e eq "ARRAY") {                          ' \
+               -e '        # flatten second level array                    ' \
+               -e '        foreach my $f (@{ $e }) {                       ' \
+               -e '           print "${f}\n";                              ' \
+               -e '        }                                               ' \
+               -e '      } else { # string                                 ' \
+               -e '        print "${e}\n";                                 ' \
+               -e '      }                                                 ' \
+               -e '    }                                                   '
 }
 
 function upcase() {

--- a/run.sh
+++ b/run.sh
@@ -192,16 +192,21 @@ function run_scenario() {
               -e SYSTEM_TESTS_HOST_PROJECT_DIR="${PWD}"
               --name system-tests-runner
               system_tests/runner
-              venv/bin/pytest -S "${scenario}" "${pytest_args[@]}"
+              venv/bin/pytest
             )
             ;;
         'direct')
-            cmd+=(pytest -S "${scenario}" "${pytest_args[@]}")
+            cmd+=(pytest)
             ;;
         *)
             die "unsupported run mode: ${mode}"
             ;;
     esac
+
+    cmd+=(
+        -S "${scenario}"
+        "${pytest_args[@]}"
+    )
 
     "${cmd[@]}"
 }

--- a/run.sh
+++ b/run.sh
@@ -31,6 +31,9 @@ SYNOPSIS
 OPTIONS
     Using option flags is the recommended way to use ${program}.
 
+    +v, ++verbose
+      Increase verbosity.
+
     +d, ++docker
       Run tests in a Docker container. The runner image must be built beforehand.
 
@@ -156,6 +159,7 @@ function run_scenario() {
 
 function main() {
     local docker="${DOCKER_MODE:-0}"
+    local verbosity=0
     local scenarios=()
     local libraries=()
     local pytest_args=()
@@ -174,6 +178,9 @@ function main() {
             +h|++help)
                 help
                 exit
+                ;;
+            +v|++verbose)
+                verbosity=$(( verbosity + 1 ))
                 ;;
             +d|++docker)
                 docker=1
@@ -300,6 +307,15 @@ function main() {
         if ! is_using_nix; then
             activate_venv
         fi
+    fi
+
+    if [[ "${verbosity}" -gt 0 ]]; then
+        echo "plan:"
+        echo "  mode: ${run_mode}"
+        echo "  scenarios:"
+        for scenario in "${scenarios[@]}"; do
+            echo "    - ${scenario}"
+        done
     fi
 
     for scenario in "${scenarios[@]}"; do

--- a/shell.nix
+++ b/shell.nix
@@ -31,6 +31,9 @@ in llvm.stdenv.mkDerivation {
     pinned.bash
     pinned.fswatch
     pinned.rsync
+    pinned.perl536
+    pinned.perl536Packages.DBFile
+    pinned.perl536Packages.YAML
 
     # for c++ dependencies such as grpcio-tools
     llvm.libcxx.dev

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@
   pkgs ? import <nixpkgs> {},
 
   # use a pinned package state
-  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/14d9b465c71.tar.gz")) {},
+  pinned ? import(fetchTarball("https://github.com/NixOS/nixpkgs/archive/88f63d51109.tar.gz")) {},
 }:
 let
   # get these python packages from nix

--- a/shell.nix
+++ b/shell.nix
@@ -31,9 +31,6 @@ in llvm.stdenv.mkDerivation {
     pinned.bash
     pinned.fswatch
     pinned.rsync
-    pinned.perl536
-    pinned.perl536Packages.DBFile
-    pinned.perl536Packages.YAML
 
     # for c++ dependencies such as grpcio-tools
     llvm.libcxx.dev


### PR DESCRIPTION
## Description

In contexts where we run, `perl` is available with `YAML` module. Use that instead of `python` to read `yml`.

This PR also introduce:

- a verbosity control flag
- a dry run flag

Both being very useful for debugging the `run.sh` script.

## Motivation

The need for `activate_venv` in #1427 is caused by `pyyaml` being needed byt not being available as a default.

It's a bit early to activate the virtualenv in some scenarios, and in others, activating the venv is potentially harmful (e.g when there is no need for a venv).

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
