### PR TITLE
Test for RC client extra_services field

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -129,7 +129,7 @@ In particular, it accepts and parse JSON and XML content. A typical XML content 
 
 ## \[GET, POST, OPTIONS\] /tag_value/%s/%d
 
-This endpoint must accept two required parameters (the first is a string, the second is an integer) and are part of the URL path. 
+This endpoint must accept two required parameters (the first is a string, the second is an integer) and are part of the URL path.
 
 This endpoint must accept all query parameters and all content types.
 
@@ -254,13 +254,13 @@ Expected query parameters:
 
 ## GET /load_dependency
 
-This endpoint loads a module/package in applicable languages. It's mainly used for telemetry tests to verify that 
+This endpoint loads a module/package in applicable languages. It's mainly used for telemetry tests to verify that
 the `dependencies-loaded` event is appropriately triggered.
 
 ## GET /e2e_single_span
 
 This endpoint will create two spans, a parent span (which is a root-span), and a child span.
-The spans created are not sub-spans of the main root span automatically created by system-tests, but 
+The spans created are not sub-spans of the main root span automatically created by system-tests, but
 they will have the same `user-agent` containing the request ID in order to allow assertions on them.
 
 The following query parameters are required:
@@ -275,7 +275,7 @@ This endpoint is used for the Single Spans tests (`test_single_span.py`).
 ## GET /e2e_otel_span
 
 This endpoint will create two spans, a parent span (which is a root-span), and a child span.
-The spans created are not sub-spans of the main root span automatically created by system-tests, but 
+The spans created are not sub-spans of the main root span automatically created by system-tests, but
 they will have the same `user-agent` containing the request ID in order to allow assertions on them.
 
 The following query parameters are required:
@@ -304,7 +304,7 @@ Additionally both methods support the following query parameters to use the sdk 
 These endpoints are used for the Live Debugger tests in `test_debugger.py`. Currently, they are placeholders but will eventually be used to create and test different probe definitions.
 
 ### GET /debugger/log
-This endpoint will be used to validate the log probe. 
+This endpoint will be used to validate the log probe.
 
 ### GET /debugger/metric
 This endpoint will be used to validate the metric probe.
@@ -318,3 +318,8 @@ This endpoint will be used to validate the span decoration probe.
 The following query parameters are required for each endpoint:
 - `arg`: This is a parameter that can take any string as an argument.
 - `intArg`: This is a parameter that can take any integer as an argument.
+
+### GET /createextraservice
+should rename the trace service, creating a "fake" service
+
+The parameter `serviceName` is required and should be a string with the name for the fake service

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -76,6 +76,7 @@ tests/:
       TestDynamicConfigV1: missing_feature
   remote_config/:
     test_remote_configuration.py:
+      Test_RemoteConfigurationExtraServices: missing_feature
       Test_RemoteConfigurationUpdateSequenceASMDD: missing_feature
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: missing_feature
       Test_RemoteConfigurationUpdateSequenceFeatures: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -173,6 +173,7 @@ tests/:
       TestDynamicConfigV1: v2.33.0
   remote_config/:
     test_remote_configuration.py:
+      Test_RemoteConfigurationExtraServices: "v2.36.0"
       Test_RemoteConfigurationUpdateSequenceASMDD: v2.15.0
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: v2.15.0
       Test_RemoteConfigurationUpdateSequenceFeatures: v2.15.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -264,6 +264,7 @@ tests/:
       TestDynamicConfigV1: missing_feature
   remote_config/:
     test_remote_configuration.py:
+      Test_RemoteConfigurationExtraServices: "missing_feature"
       Test_RemoteConfigurationUpdateSequenceASMDD: missing_feature
       Test_RemoteConfigurationUpdateSequenceFeatures: v1.44.1
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -15,3 +15,6 @@ tests/:
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers:
         "*": "missing_feature"
+  remote_config/:
+    test_remote_configuration.py:
+      Test_RemoteConfigurationExtraServices: "missing_feature"

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -190,6 +190,7 @@ tests/:
       Test_Debugger_Method_Probe_Statuses: missing_feature
   remote_config/:
     test_remote_configuration.py:
