### PR TITLE
Check the seq_id of the app-started request [APPSEC-10465]

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -188,7 +188,6 @@ class Test_Telemetry:
 
     @bug(library="ruby", reason="app-started not sent")
     @bug(library="python", reason="app-started not sent first")
-    @flaky(library="nodejs", reason="APPSEC-10465")
     def test_app_started_is_first_message(self):
         """Request type app-started is the first telemetry message or the first message in the first batch"""
         telemetry_data = list(interfaces.library.get_telemetry_data(flatten_message_batches=False))
@@ -199,8 +198,14 @@ class Test_Telemetry:
                 first_message.get("request_type") == "app-started"
             ), "app-started was not the first message in the first batch"
         else:
-            first_message = telemetry_data[0]["request"]["content"]
-            assert first_message.get("request_type") == "app-started", "app-started was not the first message"
+            for data in telemetry_data:
+                req_content = data["request"]["content"]
+                if req_content["request_type"] == "app-started":
+                    seq_id = req_content["seq_id"]
+                    assert seq_id == 1, f"app-started found but it was not the first message sent"
+                    return
+
+            raise Exception(f"app-started message not found")
 
     @bug(
         library="java",


### PR DESCRIPTION
## Description

Make `test_app_started_is_first_message` less strict checking that `app-started` message was sent first, based on the request's `seq_id`, allowing the message to not necessarily arrive first

## Motivation

Remove flaky `test_app_started_is_first_message` test in nodejs

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
