### PR TITLE
Add hsts and x content type missing headers to nodejs system tests

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -21,6 +21,7 @@ tests/:
             '*': missing_feature
             express4: v3.11.0
         test_hsts_missing_header.py: 
+          Test_HstsMissingHeader:
             '*': missing_feature
             express4: v4.8.0
         test_insecure_cookie.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -21,7 +21,8 @@ tests/:
             '*': missing_feature
             express4: v3.11.0
         test_hsts_missing_header.py: 
-          Test_HstsMissingHeader: missing_feature
+            '*': missing_feature
+            express4: v4.8.0
         test_insecure_cookie.py:
           TestInsecureCookie:
             '*': missing_feature
@@ -59,7 +60,9 @@ tests/:
         test_weak_randomness.py:
           TestWeakRandomness: missing_feature
         test_xcontent_sniffing.py:
-          Test_XContentSniffing: missing_feature        
+          Test_XContentSniffing: 
+            '*': missing_feature
+            express4: v4.8.0
         test_xpath_injection.py:
           TestXPathInjection: missing_feature
         test_xss.py:

--- a/tests/appsec/iast/sink/test_hsts_missing_header.py
+++ b/tests/appsec/iast/sink/test_hsts_missing_header.py
@@ -15,7 +15,6 @@ class Test_HstsMissingHeader:
         http_method="GET",
         insecure_endpoint="/iast/hstsmissing/test_insecure",
         secure_endpoint="/iast/hstsmissing/test_secure",
-        location_map={"nodejs": "iast/index.js",},
         data={},
     )
 
@@ -44,7 +43,6 @@ class Test_HstsMissingHeader:
     def setup_telemetry_metric_instrumented_sink(self):
         self.sink_fixture.setup_telemetry_metric_instrumented_sink()
 
-    @missing_feature(library="nodejs", reason="Metrics implemented")
     @missing_feature(library="java", reason="Metrics implemented")
     def test_telemetry_metric_instrumented_sink(self):
         self.sink_fixture.test_telemetry_metric_instrumented_sink()
@@ -52,7 +50,6 @@ class Test_HstsMissingHeader:
     def setup_telemetry_metric_executed_sink(self):
         self.sink_fixture.setup_telemetry_metric_executed_sink()
 
-    @missing_feature(library="nodejs", reason="Metrics implemented")
     @missing_feature(library="java", reason="Metrics implemented")
     def test_telemetry_metric_executed_sink(self):
         self.sink_fixture.test_telemetry_metric_executed_sink()

--- a/tests/appsec/iast/sink/test_xcontent_sniffing.py
+++ b/tests/appsec/iast/sink/test_xcontent_sniffing.py
@@ -33,7 +33,6 @@ class Test_XContentSniffing:
     def setup_telemetry_metric_instrumented_sink(self):
         self.sink_fixture.setup_telemetry_metric_instrumented_sink()
 
-    @missing_feature(library="nodejs", reason="Metrics implemented")
     @missing_feature(library="java", reason="Metrics implemented")
     def test_telemetry_metric_instrumented_sink(self):
         self.sink_fixture.test_telemetry_metric_instrumented_sink()
@@ -41,7 +40,6 @@ class Test_XContentSniffing:
     def setup_telemetry_metric_executed_sink(self):
         self.sink_fixture.setup_telemetry_metric_executed_sink()
 
-    @missing_feature(library="nodejs", reason="Metrics implemented")
     @missing_feature(library="java", reason="Metrics implemented")
     def test_telemetry_metric_executed_sink(self):
         self.sink_fixture.test_telemetry_metric_executed_sink()

--- a/utils/build/docker/nodejs/express4/app.js
+++ b/utils/build/docker/nodejs/express4/app.js
@@ -10,11 +10,15 @@ const axios = require('axios');
 const fs = require('fs');
 const passport = require('passport')
 
+const iast = require("./iast")
+
+iast.initData().catch(() => {})
 
 app.use(require("body-parser").json());
 app.use(require("body-parser").urlencoded({ extended: true }));
 app.use(require("express-xml-bodyparser")());
 app.use(require("cookie-parser")());
+iast.initMiddlewares(app)
 
 app.get("/", (req, res) => {
   console.log("Received a request");
@@ -222,7 +226,8 @@ app.get('/db', async (req, res) => {
   }
 });
 
-require("./iast")(app, tracer);
+iast.initRoutes(app, tracer)
+
 require('./auth')(app, passport, tracer)
 require('./graphql')(app)
 

--- a/utils/build/docker/nodejs/express4/iast/index.js
+++ b/utils/build/docker/nodejs/express4/iast/index.js
@@ -229,6 +229,7 @@ function initRoutes (app, tracer) {
   });
 
   app.get('/iast/xcontent-missing-header/test_secure', (req, res) => {
+    res.setHeader('Content-Type', 'text/html')
     res.send('<html><body><h1>Test</h1></html>')
   })
 

--- a/utils/build/docker/nodejs/express4/iast/index.js
+++ b/utils/build/docker/nodejs/express4/iast/index.js
@@ -3,8 +3,8 @@
 const { Client, Pool } = require('pg')
 const { readFileSync, statSync } = require('fs')
 const { join } = require('path')
-const crypto = require('crypto');
-const { execSync } = require('child_process');
+const crypto = require('crypto')
+const { execSync } = require('child_process')
 const https = require('https');
 
 function initData () {
@@ -14,9 +14,22 @@ function initData () {
     return client.query(query)
   })
 }
-function init (app, tracer) {  
-  initData().catch(() => {})
 
+function initMiddlewares (app) {
+  const hstsMissingInsecurePattern = /.*hstsmissing\/test_insecure$/gmi
+  const xcontenttypeMissingInsecurePattern = /.*xcontent-missing-header\/test_insecure$/gmi
+  app.use((req, res, next) => {
+    if (!req.url.match(hstsMissingInsecurePattern)) {
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000')
+    }
+    if (!req.url.match(xcontenttypeMissingInsecurePattern)) {
+      res.setHeader('X-Content-Type-Options', 'nosniff')
+    }
+    next()
+  })
+}
+
+function initRoutes (app, tracer) { 
   app.get('/iast/insecure_hashing/deduplicate', (req, res) => {
     const span = tracer.scope().active();
     span.setTag('appsec.event"', true);
@@ -199,8 +212,28 @@ function init (app, tracer) {
     res.redirect(req.body.location)
   });
 
-  require('./sources')(app, tracer);
+  app.get('/iast/hstsmissing/test_insecure', (req, res) => {
+    res.setHeader('Content-Type', 'text/html')
+    res.end('<html><body><h1>Test</h1></html>')
+  })
+
+  app.get('/iast/hstsmissing/test_secure', (req, res) => {
+    res.setHeader('Strict-Transport-Security', 'max-age=31536000')
+    res.setHeader('X-Content-Type-Options', 'nosniff')
+    res.send('<html><body><h1>Test</h1></html>')
+  })
+
+  app.get('/iast/xcontent-missing-header/test_insecure', (req, res) => {
+    res.setHeader('Content-Type', 'text/html')
+    res.end('<html><body><h1>Test</h1></html>')
+  });
+
+  app.get('/iast/xcontent-missing-header/test_secure', (req, res) => {
+    res.send('<html><body><h1>Test</h1></html>')
+  })
+
+  require('./sources')(app, tracer)
 
 }
 
-module.exports = init;
+module.exports = { initRoutes, initData, initMiddlewares }


### PR DESCRIPTION
## Description
Enable HSTS and X-Content-Type missing headers for nodejs.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
