### PR TITLE
Refactor Interface object

### DIFF
--- a/tests/otel_tracing_e2e/test_e2e.py
+++ b/tests/otel_tracing_e2e/test_e2e.py
@@ -1,11 +1,12 @@
 import base64
 import os
 import time
+
+from utils import context, weblog, interfaces, scenarios, irrelevant
+from utils.tools import get_rid_from_request
 from ._test_validator_trace import validate_all_traces
 from ._test_validator_log import validate_log, validate_log_trace_correlation
 from ._test_validator_metric import validate_metrics
-from utils import context, weblog, interfaces, scenarios, irrelevant
-from utils.interfaces._core import get_rid_from_request
 
 
 def _get_dd_trace_id(otel_trace_id: str, use_128_bits_trace_id: bool) -> int:

--- a/tests/test_the_test/test_stdout_reader.py
+++ b/tests/test_the_test/test_stdout_reader.py
@@ -18,7 +18,7 @@ class Test_Main:
         stdout = _LibraryStdout()
         stdout.configure(False)
 
-        stdout.wait(0)
+        stdout.load_data()
 
         stdout.assert_absence(r"System\.Exception")
         stdout.assert_presence(r"some.*file")

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -456,13 +456,17 @@ class EndToEndScenario(_DockerScenario):
         from utils import interfaces
 
         if self.replay:
-            interfaces.library.load_data_from_logs(f"{self.host_log_folder}/interfaces/library")
-            interfaces.agent.load_data_from_logs(f"{self.host_log_folder}/interfaces/agent")
-            interfaces.backend.load_data_from_logs(f"{self.host_log_folder}/interfaces/backend")
 
-            self._wait_interface(interfaces.library_stdout, 0)
-            self._wait_interface(interfaces.library_dotnet_managed, 0)
-            self._wait_interface(interfaces.agent_stdout, 0)
+            self.terminal.write_sep("-", "Load all data from logs")
+            self.terminal.flush()
+
+            interfaces.library.load_data_from_logs()
+            interfaces.agent.load_data_from_logs()
+            interfaces.backend.load_data_from_logs()
+
+            interfaces.library_stdout.load_data()
+            interfaces.library_dotnet_managed.load_data()
+            interfaces.agent_stdout.load_data()
 
             return
 
@@ -475,9 +479,9 @@ class EndToEndScenario(_DockerScenario):
 
             self.collect_logs()
 
-            self._wait_interface(interfaces.library_stdout, 0)
-            self._wait_interface(interfaces.library_dotnet_managed, 0)
-            self._wait_interface(interfaces.agent_stdout, 0)
+            interfaces.library_stdout.load_data()
+            interfaces.library_dotnet_managed.load_data()
+            interfaces.agent_stdout.load_data()
         else:
             self.collect_logs()
 
@@ -649,8 +653,8 @@ class OpenTelemetryScenario(_DockerScenario):
 
             self.collect_logs()
 
-            self._wait_interface(interfaces.library_stdout, 0)
-            self._wait_interface(interfaces.library_dotnet_managed, 0)
+            interfaces.library_stdout.load_data()
+            interfaces.library_dotnet_managed.load_data()
         else:
             self.collect_logs()
 

--- a/utils/interfaces/_agent.py
+++ b/utils/interfaces/_agent.py
@@ -10,13 +10,13 @@ import json
 import threading
 import copy
 
-from utils.tools import logger
-from utils.interfaces._core import InterfaceValidator, get_rid_from_request, get_rid_from_span
+from utils.tools import logger, get_rid_from_span, get_rid_from_request
+from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils.interfaces._schemas_validators import SchemaValidator
 from utils.interfaces._misc_validators import HeadersPresenceValidator, HeadersMatchValidator
 
 
-class AgentInterfaceValidator(InterfaceValidator):
+class AgentInterfaceValidator(ProxyBasedInterfaceValidator):
     """Validate agent/backend interface"""
 
     def __init__(self):

