### PR TITLE
chore(python): bump telemetry tests version

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -492,5 +492,5 @@ tests/:
     Test_Metric_Generation_Disabled: missing_feature
     Test_Metric_Generation_Enabled: missing_feature
     Test_ProductsDisabled: missing_feature
-    Test_Telemetry: v1.7.0
+    Test_Telemetry: v1.16.0
     Test_TelemetryV2: v1.17.3


### PR DESCRIPTION
## Description

Telemetry tests are filing in 1.15 version and older

```
        heartbeats = [d for d in telemetry_data if d["request"]["content"].get("request_type") == "app-heartbeat"]
>       assert len(heartbeats) >= 2, "Did not receive, at least, 2 heartbeats"
E       AssertionError: Did not receive, at least, 2 heartbeats
E       assert 0 >= 2
E        +  where 0 = len([])
```

This PR fix:
- https://github.com/DataDog/dd-trace-py/pull/7308
- https://github.com/DataDog/dd-trace-py/pull/7309

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
