### PR TITLE
Cleanup sampling test cases

### DIFF
--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -144,7 +144,7 @@ class Test_SamplingDecisions:
                     f"Message: {data['log_filename']}:"
                     "Metric _sampling_priority_v1 should be set on traces that with sampling decision"
                 )
-            
+
             expected_priority = get_sampling_decision(context.tracer_sampling_rate, root_span["trace_id"])
             if sampling_priority != expected_priority:
                 raise ValueError(
@@ -204,9 +204,6 @@ class Test_SamplingDecisions:
         self.traces_determinism = [
             {"trace_id": randint(1, 2 ** 64 - 1), "parent_id": randint(1, 2 ** 64 - 1)} for _ in range(20)
         ]
-
-        for t in self.traces_determinism:
-            interfaces.library.uniqueness_exceptions.add_trace_id(t["trace_id"])
 
         # Send requests with the same trace and parent id twice
         for _ in range(2):

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -134,6 +134,7 @@ class Test_SamplingDecisions:
     )
     @bug(context.library >= "python@1.11.0rc2.dev8", reason="Under investigation")
     @bug(library="golang", reason="Need investigation")
+    @bug(library="ruby", reason="Route /sample_rate_route not implemented")
     def test_sampling_decision(self):
         """Verify that traces are sampled following the sample rate"""
 
@@ -166,7 +167,7 @@ class Test_SamplingDecisions:
             )
 
     @bug(library="python", reason="Sampling decisions are not taken by the tracer APMRP-259")
-    @bug(library="ruby", reason="Unknown reason")
+    @bug(library="ruby", reason="Route /sample_rate_route not implemented")
     @bug(context.library > "nodejs@3.14.1", reason="_sampling_priority_v1 is missing")
     @missing_feature(library="ruby", reason="Endpoint not implemented on weblog")
     def test_sampling_decision_added(self):

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -27,7 +27,6 @@ class LibraryInterfaceValidator(InterfaceValidator):
     def __init__(self):
         super().__init__("library")
         self.ready = threading.Event()
-        self.uniqueness_exceptions = _TraceIdUniquenessExceptions()
 
     def ingest_file(self, src_path):
         self.ready.set()
@@ -303,17 +302,3 @@ class LibraryInterfaceValidator(InterfaceValidator):
 
     def validate_remote_configuration(self, validator, success_by_default=False):
         self.validate(validator, success_by_default=success_by_default, path_filters=r"/v\d+.\d+/config")
-
-
-class _TraceIdUniquenessExceptions:
-    def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self.traces_ids = set()
-
-    def add_trace_id(self, trace_id):
-        with self._lock:
-            self.traces_ids.add(trace_id)
-
-    def should_be_unique(self, trace_id):
-        with self._lock:
-            return trace_id not in self.traces_ids


### PR DESCRIPTION
## Description

- Remove unused `uniqueness_exceptions` variable
- Simplify `get_sampling_decision` function signature
- Disable Ruby tests, given that `/sample_rate_route/*` isn't implemented in any of the Rails nor Sinatra app.
Commits can be reviewed independently.

## Motivation

I'm working on adding additional sampling tests cases to the suite. I'm starting with preliminary minor cleanups before opening PRs with the new logic.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [x] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