--- a/utils/interfaces/_backend.py
+++ b/utils/interfaces/_backend.py
@@ -10,12 +10,11 @@ import time
 
 import requests
 
-from utils._context.core import context
-from utils.interfaces._core import InterfaceValidator, get_rid_from_span, get_rid_from_request
-from utils.tools import logger
+from utils.interfaces._core import ProxyBasedInterfaceValidator
+from utils.tools import logger, get_rid_from_span, get_rid_from_request
 
 
-class _BackendInterfaceValidator(InterfaceValidator):
+class _BackendInterfaceValidator(ProxyBasedInterfaceValidator):
     """Validate backend data processors"""
 
     def __init__(self, library_interface):
@@ -27,11 +26,6 @@ class _BackendInterfaceValidator(InterfaceValidator):
         self.message_count = 0
 
         self.library_interface = library_interface
-
-    @property
-    def _log_folder(self):
-
-        return f"{context.scenario.host_log_folder}/interfaces/backend"
 
     @staticmethod
     def _get_dd_site_api_host():
@@ -63,8 +57,8 @@ class _BackendInterfaceValidator(InterfaceValidator):
         super().wait(timeout)
         self._init_rid_to_library_trace_ids()
 
-    def load_data_from_logs(self, folder_path):
-        super().load_data_from_logs(folder_path)
+    def load_data_from_logs(self):
+        super().load_data_from_logs()
         self._init_rid_to_library_trace_ids()
 
     def _init_rid_to_library_trace_ids(self):

--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -6,11 +6,14 @@
 
 import threading
 import json
+from os import listdir
+from os.path import isfile, join
 import re
 import time
 
 import pytest
 
+from utils._context.core import context
 from utils.tools import logger
 
 
@@ -23,13 +26,6 @@ class InterfaceValidator:
     def __init__(self, name):
         self.name = name
 
-        self._wait_for_event = threading.Event()
-        self._wait_for_function = None
-
-        self._lock = threading.RLock()
-        self._data_list = []
-        self._ingested_files = set()
-
         self.replay = False
 
     def configure(self, replay):
@@ -41,18 +37,23 @@ class InterfaceValidator:
     def __str__(self):
         return f"{self.name} interface"
 
-    def wait(self, timeout):
-        time.sleep(timeout)
 
-        for data in self._data_list:
-            filename = data["log_filename"]
-            if "content" not in data["request"]:
-                traceback = data["request"].get("traceback", "no traceback")
-                pytest.exit(reason=f"Unexpected error while deserialize {filename}:\n {traceback}", returncode=1)
+class ProxyBasedInterfaceValidator(InterfaceValidator):
+    """ Interfaces based on proxy container """
 
-            if data["response"] and "content" not in data["response"]:
-                traceback = data["response"].get("traceback", "no traceback")
-                pytest.exit(reason=f"Unexpected error while deserialize {filename}:\n {traceback}", returncode=1)
+    def __init__(self, name):
+        super().__init__(name)
+
+        self._wait_for_event = threading.Event()
+        self._wait_for_function = None
+
+        self._lock = threading.RLock()
+        self._data_list = []
+        self._ingested_files = set()
+
+    @property
+    def _log_folder(self):
+        return f"{context.scenario.host_log_folder}/interfaces/{self.name}"
 
     def ingest_file(self, src_path):
 
@@ -69,7 +70,7 @@ class InterfaceValidator:
                     # the file may not be finished
                     return
 
-            self._data_list.append(data)
+            self._append_data(data)
             self._ingested_files.add(src_path)
 
             # make 100% sure that the list is sorted
@@ -78,19 +79,32 @@ class InterfaceValidator:
         if self._wait_for_function and self._wait_for_function(data):
             self._wait_for_event.set()
 
-    def load_data_from_logs(self, folder_path):
-        from os import listdir
-        from os.path import isfile, join
+    def wait(self, timeout):
+        time.sleep(timeout)
 
