### PR TITLE
Remove 1.18 for some IAST test on python

### DIFF
--- a/tests/appsec/iast/sink/test_insecure_cookie.py
+++ b/tests/appsec/iast/sink/test_insecure_cookie.py
@@ -14,6 +14,7 @@ if context.library == "cpp":
 @released(dotnet="?", golang="?", php_appsec="?", python="1.18.0", ruby="?")
 @released(nodejs={"express4": "4.1.0", "*": "?"})
 @released(java={"akka-http": "?", "ratpack": "?", "spring-boot-3-native": "?", "*": "1.18.0"})
+@bug(library="python")
 class TestInsecureCookie:
     """Test insecure cookie detection."""
 

--- a/tests/appsec/iast/sink/test_no_httponly_cookie.py
+++ b/tests/appsec/iast/sink/test_no_httponly_cookie.py
@@ -13,6 +13,7 @@ if context.library == "cpp":
 @coverage.basic
 @released(dotnet="?", golang="?", php_appsec="?", python="1.18.0", ruby="?", nodejs="?")
 @released(java={"akka-http": "?", "ratpack": "?", "spring-boot-3-native": "?", "*": "1.18.0"})
+@bug(library="python")
 class TestNoHttponlyCookie:
     """Test no HttpOnly cookie detection."""
 

--- a/tests/appsec/iast/sink/test_no_samesite_cookie.py
+++ b/tests/appsec/iast/sink/test_no_samesite_cookie.py
@@ -13,6 +13,7 @@ if context.library == "cpp":
 @coverage.basic
 @released(dotnet="?", golang="?", php_appsec="?", python="1.18.0", ruby="?", nodejs="?")
 @released(java={"akka-http": "?", "ratpack": "?", "spring-boot-3-native": "?", "*": "1.18.0"})
+@bug(library="python")
 class TestNoSamesiteCookie:
     """Test No SameSite cookie detection."""
 

--- a/tests/appsec/iast/source/test_parameter_value.py
+++ b/tests/appsec/iast/source/test_parameter_value.py
@@ -12,6 +12,7 @@ if context.library == "cpp":
 
 @coverage.basic
 @released(dotnet="?", golang="?", php_appsec="?", python="1.18.0", ruby="?")
+@bug(library="python")
 @released(
     java={
         "resteasy-netty3": "1.11.0",


### PR DESCRIPTION
## Description

Some IAST tests were supposed to be ok for `1.18` python tracer. They are not. Skipping them as missing feature.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
