### PR TITLE
fix(remote-config): Disable Remote Config in the system-tests agents by default

### DIFF
--- a/utils/build/docker/agent.Dockerfile
+++ b/utils/build/docker/agent.Dockerfile
@@ -11,6 +11,8 @@ RUN echo '\
 log_level: DEBUG\n\
 apm_config:\n\
   apm_non_local_traffic: true\n\
+remote_configuration:\n\
+  enabled: false\n\
 otlp_config:\n\
   debug:\n\
     verbosity: detailed\n\


### PR DESCRIPTION
## Description
As we enable Remote Config by default in the agent, this means it'd get enabled by default in system-tests agents too by default. Though, these tests don't need RC and as they can either be ran on staging or prod, it is better to disable RC by default than to add staging security keys where they're needed. This PR does that.

## Motivation
Less errors on Remote Config side

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
