### PR TITLE
Migrate some leftovers in manifest files

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -179,11 +179,11 @@ tests/:
     test_remote_configuration.py:
       Test_RemoteConfigurationExtraServices: v2.36.0
       Test_RemoteConfigurationUpdateSequenceASMDD: v2.15.0
-      Test_RemoteConfigurationUpdateSequenceASMDDNoCache: v2.15.0
+      Test_RemoteConfigurationUpdateSequenceASMDDNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceFeatures: v2.15.0
-      Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: v2.15.0
+      Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: v2.15.0
-      Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: v2.15.0
+      Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:
@@ -194,6 +194,8 @@ tests/:
     Test_HeaderTags: v2.27.0
     Test_HeaderTagsLongFormat: v2.1.0
     Test_HeaderTagsShortFormat: v2.1.0
+  test_profiling.py:
+    Test_Profile: missing_feature (Not receiving profiles)
   test_scrubbing.py:
     Test_UrlField: v2.29.0
     Test_UrlQuery: v2.13.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1,4 +1,9 @@
 tests/:
+  apm_tracing_e2e/:
+    test_otel.py:
+      Test_Otel_Span: missing_feature (missing /e2e_otel_span endpoint on weblog)
+    test_single_span:
+      Test_SingleSpan: missing_feature (missing /e2e_otel_span endpoint on weblog)
   appsec/:
     api_security/:
       test_schemas.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -181,12 +181,24 @@ tests/:
       Test_BlockingGraphqlResolvers:
         '*': missing_feature
       Test_Blocking_request_body: missing_feature
-      Test_Blocking_request_cookies: v1.51.0
-      Test_Blocking_request_headers: v1.51.0
-      Test_Blocking_request_method: v1.51.0
-      Test_Blocking_request_path_params: v1.51.0
-      Test_Blocking_request_query: v1.51.0
-      Test_Blocking_request_uri: v1.51.0
+      Test_Blocking_request_cookies:
+        '*': v1.51.0
+        net-http: irrelevant
+      Test_Blocking_request_headers:
+        '*': v1.51.0
+        net-http: irrelevant
+      Test_Blocking_request_method:
+        '*': v1.51.0
+        net-http: irrelevant
+      Test_Blocking_request_path_params:
+        '*': v1.51.0
+        net-http: irrelevant
+      Test_Blocking_request_query:
+        '*': v1.51.0
+        net-http: irrelevant
+      Test_Blocking_request_uri:
+        '*': v1.51.0
+        net-http: irrelevant
       Test_Blocking_response_headers: missing_feature
       Test_Blocking_response_status: missing_feature
       Test_Suspicious_Request_Blocking: missing_feature
@@ -250,7 +262,9 @@ tests/:
         gin: v1.37.0
   debugger/:
     test_debugger.py:
+      Test_Debugger_Line_Probe_Snaphots: irrelevant
       Test_Debugger_Line_Probe_Statuses: missing_feature
+      Test_Debugger_Method_Probe_Snaphots: irrelevant
       Test_Debugger_Method_Probe_Statuses: missing_feature
   integrations/:
     test_db_integrations_sql.py:
@@ -272,10 +286,11 @@ tests/:
     test_remote_configuration.py:
       Test_RemoteConfigurationExtraServices: missing_feature
       Test_RemoteConfigurationUpdateSequenceASMDD: missing_feature
+      Test_RemoteConfigurationUpdateSequenceASMDDNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceFeatures: v1.44.1
-      Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: missing_feature
+      Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
-      Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
+      Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:
@@ -286,6 +301,8 @@ tests/:
     Test_HeaderTags: missing_feature
     Test_HeaderTagsLongFormat: missing_feature
     Test_HeaderTagsShortFormat: missing_feature
+  test_profiling.py:
+    Test_Profile: bug (Not receiving profiles)
   test_scrubbing.py:
     Test_UrlQuery: v1.40.0
   test_semantic_conventions.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1,4 +1,13 @@
 tests/:
+  apm_tracing_e2e/:
+    test_otel.py:
+      Test_Otel_Span:
+        '*': missing_feature (missing /e2e_otel_span endpoint on weblog)
+        net-http: v0.1  # real version not known
+    test_single_span:
+      Test_SingleSpan:
+        '*': missing_feature (missing /e2e_otel_span endpoint on weblog)
+        chi: v0.1  # real version not known
   appsec/:
     api_security/:
       test_schemas.py:
