### PR TITLE
[ASM] Fix dotnet CI for older tracers

### DIFF
--- a/utils/build/docker/dotnet/Controllers/LoginController.cs
+++ b/utils/build/docker/dotnet/Controllers/LoginController.cs
@@ -1,3 +1,5 @@
+#if DDTRACE_2_23_0_OR_GREATER
+
 #nullable enable
 using System;
 using System.Text;
@@ -100,3 +102,4 @@ public class LoginController : Controller
         return RedirectToAction(nameof(Index));
     }
 }
+#endif

--- a/utils/build/docker/dotnet/Controllers/TagValueController.cs
+++ b/utils/build/docker/dotnet/Controllers/TagValueController.cs
@@ -1,3 +1,5 @@
+
+#if DDTRACE_2_23_0_OR_GREATER
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -75,3 +77,4 @@ namespace weblog
         }
     }
 }
+#endif

--- a/utils/build/docker/dotnet/Controllers/UsersController.cs
+++ b/utils/build/docker/dotnet/Controllers/UsersController.cs
@@ -1,3 +1,4 @@
+#if DDTRACE_2_7_0_OR_GREATER
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -29,3 +30,4 @@ namespace weblog
         }
     }
 }
+#endif

--- a/utils/build/docker/dotnet/Endpoints/EventTrackingSdkEndPoint.cs
+++ b/utils/build/docker/dotnet/Endpoints/EventTrackingSdkEndPoint.cs
@@ -1,3 +1,4 @@
+#if DDTRACE_2_23_0_OR_GREATER
 using Microsoft.AspNetCore.Builder;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
@@ -47,3 +48,4 @@ namespace weblog
         }
     }
 }
+#endif

--- a/utils/build/docker/dotnet/app.csproj
+++ b/utils/build/docker/dotnet/app.csproj
@@ -9,6 +9,9 @@
 	<PropertyGroup Condition="'$(DDTRACE_VERSION)' != '' and '$(DDTRACE_VERSION)' >= '2.7.0'">
 		<DefineConstants>$(DefineConstants);DDTRACE_2_7_0_OR_GREATER</DefineConstants>
 	</PropertyGroup>
+	<PropertyGroup Condition="'$(DDTRACE_VERSION)' != '' and '$(DDTRACE_VERSION)' >= '2.23.0'">
+		<DefineConstants>$(DefineConstants);DDTRACE_2_23_0_OR_GREATER</DefineConstants>
+	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="MySql.Data" Version="8.0.30" />
 		<PackageReference Include="Npgsql" Version="4.0.10" />


### PR DESCRIPTION
## Description

`EventTrackingSdk` and `UserDetails` didnt exist respectively before 2.23 see https://github.com/DataDog/dd-trace-dotnet/pull/3703 and 2.7 see https://github.com/DataDog/dd-trace-dotnet/pull/2546

## Motivation

The ruleset ci testing older tracer versions fails: https://github.com/DataDog/appsec-event-rules/pull/162
