### PR TITLE
wait for a heartbeat with reqired service

### DIFF
--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -292,14 +292,13 @@ class Test_RemoteConfigurationExtraServices:
                 if "extra_services" in client_tracer:
                     extra_services = client_tracer["extra_services"]
 
-                    if extra_services is not None and len(extra_services) > 0:
+                    if extra_services is not None and "extraVegetables" in extra_services:
                         return True
 
                 return False
 
         interfaces.library.wait_for(remote_config_asm_extra_services_available, timeout=30)
 
-    @bug(library="dotnet", reason="dotNet is not complying with the RFC specifications.")
     def test_tracer_extra_services(self):
         """Test extra services field"""
         import itertools

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -297,7 +297,7 @@ class Test_RemoteConfigurationExtraServices:
 
                 return False
 
-        interfaces.library.wait_for(remote_config_asm_extra_services_available, timeout=30)
+        interfaces.library.wait_for(remote_config_asm_extra_services_available, timeout=300)
 
     def test_tracer_extra_services(self):
         """Test extra services field"""

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -297,7 +297,7 @@ class Test_RemoteConfigurationExtraServices:
 
                 return False
 
-        interfaces.library.wait_for(remote_config_asm_extra_services_available, timeout=300)
+        interfaces.library.wait_for(remote_config_asm_extra_services_available, timeout=30)
 
     def test_tracer_extra_services(self):
         """Test extra services field"""
@@ -309,7 +309,7 @@ class Test_RemoteConfigurationExtraServices:
             if data["path"] == "/v0.7/config":
                 client_tracer = data["request"]["content"]["client"]["client_tracer"]
                 if "extra_services" in client_tracer:
-                    extra_services.append(client_tracer["extra_services"])
+                    extra_services.append(client_tracer["extra_services"] or [])
         assert self.r_outgoing.status_code == 200
         assert extra_services, "extra_services not found"
         extra_services = list(itertools.dropwhile(lambda es: "extraVegetables" not in es, extra_services))


### PR DESCRIPTION
Not just any service

## Description

Fix bug in `Test_RemoteConfigurationExtraServices:` and re-enable dotnet test on dotnet platform.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
