### PR TITLE
Set Test_HstsMissingHeader as bugged in Java

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -32,12 +32,12 @@ tests/:
             vertx4: v1.12.0
         test_hsts_missing_header.py:
           Test_HstsMissingHeader:
-            "*": "missing_feature"
-            sping-boot-undertow: "v1.20.0"
-            spring-boot: "v1.20.0"
-            spring-boot-jetty: "v1.20.0"
-            spring-boot-wildfly: "v1.20.0"
-            uds-spring-boot: "v1.20.0"            
+            '*': missing_feature
+            sping-boot-undertow: v1.22.0
+            spring-boot: v1.22.0
+            spring-boot-jetty: v1.22.0
+            spring-boot-wildfly: v1.22.0
+            uds-spring-boot: v1.22.0
         test_insecure_cookie.py:
           TestInsecureCookie:
             '*': v1.18.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -32,12 +32,12 @@ tests/:
             vertx4: v1.12.0
         test_hsts_missing_header.py:
           Test_HstsMissingHeader:
-            '*': missing_feature
-            sping-boot-undertow: v1.22.0
-            spring-boot: v1.22.0
-            spring-boot-jetty: v1.22.0
-            spring-boot-wildfly: v1.22.0
-            uds-spring-boot: v1.22.0
+            "*": "missing_feature"
+            sping-boot-undertow: "v1.20.0"
+            spring-boot: "v1.20.0"
+            spring-boot-jetty: "v1.20.0"
+            spring-boot-wildfly: "v1.20.0"
+            uds-spring-boot: "v1.20.0"            
         test_insecure_cookie.py:
           TestInsecureCookie:
             '*': v1.18.0

--- a/tests/appsec/iast/sink/test_hsts_missing_header.py
+++ b/tests/appsec/iast/sink/test_hsts_missing_header.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, coverage, missing_feature, weblog
+from utils import bug, context, coverage, missing_feature, weblog
 from .._test_iast_fixtures import SinkFixture
 
 
@@ -30,6 +30,7 @@ class Test_HstsMissingHeader:
     def test_insecure(self):
         self.sink_fixture.test_insecure()
 
+    @bug(library="java", reason="Unrelated bug interferes with this test APPSEC-11353")
     def setup_secure(self):
         self.sink_fixture.secure_request = weblog.request(
             method=self.sink_fixture.http_method,


### PR DESCRIPTION
## Description

Related to APPSEC-11353

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
