### PR TITLE
Add conditions to custom rules with errors for waf 1.13

### DIFF
--- a/tests/appsec/custom_rules_with_errors.json
+++ b/tests/appsec/custom_rules_with_errors.json
@@ -7,7 +7,38 @@
     {
       "id": "missing-tags",
       "name": "Unicode Full/Half Width Abuse Attack Attempt",
-      "conditions": [],
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              }
+            ],
+            "regex": "[oOcC]:\\d+:\\\".+?\\\":\\d+:{[\\W\\w]*}",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 12
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
       "transformers": []
     },
     {
@@ -16,6 +47,36 @@
         "type": "http_protocol_violation"
       },
       "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              }
+            ],
+            "regex": "[oOcC]:\\d+:\\\".+?\\\":\\d+:{[\\W\\w]*}",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 12
+            }
+          },
+          "operator": "match_regex"
+        }
       ],
       "transformers": []
     },


### PR DESCRIPTION
## Description

Waf 1.13.0, with current custom rules with error ruleset, gives:
`   Exception: unexpected span tag _dd.appsec.event_rules.errors value: got {'rule has no valid conditions': ['missing-tags', 'missing-name']} instead of {"missing key 'name'": ['missing-name'], "missing key 'tags'": ['missing-tags']}` on test `test_waf_monitoring_errors` 
It's because from 1.13, there are checks for rules without conditions. With valid conditions, the other errors are now visible.


## Motivation

Error on [dotnet ci pipeline ](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=142794&view=logs&j=db9fa4c5-7955-555f-a768-e4035391ef90&t=7d5d711c-4a8f-5e4b-8411-167d1ffbaddc) when integrating waf 1.13 (confirmed with Anil)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
