### PR TITLE
Update version number for python/api-security

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -9,39 +9,39 @@ tests/:
       test_schemas.py:
         Test_Schema_Request_Body:
           '*': missing_feature
-          django-poc: v1.21.0.dev
-          flask-poc: v1.21.0.dev
-          python3.12: v1.21.0.dev
+          django-poc: v2.1.0.dev
+          flask-poc: v2.1.0.dev
+          python3.12: v2.1.0.dev
         Test_Schema_Request_Cookies:
           '*': missing_feature
-          django-poc: v1.21.0.dev
-          flask-poc: v1.21.0.dev
-          python3.12: v1.21.0.dev
+          django-poc: v2.1.0.dev
+          flask-poc: v2.1.0.dev
+          python3.12: v2.1.0.dev
         Test_Schema_Request_Headers:
           '*': missing_feature
-          django-poc: v1.21.0.dev
-          flask-poc: v1.21.0.dev
-          python3.12: v1.21.0.dev
+          django-poc: v2.1.0.dev
+          flask-poc: v2.1.0.dev
+          python3.12: v2.1.0.dev
         Test_Schema_Request_Path_Parameters:
           '*': missing_feature
-          django-poc: v1.21.0.dev
-          flask-poc: v1.21.0.dev
-          python3.12: v1.21.0.dev
+          django-poc: v2.1.0.dev
+          flask-poc: v2.1.0.dev
+          python3.12: v2.1.0.dev
         Test_Schema_Request_Query_Parameters:
           '*': missing_feature
-          django-poc: v1.21.0.dev
-          flask-poc: v1.21.0.dev
-          python3.12: v1.21.0.dev
+          django-poc: v2.1.0.dev
+          flask-poc: v2.1.0.dev
+          python3.12: v2.1.0.dev
         Test_Schema_Response_Body:
           '*': missing_feature
-          django-poc: v1.21.0.dev
-          flask-poc: v1.21.0.dev
-          python3.12: v1.21.0.dev
+          django-poc: v2.1.0.dev
+          flask-poc: v2.1.0.dev
+          python3.12: v2.1.0.dev
         Test_Schema_Response_Headers:
           '*': missing_feature
-          django-poc: v1.21.0.dev
-          flask-poc: v1.21.0.dev
-          python3.12: v1.21.0.dev
+          django-poc: v2.1.0.dev
+          flask-poc: v2.1.0.dev
+          python3.12: v2.1.0.dev
     iast/:
       sink/:
         test_command_injection.py:

--- a/tests/test_the_test/test_version.py
+++ b/tests/test_the_test/test_version.py
@@ -42,6 +42,9 @@ def test_version_comparizon():
     assert Version("1.1.0rc2.dev15+gc41d325d", "python") >= "1.1.0rc2.dev"
     assert Version("1.1.0", "python") > "1.1.0rc2.dev"
 
+    assert Version("2.1.0.dev", "python") < "2.1.0.dev83+gac1037728"
+    assert Version("2.1.0.dev", "python") < "2.1.0"
+
 
 def test_version_serialization():
 


### PR DESCRIPTION
## Description

`tests/appsec/api_security/test_schemas.py` tests are failing on `2.0.0`, but are ok on the `2.x` branch.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
