### PR TITLE
Optimize python build

### DIFF
--- a/utils/build/docker/python/django-poc.Dockerfile
+++ b/utils/build/docker/python/django-poc.Dockerfile
@@ -1,11 +1,13 @@
 FROM datadog/system-tests:django-poc.base-v0
 
-COPY utils/build/docker/python/django/app.sh /app/app.sh
-COPY utils/build/docker/python/django/django.app.urls.py /app/app/urls.py
-COPY utils/build/docker/python/iast.py /app/iast.py
+WORKDIR /app
 
 COPY utils/build/docker/python/install_ddtrace.sh utils/build/docker/python/get_appsec_rules_version.py binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
+
+COPY utils/build/docker/python/django/app.sh /app/app.sh
+COPY utils/build/docker/python/django/django.app.urls.py /app/app/urls.py
+COPY utils/build/docker/python/iast.py /app/iast.py
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_REMOTECONFIG_POLL_SECONDS=1

--- a/utils/build/docker/python/flask-poc.Dockerfile
+++ b/utils/build/docker/python/flask-poc.Dockerfile
@@ -1,11 +1,12 @@
 FROM datadog/system-tests:flask-poc.base-v1
 
-COPY utils/build/docker/python/flask /app
-COPY utils/build/docker/python/iast.py /app/iast.py
 WORKDIR /app
 
 COPY utils/build/docker/python/install_ddtrace.sh utils/build/docker/python/get_appsec_rules_version.py binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
+
+COPY utils/build/docker/python/flask /app
+COPY utils/build/docker/python/iast.py /app/iast.py
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_REMOTECONFIG_POLL_SECONDS=1

--- a/utils/build/docker/python/uds-flask.Dockerfile
+++ b/utils/build/docker/python/uds-flask.Dockerfile
@@ -1,11 +1,12 @@
 FROM datadog/system-tests:flask-poc.base-v0
 
-COPY utils/build/docker/python/flask /app
-COPY utils/build/docker/python/iast.py /app/iast.py
 WORKDIR /app
 
 COPY utils/build/docker/python/install_ddtrace.sh utils/build/docker/python/get_appsec_rules_version.py binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
+
+COPY utils/build/docker/python/flask /app
+COPY utils/build/docker/python/iast.py /app/iast.py
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_REMOTECONFIG_POLL_SECONDS=1

--- a/utils/build/docker/python/uwsgi-poc.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.Dockerfile
@@ -1,12 +1,13 @@
 FROM datadog/system-tests:uwsgi-poc.base-v0
 
-COPY utils/build/docker/python/flask /app
-COPY utils/build/docker/python/iast.py /app/iast.py
 WORKDIR /app
-ENV FLASK_APP=app.py
 
 COPY utils/build/docker/python/install_ddtrace.sh utils/build/docker/python/get_appsec_rules_version.py binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
+
+COPY utils/build/docker/python/flask /app
+COPY utils/build/docker/python/iast.py /app/iast.py
+ENV FLASK_APP=app.py
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_REMOTECONFIG_POLL_SECONDS=1


### PR DESCRIPTION
## Description

Building weblog from python tracer source is slow (and terribly slow on Mac M1).

This PR does not solve the underlying issue, but mitigate it for one use case: when you modify the weblog code, the python file were copied in first in the docker file, invalidating the whole cache.

By copying those file after installing the tracer, docker can use the cache for this step.

It does not change anything for the other use case (modifying the tracer), as the base issue is not solved.

## Motivation

Faster local iterations

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
