### PR TITLE
chore(python): improve build time

### DIFF
--- a/utils/build/docker/python/install_ddtrace.sh
+++ b/utils/build/docker/python/install_ddtrace.sh
@@ -6,6 +6,7 @@ cd /binaries
 
 if [ -e "dd-trace-py" ]; then
     echo "Install from local folder /binaries/dd-trace-py"
+    export CMAKE_BUILD_PARALLEL_LEVEL=12
     pip install /binaries/dd-trace-py
 elif [ "$(ls *.whl *.tar.gz | wc -l)" = "1" ]; then
     path=$(readlink -f $(ls *.whl *.tar.gz))


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

Improve Python tracer build times by leveraging CMake parallel build env var.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
