### PR TITLE
ASM - Work around changes in crs-944-110

### DIFF
--- a/tests/appsec/custom_rules.json
+++ b/tests/appsec/custom_rules.json
@@ -3021,6 +3021,39 @@
           "operator": "phrase_match"
         }
       ]
+    },
+    {
+      "id": "multiple_highlight_rule",
+      "name": "noname",
+      "tags": {
+        "type": "testing",
+        "crs_id": "0",
+        "category": "testing"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "regex": "highlight1"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "regex": "highlight2"
+          },
+          "operator": "match_regex"
+        }
+      ]
     }
   ]
 }

--- a/tests/appsec/waf/test_miscs.py
+++ b/tests/appsec/waf/test_miscs.py
@@ -28,17 +28,18 @@ class Test_404:
         )
 
 
+@scenarios.appsec_custom_rules
 @coverage.basic
 class Test_MultipleHighlight:
     """Appsec reports multiple attacks on same request"""
 
     def setup_multiple_hightlight(self):
-        self.r = weblog.get("/waf", params={"value": "processbuilder unmarshaller"})
+        self.r = weblog.get("/waf", params={"value": "highlight1 highlight2"})
 
     def test_multiple_hightlight(self):
         """Rule with multiple condition are reported on all conditions"""
         interfaces.library.assert_waf_attack(
-            self.r, rules.java_code_injection.crs_944_110, patterns=["processbuilder", "unmarshaller"]
+            self.r, "multiple_highlight_rule", patterns=["highlight1", "highlight2"]
         )
 
 

--- a/tests/appsec/waf/test_rules.py
+++ b/tests/appsec/waf/test_rules.py
@@ -281,7 +281,7 @@ class Test_JavaCodeInjection:
 
     def setup_java_code_injection(self):
         self.r_1 = weblog.get("/waf/", params={"value": "java.lang.runtime"})
-        self.r_2 = weblog.get("/waf/", params={"value": "processbuilder unmarshaller"})
+        self.r_2 = weblog.get("/waf/", params={"value": "unmarshaller processbuilder"})
         self.r_3 = weblog.get("/waf/", params={"value": "java.beans.xmldecode"})
 
     def test_java_code_injection(self):


### PR DESCRIPTION
## Description

Changes to the crs-944-110 WAF rule in the next version of the event rules break those two tests

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly