### PR TITLE
[dotnet] deactivate query obfuscation legacy regex tests for 2.40

### DIFF
--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -79,7 +79,7 @@ class Test_StandardTagsUrl:
     # when tracer is updated, add (for example)
     @irrelevant(context.library >= "java@1.21.0", reason="java released the new version at 1.21.0")
     @irrelevant(context.library >= "python@1.18.0rc1", reason="python released the new version at 1.19.0")
-    @irrelevant(context.library >= "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
+    @irrelevant(context.library >= "dotnet@2.40", reason="dotnet released the new version at 2.39.0")
     def test_url_with_sensitive_query_string_legacy(self):
         for r, tag in self.requests_sensitive_query_string:
             interfaces.library.add_span_tag_validation(
@@ -116,7 +116,7 @@ class Test_StandardTagsUrl:
     @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
     # remove = of <= when PR https://github.com/DataDog/dd-trace-dotnet/pull/4504 is merged
-    @irrelevant(context.library <= "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
+    @irrelevant(context.library <= "dotnet@2.40", reason="dotnet released the new version at 2.39.0")
     def test_url_with_sensitive_query_string(self):
         for r, tag in self.requests_sensitive_query_string:
             interfaces.library.add_span_tag_validation(
@@ -131,7 +131,7 @@ class Test_StandardTagsUrl:
     # when tracer is updated, add (for example)
     @irrelevant(context.library >= "java@1.21.0", reason="java released the new version at 1.21.0")
     @irrelevant(context.library >= "python@1.18.0rc1", reason="python released the new version at 1.19.0")
-    @irrelevant(context.library >= "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
+    @irrelevant(context.library >= "dotnet@2.40", reason="dotnet released the new version at 2.39.0")
     def test_multiple_matching_substring_legacy(self):
         tag = r"^.*/waf\?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20%22<redacted>%7D$"  # pylint: disable=line-too-long
         interfaces.library.add_span_tag_validation(
@@ -150,7 +150,7 @@ class Test_StandardTagsUrl:
     @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
     # remove = of <= when PR https://github.com/DataDog/dd-trace-dotnet/pull/4504 is merged
-    @irrelevant(context.library <= "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
+    @irrelevant(context.library <= "dotnet@2.40", reason="dotnet released the new version at 2.39.0")
     def test_multiple_matching_substring(self):
         tag = r"^.*/waf\?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20<redacted>%7D$"  # pylint: disable=line-too-long
         interfaces.library.add_span_tag_validation(

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -115,7 +115,8 @@ class Test_StandardTagsUrl:
     )
     @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
-    @irrelevant(context.library < "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
+    # remove = of <= when PR https://github.com/DataDog/dd-trace-dotnet/pull/4504 is merged
+    @irrelevant(context.library <= "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
     def test_url_with_sensitive_query_string(self):
         for r, tag in self.requests_sensitive_query_string:
             interfaces.library.add_span_tag_validation(
@@ -148,7 +149,8 @@ class Test_StandardTagsUrl:
     )
     @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
-    @irrelevant(context.library < "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
+    # remove = of <= when PR https://github.com/DataDog/dd-trace-dotnet/pull/4504 is merged
+    @irrelevant(context.library <= "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
     def test_multiple_matching_substring(self):
         tag = r"^.*/waf\?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20<redacted>%7D$"  # pylint: disable=line-too-long
         interfaces.library.add_span_tag_validation(

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -79,7 +79,7 @@ class Test_StandardTagsUrl:
     # when tracer is updated, add (for example)
     @irrelevant(context.library >= "java@1.21.0", reason="java released the new version at 1.21.0")
     @irrelevant(context.library >= "python@1.18.0rc1", reason="python released the new version at 1.19.0")
-    @irrelevant(context.library >= "dotnet@2.40", reason="dotnet released the new version at 2.39.0")
+    @irrelevant(context.library >= "dotnet@2.40", reason="dotnet released the new version at 2.40.0")
     def test_url_with_sensitive_query_string_legacy(self):
         for r, tag in self.requests_sensitive_query_string:
             interfaces.library.add_span_tag_validation(
@@ -116,7 +116,7 @@ class Test_StandardTagsUrl:
     @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
     # remove = of <= when PR https://github.com/DataDog/dd-trace-dotnet/pull/4504 is merged
-    @irrelevant(context.library <= "dotnet@2.40", reason="dotnet released the new version at 2.39.0")
+    @irrelevant(context.library <= "dotnet@2.40", reason="dotnet released the new version at 2.40.0")
     def test_url_with_sensitive_query_string(self):
         for r, tag in self.requests_sensitive_query_string:
             interfaces.library.add_span_tag_validation(
@@ -131,7 +131,7 @@ class Test_StandardTagsUrl:
     # when tracer is updated, add (for example)
     @irrelevant(context.library >= "java@1.21.0", reason="java released the new version at 1.21.0")
     @irrelevant(context.library >= "python@1.18.0rc1", reason="python released the new version at 1.19.0")
-    @irrelevant(context.library >= "dotnet@2.40", reason="dotnet released the new version at 2.39.0")
+    @irrelevant(context.library >= "dotnet@2.40", reason="dotnet released the new version at 2.40.0")
     def test_multiple_matching_substring_legacy(self):
         tag = r"^.*/waf\?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20%22<redacted>%7D$"  # pylint: disable=line-too-long
         interfaces.library.add_span_tag_validation(
@@ -150,7 +150,7 @@ class Test_StandardTagsUrl:
     @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
     # remove = of <= when PR https://github.com/DataDog/dd-trace-dotnet/pull/4504 is merged
-    @irrelevant(context.library <= "dotnet@2.40", reason="dotnet released the new version at 2.39.0")
+    @irrelevant(context.library <= "dotnet@2.40", reason="dotnet released the new version at 2.40.0")
     def test_multiple_matching_substring(self):
         tag = r"^.*/waf\?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20<redacted>%7D$"  # pylint: disable=line-too-long
         interfaces.library.add_span_tag_validation(

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -79,6 +79,7 @@ class Test_StandardTagsUrl:
     # when tracer is updated, add (for example)
     @irrelevant(context.library >= "java@1.21.0", reason="java released the new version at 1.21.0")
     @irrelevant(context.library >= "python@1.18.0rc1", reason="python released the new version at 1.19.0")
+    @irrelevant(context.library >= "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
     def test_url_with_sensitive_query_string_legacy(self):
         for r, tag in self.requests_sensitive_query_string:
             interfaces.library.add_span_tag_validation(
@@ -109,11 +110,12 @@ class Test_StandardTagsUrl:
         ]
 
     @missing_feature(
-        context.library in ["dotnet", "golang", "nodejs", "php", "ruby"],
+        context.library in ["golang", "nodejs", "php", "ruby"],
         reason="tracer did not yet implemented the new version of query parameters obfuscation regex",
     )
     @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
+    @irrelevant(context.library < "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
     def test_url_with_sensitive_query_string(self):
         for r, tag in self.requests_sensitive_query_string:
             interfaces.library.add_span_tag_validation(
@@ -125,9 +127,10 @@ class Test_StandardTagsUrl:
             "/waf?token=03cb9f67dbbc4cb8b9&key1=val1&key2=val2&pass=03cb9f67-dbbc-4cb8-b966-329951e10934&public_key=MDNjYjlmNjctZGJiYy00Y2I4LWI5NjYtMzI5OTUxZTEwOTM0&key3=val3&json=%7B%20%22sign%22%3A%20%22%7D%7D%22%7D"  # pylint: disable=line-too-long
         )
 
-    # when tracer is updated, add (for exemple)
+    # when tracer is updated, add (for example)
     @irrelevant(context.library >= "java@1.21.0", reason="java released the new version at 1.21.0")
     @irrelevant(context.library >= "python@1.18.0rc1", reason="python released the new version at 1.19.0")
+    @irrelevant(context.library >= "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
     def test_multiple_matching_substring_legacy(self):
         tag = r"^.*/waf\?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20%22<redacted>%7D$"  # pylint: disable=line-too-long
         interfaces.library.add_span_tag_validation(
@@ -140,11 +143,12 @@ class Test_StandardTagsUrl:
         )
 
     @missing_feature(
-        context.library in ["dotnet", "golang", "nodejs", "php", "ruby"],
+        context.library in ["golang", "nodejs", "php", "ruby"],
         reason="tracer did not yet implemented the new version of query parameters obfuscation regex",
     )
     @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
+    @irrelevant(context.library < "dotnet@2.39", reason="dotnet released the new version at 2.39.0")
     def test_multiple_matching_substring(self):
         tag = r"^.*/waf\?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20<redacted>%7D$"  # pylint: disable=line-too-long
         interfaces.library.add_span_tag_validation(


### PR DESCRIPTION
## Description
After query string obfuscation regex was updated, dotnet tracer will contain the new regex from 2.39
Tested locally with before and after versions
<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
