### PR TITLE
Deserilize appsec tags in deserializer

### DIFF
--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -1,5 +1,3 @@
-import json
-
 from utils import weblog, interfaces, context
 from utils.tools import logging
 
@@ -29,7 +27,7 @@ def _get_span_meta(request):
 def get_iast_event(request):
     meta = _get_span_meta(request=request)
     assert "_dd.iast.json" in meta, "No _dd.iast.json tag in span"
-    return json.loads(meta["_dd.iast.json"])
+    return meta["_dd.iast.json"]
 
 
 def assert_iast_vulnerability(

--- a/utils/interfaces/_agent.py
+++ b/utils/interfaces/_agent.py
@@ -6,7 +6,6 @@
 This files will validate data flow between agent and backend
 """
 
-import json
 import threading
 import copy
 
@@ -44,7 +43,7 @@ class AgentInterfaceValidator(ProxyBasedInterfaceValidator):
                         if "meta" not in span or "_dd.appsec.json" not in span["meta"]:
                             continue
 
-                        appsec_data = json.loads(span["meta"]["_dd.appsec.json"])
+                        appsec_data = span["meta"]["_dd.appsec.json"]
 
                         if rid is None:
                             yield data, payload, chunk, span, appsec_data

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -81,7 +81,7 @@ class LibraryInterfaceValidator(ProxyBasedInterfaceValidator):
                 if request:  # do not spam log if all data are sent to the validator
                     logger.debug(f"Try to find relevant appsec data in {data['log_filename']}; span #{span['span_id']}")
 
-                appsec_data = json.loads(span["meta"]["_dd.appsec.json"])
+                appsec_data = span["meta"]["_dd.appsec.json"]
                 yield data, trace, span, appsec_data
 
     def get_legacy_appsec_events(self, request=None):

--- a/utils/interfaces/schemas/library/v0.4/misc/trace-item.json
+++ b/utils/interfaces/schemas/library/v0.4/misc/trace-item.json
@@ -15,7 +15,7 @@
         "type": "object",
         "properties": {
           "appsec.event": { "enum": ["true"] },
-          "_dd.appsec.json": { "type": "string" }
+          "_dd.appsec.json": { "type": "object" }
         }
       },
       "metrics": { "type": "object" },

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -133,10 +133,12 @@ def deserialize_http_message(path, message, content: bytes, interface, key):
         if interface == "library":
             if path == "/v0.4/traces":
                 _decode_unsigned_int_traces(result)
+                _deserialized_nested_json_from_trace_payloads(result, interface)
 
             elif path == "/v0.5/traces":
                 result = _decode_v_0_5_traces(result)
                 _decode_unsigned_int_traces(result)
+                _deserialized_nested_json_from_trace_payloads(result, interface)
 
         _convert_bytes_values(result)
 
@@ -160,7 +162,9 @@ def deserialize_http_message(path, message, content: bytes, interface, key):
         if path == "/v1/logs":
             return MessageToDict(ExportLogsServiceResponse.FromString(content))
         if path == "/api/v0.2/traces":
-            return MessageToDict(TracePayload.FromString(content))
+            result = MessageToDict(TracePayload.FromString(content))
+            _deserialized_nested_json_from_trace_payloads(result, interface)
+            return result
 
     if content_type == "application/x-www-form-urlencoded" and content == b"[]" and path == "/v0.4/traces":
         return []
@@ -180,6 +184,29 @@ def deserialize_http_message(path, message, content: bytes, interface, key):
         return decoded
 
     return content
+
+
+def _deserialized_nested_json_from_trace_payloads(content, interface):
+    """ trace payload from agent contains strings that are json """
+
+    keys = ("_dd.appsec.json", "_dd.iast.json")
+
+    if interface == "agent":
+        for tracer_payload in content.get("tracerPayloads", []):
+            for chunk in tracer_payload.get("chunks", []):
+                for span in chunk.get("spans", []):
+                    meta = span.get("meta", {})
+                    for key in keys:
+                        if key in meta:
+                            meta[key] = json.loads(meta[key])
+
+    elif interface == "library":
+        for traces in content:
+            for span in traces:
+                meta = span.get("meta", {})
+                for key in keys:
+                    if key in meta:
+                        meta[key] = json.loads(meta[key])
 
 
 def _convert_bytes_values(item):

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -147,3 +147,32 @@ def get_rid_from_user_agent(user_agent):
         return None
 
     return match.group(1)
+
+
+def nested_lookup(needle: str, heystack, look_in_keys=False, exact_match=False):
+    """ look for needle in heystack, heystack can be a dict or an array """
+
+    if isinstance(heystack, str):
+        return (needle == heystack) if exact_match else (needle in heystack)
+
+    if isinstance(heystack, (list, tuple)):
+        for item in heystack:
+            if nested_lookup(needle, item, look_in_keys=look_in_keys, exact_match=exact_match):
+                return True
+
+        return False
+
+    if isinstance(heystack, dict):
+        for key, value in heystack.items():
+            if look_in_keys and nested_lookup(needle, key, look_in_keys=look_in_keys, exact_match=exact_match):
+                return True
+
+            if nested_lookup(needle, value, look_in_keys=look_in_keys, exact_match=exact_match):
+                return True
+
+        return False
+
+    if isinstance(heystack, (bool, float, int)) or heystack is None:
+        return False
+
+    raise TypeError(f"Can't handle type {type(heystack)}")


### PR DESCRIPTION
## Description

appsec & iast data are json-strings in meta tag. They are currently deserialized at test level. This PR modify this to deserialize them in the deserializer, in order to have easier logs to read.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
