### PR TITLE
tests/parametric: align Go with client-stats spec

### DIFF
--- a/tests/parametric/test_library_tracestats.py
+++ b/tests/parametric/test_library_tracestats.py
@@ -26,8 +26,7 @@ def _human_stats(stats: V06StatsAggr) -> str:
 
 def enable_tracestats(sample_rate: Optional[float] = None) -> Any:
     env = {
-        "DD_TRACE_STATS_COMPUTATION_ENABLED": "1",  # reference, dotnet, python
-        "DD_TRACE_FEATURES": "discovery",  # golang
+        "DD_TRACE_STATS_COMPUTATION_ENABLED": "1",  # reference, dotnet, python, golang
         "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
     }
     if sample_rate is not None:

--- a/tests/parametric/test_library_tracestats.py
+++ b/tests/parametric/test_library_tracestats.py
@@ -29,6 +29,8 @@ def enable_tracestats(sample_rate: Optional[float] = None) -> Any:
         "DD_TRACE_STATS_COMPUTATION_ENABLED": "1",  # reference, dotnet, python, golang
         "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
     }
+    if context.library == "golang" and context.library.version < "v1.55.0":
+        env["DD_TRACE_FEATURES"] = "discovery"
     if sample_rate is not None:
         assert 0 <= sample_rate <= 1.0
         env.update(

--- a/utils/build/docker/golang/parametric/go.mod
+++ b/utils/build/docker/golang/parametric/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.16.0
 	google.golang.org/grpc v1.54.0
 	google.golang.org/protobuf v1.30.0
-	gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20230801190547-5ebe300ac718
+	gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20230808142237-30bfd5205d6a
 )
 
 require (

--- a/utils/build/docker/golang/parametric/go.sum
+++ b/utils/build/docker/golang/parametric/go.sum
@@ -169,8 +169,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20230801190547-5ebe300ac718 h1:lurfzON3rJTalJlBfnsWR1aDsFGNoGgIbKAvrrP3GNI=
-gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20230801190547-5ebe300ac718/go.mod h1:9l+gJVds2iYls2ySSNNPm842vz2clDn4eRL2uoabz2U=
+gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20230808142237-30bfd5205d6a h1:RMV0bJU3f8/g33nmxJrHiC+l9jxOWFvU1klZSI6TiE4=
+gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20230808142237-30bfd5205d6a/go.mod h1:1JqaWiPl1+vHNYuVNmHOG4HDyHbF84z98BW/hwq8FeU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

Make sure client-stats computation is aligned with the spec in the Go tracer - https://github.com/DataDog/dd-trace-go/pull/2168

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