@@ -83,6 +92,7 @@ tests/:
         Test_PathParams:
           '*': v1.36.0
           gin: v1.37.0
+          net-http: irrelevant (net-http doesn't handle path params)
         Test_ResponseStatus:
           '*': v1.36.0
           gin: v1.37.0
@@ -98,7 +108,9 @@ tests/:
         Test_gRPC: v1.36.0
       test_blocking.py:
         Test_Blocking: v1.50.0-rc.1
-        Test_CustomBlockingResponse: v1.53.0
+        Test_CustomBlockingResponse:
+          '*': v1.53.0
+          uds-echo: bug
       test_custom_rules.py:
         Test_CustomRules: v1.51.0
       test_exclusions.py:
@@ -215,7 +227,9 @@ tests/:
     test_identify.py:
       Test_Basic: v1.37.0
     test_ip_blocking_full_denylist.py:
-      Test_AppSecIPBlockingFullDenylist: v1.47.0
+      Test_AppSecIPBlockingFullDenylist:
+        '*': v1.47.0
+        uds-echo: bug
     test_logs.py:
       Test_Standardization: missing_feature
       Test_StandardizationBlockMode: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -91,7 +91,7 @@ tests/:
             uds-flask: missing_feature
             uwsgi-poc: missing_feature
         test_parameter_value.py:
-          TestParameterValue: v1.18.0
+          TestParameterValue: bug (should have been v1.18.0)
     waf/:
       test_addresses.py:
         Test_BodyJson: v1.4.0rc1.dev
@@ -263,7 +263,9 @@ tests/:
       Test_Events: v0.58.5
   debugger/:
     test_debugger.py:
+      Test_Debugger_Line_Probe_Snaphots: missing_feature
       Test_Debugger_Line_Probe_Statuses: missing_feature
+      Test_Debugger_Method_Probe_Snaphots: missing_feature
       Test_Debugger_Method_Probe_Statuses: missing_feature
   integrations/:
     test_db_integrations_sql.py:
@@ -293,7 +295,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceASMDD: missing_feature
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: missing_feature
       Test_RemoteConfigurationUpdateSequenceFeatures: v1.7.4
-      Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: v1.6.0rc1
+      Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
   test_distributed.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1,4 +1,9 @@
 tests/:
+  apm_tracing_e2e/:
+    test_otel.py:
+      Test_Otel_Span: missing_feature (missing /e2e_otel_span endpoint on weblog)
+    test_single_span:
+      Test_SingleSpan: missing_feature (missing /e2e_otel_span endpoint on weblog)
   appsec/:
     api_security/:
       test_schemas.py:
@@ -235,7 +240,7 @@ tests/:
     test_identify.py:
       Test_Basic: v1.5.0rc1.dev
     test_ip_blocking_full_denylist.py:
-      Test_AppSecIPBlockingFullDenylist: v1.10.0
+      Test_AppSecIPBlockingFullDenylist: missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
     test_logs.py:
       Test_Standardization: missing_feature
       Test_StandardizationBlockMode: missing_feature
@@ -256,9 +261,9 @@ tests/:
       Test_RetainTraces: v1.1.0rc2.dev
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist:
-        '*': missing_feature
-        django-poc: v1.10
-        flask-poc: v1.10
+        '*': missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
+        # django-poc: v1.10
+        # flask-poc: v1.10
     test_versions.py:
       Test_Events: v0.58.5
   debugger/:
@@ -278,6 +283,10 @@ tests/:
       Test_Postgres_db_integration:
         '*': missing_feature
         flask-poc: v1.18.3
+    test_dbm.py:
+      Test_Dbm:
+        '*': missing_feature (Missing on weblog)
+        flask-poc: v0.1  # real version not known
     test_dsm.py:
       Test_DsmHttp: missing_feature
       Test_DsmKafka: missing_feature
@@ -315,6 +324,7 @@ tests/:
     Test_UrlQuery: v1.6.0rc1.dev
   test_semantic_conventions.py:
     Test_Meta: v1.80.0
+    Test_MetaDatadogTags: bug (Inconsistent implementation across tracers; will need a dedicated testing scenario)
   test_standard_tags.py:
     Test_StandardTagsClientIp: v1.5.0
     Test_StandardTagsMethod: v1.2.1

--- a/tests/apm_tracing_e2e/test_otel.py
+++ b/tests/apm_tracing_e2e/test_otel.py
@@ -1,11 +1,12 @@
 from tests.apm_tracing_e2e.test_single_span import _get_spans_submitted, _assert_msg
-from utils import context, weblog, scenarios, interfaces, missing_feature, irrelevant, flaky
+from utils import context, weblog, scenarios, interfaces, missing_feature, irrelevant
 
 
 @missing_feature(
-    context.weblog_variant not in ("net-http", "spring-boot"),
-    reason="The /e2e_otel_span endpoint is only implemented in Go net/http and Java Spring Boot at the moment.",
+    context.library == "java" and context.weblog_variant != "spring-boot",
+    reason="The /e2e_otel_span endpoint is only implemented in Java Spring Boot at the moment.",
 )
+@missing_feature(context.library in ("cpp", "ruby", "php", "nodejs"), reason="Missing weblog endpoint")
 @scenarios.apm_tracing_e2e_otel
 class Test_Otel_Span:
     """This is a test that that exercises the full flow of APM Tracing with the use of Datadog OTel API.

--- a/tests/apm_tracing_e2e/test_single_span.py
+++ b/tests/apm_tracing_e2e/test_single_span.py
@@ -1,5 +1,4 @@
 from utils import context, weblog, interfaces, rfc, scenarios, missing_feature
-from utils.tools import logger
 from tests.apm_tracing_e2e.constants import (
     SAMPLING_PRIORITY_KEY,
     SINGLE_SPAN_SAMPLING_MECHANISM,
@@ -12,9 +11,10 @@ from tests.apm_tracing_e2e.constants import (
 @rfc("ATI-2419")
 @missing_feature(context.agent_version < "7.40", reason="Single Spans is not available in agents pre 7.40.")
 @missing_feature(
-    context.weblog_variant not in ("chi", "spring-boot"),
+    context.library == "java" and context.weblog_variant != "spring-boot",
     reason="The /e2e_single_span endpoint is only implemented in Go chi at the moment.",
 )
+@missing_feature(context.library in ("cpp", "ruby", "php", "nodejs"), reason="Missing weblog endpoint")
 @scenarios.apm_tracing_e2e_single_span
 class Test_SingleSpan:
     """This is a test that exercises the Single Span Ingestion Control feature.

--- a/tests/appsec/iast/source/test_parameter_value.py
+++ b/tests/appsec/iast/source/test_parameter_value.py
@@ -7,7 +7,6 @@ from .._test_iast_fixtures import SourceFixture
 
 
 @coverage.basic
-@bug(library="python")
 class TestParameterValue:
     """Verify that request parameters are tainted"""
 

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -201,7 +201,6 @@ def _assert_custom_event_tag_absence():
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
 @scenarios.appsec_blocking
 @coverage.good
-@irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
 @bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_method:
     """Test if blocking is supported on server.request.method address"""
@@ -241,7 +240,6 @@ class Test_Blocking_request_method:
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
 @scenarios.appsec_blocking
 @coverage.good
-@irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
 @bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_uri:
     """Test if blocking is supported on server.request.uri.raw address"""
@@ -291,7 +289,6 @@ class Test_Blocking_request_uri:
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
 @scenarios.appsec_blocking
 @coverage.good
-@irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
 @bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_path_params:
     """Test if blocking is supported on server.request.path_params address"""
@@ -333,7 +330,6 @@ class Test_Blocking_request_path_params:
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
 @scenarios.appsec_blocking
 @coverage.good
-@irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
 @bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_query:
     """Test if blocking is supported on server.request.query address"""
@@ -378,7 +374,6 @@ class Test_Blocking_request_query:
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
 @scenarios.appsec_blocking
 @coverage.good
-@irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
 @bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_headers:
     """Test if blocking is supported on server.request.headers.no_cookies address"""
@@ -423,7 +418,6 @@ class Test_Blocking_request_headers:
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
 @scenarios.appsec_blocking
 @coverage.good
-@irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
 @bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
 class Test_Blocking_request_cookies:
     """Test if blocking is supported on server.request.cookies address"""

--- a/tests/appsec/test_ip_blocking_full_denylist.py
+++ b/tests/appsec/test_ip_blocking_full_denylist.py
@@ -15,10 +15,6 @@ with open("tests/appsec/rc_expected_requests_block_full_denylist_asm_data.json",
 @irrelevant(
     context.appsec_rules_file is not None, reason="No Remote Config sub with custom rules file",
 )
-@missing_feature(
-    library="python", reason="Python supported denylists of 2500 entries but it fails to block this those 15000"
-)
-@bug(context.weblog_variant == "uds-echo")
 @bug("nodejs@3.16.0" < context.library < "nodejs@3.18.0", reason="bugged on that version range")
 @coverage.basic
 @scenarios.appsec_blocking_full_denylist

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -1,9 +1,6 @@
-from utils import context, coverage, interfaces, scenarios, weblog, bug, missing_feature
+from utils import context, coverage, interfaces, scenarios, weblog, bug
 
 
-@missing_feature(
-    library="python", reason="Python supported denylists of 2500 entries but it fails to block this those 15000"
-)
 @coverage.basic
 @scenarios.appsec_blocking_full_denylist
 class Test_UserBlocking_FullDenylist:

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -371,9 +371,6 @@ class Test_ResponseStatus:
         interfaces.library.assert_waf_attack(self.r, pattern="404", address="server.response.status")
 
 
-@irrelevant(
-    context.library == "golang" and context.weblog_variant == "net-http", reason="net-http doesn't handle path params"
-)
 @coverage.basic
 class Test_PathParams:
     """Appsec supports values on server.request.path_params"""

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -202,7 +202,6 @@ class Test_Blocking:
 
 
 @rfc("https://docs.google.com/document/d/1a_-isT9v_LiiGshzQZtzPzCK_CxMtMIil_2fOq9Z1RE/edit")
-@bug(context.weblog_variant == "uds-echo")
 @coverage.basic
 @scenarios.appsec_blocking
 @bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")

--- a/tests/debugger/test_debugger.py
+++ b/tests/debugger/test_debugger.py
@@ -103,7 +103,6 @@ def check_info_endpoint():
     context.library == "java" and context.weblog_variant not in ["spring-boot", "uds-spring-boot"],
     reason="not supported",
 )
-@irrelevant(library="golang")
 @irrelevant(library="nodejs")
 @scenarios.debugger_method_probes_status
 class Test_Debugger_Method_Probe_Statuses:
@@ -125,7 +124,6 @@ class Test_Debugger_Method_Probe_Statuses:
     context.library == "java" and context.weblog_variant not in ["spring-boot", "uds-spring-boot"],
     reason="not supported",
 )
