### PR TITLE
Merge graalVM in base matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
         - library: java
           weblog: spring-boot
         - library: java
+          weblog: spring-boot-3-native
+        - library: java
           weblog: uds-spring-boot
         - library: java
           weblog: spring-boot-openliberty
@@ -412,6 +414,23 @@ jobs:
       run: ./run.sh SAMPLING
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
+
+    - name: Run TELEMETRY_APP_STARTED_PRODUCTS_DISABLED scenario
+      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
+      run: ./run.sh TELEMETRY_APP_STARTED_PRODUCTS_DISABLED
+      env:
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+    - name: Run TELEMETRY_LOG_GENERATION_DISABLED scenario
+      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
+      run: ./run.sh TELEMETRY_LOG_GENERATION_DISABLED
+      env:
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+    - name: Run TELEMETRY_METRIC_GENERATION_DISABLED scenario
+      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
+      run: ./run.sh TELEMETRY_METRIC_GENERATION_DISABLED
+      env:
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+
     - name: Run TELEMETRY_DEPENDENCY_LOADED_TEST_FOR_DEPENDENCY_COLLECTION_DISABLED scenario
       if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
       run: ./run.sh TELEMETRY_DEPENDENCY_LOADED_TEST_FOR_DEPENDENCY_COLLECTION_DISABLED
@@ -477,223 +496,6 @@ jobs:
         path: artifact.tar.gz
     - name: Upload results CI Visibility
       if: ${{ always() }}
-      run: ./utils/scripts/upload_results_CI_visibility.sh ${{ matrix.version }} system-tests ${{ github.run_id }}-${{ github.run_attempt }}
-      env:
-        DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}
-    - name: Print fancy log report
-      if: ${{ always() }}
-      run: python utils/scripts/markdown_logs.py >> $GITHUB_STEP_SUMMARY
-
-  graalvm:
-    runs-on:
-      labels: ubuntu-latest-16-cores
-      group: APM Larger Runners
-    needs:
-    - lint
-    - test_the_test
-    - scenarios
-    strategy:
-      matrix:
-        variant:
-        - library: java
-          weblog: spring-boot-3-native
-        version:
-        - prod
-        - dev
-      fail-fast: false
-    env:
-      TEST_LIBRARY: ${{ matrix.variant.library }}
-      WEBLOG_VARIANT: ${{ matrix.variant.weblog }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Install runner
-      uses: ./.github/actions/install_runner
-    - name: Pull images
-      uses: ./.github/actions/pull_images
-    - name: Load WAF rules
-      if: ${{ matrix.version == 'dev' }}
-      run: ./utils/scripts/load-binary.sh waf_rule_set
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Load library binary
-      if: ${{ matrix.version == 'dev' }}
-      run: ./utils/scripts/load-binary.sh ${{ matrix.variant.library }}
-    - name: Load library PHP appsec binary
-      if: ${{ matrix.variant.library == 'php' }}
-      run: ./utils/scripts/load-binary.sh php_appsec ${{matrix.version}}
-    - name: Load agent binary
-      if: ${{ matrix.version == 'dev' }}
-      run: ./utils/scripts/load-binary.sh agent
-    - name: Log in to the Container registry
-      if: ${{ matrix.variant.library == 'ruby' }}
-      run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
-    - name: Build proxy image
-      if: contains(github.event.pull_request.labels.*.name, 'build-proxy-image')
-      run: ./build.sh -i proxy
-    - name: Build agent
-      run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i agent
-    - name: Build weblog
-      id: build
-      run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i weblog
-    - name: Run DEFAULT scenario
-      if: steps.build.outcome == 'success'
-      run: ./run.sh DEFAULT
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run PROFILING scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_profiling == 'true'
-      run: ./run.sh PROFILING
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run TRACE_PROPAGATION_STYLE_W3C scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh TRACE_PROPAGATION_STYLE_W3C
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run INTEGRATIONS scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh INTEGRATIONS
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APM_TRACING_E2E_OTEL scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_open_telemetry == 'true'
-      run: ./run.sh APM_TRACING_E2E_OTEL
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-        DD_APP_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-    - name: Run LIBRARY_CONF_CUSTOM_HEADERS_SHORT scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh LIBRARY_CONF_CUSTOM_HEADERS_SHORT
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run LIBRARY_CONF_CUSTOM_HEADERS_LONG scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh LIBRARY_CONF_CUSTOM_HEADERS_LONG
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING_NOCACHE scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING_NOCACHE
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_MISSING_RULES scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh APPSEC_MISSING_RULES
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_CORRUPTED_RULES scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh APPSEC_CORRUPTED_RULES
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_CUSTOM_RULES scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh APPSEC_CUSTOM_RULES
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_RULES_MONITORING_WITH_ERRORS scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh APPSEC_RULES_MONITORING_WITH_ERRORS
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_BLOCKING scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh APPSEC_BLOCKING
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_DISABLED scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh APPSEC_DISABLED
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_LOW_WAF_TIMEOUT scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh APPSEC_LOW_WAF_TIMEOUT
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_CUSTOM_OBFUSCATION scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh APPSEC_CUSTOM_OBFUSCATION
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_RATE_LIMITER scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh APPSEC_RATE_LIMITER
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_RUNTIME_ACTIVATION scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh APPSEC_RUNTIME_ACTIVATION
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_WAF_TELEMETRY scenario
-      if: always() && steps.build.outcome == 'success'
-      run: ./run.sh APPSEC_WAF_TELEMETRY
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run APPSEC_AUTO_EVENTS_EXTENDED scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh APPSEC_AUTO_EVENTS_EXTENDED
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run SAMPLING scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_sampling == 'true'
-      run: ./run.sh SAMPLING
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run TELEMETRY_APP_STARTED_PRODUCTS_DISABLED scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh TELEMETRY_APP_STARTED_PRODUCTS_DISABLED
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run TELEMETRY_LOG_GENERATION_DISABLED scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh TELEMETRY_LOG_GENERATION_DISABLED
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Run TELEMETRY_METRIC_GENERATION_DISABLED scenario
-      if: always() && steps.build.outcome == 'success' && needs.scenarios.outputs.run_all == 'true'
-      run: ./run.sh TELEMETRY_METRIC_GENERATION_DISABLED      
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    - name: Compress logs
-      if: steps.build.outcome == 'success'
-      run: tar -czvf artifact.tar.gz $(ls | grep logs)
-    - name: Upload artifact
-      if: steps.build.outcome == 'success'
-      uses: actions/upload-artifact@v3
-      with:
-        name: logs_${{ matrix.variant.library }}_${{ matrix.variant.weblog }}_${{ matrix.version }}_graalvm
-        path: artifact.tar.gz
-    - name: Upload results CI Visibility
-      if: steps.build.outcome == 'success'
       run: ./utils/scripts/upload_results_CI_visibility.sh ${{ matrix.version }} system-tests ${{ github.run_id }}-${{ github.run_attempt }}
       env:
         DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}
