### PR TITLE
response body support for api security

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -139,13 +139,22 @@ The second path parameter must be used as a response status code.
 
 All query parameters (key, value) must be used as (key, value) in the response headers.
 
+### Reponse
+
 The following text should be written to the body of the response:
 
 ```
 Value tagged
 ```
 
-Example :
+Exception (introduced for API Security): if the first string parameter starts with `payload_in_response_body` and the method is `POST`. Then the response should contain a json (content_type='application/json') with the format
+```
+{"payload": payload}
+```
+where payload is the parsed body of the request
+
+### Example
+
 ```
 /tag_value/tainted_value/418?Content-Language=fr&custom_field=myvalue
 ```

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -174,15 +174,26 @@ class Test_Schema_Reponse_Headers:
 
 
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
-@released(dotnet="?", golang="?", java="?", php_appsec="?", python="?", ruby="?")
-@coverage.not_implemented
+@released(dotnet="?", golang="?", java="?", php_appsec="?", python="1.19.0dev", ruby="?")
 @scenarios.appsec_api_security
 class Test_Schema_Reponse_Body:
-    """Test API Security - Reponse Body Schema"""
+    """Test API Security - Reponse Body Schema with urlencoded body"""
 
     def setup_request_method(self):
-        pass
+        self.request = weblog.post(
+            "/tag_value/payload_in_response_body_001/200",
+            data={"test_int": 1, "test_str": "anything", "test_bool": True, "test_float": 1.5234},
+        )
 
     def test_request_method(self):
         """can provide response body schema"""
-        pass
+        schema = get_schema(self.request, "res.body")
+        assert self.request.status_code == 200
+        print(self.request.request, self.request.status_code, self.request.headers, self.request.text)
+        assert isinstance(schema, list)
+        assert len(schema) == 1
+        for key in ("payload",):
+            assert key in schema[0]
+        payload_schema = schema[0]["payload"][0]
+        for key in ("test_bool", "test_int", "test_str"):
+            assert key in payload_schema

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -18,7 +18,6 @@ def get_schema(request, address):
 def equal_without_meta(t1, t2):
     """compare two schema types, ignoring any metadata"""
     if t1 is None or t2 is None:
-        print("NONE")
         return False
     return equal_value(t1[0], t2[0])
 
@@ -164,7 +163,6 @@ class Test_Schema_Reponse_Body:
         """can provide response body schema"""
         schema = get_schema(self.request, "res.body")
         assert self.request.status_code == 200
-        print(self.request.request, self.request.status_code, self.request.headers, self.request.text)
         assert isinstance(schema, list)
         assert len(schema) == 1
         for key in ("payload",):

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -2,8 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import (context, coverage, interfaces, missing_feature, released,
-                   rfc, scenarios, weblog)
+from utils import context, coverage, interfaces, missing_feature, released, rfc, scenarios, weblog
 
 
 def get_schema(request, address):
