### PR TITLE
[node.js] Enable RC extra services test [APPSEC-11927]

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -300,9 +300,7 @@ tests/:
       Test_TracerSCITagging: v3.21.0
   remote_config/:
     test_remote_configuration.py:
-      Test_RemoteConfigurationExtraServices:
-        '*': missing_feature
-        express4: v4.17.0
+      Test_RemoteConfigurationExtraServices: v4.17.0
       Test_RemoteConfigurationUpdateSequenceASMDD: v3.19.0
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceFeatures: v3.9.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -300,7 +300,9 @@ tests/:
       Test_TracerSCITagging: v3.21.0
   remote_config/:
     test_remote_configuration.py:
-      Test_RemoteConfigurationExtraServices: missing_feature
+      Test_RemoteConfigurationExtraServices:
+        '*': missing_feature
+        express4: v4.17.0
       Test_RemoteConfigurationUpdateSequenceASMDD: v3.19.0
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceFeatures: v3.9.0

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -202,6 +202,15 @@ app.post('/shell_execution', (req: Request, res: Response) => {
   res.send(response)
 })
 
+app.get('/createextraservice', (req: Request, res: Response) => {
+  const serviceName = req.query['serviceName']
+
+  const span = tracer.scope().active()
+  span.setTag('service.name', serviceName)
+
+  res.send('OK')
+})
+
 app.listen(7777, '0.0.0.0', () => {
   tracer.trace('init.service', () => {});
   console.log('listening');

--- a/utils/build/docker/nodejs/express4/app.js
+++ b/utils/build/docker/nodejs/express4/app.js
@@ -235,6 +235,15 @@ app.post('/shell_execution', (req, res) => {
   res.send(response)
 })
 
+app.get('/createextraservice', (req, res) => {
+  const serviceName = req.query['serviceName']
+
+  const span = tracer.scope().active()
+  span.setTag('service.name', serviceName)
+
+  res.send('OK')
+})
+
 iast.initRoutes(app, tracer)
 
 require('./auth')(app, passport, tracer)

--- a/utils/build/docker/nodejs/nextjs/src/app/createextraservice/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/createextraservice/route.js
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET (request) {
+  const serviceName = request.nextUrl.searchParams.get('serviceName')
+  const span = global._ddtrace?.scope().active()
+  span?.setTag('service.name', serviceName)
+
+  return NextResponse.json({ message: 'OK' })
+}


### PR DESCRIPTION
## Description

Implement and enable RC extra services test

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
