### PR TITLE
Fix Java parametric client OTel span kind mapping

### DIFF
--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/OpenTelemetryClient.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/OpenTelemetryClient.java
@@ -130,6 +130,8 @@ public class OpenTelemetryClient extends APMClientGrpc.APMClientImplBase {
             case 3:
                 return SpanKind.CLIENT;
             case 4:
+                return SpanKind.PRODUCER;
+            case 5:
                 return SpanKind.CONSUMER;
             case 0:
             default:


### PR DESCRIPTION
## Description

Looks like the OTel span kind got a new enum value.

## Motivation

This PR adds it to fix the parametric OTel tests.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [x] CI is green
   * [x] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
