### PR TITLE
Add a helper to build manifest files

### DIFF
--- a/utils/_decorators.py
+++ b/utils/_decorators.py
@@ -1,7 +1,12 @@
 import inspect
+import os
 import pytest
 
 from utils._context.core import context
+
+
+# temp code, for manifest file migrations
+_released_declarations = {}
 
 
 def _get_skipped_item(item, skip_reason):
@@ -128,6 +133,10 @@ def released(
 
             if component_name in test_class.__released__:
                 raise ValueError(f"A {component_name}' version for {test_class.__name__} has been declared twice")
+
+            if component_name == context.library.library:
+                file = os.path.relpath(inspect.getfile(test_class))
+                _released_declarations[f"{file}::{test_class.__name__}"] = released_version
 
             released_version = _compute_released_version(released_version)
 


### PR DESCRIPTION
## Description

By running `./run.sh --collect-only`, it will produce a valid `logs/manifest.yaml` that can be copy paste in manifest file for the relevant tracer (the one that would have been run in `run.sh`).

## Motivation

Helping migrate all `@released` decorators, otherwise, it will never be done.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
