### PR TITLE
logic change for product disabled on ap-started

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -420,7 +420,7 @@ class Test_Telemetry:
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @irrelevant(library="golang", reason="products info is always in app-started for golang")
 class Test_ProductsDisabled:
-    """Assert that product informations are not reported when products are disabled in telemetry"""
+    """Assert that product informations are reported with enabled as false when products are disabled in telemetry"""
 
     @scenarios.telemetry_app_started_products_disabled
     def test_app_started_product_disabled(self):
@@ -432,9 +432,10 @@ class Test_ProductsDisabled:
         for data in telemetry_data:
             if data["request"]["content"].get("request_type") == "app-started":
                 content = data["request"]["content"]
+                products = content["payload"]["products"]
                 assert (
-                    "products" not in content["payload"]
-                ), "Product information is present telemetry data on app-started event when all products are disabled"
+                   products["appsec"]["enabled"] == False and products["profiler"]["enabled"] == False and products["dynamic_instrumentation"]["enabled"] == False
+                ), "Product information is not reported correctly on app-started event when all products are disabled, 'enabled' field should be false"
 
 
 @released(cpp="?", dotnet="?", golang="?", java="?", nodejs="?", php="?", python="?", ruby="?")


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
