### PR TITLE
[parametric] Update parametric tests for b3 trace context propagation headers

### DIFF
--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -151,7 +151,8 @@ class Test_Headers_B3:
     @enable_b3_single_key()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     @missing_feature(
-        context.library == "ruby", reason="Propagators not configured for DD_TRACE_PROPAGATION_STYLE config",
+        context.library > "ruby@1.99.0",
+        reason="Added DD_TRACE_PROPAGATION_STYLE config in version 1.8.0 but the name is no longer recognized in 2.x",
     )
     def test_headers_b3_single_key_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3_propagate_valid(test_agent, test_library)
@@ -212,8 +213,6 @@ class Test_Headers_B3:
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
-    @missing_feature(
-        context.library == "ruby", reason="Propagators not configured for DD_TRACE_PROPAGATION_STYLE config",
-    )
+    @missing_feature(context.library < "ruby@1.8.0", reason="Added DD_TRACE_PROPAGATION_STYLE config in version 1.8.0")
     def test_headers_b3_migrated_single_key_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3_propagate_valid(test_agent, test_library)

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -158,7 +158,7 @@ class Test_Headers_B3:
         self.test_headers_b3_propagate_valid(test_agent, test_library)
 
     @enable_migrated_b3()
-    @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "cpp", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "dotnet", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "golang", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
@@ -168,7 +168,7 @@ class Test_Headers_B3:
         self.test_headers_b3_extract_valid(test_agent, test_library)
 
     @enable_migrated_b3()
-    @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "cpp", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "golang", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
@@ -177,7 +177,7 @@ class Test_Headers_B3:
         self.test_headers_b3_extract_invalid(test_agent, test_library)
 
     @enable_migrated_b3()
-    @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "cpp", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "dotnet", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "golang", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
@@ -187,7 +187,7 @@ class Test_Headers_B3:
         self.test_headers_b3_inject_valid(test_agent, test_library)
 
     @enable_migrated_b3()
-    @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "cpp", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "dotnet", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "golang", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
@@ -197,7 +197,7 @@ class Test_Headers_B3:
         self.test_headers_b3_propagate_valid(test_agent, test_library)
 
     @enable_migrated_b3()
-    @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "cpp", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "dotnet", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "golang", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
@@ -207,7 +207,7 @@ class Test_Headers_B3:
         self.test_headers_b3_propagate_invalid(test_agent, test_library)
 
     @enable_migrated_b3_single_key()
-    @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library == "cpp", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "dotnet", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "golang", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -26,17 +26,6 @@ def enable_b3multi_single_key() -> Any:
     return parametrize("library_env", [env])
 
 
-def enable_b3_deprecated() -> Any:
-    env1 = {
-        "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "b3",
-        "DD_TRACE_PROPAGATION_STYLE_INJECT": "b3",
-    }
-    env2 = {
-        "DD_TRACE_PROPAGATION_STYLE": "b3",
-    }
-    return parametrize("library_env", [env1, env2])
-
-
 def enable_case_insensitive_b3multi() -> Any:
     env1 = {
         "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "B3MULTI",
@@ -167,32 +156,3 @@ class Test_Headers_B3multi:
     @missing_feature(context.library < "ruby@2.0.0", reason="Implemented in 2.x")
     def test_headers_b3multi_case_insensitive_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3multi_propagate_valid(test_agent, test_library)
-
-    @enable_b3_deprecated()
-    @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
-    @irrelevant(context.library == "python", reason="library removed deprecated b3 config")
-    def test_headers_b3multi_deprecated_extract_valid(self, test_agent, test_library):
-        self.test_headers_b3multi_extract_valid(test_agent, test_library)
-
-    @enable_b3_deprecated()
-    @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
-    def test_headers_b3multi_deprecated_extract_invalid(self, test_agent, test_library):
-        self.test_headers_b3multi_extract_invalid(test_agent, test_library)
-
-    @enable_b3_deprecated()
-    @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
-    @irrelevant(context.library == "python", reason="library removed deprecated b3 config")
-    def test_headers_b3multi_deprecated_inject_valid(self, test_agent, test_library):
-        self.test_headers_b3multi_inject_valid(test_agent, test_library)
-
-    @enable_b3_deprecated()
-    @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
-    @irrelevant(context.library == "python", reason="library removed deprecated b3 config")
-    def test_headers_b3multi_deprecated_propagate_valid(self, test_agent, test_library):
-        self.test_headers_b3multi_propagate_valid(test_agent, test_library)
-
-    @enable_b3_deprecated()
-    @irrelevant(context.library == "ruby", reason="library does not use deprecated b3 config")
-    @irrelevant(context.library == "python", reason="library removed deprecated b3 config")
-    def test_headers_b3multi_deprecated_propagate_invalid(self, test_agent, test_library):
-        self.test_headers_b3multi_propagate_invalid(test_agent, test_library)

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -156,6 +156,7 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi_single_key()
+    @missing_feature(context.library < "ruby@1.8.0", reason="Added DD_TRACE_PROPAGATION_STYLE config in version 1.8.0")
     def test_headers_b3multi_single_key_propagate_valid(self, test_agent, test_library):
         """Ensure that b3multi distributed tracing headers are extracted
         and injected properly.
@@ -163,6 +164,7 @@ class Test_Headers_B3multi:
         self.test_headers_b3multi_propagate_valid(test_agent, test_library)
 
     @enable_case_insensitive_b3multi()
+    @missing_feature(context.library < "ruby@2.0.0", reason="Implemented in 2.x")
     def test_headers_b3multi_case_insensitive_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3multi_propagate_valid(test_agent, test_library)
 


### PR DESCRIPTION
## Description

Updates the test skip annotations for Ruby and C++ b3 trace context propagation header tests, including unskipping tests for Ruby on new tracer versions.

## Motivation

Keeps the parametric test skip reasons up-to-date so we have a better understanding of why they are currently being skipped.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
