### PR TITLE
replace HttpOnly=true with HttpOnly

### DIFF
--- a/tests/appsec/iast/sink/test_insecure_cookie.py
+++ b/tests/appsec/iast/sink/test_insecure_cookie.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import pytest
-from utils import context, coverage, released, missing_feature
+from utils import context, coverage, released, missing_feature, bug
 from ..iast_fixtures import SinkFixture
 
 if context.library == "cpp":
@@ -44,6 +44,7 @@ class TestInsecureCookie:
     def setup_secure(self):
         self.sink_fixture.setup_secure()
 
+    @bug(context.library < "java@1.18.3", reason="Incorrect handling of HttpOnly flag")
     def test_secure(self):
         self.sink_fixture.test_secure()
 

--- a/tests/appsec/iast/sink/test_no_httponly_cookie.py
+++ b/tests/appsec/iast/sink/test_no_httponly_cookie.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import pytest
-from utils import context, coverage, released, missing_feature
+from utils import context, coverage, released, missing_feature, bug
 from ..iast_fixtures import SinkFixture
 
 if context.library == "cpp":
@@ -43,6 +43,7 @@ class TestNoHttponlyCookie:
     def setup_secure(self):
         self.sink_fixture.setup_secure()
 
+    @bug(context.library < "java@1.18.3", reason="Incorrect handling of HttpOnly flag")
     def test_secure(self):
         self.sink_fixture.test_secure()
 

--- a/tests/appsec/iast/sink/test_no_samesite_cookie.py
+++ b/tests/appsec/iast/sink/test_no_samesite_cookie.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import pytest
-from utils import context, coverage, released, missing_feature
+from utils import context, coverage, released, missing_feature, bug
 from ..iast_fixtures import SinkFixture
 
 if context.library == "cpp":
@@ -43,6 +43,7 @@ class TestNoSamesiteCookie:
     def setup_secure(self):
         self.sink_fixture.setup_secure()
 
