### PR TITLE
Marking some otel test as flaky

### DIFF
--- a/tests/otel_tracing_e2e/test_e2e.py
+++ b/tests/otel_tracing_e2e/test_e2e.py
@@ -2,7 +2,7 @@ import base64
 import os
 import time
 
-from utils import context, weblog, interfaces, scenarios, irrelevant, released
+from utils import context, weblog, interfaces, scenarios, irrelevant, released, flaky
 from utils.tools import get_rid_from_request
 from ._test_validator_trace import validate_all_traces
 from ._test_validator_log import validate_log, validate_log_trace_correlation
@@ -66,6 +66,7 @@ class Test_OTelTracingE2E:
 
 @scenarios.otel_metric_e2e
 @irrelevant(context.library != "open_telemetry")
+@flaky(reason="Backend responses often don't include series")
 class Test_OTelMetricE2E:
     def setup_main(self):
         self.start = int(time.time())


### PR DESCRIPTION
## Description

The source of those flakyness is mainly the backend. If we don't find a way to make the test reliable, the signal/noise ratio is terrible.

## Motivation

Test must not be flaky

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
