### PR TITLE
Improve doc and debug logs for lib-injection tests

### DIFF
--- a/lib-injection/README.md
+++ b/lib-injection/README.md
@@ -138,24 +138,32 @@ To run lib-injection tests in your CI you need:
 
 You can also run the tests locally, but in this case we will create the docker init image using the corresponding tracer library.
 
-The first step is do loging in docker hub:
-``` docker login --username MY_USERNAME ```
+The first step is to login in docker hub, either with Docker Desktop app or with CLI (you may need to generate an access token [here](https://hub.docker.com/settings/security)):
+``` docker login --username MY_DOCKERHUB_USERNAME ```
 
 The second step is define the environment variables:
 
 ```sh
 export TEST_LIBRARY=java
 export WEBLOG_VARIANT=dd-lib-java-init-test-app
-export DOCKER_REGISTRY_IMAGES_PATH=docker.io/MY_USERNAME
+export DOCKER_REGISTRY_IMAGES_PATH=docker.io/MY_DOCKERHUB_USERNAME
 export LIBRARY_INJECTION_CONNECTION=‘network’
 export LIBRARY_INJECTION_ADMISSION_CONTROLLER='use-admission-controller'
 export BUILDX_PLATFORMS=linux/arm64
 ```
 
-The next is to dwnload or compile the tracer libray that you want to test. You have to locate binary libary in the system-tests/binaries folder.
+The next is to download or compile the tracer libray that you want to test. You have to locate binary libary in the system-tests/binaries folder.
 When we have the environment ready, we have to execute this logic:
 
 * Build and push the init image
+
+  To use an existing image, you need to push it to your dockerhub account, for example:
+```sh
+docker pull ghcr.io/datadog/dd-trace-js/dd-lib-js-init:latest_snapshot
+docker tag ghcr.io/datadog/dd-trace-js/dd-lib-js-init:latest_snapshot ${DOCKER_REGISTRY_IMAGES_PATH}/dd-lib-js-init:local
+docker push ${DOCKER_REGISTRY_IMAGES_PATH}/dd-lib-js-init:local
+```
+
 * Build and push the app image
 * Create the Kubernetes cluster
 
@@ -166,6 +174,9 @@ When we have the environment ready, we have to execute this logic:
 ```
 
 * Execute the manual tests
+
+  * Make sure that init and app images are public on your dockerhub account.
+  * Comment name, tag and repository in `clusterAgent.image` section of `operator-helm-values*.yaml`
 
 ```sh
 ./lib-injection/run-manual-lib-injection.sh
@@ -183,7 +194,7 @@ TEST_CASE=<TestCaseN>  # define the test case
 After running the tests you can always run the following command to export all the information from the kubernetes cluster to the logs folder:
 
 ```sh
-./lib-injection/execFunction.sh print-debug-info
+./lib-injection/execFunction.sh $LIBRARY_INJECTION_ADMISSION_CONTROLLER print-debug-info
 ```
 
 ## How to create init images in your tracer repository

--- a/lib-injection/runner/action.yml
+++ b/lib-injection/runner/action.yml
@@ -59,7 +59,7 @@ runs:
         if: ${{ always() }}
         run: |
           cd system-tests
-          ./lib-injection/execFunction.sh print-debug-info
+          ./lib-injection/execFunction.sh $LIBRARY_INJECTION_ADMISSION_CONTROLLER print-debug-info
 
       - name: Compress lib injection logs
         shell: bash


### PR DESCRIPTION
## Description

* Add back missing debug logs for datadog-cluster-agent status and pod description.
* Improve doc to run lib-injection tests locally.

## Motivation

Following #1317 datadog-cluster-agent status and pod description were missing from debug logs because USE_ADMISSION_CONTROLLER env variable  was not set when calling print-debug-info.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
