### PR TITLE
Upgrade golang to 1.20 and optimize dockerfile caching

### DIFF
--- a/utils/build/docker/golang/app/go.mod
+++ b/utils/build/docker/golang/app/go.mod
@@ -1,6 +1,6 @@
 module weblog
 
-go 1.17
+go 1.20
 
 require (
 	github.com/gin-gonic/gin v1.8.1

--- a/utils/build/docker/golang/install_ddtrace.sh
+++ b/utils/build/docker/golang/install_ddtrace.sh
@@ -15,7 +15,8 @@ else
     go get -v -d -u gopkg.in/DataDog/dd-trace-go.v1
 fi
 
-go mod tidy -compat=1.17
+# Downloading a newer version of the tracer may require to resolve again all dependencies
+go mod tidy
 
 # Read the library version out of the version.go file
 mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)

--- a/utils/build/docker/golang/uds-echo.Dockerfile
+++ b/utils/build/docker/golang/uds-echo.Dockerfile
@@ -1,16 +1,24 @@
-FROM golang:1.18
+FROM golang:1.20
 
-# print versions
+# print important lib versions
 RUN go version && curl --version
 
-COPY utils/build/docker/golang/install_ddtrace.sh binaries* /binaries/
+# install jq and socat
+RUN apt-get update && apt-get -y install jq socat
+
+# download go dependencies
+RUN mkdir -p /app
+COPY utils/build/docker/golang/app/go.mod utils/build/docker/golang/app/go.sum /app
+WORKDIR /app
+RUN go mod download && go mod verify
+
+# copy the app code
 COPY utils/build/docker/golang/app /app
 COPY utils/build/docker/golang/app.sh /app/app.sh
 COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh
 
-WORKDIR /app
-
-RUN apt-get update && apt-get -y install jq socat
+# download the proper tracer version
+COPY utils/build/docker/golang/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 ENV DD_TRACE_HEADER_TAGS='user-agent'
 


### PR DESCRIPTION
## Description

- Upgrade golang weblog to 1.20 from a mix of 1.18 (golang) and 1.17 (gomod)
- Change dockerfile command orders to downlaod apt and golang packages first. These steps are now cached even if the tracer version or the app code is changed.

## Motivation

Speed up the local dev experience. Bonus points if it makes our CI a bit faster.


## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [x] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