-        for filename in sorted(listdir(folder_path)):
-            file_path = join(folder_path, filename)
+    def load_data_from_logs(self):
+
+        for filename in sorted(listdir(self._log_folder)):
+            file_path = join(self._log_folder, filename)
             if isfile(file_path):
 
                 with open(file_path, "r", encoding="utf-8") as f:
                     data = json.load(f)
 
-                self._data_list.append(data)
+                self._append_data(data)
                 logger.info(f"{self.name} interface gets {file_path}")
+
+    def _append_data(self, data):
+        filename = data["log_filename"]
+        if "content" not in data["request"]:
+            traceback = data["request"].get("traceback", "no traceback")
+            pytest.exit(reason=f"Unexpected error while deserialize {filename}:\n {traceback}", returncode=1)
+
+        if data["response"] and "content" not in data["response"]:
+            traceback = data["response"].get("traceback", "no traceback")
+            pytest.exit(reason=f"Unexpected error while deserialize {filename}:\n {traceback}", returncode=1)
+
+        self._data_list.append(data)
 
     def get_data(self, path_filters=None):
 
@@ -153,55 +167,3 @@ class ValidationError(Exception):
     def __init__(self, *args: object, extra_info=None) -> None:
         super().__init__(*args)
         self.extra_info = extra_info
-
-
-def get_rid_from_request(request):
-    if request is None:
-        return None
-
-    user_agent = [v for k, v in request.request.headers.items() if k.lower() == "user-agent"][0]
-    return user_agent[-36:]
-
-
-def get_rid_from_span(span):
-
-    if not isinstance(span, dict):
-        logger.error(f"Span should be an object, not {type(span)}")
-        return None
-
-    meta = span.get("meta", {})
-    metrics = span.get("metrics", {})
-
-    user_agent = None
-
-    if span.get("type") == "rpc":
-        user_agent = meta.get("grpc.metadata.user-agent")
-        # java does not fill this tag; it uses the normal http tags
-
-    if not user_agent and metrics.get("_dd.top_level") == 1.0:
-        # The top level span (aka root span) is mark via the _dd.top_level tag by the tracers
-        user_agent = meta.get("http.request.headers.user-agent")
-
-    if not user_agent:  # try something for .NET
-        user_agent = meta.get("http_request_headers_user-agent")
-
-    if not user_agent:
-        # cpp tracer
-        user_agent = meta.get("http_user_agent")
-
-    if not user_agent:  # last hope
-        user_agent = meta.get("http.useragent")
-
-    return get_rid_from_user_agent(user_agent)
-
-
-def get_rid_from_user_agent(user_agent):
-    if not user_agent:
-        return None
-
-    match = re.search("rid/([A-Z]{36})", user_agent)
-
-    if not match:
-        return None
-
-    return match.group(1)

--- a/utils/interfaces/_library/_utils.py
+++ b/utils/interfaces/_library/_utils.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 from urllib.parse import urlparse
-from utils.tools import logger
-from utils.interfaces._core import get_rid_from_span
+from utils.tools import logger, get_rid_from_span
 
 
 def get_spans_related_to_rid(traces, rid):

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -6,8 +6,8 @@ import copy
 import json
 import threading
 
-from utils.tools import logger
-from utils.interfaces._core import InterfaceValidator, get_rid_from_request, get_rid_from_span, get_rid_from_user_agent
+from utils.tools import logger, get_rid_from_user_agent, get_rid_from_span, get_rid_from_request
+from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils.interfaces._library._utils import get_trace_request_path
 from utils.interfaces._library.appsec import _WafAttack, _ReportedHeader
 from utils.interfaces._library.miscs import _SpanTagValidator
@@ -20,7 +20,7 @@ from utils.interfaces._misc_validators import HeadersPresenceValidator
 from utils.interfaces._schemas_validators import SchemaValidator
 
 
