### PR TITLE
Enable test_sample_rate_function for dotnet

### DIFF
--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -297,9 +297,9 @@ class Test_SamplingDecisions:
 
     @bug(library="python", reason="APMRP-259")
     @bug(library="nodejs", reason="APMRP-258")
-    @bug(library="dotnet", reason="APMRP-258")
     @bug(library="php", reason="APMRP-258")
     @bug(library="cpp", reason="APMRP-258")
+    @bug(context.library < "dotnet@2.37.0", reason="APMRP-258")
     def test_sample_rate_function(self):
         """Tests the sampling decision follows the one from the sampling function specification."""
 


### PR DESCRIPTION
## Description

Enable `test_sample_rate_function` for dotnet.

## Motivation

Fixed in 2.37.0. https://github.com/DataDog/dd-trace-dotnet/pull/4548

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [x] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
