### PR TITLE
Changed example so it only generates one vulnerability

### DIFF
--- a/utils/build/docker/java/iast-common/src/main/java/com/datadoghq/system_tests/iast/utils/CryptoExamples.java
+++ b/utils/build/docker/java/iast-common/src/main/java/com/datadoghq/system_tests/iast/utils/CryptoExamples.java
@@ -73,10 +73,8 @@ public class CryptoExamples {
 
     private static String doCipher(final String password, final String algorithm) {
         try {
-            KeyGenerator keygenerator = KeyGenerator.getInstance(algorithm);
-            SecretKey key = keygenerator.generateKey();
             Cipher cipher = Cipher.getInstance(algorithm);
-            cipher.init(Cipher.ENCRYPT_MODE, key);
+            cipher.init(Cipher.ENCRYPT_MODE, KeyGenerator.getInstance(algorithm).generateKey());
             return new String(cipher.doFinal(password.getBytes()));
         } catch (final Exception e) {
             throw new UndeclaredThrowableException(e);


### PR DESCRIPTION
## Description

A simple change in Cryptoexamples so only one weak cipher vulnerability is reported. Before the change two of them were reported.

## Motivation

We are adding instrumentation to KeyGenerator and this resulted in two vulnerabilities being reported in this example where we had one before. This confuses the vulnerability parser.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
