### PR TITLE
Skip flaky IAST test on java

### DIFF
--- a/tests/appsec/iast/sink/test_hsts_missing_header.py
+++ b/tests/appsec/iast/sink/test_hsts_missing_header.py
@@ -17,7 +17,7 @@ class Test_HstsMissingHeader(BaseSinkTest):
     data = {}
     headers = {"X-Forwarded-Proto": "https"}
 
-    @flaky(context.library < "java@1.22.0", reason="Unrelated bug interferes with this test APPSEC-11353")
+    @flaky(context.library == "java", reason="An XCONTENTTYPE_HEADER_MISSING event is reported")
     def test_secure(self):
         super().test_secure()
 


### PR DESCRIPTION
## Description

The IAST test on HSTS report some times a XCONTENTTYPE_HEADER_MISSING event

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
