### PR TITLE
[dotnet] activate new tests for regex obfuscation

### DIFF
--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -115,8 +115,7 @@ class Test_StandardTagsUrl:
     )
     @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
-    # remove = of <= when PR https://github.com/DataDog/dd-trace-dotnet/pull/4504 is merged
-    @irrelevant(context.library <= "dotnet@2.41", reason="dotnet released the new version at 2.41.0")
+    @irrelevant(context.library < "dotnet@2.41", reason="dotnet released the new version at 2.41.0")
     def test_url_with_sensitive_query_string(self):
         for r, tag in self.requests_sensitive_query_string:
             interfaces.library.add_span_tag_validation(
@@ -149,8 +148,7 @@ class Test_StandardTagsUrl:
     )
     @missing_feature(context.library < "java@1.21.0", reason="previous obfuscation regex")
     @irrelevant(context.library < "python@1.19", reason="python released the new version at 1.19.0")
-    # remove = of <= when PR https://github.com/DataDog/dd-trace-dotnet/pull/4504 is merged
-    @irrelevant(context.library <= "dotnet@2.41", reason="dotnet released the new version at 2.41.0")
+    @irrelevant(context.library < "dotnet@2.41", reason="dotnet released the new version at 2.41.0")
     def test_multiple_matching_substring(self):
         tag = r"^.*/waf\?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20<redacted>%7D&<redacted>$"  # pylint: disable=line-too-long
         interfaces.library.add_span_tag_validation(

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -140,7 +140,7 @@ class Test_StandardTagsUrl:
 
     def setup_multiple_matching_substring(self):
         self.request_multiple_matching_substring = weblog.get(
-            "/waf?token=03cb9f67dbbc4cb8b9&key1=val1&key2=val2&pass=03cb9f67-dbbc-4cb8-b966-329951e10934&public_key=MDNjYjlmNjctZGJiYy00Y2I4LWI5NjYtMzI5OTUxZTEwOTM0&key3=val3&json=%7B%20%22sign%22%3A%20%22%7D%7D%22%7D"  # pylint: disable=line-too-long
+            "/waf?token=03cb9f67dbbc4cb8b9&key1=val1&key2=val2&pass=03cb9f67-dbbc-4cb8-b966-329951e10934&public_key=MDNjYjlmNjctZGJiYy00Y2I4LWI5NjYtMzI5OTUxZTEwOTM0&key3=val3&json=%7B%20%22sign%22%3A%20%22%7D%7D%22%7D&ecdsa-1-1%20aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=%09test"  # pylint: disable=line-too-long
         )
 
     @missing_feature(
@@ -152,7 +152,7 @@ class Test_StandardTagsUrl:
     # remove = of <= when PR https://github.com/DataDog/dd-trace-dotnet/pull/4504 is merged
     @irrelevant(context.library <= "dotnet@2.41", reason="dotnet released the new version at 2.41.0")
     def test_multiple_matching_substring(self):
-        tag = r"^.*/waf\?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20<redacted>%7D$"  # pylint: disable=line-too-long
+        tag = r"^.*/waf\?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20<redacted>%7D&<redacted>$"  # pylint: disable=line-too-long
         interfaces.library.add_span_tag_validation(
             self.request_multiple_matching_substring, tags={"http.url": tag}, value_as_regular_expression=True
         )


### PR DESCRIPTION
## Description

Complete one of the test with a key that was not handled before by previous regex
Activate tests for dotnet

## Motivation

Thought mostly json and quotes were tested so far but testing new keys might be relevant too 
Activate dotnet tests since regex is now updated and merged

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
