### PR TITLE
Hardcoded secrets test [APPSEC-11807]

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -191,6 +191,10 @@ The endpoint executes a unique operation of String hashing with given algorithm 
 
 The endpoint executes a unique operation of String hashing with unsecure MD5 algorithm
 
+### GET /iast/hardcoded_secrets/test_insecure
+
+Parameterless endpoint. This endpoint contains a hardcoded secret. The declaration of the hardcoded secret should be sufficient to trigger the vulnerability, so returning it in the response is optional.
+
 ### \[GET, POST\] /iast/source/*
 
 This group of endpoints should trigger vulnerabilities detected by IAST with untrusted data coming from certain sources. The used vulnerability is irrelevant. It could be a command injection, SQL injection, or something else.

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -10,6 +10,7 @@ tests/:
     iast/:
       sink/:
         test_command_injection.py: irrelevant (ASM is not implemented in C++)
+        test_hardcoded_secrets.py: irrelevant (ASM is not implemented in C++)
         test_hsts_missing_header.py: irrelevant (ASM is not implemented in C++)
         test_insecure_cookie.py: irrelevant (ASM is not implemented in C++)
         test_ldap_injection.py: irrelevant (ASM is not implemented in C++)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -18,6 +18,8 @@ tests/:
       sink/:
         test_command_injection.py:
           TestCommandInjection: v2.28.0
+        test_hardcoded_secrets.py:
+          Test_HardcodedSecrets: missing_feature             
         test_hsts_missing_header.py: 
           Test_HstsMissingHeader: missing_feature
         test_insecure_cookie.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -21,7 +21,9 @@ tests/:
     iast/:
       sink/:
         test_command_injection.py:
-          TestCommandInjection: missing_feature
+          TestCommandInjection: 
+        test_hardcoded_secrets.py:
+          Test_HardcodedSecrets: missing_feature          
         test_hsts_missing_header.py: 
           Test_HstsMissingHeader: missing_feature
         test_insecure_cookie.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -21,7 +21,7 @@ tests/:
     iast/:
       sink/:
         test_command_injection.py:
-          TestCommandInjection: 
+          TestCommandInjection: missing_feature
         test_hardcoded_secrets.py:
           Test_HardcodedSecrets: missing_feature          
         test_hsts_missing_header.py: 

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -31,6 +31,8 @@ tests/:
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
             vertx3: v1.12.0
             vertx4: v1.12.0
+        test_hardcoded_secrets.py:
+          Test_HardcodedSecrets: missing_feature            
         test_hsts_missing_header.py:
           Test_HstsMissingHeader:
             '*': missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -20,6 +20,10 @@ tests/:
           TestCommandInjection:
             '*': missing_feature
             express4: v3.11.0
+        test_hardcoded_secrets.py:
+          Test_HardcodedSecrets:
+            '*': missing_feature
+            express4: v4.18.0
         test_hsts_missing_header.py: 
           Test_HstsMissingHeader:
             '*': missing_feature

--- a/manifests/php_appsec.yml
+++ b/manifests/php_appsec.yml
@@ -13,6 +13,8 @@ tests/:
       sink/:
         test_command_injection.py:
           TestCommandInjection: missing_feature
+        test_hardcoded_secrets.py:
+          Test_HardcodedSecrets: missing_feature          
         test_hsts_missing_header.py: 
           Test_HstsMissingHeader: missing_feature
         test_insecure_cookie.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -49,6 +49,8 @@ tests/:
             '*': v2.2.0
             fastapi: missing_feature
             python3.12: missing_feature
+        test_hardcoded_secrets.py:
+          Test_HardcodedSecrets: missing_feature            
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: missing_feature
         test_insecure_cookie.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -20,6 +20,8 @@ tests/:
       sink/:
         test_command_injection.py:
           TestCommandInjection: missing_feature
+        test_hardcoded_secrets.py:
+          Test_HardcodedSecrets: missing_feature          
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: missing_feature
         test_insecure_cookie.py:

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -5,6 +5,7 @@ from utils.tools import logging
 
 DetectionStage = Enum("DetectionStage", ["REQUEST", "STARTUP"])
 
+
 def _get_expectation(d):
     if d is None or isinstance(d, str):
         return d
