### PR TITLE
Enable parametric OpenTelemetry span naming tests for Java tracer 

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.parametrize(
 @scenarios.parametric
 class Test_Otel_Span_Methods:
     @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "java", reason="New operation name mapping not yet implemented")
+    @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
@@ -49,7 +49,7 @@ class Test_Otel_Span_Methods:
         assert root_span["duration"] == duration * 1_000  # OTEL expects microseconds but we convert it to ns internally
 
     @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "java", reason="New operation name mapping not yet implemented")
+    @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
@@ -69,9 +69,9 @@ class Test_Otel_Span_Methods:
         assert root_span["service"] == "new_service"
 
     @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
-    @missing_feature(
+    @irrelevant(
         context.library == "java",
-        reason="New operation name mapping not yet implemented - note 1.22.0 uses new array encoding too",
+        reason="Old array encoding was removed in 1.22.0 and new span naming introduced in 1.24.0: no version elligible for this test.",
     )
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
@@ -147,8 +147,8 @@ class Test_Otel_Span_Methods:
         context.library == "golang", reason="New operation name mapping & array encoding not yet implemented"
     )
     @missing_feature(
-        context.library == "java",
-        reason="New operation name mapping & array encoding not yet implemented - < 1.22.0 doesn't have new array encoding",
+        context.library < "java@1.24.0",
+        reason="New array encoding implemented in 1.22.0 and new operation name mapping in 1.24.0",
     )
     @missing_feature(
         context.library == "nodejs", reason="New operation name mapping & array encoding not yet implemented"
@@ -232,7 +232,7 @@ class Test_Otel_Span_Methods:
                 assert not parent.is_recording()
 
     @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "java", reason="New operation name mapping not yet implemented")
+    @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(
         context.library == "dotnet",
@@ -261,7 +261,7 @@ class Test_Otel_Span_Methods:
         assert s.get("duration") == duration * 1_000
 
     @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "java", reason="New operation name mapping not yet implemented")
+    @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
@@ -298,7 +298,7 @@ class Test_Otel_Span_Methods:
         assert child["parent_id"] == parent_span["span_id"]
 
     @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "java", reason="New operation name mapping not yet implemented")
+    @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(
         context.library == "dotnet",
@@ -327,7 +327,7 @@ class Test_Otel_Span_Methods:
         assert s.get("resource") == "error_span"
 
     @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "java", reason="New operation name mapping not yet implemented")
+    @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(
         context.library == "dotnet",
@@ -379,7 +379,7 @@ class Test_Otel_Span_Methods:
                     assert context.get("trace_flags") == "01"
 
     @missing_feature(context.library == "golang", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
@@ -423,7 +423,7 @@ class Test_Otel_Span_Methods:
         )
 
     @missing_feature(context.library == "golang", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")


### PR DESCRIPTION
## Description

Enable parametric OpenTelemetry span naming tests for Java tracer.

## Motivation

As the tests was just merged, we want to enable them on our CI as soon as possible.
Feature is expected to be merged by the end of the week.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
