### PR TITLE
[.Net] Test query parameter names

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -42,7 +42,7 @@ tests/:
         test_trust_boundary_violation.py:
           Test_TrustBoundaryViolation: missing_feature
         test_unvalidated_redirect.py:
-          TestUnvalidatedHeader: missing_feature        
+          TestUnvalidatedHeader: missing_feature
           TestUnvalidatedRedirect: missing_feature
         test_unvalidated_redirect_forward.py:
           TestUnvalidatedForward: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -70,7 +70,7 @@ tests/:
         test_header_value.py:
           TestHeaderValue: missing_feature
         test_multipart.py:
-          TestMultipart: missing_feature          
+          TestMultipart: missing_feature
         test_parameter_name.py:
           TestParameterName:
               '*': v2.28.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -42,6 +42,7 @@ tests/:
         test_trust_boundary_violation.py:
           Test_TrustBoundaryViolation: missing_feature
         test_unvalidated_redirect.py:
+          TestUnvalidatedHeader: missing_feature        
           TestUnvalidatedRedirect: missing_feature
         test_unvalidated_redirect_forward.py:
           TestUnvalidatedForward: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -40,7 +40,6 @@ tests/:
         test_trust_boundary_violation.py:
           Test_TrustBoundaryViolation: missing_feature
         test_unvalidated_redirect.py:
-          TestUnvalidatedHeader: missing_feature
           TestUnvalidatedRedirect: missing_feature
         test_unvalidated_redirect_forward.py:
           TestUnvalidatedForward: missing_feature
@@ -69,11 +68,13 @@ tests/:
         test_header_value.py:
           TestHeaderValue: missing_feature
         test_multipart.py:
-          TestMultipart: missing_feature
+          TestMultipart: missing_feature          
         test_parameter_name.py:
-          TestParameterName: missing_feature
+          TestParameterName:
+              '*': v2.28.0
         test_parameter_value.py:
-          TestParameterValue: missing_feature
+          TestParameterValue:
+              '*': v2.28.0
     waf/:
       test_addresses.py:
         Test_BodyJson: v2.8.0

--- a/tests/appsec/iast/source/test_parameter_name.py
+++ b/tests/appsec/iast/source/test_parameter_name.py
@@ -22,6 +22,7 @@ class TestParameterName(BaseSourceTest):
     @missing_feature(weblog_variant="express4", reason="Tainted as request body")
     @bug(weblog_variant="resteasy-netty3", reason="Not reported")
     @bug(library="python", reason="Python frameworks need a header, if not, 415 status code")
+    @missing_feature(library="dotnet", reason="Tainted as request body")
     def test_source_post_reported(self):
         """ for use case where only one is reported, we want to keep a test on the one reported """
         self.validate_request_reported(self.requests["POST"])
@@ -36,9 +37,11 @@ class TestParameterName(BaseSourceTest):
     @bug(weblog_variant="jersey-grizzly2", reason="Not reported")
     @bug(weblog_variant="resteasy-netty3", reason="Not reported")
     @bug(library="python", reason="Python frameworks need a header, if not, 415 status code")
+    @missing_feature(library="dotnet", reason="Tainted as request body")
     def test_source_reported(self):
         super().test_source_reported()
 
+    @missing_feature(library="dotnet", reason="Not implemented")
     @bug(library="java", reason="Not working as expected")
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -1,7 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
 using System.Diagnostics;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 
@@ -9,7 +12,9 @@ namespace weblog
 {
     public class RequestData
     {
+        public string user{get; set;}
         public string cmd{get; set;}
+        public string table{get; set;}
     };
     
     [ApiController]
@@ -59,6 +64,66 @@ namespace weblog
             }
             
             return Content(result.ToString());
+        }
+        
+        [HttpPost("source/parameter/test")]
+        public IActionResult parameterTestPost([FromForm] RequestData data)
+        {
+            try
+            {
+                System.Diagnostics.Process.Start(data.table);
+                
+                return Content("Ok");
+            }
+            catch(Exception ex)
+            {
+                return StatusCode(500, "NotOk");
+            }
+        }
+
+        [HttpGet("source/parameter/test")]
+        public IActionResult parameterTest(string table)
+        {
+            try
+            {
+                System.Diagnostics.Process.Start(table);
+                
+                return Content("Ok");
+            }
+            catch(Exception ex)
+            {
+                return StatusCode(500, "NotOk");
+            }
+        }
+        
+        [HttpPost("source/parametername/test")]
+        public IActionResult parameterNameTestPost([FromForm] RequestData data)
+        {
+            try
+            {
+                System.Diagnostics.Process.Start(data.user);
+                
+                return Content("Ok");
+            }
+            catch(Exception ex)
+            {
+                return StatusCode(500, "NotOk");
+            }
+        }
+
+        [HttpGet("source/parametername/test")]
+        public IActionResult parameterNameTest(string user)
+        {
+            try
+            {
+                System.Diagnostics.Process.Start(Request.Query.First().Key);
+                
+                return Content("Ok");
+            }
+            catch(Exception ex)
+            {
+                return StatusCode(500, "NotOk");
+            }
         }
 
         [HttpPost("cmdi/test_insecure")]


### PR DESCRIPTION
## Description

This PR implements the tests that check if a parameter name has been tainted.

## Motivation

It's a feature that we already support.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