+    @bug(context.library < "java@1.18.3", reason="Incorrect handling of HttpOnly flag")
     def test_secure(self):
         self.sink_fixture.test_secure()
 

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/IastSinkResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/IastSinkResource.java
@@ -208,19 +208,19 @@ public class IastSinkResource {
     @GET
     @Path("/insecure-cookie/test_insecure")
     public Response  insecureCookie() {
-        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;HttpOnly=true;SameSite=Strict").build();
+        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;HttpOnly;SameSite=Strict").build();
     }
 
     @GET
     @Path("/insecure-cookie/test_secure")
     public Response  secureCookie() {
-        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").build();
+        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").build();
     }
 
     @GET
     @Path("/no-samesite-cookie/test_insecure")
     public Response  noSameSiteCookieInsecure() {
-        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;HttpOnly=true;Secure").build();
+        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;HttpOnly;Secure").build();
     }
 
     @GET
@@ -232,7 +232,7 @@ public class IastSinkResource {
     @GET
     @Path("/no-samesite-cookie/test_secure")
     public Response  noSameSiteCookieSecure() {
-        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").build();
+        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").build();
     }
 
     @GET
@@ -250,7 +250,7 @@ public class IastSinkResource {
     @GET
     @Path("/no-httponly-cookie/test_secure")
     public Response  noHttpOnlyCookieSecure() {
-        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").build();
+        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").build();
     }
 
 }

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/IastSinkResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/IastSinkResource.java
@@ -209,19 +209,19 @@ public class IastSinkResource {
     @GET
     @Path("/insecure-cookie/test_insecure")
     public Response  insecureCookie() {
-        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;HttpOnly=true;SameSite=Strict").build();
+        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;HttpOnly;SameSite=Strict").build();
     }
 
     @GET
     @Path("/insecure-cookie/test_secure")
     public Response  secureCookie() {
-        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").build();
+        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").build();
     }
 
     @GET
     @Path("/no-samesite-cookie/test_insecure")
     public Response  noSameSiteCookieInsecure() {
-        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;HttpOnly=true;Secure").build();
+        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;HttpOnly;Secure").build();
     }
 
     @GET
@@ -233,7 +233,7 @@ public class IastSinkResource {
     @GET
     @Path("/no-samesite-cookie/test_secure")
     public Response  noSameSiteCookieSecure() {
-        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").build();
+        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").build();
     }
 
     @GET
@@ -250,6 +250,6 @@ public class IastSinkResource {
     @GET
     @Path("/no-httponly-cookie/test_secure")
     public Response  noHttpOnlyCookieSecure() {
-        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").build();
+        return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").build();
     }
 }

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
@@ -216,19 +216,19 @@ public class AppSecIast {
     }
     @GetMapping("/insecure-cookie/test_insecure")
     String insecureCookie(final HttpServletResponse response) {
-        response.addHeader("Set-Cookie", "user-id=7;HttpOnly=true;SameSite=Strict");
+        response.addHeader("Set-Cookie", "user-id=7;HttpOnly;SameSite=Strict");
         return "ok";
     }
 
     @GetMapping("/insecure-cookie/test_secure")
     String secureCookie(final HttpServletResponse response) {
-        response.addHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict");
+        response.addHeader("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict");
         return "ok";
     }
 
     @GetMapping("/no-samesite-cookie/test_insecure")
     String noSameSiteCookieInsecure(final HttpServletResponse response) {
-        response.addHeader("Set-Cookie", "user-id=7;HttpOnly=true;Secure");
+        response.addHeader("Set-Cookie", "user-id=7;HttpOnly;Secure");
         return "ok";
     }
 
@@ -240,7 +240,7 @@ public class AppSecIast {
 
     @GetMapping("/no-samesite-cookie/test_secure")
     String noSameSiteCookieSecure(final HttpServletResponse response) {
-        response.addHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict");
+        response.addHeader("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict");
         return "ok";
     }
 
@@ -257,7 +257,7 @@ public class AppSecIast {
 
     @GetMapping("/no-httponly-cookie/test_secure")
     String noHttpOnlyCookieSecure(final HttpServletResponse response) {
-        response.addHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict");
+        response.addHeader("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict");
         return "ok";
     }
 

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
@@ -114,19 +114,19 @@ public class IastSinkRouteProvider implements Consumer<Router> {
                 ctx.response().putHeader("Set-Cookie", "").end()
         );
         router.get("/iast/insecure-cookie/test_insecure").handler(ctx ->
-                ctx.response().putHeader("Set-Cookie", "user-id=7;HttpOnly=true;SameSite=Strict").end()
+                ctx.response().putHeader("Set-Cookie", "user-id=7;HttpOnly;SameSite=Strict").end()
         );
         router.get("/iast/insecure-cookie/test_secure").handler(ctx ->
-                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").end()
+                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").end()
         );
         router.get("/iast/no-samesite-cookie/test_insecure").handler(ctx ->
-                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true").end()
+                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly").end()
         );
         router.get("/iast/no-samesite-cookie/test_empty_cookie").handler(ctx ->
                 ctx.response().putHeader("Set-Cookie", "").end()
         );
         router.get("/iast/no-samesite-cookie/test_secure").handler(ctx ->
-                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").end()
+                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").end()
         );
         router.get("/iast/no-httponly-cookie/test_empty_cookie").handler(ctx ->
                 ctx.response().putHeader("Set-Cookie", "").end()
@@ -135,7 +135,7 @@ public class IastSinkRouteProvider implements Consumer<Router> {
                 ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;SameSite=Strict").end()
         );
         router.get("/iast/no-httponly-cookie/test_secure").handler(ctx ->
-                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").end()
+                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").end()
         );
         router.post("/iast/xpathi/test_insecure").handler(ctx -> {
             final HttpServerRequest request = ctx.request();

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
@@ -129,19 +129,19 @@ public class IastSinkRouteProvider implements Consumer<Router> {
                 ctx.response().putHeader("Set-Cookie", "").end()
         );
         router.get("/iast/insecure-cookie/test_insecure").handler(ctx ->
-                ctx.response().putHeader("Set-Cookie", "user-id=7;HttpOnly=true;SameSite=Strict").end()
+                ctx.response().putHeader("Set-Cookie", "user-id=7;HttpOnly;SameSite=Strict").end()
         );
         router.get("/iast/insecure-cookie/test_secure").handler(ctx ->
-                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").end()
+                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").end()
         );
         router.get("/iast/no-samesite-cookie/test_insecure").handler(ctx ->
-                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true").end()
+                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly").end()
         );
         router.get("/iast/no-samesite-cookie/test_empty_cookie").handler(ctx ->
                 ctx.response().putHeader("Set-Cookie", "").end()
         );
         router.get("/iast/no-samesite-cookie/test_secure").handler(ctx ->
-                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").end()
+                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").end()
         );
         router.get("/iast/no-httponly-cookie/test_empty_cookie").handler(ctx ->
                 ctx.response().putHeader("Set-Cookie", "").end()
@@ -150,7 +150,7 @@ public class IastSinkRouteProvider implements Consumer<Router> {
                 ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;SameSite=Strict").end()
         );
         router.get("/iast/no-httponly-cookie/test_secure").handler(ctx ->
-                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly=true;SameSite=Strict").end()
+                ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").end()
         );
 
     }


### PR DESCRIPTION
## Description

Replace HttpOnly=true with HttpOnly in the vulnerability tests for HttpOnly Cookie

## Motivation

HttpOnly is meant to be used as a flag, not as name value pair

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
