### PR TITLE
Fix product assertion that is part of payload according to the spec

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -484,7 +484,7 @@ class Test_Telemetry:
                         raise Exception(
                             "Client Configuration information is not accurately reported, "
                             + cnf
-                            + "is not present in configuration on app-started event"
+                            + " is not present in configuration on app-started event"
                         )
 
         self.validate_library_telemetry_data(validator)
@@ -538,7 +538,7 @@ class Test_TelemetryV2:
             if not is_v2_payload(data):
                 continue
             if get_request_type(data) == "app-started":
-                products = data["request"]["content"]["application"]["products"]
+                products = data["request"]["content"]["payload"]["products"]
                 assert (
                     "appsec" in products
                 ), "Product information is not accurately reported by telemetry on app-started event"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -531,6 +531,7 @@ class Test_TelemetryV2:
     @missing_feature(library="golang", reason="Product started missing")
     @missing_feature(library="dotnet", reason="Product started missing")
     @missing_feature(library="php", reason="Product started missing (both in libdatadog and php)")
+    @missing_feature(library="python", reason="Product started missing in app-started payload")
     def test_app_started_product_info(self):
         """Assert that product information is accurately reported by telemetry"""
 


### PR DESCRIPTION
## Description

Fix product assertion that is part of payload according to the spec

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
