### PR TITLE
[.Net] IAST: No http only cookie vulnerability test

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -27,7 +27,8 @@ tests/:
         test_ldap_injection.py:
           TestLDAPInjection: missing_feature
         test_no_httponly_cookie.py:
-          TestNoHttponlyCookie: missing_feature
+          TestNoHttponlyCookie:
+              '*': v2.39.0
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie:
               '*': v2.39.0

--- a/tests/appsec/iast/sink/test_no_httponly_cookie.py
+++ b/tests/appsec/iast/sink/test_no_httponly_cookie.py
@@ -30,6 +30,7 @@ class TestNoHttponlyCookie(BaseSinkTest):
     @missing_feature(library="nodejs", reason="Metrics implemented")
     @missing_feature(library="java", reason="Metrics implemented")
     @missing_feature(library="python", reason="Metrics implemented")
+    @missing_feature(library="dotnet", reason="Metrics implemented")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -206,17 +206,26 @@ namespace weblog
             return StatusCode(200);
         }
         
+        [HttpGet("no-httponly-cookie/test_empty_cookie")]
+        [HttpGet("no-samesite-cookie/test_empty_cookie")]
+        [HttpGet("insecure-cookie/test_empty_cookie")]
+        public IActionResult test_EmptyCookie()
+        {
+            Response.Headers.Append("Set-Cookie", string.Empty);
+            return StatusCode(200);
+        }
+
         [HttpGet("no-httponly-cookie/test_insecure")]
         public IActionResult test_insecure_noHttpOnly()
         {
-            Response.Headers.Append("Set-Cookie", "user-id=7;Secure");
+            Response.Headers.Append("Set-Cookie", "user-id=7;Secure;SameSite=Strict");
             return StatusCode(200);
         }
         
         [HttpGet("no-httponly-cookie/test_secure")]
         public IActionResult test_secure_noHttpOnly()
         {
-            Response.Headers.Append("Set-Cookie", "user-id=7;Secure;SameSite=Strict");
+            Response.Headers.Append("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict");
             return StatusCode(200);
         }        
         

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -206,6 +206,20 @@ namespace weblog
             return StatusCode(200);
         }
         
+        [HttpGet("no-httponly-cookie/test_insecure")]
+        public IActionResult test_insecure_noHttpOnly()
+        {
+            Response.Headers.Append("Set-Cookie", "user-id=7;Secure");
+            return StatusCode(200);
+        }
+        
+        [HttpGet("no-httponly-cookie/test_secure")]
+        public IActionResult test_secure_noHttpOnly()
+        {
+            Response.Headers.Append("Set-Cookie", "user-id=7;Secure;SameSite=Strict");
+            return StatusCode(200);
+        }        
+        
         [HttpPost("path_traversal/test_insecure")]
         public IActionResult TestInsecurePathTraversal([FromForm] RequestData data)
         {


### PR DESCRIPTION
## Description

This PR contains the tests for the no http only cookie vulnerability.

## Motivation

This is a feature already supported, but no system test was done.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
