### PR TITLE
Enabled test for extra tags in AppSecEvent report for Java

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -643,10 +643,7 @@ tests/:
       Test_AttackTimestamp:
         akka-http: missing_feature (No AppSec support)
         spring-boot-payara: missing_feature (No AppSec support)
-      Test_ExtraTagsFromRule:
-        '*': v1.14.0
-        akka-http: missing_feature (No AppSec support)
-        spring-boot-payara: missing_feature (No AppSec support)
+      Test_ExtraTagsFromRule: v1.22.0    # Supported since v1.22.0
       Test_HttpClientIP:
         '*': v0.98.1
         akka-http: missing_feature (No AppSec support)

--- a/tests/appsec/test_reports.py
+++ b/tests/appsec/test_reports.py
@@ -164,7 +164,6 @@ class Test_TagsFromRule:
 
 
 @coverage.basic
-@bug(context.library >= "java@1.14.0", reason="APPSEC-11111")  # released at 1.14.0, but bugged
 class Test_ExtraTagsFromRule:
     """Extra tags may be added to the rule match since libddwaf 1.10.0"""
 


### PR DESCRIPTION
## Description
Enabled test for extra tags in AppSecEvent report for Java.

## Motivation
Missing functionality have been added in the Java tracer
See: [APPSEC-11111](https://datadoghq.atlassian.net/browse/APPSEC-11111)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly


[APPSEC-11111]: https://datadoghq.atlassian.net/browse/APPSEC-11111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