@@ -136,7 +135,7 @@ class Test_Schema_Request_Body:
 @released(
     java="?",
     php_appsec="?",
-    python={"django-poc": "1.19.0.dev", "flask-poc": "1.19.0.dev, "*": "?"},
+    python={"django-poc": "1.19.0.dev", "flask-poc": "1.19.0.dev", "*": "?"},
 )
 @coverage.basic
 @scenarios.appsec_api_security

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -35,9 +35,7 @@ def equal_value(t1, t2):
 
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @released(
-    java="?",
-    php_appsec="?",
-    python={"django-poc": "1.19.0.dev", "flask-poc": "1.19.0.dev", "*": "?"},
+    java="?", php_appsec="?", python={"django-poc": "1.19.0.dev", "flask-poc": "1.19.0.dev", "*": "?"},
 )
 @coverage.basic
 @scenarios.appsec_api_security
@@ -59,9 +57,7 @@ class Test_Schema_Request_Headers:
 
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @released(
-    java="?",
-    php_appsec="?",
-    python={"django-poc": "1.18", "flask-poc": "1.18", "*": "?"},
+    java="?", php_appsec="?", python={"django-poc": "1.18", "flask-poc": "1.18", "*": "?"},
 )
 @coverage.basic
 @scenarios.appsec_api_security
@@ -84,9 +80,7 @@ class Test_Schema_Request_Query_Parameters:
 
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @released(
-    java="?",
-    php_appsec="?",
-    python={"django-poc": "1.18", "flask-poc": "1.18", "*": "?"},
+    java="?", php_appsec="?", python={"django-poc": "1.18", "flask-poc": "1.18", "*": "?"},
 )
 @coverage.basic
 @scenarios.appsec_api_security
@@ -111,9 +105,7 @@ class Test_Schema_Request_Path_Parameters:
 
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @released(
-    java="?",
-    php_appsec="?",
-    python={"django-poc": "1.18", "flask-poc": "1.18", "*": "?"},
+    java="?", php_appsec="?", python={"django-poc": "1.18", "flask-poc": "1.18", "*": "?"},
 )
 @coverage.basic
 @scenarios.appsec_api_security
@@ -133,9 +125,7 @@ class Test_Schema_Request_Body:
 
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @released(
-    java="?",
-    php_appsec="?",
-    python={"django-poc": "1.19.0.dev", "flask-poc": "1.19.0.dev", "*": "?"},
+    java="?", php_appsec="?", python={"django-poc": "1.19.0.dev", "flask-poc": "1.19.0.dev", "*": "?"},
 )
 @coverage.basic
 @scenarios.appsec_api_security
@@ -158,9 +148,7 @@ class Test_Schema_Reponse_Headers:
 
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @released(
-    java="?",
-    php_appsec="?",
-    python={"django-poc": "1.19.0.dev", "flask-poc": "1.19.0.dev", "*": "?"},
+    java="?", php_appsec="?", python={"django-poc": "1.19.0.dev", "flask-poc": "1.19.0.dev", "*": "?"},
 )
 @scenarios.appsec_api_security
 class Test_Schema_Reponse_Body:

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -2,7 +2,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, coverage, interfaces, missing_feature, released, rfc, scenarios, weblog
+from utils import (context, coverage, interfaces, missing_feature, released,
+                   rfc, scenarios, weblog)
 
 
 def get_schema(request, address):
@@ -37,7 +38,7 @@ def equal_value(t1, t2):
 @released(
     java="?",
     php_appsec="?",
-    python={"django-poc": "1.18", "flask-poc": "1.18", "*": "?"},
+    python={"django-poc": "1.19.0.dev", "flask-poc": "1.19.0.dev", "*": "?"},
 )
 @coverage.basic
 @scenarios.appsec_api_security
@@ -135,7 +136,7 @@ class Test_Schema_Request_Body:
 @released(
     java="?",
     php_appsec="?",
-    python={"django-poc": "1.18", "flask-poc": "1.18", "*": "?"},
+    python={"django-poc": "1.19.0.dev", "flask-poc": "1.19.0.dev, "*": "?"},
 )
 @coverage.basic
 @scenarios.appsec_api_security
@@ -145,7 +146,6 @@ class Test_Schema_Reponse_Headers:
     def setup_request_method(self):
         self.request = weblog.get("/tag_value/api_match_AS005/200?X-option=test_value")
 
-    @missing_feature(context.library < "python@1.19.0.dev")
     def test_request_method(self):
         """can provide response header schema"""
         schema = get_schema(self.request, "res.headers")
@@ -158,7 +158,11 @@ class Test_Schema_Reponse_Headers:
 
 
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
-@released(java="?", php_appsec="?", python="1.19.0dev", ruby="?")
+@released(
+    java="?",
+    php_appsec="?",
+    python={"django-poc": "1.19.0.dev", "flask-poc": "1.19.0.dev", "*": "?"},
+)
 @scenarios.appsec_api_security
 class Test_Schema_Reponse_Body:
     """Test API Security - Reponse Body Schema with urlencoded body"""

--- a/utils/build/docker/python/install_ddtrace.sh
+++ b/utils/build/docker/python/install_ddtrace.sh
@@ -6,6 +6,8 @@ cd /binaries
 
 if [ -e "dd-trace-py" ]; then
     echo "Install from local folder /binaries/dd-trace-py"
+    export CMAKE_BUILD_PARALLEL_LEVEL=12
+    export CMAKE_OSX_ARCHITECTURES=arm64
     pip install /binaries/dd-trace-py
 elif [ "$(ls *.whl *.tar.gz | wc -l)" = "1" ]; then
     path=$(readlink -f $(ls *.whl *.tar.gz))

--- a/utils/build/docker/python/install_ddtrace.sh
+++ b/utils/build/docker/python/install_ddtrace.sh
@@ -6,8 +6,6 @@ cd /binaries
 
 if [ -e "dd-trace-py" ]; then
     echo "Install from local folder /binaries/dd-trace-py"
-    export CMAKE_BUILD_PARALLEL_LEVEL=12
-    export CMAKE_OSX_ARCHITECTURES=arm64
     pip install /binaries/dd-trace-py
 elif [ "$(ls *.whl *.tar.gz | wc -l)" = "1" ]; then
     path=$(readlink -f $(ls *.whl *.tar.gz))

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -99,6 +99,7 @@ def deserialize_dd_appsec_s_meta(key, payload):
         # b64/gzip is optional
         return json.loads(payload)
 
+
 def deserialize_http_message(path, message, content: bytes, interface, key):
     def json_load():
         if not content:

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -9,19 +9,22 @@ import logging
 import traceback
 
 import msgpack
-from _decoders.protobuf_schemas import MetricPayload, TracePayload
-from google.protobuf.json_format import MessageToDict
 from requests_toolbelt.multipart.decoder import MultipartDecoder
-
-from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest, ExportLogsServiceResponse
-from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
-    ExportMetricsServiceRequest,
-    ExportMetricsServiceResponse,
-)
+from google.protobuf.json_format import MessageToDict
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
     ExportTraceServiceResponse,
 )
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
+    ExportMetricsServiceRequest,
+    ExportMetricsServiceResponse,
+)
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
+    ExportLogsServiceRequest,
+    ExportLogsServiceResponse,
+)
+from _decoders.protobuf_schemas import MetricPayload, TracePayload
+
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +98,6 @@ def deserialize_dd_appsec_s_meta(key, payload):
     except Exception as e:
         # b64/gzip is optional
         return json.loads(payload)
