### PR TITLE
Fixing APPSEC_BLOCKING scenario

### DIFF
--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -240,6 +240,7 @@ def _assert_custom_event_tag_absence():
 @missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
 @missing_feature(weblog_variant="akka-http", reason="Missing support")
 @irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
+@bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_method:
     """Test if blocking is supported on server.request.method address"""
 
@@ -289,6 +290,7 @@ class Test_Blocking_request_method:
 @missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
 @missing_feature(weblog_variant="akka-http", reason="Missing support")
 @irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
+@bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_uri:
     """Test if blocking is supported on server.request.uri.raw address"""
 
@@ -350,6 +352,7 @@ class Test_Blocking_request_uri:
 @missing_feature(weblog_variant="akka-http", reason="Missing support")
 @irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
 @irrelevant(context.library == "ruby" and context.weblog_variant == "rack")
+@bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_path_params:
     """Test if blocking is supported on server.request.path_params address"""
 
@@ -402,6 +405,7 @@ class Test_Blocking_request_path_params:
 @missing_feature(weblog_variant="spring-boot-payara", reason="Missing support")
 @missing_feature(weblog_variant="akka-http", reason="Missing support")
 @irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
+@bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_query:
     """Test if blocking is supported on server.request.query address"""
 
@@ -457,6 +461,7 @@ class Test_Blocking_request_query:
 @missing_feature(weblog_variant="spring-boot-payara", reason="Missing support")
 @missing_feature(weblog_variant="akka-http", reason="Missing support")
 @irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
+@bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_headers:
     """Test if blocking is supported on server.request.headers.no_cookies address"""
 
@@ -512,6 +517,7 @@ class Test_Blocking_request_headers:
 @missing_feature(weblog_variant="spring-boot-payara", reason="Missing support")
 @missing_feature(weblog_variant="akka-http", reason="Missing support")
 @irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
+@bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_cookies:
     """Test if blocking is supported on server.request.cookies address"""
 
@@ -567,6 +573,7 @@ class Test_Blocking_request_cookies:
 @missing_feature(weblog_variant="spring-boot-payara", reason="Missing support")
 @missing_feature(weblog_variant="akka-http", reason="Missing support")
 @irrelevant(library="php", reason="Php does not accept url encoded entries without key")
+@bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_body:
     """Test if blocking is supported on server.request.body address for urlencoded body"""
 

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -234,6 +234,7 @@ class Test_Blocking:
 @bug(context.weblog_variant == "uds-echo")
 @coverage.basic
 @scenarios.appsec_blocking
+@bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_CustomBlockingResponse:
     """Custom Blocking response"""
 

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -116,7 +116,7 @@ class Test_StandardTagsUrl:
         context.library in ["dotnet", "golang", "nodejs", "php", "ruby"],
         reason="tracer did not yet implemented the new version of query parameters obfuscation regex",
     )
-    @missing_feature(context.library < "java@1.21.0", "previous obfuscation regex")
+    @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
     def test_url_with_sensitive_query_string(self):
         for r, tag in self.requests_sensitive_query_string:
@@ -147,7 +147,7 @@ class Test_StandardTagsUrl:
         context.library in ["dotnet", "golang", "nodejs", "php", "ruby"],
         reason="tracer did not yet implemented the new version of query parameters obfuscation regex",
     )
-    @missing_feature(context.library < "java@1.21.0", "previous obfuscation regex")
+    @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
     def test_multiple_matching_substring(self):
         tag = r"^.*/waf\?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20<redacted>%7D$"  # pylint: disable=line-too-long

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -86,7 +86,11 @@ public class App {
     MongoClient mongoClient;
 
     @RequestMapping("/")
-    String home() {
+    String home(HttpServletResponse response) {
+        // open liberty set this header to en-US by default, it breaks the APPSEC-BLOCKING scenario
+        // if a java engineer knows how to remove this?
+        // waiting for that, just set a random value 
+        response.setHeader("Content-Language", "not-set");
         return "Hello World!";
     }
 


### PR DESCRIPTION
## Description

The scenario APPSEC_BLOCKING was using a rule that block any request with a **response** header `content-language=en-US`. Turns out that `spring-boot-openliberty` adds this header by default, blocking the healthcheck...

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