-@irrelevant(library="golang")
 @irrelevant(library="nodejs")
 @scenarios.debugger_line_probes_status
 class Test_Debugger_Line_Probe_Statuses:
@@ -165,7 +163,6 @@ class _Base_Debugger_Snapshot_Test:
     context.library == "java" and context.weblog_variant not in ["spring-boot", "uds-spring-boot"],
     reason="not supported",
 )
-@irrelevant(library="golang")
 @irrelevant(library="nodejs")
 @scenarios.debugger_method_probes_snapshot
 class Test_Debugger_Method_Probe_Snaphots(_Base_Debugger_Snapshot_Test):
@@ -207,7 +204,6 @@ class Test_Debugger_Method_Probe_Snaphots(_Base_Debugger_Snapshot_Test):
     context.library == "java" and context.weblog_variant not in ["spring-boot", "uds-spring-boot"],
     reason="not supported",
 )
-@irrelevant(library="golang")
 @irrelevant(library="nodejs")
 @scenarios.debugger_line_probes_snapshot
 class Test_Debugger_Line_Probe_Snaphots(_Base_Debugger_Snapshot_Test):

--- a/tests/debugger/test_debugger.py
+++ b/tests/debugger/test_debugger.py
@@ -103,7 +103,6 @@ def check_info_endpoint():
     context.library == "java" and context.weblog_variant not in ["spring-boot", "uds-spring-boot"],
     reason="not supported",
 )
