### PR TITLE
Fix a bug with ASM span tags reporting the number of WAF failed loaded rules

### DIFF
--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -7,7 +7,7 @@ import json
 import pytest
 
 from tests.constants import PYTHON_RELEASE_GA_1_1
-from utils import weblog, context, interfaces, released, irrelevant, coverage, scenarios, missing_feature, bug
+from utils import weblog, context, interfaces, released, irrelevant, coverage, scenarios, missing_feature
 
 if context.weblog_variant in ("akka-http", "spring-boot-payara"):
     pytestmark = pytest.mark.skip("missing feature: No AppSec support")
@@ -173,7 +173,6 @@ class Test_Monitoring:
         self.r_errors = weblog.get("/waf/", params={"v": ".htaccess"})
 
     @scenarios.appsec_rules_monitoring_with_errors
-    @bug(context.library >= "ruby@1.14.0", reason="Reported error count is 4 instead of 2")
     def test_waf_monitoring_errors(self):
         """
         Some WAF monitoring span tags and metrics are expected to be sent at


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

Found the issue for why the test was failing for ruby. 

We can merge this PR once this [PR](https://github.com/DataDog/dd-trace-rb/pull/3106) is merged 

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
