### PR TITLE
Restrict HSTS @bug to java <1.22.0

### DIFF
--- a/tests/appsec/iast/sink/test_hsts_missing_header.py
+++ b/tests/appsec/iast/sink/test_hsts_missing_header.py
@@ -30,7 +30,7 @@ class Test_HstsMissingHeader:
     def test_insecure(self):
         self.sink_fixture.test_insecure()
 
-    @bug(library="java", reason="Unrelated bug interferes with this test APPSEC-11353")
+    @bug(context.library < "java@1.22.0", reason="Unrelated bug interferes with this test APPSEC-11353")
     def setup_secure(self):
         self.sink_fixture.secure_request = weblog.request(
             method=self.sink_fixture.http_method,


### PR DESCRIPTION
## Description

Now fixed in master: https://github.com/DataDog/dd-trace-java/pull/5950

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [x] CI is green
   * [x] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
