### PR TITLE
[cpp] Enable test_sample_rate_function for cpp

### DIFF
--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -301,7 +301,6 @@ class Test_SamplingDecisions:
     @bug(library="python", reason="APMRP-259")
     @bug(library="nodejs", reason="APMRP-258")
     @bug(library="php", reason="APMRP-258")
-    @bug(library="cpp", reason="APMRP-258")
     @bug(context.library < "dotnet@2.37.0", reason="APMRP-258")
     def test_sample_rate_function(self):
         """Tests the sampling decision follows the one from the sampling function specification."""


### PR DESCRIPTION
## Description

Enable test_sample_rate_function for C++.

## Motivation

Expend the coverage of `test_sample_rate_function` to C++.

That PR has been a draft for a year (oopsy) and was also enabling the test for .NET. Enabling the test for .NET has been done since then in https://github.com/DataDog/system-tests/pull/1575


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
