### PR TITLE
Allow other tags to be present in the telemetry metrics and distributions payload

### DIFF
--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -70,7 +70,7 @@ class Test_TelemetryMetrics:
             "waf_version",
             "event_rules_version",
             "version",
-            "lib_language"
+            "lib_language",
         }
         series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
         # TODO(Python). Gunicorn creates 2 process (main gunicorn process + X child workers). It generates two init
@@ -108,7 +108,7 @@ class Test_TelemetryMetrics:
             "waf_version",
             "event_rules_version",
             "version",
-            "lib_language"
+            "lib_language",
         }
         series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
         assert len(series) == 1
@@ -141,7 +141,7 @@ class Test_TelemetryMetrics:
             "request_excluded",
             "waf_timeout",
             "version",
-            "lib_language"
+            "lib_language",
         }
         mandatory_tag_prefixes = {
             "waf_version",

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -66,7 +66,12 @@ class Test_TelemetryMetrics:
             "waf_version",
             "event_rules_version",
         }
-        valid_tag_prefixes = mandatory_tag_prefixes
+        valid_tag_prefixes = {
+            "waf_version",
+            "event_rules_version",
+            "version",
+            "lib_language"
+        }
         series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
         # TODO(Python). Gunicorn creates 2 process (main gunicorn process + X child workers). It generates two init
         if context.library == "python" and context.weblog_variant != "uwsgi-poc":
@@ -99,7 +104,12 @@ class Test_TelemetryMetrics:
             "waf_version",
             "event_rules_version",
         }
-        valid_tag_prefixes = mandatory_tag_prefixes
+        valid_tag_prefixes = {
+            "waf_version",
+            "event_rules_version",
+            "version",
+            "lib_language"
+        }
         series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
         assert len(series) == 1
         s = series[0]
@@ -130,6 +140,8 @@ class Test_TelemetryMetrics:
             "request_blocked",
             "request_excluded",
             "waf_timeout",
+            "version",
+            "lib_language"
         }
         mandatory_tag_prefixes = {
             "waf_version",


### PR DESCRIPTION
## Description

Include optional telemetry metrics and distributions tags

## Motivation

`APPSEC_WAF_TELEMETRY` tests fail in nodejs because `version` and `lib_version` tags are included in the telemetry metrics and distributions payloads

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [x] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
