### PR TITLE
Fix flaky HSTS header missing request test

### DIFF
--- a/tests/appsec/iast/sink/test_hsts_missing_header.py
+++ b/tests/appsec/iast/sink/test_hsts_missing_header.py
@@ -17,7 +17,6 @@ class Test_HstsMissingHeader(BaseSinkTest):
     data = {}
     headers = {"X-Forwarded-Proto": "https"}
 
-    @flaky(context.library == "java", reason="An XCONTENTTYPE_HEADER_MISSING event is reported")
     def test_secure(self):
         super().test_secure()
 

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/iast/XContentTypeInterceptor.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/iast/XContentTypeInterceptor.java
@@ -16,14 +16,11 @@ public class XContentTypeInterceptor implements HandlerInterceptor {
     private static final String NOSNIFF = "nosniff";
 
     @Override
-    public void postHandle(@Nonnull final HttpServletRequest request,
-                           @Nonnull final HttpServletResponse response,
-                           @Nonnull final Object handler,
-                           final ModelAndView modelAndView) throws Exception {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         if (!isXContentTypeVulnerabilityEndpoint(request)) {
-            // XXX: Avoid triggering XCONTENTTYPE_MISSING_HEADER vulnerability.
             response.setHeader(XCONTENT_TYPE_HEADER, NOSNIFF);
         }
+        return true;
     }
 
     private boolean isXContentTypeVulnerabilityEndpoint(final HttpServletRequest request) {


### PR DESCRIPTION
## Description

The error showed up depending on the order of the tests. The deduplication code did remove it most of the time. The error showed up because the XContentType header was set post request and not pre request, so the header was not present during analysis.

## Motivation

To get the test to pass every time.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
