### PR TITLE
feat(python): enable iast ssrf vulnerability

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -68,14 +68,11 @@ tests/:
             python3.12: missing_feature
         test_sql_injection.py:
           TestSqlInjection:
-            django-poc: v1.12.0
-            flask-poc: v1.12.0
-            pylons: missing_feature
+            '*': v1.12.0
             python3.12: missing_feature
-            uds-flask: missing_feature
-            uwsgi-poc: missing_feature
         test_ssrf.py:
-          TestSSRF: missing_feature
+            '*': v2.2.0
+            python3.12: missing_feature
         test_trust_boundary_violation.py:
           Test_TrustBoundaryViolation: missing_feature
         test_unvalidated_redirect.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -71,6 +71,7 @@ tests/:
             '*': v1.12.0
             python3.12: missing_feature
         test_ssrf.py:
+          TestSSRF:
             '*': v2.2.0
             python3.12: missing_feature
         test_trust_boundary_violation.py:

--- a/tests/appsec/iast/sink/test_ssrf.py
+++ b/tests/appsec/iast/sink/test_ssrf.py
@@ -16,7 +16,11 @@ class TestSSRF:
         insecure_endpoint="/iast/ssrf/test_insecure",
         secure_endpoint="/iast/ssrf/test_secure",
         data={"url": "https://www.datadoghq.com"},
-        location_map={"java": "com.datadoghq.system_tests.iast.utils.SsrfExamples", "nodejs": "iast/index.js",},
+        location_map={
+            "java": "com.datadoghq.system_tests.iast.utils.SsrfExamples",
+            "nodejs": "iast/index.js",
+            "python": {"flask-poc": "app.py", "django-poc": "app/urls.py"},
+        },
     )
 
     def setup_insecure(self):
@@ -35,6 +39,7 @@ class TestSSRF:
     def setup_telemetry_metric_instrumented_sink(self):
         self.sink_fixture.setup_telemetry_metric_instrumented_sink()
 
+    @missing_feature(library="python", reason="Endpoint not implemented")
     def test_telemetry_metric_instrumented_sink(self):
         self.sink_fixture.test_telemetry_metric_instrumented_sink()
 

--- a/utils/build/docker/python/django/django.app.urls.py
+++ b/utils/build/docker/python/django/django.app.urls.py
@@ -263,6 +263,39 @@ def view_sqli_secure(request):
     return HttpResponse("OK")
 
 
+@csrf_exempt
+def view_iast_ssrf_insecure(request):
+    import requests
+
+    url = request.POST.get("url", "")
+    try:
+        requests.get(url)
+    except Exception:
+        pass
+    return HttpResponse("OK")
+
+
+@csrf_exempt
+def view_iast_ssrf_secure(request):
+    from urllib.parse import urlparse
+    import requests
+
+    url = request.POST.get("url", "")
+    # Validate the URL and enforce whitelist
+    allowed_domains = ["example.com", "api.example.com"]
+    parsed_url = urlparse(url)
+
+    if parsed_url.hostname not in allowed_domains:
+        return HttpResponseBadRequest("ERROR")
+
+    try:
+        requests.get(url)
+    except Exception:
+        pass
+
+    return HttpResponse("OK")
+
+
 def _sink_point(table="user", id="1"):
     sql = "SELECT * FROM " + table + " WHERE id = '" + id + "'"
     with connection.cursor() as cursor:
@@ -446,6 +479,8 @@ urlpatterns = [
     path("iast/weak_randomness/test_secure", view_iast_weak_randomness_secure),
     path("iast/path_traversal/test_insecure", view_iast_path_traversal_insecure),
     path("iast/path_traversal/test_secure", view_iast_path_traversal_secure),
+    path("iast/ssrf/test_insecure", view_iast_ssrf_insecure),
+    path("iast/ssrf/test_secure", view_iast_ssrf_secure),
     path("iast/source/body/test", view_iast_source_body),
     path("iast/source/cookiename/test", view_iast_source_cookie_name),
     path("iast/source/cookievalue/test", view_iast_source_cookie_value),

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -288,6 +288,39 @@ def view_iast_path_traversal_secure():
     return Response("OK")
 
 
+@app.route("/iast/ssrf/test_insecure", methods=["POST"])
+def view_iast_ssrf_insecure():
+    import requests
+
+    url = flask_request.form["url"]
+    try:
+        requests.get(url)
+    except Exception:
+        pass
+    return Response("OK")
+
+
+@app.route("/iast/ssrf/test_secure", methods=["POST"])
+def view_iast_ssrf_secure():
+    from urllib.parse import urlparse
+    import requests
+
+    url = flask_request.form["url"]
+    # Validate the URL and enforce whitelist
+    allowed_domains = ["example.com", "api.example.com"]
+    parsed_url = urlparse(url)
+
+    if parsed_url.hostname not in allowed_domains:
+        return "Forbidden", 403
+
+    try:
+        requests.get(url)
+    except Exception:
+        pass
+
+    return Response("OK")
+
+
 _TRACK_METADATA = {
     "metadata0": "value0",
     "metadata1": "value1",


### PR DESCRIPTION
Enable IAST SSRF vulnerability for Flask, UWSGI and Django
## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
