### PR TITLE
Allow multiple source names in tests and use the feature in the multipart test

### DIFF
--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -225,7 +225,6 @@ class BaseSourceTest:
         sources = iast["sources"]
         assert sources, "No source reported"
         if source_type:
-            assert isinstance(source_type, (tuple, set, list)), "source_type must a set, a tuple or a list"
             assert any(x in source_type for x in {s.get("origin") for s in sources})
             sources = [s for s in sources if s["origin"] in source_type]
         if self.source_name:

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -225,7 +225,7 @@ class BaseSourceTest:
         sources = iast["sources"]
         assert sources, "No source reported"
         if source_type:
-            assert any(x in self.source_type for x in {s.get("origin") for s in sources})
+            assert any(x in source_type for x in {s.get("origin") for s in sources})
             sources = [s for s in sources if s["origin"] in self.source_type]
         if self.source_name:
             assert any(x in self.source_name for x in {s.get("name") for s in sources})

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -225,14 +225,14 @@ class BaseSourceTest:
         sources = iast["sources"]
         assert sources, "No source reported"
         if source_type:
-            assert source_type in {s.get("origin") for s in sources}
-            sources = [s for s in sources if s["origin"] == source_type]
+            assert any(x in self.source_type for x in {s.get("origin") for s in sources})
+            sources = [s for s in sources if s["origin"] in self.source_type]
         if self.source_name:
-            assert self.source_name in {s.get("name") for s in sources}
-            sources = [s for s in sources if s["name"] == self.source_name]
+            assert any(x in self.source_name for x in {s.get("name") for s in sources})
+            sources = [s for s in sources if s["name"] in self.source_name]
         if self.source_value:
-            assert self.source_value in {s.get("value") for s in sources}
-            sources = [s for s in sources if s["value"] == self.source_value]
+            assert any(x in self.source_value for x in {s.get("value") for s in sources})
+            sources = [s for s in sources if s["value"] in self.source_value]
         assert sources, f"No source found with origin={source_type}, name={self.source_name}, value={self.source_value}"
         assert len(sources) == 1, "Expected a single source with the matching criteria"
 

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -226,7 +226,7 @@ class BaseSourceTest:
         assert sources, "No source reported"
         if source_type:
             assert any(x in source_type for x in {s.get("origin") for s in sources})
-            sources = [s for s in sources if s["origin"] in self.source_type]
+            sources = [s for s in sources if s["origin"] in source_type]
         if self.source_name:
             assert any(x in self.source_name for x in {s.get("name") for s in sources})
             sources = [s for s in sources if s["name"] in self.source_name]

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -225,6 +225,7 @@ class BaseSourceTest:
         sources = iast["sources"]
         assert sources, "No source reported"
         if source_type:
+            assert isinstance(source_type, (tuple, set, list)), "source_type must a set, a tuple or a list"
             assert any(x in source_type for x in {s.get("origin") for s in sources})
             sources = [s for s in sources if s["origin"] in source_type]
         if self.source_name:

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -234,7 +234,9 @@ class BaseSourceTest:
         if self.source_value:
             assert self.source_value in {s.get("value") for s in sources}
             sources = [s for s in sources if s["value"] == self.source_value]
-        assert sources, f"No source found with origin={source_type}, name={self.source_names}, value={self.source_value}"
+        assert (
+            sources
+        ), f"No source found with origin={source_type}, name={self.source_names}, value={self.source_value}"
         assert len(sources) == 1, "Expected a single source with the matching criteria"
 
     setup_telemetry_metric_instrumented_source = setup_source_reported

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -194,7 +194,7 @@ class BaseSourceTest:
     endpoint = None
     requests_kwargs = None
     source_type = None
-    source_name = None
+    source_names = None
     source_value = None
     requests: dict = None
 
@@ -225,15 +225,16 @@ class BaseSourceTest:
         sources = iast["sources"]
         assert sources, "No source reported"
         if source_type:
-            assert any(x in source_type for x in {s.get("origin") for s in sources})
-            sources = [s for s in sources if s["origin"] in source_type]
-        if self.source_name:
-            assert any(x in self.source_name for x in {s.get("name") for s in sources})
-            sources = [s for s in sources if s["name"] in self.source_name]
+            assert source_type in {s.get("origin") for s in sources}
+            sources = [s for s in sources if s["origin"] == source_type]
+        if self.source_names:
+            assert isinstance(self.source_names, list)
+            assert any(x in self.source_names for x in {s.get("name") for s in sources})
+            sources = [s for s in sources if s["name"] in self.source_names]
         if self.source_value:
