### PR TITLE
Change test so it only generates one weak cipher vulnerability

### DIFF
--- a/utils/build/docker/java/iast-common/src/main/java/com/datadoghq/system_tests/iast/utils/CryptoExamples.java
+++ b/utils/build/docker/java/iast-common/src/main/java/com/datadoghq/system_tests/iast/utils/CryptoExamples.java
@@ -73,8 +73,7 @@ public class CryptoExamples {
 
     private static String doCipher(final String password, final String algorithm) {
         try {
-            Cipher cipher = Cipher.getInstance(algorithm);
-            cipher.init(Cipher.ENCRYPT_MODE, KeyGenerator.getInstance(algorithm).generateKey());
+            Cipher cipher = Cipher.getInstance(algorithm); cipher.init(Cipher.ENCRYPT_MODE, KeyGenerator.getInstance(algorithm).generateKey());
             return new String(cipher.doFinal(password.getBytes()));
         } catch (final Exception e) {
             throw new UndeclaredThrowableException(e);


### PR DESCRIPTION
## Description

Change CryptoExamples so it generates a single vulnerability for weak cipher as opposed to two

## Motivation

Avoid cases where two vulnerabilities are reported on the same endpoint.