+      Test_RemoteConfigurationExtraServices: missing_feature
       Test_RemoteConfigurationUpdateSequenceASMDD: v3.19.0
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: missing_feature
       Test_RemoteConfigurationUpdateSequenceFeatures: v3.9.0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -8,3 +8,6 @@ tests/:
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers:
         "*": "missing_feature"
+  remote_config/:
+    test_remote_configuration.py:
+      Test_RemoteConfigurationExtraServices: "missing_feature"

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -10,3 +10,6 @@ tests/:
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers:
         "*": "missing_feature"
+  remote_config/:
+    test_remote_configuration.py:
+      Test_RemoteConfigurationExtraServices: "missing_feature"

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -159,6 +159,7 @@ tests/:
       TestDynamicConfigV1: v1.13.0
   remote_config/:
     test_remote_configuration.py:
+      Test_RemoteConfigurationExtraServices: "missing_feature"
       Test_RemoteConfigurationUpdateSequenceASMDD: missing_feature
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: missing_feature
       Test_RemoteConfigurationUpdateSequenceFeatures: missing_feature

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -53,7 +53,6 @@ class RemoteConfigurationFieldsBasicTests:
 
     @bug(context.library < "golang@1.36.0")
     @bug(context.library < "java@0.93.0")
-    @bug(context.library >= "dotnet@2.24.0")
     @bug(context.library >= "nodejs@3.14.1")
     @bug(context.library == "php" and context.php_appsec >= "0.10.0")
     def test_schemas(self):
@@ -307,25 +306,20 @@ class Test_RemoteConfigurationExtraServices:
     def test_tracer_extra_services(self):
         """ test """
 
-        def validate(data):
-            """ Helper to validate config request content """
-            client_tracer = data["request"]["content"]["client"]["client_tracer"]
+        for data in interfaces.library.get_data():
+            if data["path"] == "/v0.7/config":
+                client_tracer = data["request"]["content"]["client"]["client_tracer"]
+                if "extra_services" in client_tracer:
+                    extra_services = client_tracer["extra_services"]
 
-            if not ("extra_services" in client_tracer):
-                raise ValidationError(
-                    "client_tracer should contain extra_services", extra_info={"client_tracer": client_tracer},
-                )
+                    if (
+                        extra_services is not None
+                        and len(extra_services) == 1
+                        and extra_services[0] == "extraVegetables"
+                    ):
+                        return
 
-            extra_services = client_tracer["extra_services"]
-
-            if extra_services is None or len(extra_services) != 1 or extra_services[0] != "extraVegetables":
-                raise ValidationError(
-                    "extra_services should be reported", extra_info={"extra_services": extra_services},
-                )
-
-            return True
-
-        interfaces.library.validate_remote_configuration(validator=validate)
+        raise ValueError("extra_services not found")
 
 
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -283,7 +283,7 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
         interfaces.library.validate_remote_configuration(validator=validate)
 
 
-@released(cpp="?", dotnet="2.35.0", golang="?", java="?", php_appsec="?", python="?", ruby="?", nodejs="?")
+@released(cpp="?", dotnet="2.36.0", golang="?", java="?", php_appsec="?", python="?", ruby="?", nodejs="?")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_asm_features
 class Test_RemoteConfigurationExtraServices:

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -288,6 +288,7 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
 @scenarios.remote_config_mocked_backend_asm_features
 class Test_RemoteConfigurationExtraServices:
     """Tests that extra services are sent in the RC message"""
+
     remote_config_is_sent = False
 
     def setup_tracer_extra_services(self):
@@ -298,12 +299,8 @@ class Test_RemoteConfigurationExtraServices:
 
         def remote_config_asm_extra_services_available(data):
             if data["path"] == "/v0.7/config":
-                if "extra_services" in data.get("request", {}).get("content", {}).get("client", {}).get("client_tracer", {}):
-                    client_tracer = data["request"]["content"]["client"]["client_tracer"]
-
-                    if not ("extra_services" in client_tracer):
-                        return False
-
+                client_tracer = data.get("request", {}).get("content", {}).get("client", {}).get("client_tracer", {})
+                if "extra_services" in client_tracer:
                     extra_services = client_tracer["extra_services"]
 
                     if extra_services is not None and len(extra_services) > 0:

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -283,7 +283,7 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
         interfaces.library.validate_remote_configuration(validator=validate)
 
 