-class LibraryInterfaceValidator(InterfaceValidator):
+class LibraryInterfaceValidator(ProxyBasedInterfaceValidator):
     """Validate library/agent interface"""
 
     def __init__(self):

--- a/utils/interfaces/_logs.py
+++ b/utils/interfaces/_logs.py
@@ -73,9 +73,7 @@ class _LogsInterfaceValidator(InterfaceValidator):
             except FileNotFoundError:
                 logger.error(f"File not found: {filename}")
 
-    def wait(self, timeout):
-        super().wait(timeout)
-
+    def load_data(self):
         for log_line in self._read():
 
             parsed = {}
@@ -91,8 +89,10 @@ class _LogsInterfaceValidator(InterfaceValidator):
 
             self._data_list.append(parsed)
 
-    def validate(self, validator, path_filters=None, success_by_default=False):
-        assert path_filters is None, "There is no concpet of path in a log file"
+    def get_data(self):
+        yield from self._data_list
+
+    def validate(self, validator, success_by_default=False):
 
         for data in self.get_data():
             try:
@@ -284,7 +284,7 @@ class Test:
         """Test example"""
         i = _LibraryStdout()
         i.configure(False)
-        i.wait(0)
+        i.load_data()
         i.assert_presence(r"AppSec loaded \d+ rules from file <?.*>?$", level="INFO")
 
 

--- a/utils/interfaces/_open_telemetry.py
+++ b/utils/interfaces/_open_telemetry.py
@@ -8,11 +8,11 @@ This files will validate data flow between agent and backend
 
 import threading
 
-from utils.tools import logger
-from utils.interfaces._core import InterfaceValidator, get_rid_from_request
+from utils.tools import logger, get_rid_from_request
+from utils.interfaces._core import ProxyBasedInterfaceValidator
 
 
-class OpenTelemetryInterfaceValidator(InterfaceValidator):
+class OpenTelemetryInterfaceValidator(ProxyBasedInterfaceValidator):
     """ Validated communication between open telemetry and datadog backend"""
 
     def __init__(self):

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -76,3 +76,55 @@ def e(message):
 
 
 logger = get_logger()
+
+
+def get_rid_from_request(request):
+    if request is None:
+        return None
+
+    user_agent = [v for k, v in request.request.headers.items() if k.lower() == "user-agent"][0]
+    return user_agent[-36:]
+
+
+def get_rid_from_span(span):
+
+    if not isinstance(span, dict):
+        logger.error(f"Span should be an object, not {type(span)}")
+        return None
+
+    meta = span.get("meta", {})
+    metrics = span.get("metrics", {})
+
+    user_agent = None
+
+    if span.get("type") == "rpc":
+        user_agent = meta.get("grpc.metadata.user-agent")
+        # java does not fill this tag; it uses the normal http tags
+
+    if not user_agent and metrics.get("_dd.top_level") == 1.0:
+        # The top level span (aka root span) is mark via the _dd.top_level tag by the tracers
+        user_agent = meta.get("http.request.headers.user-agent")
+
+    if not user_agent:  # try something for .NET
+        user_agent = meta.get("http_request_headers_user-agent")
+
+    if not user_agent:
+        # cpp tracer
+        user_agent = meta.get("http_user_agent")
+
+    if not user_agent:  # last hope
+        user_agent = meta.get("http.useragent")
+
+    return get_rid_from_user_agent(user_agent)
+
+
+def get_rid_from_user_agent(user_agent):
+    if not user_agent:
+        return None
+
+    match = re.search("rid/([A-Z]{36})", user_agent)
+
+    if not match:
+        return None
+
+    return match.group(1)


### PR DESCRIPTION
## Description

Lot of code in InterfaceValidator is only used by proxy based interface (library, agent, backend), leading to lot of distorsion in client code.

* splitting this feature in a based dedicated class
* cleaning some code that do not belong to interface

## Motivation

Clean code and designs

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
