### PR TITLE
skip deprecated b3 headers tests since we dropped support for b3

### DIFF
--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -171,25 +171,30 @@ class Test_Headers_B3multi:
 
     @enable_b3_deprecated()
     @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
+    @irrelevant(context.library == "python", reason="library removed deprecated b3 config")
     def test_headers_b3multi_deprecated_extract_valid(self, test_agent, test_library):
         self.test_headers_b3multi_extract_valid(test_agent, test_library)
 
     @enable_b3_deprecated()
     @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
+    @irrelevant(context.library == "python", reason="library removed deprecated b3 config")
     def test_headers_b3multi_deprecated_extract_invalid(self, test_agent, test_library):
         self.test_headers_b3multi_extract_invalid(test_agent, test_library)
 
     @enable_b3_deprecated()
     @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
+    @irrelevant(context.library == "python", reason="library removed deprecated b3 config")
     def test_headers_b3multi_deprecated_inject_valid(self, test_agent, test_library):
         self.test_headers_b3multi_inject_valid(test_agent, test_library)
 
     @enable_b3_deprecated()
     @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
+    @irrelevant(context.library == "python", reason="library removed deprecated b3 config")
     def test_headers_b3multi_deprecated_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3multi_propagate_valid(test_agent, test_library)
 
     @enable_b3_deprecated()
     @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
+    @irrelevant(context.library == "python", reason="library removed deprecated b3 config")
     def test_headers_b3multi_deprecated_propagate_invalid(self, test_agent, test_library):
         self.test_headers_b3multi_propagate_invalid(test_agent, test_library)


### PR DESCRIPTION
Python tracer currently support `b3 single header` and `b3multi` after dropping support for `b3` which was deprecated in lieu of `b3multi`

## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
