### PR TITLE
lib-injection workaround helm charts

### DIFF
--- a/lib-injection/src/test/shell/functions.sh
+++ b/lib-injection/src/test/shell/functions.sh
@@ -134,7 +134,8 @@ function deploy-operator() {
     helm repo update
 
     echo "[Deploy operator] helm install datadog with config file [${operator_file}]"
-    helm install datadog --wait --set datadog.apiKey=${DD_API_KEY} --set datadog.appKey=${DD_APP_KEY} -f "${operator_file}" datadog/datadog 
+    #Please REMOVE [--debug --version 3.33.10] when this issue would is solved: https://datadoghq.atlassian.net/browse/AIT-8173
+    helm install datadog --debug --version 3.33.10 --wait --set datadog.apiKey=${DD_API_KEY} --set datadog.appKey=${DD_APP_KEY} -f "${operator_file}" datadog/datadog 
     kubectl get pods
 
     pod_name=$(kubectl get pods -l app=datadog-cluster-agent -o name)


### PR DESCRIPTION
## Description

Downgrade the dd helm charts, because last release has a bug.
See lib-injection issue: https://datadoghq.atlassian.net/browse/AIT-8173


<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
