### PR TITLE
[DSM][Context Propagation]Add Kafka consume and produce endpoints for testing context propagation behavior

### DIFF
--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -286,6 +286,32 @@ public class App {
         return "hi Mongo";
     }
 
+    @RequestMapping("/kafka/produce")
+    String kafkaProduce() {
+        KafkaConnector kafka = new KafkaConnector();
+        try {
+            kafka.startProducingMessage("DistributedTracing");
+        } catch (Exception e) {
+            System.out.println("[kafka] Failed to start producing message...");
+            e.printStackTrace();
+            return "failed to start producing message";
+        }
+        return "ok";
+    }
+
+    @RequestMapping("/kafka/consume")
+    String kafkaConsume() {
+        KafkaConnector kafka = new KafkaConnector();
+        try {
+                kafka.startConsumingMessages();
+            } catch (Exception e) {
+                System.out.println("[kafka] Failed to start consuming message...");
+                e.printStackTrace();
+                return "failed to start consuming message";
+            }
+        return "ok";
+    }
+
     @RequestMapping("/dsm")
     String publishToKafka(@RequestParam(required = true, name="integration") String integration) {
         if ("kafka".equals(integration)) {

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -290,7 +290,7 @@ public class App {
     String kafkaProduce() {
         KafkaConnector kafka = new KafkaConnector();
         try {
-            kafka.startProducingMessage("DistributedTracing");
+            kafka.produceMessageWithoutNewThread("DistributedTracing");
         } catch (Exception e) {
             System.out.println("[kafka] Failed to start producing message...");
             e.printStackTrace();
@@ -303,7 +303,7 @@ public class App {
     String kafkaConsume() {
         KafkaConnector kafka = new KafkaConnector();
         try {
-                kafka.startConsumingMessages();
+                kafka.consumeMessageWithoutNewThread();
             } catch (Exception e) {
                 System.out.println("[kafka] Failed to start consuming message...");
                 e.printStackTrace();

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/kafka/KafkaConnector.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/kafka/KafkaConnector.java
@@ -77,4 +77,21 @@ public class KafkaConnector {
         thread.start();
         System.out.println("Started Kafka consumer thread");
     }
+
+    // For APM testing, produce message without starting a new thread
+    public void produceMessageWithoutNewThread(String message) throws Exception {
+        KafkaTemplate kafkaTemplate = createKafkaTemplateForProducer();
+        System.out.println(String.format("Publishing message: %s", message));
+        kafkaTemplate.send(TOPIC, message);
+    }
+
+    // For APM testing, a consume message without starting a new thread
+    public void consumeMessageWithoutNewThread() throws Exception {
+        KafkaConsumer<String, String> consumer = createKafkaConsumer();
+        consumer.subscribe(Arrays.asList(TOPIC));
+        ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
+        for (ConsumerRecord<String, String> record : records) {
+            System.out.println("got record! " + record.value() + " from " + record.topic());
+        }
+    }
 }


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

This PR adds the following endpoints without creating new threads for Kafka produce and consume:

- `/kafka/produce` 

<img width="936" alt="image" src="https://github.com/DataDog/system-tests/assets/26727996/eb960d5e-1feb-4a8f-9fd4-f3ca08aee223">

- `/kafka/consume` 

<img width="1047" alt="image" src="https://github.com/DataDog/system-tests/assets/26727996/51f58dda-3423-4197-9f08-2c63101bc654">


## Motivation

<!-- What inspired you to submit this pull request? -->

Relates to the goals of https://github.com/DataDog/system-tests/pull/1757 and https://github.com/DataDog/system-tests/pull/1783, this PR adds consume and produce endpoints for Java.


## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