-@released(cpp="?", dotnet="2.34.0", golang="?", java="?", php_appsec="?", python="?", ruby="?", nodejs="?")
+@released(cpp="?", dotnet="2.35.0", golang="?", java="?", php_appsec="?", python="?", ruby="?", nodejs="?")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_asm_features
 class Test_RemoteConfigurationExtraServices:

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -288,12 +288,28 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
 @scenarios.remote_config_mocked_backend_asm_features
 class Test_RemoteConfigurationExtraServices:
     """Tests that extra services are sent in the RC message"""
+    remote_config_is_sent = False
 
     def setup_tracer_extra_services(self):
         self.r_outgoing = weblog.get("/createextraservice/?serviceName=extraVegetables")
 
     def test_tracer_extra_services(self):
         """ test """
+
+        def remote_config_asm_extra_services_available(data):
+            if data["path"] == "/v0.7/config":
+                if "extra_services" in data.get("request", {}).get("content", {}).get("client", {}).get("client_tracer", {}):
+                    client_tracer = data["request"]["content"]["client"]["client_tracer"]
+
+                    if not ("extra_services" in client_tracer):
+                        return False
+
+                    extra_services = client_tracer["extra_services"]
+
+                    if extra_services is not None and len(extra_services) > 0:
+                        return True
+
+                return False
 
         def validate(data):
             """ Helper to validate config request content """
@@ -313,6 +329,7 @@ class Test_RemoteConfigurationExtraServices:
 
             return True
 
+        interfaces.library.wait_for(remote_config_asm_extra_services_available, timeout=30)
         interfaces.library.validate_remote_configuration(validator=validate)
 
 

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -283,11 +283,11 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
         interfaces.library.validate_remote_configuration(validator=validate)
 
 
-@released(cpp="?", dotnet="2.33.0", golang="?", java="?", php_appsec="?", python="?", ruby="?", nodejs="?")
+@released(cpp="?", dotnet="2.34.0", golang="?", java="?", php_appsec="?", python="?", ruby="?", nodejs="?")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_asm_features
 class Test_RemoteConfigurationExtraServices:
-    """Tests that """
+    """Tests that extra services are sent in the RC message"""
 
     def setup_tracer_extra_services(self):
         self.r_outgoing = weblog.get("/createextraservice/?serviceName=extraVegetables")

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -283,19 +283,13 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
         interfaces.library.validate_remote_configuration(validator=validate)
 
 
-@released(cpp="?", dotnet="2.36.0", golang="?", java="?", php_appsec="?", python="?", ruby="?", nodejs="?")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_asm_features
 class Test_RemoteConfigurationExtraServices:
     """Tests that extra services are sent in the RC message"""
 
-    remote_config_is_sent = False
-
     def setup_tracer_extra_services(self):
         self.r_outgoing = weblog.get("/createextraservice/?serviceName=extraVegetables")
-
-    def test_tracer_extra_services(self):
-        """ test """
 
         def remote_config_asm_extra_services_available(data):
             if data["path"] == "/v0.7/config":
@@ -307,6 +301,11 @@ class Test_RemoteConfigurationExtraServices:
                         return True
 
                 return False
+
+        interfaces.library.wait_for(remote_config_asm_extra_services_available, timeout=30)
+
+    def test_tracer_extra_services(self):
+        """ test """
 
         def validate(data):
             """ Helper to validate config request content """
@@ -326,7 +325,6 @@ class Test_RemoteConfigurationExtraServices:
 
             return True
 
-        interfaces.library.wait_for(remote_config_asm_extra_services_available, timeout=30)
         interfaces.library.validate_remote_configuration(validator=validate)
 
 

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -283,17 +283,10 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
         interfaces.library.validate_remote_configuration(validator=validate)
 
 
