### PR TITLE
Doc : Get core info on segfault

### DIFF
--- a/docs/internals/generate-core-dump.md
+++ b/docs/internals/generate-core-dump.md
@@ -1,0 +1,22 @@
+When weblog experiences segmentation fault, it may be difficult to get a core dump. Here is an helpful recipe from @sanchda : 
+
+> * Assumes a glibc-compatible container
+> * download https://github.com/sanchda/test_gcr/releases/download/v1.16.1_innerapi/libSegFault.so into the image
+> * Make it executable
+> * LD_PRELOAD the resulting file somewhere in the environment python will pick up
+> * It’ll emit the backtrace at the crash site as well as some useful diagnostic information to stdio
+
+For instance, on python django weblog : 
+
+```bash
+> docker run -it system_tests/weblog bash
+root@x:/app# apt-get install weget
+root@x:/app# wget https://github.com/sanchda/test_gcr/releases/download/v1.16.1_innerapi/libSegFault.so
+root@x:/app# chmod +x libSegFault.so
+root@x:/app# LD_PRELOAD=/app/libSegFault.so ddtrace-run gunicorn -w 1 -b 0.0.0.0:7777 --access-logfile - django_app.wsgi -k gevent
+
+
+... And here comes the fun !!!
+
+
+```


### PR DESCRIPTION
## Description

Profiling is flaky at startup on profiling/python3.12

A core is dumped, but is not present in artifact. This PR fixes this.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
