### PR TITLE
Add library version detection for parametric tests

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -920,7 +920,7 @@ def test_library(test_server: APMLibraryTestServer, test_server_timeout: int) ->
 
 
 @pytest.fixture(autouse=True)
-def test_library_version(request, test_library, test_agent) -> LooseVersion:
+def check_library_version(request, test_library, test_agent) -> LooseVersion:
     """Check and skip parametric test cases if the library version does not match.
 
     The library version is detected by querying the library with a trace and checking the version

--- a/tests/parametric/test_tracer.py
+++ b/tests/parametric/test_tracer.py
@@ -1,4 +1,3 @@
-import os
 from typing import Dict
 
 import pytest

--- a/tests/parametric/test_tracer.py
+++ b/tests/parametric/test_tracer.py
@@ -1,20 +1,46 @@
+import os
 from typing import Dict
 
 import pytest
-import time
 
 from utils.parametric.spec.trace import Span
 from utils.parametric.spec.trace import find_trace_by_root
 from utils.parametric.spec.trace import find_span
 from .conftest import _TestAgentAPI
 from .conftest import APMLibrary
-from utils import missing_feature, context, scenarios
+from utils import missing_feature, context, scenarios, released
+
+
+parametrize = pytest.mark.parametrize
 
 
 @scenarios.parametric
 class Test_Tracer:
+    @missing_feature(context.library == "cpp", reason="version not detected by parametric tests yet")
+    @missing_feature(context.library == "php", reason="version not detected by parametric tests yet")
+    def test_tracer_parametric_version(self, test_agent: _TestAgentAPI, test_library: APMLibrary) -> None:
+        """Ensure the version used by parametric tests matches the library version being tested.
 
-    parametrize = pytest.mark.parametrize
+        If this test fails then either the version detected/used by the parametric testing framework is wrong
+        or the library is not reporting the right version.
+        """
+        if "PYTHON_DDTRACE_PACKAGE" in os.environ:
+            pytest.skip("Custom python library versions are not yet supported by the parametric tests")
+        if "RUBY_DDTRACE_SHA" in os.environ:
+            pytest.skip("Custom ruby library versions are not supported by the parametric tests")
+
+        with test_library:
+            with test_library.start_span("operation"):
+                pass
+        test_agent.wait_for_num_traces(1)
+        request = [r for r in test_agent.requests() if "trace" in r["url"]][0]
+        reported_tracer_version = request["headers"]["Datadog-Meta-Tracer-Version"]
+        assert reported_tracer_version == context.library.version, (
+            "Parametric library detected version %r does not match library "
+            "version %r seen in trace request.\n"
+            "Likely reasons for this test failing: 1) Parametric library detection being wrong; 2) library reporting "
+            "the wrong version"
+        ) % (context.library.version, reported_tracer_version)
 
     @missing_feature(context.library == "cpp", reason="metrics cannot be set manually")
     @missing_feature(context.library == "nodejs", reason="nodejs overrides the manually set service name")
@@ -42,7 +68,11 @@ class Test_Tracer:
         assert child_span["name"] == "operation.child"
         assert child_span["meta"]["key"] == "val"
 
-    @missing_feature(reason="Libraries use empty string for service")
+
+@scenarios.parametric
+@released(python="1.18.0")
+class Test_TracerUniversalServiceTagging:
+    @missing_feature(reason="FIXME: library test client sets empty string as the service name")
     @parametrize("library_env", [{"DD_SERVICE": "service1"}])
     def test_tracer_service_name_environment_variable(
         self, library_env: Dict[str, str], test_agent: _TestAgentAPI, test_library: APMLibrary
@@ -82,3 +112,27 @@ class Test_Tracer:
         span = find_span(trace, Span(name="operation"))
         assert span["name"] == "operation"
         assert span["meta"]["env"] == library_env["DD_ENV"]
+        assert 0
+
+    # @parametrize("library_env", [{"DD_VERSION": "1.2.3"}])
+    # def test_tracer_version_environment_variable(
+    #         self, library_env: Dict[str, str], test_agent: _TestAgentAPI, test_library: APMLibrary
+    # ) -> None:
+    #     """
+    #     When DD_VERSION is specified
+    #         When a service-entry span is created
+    #             The service-entry span should have the value of DD_VERSION in meta.version
+    #             A child span should not have the value of DD_VERSION in meta.version
+
+    #     """
+    #     with test_library:
+    #         with test_library.start_span("operation"):
+    #             with test_library.start_span("child"):
+    #                 pass
+
+    #     traces = test_agent.wait_for_num_traces(1)
+    #     trace = find_trace_by_root(traces, Span(name="operation"))
+    #     service_entry_span = find_span(trace, Span(name="operation"))
+    #     child_span = find_span(trace, Span(name="child"))
+    #     assert service_entry_span["meta"]["version"] == library_env["DD_VERSION"]
+    #     assert "version" not in child_span["meta"]

