### PR TITLE
Add docker host other protocols

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -528,7 +528,9 @@ class OpenTelemetryCollectorContainer(TestedContainer):
         self._otel_config_host_path = "./utils/build/docker/otelcol-config.yaml"
 
         if "DOCKER_HOST" in os.environ:
-            self._otel_host = re.sub(r"^ssh://([^@]+@|)", "", os.environ["DOCKER_HOST"])
+            m = re.match(r"(?:ssh:|tcp:|fd:|)//(?:[^@]+@|)([^:]+)", os.environ["DOCKER_HOST"])
+            if m is not None:
+                self._otel_host = m.group(1)
         else:
             self._otel_host = "localhost"
 

--- a/utils/_weblog.py
+++ b/utils/_weblog.py
@@ -71,7 +71,9 @@ class _Weblog:
         if "SYSTEM_TESTS_WEBLOG_HOST" in os.environ:
             self.domain = os.environ["SYSTEM_TESTS_WEBLOG_HOST"]
         elif "DOCKER_HOST" in os.environ:
-            self.domain = re.sub(r"^ssh://([^@]+@|)", "", os.environ["DOCKER_HOST"])
+            m = re.match(r"(?:ssh:|tcp:|fd:|)//(?:[^@]+@|)([^:]+)", os.environ["DOCKER_HOST"])
+            if m is not None:
+                self.domain = m.group(1)
         else:
             self.domain = "localhost"
 


### PR DESCRIPTION
## Description

- Add docker host other protocols
  - ... and actually extract only the host, ignoring the dockerd port
- Ignore protocols that don't make sense to find host/ip in, falling back to `localhost`, overridable by `env SYSTEM_TESTS_WEBLOG_HOST=something`

## Motivation

The previously implemented attempt was merely replacing a prefix matching the ssh protocol.

As reported by @LotharSee this failed e.g when using `colima` which sets a `unix://` link to the socket, and tried to stuff that in the weblog URL:

```
Request SKVRAMWGIWEOGZULCINYCOSOVOZPPLPKOHEE raise an error: HTTPSConnectionPool(host='unix', port=443): Max retries exceeded with url: /Users/benjamin/.colima/docker.sock:7777/sample_rate_route/1 (Caused by SSLError(CertificateError("hostname 'unix' doesn't match either of '*.us1.something.something', 'us1.something.something'")))
```

## Additional notes

Probably this kind of thing should be factored out so as not to be repeated, but current as to where that would be is unclear. Consider this a hotfix.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
