### PR TITLE
Reactivate test_app_started_sent_exactly_once for python

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -169,7 +169,7 @@ class Test_Telemetry:
                     raise Exception(f"Detected non consecutive seq_ids between {seq_ids[i + 1][1]} and {seq_ids[i][1]}")
 
     @bug(library="ruby", reason="app-started not sent")
-    @flaky(library="python", reason="app-started is sent twice")
+    @flaky(context.library <= "python@1.20.2", reason="app-started is sent twice")
     def test_app_started_sent_exactly_once(self):
         """Request type app-started is sent exactly once"""
 


### PR DESCRIPTION
## Description

Reactivating a test that should have been fixed by https://github.com/DataDog/dd-trace-py/pull/7043

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
