### PR TITLE
Provide an universal way to send message to stdout

### DIFF
--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -34,7 +34,6 @@ update_environ_with_local_env()
 class _Scenario:
     def __init__(self, name, doc) -> None:
         self.name = name
-        self.terminal = None
         self.replay = False
         self.doc = doc
 
@@ -67,16 +66,15 @@ class _Scenario:
 
             weblog.init_replay_mode(self.host_log_folder)
 
-    def session_start(self, session):
+    def session_start(self):
         """ called at the very begning of the process """
 
-        self.terminal = session.config.pluginmanager.get_plugin("terminalreporter")
         self.print_test_context()
 
         if self.replay:
             return
 
-        self.print_info("Executing warmups...")
+        logger.stdout("Executing warmups...")
 
         try:
             for warmup in self._get_warmups():
@@ -91,15 +89,9 @@ class _Scenario:
         """ called at the end of the process  """
 
     def print_test_context(self):
-        self.terminal.write_sep("=", "test context", bold=True)
-        self.print_info(f"Scenario: {self.name}")
-        self.print_info(f"Logs folder: ./{self.host_log_folder}")
-
-    def print_info(self, info):
-        """ print info in stdout """
-        logger.info(info)
-        if self.terminal is not None:
-            self.terminal.write_line(info)
+        logger.terminal.write_sep("=", "test context", bold=True)
+        logger.stdout(f"Scenario: {self.name}")
+        logger.stdout(f"Logs folder: ./{self.host_log_folder}")
 
     def _get_warmups(self):
         return []
@@ -381,23 +373,23 @@ class EndToEndScenario(_DockerScenario):
 
         logger.debug(f"Docker host is {weblog.domain}")
 
-        self.print_info(f"Library: {self.library}")
-        self.print_info(f"Agent: {self.agent_version}")
+        logger.stdout(f"Library: {self.library}")
+        logger.stdout(f"Agent: {self.agent_version}")
 
         if self.library == "php":
-            self.print_info(f"AppSec: {self.weblog_container.php_appsec}")
+            logger.stdout(f"AppSec: {self.weblog_container.php_appsec}")
 
         if self.weblog_container.libddwaf_version:
-            self.print_info(f"libddwaf: {self.weblog_container.libddwaf_version}")
+            logger.stdout(f"libddwaf: {self.weblog_container.libddwaf_version}")
 
         if self.weblog_container.appsec_rules_file:
-            self.print_info(f"AppSec rules version: {self.weblog_container.appsec_rules_version}")
+            logger.stdout(f"AppSec rules version: {self.weblog_container.appsec_rules_version}")
 
         if self.weblog_container.uds_mode:
-            self.print_info(f"UDS socket: {self.weblog_container.uds_socket}")
+            logger.stdout(f"UDS socket: {self.weblog_container.uds_socket}")
 
-        self.print_info(f"Weblog variant: {self.weblog_container.weblog_variant}")
-        self.print_info(f"Backend: {self.agent_container.dd_site}")
+        logger.stdout(f"Weblog variant: {self.weblog_container.weblog_variant}")
+        logger.stdout(f"Backend: {self.agent_container.dd_site}")
 
     def _create_interface_folders(self):
         for interface in ("agent", "library", "backend"):
@@ -457,8 +449,8 @@ class EndToEndScenario(_DockerScenario):
 
         if self.replay:
 
-            self.terminal.write_sep("-", "Load all data from logs")
-            self.terminal.flush()
+            logger.terminal.write_sep("-", "Load all data from logs")
+            logger.terminal.flush()
 
             interfaces.library.load_data_from_logs()
             interfaces.agent.load_data_from_logs()
@@ -488,8 +480,8 @@ class EndToEndScenario(_DockerScenario):
         self.close_targets()
 
     def _wait_interface(self, interface, timeout):
-        self.terminal.write_sep("-", f"Wait for {interface} ({timeout}s)")
-        self.terminal.flush()
+        logger.terminal.write_sep("-", f"Wait for {interface} ({timeout}s)")
+        logger.terminal.flush()
 
         interface.wait(timeout)
 
@@ -659,8 +651,8 @@ class OpenTelemetryScenario(_DockerScenario):
             self.collect_logs()
 
     def _wait_interface(self, interface, timeout):
-        self.terminal.write_sep("-", f"Wait for {interface} ({timeout}s)")
-        self.terminal.flush()
+        logger.terminal.write_sep("-", f"Wait for {interface} ({timeout}s)")
+        logger.terminal.flush()
 
         interface.wait(timeout)
 

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -45,6 +45,25 @@ def update_environ_with_local_env():
         pass
 
 
+DEBUG_LEVEL_STDOUT = 100
+
+logging.addLevelName(DEBUG_LEVEL_STDOUT, "STDOUT")
+
+
+def stdout(self, message, *args, **kws):
+
+    if self.isEnabledFor(DEBUG_LEVEL_STDOUT):
+        # Yes, logger takes its '*args' as 'args'.
+        self._log(DEBUG_LEVEL_STDOUT, message, args, **kws)  # pylint: disable=protected-access
+
+        if hasattr(self, "terminal"):
+            self.terminal.write_line(message)
+            self.terminal.flush()
+
+
+logging.Logger.stdout = stdout
+
+
 def get_logger(name="tests", use_stdout=False):
     result = logging.getLogger(name)
 


### PR DESCRIPTION
## Description

Access to stdout in pytest is restricted, and a dedicated object (terminal) is used. Provide an access to this object with two methods : 

* `logger.stdout(message)`, simple method
* `logger.terminal` for direct access to more features

`logger` is accessible with `from utils.tools import logger`

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
