### PR TITLE
[.Net] Ldap tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -23,7 +23,7 @@ tests/:
         test_insecure_cookie.py:
           TestInsecureCookie: v2.39.0
         test_ldap_injection.py:
-          TestLDAPInjection: missing_feature
+          TestLDAPInjection: v2.36.0
         test_no_httponly_cookie.py:
           TestNoHttponlyCookie: v2.39.0
         test_no_samesite_cookie.py:

--- a/tests/appsec/iast/sink/test_ldap_injection.py
+++ b/tests/appsec/iast/sink/test_ldap_injection.py
@@ -21,6 +21,7 @@ class TestLDAPInjection(BaseSinkTest):
     }
 
     @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -285,16 +285,30 @@ namespace weblog
         [HttpPost("ldapi/test_insecure")]
         public IActionResult TestInsecureLdap([FromForm] string username, [FromForm] string password)
         {
-            string ldapPath = "LDAP://" + username + ":" + password + "@ldap.example.com/OU=Users,DC=example,DC=com";
-            _ = new System.DirectoryServices.DirectoryEntry(ldapPath);
-            return Content($"Conection created");
+            try
+            {
+                string ldapPath = "LDAP://" + username + ":" + password + "@ldap.example.com/OU=Users,DC=example,DC=com";
+                _ = new System.DirectoryServices.DirectoryEntry(ldapPath);
+                return Content($"Conection created");
+            }
+            catch
+            {
+                return Content($"Error creating connection");
+            }
         }
         
         [HttpPost("ldapi/test_secure")]
         public IActionResult TestSecureLdap([FromForm] string username, [FromForm] string password)
         {
-            _ = new System.DirectoryServices.DirectoryEntry("LDAP://ldap.example.com/OU=Users,DC=example,DC=com", username, password);
-            return Content($"Conection created");
+            try
+            {        
+                _ = new System.DirectoryServices.DirectoryEntry("LDAP://ldap.example.com/OU=Users,DC=example,DC=com", username, password);
+                return Content($"Conection created");
+            }
+            catch
+            {
+                return Content($"Error creating connection");
+            }                
         }
         
         [HttpPost("sqli/test_insecure")]

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -72,25 +72,61 @@ namespace weblog
         [HttpPost("source/parameter/test")]
         public IActionResult parameterTestPost([FromForm] RequestData data)
         {
-            LaunchProcess(data.table);
+            try
+            {
+                System.Diagnostics.Process.Start(data.table);
+                
+                return Content("Ok");
+            }
+            catch
+            {
+                return StatusCode(500, "NotOk");
+            }
         }
 
         [HttpGet("source/parameter/test")]
         public IActionResult parameterTest(string table)
         {
-            LaunchProcess(table);
+            try
+            {
+                System.Diagnostics.Process.Start(table);
+                
+                return Content("Ok");
+            }
+            catch
+            {
+                return StatusCode(500, "NotOk");
+            }
         }
         
         [HttpPost("source/parametername/test")]
         public IActionResult parameterNameTestPost([FromForm] RequestData data)
         {
-            LaunchProcess(data.user);
+            try
+            {
+                System.Diagnostics.Process.Start(data.user);
+                
+                return Content("Ok");
+            }
+            catch
+            {
+                return StatusCode(500, "NotOk");
+            }
         }
 
         [HttpGet("source/parametername/test")]
         public IActionResult parameterNameTest(string user)
         {
-            LaunchProcess(Request.Query.First().Key);
+            try
+            {
+                System.Diagnostics.Process.Start(Request.Query.First().Key);
+                
+                return Content("Ok");
+            }
+            catch
+            {
+                return StatusCode(500, "NotOk");
+            }
         }
 
         [HttpGet("insecure_cipher/test_insecure_algorithm")]
