### PR TITLE
Fix DEBUGGER_METHOD_PROBES_SNAPSHOT scenario

### DIFF
--- a/tests/debugger/test_debugger.py
+++ b/tests/debugger/test_debugger.py
@@ -36,16 +36,18 @@ def get_debugger_map():
     hash = {"probes": {}, "snapshots": {}}
 
     for request in agent_logs_endpoint_requests:
-        for content in request["request"]["content"]:
-            debugger = content["debugger"]
+        content = request["request"]["content"]
+        if content is not None:
+            for content in content:
+                debugger = content["debugger"]
 
-            if "diagnostics" in debugger:
-                probe_id = debugger["diagnostics"]["probeId"]
-                hash["probes"][probe_id] = debugger["diagnostics"]
+                if "diagnostics" in debugger:
+                    probe_id = debugger["diagnostics"]["probeId"]
+                    hash["probes"][probe_id] = debugger["diagnostics"]
 
-            if "snapshot" in debugger:
-                probe_id = debugger["snapshot"]["probe"]["id"]
-                hash["snapshots"][probe_id] = debugger["snapshot"]
+                if "snapshot" in debugger:
+                    probe_id = debugger["snapshot"]["probe"]["id"]
+                    hash["snapshots"][probe_id] = debugger["snapshot"]
 
     return hash
 

--- a/tests/debugger/test_debugger.py
+++ b/tests/debugger/test_debugger.py
@@ -148,6 +148,10 @@ class Test_Debugger_Method_Probe_Snaphots:
         def wait_for_probe(data):
             if data["path"] == "/api/v2/logs":
                 contents = data.get("request", {}).get("content", {})
+
+                if contents is None:
+                    return False
+
                 for content in contents:
                     debuggerData = content["debugger"]
                     if "diagnostics" in debuggerData:
@@ -161,8 +165,8 @@ class Test_Debugger_Method_Probe_Snaphots:
         self.log_probe_response = weblog.get("/debugger/log")
 
     def test_method_probe_snaphots(self):
-        assert self.remote_config_is_sent == True
-        assert self.probe_installed == True
+        assert self.remote_config_is_sent is True
+        assert self.probe_installed is True
         assert self.log_probe_response.status_code == 200
 
         expected_data = ["logProbe-installed"]


### PR DESCRIPTION
## Description

`content` can be `null` on `/api/v2/logs` requests

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
