### PR TITLE
[APPSEC-10967] Update ruby weblog variants for API security response body test

### DIFF
--- a/utils/build/docker/ruby/rails32/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails32/app/controllers/system_test_controller.rb
@@ -95,7 +95,7 @@ class SystemTestController < ApplicationController
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)
 
     headers.each do |key, value|
-      response.set_header(key, value)
+      response.headers[key] = value
     end
 
     render text: 'Value tagged', status: status_code

--- a/utils/build/docker/ruby/rails32/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails32/app/controllers/system_test_controller.rb
@@ -81,15 +81,21 @@ class SystemTestController < ApplicationController
   end
 
   def tag_value
-    headers = request.query_string.split('&').map {|e | e.split('=')} || []
-    event_value = params[:key]
+    event_value = params[:tag_value]
     status_code = params[:status_code]
+
+    if request.method == "POST" && event_value.include?('payload_in_response_body')
+      render json: { payload: request.POST }
+      return
+    end
+
+    headers = request.query_string.split('&').map {|e | e.split('=')} || []
 
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)
 
     headers.each do |key, value|
-      response.headers[key] = value
+      response.set_header(key, value)
     end
 
     render text: 'Value tagged', status: status_code

--- a/utils/build/docker/ruby/rails32/config/routes.rb
+++ b/utils/build/docker/ruby/rails32/config/routes.rb
@@ -76,8 +76,8 @@ Rails32::Application.routes.draw do
   get 'user_login_failure_event' => 'system_test#user_login_failure_event'
   get 'custom_event' => 'system_test#custom_event'
   %i(get post).each do |request_method|
-    send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
+    send(request_method, '/tag_value/:tag_value/:status_code' => 'system_test#tag_value')
   end
-  match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  match '/tag_value/:tag_value/:status_code' => 'system_test#tag_value', via: :options
   get '/users' => 'system_test#users'
 end

--- a/utils/build/docker/ruby/rails40/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails40/app/controllers/system_test_controller.rb
@@ -95,7 +95,7 @@ class SystemTestController < ApplicationController
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)
 
     headers.each do |key, value|
-      response.set_header(key, value)
+      response.headers[key] = value
     end
 
     render text: 'Value tagged', status: status_code

--- a/utils/build/docker/ruby/rails40/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails40/app/controllers/system_test_controller.rb
@@ -81,15 +81,21 @@ class SystemTestController < ApplicationController
   end
 
   def tag_value
-    headers = request.query_string.split('&').map {|e | e.split('=')} || []
-    event_value = params[:key]
+    event_value = params[:tag_value]
     status_code = params[:status_code]
+
+    if request.method == "POST" && event_value.include?('payload_in_response_body')
+      render json: { payload: request.POST }
+      return
+    end
+
+    headers = request.query_string.split('&').map {|e | e.split('=')} || []
 
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)
 
     headers.each do |key, value|
-      response.headers[key] = value
+      response.set_header(key, value)
     end
 
     render text: 'Value tagged', status: status_code

--- a/utils/build/docker/ruby/rails40/config/routes.rb
+++ b/utils/build/docker/ruby/rails40/config/routes.rb
@@ -20,9 +20,9 @@ Rails40::Application.routes.draw do
   get 'custom_event' => 'system_test#custom_event'
 
   %i(get post).each do |request_method|
-    send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
+    send(request_method, '/tag_value/:tag_value/:status_code' => 'system_test#tag_value')
   end
-  match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  match '/tag_value/:tag_value/:status_code' => 'system_test#tag_value', via: :options
   get '/users' => 'system_test#users'
 
   devise_for :users

--- a/utils/build/docker/ruby/rails41/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails41/app/controllers/system_test_controller.rb
@@ -104,15 +104,21 @@ class SystemTestController < ApplicationController
   end
 
   def tag_value
-    headers = request.query_string.split('&').map {|e | e.split('=')} || []
-    event_value = params[:key]
+    event_value = params[:tag_value]
     status_code = params[:status_code]
+
+    if request.method == "POST" && event_value.include?('payload_in_response_body')
+      render json: { payload: request.POST }
+      return
+    end
+
+    headers = request.query_string.split('&').map {|e | e.split('=')} || []
 
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)
 
     headers.each do |key, value|
-      response.headers[key] = value
+      response.set_header(key, value)
     end
 
     render plain: 'Value tagged', status: status_code

--- a/utils/build/docker/ruby/rails41/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails41/app/controllers/system_test_controller.rb
@@ -118,7 +118,7 @@ class SystemTestController < ApplicationController
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)
 
     headers.each do |key, value|
-      response.set_header(key, value)
+      response.headers[key] = value
     end
 
     render plain: 'Value tagged', status: status_code

--- a/utils/build/docker/ruby/rails41/config/routes.rb
+++ b/utils/build/docker/ruby/rails41/config/routes.rb
@@ -20,9 +20,9 @@ Rails.application.routes.draw do
   get 'custom_event' => 'system_test#custom_event'
 
  %i(get post).each do |request_method|
-    send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
+    send(request_method, '/tag_value/:tag_value/:status_code' => 'system_test#tag_value')
   end
-  match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  match '/tag_value/:tag_value/:status_code' => 'system_test#tag_value', via: :options
   get '/users' => 'system_test#users'
 
   devise_for :users

--- a/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
@@ -104,15 +104,21 @@ class SystemTestController < ApplicationController
   end
 
   def tag_value
-    headers = request.query_string.split('&').map {|e | e.split('=')} || []
-    event_value = params[:key]
+    event_value = params[:tag_value]
     status_code = params[:status_code]
+
+    if request.method == "POST" && event_value.include?('payload_in_response_body')
+      render json: { payload: request.POST }
+      return
+    end
+
+    headers = request.query_string.split('&').map {|e | e.split('=')} || []
 
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)
 
     headers.each do |key, value|
-      response.headers[key] = value
+      response.set_header(key, value)
     end
 
     render plain: 'Value tagged', status: status_code

--- a/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
@@ -118,7 +118,7 @@ class SystemTestController < ApplicationController
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)
 
     headers.each do |key, value|
-      response.set_header(key, value)
+      response.headers[key] = value
     end
 
     render plain: 'Value tagged', status: status_code

--- a/utils/build/docker/ruby/rails42/config/routes.rb
+++ b/utils/build/docker/ruby/rails42/config/routes.rb
@@ -19,9 +19,9 @@ Rails.application.routes.draw do
   get 'user_login_failure_event' => 'system_test#user_login_failure_event'
   get 'custom_event' => 'system_test#custom_event'
  %i(get post).each do |request_method|
-    send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
+    send(request_method, '/tag_value/:tag_value/:status_code' => 'system_test#tag_value')
   end
-  match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  match '/tag_value/:tag_value/:status_code' => 'system_test#tag_value', via: :options
   get '/users' => 'system_test#users'
 
   devise_for :users

--- a/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
@@ -104,9 +104,15 @@ class SystemTestController < ApplicationController
   end
 
   def tag_value
-    headers = request.query_string.split('&').map {|e | e.split('=')} || []
-    event_value = params[:key]
+    event_value = params[:tag_value]
     status_code = params[:status_code]
+
+    if request.method == "POST" && event_value.include?('payload_in_response_body')
+      render json: { payload: request.POST }
+      return
+    end
+
+    headers = request.query_string.split('&').map {|e | e.split('=')} || []
 
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)

--- a/utils/build/docker/ruby/rails50/config/routes.rb
+++ b/utils/build/docker/ruby/rails50/config/routes.rb
@@ -22,9 +22,9 @@ Rails.application.routes.draw do
   get 'custom_event' => 'system_test#custom_event'
 
  %i(get post).each do |request_method|
