### PR TITLE
Adjust extra_services assertions

### DIFF
--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -299,7 +299,6 @@ class Test_RemoteConfigurationExtraServices:
 
         interfaces.library.wait_for(remote_config_asm_extra_services_available, timeout=30)
 
-    @bug(library="dotnet", reason="APPSEC-11886")
     def test_tracer_extra_services(self):
         """Test extra services field"""
         import itertools

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -301,7 +301,8 @@ class Test_RemoteConfigurationExtraServices:
 
     @bug(library="dotnet", reason="APPSEC-11886")
     def test_tracer_extra_services(self):
-        """test"""
+        """Test extra services field"""
+        import itertools
 
         # filter extra services
         extra_services = []
@@ -311,8 +312,12 @@ class Test_RemoteConfigurationExtraServices:
                 if "extra_services" in client_tracer:
                     extra_services.append(client_tracer["extra_services"])
         assert self.r_outgoing.status_code == 200
-        assert len(extra_services) != 0, "extra_services not found"
-        assert any(es == ["extraVegetables"] for es in extra_services), "extraVegetables extra service not found"
+        assert extra_services, "extra_services not found"
+        extra_services = list(itertools.dropwhile(lambda es: "extraVegetables" not in es, extra_services))
+        assert extra_services, "no extra_services contains extraVegetables"
+        assert all(
+            "extraVegetables" in es for es in extra_services
+        ), "extraVegetables is not found in all requests after it was initially added"
 
 
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")


### PR DESCRIPTION
## Description

* Allows additional extra_services beyond the one added by the test. This can happen peer services like kafka, mysql, etc.
* Ensure that once the extra_service of interest is seen, it is also seen in all subsequent requests.

## Motivation

JIRA issue: [APPSEC-11886]

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly


[APPSEC-11886]: https://datadoghq.atlassian.net/browse/APPSEC-11886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