--- a/tests/parametric/test_tracer.py
+++ b/tests/parametric/test_tracer.py
@@ -16,32 +16,6 @@ parametrize = pytest.mark.parametrize
 
 @scenarios.parametric
 class Test_Tracer:
-    @missing_feature(context.library == "cpp", reason="version not detected by parametric tests yet")
-    @missing_feature(context.library == "php", reason="version not detected by parametric tests yet")
-    def test_tracer_parametric_version(self, test_agent: _TestAgentAPI, test_library: APMLibrary) -> None:
-        """Ensure the version used by parametric tests matches the library version being tested.
-
-        If this test fails then either the version detected/used by the parametric testing framework is wrong
-        or the library is not reporting the right version.
-        """
-        if "PYTHON_DDTRACE_PACKAGE" in os.environ:
-            pytest.skip("Custom python library versions are not yet supported by the parametric tests")
-        if "RUBY_DDTRACE_SHA" in os.environ:
-            pytest.skip("Custom ruby library versions are not supported by the parametric tests")
-
-        with test_library:
-            with test_library.start_span("operation"):
-                pass
-        test_agent.wait_for_num_traces(1)
-        request = [r for r in test_agent.requests() if "trace" in r["url"]][0]
-        reported_tracer_version = request["headers"]["Datadog-Meta-Tracer-Version"]
-        assert reported_tracer_version == context.library.version, (
-            "Parametric library detected version %r does not match library "
-            "version %r seen in trace request.\n"
-            "Likely reasons for this test failing: 1) Parametric library detection being wrong; 2) library reporting "
-            "the wrong version"
-        ) % (context.library.version, reported_tracer_version)
-
     @missing_feature(context.library == "cpp", reason="metrics cannot be set manually")
     @missing_feature(context.library == "nodejs", reason="nodejs overrides the manually set service name")
     def test_tracer_span_top_level_attributes(self, test_agent: _TestAgentAPI, test_library: APMLibrary) -> None:
@@ -70,7 +44,7 @@ class Test_Tracer:
 
 
 @scenarios.parametric
-@released(python="1.18.0")
+@released(python="0.36.0")
 class Test_TracerUniversalServiceTagging:
     @missing_feature(reason="FIXME: library test client sets empty string as the service name")
     @parametrize("library_env", [{"DD_SERVICE": "service1"}])
@@ -112,27 +86,3 @@ class Test_TracerUniversalServiceTagging:
         span = find_span(trace, Span(name="operation"))
         assert span["name"] == "operation"
         assert span["meta"]["env"] == library_env["DD_ENV"]
-        assert 0
-
-    # @parametrize("library_env", [{"DD_VERSION": "1.2.3"}])
-    # def test_tracer_version_environment_variable(
-    #         self, library_env: Dict[str, str], test_agent: _TestAgentAPI, test_library: APMLibrary
-    # ) -> None:
-    #     """
-    #     When DD_VERSION is specified
-    #         When a service-entry span is created
-    #             The service-entry span should have the value of DD_VERSION in meta.version
-    #             A child span should not have the value of DD_VERSION in meta.version
-
-    #     """
-    #     with test_library:
-    #         with test_library.start_span("operation"):
-    #             with test_library.start_span("child"):
-    #                 pass
-
-    #     traces = test_agent.wait_for_num_traces(1)
-    #     trace = find_trace_by_root(traces, Span(name="operation"))
-    #     service_entry_span = find_span(trace, Span(name="operation"))
-    #     child_span = find_span(trace, Span(name="child"))
-    #     assert service_entry_span["meta"]["version"] == library_env["DD_VERSION"]
-    #     assert "version" not in child_span["meta"]

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1,10 +1,13 @@
+from distutils.version import LooseVersion
 from logging import FileHandler
 import os
 from pathlib import Path