-
 
 def deserialize_http_message(path, message, content: bytes, interface, key):
     def json_load():

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -94,7 +94,7 @@ def deserialize_dd_appsec_s_meta(key, payload):
         return json.loads(gzip.decompress(base64.b64decode(payload)).decode())
     except Exception as e:
         # b64/gzip is optional
-        return payload
+        return json.loads(payload)
 
 
 def deserialize_http_message(path, message, content: bytes, interface, key):

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -9,22 +9,19 @@ import logging
 import traceback
 
 import msgpack
-from requests_toolbelt.multipart.decoder import MultipartDecoder
+from _decoders.protobuf_schemas import MetricPayload, TracePayload
 from google.protobuf.json_format import MessageToDict
-from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
-    ExportTraceServiceRequest,
-    ExportTraceServiceResponse,
-)
+from requests_toolbelt.multipart.decoder import MultipartDecoder
+
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest, ExportLogsServiceResponse
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
     ExportMetricsServiceRequest,
     ExportMetricsServiceResponse,
 )
-from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
-    ExportLogsServiceRequest,
-    ExportLogsServiceResponse,
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+    ExportTraceServiceResponse,
 )
-from _decoders.protobuf_schemas import MetricPayload, TracePayload
-
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +93,8 @@ def deserialize_dd_appsec_s_meta(key, payload):
     try:
         return json.loads(gzip.decompress(base64.b64decode(payload)).decode())
     except Exception as e:
-        raise ValueError(f"meta {key} should be b64/gziped JSON.\nPayload: {payload}") from e
+        # b64/gzip is optional
+        return payload
 
 
 def deserialize_http_message(path, message, content: bytes, interface, key):


### PR DESCRIPTION
Add body response test for api security

- add new capability to tag_value end point of the weblog
- use that to test schema computation of body response for api security
- allow meta tags for api security to be gzip/b64 encoded or not (before it was mandatory, but it's not in the RFC)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
