### PR TITLE
chore(python): fix Weak Hash and Weak Cipher version

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -92,12 +92,12 @@ tests/:
           TestUnvalidatedForward: missing_feature
         test_weak_cipher.py:
           TestWeakCipher:
-            '*': v1.7.0
+            '*': v1.18.0
             fastapi: missing_feature
             python3.12: missing_feature
         test_weak_hash.py:
           TestWeakHash:
-            '*': v1.6.0
+            '*': v1.18.0
             fastapi: missing_feature
             python3.12: missing_feature
         test_weak_randomness.py:


### PR DESCRIPTION
## Description
Both Weak Hash and Weak Cipher were introduced in version 1.7, but the metrics that validate those vulnerabilities were released in version 1.18.

This PR fix the backport https://github.com/DataDog/dd-trace-py/pull/7298
## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
