### PR TITLE
Fix B3 parametric tests when 128-bit trace id generation is enabled

### DIFF
--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -88,7 +88,7 @@ class Test_Headers_B3:
         b3_sampling = b3Arr[2]
 
         assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
+        assert int(b3_trace_id[-16:], base=16) == span.get("trace_id")
         assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
         assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
         assert span["meta"].get(ORIGIN) is None
@@ -135,7 +135,7 @@ class Test_Headers_B3:
         b3_sampling = b3Arr[2]
 
         assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
+        assert int(b3_trace_id[-16:], base=16) == span.get("trace_id")
         assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
         assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
         assert span["meta"].get(ORIGIN) is None

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -98,7 +98,7 @@ class Test_Headers_B3multi:
         b3_sampling = headers["x-b3-sampled"]
 
         assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
+        assert int(b3_trace_id[-16:], base=16) == span.get("trace_id")
         assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
         assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
         assert span["meta"].get(ORIGIN) is None
@@ -149,7 +149,7 @@ class Test_Headers_B3multi:
         b3_sampling = headers["x-b3-sampled"]
 
         assert len(b3_trace_id) == 16 or len(b3_trace_id) == 32
-        assert int(b3_trace_id, base=16) == span.get("trace_id")
+        assert int(b3_trace_id[-16:], base=16) == span.get("trace_id")
         assert int(b3_span_id, base=16) == span.get("span_id") and len(b3_span_id) == 16
         assert b3_sampling == "1" if span["metrics"].get(SAMPLING_PRIORITY_KEY) > 0 else "0"
         assert span["meta"].get(ORIGIN) is None


### PR DESCRIPTION
## Description

If 128-bit trace id generation is enabled, B3 parametric tests do not check the the low order bits only.

<!-- A brief description of the change being made with this pull request. -->

## Motivation

Test will break if we enable 128-bit trace id generation by default.

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