-    send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
+    send(request_method, '/tag_value/:tag_value/:status_code' => 'system_test#tag_value')
   end
-  match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  match '/tag_value/:tag_value/:status_code' => 'system_test#tag_value', via: :options
   get '/users' => 'system_test#users'
 
   devise_for :users

--- a/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
@@ -103,9 +103,15 @@ class SystemTestController < ApplicationController
   end
 
   def tag_value
-    headers = request.query_string.split('&').map {|e | e.split('=')} || []
-    event_value = params[:key]
+    event_value = params[:tag_value]
     status_code = params[:status_code]
+
+    if request.method == "POST" && event_value.include?('payload_in_response_body')
+      render json: { payload: request.POST }
+      return
+    end
+
+    headers = request.query_string.split('&').map {|e | e.split('=')} || []
 
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)

--- a/utils/build/docker/ruby/rails51/config/routes.rb
+++ b/utils/build/docker/ruby/rails51/config/routes.rb
@@ -22,9 +22,9 @@ Rails.application.routes.draw do
   get 'custom_event' => 'system_test#custom_event'
 
  %i(get post).each do |request_method|
-    send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
+    send(request_method, '/tag_value/:tag_value/:status_code' => 'system_test#tag_value')
   end
-  match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  match '/tag_value/:tag_value/:status_code' => 'system_test#tag_value', via: :options
   get '/users' => 'system_test#users'
 
   devise_for :users

--- a/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
@@ -104,9 +104,15 @@ class SystemTestController < ApplicationController
   end
 
   def tag_value
-    headers = request.query_string.split('&').map {|e | e.split('=')} || []
-    event_value = params[:key]
+    event_value = params[:tag_value]
     status_code = params[:status_code]
+
+    if request.method == "POST" && event_value.include?('payload_in_response_body')
+      render json: { payload: request.POST }
+      return
+    end
+
+    headers = request.query_string.split('&').map {|e | e.split('=')} || []
 
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)

--- a/utils/build/docker/ruby/rails52/config/routes.rb
+++ b/utils/build/docker/ruby/rails52/config/routes.rb
@@ -22,9 +22,9 @@ Rails.application.routes.draw do
   get 'custom_event' => 'system_test#custom_event'
 
  %i(get post).each do |request_method|
-    send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
+    send(request_method, '/tag_value/:tag_value/:status_code' => 'system_test#tag_value')
   end
-  match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  match '/tag_value/:tag_value/:status_code' => 'system_test#tag_value', via: :options
   get '/users' => 'system_test#users'
 
   devise_for :users

--- a/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
@@ -124,9 +124,15 @@ class SystemTestController < ApplicationController
   end
 
   def tag_value
-    headers = request.query_string.split('&').map {|e | e.split('=')} || []
-    event_value = params[:key]
+    event_value = params[:tag_value]
     status_code = params[:status_code]
+
+    if request.method == "POST" && event_value.include?('payload_in_response_body')
+      render json: { payload: request.POST }
+      return
+    end
+
+    headers = request.query_string.split('&').map {|e | e.split('=')} || []
 
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)

--- a/utils/build/docker/ruby/rails60/config/routes.rb
+++ b/utils/build/docker/ruby/rails60/config/routes.rb
@@ -22,9 +22,9 @@ Rails.application.routes.draw do
   get 'custom_event' => 'system_test#custom_event'
 
  %i(get post).each do |request_method|
-    send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
+    send(request_method, '/tag_value/:tag_value/:status_code' => 'system_test#tag_value')
   end
-  match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  match '/tag_value/:tag_value/:status_code' => 'system_test#tag_value', via: :options
   get '/users' => 'system_test#users'
 
   devise_for :users

--- a/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
@@ -104,9 +104,15 @@ class SystemTestController < ApplicationController
   end
 
   def tag_value
