### PR TITLE
Remove postgres container from default scenario

### DIFF
--- a/tests/appsec/iast/sink/test_sql_injection.py
+++ b/tests/appsec/iast/sink/test_sql_injection.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, coverage, missing_feature
+from utils import context, coverage, missing_feature, scenarios
 from .._test_iast_fixtures import SinkFixture
 
 
@@ -26,12 +26,14 @@ class TestSqlInjection:
     def setup_insecure(self):
         self.sink_fixture.setup_insecure()
 
+    @scenarios.integrations
     def test_insecure(self):
         self.sink_fixture.test_insecure()
 
     def setup_secure(self):
         self.sink_fixture.setup_secure()
 
+    @scenarios.integrations
     def test_secure(self):
         self.sink_fixture.test_secure()
 

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -898,9 +898,7 @@ class scenarios:
     mock_the_test = TestTheTestScenario("MOCK_THE_TEST", doc="Mock scenario that check system-tests internals")
 
     default = EndToEndScenario(
-        "DEFAULT",
-        include_postgres_db=True,
-        doc="Default scenario, spwan tracer and agent, and run most of exisiting tests",
+        "DEFAULT", doc="Default scenario, spwan tracer and agent, and run most of exisiting tests",
     )
     sleep = EndToEndScenario(
         "SLEEP",

--- a/utils/build/docker/nodejs/express4/iast/index.js
+++ b/utils/build/docker/nodejs/express4/iast/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Client, Pool } = require('pg')
+const { Client } = require('pg')
 const { readFileSync, statSync } = require('fs')
 const { join } = require('path')
 const crypto = require('crypto')
@@ -12,6 +12,8 @@ function initData () {
   const client = new Client()
   return client.connect().then(() => {
     return client.query(query)
+  }).catch(() => {
+    // do nothing, just continue
   })
 }
 


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
