### PR TITLE
[parametric] Unskip Ruby parametric tests

### DIFF
--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -13,15 +13,15 @@ parametrize = pytest.mark.parametrize
 
 def enable_b3() -> Any:
     env = {
-        "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "B3 SINGLE HEADER",
-        "DD_TRACE_PROPAGATION_STYLE_INJECT": "b3 single header",
+        "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "B3 single header",
+        "DD_TRACE_PROPAGATION_STYLE_INJECT": "B3 single header",
     }
     return parametrize("library_env", [env])
 
 
 def enable_b3_single_key() -> Any:
     env = {
-        "DD_TRACE_PROPAGATION_STYLE": "B3 SINGLE HEADER",
+        "DD_TRACE_PROPAGATION_STYLE": "B3 single header",
     }
     return parametrize("library_env", [env])
 
@@ -45,7 +45,6 @@ def enable_migrated_b3_single_key() -> Any:
 class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_extract_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and activated properly.
@@ -63,7 +62,6 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_extract_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted.
         """
@@ -77,7 +75,6 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_inject_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are injected properly.
         """
@@ -98,7 +95,6 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_propagate_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and injected properly.
@@ -122,7 +118,6 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted
         and the new span context is injected properly.
@@ -147,7 +142,6 @@ class Test_Headers_B3:
 
     @enable_b3_single_key()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_single_key_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3_propagate_valid(test_agent, test_library)
 

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -75,9 +75,6 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(
-        context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
-    )
     def test_headers_b3_inject_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are injected properly.
         """
@@ -98,9 +95,6 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(
-        context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
-    )
     def test_headers_b3_propagate_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and injected properly.
@@ -187,9 +181,6 @@ class Test_Headers_B3:
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
-    @missing_feature(
-        context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
-    )
     def test_headers_b3_migrated_inject_valid(self, test_agent, test_library):
         self.test_headers_b3_inject_valid(test_agent, test_library)
 
@@ -202,9 +193,6 @@ class Test_Headers_B3:
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
-    @missing_feature(
-        context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
-    )
     def test_headers_b3_migrated_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3_propagate_valid(test_agent, test_library)
 
@@ -217,9 +205,6 @@ class Test_Headers_B3:
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
-    @missing_feature(
-        context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
-    )
     def test_headers_b3_migrated_propagate_invalid(self, test_agent, test_library):
         self.test_headers_b3_propagate_invalid(test_agent, test_library)
 

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -76,7 +76,7 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    def test_headers_b3multi_propagate_valid(self, test_agent, test_library):
+    def test_headers_b3_propagate_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and injected properly.
         """
@@ -99,7 +99,7 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    def test_headers_b3multi_propagate_invalid(self, test_agent, test_library):
+    def test_headers_b3_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted
         and the new span context is injected properly.
         """

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -190,6 +190,10 @@ class Test_Headers_B3:
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
+    @missing_feature(
+        context.library == "ruby",
+        reason="1) b3 traceid should be padded to 16 or 32 hex characters and 2) b3 header not injected for DD_TRACE_PROPAGATION_STYLE=b3 config",
+    )
     def test_headers_b3_migrated_inject_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are injected properly.
         """
@@ -217,6 +221,10 @@ class Test_Headers_B3:
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
+    @missing_feature(
+        context.library == "ruby",
+        reason="1) b3 traceid should be padded to 16 or 32 hex characters and 2) b3 header not injected for DD_TRACE_PROPAGATION_STYLE=b3 config",
+    )
     def test_headers_b3_migrated_propagate_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and injected properly.
@@ -247,6 +255,10 @@ class Test_Headers_B3:
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
+    @missing_feature(
+        context.library == "ruby",
+        reason="1) b3 traceid should be padded to 16 or 32 hex characters and 2) b3 header not injected for DD_TRACE_PROPAGATION_STYLE=b3 config",
+    )
     def test_headers_b3_migrated_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted
         and the new span context is injected properly.

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -149,25 +149,7 @@ class Test_Headers_B3:
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_single_key_propagate_valid(self, test_agent, test_library):
-        """Ensure that b3 distributed tracing headers are extracted
-        and injected properly.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(
-                test_library, [["b3", "000000000000000000000000075bcd15-000000003ade68b1-1"]]
-            )
-
-        span = get_span(test_agent)
-        b3Arr = headers["b3"].split("-")
-        b3_trace_id = b3Arr[0]
-        b3_span_id = b3Arr[1]
-        b3_sampling = b3Arr[2]
-
-        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
-        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
-        assert b3_sampling == "1"
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3_propagate_valid(test_agent, test_library)
 
     @enable_migrated_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
@@ -179,19 +161,7 @@ class Test_Headers_B3:
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
     def test_headers_b3_migrated_extract_valid(self, test_agent, test_library):
-        """Ensure that b3 distributed tracing headers are extracted
-        and activated properly.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(
-                test_library, [["b3", "000000000000000000000000075bcd15-000000003ade68b1-1"]]
-            )
-
-        span = get_span(test_agent)
-        assert span.get("trace_id") == 123456789
-        assert span.get("parent_id") == 987654321
-        assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == 1
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3_extract_invalid(test_agent, test_library)
 
     @enable_migrated_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
@@ -203,15 +173,7 @@ class Test_Headers_B3:
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
     def test_headers_b3_migrated_extract_invalid(self, test_agent, test_library):
-        """Ensure that invalid b3 distributed tracing headers are not extracted.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(test_library, [["b3", "0-0-1"]])
-
-        span = get_span(test_agent)
-        assert span.get("trace_id") != 0
-        assert span_has_no_parent(span)
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3_extract_invalid(test_agent, test_library)
 
     @enable_migrated_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
@@ -226,22 +188,7 @@ class Test_Headers_B3:
         context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
     )
     def test_headers_b3_migrated_inject_valid(self, test_agent, test_library):
-        """Ensure that b3 distributed tracing headers are injected properly.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(test_library, [])
-
-        span = get_span(test_agent)
-        b3Arr = headers["b3"].split("-")
-        b3_trace_id = b3Arr[0]
-        b3_span_id = b3Arr[1]
-        b3_sampling = b3Arr[2]
-
-        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
-        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
-        assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3_inject_valid(test_agent, test_library)
 
     @enable_migrated_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
@@ -256,25 +203,7 @@ class Test_Headers_B3:
         context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
     )
     def test_headers_b3_migrated_propagate_valid(self, test_agent, test_library):
-        """Ensure that b3 distributed tracing headers are extracted
-        and injected properly.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(
-                test_library, [["b3", "000000000000000000000000075bcd15-000000003ade68b1-1"]]
-            )
-
-        span = get_span(test_agent)
-        b3Arr = headers["b3"].split("-")
-        b3_trace_id = b3Arr[0]
-        b3_span_id = b3Arr[1]
-        b3_sampling = b3Arr[2]
-
-        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
-        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
-        assert b3_sampling == "1"
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3_propagate_valid(test_agent, test_library)
 
     @enable_migrated_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
@@ -289,26 +218,7 @@ class Test_Headers_B3:
         context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
     )
     def test_headers_b3_migrated_propagate_invalid(self, test_agent, test_library):
-        """Ensure that invalid b3 distributed tracing headers are not extracted
-        and the new span context is injected properly.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(test_library, [["b3", "0-0-1"]])
-
-        span = get_span(test_agent)
-        assert span.get("trace_id") != 0
-        assert span.get("span_id") != 0
-
-        b3Arr = headers["b3"].split("-")
-        b3_trace_id = b3Arr[0]
-        b3_span_id = b3Arr[1]
-        b3_sampling = b3Arr[2]
-
-        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
-        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
-        assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3_propagate_invalid(test_agent, test_library)
 
     @enable_migrated_b3_single_key()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
