### PR TITLE
chore(python): fix SQLi version

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -74,9 +74,9 @@ tests/:
             python3.12: missing_feature
         test_sql_injection.py:
           TestSqlInjection:
-            django-poc: v1.12.0
+            django-poc: v1.18.0
             fastapi: missing_feature
-            flask-poc: v1.12.0
+            flask-poc: v1.18.0
             pylons: missing_feature
             python3.12: missing_feature
         test_ssrf.py:


### PR DESCRIPTION
## Description
SQLi was introduced in version 1.12, but the metrics that validate this vulnerabilities were released in version 1.18.

This PR fix the backport https://github.com/DataDog/dd-trace-py/pull/7308

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