-@released(cpp="?",
-          dotnet="2.33.0",
-          golang="?",
-          java="?",
-          php_appsec="?",
-          python="?",
-          ruby="?",
-          nodejs="?")
+@released(cpp="?", dotnet="2.33.0", golang="?", java="?", php_appsec="?", python="?", ruby="?", nodejs="?")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_asm_features
-class Test_RemoteConfigurationExtraServices():
+class Test_RemoteConfigurationExtraServices:
     """Tests that """
 
     def setup_tracer_extra_services(self):
@@ -308,16 +301,14 @@ class Test_RemoteConfigurationExtraServices():
 
             if not ("extra_services" in client_tracer):
                 raise ValidationError(
-                    "client_tracer should contain extra_services",
-                    extra_info={"client_tracer": client_tracer},
+                    "client_tracer should contain extra_services", extra_info={"client_tracer": client_tracer},
                 )
 
             extra_services = client_tracer["extra_services"]
 
             if extra_services is None or len(extra_services) != 1 or extra_services[0] != "extraVegetables":
                 raise ValidationError(
-                    "extra_services should be reported",
-                    extra_info={"extra_services": extra_services},
+                    "extra_services should be reported", extra_info={"extra_services": extra_services},
                 )
 
             return True

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -16,6 +16,7 @@ from utils import (
     rfc,
     bug,
     irrelevant,
+    weblog,
 )
 from utils.tools import logger
 
@@ -138,8 +139,8 @@ def dict_is_included(sub_dict: dict, main_dict: dict):
 
 
 def dict_is_in_array(needle: dict, haystack: list, allow_additional_fields=True):
-    """ 
-    returns true is needle is contained in haystack. 
+    """
+    returns true is needle is contained in haystack.
     If allow_additional_field is true, needle can contains less field than the one in haystack
     """
 
@@ -278,6 +279,48 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
                 self.request_number += 1
 
             return False
+
+        interfaces.library.validate_remote_configuration(validator=validate)
+
+
+@released(cpp="?",
+          dotnet="2.33.0",
+          golang="?",
+          java="?",
+          php_appsec="?",
+          python="?",
+          ruby="?",
+          nodejs="?")
+@coverage.basic
+@scenarios.remote_config_mocked_backend_asm_features
+class Test_RemoteConfigurationExtraServices():
+    """Tests that """
+
+    def setup_tracer_extra_services(self):
+        self.r_outgoing = weblog.get("/createextraservice/?serviceName=extraVegetables")
+
+    def test_tracer_extra_services(self):
+        """ test """
+
+        def validate(data):
+            """ Helper to validate config request content """
+            client_tracer = data["request"]["content"]["client"]["client_tracer"]
+
+            if not ("extra_services" in client_tracer):
+                raise ValidationError(
+                    "client_tracer should contain extra_services",
+                    extra_info={"client_tracer": client_tracer},
+                )
+
+            extra_services = client_tracer["extra_services"]
+
+            if extra_services is None or len(extra_services) != 1 or extra_services[0] != "extraVegetables":
+                raise ValidationError(
+                    "extra_services should be reported",
+                    extra_info={"extra_services": extra_services},
+                )
+
+            return True
 
         interfaces.library.validate_remote_configuration(validator=validate)
 

--- a/utils/build/docker/dotnet/Controllers/CreateExtraServiceController.cs
+++ b/utils/build/docker/dotnet/Controllers/CreateExtraServiceController.cs
@@ -1,0 +1,19 @@
+#nullable enable
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Datadog.Trace;
+
+namespace weblog;
+
+public class CreateExtraServiceController: Controller
+{
+    [HttpGet]
+    public IActionResult Index(string? serviceName)
+    {
+        using var scope = Tracer.Instance.StartActive("create-extra-service");
+        scope.Span.ServiceName = serviceName;
+
+        return Content("Created: " + serviceName);
+    }
+}


### PR DESCRIPTION
## Description

Checks that the extra_services tag is correctly populated by the remote config client.

## Motivation

This feature will be used to help give any fake services that appear the correct status.


## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [x] CI is green
   * [x] Java tests failing because of known issue, should pass after that
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
