### PR TITLE
parametric: add version checking support, use latest version of each library

### DIFF
--- a/tests/test_the_test/test_apm_library.py
+++ b/tests/test_the_test/test_apm_library.py
@@ -1,0 +1,20 @@
+import packaging.version
+import pytest
+
+from utils import apm_library
+
+
+@pytest.mark.parametrize(
+    "library, version",
+    [
+        ("python", "1.17.2"),
+        ("ruby", "1.12.1"),
+        ("java", "1.18.2"),
+        ("dotnet", "2.34.0"),
+        ("nodejs", "4.9.0"),
+        ("golang", "1.52.0"),
+    ],
+)
+def test_latest_version(library: apm_library.APMLibrary, version):
+    version = packaging.version.parse(version)
+    assert apm_library.latest_version(library) >= version

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -832,7 +832,7 @@ class ParametricScenario(_Scenario):
 
     @property
     def library(self):
-        return LibraryVersion(os.getenv("TEST_LIBRARY", "**not-set**"), "0.00")
+        return LibraryVersion(os.getenv("TEST_LIBRARY", "**not-set**"), "999999.0")
 
 
 class scenarios:

--- a/utils/apm_library.py
+++ b/utils/apm_library.py
@@ -1,0 +1,58 @@
+"""
+This module provides utilities for working with APM libraries.
+"""
+import functools
+from typing import Literal
+
+import requests
+
+import packaging.version
+
+
+APMLibrary = Literal["python", "ruby", "java", "dotnet", "nodejs", "golang", "php", "cpp"]
+
+
+@functools.lru_cache
+def latest_version(library: APMLibrary) -> packaging.version.Version:
+    """Return the latest version of the library specified.
+
+    Result is cached to prevent unnecessary network requests and avoid rate limiting.
+    """
+    if library == "python":
+        data = requests.get("https://pypi.org/pypi/ddtrace/json").json()
+        versions = list(data["releases"].keys())
+        versions.sort(key=packaging.version.parse, reverse=True)
+        version = versions[0]
+    elif library == "ruby":
+        data = requests.get("https://rubygems.org/api/v1/versions/ddtrace.json").json()
+        versions = [version["number"] for version in data]
+        versions.sort(key=packaging.version.parse, reverse=True)
+        version = versions[0]
+    elif library == "java":
+        data = requests.get(
+            "https://search.maven.org/solrsearch/select?q=g:com.datadoghq+AND+a:dd-trace-api&rows=1&wt=json"
+        ).json()
+        versions = [version["latestVersion"] for version in data["response"]["docs"]]
+        versions.sort(key=packaging.version.parse, reverse=True)
+        version = versions[0]
+    elif library == "dotnet":
+        data = requests.get("https://api.nuget.org/v3-flatcontainer/datadog.trace/index.json").json()
+        versions = list(data["versions"])
+        versions.sort(key=packaging.version.parse, reverse=True)
+        version = versions[0]
+    elif library == "nodejs":
+        data = requests.get("https://registry.npmjs.org/dd-trace").json()
+        versions = list(data["versions"].keys())
+        versions.sort(key=packaging.version.parse, reverse=True)
+        version = versions[0]
+    elif library == "golang":
+        data = requests.get("https://proxy.golang.org/github.com/datadog/dd-trace-go/@latest")
+        version = data.json()["Version"]
+    elif library == "php":
+        data = requests.get("https://packagist.org/packages/datadog/dd-trace.json").json()
+        versions = list(data["package"]["versions"].keys())
+        versions.sort(key=packaging.version.parse, reverse=True)
+        version = versions[0]
+    elif library == "cpp":
+        raise NotImplementedError("cpp library not implemented")
+    return packaging.version.parse(version)

--- a/utils/build/docker/dotnet/parametric/ApmTestClient.csproj
+++ b/utils/build/docker/dotnet/parametric/ApmTestClient.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.31.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="DDTRACE_VERSION" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.52.0" />
     <PackageReference Include="LucasP.DuckTyping" Version="0.1.0" />
   </ItemGroup>

--- a/utils/build/docker/dotnet/parametric/Dockerfile
+++ b/utils/build/docker/dotnet/parametric/Dockerfile
@@ -7,6 +7,7 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 # restore nuget packages
 COPY ["./ApmTestClient.csproj", "./nuget.config", "./*.nupkg", "./"]
+RUN sed -i 's/DDTRACE_VERSION/2.34.0/g' ./ApmTestClient.csproj
 RUN dotnet restore "./ApmTestClient.csproj"
 
 # build and publish

--- a/utils/build/docker/golang/parametric/Dockerfile
+++ b/utils/build/docker/golang/parametric/Dockerfile
@@ -4,4 +4,5 @@ WORKDIR /client
 COPY ./go.mod /client
 COPY ./go.sum /client
 COPY . /client
+RUN go get gopkg.in/DataDog/dd-trace-go.v1@v1.52.0
 RUN go install

--- a/utils/build/docker/python/parametric/Dockerfile
+++ b/utils/build/docker/python/parametric/Dockerfile
@@ -3,4 +3,4 @@ FROM ghcr.io/datadog/dd-trace-py/testrunner:7ce49bd78b0d510766fc5db12756a8840724
 WORKDIR /client
 RUN pyenv global 3.9.11
 RUN python3.9 -m pip install grpcio==1.46.3 grpcio-tools==1.46.3
-RUN python3.9 -m pip install ddtrace
+RUN python3.9 -m pip install ddtrace==1.17.2

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -8,6 +8,7 @@ from typing import Tuple
 from typing import TypedDict
 
 import grpc
+import packaging
 import requests
 
 from utils.parametric.protos import apm_test_client_pb2 as pb
@@ -381,9 +382,10 @@ class APMLibraryClientGRPC:
 
 
 class APMLibrary:
-    def __init__(self, client: APMLibraryClient, lang):
+    def __init__(self, client: APMLibraryClient, lang: str, version: packaging.version.Version):
         self._client = client
         self.lang = lang
+        self.version = version
 
     def __enter__(self) -> "APMLibrary":
         return self


### PR DESCRIPTION
Update parametric test library factories to declare and use a custom tracer version so that specific versions of the library can be validated.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
