### PR TITLE
Fix setup file path

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -249,7 +249,7 @@ def pytest_collection_finish(session):
     if session.config.option.collectonly:
         return
 
-    last_file = ""
+    last_item_file = ""
     for item in session.items:
 
         if _item_is_skipped(item):
@@ -266,12 +266,13 @@ def pytest_collection_finish(session):
         if not hasattr(item.instance, setup_method_name):
             continue
 
-        if last_file != item.location[0]:
-            if len(last_file) == 0:
+        item_file = item.nodeid.split(":", 1)[0]
+        if last_item_file != item_file:
+            if len(last_item_file) == 0:
                 logger.terminal.write_sep("-", "tests setup", bold=True)
 
-            logger.terminal.write(f"\n{item.location[0]} ")
-            last_file = item.location[0]
+            logger.terminal.write(f"\n{item_file} ")
+            last_item_file = item_file
 
         setup_method = getattr(item.instance, setup_method_name)
         logger.debug(f"Call {setup_method} for {item}")


### PR DESCRIPTION
## Description

When a test is defined in a parent class located in another file, it's this another file who is reported in the setup phase, giving this ugly output : 


![image](https://github.com/DataDog/system-tests/assets/11915659/306bfc63-6038-4a94-8baa-75e87c8ffdcf)

-> report the file where the test class is defined rather than the file where the parent class is defined.
## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