@@ -323,22 +233,4 @@ class Test_Headers_B3:
         context.library == "ruby", reason="Propagators not configured for DD_TRACE_PROPAGATION_STYLE config",
     )
     def test_headers_b3_migrated_single_key_propagate_valid(self, test_agent, test_library):
-        """Ensure that b3 distributed tracing headers are extracted
-        and injected properly.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(
-                test_library, [["b3", "000000000000000000000000075bcd15-000000003ade68b1-1"]]
-            )
-
-        span = get_span(test_agent)
-        b3Arr = headers["b3"].split("-")
-        b3_trace_id = b3Arr[0]
-        b3_span_id = b3Arr[1]
-        b3_sampling = b3Arr[2]
-
-        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
-        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
-        assert b3_sampling == "1"
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3_propagate_valid(test_agent, test_library)

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -75,6 +75,9 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(
+        context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
+    )
     def test_headers_b3_inject_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are injected properly.
         """
@@ -95,6 +98,9 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(
+        context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
+    )
     def test_headers_b3_propagate_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and injected properly.
@@ -142,6 +148,9 @@ class Test_Headers_B3:
 
     @enable_b3_single_key()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(
+        context.library == "ruby", reason="Propagators not configured for DD_TRACE_PROPAGATION_STYLE config",
+    )
     def test_headers_b3_single_key_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3_propagate_valid(test_agent, test_library)
 

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -26,7 +26,6 @@ def enable_b3() -> Any:
 class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_b3_extract_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and activated properly.
@@ -57,7 +56,6 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_b3_inject_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are injected properly.
         """
@@ -78,7 +76,6 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_b3multi_propagate_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and injected properly.
@@ -102,7 +99,6 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_b3multi_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted
         and the new span context is injected properly.

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -21,11 +21,21 @@ def enable_b3() -> Any:
     }
     return parametrize("library_env", [env1, env2])
 
+def enable_migrated_b3() -> Any:
+    env1 = {
+        "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "b3",
+        "DD_TRACE_PROPAGATION_STYLE_INJECT": "b3",
+    }
+    env2 = {
+        "DD_TRACE_PROPAGATION_STYLE": "b3",
+    }
+    return parametrize("library_env", [env1, env2])
 
 @scenarios.parametric
 class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_extract_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and activated properly.
@@ -43,6 +53,7 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_extract_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted.
         """
@@ -56,6 +67,7 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_inject_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are injected properly.
         """
@@ -76,6 +88,7 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_propagate_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and injected properly.
@@ -99,7 +112,140 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "ruby", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_propagate_invalid(self, test_agent, test_library):
+        """Ensure that invalid b3 distributed tracing headers are not extracted
+        and the new span context is injected properly.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(test_library, [["b3", "0-0-1"]])
+
+        span = get_span(test_agent)
+        assert span.get("trace_id") != 0
+        assert span.get("span_id") != 0
+
+        b3Arr = headers["b3"].split("-")
+        b3_trace_id = b3Arr[0]
+        b3_span_id = b3Arr[1]
+        b3_sampling = b3Arr[2]
+
+        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
+        assert int(b3_trace_id, base=16) == span.get("trace_id")
+        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
+        assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
+        assert span["meta"].get(ORIGIN) is None
+
+    @enable_migrated_b3()
+    @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "dotnet", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "golang", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
+    def  test_headers_b3_migrated_extract_valid(self, test_agent, test_library):
+        """Ensure that b3 distributed tracing headers are extracted
+        and activated properly.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(
+                test_library, [["b3", "000000000000000000000000075bcd15-000000003ade68b1-1"]]
+            )
+
+        span = get_span(test_agent)
+        assert span.get("trace_id") == 123456789
+        assert span.get("parent_id") == 987654321
+        assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == 1
+        assert span["meta"].get(ORIGIN) is None
+
+    @enable_migrated_b3()
+    @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "dotnet", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "golang", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
+    def  test_headers_b3_migrated_extract_invalid(self, test_agent, test_library):
+        """Ensure that invalid b3 distributed tracing headers are not extracted.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(test_library, [["b3", "0-0-1"]])
+
+        span = get_span(test_agent)
+        assert span.get("trace_id") != 0
+        assert span_has_no_parent(span)
+        assert span["meta"].get(ORIGIN) is None
+
+    @enable_migrated_b3()
+    @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "dotnet", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "golang", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
+    def  test_headers_b3_migrated_inject_valid(self, test_agent, test_library):
+        """Ensure that b3 distributed tracing headers are injected properly.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(test_library, [])
+
+        span = get_span(test_agent)
+        b3Arr = headers["b3"].split("-")
+        b3_trace_id = b3Arr[0]
+        b3_span_id = b3Arr[1]
+        b3_sampling = b3Arr[2]
+
+        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
+        assert int(b3_trace_id, base=16) == span.get("trace_id")
+        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
+        assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
+        assert span["meta"].get(ORIGIN) is None
+
+    @enable_migrated_b3()
+    @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "dotnet", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "golang", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
+    def  test_headers_b3_migrated_propagate_valid(self, test_agent, test_library):
+        """Ensure that b3 distributed tracing headers are extracted
+        and injected properly.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(
+                test_library, [["b3", "000000000000000000000000075bcd15-000000003ade68b1-1"]]
+            )
+
+        span = get_span(test_agent)
+        b3Arr = headers["b3"].split("-")
+        b3_trace_id = b3Arr[0]
+        b3_span_id = b3Arr[1]
+        b3_sampling = b3Arr[2]
+
+        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
+        assert int(b3_trace_id, base=16) == span.get("trace_id")
+        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
+        assert b3_sampling == "1"
+        assert span["meta"].get(ORIGIN) is None
+
+    @enable_migrated_b3()
+    @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "dotnet", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "golang", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
+    @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
+    def  test_headers_b3_migrated_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted
         and the new span context is injected properly.
         """

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -21,6 +21,7 @@ def enable_b3() -> Any:
     }
     return parametrize("library_env", [env1, env2])
 
+
 def enable_migrated_b3() -> Any:
     env1 = {
         "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "b3",
@@ -30,6 +31,7 @@ def enable_migrated_b3() -> Any:
         "DD_TRACE_PROPAGATION_STYLE": "b3",
     }
     return parametrize("library_env", [env1, env2])
+
 
 @scenarios.parametric
 class Test_Headers_B3:
@@ -144,7 +146,7 @@ class Test_Headers_B3:
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
-    def  test_headers_b3_migrated_extract_valid(self, test_agent, test_library):
+    def test_headers_b3_migrated_extract_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and activated properly.
         """
@@ -168,7 +170,7 @@ class Test_Headers_B3:
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
-    def  test_headers_b3_migrated_extract_invalid(self, test_agent, test_library):
+    def test_headers_b3_migrated_extract_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted.
         """
         with test_library:
@@ -188,7 +190,7 @@ class Test_Headers_B3:
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
-    def  test_headers_b3_migrated_inject_valid(self, test_agent, test_library):
+    def test_headers_b3_migrated_inject_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are injected properly.
         """
         with test_library:
@@ -215,7 +217,7 @@ class Test_Headers_B3:
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
-    def  test_headers_b3_migrated_propagate_valid(self, test_agent, test_library):
+    def test_headers_b3_migrated_propagate_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and injected properly.
         """
@@ -245,7 +247,7 @@ class Test_Headers_B3:
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "python_http", reason="Need to remove b3=b3multi alias")
-    def  test_headers_b3_migrated_propagate_invalid(self, test_agent, test_library):
+    def test_headers_b3_migrated_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted
         and the new span context is injected properly.
         """

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -32,7 +32,6 @@ def enable_b3multi() -> Any:
 @scenarios.parametric
 class Test_Headers_B3multi:
     @enable_b3multi()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_b3multi_extract_valid(self, test_agent, test_library):
         """Ensure that b3multi distributed tracing headers are extracted
         and activated properly.
@@ -68,7 +67,6 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_b3multi_inject_valid(self, test_agent, test_library):
         """Ensure that b3multi distributed tracing headers are injected properly.
         """
@@ -87,7 +85,6 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_b3multi_propagate_valid(self, test_agent, test_library):
         """Ensure that b3multi distributed tracing headers are extracted
         and injected properly.
@@ -115,7 +112,6 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_b3multi_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3multi distributed tracing headers are not extracted
         and the new span context is injected properly.

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -175,161 +175,34 @@ class Test_Headers_B3multi:
         """Ensure that b3multi distributed tracing headers are extracted
         and injected properly.
         """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(
-                test_library,
-                [
-                    ["x-b3-traceid", "000000000000000000000000075bcd15"],
-                    ["x-b3-spanid", "000000003ade68b1"],
-                    ["x-b3-sampled", "1"],
-                ],
-            )
-
-        span = get_span(test_agent)
-        assert "x-b3-traceid" in headers
-        b3_trace_id = headers["x-b3-traceid"]
-        b3_span_id = headers["x-b3-spanid"]
-        b3_sampling = headers["x-b3-sampled"]
-
-        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
-        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
-        assert b3_sampling == "1"
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3multi_propagate_valid(test_agent, test_library)
 
     @enable_case_insensitive_b3multi()
     @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_b3multi_case_insensitive_propagate_valid(self, test_agent, test_library):
-        """Ensure that b3multi distributed tracing headers are extracted
-        and injected properly.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(
-                test_library,
-                [
-                    ["x-b3-traceid", "000000000000000000000000075bcd15"],
-                    ["x-b3-spanid", "000000003ade68b1"],
-                    ["x-b3-sampled", "1"],
-                ],
-            )
-
-        span = get_span(test_agent)
-        assert "x-b3-traceid" in headers
-        b3_trace_id = headers["x-b3-traceid"]
-        b3_span_id = headers["x-b3-spanid"]
-        b3_sampling = headers["x-b3-sampled"]
-
-        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
-        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
-        assert b3_sampling == "1"
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3multi_propagate_valid(test_agent, test_library)
 
     @enable_b3_deprecated()
     @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
     def test_headers_b3multi_deprecated_extract_valid(self, test_agent, test_library):
-        """Ensure that b3multi distributed tracing headers are extracted
-        and activated properly.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(
-                test_library,
-                [
-                    ["x-b3-traceid", "000000000000000000000000075bcd15"],
-                    ["x-b3-spanid", "000000003ade68b1"],
-                    ["x-b3-sampled", "1"],
-                ],
-            )
-
-        span = get_span(test_agent)
-        assert span.get("trace_id") == 123456789
-        assert span.get("parent_id") == 987654321
-        assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == 1
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3multi_extract_valid(test_agent, test_library)
 
     @enable_b3_deprecated()
     @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
     def test_headers_b3multi_deprecated_extract_invalid(self, test_agent, test_library):
-        """Ensure that invalid b3multi distributed tracing headers are not extracted.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(
-                test_library, [["x-b3-traceid", "0"], ["x-b3-spanid", "0"], ["x-b3-sampled", "1"],]
-            )
-
-        span = get_span(test_agent)
-        assert span.get("trace_id") != 0
-        assert span_has_no_parent(span)
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3multi_extract_invalid(test_agent, test_library)
 
     @enable_b3_deprecated()
     @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
     def test_headers_b3multi_deprecated_inject_valid(self, test_agent, test_library):
-        """Ensure that b3multi distributed tracing headers are injected properly.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(test_library, [])
-
-        span = get_span(test_agent)
-        b3_trace_id = headers["x-b3-traceid"]
-        b3_span_id = headers["x-b3-spanid"]
-        b3_sampling = headers["x-b3-sampled"]
-
-        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
-        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
-        assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3multi_inject_valid(test_agent, test_library)
 
     @enable_b3_deprecated()
     @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
     def test_headers_b3multi_deprecated_propagate_valid(self, test_agent, test_library):
-        """Ensure that b3multi distributed tracing headers are extracted
-        and injected properly.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(
-                test_library,
-                [
-                    ["x-b3-traceid", "000000000000000000000000075bcd15"],
-                    ["x-b3-spanid", "000000003ade68b1"],
-                    ["x-b3-sampled", "1"],
-                ],
-            )
-
-        span = get_span(test_agent)
-        assert "x-b3-traceid" in headers
-        b3_trace_id = headers["x-b3-traceid"]
-        b3_span_id = headers["x-b3-spanid"]
-        b3_sampling = headers["x-b3-sampled"]
-
-        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
-        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
-        assert b3_sampling == "1"
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3multi_propagate_valid(test_agent, test_library)
 
     @enable_b3_deprecated()
     @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
     def test_headers_b3multi_deprecated_propagate_invalid(self, test_agent, test_library):
-        """Ensure that invalid b3multi distributed tracing headers are not extracted
-        and the new span context is injected properly.
-        """
-        with test_library:
-            headers = make_single_request_and_get_inject_headers(
-                test_library, [["x-b3-traceid", "0"], ["x-b3-spanid", "0"], ["x-b3-sampled", "1"],]
-            )
-
-        span = get_span(test_agent)
-        assert span.get("trace_id") != 0
-        assert span.get("span_id") != 0
-
-        b3_trace_id = headers["x-b3-traceid"]
-        b3_span_id = headers["x-b3-spanid"]
-        b3_sampling = headers["x-b3-sampled"]
-
-        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
-        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
-        assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
-        assert span["meta"].get(ORIGIN) is None
+        self.test_headers_b3multi_propagate_invalid(test_agent, test_library)

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -6,7 +6,7 @@ from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
 from utils.parametric.spec.trace import span_has_no_parent
 from utils.parametric.headers import make_single_request_and_get_inject_headers
 from utils.parametric.test_agent import get_span
-from utils import missing_feature, context, scenarios
+from utils import missing_feature, irrelevant, context, scenarios
 
 parametrize = pytest.mark.parametrize
 
@@ -19,14 +19,18 @@ def enable_b3multi() -> Any:
     env2 = {
         "DD_TRACE_PROPAGATION_STYLE": "b3multi",
     }
-    env3 = {
+    return parametrize("library_env", [env1, env2])
+
+
+def enable_b3_deprecated() -> Any:
+    env1 = {
         "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "b3",
         "DD_TRACE_PROPAGATION_STYLE_INJECT": "b3",
     }
-    env4 = {
+    env2 = {
         "DD_TRACE_PROPAGATION_STYLE": "b3",
     }
-    return parametrize("library_env", [env1, env2, env3, env4])
+    return parametrize("library_env", [env1, env2])
 
 
 def enable_case_insensitive_b3multi() -> Any:
@@ -37,14 +41,7 @@ def enable_case_insensitive_b3multi() -> Any:
     env2 = {
         "DD_TRACE_PROPAGATION_STYLE": "B3multi",
     }
-    env3 = {
-        "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "B3",
-        "DD_TRACE_PROPAGATION_STYLE_INJECT": "b3",
-    }
-    env4 = {
-        "DD_TRACE_PROPAGATION_STYLE": "B3",
-    }
-    return parametrize("library_env", [env1, env2, env3, env4])
+    return parametrize("library_env", [env1, env2])
 
 
 @scenarios.parametric
@@ -179,4 +176,113 @@ class Test_Headers_B3multi:
         assert int(b3_trace_id, base=16) == span.get("trace_id")
         assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
         assert b3_sampling == "1"
+        assert span["meta"].get(ORIGIN) is None
+
+    @enable_b3_deprecated()
+    @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
+    def test_headers_b3multi_deprecated_extract_valid(self, test_agent, test_library):
+        """Ensure that b3multi distributed tracing headers are extracted
+        and activated properly.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(
+                test_library,
+                [
+                    ["x-b3-traceid", "000000000000000000000000075bcd15"],
+                    ["x-b3-spanid", "000000003ade68b1"],
+                    ["x-b3-sampled", "1"],
+                ],
+            )
+
+        span = get_span(test_agent)
+        assert span.get("trace_id") == 123456789
+        assert span.get("parent_id") == 987654321
+        assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == 1
+        assert span["meta"].get(ORIGIN) is None
+
+    @enable_b3_deprecated()
+    @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
+    def test_headers_b3multi_deprecated_extract_invalid(self, test_agent, test_library):
+        """Ensure that invalid b3multi distributed tracing headers are not extracted.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(
+                test_library, [["x-b3-traceid", "0"], ["x-b3-spanid", "0"], ["x-b3-sampled", "1"],]
+            )
+
+        span = get_span(test_agent)
+        assert span.get("trace_id") != 0
+        assert span_has_no_parent(span)
+        assert span["meta"].get(ORIGIN) is None
+
+    @enable_b3_deprecated()
+    @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
+    def test_headers_b3multi_deprecated_inject_valid(self, test_agent, test_library):
+        """Ensure that b3multi distributed tracing headers are injected properly.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(test_library, [])
+
+        span = get_span(test_agent)
+        b3_trace_id = headers["x-b3-traceid"]
+        b3_span_id = headers["x-b3-spanid"]
+        b3_sampling = headers["x-b3-sampled"]
+
+        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
+        assert int(b3_trace_id, base=16) == span.get("trace_id")
+        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
+        assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
+        assert span["meta"].get(ORIGIN) is None
+
+    @enable_b3_deprecated()
+    @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
+    def test_headers_b3multi_deprecated_propagate_valid(self, test_agent, test_library):
+        """Ensure that b3multi distributed tracing headers are extracted
+        and injected properly.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(
+                test_library,
+                [
+                    ["x-b3-traceid", "000000000000000000000000075bcd15"],
+                    ["x-b3-spanid", "000000003ade68b1"],
+                    ["x-b3-sampled", "1"],
+                ],
+            )
+
+        span = get_span(test_agent)
+        assert "x-b3-traceid" in headers
+        b3_trace_id = headers["x-b3-traceid"]
+        b3_span_id = headers["x-b3-spanid"]
+        b3_sampling = headers["x-b3-sampled"]
+
+        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
+        assert int(b3_trace_id, base=16) == span.get("trace_id")
+        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
+        assert b3_sampling == "1"
+        assert span["meta"].get(ORIGIN) is None
+
+    @enable_b3_deprecated()
+    @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
+    def test_headers_b3multi_deprecated_propagate_invalid(self, test_agent, test_library):
+        """Ensure that invalid b3multi distributed tracing headers are not extracted
+        and the new span context is injected properly.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(
+                test_library, [["x-b3-traceid", "0"], ["x-b3-spanid", "0"], ["x-b3-sampled", "1"],]
+            )
+
+        span = get_span(test_agent)
+        assert span.get("trace_id") != 0
+        assert span.get("span_id") != 0
+
+        b3_trace_id = headers["x-b3-traceid"]
+        b3_span_id = headers["x-b3-spanid"]
+        b3_sampling = headers["x-b3-sampled"]
+
+        assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
+        assert int(b3_trace_id, base=16) == span.get("trace_id")
+        assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
+        assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
         assert span["meta"].get(ORIGIN) is None

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -82,6 +82,10 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
+    @missing_feature(
+        context.library == "ruby",
+        reason="1) b3 traceid should be padded to 16 or 32 hex characters and 2) b3 header not injected for DD_TRACE_PROPAGATION_STYLE=b3multi config",
+    )
     def test_headers_b3multi_inject_valid(self, test_agent, test_library):
         """Ensure that b3multi distributed tracing headers are injected properly.
         """
@@ -100,6 +104,10 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
+    @missing_feature(
+        context.library == "ruby",
+        reason="1) b3 traceid should be padded to 16 or 32 hex characters and 2) b3 header not injected for DD_TRACE_PROPAGATION_STYLE=b3multi config",
+    )
     def test_headers_b3multi_propagate_valid(self, test_agent, test_library):
         """Ensure that b3multi distributed tracing headers are extracted
         and injected properly.
@@ -127,6 +135,10 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
+    @missing_feature(
+        context.library == "ruby",
+        reason="1) b3 traceid should be padded to 16 or 32 hex characters and 2) b3 header not injected for DD_TRACE_PROPAGATION_STYLE=b3multi config",
+    )
     def test_headers_b3multi_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3multi distributed tracing headers are not extracted
         and the new span context is injected properly.

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -86,9 +86,6 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
-    @missing_feature(
-        context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
-    )
     def test_headers_b3multi_inject_valid(self, test_agent, test_library):
         """Ensure that b3multi distributed tracing headers are injected properly.
         """
@@ -107,9 +104,6 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
-    @missing_feature(
-        context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
-    )
     def test_headers_b3multi_propagate_valid(self, test_agent, test_library):
         """Ensure that b3multi distributed tracing headers are extracted
         and injected properly.
@@ -137,9 +131,6 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
-    @missing_feature(
-        context.library == "ruby", reason="b3 traceid should be padded to 16 or 32 hex characters",
-    )
     def test_headers_b3multi_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3multi distributed tracing headers are not extracted
         and the new span context is injected properly.

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -27,18 +27,14 @@ def enable_b3multi_single_key() -> Any:
 
 
 def enable_b3_deprecated() -> Any:
-    env = {
+    env1 = {
         "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "b3",
         "DD_TRACE_PROPAGATION_STYLE_INJECT": "b3",
     }
-    return parametrize("library_env", [env])
-
-
-def enable_b3_deprecated_single_key() -> Any:
-    env = {
+    env2 = {
         "DD_TRACE_PROPAGATION_STYLE": "b3",
     }
-    return parametrize("library_env", [env])
+    return parametrize("library_env", [env1, env2])
 
 
 def enable_case_insensitive_b3multi() -> Any:
@@ -167,7 +163,7 @@ class Test_Headers_B3multi:
         assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
         assert span["meta"].get(ORIGIN) is None
 
-    @enable_case_insensitive_b3multi()
+    @enable_b3multi_single_key()
     @missing_feature(
         context.library == "ruby", reason="Propagators not configured for DD_TRACE_PROPAGATION_STYLE config",
     )

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -28,6 +28,7 @@ def enable_b3multi() -> Any:
     }
     return parametrize("library_env", [env1, env2, env3, env4])
 
+
 def enable_case_insensitive_b3multi() -> Any:
     env1 = {
         "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "B3MULTI",

--- a/tests/parametric/test_headers_datadog.py
+++ b/tests/parametric/test_headers_datadog.py
@@ -4,7 +4,7 @@ from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
 from utils.parametric.spec.trace import span_has_no_parent
 from utils.parametric.headers import make_single_request_and_get_inject_headers
 from utils.parametric.test_agent import get_span
-from utils import missing_feature, bug, context, scenarios
+from utils import bug, context, scenarios
 
 
 @scenarios.parametric

--- a/tests/parametric/test_headers_none.py
+++ b/tests/parametric/test_headers_none.py
@@ -11,34 +11,31 @@ parametrize = pytest.mark.parametrize
 
 
 def enable_none() -> Any:
-    env1 = {
-        "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "NoNe",
+    env = {
+        "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "none",
         "DD_TRACE_PROPAGATION_STYLE_INJECT": "none",
     }
-    env2 = {
-        "DD_TRACE_PROPAGATION_STYLE": "NONE",
+    return parametrize("library_env", [env])
+
+
+def enable_none_single_key() -> Any:
+    env = {
+        "DD_TRACE_PROPAGATION_STYLE": "none",
     }
-    return parametrize("library_env", [env1, env2])
+    return parametrize("library_env", [env])
 
 
 def enable_none_invalid() -> Any:
-    env1 = {
-        "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "NoNe,Datadog",
+    env = {
+        "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "none,Datadog",
         "DD_TRACE_PROPAGATION_STYLE_INJECT": "none,Datadog",
     }
-    env2 = {
-        "DD_TRACE_PROPAGATION_STYLE": "NONE,Datadog",
-    }
-    return parametrize("library_env", [env1, env2])
+    return parametrize("library_env", [env])
 
 
 @scenarios.parametric
 class Test_Headers_None:
     @enable_none()
-    @missing_feature(
-        context.library == "ruby",
-        reason="None propagator not configured for DD_TRACE_PROPAGATION_STYLE=none config",
-    )
     def test_headers_none_extract(self, test_agent, test_library):
         """Ensure that no distributed tracing headers are extracted.
         """
@@ -87,10 +84,6 @@ class Test_Headers_None:
         assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
 
     @enable_none()
-    @missing_feature(
-        context.library == "ruby",
-        reason="None propagator not configured for DD_TRACE_PROPAGATION_STYLE=none config",
-    )
     def test_headers_none_inject(self, test_agent, test_library):
         """Ensure that the 'none' propagator is used and
         no Datadog distributed tracing headers are injected.
@@ -120,11 +113,42 @@ class Test_Headers_None:
         assert int(headers["x-datadog-sampling-priority"]) == span["metrics"].get(SAMPLING_PRIORITY_KEY)
 
     @enable_none()
-    @missing_feature(
-        context.library == "ruby",
-        reason="None propagator not configured for DD_TRACE_PROPAGATION_STYLE=none config",
-    )
     def test_headers_none_propagate(self, test_agent, test_library):
+        """Ensure that the 'none' propagator is used and
+        no Datadog distributed tracing headers are extracted or injected.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(
+                test_library,
+                [
+                    ["x-datadog-trace-id", "123456789"],
+                    ["x-datadog-parent-id", "987654321"],
+                    ["x-datadog-sampling-priority", "2"],
+                    ["x-datadog-origin", "synthetics"],
+                    ["x-datadog-tags", "_dd.p.dm=-4"],
+                ],
+            )
+
+        span = get_span(test_agent)
+        assert span.get("trace_id") != 123456789
+        assert span.get("parent_id") != 987654321
+        assert span["meta"].get(ORIGIN) is None
+        assert span["meta"].get("_dd.p.dm") != "-4"
+        assert span["metrics"].get(SAMPLING_PRIORITY_KEY) != 2
+
+        assert "traceparent" not in headers
+        assert "tracestate" not in headers
+        assert "x-datadog-trace-id" not in headers
+        assert "x-datadog-parent-id" not in headers
+        assert "x-datadog-sampling-priority" not in headers
+        assert "x-datadog-origin" not in headers
+        assert "x-datadog-tags" not in headers
+
+    @enable_none_single_key()
+    @missing_feature(
+        context.library == "ruby", reason="Propagators not configured for DD_TRACE_PROPAGATION_STYLE config",
+    )
+    def test_headers_none_single_key_propagate(self, test_agent, test_library):
         """Ensure that the 'none' propagator is used and
         no Datadog distributed tracing headers are extracted or injected.
         """

--- a/tests/parametric/test_headers_none.py
+++ b/tests/parametric/test_headers_none.py
@@ -35,7 +35,6 @@ def enable_none_invalid() -> Any:
 @scenarios.parametric
 class Test_Headers_None:
     @enable_none()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_none_extract(self, test_agent, test_library):
         """Ensure that no distributed tracing headers are extracted.
         """
@@ -84,7 +83,6 @@ class Test_Headers_None:
         assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
 
     @enable_none()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_none_inject(self, test_agent, test_library):
         """Ensure that the 'none' propagator is used and
         no Datadog distributed tracing headers are injected.
@@ -114,7 +112,6 @@ class Test_Headers_None:
         assert int(headers["x-datadog-sampling-priority"]) == span["metrics"].get(SAMPLING_PRIORITY_KEY)
 
     @enable_none()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_none_propagate(self, test_agent, test_library):
         """Ensure that the 'none' propagator is used and
         no Datadog distributed tracing headers are extracted or injected.

--- a/tests/parametric/test_headers_none.py
+++ b/tests/parametric/test_headers_none.py
@@ -35,6 +35,10 @@ def enable_none_invalid() -> Any:
 @scenarios.parametric
 class Test_Headers_None:
     @enable_none()
+    @missing_feature(
+        context.library == "ruby",
+        reason="None propagator not configured for DD_TRACE_PROPAGATION_STYLE=none config",
+    )
     def test_headers_none_extract(self, test_agent, test_library):
         """Ensure that no distributed tracing headers are extracted.
         """
@@ -83,6 +87,10 @@ class Test_Headers_None:
         assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
 
     @enable_none()
+    @missing_feature(
+        context.library == "ruby",
+        reason="None propagator not configured for DD_TRACE_PROPAGATION_STYLE=none config",
+    )
     def test_headers_none_inject(self, test_agent, test_library):
         """Ensure that the 'none' propagator is used and
         no Datadog distributed tracing headers are injected.
@@ -112,6 +120,10 @@ class Test_Headers_None:
         assert int(headers["x-datadog-sampling-priority"]) == span["metrics"].get(SAMPLING_PRIORITY_KEY)
 
     @enable_none()
+    @missing_feature(
+        context.library == "ruby",
+        reason="None propagator not configured for DD_TRACE_PROPAGATION_STYLE=none config",
+    )
     def test_headers_none_propagate(self, test_agent, test_library):
         """Ensure that the 'none' propagator is used and
         no Datadog distributed tracing headers are extracted or injected.

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -149,6 +149,10 @@ class Test_Headers_Precedence:
         assert "tracestate" not in headers6
 
     @enable_tracecontext()
+    @missing_feature(
+        context.library == "ruby",
+        reason="traceparent and tracestate header not injected for DD_TRACE_PROPAGATION_STYLE=tracecontext config",
+    )
     def test_headers_precedence_propagationstyle_tracecontext(self, test_agent, test_library):
         with test_library:
             # 1) No headers
@@ -375,6 +379,10 @@ class Test_Headers_Precedence:
     @missing_feature(
         context.library == "golang",
         reason="BUG: suite #4 is failing - if context is successfully retrieved from W3C propagator, datadog propagator is NOT.run, thus not retrieving / overwriting the headers",
+    )
+    @missing_feature(
+        context.library == "ruby",
+        reason="traceparent and tracestate header not injected for DD_TRACE_PROPAGATION_STYLE=tracecontext config",
     )
     def test_headers_precedence_propagationstyle_datadog_tracecontext(self, test_agent, test_library):
         with test_library:

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -149,7 +149,6 @@ class Test_Headers_Precedence:
         assert "tracestate" not in headers6
 
     @enable_tracecontext()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_precedence_propagationstyle_tracecontext(self, test_agent, test_library):
         with test_library:
             # 1) No headers
@@ -377,7 +376,6 @@ class Test_Headers_Precedence:
         context.library == "golang",
         reason="BUG: suite #4 is failing - if context is successfully retrieved from W3C propagator, datadog propagator is NOT.run, thus not retrieving / overwriting the headers",
     )
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_precedence_propagationstyle_datadog_tracecontext(self, test_agent, test_library):
         with test_library:
             # 1) No headers

--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -45,6 +45,9 @@ class Test_Headers_Tracecontext:
             traceparent, tracestate = make_single_request_and_get_tracecontext(test_library, [])
 
     @temporary_enable_optin_tracecontext_single_key()
+    @missing_feature(
+        context.library == "ruby", reason="Propagators not configured for DD_TRACE_PROPAGATION_STYLE config",
+    )
     def test_single_key_traceparent_included_tracestate_missing(self, test_agent, test_library):
         """
         harness sends a request with traceparent but without tracestate

--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -491,7 +491,6 @@ class Test_Headers_Tracecontext:
         assert len(tracestate1.split(",")) == len(tracestate2.split(","))
 
     @temporary_enable_optin_tracecontext()
-    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_included_traceparent_included(self, test_agent, test_library):
         """
         harness sends a request with both tracestate and traceparent
@@ -586,7 +585,6 @@ class Test_Headers_Tracecontext:
         context.library == "python_http",
         reason="python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
     )
-    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_empty_header(self, test_agent, test_library):
         """
         harness sends a request with empty tracestate header
@@ -647,7 +645,6 @@ class Test_Headers_Tracecontext:
         context.library == "python_http",
         reason="python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
     )
-    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_multiple_headers_different_keys(self, test_agent, test_library):
         """
         harness sends a request with multiple tracestate headers, each contains different set of keys
@@ -676,7 +673,6 @@ class Test_Headers_Tracecontext:
         assert str(tracestate).index("congo=2") < str(tracestate).index("baz=3")
 
     @temporary_enable_optin_tracecontext()
-    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_duplicated_keys(self, test_agent, test_library):
         """
         harness sends a request with an invalid tracestate header with duplicated keys
@@ -731,7 +727,6 @@ class Test_Headers_Tracecontext:
         assert "foo=1" in str(tracestate4) or "foo=2" in str(tracestate4)
 
     @temporary_enable_optin_tracecontext()
-    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_all_allowed_characters(self, test_agent, test_library):
         """
         harness sends a request with a valid tracestate header with all legal characters
@@ -776,7 +771,6 @@ class Test_Headers_Tracecontext:
     @missing_feature(
         context.library == "php", reason="PHP may preserve whitespace of foreign vendors trracestate (allowed per spec)"
     )
-    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_ows_handling(self, test_agent, test_library):
         """
         harness sends a request with a valid tracestate header with OWS

--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -109,6 +109,7 @@ class Test_Headers_Tracecontext:
         assert traceparent2.trace_id != "12345678901234567890123456789012"
 
     @temporary_enable_optin_tracecontext()
+    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_traceparent_header_name_valid_casing(self, test_agent, test_library):
         """
         harness sends a valid traceparent using different combination of casing
@@ -204,6 +205,7 @@ class Test_Headers_Tracecontext:
         assert traceparent.trace_id != "12345678901234567890123456789012"
 
     @temporary_enable_optin_tracecontext()
+    @missing_feature(context.library == "ruby", reason="traceparent version validation not implemented")
     def test_traceparent_version_illegal_characters(self, test_agent, test_library):
         """
         harness sends an invalid traceparent with illegal characters in version
@@ -461,6 +463,7 @@ class Test_Headers_Tracecontext:
         assert len(tracestate1.split(",")) == len(tracestate2.split(","))
 
     @temporary_enable_optin_tracecontext()
+    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_included_traceparent_included(self, test_agent, test_library):
         """
         harness sends a request with both tracestate and traceparent
@@ -507,6 +510,7 @@ class Test_Headers_Tracecontext:
         assert "foo" not in tracestate2
 
     @temporary_enable_optin_tracecontext()
+    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_tracestate_header_name_valid_casing(self, test_agent, test_library):
         """
         harness sends a valid tracestate using different combination of casing
@@ -554,6 +558,7 @@ class Test_Headers_Tracecontext:
         context.library == "python_http",
         reason="python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
     )
+    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_empty_header(self, test_agent, test_library):
         """
         harness sends a request with empty tracestate header
@@ -614,6 +619,7 @@ class Test_Headers_Tracecontext:
         context.library == "python_http",
         reason="python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
     )
+    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_multiple_headers_different_keys(self, test_agent, test_library):
         """
         harness sends a request with multiple tracestate headers, each contains different set of keys
@@ -642,6 +648,7 @@ class Test_Headers_Tracecontext:
         assert str(tracestate).index("congo=2") < str(tracestate).index("baz=3")
 
     @temporary_enable_optin_tracecontext()
+    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_duplicated_keys(self, test_agent, test_library):
         """
         harness sends a request with an invalid tracestate header with duplicated keys
@@ -696,6 +703,7 @@ class Test_Headers_Tracecontext:
         assert "foo=1" in str(tracestate4) or "foo=2" in str(tracestate4)
 
     @temporary_enable_optin_tracecontext()
+    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_all_allowed_characters(self, test_agent, test_library):
         """
         harness sends a request with a valid tracestate header with all legal characters
@@ -740,6 +748,7 @@ class Test_Headers_Tracecontext:
     @missing_feature(
         context.library == "php", reason="PHP may preserve whitespace of foreign vendors trracestate (allowed per spec)"
     )
+    @missing_feature(context.library == "ruby", reason="Issue initializing tracestate with other vendor")
     def test_tracestate_ows_handling(self, test_agent, test_library):
         """
         harness sends a request with a valid tracestate header with OWS

--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -73,7 +73,6 @@ class Test_Headers_Tracecontext:
         context.library == "golang",
         reason="golang does not reconcile duplicate http headers, if duplicate headers received the propagator will not be used",
     )
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_traceparent_duplicated(self, test_agent, test_library):
         """
         harness sends a request with two traceparent headers
@@ -110,7 +109,6 @@ class Test_Headers_Tracecontext:
         assert traceparent2.trace_id != "12345678901234567890123456789012"
 
     @temporary_enable_optin_tracecontext()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_traceparent_header_name_valid_casing(self, test_agent, test_library):
         """
         harness sends a valid traceparent using different combination of casing
@@ -206,7 +204,6 @@ class Test_Headers_Tracecontext:
         assert traceparent.trace_id != "12345678901234567890123456789012"
 
     @temporary_enable_optin_tracecontext()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_traceparent_version_illegal_characters(self, test_agent, test_library):
         """
         harness sends an invalid traceparent with illegal characters in version
@@ -464,7 +461,6 @@ class Test_Headers_Tracecontext:
         assert len(tracestate1.split(",")) == len(tracestate2.split(","))
 
     @temporary_enable_optin_tracecontext()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_tracestate_included_traceparent_included(self, test_agent, test_library):
         """
         harness sends a request with both tracestate and traceparent
@@ -511,7 +507,6 @@ class Test_Headers_Tracecontext:
         assert "foo" not in tracestate2
 
     @temporary_enable_optin_tracecontext()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_tracestate_header_name_valid_casing(self, test_agent, test_library):
         """
         harness sends a valid tracestate using different combination of casing
@@ -559,7 +554,6 @@ class Test_Headers_Tracecontext:
         context.library == "python_http",
         reason="python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
     )
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_tracestate_empty_header(self, test_agent, test_library):
         """
         harness sends a request with empty tracestate header
@@ -620,7 +614,6 @@ class Test_Headers_Tracecontext:
         context.library == "python_http",
         reason="python does not reconcile duplicate http headers, if duplicate headers received one only one will be used",
     )
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_tracestate_multiple_headers_different_keys(self, test_agent, test_library):
         """
         harness sends a request with multiple tracestate headers, each contains different set of keys
@@ -649,7 +642,6 @@ class Test_Headers_Tracecontext:
         assert str(tracestate).index("congo=2") < str(tracestate).index("baz=3")
 
     @temporary_enable_optin_tracecontext()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_tracestate_duplicated_keys(self, test_agent, test_library):
         """
         harness sends a request with an invalid tracestate header with duplicated keys
@@ -704,7 +696,6 @@ class Test_Headers_Tracecontext:
         assert "foo=1" in str(tracestate4) or "foo=2" in str(tracestate4)
 
     @temporary_enable_optin_tracecontext()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_tracestate_all_allowed_characters(self, test_agent, test_library):
         """
         harness sends a request with a valid tracestate header with all legal characters
@@ -749,7 +740,6 @@ class Test_Headers_Tracecontext:
     @missing_feature(
         context.library == "php", reason="PHP may preserve whitespace of foreign vendors trracestate (allowed per spec)"
     )
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_tracestate_ows_handling(self, test_agent, test_library):
         """
         harness sends a request with a valid tracestate header with OWS

--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -233,7 +233,6 @@ class Test_Headers_Tracecontext:
         assert traceparent.trace_id != "12345678901234567890123456789012"
 
     @temporary_enable_optin_tracecontext()
-    @missing_feature(context.library == "ruby", reason="traceparent version validation not implemented")
     def test_traceparent_version_illegal_characters(self, test_agent, test_library):
         """
         harness sends an invalid traceparent with illegal characters in version

--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -73,6 +73,10 @@ class Test_Headers_Tracecontext:
         context.library == "golang",
         reason="golang does not reconcile duplicate http headers, if duplicate headers received the propagator will not be used",
     )
+    @missing_feature(
+        context.library == "ruby",
+        reason="the tracer should reject the incoming traceparent(s) when there are multiple traceparent headers",
+    )
     def test_traceparent_duplicated(self, test_agent, test_library):
         """
         harness sends a request with two traceparent headers

--- a/tests/parametric/test_headers_tracestate_dd.py
+++ b/tests/parametric/test_headers_tracestate_dd.py
@@ -190,7 +190,6 @@ class Test_Headers_Tracestate_DD:
         assert "s:0" in dd_items8 or not any(item.startswith("s:") for item in dd_items8)
 
     @temporary_enable_propagationstyle_default()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_tracestate_dd_propagate_origin(self, test_agent, test_library):
         """
         harness sends a request with both tracestate and traceparent
@@ -328,7 +327,6 @@ class Test_Headers_Tracestate_DD:
         context.library == "golang",
         reason="False Bug: header[3,6]: can't guarantee the order of strings in the tracestate since they came from the map. BUG: header[4,5]: w3cTraceID shouldn't be present",
     )
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_tracestate_dd_propagate_propagatedtags(self, test_agent, test_library):
         """
         harness sends a request with both tracestate and traceparent

--- a/tests/parametric/test_headers_tracestate_dd.py
+++ b/tests/parametric/test_headers_tracestate_dd.py
@@ -190,6 +190,7 @@ class Test_Headers_Tracestate_DD:
         assert "s:0" in dd_items8 or not any(item.startswith("s:") for item in dd_items8)
 
     @temporary_enable_propagationstyle_default()
+    @missing_feature(context.library == "ruby", reason="The encoding logic to convert '=' to '~' and remaining invalid characters to '_' is not implemented")
     def test_headers_tracestate_dd_propagate_origin(self, test_agent, test_library):
         """
         harness sends a request with both tracestate and traceparent

--- a/tests/parametric/test_headers_tracestate_dd.py
+++ b/tests/parametric/test_headers_tracestate_dd.py
@@ -190,10 +190,6 @@ class Test_Headers_Tracestate_DD:
         assert "s:0" in dd_items8 or not any(item.startswith("s:") for item in dd_items8)
 
     @temporary_enable_propagationstyle_default()
-    @missing_feature(
-        context.library == "ruby",
-        reason="The encoding logic to convert '=' to '~' and remaining invalid characters to '_' is not implemented",
-    )
     def test_headers_tracestate_dd_propagate_origin(self, test_agent, test_library):
         """
         harness sends a request with both tracestate and traceparent