@@ -110,28 +146,31 @@ namespace weblog
         [HttpPost("cmdi/test_insecure")]
         public IActionResult test_insecure_cmdI([FromForm] RequestData data)
         {
-           LaunchProcess(data.cmd);
-        }
-        
-        [HttpPost("cmdi/test_secure")]
-        public IActionResult test_secure_cmdI([FromForm] RequestData data)
-        {
-            LaunchProcess("ls");
-        }
-        
-        private IActionResult LaunchProcess(string processName)
-        {
             try
             {            
-                if (!string.IsNullOrEmpty(processName))
+                if (!string.IsNullOrEmpty(data.cmd))
                 {
-                    var result = Process.Start(processName);
+                    var result = Process.Start(data.cmd);
                     return Content($"Process launched: " + result.ProcessName);
                 }
                 else
                 {
                     return BadRequest($"No file was provided");
                 }
+            }
+            catch
+            {
+                return StatusCode(500, "Error launching process.");
+            }
+        }
+        
+        [HttpPost("cmdi/test_secure")]
+        public IActionResult test_secure_cmdI([FromForm] RequestData data)
+        {
+            try
+            {
+                var result = Process.Start("ls");
+                return Content($"Process launched: " + result.ProcessName);
             }
             catch
             {

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -72,61 +72,25 @@ namespace weblog
         [HttpPost("source/parameter/test")]
         public IActionResult parameterTestPost([FromForm] RequestData data)
         {
-            try
-            {
-                System.Diagnostics.Process.Start(data.table);
-                
-                return Content("Ok");
-            }
-            catch
-            {
-                return StatusCode(500, "NotOk");
-            }
+            LaunchProcess(data.table);
         }
 
         [HttpGet("source/parameter/test")]
         public IActionResult parameterTest(string table)
         {
-            try
-            {
-                System.Diagnostics.Process.Start(table);
-                
-                return Content("Ok");
-            }
-            catch
-            {
-                return StatusCode(500, "NotOk");
-            }
+            LaunchProcess(table);
         }
         
         [HttpPost("source/parametername/test")]
         public IActionResult parameterNameTestPost([FromForm] RequestData data)
         {
-            try
-            {
-                System.Diagnostics.Process.Start(data.user);
-                
-                return Content("Ok");
-            }
-            catch
-            {
-                return StatusCode(500, "NotOk");
-            }
+            LaunchProcess(data.user);
         }
 
         [HttpGet("source/parametername/test")]
         public IActionResult parameterNameTest(string user)
         {
-            try
-            {
-                System.Diagnostics.Process.Start(Request.Query.First().Key);
-                
-                return Content("Ok");
-            }
-            catch
-            {
-                return StatusCode(500, "NotOk");
-            }
+            LaunchProcess(Request.Query.First().Key);
         }
 
         [HttpGet("insecure_cipher/test_insecure_algorithm")]
@@ -146,31 +110,28 @@ namespace weblog
         [HttpPost("cmdi/test_insecure")]
         public IActionResult test_insecure_cmdI([FromForm] RequestData data)
         {
+           LaunchProcess(data.cmd);
+        }
+        
+        [HttpPost("cmdi/test_secure")]
+        public IActionResult test_secure_cmdI([FromForm] RequestData data)
+        {
+            LaunchProcess("ls");
+        }
+        
+        private IActionResult LaunchProcess(string processName)
+        {
             try
             {            
-                if (!string.IsNullOrEmpty(data.cmd))
+                if (!string.IsNullOrEmpty(processName))
                 {
-                    var result = Process.Start(data.cmd);
+                    var result = Process.Start(processName);
                     return Content($"Process launched: " + result.ProcessName);
                 }
                 else
                 {
                     return BadRequest($"No file was provided");
                 }
-            }
-            catch
-            {
-                return StatusCode(500, "Error launching process.");
-            }
-        }
-        
-        [HttpPost("cmdi/test_secure")]
-        public IActionResult test_secure_cmdI([FromForm] RequestData data)
-        {
-            try
-            {
-                var result = Process.Start("ls");
-                return Content($"Process launched: " + result.ProcessName);
             }
             catch
             {

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -281,7 +281,22 @@ namespace weblog
                 return StatusCode(500, "Error in request.");
             }
         }
-
+        
+        [HttpPost("ldapi/test_insecure")]
+        public IActionResult TestInsecureLdap([FromForm] string username, [FromForm] string password)
+        {
+            string ldapPath = "LDAP://" + username + ":" + password + "@ldap.example.com/OU=Users,DC=example,DC=com";
+            _ = new System.DirectoryServices.DirectoryEntry(ldapPath);
+            return Content($"Conection created");
+        }
+        
+        [HttpPost("ldapi/test_secure")]
+        public IActionResult TestSecureLdap([FromForm] string username, [FromForm] string password)
+        {
+            _ = new System.DirectoryServices.DirectoryEntry("LDAP://ldap.example.com/OU=Users,DC=example,DC=com", username, password);
+            return Content($"Conection created");
+        }
+        
         [HttpPost("sqli/test_insecure")]
         public IActionResult test_insecure_sqlI([FromForm] string username, [FromForm] string password)
         {

--- a/utils/build/docker/dotnet/app.csproj
+++ b/utils/build/docker/dotnet/app.csproj
@@ -17,6 +17,7 @@
 		<PackageReference Include="Npgsql" Version="4.0.10" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
 		<PackageReference Include="Microsoft.Data.Sqlite " />
+		<PackageReference Include="System.DirectoryServices" Version="6.0.0" />
 		<PackageReference Include="NodaTime" Version="3.1.6"/>
                 <PackageReference Include="Confluent.Kafka" Version="1.9.3" />
                 <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />


### PR DESCRIPTION
## Description

This PR contains the implementation of the Ldap tests for .net

## Motivation

This is a feature not tested that we already support.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
