### PR TITLE
[DSM] - Accept empty payloads for stats in DSM

### DIFF
--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -189,8 +189,10 @@ class DsmHelper:
         logger.info(f"Look for {hash_}, {parent_hash}, {tags}")
 
         for data in interfaces.agent.get_dsm_data():
-            for stats_bucket in data["request"]["content"]["Stats"]:
-                for stats_point in stats_bucket["Stats"]:
+            # some tracers may send separate payloads with stats
+            # or backlogs so "Stats" may be empty
+            for stats_bucket in data["request"]["content"].get("Stats", {}):
+                for stats_point in stats_bucket.get("Stats", {}):
                     observed_hash = stats_point["Hash"]
                     observed_parent_hash = stats_point["ParentHash"]
                     observed_tags = tuple(stats_point["EdgeTags"])


### PR DESCRIPTION
## Description
DSM tests are failing when the payload has no stats (it can be Backlogs-only payload).

## Motivation
Fix broken tests and unblock changes to .NET tracer (see https://github.com/DataDog/dd-trace-dotnet/pull/4704)
<img width="554" alt="Screenshot 2023-10-11 at 3 29 40 PM" src="https://github.com/DataDog/system-tests/assets/21974069/70c9cce6-8b7d-41c4-abfc-317466db6b7e">

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [x] CI is green
   * [x] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
