### PR TITLE
Automate stdout interface with their container

### DIFF
--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -334,9 +334,7 @@ class EndToEndScenario(_DockerScenario):
         interfaces.agent.configure(self.replay)
         interfaces.library.configure(self.replay)
         interfaces.backend.configure(self.replay)
-        interfaces.library_stdout.configure(self.replay)
         interfaces.library_dotnet_managed.configure(self.replay)
-        interfaces.agent_stdout.configure(self.replay)
 
         if self.library_interface_timeout is None:
             if self.weblog_container.library == "java":
@@ -443,13 +441,7 @@ class EndToEndScenario(_DockerScenario):
             interfaces.agent.load_data_from_logs()
             interfaces.backend.load_data_from_logs()
 
-            interfaces.library_stdout.load_data()
-            interfaces.library_dotnet_managed.load_data()
-            interfaces.agent_stdout.load_data()
-
-            return
-
-        if self.use_proxy:
+        elif self.use_proxy:
             self._wait_interface(interfaces.library, self.library_interface_timeout)
             self.weblog_container.stop()
             self._wait_interface(interfaces.agent, self.agent_interface_timeout)
@@ -458,9 +450,7 @@ class EndToEndScenario(_DockerScenario):
 
         self.close_targets()
 
-        interfaces.library_stdout.load_data()
         interfaces.library_dotnet_managed.load_data()
-        interfaces.agent_stdout.load_data()
 
     def _wait_interface(self, interface, timeout):
         logger.terminal.write_sep("-", f"Wait for {interface} ({timeout}s)")
@@ -628,7 +618,6 @@ class OpenTelemetryScenario(_DockerScenario):
 
         self.close_targets()
 
-        interfaces.library_stdout.load_data()
         interfaces.library_dotnet_managed.load_data()
 
     def _wait_interface(self, interface, timeout):

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -14,6 +14,7 @@ import requests
 
 from utils._context.library_version import LibraryVersion, Version
 from utils.tools import logger
+from utils import interfaces
 
 
 @lru_cache
@@ -44,6 +45,7 @@ class TestedContainer:
         environment=None,
         allow_old_container=False,
         healthcheck=None,
+        stdout_interface=None,
         **kwargs,
     ) -> None:
         self.name = name
@@ -56,6 +58,7 @@ class TestedContainer:
         self.environment = environment
         self.kwargs = kwargs
         self._container = None
+        self.stdout_interface = stdout_interface
 
     def configure(self, replay):
 
@@ -69,6 +72,9 @@ class TestedContainer:
             self.image.save_image_info(self.log_folder_path)
         else:
             self.image.load_from_logs(self.log_folder_path)
+
+        if self.stdout_interface is not None:
+            self.stdout_interface.configure(replay)
 
     @property
     def container_name(self):
@@ -202,6 +208,9 @@ class TestedContainer:
 
             pass
 
+        if self.stdout_interface is not None:
+            self.stdout_interface.load_data()
+
 
 class ImageInfo:
     """data on docker image. data comes from `docker inspect`"""
@@ -285,6 +294,7 @@ class AgentContainer(TestedContainer):
                 "retries": 60,
             },
             ports={self.agent_port: f"{self.agent_port}/tcp"},
+            stdout_interface=interfaces.agent_stdout,
         )
 
         self.agent_version = None
@@ -336,6 +346,7 @@ class WeblogContainer(TestedContainer):
             security_opt=["seccomp=unconfined"],
             healthcheck={"test": f"curl --fail --silent --show-error localhost:{weblog.port}", "retries": 60},
             ports={"7777/tcp": weblog.port, "7778/tcp": weblog._grpc_port},
+            stdout_interface=interfaces.library_stdout,
         )
 
         self.tracer_sampling_rate = tracer_sampling_rate


### PR DESCRIPTION
## Description

Each container handles and feed its stdout interface

## Motivation

Pave the way for DB stdout interfaces

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