-            assert any(x in self.source_value for x in {s.get("value") for s in sources})
-            sources = [s for s in sources if s["value"] in self.source_value]
-        assert sources, f"No source found with origin={source_type}, name={self.source_name}, value={self.source_value}"
+            assert self.source_value in {s.get("value") for s in sources}
+            sources = [s for s in sources if s["value"] == self.source_value]
+        assert sources, f"No source found with origin={source_type}, name={self.source_names}, value={self.source_value}"
         assert len(sources) == 1, "Expected a single source with the matching criteria"
 
     setup_telemetry_metric_instrumented_source = setup_source_reported

--- a/tests/appsec/iast/source/test_body.py
+++ b/tests/appsec/iast/source/test_body.py
@@ -13,7 +13,7 @@ class TestRequestBody(BaseSourceTest):
     endpoint = "/iast/source/body/test"
     requests_kwargs = [{"method": "POST", "json": {"name": "table", "value": "user"}}]
     source_type = "http.request.body"
-    source_name = None
+    source_names = None
     source_value = None
 
     @bug(weblog_variant="jersey-grizzly2", reason="Not reported")

--- a/tests/appsec/iast/source/test_cookie_name.py
+++ b/tests/appsec/iast/source/test_cookie_name.py
@@ -13,7 +13,7 @@ class TestCookieName(BaseSourceTest):
     endpoint = "/iast/source/cookiename/test"
     requests_kwargs = [{"method": "GET", "cookies": {"user": "unused"}}]
     source_type = "http.request.cookie.name"
-    source_name = "user"
+    source_names = ["user"]
     source_value = "user"
 
     @bug(library="java", reason="Not working as expected")

--- a/tests/appsec/iast/source/test_cookie_value.py
+++ b/tests/appsec/iast/source/test_cookie_value.py
@@ -13,7 +13,7 @@ class TestCookieValue(BaseSourceTest):
     endpoint = "/iast/source/cookievalue/test"
     requests_kwargs = [{"method": "GET", "cookies": {"table": "user"}}]
     source_type = "http.request.cookie.value"
-    source_name = "table"
+    source_names = ["table"]
     source_value = "user"
 
     @bug(context.weblog_variant == "jersey-grizzly2", reason="name field of source not set")

--- a/tests/appsec/iast/source/test_multipart.py
+++ b/tests/appsec/iast/source/test_multipart.py
@@ -13,5 +13,5 @@ class TestMultipart(BaseSourceTest):
     endpoint = "/iast/source/multipart/test"
     requests_kwargs = [{"method": "POST", "files": {"file1": ("file1", "bsldhkuqwgervf")}}]
     source_type = "http.request.multipart.parameter"
-    source_name = {"name", "Content-Disposition"}
+    source_names = ["name", "Content-Disposition"]
     source_value = None

--- a/tests/appsec/iast/source/test_multipart.py
+++ b/tests/appsec/iast/source/test_multipart.py
@@ -13,5 +13,5 @@ class TestMultipart(BaseSourceTest):
     endpoint = "/iast/source/multipart/test"
     requests_kwargs = [{"method": "POST", "files": {"file1": ("file1", "bsldhkuqwgervf")}}]
     source_type = "http.request.multipart.parameter"
-    source_name = "Content-Disposition"
+    source_name = {"name", "Content-Disposition"}
     source_value = None

--- a/tests/appsec/iast/source/test_parameter_name.py
+++ b/tests/appsec/iast/source/test_parameter_name.py
@@ -16,7 +16,7 @@ class TestParameterName(BaseSourceTest):
         {"method": "POST", "data": {"user": "unused"}},
     ]
     source_type = "http.request.parameter.name"
-    source_name = "user"
+    source_names = ["user"]
     source_value = None
 
     setup_source_post_reported = BaseSourceTest.setup_source_reported

--- a/tests/appsec/iast/source/test_parameter_value.py
+++ b/tests/appsec/iast/source/test_parameter_value.py
@@ -22,7 +22,7 @@ class TestParameterValue(BaseSourceTest):
         if context.library.library == "nodejs" or context.library.library == "dotnet"
         else "http.request.parameter"
     )
-    source_name = "table"
+    source_names = ["table"]
 
     def test_source_reported(self):
         # overwrite the base test, to handle the source_type spcial use case in node

--- a/tests/appsec/iast/source/test_path.py
+++ b/tests/appsec/iast/source/test_path.py
@@ -12,6 +12,6 @@ class TestPath(BaseSourceTest):
 
     endpoint = "/iast/source/path/test"
     source_type = "http.request.path"
-    source_name = None
+    source_names = None
     source_value = "/iast/source/path/test"
     requests_kwargs = [{"method": "GET"}]


### PR DESCRIPTION
…part test

## Description

Allow multiple Source names in vulnerability specifications.

## Motivation

For some tests, in this case the multipart file upload test, some web servers (openliberty) will report a different source name from other web servers (tomcat). Both source names are correct and we need a way to allow more than one source name for the test to pass.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
