### PR TITLE
Fix extension path permissions

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -34,11 +34,6 @@ def is_v1_payload(data):
 
 @released(python="1.7.0", dotnet="2.12.0", java="0.108.1", nodejs="3.2.0", ruby="1.4.0", golang="1.49.0", php="0.90")
 @bug(context.uds_mode and context.library < "nodejs@3.7.0")
-@bug(
-    context.weblog_variant.startswith("apache-mod"),
-    library="php",
-    reason="The libadatadog sidecar doesn't start with the apache weblog",
-)
 @missing_feature(library="cpp")
 @missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
 class Test_Telemetry:
@@ -293,6 +288,7 @@ class Test_Telemetry:
     @flaky(context.library < "nodejs@4.13.1", reason="Heartbeats are sometimes sent too fast")
     @bug(context.library < "java@1.18.0", reason="Telemetry interval drifts")
     @missing_feature(context.library < "ruby@1.13.0", reason="DD_TELEMETRY_HEARTBEAT_INTERVAL not supported")
+    @bug(context.library > "php@0.90")
     def test_app_heartbeat(self):
         """Check for heartbeat or messages within interval and valid started and closing messages"""
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -289,6 +289,7 @@ class Test_Telemetry:
     @bug(context.library < "java@1.18.0", reason="Telemetry interval drifts")
     @missing_feature(context.library < "ruby@1.13.0", reason="DD_TELEMETRY_HEARTBEAT_INTERVAL not supported")
     @bug(context.library > "php@0.90")
+    @flaky(context.library <= "php@0.90", reason="Heartbeats are sometimes sent too slow")
     def test_app_heartbeat(self):
         """Check for heartbeat or messages within interval and valid started and closing messages"""
 

--- a/utils/build/docker/php/apache-mod/entrypoint.sh
+++ b/utils/build/docker/php/apache-mod/entrypoint.sh
@@ -5,6 +5,9 @@ if [[ $# -gt 0 ]]; then
   exit $?
 fi
 
+# This is required to allow the tracer to open itself
+chmod a+rx /root
+
 rm -f /tmp/ddappsec.lock
 LOGS_PHP=(/tmp/appsec.log /tmp/helper.log /tmp/php_error.log)
 touch "${LOGS_PHP[@]}"

--- a/utils/build/docker/php/php-fpm/entrypoint.sh
+++ b/utils/build/docker/php/php-fpm/entrypoint.sh
@@ -5,6 +5,9 @@ if [[ $# -gt 0 ]]; then
   exit $?
 fi
 
+# This is required to allow the tracer to open itself
+chmod a+rx /root
+
 rm -f /tmp/ddappsec.lock
 LOGS_PHP=(/tmp/appsec.log /tmp/helper.log /tmp/php_error.log)
 touch "${LOGS_PHP[@]}"


### PR DESCRIPTION
## Description

The tracer extension now launches a sidecar process which is contained within `ddtrace.so`. Once apache / fpm forked, the tracer couldn't open `ddtrace.so` due to invalid permissions of the root directory, which didn't allow read or execute for others. This in turn resulted in timeouts, however the predictable nature of the timeouts is unclear.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
