### PR TITLE
Update DSM system tests to not fail on extra tags

### DIFF
--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -173,6 +173,16 @@ class Test_DsmRabbitmq_FanoutExchange:
 
 class DsmHelper:
     @staticmethod
+    def is_tags_included(actual_tags, expected_tags):
+        assert isinstance(actual_tags, tuple)
+        assert isinstance(expected_tags, tuple)
+        for expected_tag in expected_tags:
+            if expected_tag not in actual_tags:
+                return False
+        return True
+
+
+    @staticmethod
     def assert_checkpoint_presence(hash_, parent_hash, tags):
 
         assert isinstance(tags, tuple)
@@ -187,7 +197,8 @@ class DsmHelper:
                     observed_tags = tuple(stats_point["EdgeTags"])
 
                     logger.debug(f"Observed checkpoint: {observed_hash}, {observed_parent_hash}, {observed_tags}")
-                    if observed_hash == hash_ and observed_parent_hash == parent_hash and observed_tags == tags:
+                    if observed_hash == hash_ and observed_parent_hash == parent_hash and DsmHelper.is_tags_included(
+                            observed_tags, tags):
                         logger.info("checkpoint found ✅")
                         return
 

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -181,7 +181,6 @@ class DsmHelper:
                 return False
         return True
 
-
     @staticmethod
     def assert_checkpoint_presence(hash_, parent_hash, tags):
 
@@ -197,8 +196,11 @@ class DsmHelper:
                     observed_tags = tuple(stats_point["EdgeTags"])
 
                     logger.debug(f"Observed checkpoint: {observed_hash}, {observed_parent_hash}, {observed_tags}")
-                    if observed_hash == hash_ and observed_parent_hash == parent_hash and DsmHelper.is_tags_included(
-                            observed_tags, tags):
+                    if (
+                        observed_hash == hash_
+                        and observed_parent_hash == parent_hash
+                        and DsmHelper.is_tags_included(observed_tags, tags)
+                    ):
                         logger.info("checkpoint found ✅")
                         return
 


### PR DESCRIPTION
## Description

Currently, the DSM system tests try to check for exact tags match. This leads to issues when developing new features where system-tests would fail for any new tags that are added for DSM data. See example from a PR with a new feature:
<img width="1455" alt="Screen Shot 2023-10-10 at 3 25 23 PM" src="https://github.com/DataDog/system-tests/assets/49738731/9b0d581e-34e4-49ab-8c59-89490a864bea">

## Motivation

Makes it easier to add new features to DSM without triggering system-tests failures.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