--- a/tests/parametric/test_headers_tracestate_dd.py
+++ b/tests/parametric/test_headers_tracestate_dd.py
@@ -190,7 +190,10 @@ class Test_Headers_Tracestate_DD:
         assert "s:0" in dd_items8 or not any(item.startswith("s:") for item in dd_items8)
 
     @temporary_enable_propagationstyle_default()
-    @missing_feature(context.library == "ruby", reason="The encoding logic to convert '=' to '~' and remaining invalid characters to '_' is not implemented")
+    @missing_feature(
+        context.library == "ruby",
+        reason="The encoding logic to convert '=' to '~' and remaining invalid characters to '_' is not implemented",
+    )
     def test_headers_tracestate_dd_propagate_origin(self, test_agent, test_library):
         """
         harness sends a request with both tracestate and traceparent

--- a/utils/build/docker/ruby/parametric/generate_proto.sh
+++ b/utils/build/docker/ruby/parametric/generate_proto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ ! -f apm_test_client.proto ]; then
-  cp ../../protos/apm_test_client.proto .
+  cp ../../../../parametric/protos/apm_test_client.proto .
 fi
 
 grpc_tools_ruby_protoc -I . --ruby_out=./ --grpc_out=./ ./apm_test_client.proto

--- a/utils/build/docker/ruby/parametric/server.rb
+++ b/utils/build/docker/ruby/parametric/server.rb
@@ -10,10 +10,12 @@ require 'apm_test_client_services_pb'
 Datadog.configure do |c|
   c.diagnostics.debug = true # When tests fail, ensure there's enough data to debug the failure.
   c.logger.instance = Logger.new(STDOUT) # Make sure logs are available for inspection from outside the container.
+  c.tracing.instrument :http # Used for `http_client_request`
 end
 
 # Ensure output is always flushed, to prevent a forced shutdown from losing all logs.
 STDOUT.sync = true
+puts 'Loading server classes...'
 
 class ServerImpl < APMClient::Service
   def start_span(start_span_args, _call)
@@ -22,7 +24,12 @@ class ServerImpl < APMClient::Service
     end
 
     digest = if start_span_args.http_headers.http_headers.size != 0
-               Datadog::Tracing::Contrib::GRPC::Distributed::Propagation.new.extract(start_span_args.http_headers.http_headers.map { |t| [t.key, t.value] }.to_h)
+               # Emulate how Rack headers concatenates header with duplicate values with a `, `.
+               headers = start_span_args.http_headers.http_headers.group_by(&:key).map do |name, values|
+                 [name, values.map(&:value).join(', ')]
+               end
+
+               Datadog::Tracing::Contrib::GRPC::Distributed::Propagation.new.extract(headers.to_h)
              elsif !start_span_args.origin.empty? || start_span_args.parent_id != 0
                # DEV: Parametric tests do not differentiate between a distributed span request from a span parenting request.
                # DEV: We have to consider the parent_id being present present and origin being absent as a span parenting request.
@@ -89,6 +96,26 @@ class ServerImpl < APMClient::Service
     SpanSetErrorReturn.new
   end
 
+  def http_client_request(httprequest_args, _call)
+    url = URI(httprequest_args.url)
+    headers = httprequest_args.headers.http_headers.map{|x|[x.key, x.value] }.to_h
+    method = httprequest_args.to_h[:method]
+
+    request_class = Net::HTTP.const_get(method.capitalize)
+    request = request_class.new(url, headers).tap { |r| r.body = httprequest_args.body }
+
+    response = Net::HTTP.start(url.hostname, url.port, use_ssl: url.scheme == 'https') do |http|
+      http.request(request)
+    end
+
+    HTTPRequestReturn.new(status_code: response.code)
+  end
+
+  # DEV: Defined in proto but not yet used in any test.
+  def http_server_request(_httprequest_args, _call)
+    raise NotImplementedError
+  end
+
   def inject_headers(inject_headers_args, _call)
     find_span(inject_headers_args.span_id)
 
@@ -110,6 +137,17 @@ class ServerImpl < APMClient::Service
   def flush_trace_stats(flush_trace_stats_args, _call)
     FlushTraceStatsReturn.new
   end
+
+  # TODO: Implement the following OTel methods
+  # :otel_start_span, ::OtelStartSpanArgs, ::OtelStartSpanReturn
+  # :otel_end_span, ::OtelEndSpanArgs, ::OtelEndSpanReturn
+  # :otel_is_recording, ::OtelIsRecordingArgs, ::OtelIsRecordingReturn
+  # :otel_span_context, ::OtelSpanContextArgs, ::OtelSpanContextReturn
+  # :otel_set_status, ::OtelSetStatusArgs, ::OtelSetStatusReturn
+  # :otel_set_name, ::OtelSetNameArgs, ::OtelSetNameReturn
+  # :otel_set_attributes, ::OtelSetAttributesArgs, ::OtelSetAttributesReturn
+  # :otel_flush_spans, ::OtelFlushSpansArgs, ::OtelFlushSpansReturn
+  # :otel_flush_trace_stats, ::OtelFlushTraceStatsArgs, ::OtelFlushTraceStatsReturn
 
   def stop_tracer(stop_tracer_args, _call)
     Datadog.shutdown!
@@ -147,7 +185,12 @@ class ServerImpl < APMClient::Service
     define_method(m) do |*args|
       @request_queue.push ["wrapped_#{m}", args]
       res = @return_queue.pop
-      raise res if res.is_a?(Exception)
+
+      if res.is_a?(Exception)
+        # Include the backtrace in the error returned to the test suite.
+        res.message << ": #{res.backtrace}"
+        raise res
+      end
 
       res
     end


### PR DESCRIPTION
## Description

Unskip Ruby tests and update the skip message for tests that are still failing with the latest Ruby release. Changes include:
- Update of Ruby parametric web server app
- Change header propagation tests to use `DD_TRACE_PROPAGATION_STYLE_EXTRACT` and `DD_TRACE_PROPAGATION_STYLE_INJECT` configuration variables so Ruby can run them
- Add secondary test scenarios:
  - "Single key" where the `DD_TRACE_PROPAGATION_STYLE` configuration variable is used
  - "Case insensitive" where the value of the propagation variable is mixed case
- Add duplicate set of b3single tests where the tracer understands `b3`==`B3 single header`
- 

## Motivation

At first the goal was to run the `tracecontext` parametric tests, but in the end we ended up running more tests and fixing them so that they now pass for the Ruby tracer.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
