### PR TITLE
build: go: switch rules location

### DIFF
--- a/utils/build/docker/golang/install_ddtrace.sh
+++ b/utils/build/docker/golang/install_ddtrace.sh
@@ -28,8 +28,11 @@ touch SYSTEM_TESTS_LIBDDWAF_VERSION
 rules_mod_dir=$(go list -f '{{.Dir}}' -m github.com/DataDog/appsec-internal-go)
 
 # Read the rule file version
-if [[ -f $rules_mod_dir/appsec/rules.json ]]; then
-    # Parse the appsec rules version string out of the inlined rules json
+if [[ -f $lib_mod_dir/internal/appsec/rules.json ]]; then
+    # Look for the ruleset in dd-trace-go
+    rules_version=$(jq -r .metadata.rules_version $lib_mod_dir/internal/appsec/rules.json)
+elif [[ -f $rules_mod_dir/appsec/rules.json ]]; then
+    # Look for the ruleset in appsec-internal-go
     rules_version=$(jq -r .metadata.rules_version $rules_mod_dir/appsec/rules.json)
 elif [[ $(cat $rules_mod_dir/appsec/rules.go) =~ rules_version\\\":\\\"([[:digit:].-]+)\\\" ]]; then
     # Parse the appsec rules version string out of the inlined rules json

--- a/utils/build/docker/golang/install_ddtrace.sh
+++ b/utils/build/docker/golang/install_ddtrace.sh
@@ -19,17 +19,19 @@ fi
 go mod tidy
 
 # Read the library version out of the version.go file
-mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)
-version=$(sed -nrE 's#.*"v(.*)".*#\1#p' $mod_dir/internal/version/version.go) # Parse the version string content "v.*"
+lib_mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)
+version=$(sed -nrE 's#.*"v(.*)".*#\1#p' $lib_mod_dir/internal/version/version.go) # Parse the version string content "v.*"
 echo $version > SYSTEM_TESTS_LIBRARY_VERSION
 
 touch SYSTEM_TESTS_LIBDDWAF_VERSION
 
+rules_mod_dir=$(go list -f '{{.Dir}}' -m github.com/DataDog/appsec-internal-go)
+
 # Read the rule file version
-if [[ -f $mod_dir/internal/appsec/rules.json ]]; then
+if [[ -f $rules_mod_dir/appsec/rules.json ]]; then
     # Parse the appsec rules version string out of the inlined rules json
-    rules_version=$(jq -r .metadata.rules_version $mod_dir/internal/appsec/rules.json)
-elif [[ $(cat $mod_dir/internal/appsec/rule.go) =~ rules_version\\\":\\\"([[:digit:].-]+)\\\" ]]; then
+    rules_version=$(jq -r .metadata.rules_version $rules_mod_dir/appsec/rules.json)
+elif [[ $(cat $rules_mod_dir/appsec/rules.go) =~ rules_version\\\":\\\"([[:digit:].-]+)\\\" ]]; then
     # Parse the appsec rules version string out of the inlined rules json
     rules_version="${BASH_REMATCH[1]}"
 else


### PR DESCRIPTION
## Description

The recommended ruleset was moved from dd-trace-go/internal/appsec/rules.json to appsec-internal-go/appsec/rules.json (blocked by DataDog/dd-trace-go#2312). Since this script references the rules location to extract its version so we need to modify it.

## Motivation

We are moving the recommended ruleset from dd-trace-go to appsec-internal-go to centralize some code between the datadog-agent repo and the dd-trace-go repo.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
