### PR TITLE
Fix net/http sample_rate_route endpoint

### DIFF
--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -134,10 +134,6 @@ class Test_StandardTagsStatusCode:
 
 @released(dotnet="2.13.0", golang="1.39.0", nodejs="2.11.0", php="?", python="1.6.0", ruby="?")
 @released(java={"spring-boot": "0.102.0", "spring-boot-jetty": "0.102.0", "*": "?"})
-@irrelevant(
-    (context.library, context.weblog_variant) == ("golang", "net-http"),
-    reason="net-http does not handle route parameters",
-)
 @irrelevant(library="ruby", weblog_variant="rack", reason="rack can not access route pattern")
 @missing_feature(
     context.library == "ruby" and context.weblog_variant in ("rails", "sinatra14", "sinatra20", "sinatra21")
@@ -156,10 +152,12 @@ class Test_StandardTagsRoute:
         # specify the route syntax if needed
         if context.library == "nodejs":
             tags["http.route"] = "/sample_rate_route/:i"
-        if context.library == "golang" and context.weblog_variant not in [
-            "chi",
-        ]:
-            tags["http.route"] = "/sample_rate_route/:i"
+        if context.library == "golang":
+            if context.weblog_variant == "net-http":
+                # net/http doesn't support parametrized routes but a path catches anything down the tree.
+                tags["http.route"] = "/sample_rate_route/"
+            if context.weblog_variant in ("gin", "echo", "uds-echo"):
+                tags["http.route"] = "/sample_rate_route/:i"
         if context.library == "dotnet":
             tags["http.route"] = "/sample_rate_route/{i:int}"
         if context.library == "python":

--- a/utils/build/docker/golang/app/net-http.go
+++ b/utils/build/docker/golang/app/net-http.go
@@ -63,7 +63,8 @@ func main() {
 		w.Write([]byte("Hello, user!"))
 	})
 
-	mux.HandleFunc("/sample_rate_route/:i", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/sample_rate_route/", func(w http.ResponseWriter, r *http.Request) {
+		// net/http mux doesn't support advanced patterns, but the given prefix will match any /sample_rate_route/{i}
 		w.Write([]byte("OK"))
 	})
 


### PR DESCRIPTION
## Description

Fix `/sample_rate_route/{i}` route in Golang `net/http`.
Golang `net/http` doesn't support parametrized requests so all tests in SAMPLING were hitting 404, but were hidden because of poor error handling (problem I'll address in another PR).

This change fixes the endpoint, and added the endpoint to `Test_StandardTagsRoute::test_route`. 

## Motivation

While working on another PR to improve SAMPLING tests, I was using `net/http` variant for local testing, and it revealed this bug.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [x] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
