### PR TITLE
Fix node.js parametric resource name, service name, and span type setting

### DIFF
--- a/tests/parametric/test_tracer.py
+++ b/tests/parametric/test_tracer.py
@@ -16,7 +16,6 @@ parametrize = pytest.mark.parametrize
 @scenarios.parametric
 class Test_Tracer:
     @missing_feature(context.library == "cpp", reason="metrics cannot be set manually")
-    @missing_feature(context.library == "nodejs", reason="nodejs overrides the manually set service name")
     def test_tracer_span_top_level_attributes(self, test_agent: _TestAgentAPI, test_library: APMLibrary) -> None:
         """Do a simple trace to ensure that the test client is working properly."""
         with test_library:

--- a/utils/build/docker/nodejs/parametric/servicer.js
+++ b/utils/build/docker/nodejs/parametric/servicer.js
@@ -64,10 +64,10 @@ class Servicer {
         if (extracted !== null) parent = extracted
 
         const span = tracer.startSpan(request.name, {
-            type: request.type,
             childOf: parent,
             tags: {
-                service: request.service,
+                "service.name": request.service,
+                "span.type": request.type,
                 "resource.name": request.resource
             }
         })

--- a/utils/build/docker/nodejs/parametric/servicer.js
+++ b/utils/build/docker/nodejs/parametric/servicer.js
@@ -65,10 +65,10 @@ class Servicer {
 
         const span = tracer.startSpan(request.name, {
             type: request.type,
-            resource: request.resource,
             childOf: parent,
             tags: {
-                service: request.service
+                service: request.service,
+                "resource.name": request.resource
             }
         })
 


### PR DESCRIPTION
## Description

The Node.js gRPC client was not correctly setting the resource name, service name, or span type from `test_library.start_span("operation", service="service", resource="resource", typestr="web")`.

This change properly sets the required `"resource.name"`, `"service.name"`, and `"span.type"` tags.

## Motivation

Resource name, service name, and span type was not being set properly.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
