### PR TITLE
Use manifest files for telemetry + php/ruby

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -3,8 +3,14 @@ tests/:
     iast/:
       sink/:
         test_xss.py:
-          TestXSS:
-            "*": "?"
+          TestXSS: missing_feature
     test_blocking_addresses.py:
-      Test_BlockingGraphqlResolvers:
-        "*": "missing_feature"
+      Test_BlockingGraphqlResolvers: missing_feature
+  test_telemetry.py:
+    Test_DependencyEnable: missing_feature
+    Test_Log_Generation: missing_feature
+    Test_MessageBatch: v0.90
+    Test_Metric_Generation: missing_feature
+    Test_ProductsDisabled: missing_feature
+    Test_Telemetry: v0.90
+    Test_TelemetryV2: v0.90

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -3,8 +3,14 @@ tests/:
     iast/:
       sink/:
         test_xss.py:
-          TestXSS:
-            "*": "?"
+          TestXSS: missing_feature
     test_blocking_addresses.py:
-      Test_BlockingGraphqlResolvers:
-        "*": "missing_feature"
+      Test_BlockingGraphqlResolvers: missing_feature
+  test_telemetry.py:
+    Test_DependencyEnable: missing_feature 
+    Test_Log_Generation: missing_feature
+    Test_MessageBatch: missing_feature
+    Test_Metric_Generation: missing_feature
+    Test_ProductsDisabled: missing_feature
+    Test_Telemetry: v1.4.0
+    Test_TelemetryV2: v1.11


### PR DESCRIPTION
## Description

Use manifest files for telemetry tests for ruby and PHP tracers.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
