### PR TITLE
When proxy fails to deserialize, improve stdout

### DIFF
--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -455,14 +455,22 @@ class EndToEndScenario(_DockerScenario):
             logger.terminal.flush()
 
             interfaces.library.load_data_from_logs()
+            interfaces.library.check_deserialization_errors()
+
             interfaces.agent.load_data_from_logs()
+            interfaces.agent.check_deserialization_errors()
+
             interfaces.backend.load_data_from_logs()
 
         elif self.use_proxy:
             self._wait_interface(interfaces.library, self.library_interface_timeout)
             self.weblog_container.stop()
+            interfaces.library.check_deserialization_errors()
+
             self._wait_interface(interfaces.agent, self.agent_interface_timeout)
             self.agent_container.stop()
+            interfaces.agent.check_deserialization_errors()
+
             self._wait_interface(interfaces.backend, self.backend_interface_timeout)
 
         self.close_targets()

--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -82,6 +82,19 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
     def wait(self, timeout):
         time.sleep(timeout)
 
+    def check_deserialization_errors(self):
+        """ Verify that all proxy deserialization are successful """
+
+        for data in self._data_list:
+            filename = data["log_filename"]
+            if "content" not in data["request"]:
+                traceback = data["request"].get("traceback", "no traceback")
+                pytest.exit(reason=f"Unexpected error while deserialize {filename}:\n {traceback}", returncode=1)
+
+            if data["response"] and "content" not in data["response"]:
+                traceback = data["response"].get("traceback", "no traceback")
+                pytest.exit(reason=f"Unexpected error while deserialize {filename}:\n {traceback}", returncode=1)
+
     def load_data_from_logs(self):
 
         for filename in sorted(listdir(self._log_folder)):
@@ -95,15 +108,6 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
                 logger.info(f"{self.name} interface gets {file_path}")
 
     def _append_data(self, data):
-        filename = data["log_filename"]
-        if "content" not in data["request"]:
-            traceback = data["request"].get("traceback", "no traceback")
-            pytest.exit(reason=f"Unexpected error while deserialize {filename}:\n {traceback}", returncode=1)
-
-        if data["response"] and "content" not in data["response"]:
-            traceback = data["response"].get("traceback", "no traceback")
-            pytest.exit(reason=f"Unexpected error while deserialize {filename}:\n {traceback}", returncode=1)
-
         self._data_list.append(data)
 
     def get_data(self, path_filters=None):


### PR DESCRIPTION
## Description

Previously, when data coming from proxy was ingested, a check was made on it, and if it contains a deserialization error, the process was stopped with a nice error message.

But the ingestion process was moved inside a thread. In consequence : 

1. the thread exit on error, but the main process continue
2. later data are not ingested
3. tests are executed, but those who need missing ingested data fails (lot of them)
4. the good error message is it the top of stdout, followed by dazillion error messages

This PR move the error check frm the ingestion thread to the main thread, after closing the test target. Now, the error looks like this, and nothing more :

<img width="1122" alt="image" src="https://github.com/DataDog/system-tests/assets/11915659/b7cd6dab-e527-444a-9520-428617c9865a">
 



## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
6. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
7. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
8. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