+import re
 import shutil
 import time
 
 import pytest
+import requests
 from watchdog.observers.polling import PollingObserver
 from watchdog.events import FileSystemEventHandler
 from utils._context.library_version import LibraryVersion, Version
@@ -826,13 +829,66 @@ class OnBoardingScenario(_Scenario):
 
 
 class ParametricScenario(_Scenario):
+    # ref: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    semver_regex = "(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._version_cache = {}
+        super().__init__(*args, **kwargs)
+
     def configure(self, option):
         super().configure(option)
         assert "TEST_LIBRARY" in os.environ
 
     @property
     def library(self):
-        return LibraryVersion(os.getenv("TEST_LIBRARY", "**not-set**"), "0.00")
+        test_lib = os.getenv("TEST_LIBRARY", "**not-set**")
+        version = "0.00"
+
+        # Cache versions to avoid rate limits with network requests
+        if test_lib in self._version_cache:
+            return LibraryVersion(test_lib, self._version_cache[test_lib])
+
+        if test_lib == "python":
+            # https://pypi.org/project/ddtrace/
+            # parametric pulls in the latest published python library
+            if "PYTHON_DDTRACE_PACKAGE" in os.environ:
+                print(
+                    "WARNING: python version comparison does not work for custom branches, defaulting to latest version"
+                )
+            data = requests.get("https://pypi.org/pypi/ddtrace/json").json()
+            versions = list(data["releases"].keys())
+            versions.sort(key=LooseVersion, reverse=True)
+            version = versions[0]
+        elif test_lib == "ruby":
+            # https://rubygems.org/gems/ddtrace
+            if "RUBY_DDTRACE_SHA" in os.environ:
+                print(
+                    "WARNING: ruby version comparison does not work for custom branches, defaulting to latest version"
+                )
+            data = requests.get("https://rubygems.org/api/v1/gems/ddtrace.json").json()
+            version = data["version"]
+        elif test_lib == "java":
+            # https://github.com/DataDog/dd-trace-java/releases
+            data = requests.get("https://api.github.com/repos/datadog/dd-trace-java/releases/latest").json()
+            version = data["tag_name"]
+        elif test_lib == "dotnet":
+            # https://www.nuget.org/packages/dd-trace
+            # Right now the version is fixed in the csproj file, so read it from there.
+            with open("utils/build/docker/dotnet/parametric/ApmTestClient.csproj", "r") as f:
+                for line in f.readlines():
+                    if "Datadog.Trace" in line:
+                        version = re.search(self.semver_regex, line).group(0)
+            # When latest is used then we can use the code below to get the latest version.
+            ##  data = requests.get("https://www.nuget.org/packages/dd-trace")
+            ##  Pretty sketchy, but assume that the first matching semver string
+            ##  in the webpage is the Datadog library version.
+            ##  version = re.search(self.semver_regex, data.text).group(0)
+        elif test_lib == "nodejs":
+            data = requests.get("https://registry.npmjs.org/dd-trace").json()
+            version = data["dist-tags"]["latest"]
+        self._version_cache[test_lib] = version
+        return LibraryVersion(test_lib, version)
 
 
 class scenarios:

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1,13 +1,10 @@
-from distutils.version import LooseVersion
 from logging import FileHandler
 import os
 from pathlib import Path
-import re
 import shutil
 import time
 
 import pytest
-import requests
 from watchdog.observers.polling import PollingObserver
 from watchdog.events import FileSystemEventHandler
 from utils._context.library_version import LibraryVersion, Version
@@ -829,22 +826,13 @@ class OnBoardingScenario(_Scenario):
 
 
 class ParametricScenario(_Scenario):
-    # ref: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-    semver_regex = "(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
-
-    def __init__(self, *args, **kwargs) -> None:
-        self._version_cache = {}
-        super().__init__(*args, **kwargs)
-
     def configure(self, option):
         super().configure(option)
         assert "TEST_LIBRARY" in os.environ
 
     @property
     def library(self):
-        # The library version is checked by the check_library_version fixture.
-        test_lib = os.getenv("TEST_LIBRARY", "**not-set**")
-        return LibraryVersion(test_lib, "0.0.0")
+        return LibraryVersion(os.getenv("TEST_LIBRARY", "**not-set**"), "0.00")
 
 
 class scenarios:

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -832,7 +832,10 @@ class ParametricScenario(_Scenario):
 
     @property
     def library(self):
-        return LibraryVersion(os.getenv("TEST_LIBRARY", "**not-set**"), "0.00")
+        # Use large version here as it is checked by the standard system-tests version checking.
+        # Parametric version checking is done via the check_library_version pytest fixture
+        # which uses the reported library version.
+        return LibraryVersion(os.getenv("TEST_LIBRARY", "**not-set**"), "99999.99999.99999")
 
 
 class scenarios:

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -842,53 +842,9 @@ class ParametricScenario(_Scenario):
 
     @property
     def library(self):
+        # The library version is checked by the check_library_version fixture.
         test_lib = os.getenv("TEST_LIBRARY", "**not-set**")
-        version = "0.00"
-
-        # Cache versions to avoid rate limits with network requests
-        if test_lib in self._version_cache:
-            return LibraryVersion(test_lib, self._version_cache[test_lib])
-
-        if test_lib == "python":
-            # https://pypi.org/project/ddtrace/
-            # parametric pulls in the latest published python library
-            if "PYTHON_DDTRACE_PACKAGE" in os.environ:
-                print(
-                    "WARNING: python version comparison does not work for custom branches, defaulting to latest version"
-                )
-            data = requests.get("https://pypi.org/pypi/ddtrace/json").json()
-            versions = list(data["releases"].keys())
-            versions.sort(key=LooseVersion, reverse=True)
-            version = versions[0]
-        elif test_lib == "ruby":
-            # https://rubygems.org/gems/ddtrace
-            if "RUBY_DDTRACE_SHA" in os.environ:
-                print(
-                    "WARNING: ruby version comparison does not work for custom branches, defaulting to latest version"
-                )
-            data = requests.get("https://rubygems.org/api/v1/gems/ddtrace.json").json()
-            version = data["version"]
-        elif test_lib == "java":
-            # https://github.com/DataDog/dd-trace-java/releases
-            data = requests.get("https://api.github.com/repos/datadog/dd-trace-java/releases/latest").json()
-            version = data["tag_name"]
-        elif test_lib == "dotnet":
-            # https://www.nuget.org/packages/dd-trace
-            # Right now the version is fixed in the csproj file, so read it from there.
-            with open("utils/build/docker/dotnet/parametric/ApmTestClient.csproj", "r") as f:
-                for line in f.readlines():
-                    if "Datadog.Trace" in line:
-                        version = re.search(self.semver_regex, line).group(0)
-            # When latest is used then we can use the code below to get the latest version.
-            ##  data = requests.get("https://www.nuget.org/packages/dd-trace")
-            ##  Pretty sketchy, but assume that the first matching semver string
-            ##  in the webpage is the Datadog library version.
-            ##  version = re.search(self.semver_regex, data.text).group(0)
-        elif test_lib == "nodejs":
-            data = requests.get("https://registry.npmjs.org/dd-trace").json()
-            version = data["dist-tags"]["latest"]
-        self._version_cache[test_lib] = version
-        return LibraryVersion(test_lib, version)
+        return LibraryVersion(test_lib, "0.0.0")
 
 
 class scenarios:


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

As per title add version detection. This enables parametric tests to reuse the `@released` decorator used by other system tests.

It works by retrieving the real tracer version from the library being tested by reading the http headers of requests made to the test agent.

This enables tests to be merged prior to the release of a feature.

A more accurate approach is proposed in #1445

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
