### PR TITLE
Reduce flakyness in .NET telemetry check

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -285,6 +285,11 @@ class Test_Telemetry:
         heartbeats = [d for d in telemetry_data if d["request"]["content"].get("request_type") == "app-heartbeat"]
         assert len(heartbeats) >= 2, "Did not receive, at least, 2 heartbeats"
 
+        # depending on the tracer, the very first heartbeat may be sent in a request that pays the
+        # connection initialization time. This time is very unpredictible, so we remove the very
+        # first heartbeat from the list
+        heartbeats.pop(0)
+
         for data in heartbeats:
             curr_message_time = datetime.strptime(data["request"]["timestamp_start"], fmt)
             if prev_message_time is None:


### PR DESCRIPTION
## Description

The telemetry heartbeat check validate the `2s` interval between every heartbeat payload.

Depending on the tracer, the very first heartbeat may be sent in a request that pays the connection initialization time. This time is very unpredictible, so we remove the very first heartbeat from the list.

## Motivation

Reduce flakyness

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
