### PR TITLE
Prevent XCONTENTTYPE_HEADER_MISSING from showing in arbitrary endpoints

### DIFF
--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
@@ -314,16 +314,12 @@ public class AppSecIast {
 
     @GetMapping(value = "/hstsmissing/test_insecure", produces = "text/html")
     public String hstsHeaderMissingInsecure(HttpServletResponse response) {
-        // XXX: Avoid triggering XCONTENTTYPE_MISSING_HEADER vulnerability when checking HSTS.
-        response.addHeader("X-Content-Type-Options", "nosniff");
         response.setStatus(HttpStatus.OK.value());
         return "ok";
     }
 
     @GetMapping(value = "/hstsmissing/test_secure", produces = "text/html")
     public String hstsHeaderMissingSecure(HttpServletResponse response) {
-        // XXX: Avoid triggering XCONTENTTYPE_MISSING_HEADER vulnerability when checking HSTS.
-        response.addHeader("X-Content-Type-Options", "nosniff");
         response.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
         response.setStatus(HttpStatus.OK.value());
         return "ok";

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/WebMvcConfig.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/WebMvcConfig.java
@@ -1,0 +1,23 @@
+package com.datadoghq.system_tests.springboot;
+
+import com.datadoghq.system_tests.springboot.iast.XContentTypeInterceptor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import javax.annotation.Nonnull;
+
+@Component
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final XContentTypeInterceptor xContentTypeInterceptor;
+
+    public WebMvcConfig(final XContentTypeInterceptor xContentTypeInterceptor) {
+        this.xContentTypeInterceptor = xContentTypeInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(@Nonnull final InterceptorRegistry registry) {
+        registry.addInterceptor(xContentTypeInterceptor);
+    }
+}

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/iast/XContentTypeInterceptor.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/iast/XContentTypeInterceptor.java
@@ -1,0 +1,33 @@
+package com.datadoghq.system_tests.springboot.iast;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class XContentTypeInterceptor implements HandlerInterceptor {
+
+    private static final String XCONTENT_ENDPOINT = "/iast/xcontent-missing-header";
+    private static final String  XCONTENT_TYPE_HEADER = "X-Content-Type-Options";
+    private static final String NOSNIFF = "nosniff";
+
+    @Override
+    public void postHandle(@Nonnull final HttpServletRequest request,
+                           @Nonnull final HttpServletResponse response,
+                           @Nonnull final Object handler,
+                           final ModelAndView modelAndView) throws Exception {
+        if (!isXContentTypeVulnerabilityEndpoint(request)) {
+            // XXX: Avoid triggering XCONTENTTYPE_MISSING_HEADER vulnerability.
+            response.setHeader(XCONTENT_TYPE_HEADER, NOSNIFF);
+        }
+    }
+
+    private boolean isXContentTypeVulnerabilityEndpoint(final HttpServletRequest request) {
+        final String requestUri = request.getRequestURI();
+        return requestUri != null && requestUri.contains(XCONTENT_ENDPOINT);
+    }
+}


### PR DESCRIPTION
## Description

Ensures that `XCONTENTTYPE_HEADER_MISSING` is not triggered in requests other than the ones performed against the endpoint `/iast/xcontent-missing-header`

## Motivation

Not sending the proper header in non vulnerable endpoints might case the tests to be flaky. 

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
