### PR TITLE
add more test cases for Test_CustomBlockingResponse

### DIFF
--- a/tests/appsec/blocking_rule.json
+++ b/tests/appsec/blocking_rule.json
@@ -136,6 +136,60 @@
       ]
     },
     {
+      "id": "canary_rule3",
+      "name": "Canary 3",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "^Canary\\/v3"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "on_match": [
+        "block3"
+      ]
+    },
+    {
+      "id": "canary_rule4",
+      "name": "Canary 4",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "^Canary\\/v4"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "on_match": [
+        "block4"
+      ]
+    },
+    {
       "id": "tst-037-009",
       "name": "Test block on response header",
       "tags": {
@@ -479,6 +533,22 @@
       "parameters": {
         "status_code": 301,
         "location": "/you-have-been-blocked"
+      }
+    },
+    {
+      "id": "block3",
+      "type": "redirect_request",
+      "parameters": {
+        "status_code": 200,
+        "location": "/you-have-been-blocked"
+      }
+    },
+    {
+      "id": "block4",
+      "type": "redirect_request",
+      "parameters": {
+        "status_code": 303,
+        "location": ""
       }
     }
   ],

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -220,9 +220,9 @@ class Test_Blocking:
         assert self.r_html_v2.headers.get("content-type", "") in HTML_CONTENT_TYPES
         assert self.r_html_v2.text == BLOCK_TEMPLATE_HTML_MIN_V2
 
+
 @rfc("https://docs.google.com/document/d/1a_-isT9v_LiiGshzQZtzPzCK_CxMtMIil_2fOq9Z1RE/edit")
 @released(java="1.11.0")
-
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @bug(context.weblog_variant == "uds-echo")
 @coverage.basic
@@ -249,6 +249,8 @@ class Test_CustomBlockingResponse:
     def setup_custom_redirect_wrong_status_code(self):
         self.r_cr = weblog.get("/waf/", headers={"User-Agent": "Canary/v3"}, allow_redirects=False)
 
+    @bug(context.library == "java", reason="Do not check the configured redirect status code")
+    @bug(context.library == "golang", reason="Do not check the configured redirect status code")
     def test_custom_redirect_wrong_status_code(self):
         """Block with an HTTP redirection but default to 303 status code, because the configured status code is not a valid redirect status code"""
         assert self.r_cr.status_code == 303
@@ -257,6 +259,8 @@ class Test_CustomBlockingResponse:
     def setup_custom_redirect_missing_location(self):
         self.r_cr = weblog.get("/waf/", headers={"User-Agent": "Canary/v4"}, allow_redirects=False)
 
+    @bug(context.library == "java", reason="Do not check the configured redirect location value")
+    @bug(context.library == "golang", reason="Do not check the configured redirect location value")
     def test_custom_redirect_missing_location(self):
         """Block with an default page because location parameter is missing from redirect request configuration"""
         assert self.r_cr.status_code == 403

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -222,7 +222,7 @@ class Test_Blocking:
 
 
 @rfc(
-    "https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2705464728/Blocking#Custom-Blocking-Response-via-Remote-Config"
+    "https://docs.google.com/document/d/1a_-isT9v_LiiGshzQZtzPzCK_CxMtMIil_2fOq9Z1RE/edit"
 )
 @released(java="1.11.0")
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
@@ -247,3 +247,19 @@ class Test_CustomBlockingResponse:
         """Block with an HTTP redirection"""
         assert self.r_cr.status_code == 301
         assert self.r_cr.headers.get("location", "") == "/you-have-been-blocked"
+
+    def setup_custom_redirect_wrong_status_code(self):
+        self.r_cr = weblog.get("/waf/", headers={"User-Agent": "Canary/v3"}, allow_redirects=False)
+
+    def test_custom_redirect_wrong_status_code(self):
+        """Block with an HTTP redirection but default to 303 status code"""
+        assert self.r_cr.status_code == 303
+        assert self.r_cr.headers.get("location", "") == "/you-have-been-blocked"
+
+    def setup_custom_redirect_missing_location(self):
+        self.r_cr = weblog.get("/waf/", headers={"User-Agent": "Canary/v4"}, allow_redirects=False)
+
+    def test_custom_redirect_missing_location(self):
+        """Block with an default page because location parameter is missing"""
+        assert self.r_cr.status_code == 403
+        assert self.r_cr.text in BLOCK_TEMPLATE_JSON_ANY

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -220,11 +220,9 @@ class Test_Blocking:
         assert self.r_html_v2.headers.get("content-type", "") in HTML_CONTENT_TYPES
         assert self.r_html_v2.text == BLOCK_TEMPLATE_HTML_MIN_V2
 
-
-@rfc(
-    "https://docs.google.com/document/d/1a_-isT9v_LiiGshzQZtzPzCK_CxMtMIil_2fOq9Z1RE/edit"
-)
+@rfc("https://docs.google.com/document/d/1a_-isT9v_LiiGshzQZtzPzCK_CxMtMIil_2fOq9Z1RE/edit")
 @released(java="1.11.0")
+
 @missing_feature(context.weblog_variant == "spring-boot-3-native", reason="GraalVM. Tracing support only")
 @bug(context.weblog_variant == "uds-echo")
 @coverage.basic

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -250,7 +250,7 @@ class Test_CustomBlockingResponse:
         self.r_cr = weblog.get("/waf/", headers={"User-Agent": "Canary/v3"}, allow_redirects=False)
 
     def test_custom_redirect_wrong_status_code(self):
-        """Block with an HTTP redirection but default to 303 status code"""
+        """Block with an HTTP redirection but default to 303 status code, because the configured status code is not a valid redirect status code"""
         assert self.r_cr.status_code == 303
         assert self.r_cr.headers.get("location", "") == "/you-have-been-blocked"
 
@@ -258,6 +258,6 @@ class Test_CustomBlockingResponse:
         self.r_cr = weblog.get("/waf/", headers={"User-Agent": "Canary/v4"}, allow_redirects=False)
 
     def test_custom_redirect_missing_location(self):
-        """Block with an default page because location parameter is missing"""
+        """Block with an default page because location parameter is missing from redirect request configuration"""
         assert self.r_cr.status_code == 403
         assert self.r_cr.text in BLOCK_TEMPLATE_JSON_ANY


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

The PR adds a few more test cases for `Test_CustomBlockingResponse`. Also, updates the RFC link to the one that specify how the libraries should handle the blocking response configuration

From the RFC:

> Possible parameters for type redirect_request:
-  status_code : libraries should check that the provided status code starts with a 3xx and if it does, set it. If it doesn’t then a default code should be set: 303
- location : libraries should set the location as specified here.  If location is empty: ignore all other fields and fallback on default behavior.  The library won’t check the location itself, if it’s correct or reachable.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
