### PR TITLE
Add parametric test to remove credentials from repository URLs.

### DIFF
--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -173,6 +173,15 @@ class Test_DsmRabbitmq_FanoutExchange:
 
 class DsmHelper:
     @staticmethod
+    def is_tags_included(actual_tags, expected_tags):
+        assert isinstance(actual_tags, tuple)
+        assert isinstance(expected_tags, tuple)
+        for expected_tag in expected_tags:
+            if expected_tag not in actual_tags:
+                return False
+        return True
+
+    @staticmethod
     def assert_checkpoint_presence(hash_, parent_hash, tags):
 
         assert isinstance(tags, tuple)
@@ -187,7 +196,11 @@ class DsmHelper:
                     observed_tags = tuple(stats_point["EdgeTags"])
 
                     logger.debug(f"Observed checkpoint: {observed_hash}, {observed_parent_hash}, {observed_tags}")
-                    if observed_hash == hash_ and observed_parent_hash == parent_hash and observed_tags == tags:
+                    if (
+                        observed_hash == hash_
+                        and observed_parent_hash == parent_hash
+                        and DsmHelper.is_tags_included(observed_tags, tags)
+                    ):
                         logger.info("checkpoint found ✅")
                         return
 

--- a/tests/parametric/test_tracer.py
+++ b/tests/parametric/test_tracer.py
@@ -5,7 +5,7 @@ import pytest
 from utils.parametric.spec.trace import Span
 from utils.parametric.spec.trace import find_trace_by_root
 from utils.parametric.spec.trace import find_span
-from utils import missing_feature, context, scenarios
+from utils import missing_feature, context, rfc, scenarios
 
 from .conftest import _TestAgentAPI
 from .conftest import APMLibrary
@@ -43,6 +43,7 @@ class Test_Tracer:
         assert child_span["meta"]["key"] == "val"
 
 
+@rfc("https://docs.google.com/document/d/1vxuRUNzHqd6sp1lnF3T383acbLrG0R-xDGi8cdZ4cs8/edit")
 @scenarios.parametric
 class Test_TracerSCITagging:
     @parametrize("library_env", [{"DD_GIT_REPOSITORY_URL": "https://github.com/DataDog/dd-trace-go"}])
@@ -92,6 +93,54 @@ class Test_TracerSCITagging:
         assert trace[0]["meta"]["_dd.git.commit.sha"] == library_env["DD_GIT_COMMIT_SHA"]
         # and not in the others
         assert "_dd.git.commit.sha" not in trace[1].get("meta", {})
+
+    @parametrize(
+        "library_env",
+        [
+            {
+                "DD_GIT_REPOSITORY_URL": "https://gitlab-ci-token:AAA_bbb@gitlab.com/DataDog/systems-test.git",
+                "expected_repo_url": "https://gitlab.com/DataDog/systems-test.git",
+            },
+            {
+                "DD_GIT_REPOSITORY_URL": "https://token@gitlab.com/user/project.git",
+                "expected_repo_url": "https://gitlab.com/user/project.git",
+            },
+            {
+                "DD_GIT_REPOSITORY_URL": "https://gitlab.com/DataDog/systems-test.git",
+                "expected_repo_url": "https://gitlab.com/DataDog/systems-test.git",
+            },
+            {
+                "DD_GIT_REPOSITORY_URL": "gitlab.com/DataDog/systems-test.git",
+                "expected_repo_url": "gitlab.com/DataDog/systems-test.git",
+            },
+            {
+                "DD_GIT_REPOSITORY_URL": "git@github.com:user/project.git",
+                "expected_repo_url": "git@github.com:user/project.git",
+            },
+        ],
+    )
+    @missing_feature(context.library == "golang", reason="golang does not strip credentials yet")
+    @missing_feature(context.library == "nodejs", reason="nodejs does not strip credentials yet")
+    @missing_feature(context.library == "python", reason="python does not strip credentials yet")
+    @missing_feature(context.library == "python_http", reason="python does not strip credentials yet")
+    def test_tracer_repository_url_strip_credentials(
+        self, library_env: Dict[str, str], test_agent: _TestAgentAPI, test_library: APMLibrary
+    ) -> None:
+        """
+        When DD_GIT_REPOSITORY_URL is specified
+            When a trace chunk is emitted
+                The first span of the trace chunk should have the value of DD_GIT_REPOSITORY_URL
+                in meta._dd.git.repository_url, with credentials removed if any
+        """
+        with test_library:
+            with test_library.start_span("operation") as parent:
+                with test_library.start_span("operation.child", parent_id=parent.span_id):
+                    pass
+
+        traces = test_agent.wait_for_num_traces(1)
+        trace = find_trace_by_root(traces, Span(name="operation"))
+
+        assert trace[0]["meta"]["_dd.git.repository_url"] == library_env["expected_repo_url"]
 
 
 @scenarios.parametric

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -285,11 +285,10 @@ class Test_Telemetry:
 
         self.validate_library_telemetry_data(validator)
 
-    # @flaky(library="dotnet", reason="Heartbeats are sometimes sent too slowly")
-    # @flaky(library="python", reason="Heartbeats are sometimes sent too slowly")
     @flaky(context.library < "nodejs@4.13.1", reason="Heartbeats are sometimes sent too fast")
     @bug(context.library < "java@1.18.0", reason="Telemetry interval drifts")
     @missing_feature(context.library < "ruby@1.13.0", reason="DD_TELEMETRY_HEARTBEAT_INTERVAL not supported")
+    @flaky(library="ruby")
     @bug(context.library > "php@0.90")
     @flaky(context.library <= "php@0.90", reason="Heartbeats are sometimes sent too slow")
     def test_app_heartbeat(self):


### PR DESCRIPTION
## Description

Add a test to check credentials are removed from the repository URL when source code integration is configured.


## Motivation

When users configure their tracer with DD_GIT_REPOSITORY_URL, in some cases the repository URL might contain credentials (like when it's directly extracted from their git repository config).
The tracers should remove any credentials found in DD_GIT_REPOSITORY_URL before setting it as a span attribute.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
