### PR TITLE
[opentelemetry] Skip validation on trace ingestion reasons

### DIFF
--- a/tests/otel_tracing_e2e/_test_validator_trace.py
+++ b/tests/otel_tracing_e2e/_test_validator_trace.py
@@ -118,8 +118,7 @@ KNOWN_UNMATCHED_METAS = [
     "_dd.tracer_version",
     "_dd.p.dm",
     "_dd.agent_hostname",
-    # TODO(songy23): investigate otel ingestion reasons
-    "_dd.ingestion_reason",
+    "_dd.ingestion_reason",  # this is replaced by `ddtags: ingestion_reason:otel` in the latest version
 ]
 KNOWN_UNMATCHED_METRICS = [
     "_dd.agent_errors_sampler.target_tps",

--- a/tests/otel_tracing_e2e/_test_validator_trace.py
+++ b/tests/otel_tracing_e2e/_test_validator_trace.py
@@ -118,7 +118,6 @@ KNOWN_UNMATCHED_METAS = [
     "_dd.tracer_version",
     "_dd.p.dm",
     "_dd.agent_hostname",
-
     # TODO(songy23): investigate otel ingestion reasons
     "_dd.ingestion_reason",
 ]

--- a/tests/otel_tracing_e2e/_test_validator_trace.py
+++ b/tests/otel_tracing_e2e/_test_validator_trace.py
@@ -41,7 +41,6 @@ def validate_common_tags(span: dict, use_128_bits_trace_id: bool):
     assert span["ingestion_reason"] == "otel"
     expected_meta = {
         "deployment.environment": "system-tests",
-        "_dd.ingestion_reason": "otel",
         "otel.status_code": "Unset",
         "otel.library.name": "com.datadoghq.springbootnative",
     }
@@ -119,6 +118,9 @@ KNOWN_UNMATCHED_METAS = [
     "_dd.tracer_version",
     "_dd.p.dm",
     "_dd.agent_hostname",
+
+    # TODO(songy23): investigate otel ingestion reasons
+    "_dd.ingestion_reason",
 ]
 KNOWN_UNMATCHED_METRICS = [
     "_dd.agent_errors_sampler.target_tps",


### PR DESCRIPTION
## Description

Skip validation on trace meta `_dd.ingestion_reason`

## Motivation

Temporary fix to https://github.com/DataDog/system-tests/actions/runs/6641096994/job/18042876027?pr=1739#step:8:106.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
