### PR TITLE
Revert "Nodejs - telemetry heartbeat are sent too fast"

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -288,9 +288,9 @@ class Test_Telemetry:
 
         self.validate_library_telemetry_data(validator)
 
-    # @flaky(library="nodejs", reason="Heartbeats are sometimes sent too fast")
     # @flaky(library="dotnet", reason="Heartbeats are sometimes sent too slowly")
     # @flaky(library="python", reason="Heartbeats are sometimes sent too slowly")
+    @flaky(context.library < "nodejs@4.13.1", reason="Heartbeats are sometimes sent too fast")
     @bug(context.library < "java@1.18.0", reason="Telemetry interval drifts")
     @missing_feature(context.library < "ruby@1.13.0", reason="DD_TELEMETRY_HEARTBEAT_INTERVAL not supported")
     def test_app_heartbeat(self):


### PR DESCRIPTION
Reverts DataDog/system-tests#1419

Fixed in: https://github.com/DataDog/dd-trace-js/pull/3553