### PR TITLE
parametric: bump golang version

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -193,7 +193,7 @@ def golang_library_factory():
         container_name="go-test-library",
         container_tag="go118-test-library",
         container_img=f"""
-FROM golang:1.18
+FROM golang:1.20
 WORKDIR /client
 COPY ./go.mod /client
 COPY ./go.sum /client

--- a/utils/build/docker/golang/parametric/Dockerfile
+++ b/utils/build/docker/golang/parametric/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM golang:1.18
+FROM golang:1.20
 WORKDIR /client
 COPY ./go.mod /client
 COPY ./go.sum /client

--- a/utils/build/docker/golang/parametric/ddtracer_version.Dockerfile
+++ b/utils/build/docker/golang/parametric/ddtracer_version.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM golang:1.18
+FROM golang:1.20
 WORKDIR /client
 
 COPY ./utils/build/docker/golang/parametric/go.mod /client


### PR DESCRIPTION
## Description

bump golang version to 1.20 in parametric tests

## Motivation

Required for https://github.com/DataDog/dd-trace-go/pull/2274

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
