### PR TITLE
python api security enabled again

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2,34 +2,34 @@ tests/:
   appsec/:
     api_security/:
       test_schemas.py:
-        Test_Schema_Request_Body: missing_feature
-          # '*': missing_feature
-          # django-poc: v1.18
-          # flask-poc: v1.18
-        Test_Schema_Request_Cookies: missing_feature
-          # '*': missing_feature
-          # django-poc: v1.19.0.dev1
-          # flask-poc: v1.19.0.dev1
-        Test_Schema_Request_Headers: missing_feature
-          # '*': missing_feature
-          # django-poc: v1.19.0.dev1
-          # flask-poc: v1.19.0.dev1
-        Test_Schema_Request_Path_Parameters: missing_feature
-          # '*': missing_feature
-          # django-poc: v1.18
-          # flask-poc: v1.18
-        Test_Schema_Request_Query_Parameters: missing_feature
-          # '*': missing_feature
-          # django-poc: v1.18
-          # flask-poc: v1.18
-        Test_Schema_Response_Body: missing_feature
-          # '*': missing_feature
-          # django-poc: v1.19.0.dev1
-          # flask-poc: v1.19.0.dev1
-        Test_Schema_Response_Headers: missing_feature
-          # '*': missing_feature
-          # django-poc: v1.19.0.dev1
-          # flask-poc: v1.19.0.dev1
+        Test_Schema_Request_Body:
+          '*': missing_feature
+          django-poc: v1.21.0.dev
+          flask-poc: v1.21.0.dev
+        Test_Schema_Request_Cookies:
+          '*': missing_feature
+          django-poc: v1.21.0.dev
+          flask-poc: v1.21.0.dev
+        Test_Schema_Request_Headers:
+          '*': missing_feature
+          django-poc: v1.21.0.dev
+          flask-poc: v1.21.0.dev
+        Test_Schema_Request_Path_Parameters:
+          '*': missing_feature
+          django-poc: v1.21.0.dev
+          flask-poc: v1.21.0.dev
+        Test_Schema_Request_Query_Parameters:
+          '*': missing_feature
+          django-poc: v1.21.0.dev
+          flask-poc: v1.21.0.dev
+        Test_Schema_Response_Body:
+          '*': missing_feature
+          django-poc: v1.21.0.dev
+          flask-poc: v1.21.0.dev
+        Test_Schema_Response_Headers:
+          '*': missing_feature
+          django-poc: v1.21.0.dev
+          flask-poc: v1.21.0.dev
     iast/:
       sink/:
         test_command_injection.py:

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -999,7 +999,7 @@ class scenarios:
         appsec_enabled=True,
         weblog_env={
             "DD_EXPERIMENTAL_API_SECURITY_ENABLED": "true",
-            "DD_TRACE_DEBUG": "true",
+            "DD_TRACE_DEBUG": "false",
             "DD_API_SECURITY_REQUEST_SAMPLE_RATE": "1.0",
         },
         doc="""

--- a/utils/build/docker/python/django/django.app.urls.py
+++ b/utils/build/docker/python/django/django.app.urls.py
@@ -38,7 +38,7 @@ _TRACK_CUSTOM_APPSEC_EVENT_NAME = "system_tests_appsec_event"
 
 @csrf_exempt
 def waf(request, *args, **kwargs):
-    if "value" in kwargs:
+    if "tag_value" in kwargs:
         appsec_trace_utils.track_custom_event(
             tracer, event_name=_TRACK_CUSTOM_APPSEC_EVENT_NAME, metadata={"value": kwargs["tag_value"]}
         )

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -1,5 +1,7 @@
 import psycopg2
 import requests
+from ddtrace import tracer
+from ddtrace.appsec import trace_utils as appsec_trace_utils
 from flask import Flask, Response, jsonify
 from flask import request
 from flask import request as flask_request
@@ -11,12 +13,9 @@ from iast import (
     weak_hash_multiple,
     weak_hash_secure_algorithm,
 )
-from integrations.db.postgres import executePostgresOperation
-from integrations.db.mysqldb import executeMysqlOperation
 from integrations.db.mssql import executeMssqlOperation
-
-from ddtrace import tracer
-from ddtrace.appsec import trace_utils as appsec_trace_utils
+from integrations.db.mysqldb import executeMysqlOperation
+from integrations.db.postgres import executePostgresOperation
 
 try:
     from ddtrace.contrib.trace_utils import set_user
@@ -49,16 +48,16 @@ _TRACK_CUSTOM_APPSEC_EVENT_NAME = "system_tests_appsec_event"
 @app.route("/waf/", methods=["GET", "POST", "OPTIONS"])
 @app.route("/waf/<path:url>", methods=["GET", "POST", "OPTIONS"])
 @app.route("/params/<path>", methods=["GET", "POST", "OPTIONS"])
-@app.route("/tag_value/<string:value>/<int:code>", methods=["GET", "POST", "OPTIONS"])
+@app.route("/tag_value/<string:tag_value>/<int:status_code>", methods=["GET", "POST", "OPTIONS"])
 def waf(*args, **kwargs):
-    if "value" in kwargs:
+    if "tag_value" in kwargs:
         appsec_trace_utils.track_custom_event(
-            tracer, event_name=_TRACK_CUSTOM_APPSEC_EVENT_NAME, metadata={"value": kwargs["value"]}
+            tracer, event_name=_TRACK_CUSTOM_APPSEC_EVENT_NAME, metadata={"value": kwargs["tag_value"]}
         )
-        if kwargs["value"].startswith("payload_in_response_body") and request.method == "POST":
+        if kwargs["tag_value"].startswith("payload_in_response_body") and request.method == "POST":
             return jsonify({"payload": request.form})
 
-        return "Value tagged", kwargs["code"], flask_request.args
+        return "Value tagged", kwargs["status_code"], flask_request.args
     return "Hello, World!\\n"
 
 


### PR DESCRIPTION
## Description

To be merged after https://github.com/DataDog/dd-trace-py/pull/6933 [done]
- Re-enable api security tests for python after updating python tracer with rfc conformant sampling strategy.
- Improve the flask and django weblogs to follow new specifications from https://github.com/DataDog/system-tests/pull/1602
- Deactivate tracer debug log in api security scenario by default

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