@@ -101,7 +102,7 @@ class BaseSinkTestWithoutTelemetry:
 
     def test_insecure(self):
         assert_iast_vulnerability(
-            request=self.insecure_request if self.detection_stage==DetectionStage.REQUEST else None,
+            request=self.insecure_request if self.detection_stage == DetectionStage.REQUEST else None,
             vulnerability_count=1,
             vulnerability_type=self.vulnerability_type,
             expected_location=self.expected_location,

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -1,7 +1,9 @@
+from enum import Enum
 import json
 from utils import weblog, interfaces, context
 from utils.tools import logging
 
+DetectionStage = Enum("DetectionStage", ["REQUEST", "STARTUP"])
 
 def _get_expectation(d):
     if d is None or isinstance(d, str):
@@ -73,6 +75,8 @@ class BaseSinkTestWithoutTelemetry:
     insecure_request = None
     secure_request = None
 
+    detection_stage = DetectionStage.REQUEST
+
     @property
     def expected_location(self):
         return _get_expectation(self.location_map)
@@ -97,7 +101,7 @@ class BaseSinkTestWithoutTelemetry:
 
     def test_insecure(self):
         assert_iast_vulnerability(
-            request=self.insecure_request,
+            request=self.insecure_request if self.detection_stage==DetectionStage.REQUEST else None,
             vulnerability_count=1,
             vulnerability_type=self.vulnerability_type,
             expected_location=self.expected_location,

--- a/tests/appsec/iast/sink/test_hardcoded_secrets.py
+++ b/tests/appsec/iast/sink/test_hardcoded_secrets.py
@@ -17,7 +17,7 @@ class Test_HardcodedSecrets(BaseSinkTest):
     secure_endpoint = "/iast/hardcoded_secrets/test_secure"
     data = {}
     location_map = {"nodejs": "iast/index.js"}
-    detection_stage=DetectionStage.STARTUP
+    detection_stage = DetectionStage.STARTUP
 
     @missing_feature(library="nodejs", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):

--- a/tests/appsec/iast/sink/test_hardcoded_secrets.py
+++ b/tests/appsec/iast/sink/test_hardcoded_secrets.py
@@ -1,0 +1,31 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+from utils import flaky, context, coverage, missing_feature
+from utils.tools import logging
+from .._test_iast_fixtures import BaseSinkTest
+
+
+@coverage.basic
+class Test_HardcodedSecrets(BaseSinkTest):
+    """Test Hardcoded secrets detection."""
+
+    vulnerability_type = "HARDCODED_SECRET"
+    http_method = "GET"
+    insecure_endpoint = "/iast/hardcoded_secrets/test_insecure"
+    secure_endpoint = "/iast/hardcoded_secrets/test_secure"
+    data = {}
+    location_map = {"nodejs": "iast/index.js"}
+
+    def test_insecure(self):
+        self.insecure_request = None
+        super().test_insecure()
+
+    @missing_feature(library="nodejs", reason="Not implemented yet")
+    def test_telemetry_metric_instrumented_sink(self):
+        super().test_telemetry_metric_instrumented_sink()
+
+    @missing_feature(library="nodejs", reason="Not implemented yet")
+    def test_telemetry_metric_executed_sink(self):
+        super().test_telemetry_metric_executed_sink()

--- a/tests/appsec/iast/sink/test_hardcoded_secrets.py
+++ b/tests/appsec/iast/sink/test_hardcoded_secrets.py
@@ -4,7 +4,7 @@
 
 from utils import flaky, context, coverage, missing_feature
 from utils.tools import logging
-from .._test_iast_fixtures import BaseSinkTest
+from .._test_iast_fixtures import BaseSinkTest, DetectionStage
 
 
 @coverage.basic
@@ -17,10 +17,7 @@ class Test_HardcodedSecrets(BaseSinkTest):
     secure_endpoint = "/iast/hardcoded_secrets/test_secure"
     data = {}
     location_map = {"nodejs": "iast/index.js"}
-
-    def test_insecure(self):
-        self.insecure_request = None
-        super().test_insecure()
+    detection_stage=DetectionStage.STARTUP
 
     @missing_feature(library="nodejs", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):

--- a/utils/build/docker/nodejs/express4/iast/index.js
+++ b/utils/build/docker/nodejs/express4/iast/index.js
@@ -292,6 +292,16 @@ function initRoutes (app, tracer) {
     searchLdap(filter, req, res)
   })
 
+  app.get('/iast/hardcoded_secrets/test_insecure', (req, res) => {
+    const secret = 'A3TMAWZUKIWR6O0OGR7B'
+    res.send(`OK:${secret}`)
+  })
+
+  app.get('/iast/hardcoded_secrets/test_secure', (req, res) => {
+    const secret = 'unknown_secret'
+    res.send(`OK:${secret}`)
+  })
+
   require('./sources')(app, tracer)
 
 }


### PR DESCRIPTION
## Description

Includes a nodejs test for the new `HARDCODED_SECRET` vulnerability.

In the case of nodejs, the vulnerability is detected in the application startup so it differs a bit from the rest of the existing sink tests.

`test_insecure` method checks the value of the new `detection_stage` property in `BaseSinkTestWithoutTelemetry`:
- If `DetectionStage.REQUEST` (the default value), `test_insecure` passes the request as always. 
- If `DetectionStage.STARTUP` it passes a `None` request.

NOTE: Another option could be to add a `request` argument to the `test_insecure` method and pass a `None` request when necessary. 


## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
