### PR TITLE
Activate api security tests dotnet

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -12,7 +12,7 @@ tests/:
         Test_Scanners: missing_feature
         Test_Schema_Response_Headers: missing_feature
         Test_Schema_Request_Cookies: v2.42.0
-        Test_Schema_Request_FormUrlEncoded_Body: v2.42.0
+        Test_Schema_Request_FormUrlEncoded_Body: missing_feature
         Test_Schema_Request_Headers: v2.42.0
         Test_Schema_Request_Json_Body: v2.42.0
         Test_Schema_Request_Path_Parameters: v2.42.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -10,15 +10,16 @@ tests/:
         Test_API_Security_sampling: missing_feature
       test_schemas.py:
         Test_Scanners: missing_feature
-        Test_Schema_Request_Cookies: missing_feature
-        Test_Schema_Request_FormUrlEncoded_Body: missing_feature
-        Test_Schema_Request_Headers: missing_feature
-        Test_Schema_Request_Json_Body: missing_feature
-        Test_Schema_Request_Path_Parameters: missing_feature
-        Test_Schema_Request_Query_Parameters: missing_feature
-        Test_Schema_Response_Body: missing_feature
-        Test_Schema_Response_Body_env_var: missing_feature
         Test_Schema_Response_Headers: missing_feature
+        Test_Schema_Request_Cookies: v2.42.0
+        Test_Schema_Request_FormUrlEncoded_Body: v2.42.0
+        Test_Schema_Request_Headers: v2.42.0
+        Test_Schema_Request_Json_Body: v2.42.0
+        Test_Schema_Request_Path_Parameters: v2.42.0
+        Test_Schema_Request_Query_Parameters: v2.42.0
+        Test_Schema_Response_Body: v2.42.0
+        Test_Schema_Response_Body_env_var: missing_feature
+        Test_Schema_Response_Headers: v2.42.0
     iast/:
       sink/:
         test_command_injection.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -7,7 +7,7 @@ tests/:
   appsec/:
     api_security/:
       test_apisec_sampling.py:
-        Test_API_Security_sampling: missing_feature
+        Test_API_Security_sampling: v2.42.0
       test_schemas.py:
         Test_Scanners: missing_feature
         Test_Schema_Response_Headers: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -11,14 +11,14 @@ tests/:
       test_schemas.py:
         Test_Scanners: missing_feature
         Test_Schema_Request_Cookies: v2.46.0
-        Test_Schema_Request_FormUrlEncoded_Body: missing_feature
+        Test_Schema_Request_FormUrlEncoded_Body: v2.46.0
         Test_Schema_Request_Headers: v2.46.0
         Test_Schema_Request_Json_Body: v2.46.0
         Test_Schema_Request_Path_Parameters: v2.46.0
         Test_Schema_Request_Query_Parameters: v2.46.0
-        Test_Schema_Response_Headers: v2.46.0
         Test_Schema_Response_Body: v2.46.0
         Test_Schema_Response_Body_env_var: missing_feature
+        Test_Schema_Response_Headers: v2.46.0
     iast/:
       sink/:
         test_command_injection.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -7,19 +7,18 @@ tests/:
   appsec/:
     api_security/:
       test_apisec_sampling.py:
-        Test_API_Security_sampling: v2.42.0
+        Test_API_Security_sampling: v2.46.0
       test_schemas.py:
         Test_Scanners: missing_feature
-        Test_Schema_Response_Headers: missing_feature
-        Test_Schema_Request_Cookies: v2.42.0
+        Test_Schema_Request_Cookies: v2.46.0
         Test_Schema_Request_FormUrlEncoded_Body: missing_feature
-        Test_Schema_Request_Headers: v2.42.0
-        Test_Schema_Request_Json_Body: v2.42.0
-        Test_Schema_Request_Path_Parameters: v2.42.0
-        Test_Schema_Request_Query_Parameters: v2.42.0
-        Test_Schema_Response_Body: v2.42.0
+        Test_Schema_Request_Headers: v2.46.0
+        Test_Schema_Request_Json_Body: v2.46.0
+        Test_Schema_Request_Path_Parameters: v2.46.0
+        Test_Schema_Request_Query_Parameters: v2.46.0
+        Test_Schema_Response_Headers: v2.46.0
+        Test_Schema_Response_Body: v2.46.0
         Test_Schema_Response_Body_env_var: missing_feature
