### PR TITLE
chore(python): enable telemetry tests for executed sinks

### DIFF
--- a/tests/appsec/iast/sink/test_sql_injection.py
+++ b/tests/appsec/iast/sink/test_sql_injection.py
@@ -40,7 +40,7 @@ class TestSqlInjection:
 
     @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
     @missing_feature(library="nodejs", reason="Not implemented yet")
-    @missing_feature(library="python", reason="Not implemented yet")
+    @missing_feature(context.library < "python@2.1.0.dev", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         self.sink_fixture.test_telemetry_metric_instrumented_sink()
 
@@ -49,6 +49,6 @@ class TestSqlInjection:
 
     @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
     @missing_feature(library="nodejs", reason="Not implemented yet")
-    @missing_feature(library="python", reason="Not implemented yet")
+    @missing_feature(context.library < "python@2.1.0.dev", reason="Not implemented yet")
     def test_telemetry_metric_executed_sink(self):
         self.sink_fixture.test_telemetry_metric_executed_sink()

--- a/tests/appsec/iast/sink/test_sql_injection.py
+++ b/tests/appsec/iast/sink/test_sql_injection.py
@@ -40,7 +40,7 @@ class TestSqlInjection:
 
     @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
     @missing_feature(library="nodejs", reason="Not implemented yet")
-    @missing_feature(context.library < "python@2.1.0.dev", reason="Not implemented yet")
+    @missing_feature(library="python", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         self.sink_fixture.test_telemetry_metric_instrumented_sink()
 
@@ -49,6 +49,5 @@ class TestSqlInjection:
 
     @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
     @missing_feature(library="nodejs", reason="Not implemented yet")
-    @missing_feature(context.library < "python@2.1.0.dev", reason="Not implemented yet")
     def test_telemetry_metric_executed_sink(self):
         self.sink_fixture.test_telemetry_metric_executed_sink()


### PR DESCRIPTION
## Description

Enable telemetry tests for executed python sql injection sinks.

## Motivation

These tests should have been already active.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