-@missing_feature(context.library == "python", reason="not implemented yet")
 @irrelevant(library="golang")
 @irrelevant(library="nodejs")
 @scenarios.debugger_method_probes_status
@@ -126,7 +125,6 @@ class Test_Debugger_Method_Probe_Statuses:
     context.library == "java" and context.weblog_variant not in ["spring-boot", "uds-spring-boot"],
     reason="not supported",
 )
-@missing_feature(context.library == "python", reason="not implemented yet")
 @irrelevant(library="golang")
 @irrelevant(library="nodejs")
 @scenarios.debugger_line_probes_status
@@ -167,7 +165,6 @@ class _Base_Debugger_Snapshot_Test:
     context.library == "java" and context.weblog_variant not in ["spring-boot", "uds-spring-boot"],
     reason="not supported",
 )
-@missing_feature(context.library == "python", reason="not implemented yet")
 @irrelevant(library="golang")
 @irrelevant(library="nodejs")
 @scenarios.debugger_method_probes_snapshot
@@ -210,7 +207,6 @@ class Test_Debugger_Method_Probe_Snaphots(_Base_Debugger_Snapshot_Test):
     context.library == "java" and context.weblog_variant not in ["spring-boot", "uds-spring-boot"],
     reason="not supported",
 )
-@missing_feature(context.library == "python", reason="not implemented yet")
 @irrelevant(library="golang")
 @irrelevant(library="nodejs")
 @scenarios.debugger_line_probes_snapshot