@@ -770,7 +572,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - main
-    - graalvm
     if: always() && github.ref == 'refs/heads/main'
     steps:
     - name: Checkout

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -496,6 +496,7 @@ class Test_Telemetry:
             raise Exception("app-product-change is not emitted when product change is enabled")
 
 
+@irrelevant(True, reason="The test must be adapted to handle correctly v1/v2 payloads")
 @released(python="1.7.0", dotnet="2.12.0", java="0.108.1", nodejs="3.2.0", ruby="1.4.0")
 @bug(context.uds_mode and context.library < "nodejs@3.7.0")
 @missing_feature(library="cpp")
@@ -514,12 +515,12 @@ class Test_ProductsDisabled:
 
         for data in telemetry_data:
             if data["request"]["content"].get("request_type") == "app-started":
-                content = data["request"]["content"]
+                payload = data["request"]["content"]["payload"]
                 assert (
-                    "products" in content["payload"]
-                ), "Product information was expected in app-started event, but was missing"
-                products = content["payload"]["products"]
-                for product, details in products.items():
+                    "products" in payload
+                ), f"Product information was expected in app-started event, but was missing in {data['log_filename']}"
+
+                for product, details in payload["products"].items():
                     assert (
                         details.get("enabled") is False
                     ), f"Product information expected to indicate {product} is disabled, but found enabled"


### PR DESCRIPTION
## Description

GraalVM variant has it's own workflow part, making the management of scenario a pain. And what should happen happened, we missed some of them.

This PR reintegrate GraalVM in the base job, skipping not relevant scenario, and remove the dedicated part.

It also add some skip for test that fails due to the new set of run (nodejs / telemetry_app_started_products_disabled) for instance.

## Motivation

Less error prone, easier to maintan

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
