### PR TITLE
Parametric: dump scenario context to json report

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -505,6 +505,8 @@ def apm_test_server_image(
 def apm_test_server(request, library_env, test_id, apm_test_server_image):
     """Request level definition of the library test server with the session Docker image built"""
     new_env = dict(library_env)
+    context.scenario.parametrized_tests_metadata[request.node.nodeid] = new_env
+
     new_env.update(apm_test_server_image.env)
     yield dataclasses.replace(
         apm_test_server_image,

--- a/utils/_context/core.py
+++ b/utils/_context/core.py
@@ -83,8 +83,12 @@ class _Context:
         result |= self.components
 
         # If a test is parametrized, it could contain specific data for each test. This node will contain this data associated with test id
+        # If we are on multi thread environment we need to store this data on a file. We should deserialize json data (extract data from file)
         if self.parametrized_tests_metadata:
-            result["parametrized_tests_metadata"] = self.parametrized_tests_metadata
+            try:
+                result["parametrized_tests_metadata"] = self.parametrized_tests_metadata.deserialize()
+            except AttributeError:
+                result["parametrized_tests_metadata"] = self.parametrized_tests_metadata
 
         if self.library == "php":
             result["php_appsec"] = self.php_appsec


### PR DESCRIPTION
## Description

Dump test specific configuration on the json results report, in order to be uploaded correctly to FPD

## Motivation

We need to generate results report as other scenarios in order to push the content to FPD

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