--- a/tests/integrations/test_dbm.py
+++ b/tests/integrations/test_dbm.py
@@ -2,12 +2,9 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2022 Datadog, Inc.
 
-from utils import weblog, interfaces, context, missing_feature, scenarios
+from utils import weblog, interfaces, context, scenarios
 
 
-@missing_feature(
-    context.library in ["python"] and context.weblog_variant != "flask-poc", reason="Missing on weblog",
-)
 @scenarios.integrations
 class Test_Dbm:
     """Verify behavior of DBM propagation"""

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -384,7 +384,6 @@ class Test_RemoteConfigurationUpdateSequenceASMDD(RemoteConfigurationFieldsBasic
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @irrelevant(library="nodejs", reason="cache is implemented")
 @irrelevant(library="java", reason="cache is implemented")
-@irrelevant(library="golang", reason="cache is implemented")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_asm_features_nocache
 class Test_RemoteConfigurationUpdateSequenceFeaturesNoCache(RemoteConfigurationFieldsBasicTests):
@@ -440,7 +439,6 @@ class Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache(RemoteConfigura
 
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @irrelevant(library="nodejs", reason="cache is implemented")
-@irrelevant(library="golang", reason="cache is implemented")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_asm_dd_nocache
 class Test_RemoteConfigurationUpdateSequenceASMDDNoCache(RemoteConfigurationFieldsBasicTests):

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -383,8 +383,6 @@ class Test_RemoteConfigurationUpdateSequenceASMDD(RemoteConfigurationFieldsBasic
 
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @irrelevant(library="nodejs", reason="cache is implemented")
-@irrelevant(library="python", reason="cache is implemented")
-@irrelevant(library="dotnet", reason="cache is implemented")
 @irrelevant(library="java", reason="cache is implemented")
 @irrelevant(library="golang", reason="cache is implemented")
 @coverage.basic
@@ -414,7 +412,6 @@ class Test_RemoteConfigurationUpdateSequenceFeaturesNoCache(RemoteConfigurationF
 
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @irrelevant(library="nodejs", reason="cache is implemented")
-@irrelevant(library="dotnet", reason="cache is implemented")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_live_debugging_nocache
 class Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache(RemoteConfigurationFieldsBasicTests):
@@ -443,7 +440,6 @@ class Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache(RemoteConfigura
 
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @irrelevant(library="nodejs", reason="cache is implemented")
-@irrelevant(library="dotnet", reason="cache is implemented")
 @irrelevant(library="golang", reason="cache is implemented")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_asm_dd_nocache

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -11,7 +11,6 @@ from utils import weblog, interfaces, bug, scenarios
 TIMESTAMP_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z")
 
 
-@bug(library="golang", reason="Not receiving profiles")
 @bug(library="nodejs", reason="Not receiving profiles")
 @scenarios.profiling
 class Test_Profile:

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -11,7 +11,6 @@ from utils import weblog, interfaces, bug, scenarios
 TIMESTAMP_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z")
 
 
-@bug(library="dotnet", reason="Not receiving profiles")
 @bug(library="golang", reason="Not receiving profiles")
 @bug(library="nodejs", reason="Not receiving profiles")
 @scenarios.profiling

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -292,10 +292,7 @@ class Test_Meta:
         assert len(list(interfaces.library.get_root_spans())) != 0, "Did not recieve any root spans to validate."
 
 
-@bug(
-    context.library in ("cpp", "python"),
-    reason="Inconsistent implementation across tracers; will need a dedicated testing scenario",
-)
+@bug(library="cpp", reason="Inconsistent implementation across tracers; will need a dedicated testing scenario")
 class Test_MetaDatadogTags:
     """Spans carry meta tags that were set in DD_TAGS tracer environment"""
 


### PR DESCRIPTION
## Description

Migrate few leftovers in manifest files for .NET, Golang and python

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
