### PR TITLE
Deserialize `_dd.appsec.s.` meta in v0.4 traces

### DIFF
--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -193,19 +193,16 @@ def _deserialized_nested_json_from_trace_payloads(content, interface):
             for chunk in tracer_payload.get("chunks", []):
                 for span in chunk.get("spans", []):
                     meta = span.get("meta", {})
-
-                    for key in list(meta):
-                        if key.startswith("_dd.appsec.s."):
-                            meta[key] = deserialize_dd_appsec_s_meta(key, meta[key])
-                        elif key in keys:
-                            meta[key] = json.loads(meta[key])
+                    _deserialize_meta(meta)
 
     elif interface == "library":
         for traces in content:
             for span in traces:
                 meta = span.get("meta", {})
+                _deserialize_meta(meta)
 
-                for key in list(meta):
+def _deserialize_meta(meta):
+     for key in list(meta):
                     if key.startswith("_dd.appsec.s."):
                         meta[key] = deserialize_dd_appsec_s_meta(key, meta[key])
                     elif key in keys:

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -201,12 +201,13 @@ def _deserialized_nested_json_from_trace_payloads(content, interface):
                 meta = span.get("meta", {})
                 _deserialize_meta(meta)
 
+
 def _deserialize_meta(meta):
-     for key in list(meta):
-                    if key.startswith("_dd.appsec.s."):
-                        meta[key] = deserialize_dd_appsec_s_meta(meta[key])
-                    elif key in keys:
-                        meta[key] = json.loads(meta[key])
+    for key in list(meta):
+        if key.startswith("_dd.appsec.s."):
+            meta[key] = deserialize_dd_appsec_s_meta(meta[key])
+        elif key in keys:
+            meta[key] = json.loads(meta[key])
 
 
 def _convert_bytes_values(item):

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -84,7 +84,7 @@ def _decode_v_0_5_traces(content):
     return result
 
 
-def deserialize_dd_appsec_s_meta(key, payload):
+def deserialize_dd_appsec_s_meta(payload):
     """ meta value for _dd.appsec.s.<address> are b64 - gzip - json encoded strings """
 
     try:
@@ -204,7 +204,7 @@ def _deserialized_nested_json_from_trace_payloads(content, interface):
 def _deserialize_meta(meta):
      for key in list(meta):
                     if key.startswith("_dd.appsec.s."):
-                        meta[key] = deserialize_dd_appsec_s_meta(key, meta[key])
+                        meta[key] = deserialize_dd_appsec_s_meta(meta[key])
                     elif key in keys:
                         meta[key] = json.loads(meta[key])
 

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -186,23 +186,24 @@ def deserialize_http_message(path, message, content: bytes, interface, key):
 def _deserialized_nested_json_from_trace_payloads(content, interface):
     """ trace payload from agent and library contains strings that are json """
 
-    keys = ("_dd.appsec.json", "_dd.iast.json")
-
     if interface == "agent":
         for tracer_payload in content.get("tracerPayloads", []):
             for chunk in tracer_payload.get("chunks", []):
                 for span in chunk.get("spans", []):
-                    meta = span.get("meta", {})
-                    _deserialize_meta(meta)
+                    _deserialize_meta(span)
 
     elif interface == "library":
         for traces in content:
             for span in traces:
-                meta = span.get("meta", {})
-                _deserialize_meta(meta)
+                _deserialize_meta(span)
 
 
-def _deserialize_meta(meta):
+def _deserialize_meta(span):
+
+    meta = span.get("meta", {})
+
+    keys = ("_dd.appsec.json", "_dd.iast.json")
+
     for key in list(meta):
         if key.startswith("_dd.appsec.s."):
             meta[key] = deserialize_dd_appsec_s_meta(meta[key])


### PR DESCRIPTION
## Description

Meta tags starting with `_dd.appsec.s.` are JSON strings, or gzip/b64 JSON. They are decoded in v0.5 traces, but not in v0.4 traces.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