-    headers = request.query_string.split('&').map {|e | e.split('=')} || []
-    event_value = params[:key]
+    event_value = params[:tag_value]
     status_code = params[:status_code]
+
+    if request.method == "POST" && event_value.include?('payload_in_response_body')
+      render json: { payload: request.POST }
+      return
+    end
+
+    headers = request.query_string.split('&').map {|e | e.split('=')} || []
 
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)

--- a/utils/build/docker/ruby/rails61/config/routes.rb
+++ b/utils/build/docker/ruby/rails61/config/routes.rb
@@ -22,9 +22,9 @@ Rails.application.routes.draw do
   get 'custom_event' => 'system_test#custom_event'
 
  %i(get post).each do |request_method|
-    send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
+    send(request_method, '/tag_value/:tag_value/:status_code' => 'system_test#tag_value')
   end
-  match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  match '/tag_value/:tag_value/:status_code' => 'system_test#tag_value', via: :options
   get '/users' => 'system_test#users'
 
   devise_for :users

--- a/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
@@ -107,9 +107,15 @@ class SystemTestController < ApplicationController
   end
 
   def tag_value
-    headers = request.query_string.split('&').map {|e | e.split('=')} || []
-    event_value = params[:key]
+    event_value = params[:tag_value]
     status_code = params[:status_code]
+
+    if request.method == "POST" && event_value.include?('payload_in_response_body')
+      render json: { payload: request.POST }
+      return
+    end
+
+    headers = request.query_string.split('&').map {|e | e.split('=')} || []
 
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", event_value)

--- a/utils/build/docker/ruby/rails70/config/routes.rb
+++ b/utils/build/docker/ruby/rails70/config/routes.rb
@@ -26,10 +26,10 @@ Rails.application.routes.draw do
   get 'custom_event' => 'system_test#custom_event'
 
   %i(get post).each do |request_method|
-    send(request_method, '/tag_value/:key/:status_code' => 'system_test#tag_value')
+    send(request_method, '/tag_value/:tag_value/:status_code' => 'system_test#tag_value')
   end
 
-  match '/tag_value/:key/:status_code' => 'system_test#tag_value', via: :options
+  match '/tag_value/:tag_value/:status_code' => 'system_test#tag_value', via: :options
 
   get '/users' => 'system_test#users'
 

--- a/utils/build/docker/ruby/sinatra14/app.rb
+++ b/utils/build/docker/ruby/sinatra14/app.rb
@@ -154,6 +154,11 @@ end
 
 %i(get post options).each do |request_method|
   send(request_method, '/tag_value/:tag_value/:status_code') do
+    if request_method == :post && params["tag_value"].include?('payload_in_response_body')
+      content_type :json
+      return {"payload":  request.POST }.to_json
+    end
+
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", params["tag_value"])
 

--- a/utils/build/docker/ruby/sinatra20/app.rb
+++ b/utils/build/docker/ruby/sinatra20/app.rb
@@ -153,6 +153,11 @@ end
 
 %i(get post options).each do |request_method|
   send(request_method, '/tag_value/:tag_value/:status_code') do
+    if request_method == :post && params["tag_value"].include?('payload_in_response_body')
+      content_type :json
+      return {"payload":  request.POST }.to_json
+    end
+
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", params["tag_value"])
 

--- a/utils/build/docker/ruby/sinatra21/app.rb
+++ b/utils/build/docker/ruby/sinatra21/app.rb
@@ -153,6 +153,11 @@ end
 
 %i(get post options).each do |request_method|
   send(request_method, '/tag_value/:tag_value/:status_code') do
+    if request_method == :post && params["tag_value"].include?('payload_in_response_body')
+      content_type :json
+      return {"payload":  request.POST }.to_json
+    end
+
     trace = Datadog::Tracing.active_trace
     trace.set_tag("appsec.events.system_tests_appsec_event.value", params["tag_value"])
 


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

Update the Ruby weblog to be able to handle the case ASM API Security response body scenario

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
