### PR TITLE
Fix Python otel tests

### DIFF
--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -15,6 +15,7 @@ from ddtrace.opentelemetry import TracerProvider
 
 import ddtrace
 from ddtrace import Span
+from ddtrace.span import _get_64_lowest_order_bits_as_int
 from ddtrace.context import Context
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
@@ -160,7 +161,7 @@ class APMClientServicer(apm_test_client_pb2_grpc.APMClientServicer):
 
         ctx = otel_span.get_span_context()
         self._otel_spans[ctx.span_id] = otel_span
-        return apm_test_client_pb2.OtelStartSpanReturn(span_id=ctx.span_id, trace_id=ctx.trace_id)
+        return apm_test_client_pb2.OtelStartSpanReturn(span_id=ctx.span_id, trace_id=_get_64_lowest_order_bits_as_int(ctx.trace_id))
 
     def OtelEndSpan(self, request, context):
         span = self._otel_spans.get(request.id)

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -161,7 +161,9 @@ class APMClientServicer(apm_test_client_pb2_grpc.APMClientServicer):
 
         ctx = otel_span.get_span_context()
         self._otel_spans[ctx.span_id] = otel_span
-        return apm_test_client_pb2.OtelStartSpanReturn(span_id=ctx.span_id, trace_id=_get_64_lowest_order_bits_as_int(ctx.trace_id))
+        return apm_test_client_pb2.OtelStartSpanReturn(
+            span_id=ctx.span_id, trace_id=_get_64_lowest_order_bits_as_int(ctx.trace_id)
+        )
 
     def OtelEndSpan(self, request, context):
         span = self._otel_spans.get(request.id)


### PR DESCRIPTION
## Description

Now that we've switched to 128-bit trace ids by default, we'll error when we try to return what's expected to be 64-bit trace id. This change truncates the 128-bit trace id to 64-bits so we can still compare the bottom 64 bits.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