-        Test_Schema_Response_Headers: v2.42.0
     iast/:
       sink/:
         test_command_injection.py:

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1266,7 +1266,7 @@ class scenarios:
             "DD_EXPERIMENTAL_API_SECURITY_ENABLED": "true",
             "DD_TRACE_DEBUG": "false",
             "DD_API_SECURITY_REQUEST_SAMPLE_RATE": "1.0",
-            "DD_API_SECURITY_MAX_CONCURRENT_REQUESTS": "50"
+            "DD_API_SECURITY_MAX_CONCURRENT_REQUESTS": "50",
         },
         doc="""
         Scenario for API Security feature, testing schema types sent into span tags if

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1281,6 +1281,7 @@ class scenarios:
             "DD_EXPERIMENTAL_API_SECURITY_ENABLED": "true",
             "DD_TRACE_DEBUG": "false",
             "DD_API_SECURITY_REQUEST_SAMPLE_RATE": "1.0",
+            "DD_API_SECURITY_MAX_CONCURRENT_REQUESTS": "50",
             "DD_API_SECURITY_PARSE_RESPONSE_BODY": "false",
         },
         doc="""

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1266,6 +1266,7 @@ class scenarios:
             "DD_EXPERIMENTAL_API_SECURITY_ENABLED": "true",
             "DD_TRACE_DEBUG": "false",
             "DD_API_SECURITY_REQUEST_SAMPLE_RATE": "1.0",
+            "DD_API_SECURITY_MAX_CONCURRENT_REQUESTS": "50"
         },
         doc="""
         Scenario for API Security feature, testing schema types sent into span tags if

--- a/utils/build/docker/dotnet/Controllers/TagValueController.cs
+++ b/utils/build/docker/dotnet/Controllers/TagValueController.cs
@@ -80,8 +80,20 @@ namespace weblog
 
         [HttpPost("api_match_AS00{tag_value}/{status_code}")]
         // ReSharper disable once InconsistentNaming, system tests demand it
-        public IActionResult ApiSecurity([FromRoute(Name = "tag_value")] int tagValue,
-            [FromRoute(Name = "status_code")] int statusCode, RequestBodyModel bodyModel,
+        public IActionResult ApiSecurityForm([FromRoute(Name = "tag_value")] int tagValue,
+            [FromRoute(Name = "status_code")] int statusCode, [FromForm]RequestBodyModel bodyModel,
+            [FromQuery(Name = "x-option")] string? xOption)
+        {
+            HttpContext.Response.StatusCode = statusCode;
+            Response.Headers["x-option"] = xOption;
+            return Content("Ok");
+        }
+        
+        [HttpPost("api_match_AS00{tag_value}/{status_code}")]
+        [Consumes("application/json")]
+        // ReSharper disable once InconsistentNaming, system tests demand it
+        public IActionResult ApiSecurityJson([FromRoute(Name = "tag_value")] int tagValue,
+            [FromRoute(Name = "status_code")] int statusCode, [FromBody]RequestBodyModel bodyModel,
             [FromQuery(Name = "x-option")] string? xOption)
         {
             HttpContext.Response.StatusCode = statusCode;

--- a/utils/build/docker/dotnet/Models/ApiSecurity/RequestBodyModel.cs
+++ b/utils/build/docker/dotnet/Models/ApiSecurity/RequestBodyModel.cs
@@ -7,7 +7,7 @@ public class RequestBodyModel
 {
     public KeyValueItem[] main { get; set; }
 
-    public object? nullable { get; set; }
+    public string? nullable { get; set; }
 }
 
 public class KeyValueItem

--- a/utils/build/docker/dotnet/Models/ApiSecurity/RequestBodyModel.cs
+++ b/utils/build/docker/dotnet/Models/ApiSecurity/RequestBodyModel.cs
@@ -14,5 +14,5 @@ public class KeyValueItem
 {
     public string key { get; set; }
 
-    public int value { get; set; }
+    public double value { get; set; }
 }


### PR DESCRIPTION
## Description

Activate api security tests dotnet
## Motivation
[Api Security PR](https://github.com/DataDog/dd-trace-dotnet/pull/4654/) has been merged

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
