### PR TITLE
[APM][Context Propagation] Add Golang endpoints for Kafka produce and consume

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -299,7 +299,12 @@ tests/:
       Test_Debugger_Probe_Statuses: irrelevant
   integrations/:
     test_crossed_integrations.py:
-      Test_PythonKafka: missing_feature
+      Test_PythonKafka:
+        '*': v0.1  # real version not known
+        chi: missing_feature (Endpoint not implemented)
+        echo: missing_feature (Endpoint not implemented)
+        gin: missing_feature (Endpoint not implemented)
+        grpc: missing_feature (Endpoint not implemented)
     test_db_integrations_sql.py:
       Test_MsSql: missing_feature
       Test_MySql: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -304,7 +304,6 @@ tests/:
         chi: missing_feature (Endpoint not implemented)
         echo: missing_feature (Endpoint not implemented)
         gin: missing_feature (Endpoint not implemented)
-        grpc: missing_feature (Endpoint not implemented)
         uds-echo: missing_feature (Endpoint not implemented)
     test_db_integrations_sql.py:
       Test_MsSql: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -305,6 +305,7 @@ tests/:
         echo: missing_feature (Endpoint not implemented)
         gin: missing_feature (Endpoint not implemented)
         grpc: missing_feature (Endpoint not implemented)
+        uds-echo: missing_feature (Endpoint not implemented)
     test_db_integrations_sql.py:
       Test_MsSql: missing_feature
       Test_MySql: missing_feature

--- a/tests/integrations/test_crossed_integrations.py
+++ b/tests/integrations/test_crossed_integrations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 from utils import interfaces, scenarios, coverage, weblog, missing_feature
@@ -26,8 +28,8 @@ class Test_PythonKafka:
     WEBLOG_TO_BUDDY_TOPIC = "Test_PythonKafka_weblog_to_buddy"
     BUDDY_TO_WEBLOG_TOPIC = "Test_PythonKafka_buddy_to_weblog"
 
-    @staticmethod
-    def get_span(interface, span_kind, topic):
+    @classmethod
+    def get_span(cls, interface, span_kind, topic):
 
         logger.debug(f"Trying to find traces with span kind: {span_kind} and topic: {topic} in {interface}")
 
@@ -36,12 +38,7 @@ class Test_PythonKafka:
                 if span_kind != span["meta"].get("span.kind"):
                     continue
 
-                is_java_tracer = "java" in span["meta"]["component"]
-                # dd-trace-java does not add kafka.topic to its kafka.produce spans
-                if not is_java_tracer and topic != span["meta"].get("kafka.topic"):
-                    continue
-                # instead, we rely on resource
-                if is_java_tracer and not span["resource"].endswith(topic):
+                if topic != cls.get_topic(span):
                     continue
 
                 logger.debug(f"span found in {data['log_filename']}:\n{json.dumps(span, indent=2)}")
@@ -49,6 +46,19 @@ class Test_PythonKafka:
 
         logger.debug("No span found")
         return None
+
+    @staticmethod
+    def get_topic(span) -> str | None:
+        """ Extracts the topic from a span by trying various fields """
+        topic = span["meta"].get("kafka.topic")  # this is in python
+        if topic is None:
+            if "Topic" in span["resource"]:
+                # in go and java, the topic is the last "word" of the resource name
+                topic = span["resource"].split(" ")[-1]
+
+        if topic is None:
+            logger.error(f"could not extract topic from this span:\n{span}")
+        return topic
 
     def setup_produce(self):
         """
@@ -76,6 +86,7 @@ class Test_PythonKafka:
 
     @missing_feature(library="python")
     @missing_feature(library="java")
+    @missing_feature(library="golang")
     def test_produce_trace_equality(self):
         """This test relies on the setup for produce, it currently cannot be run on its own"""
         producer_span = self.get_span(interfaces.library, span_kind="producer", topic=self.WEBLOG_TO_BUDDY_TOPIC)
@@ -114,6 +125,7 @@ class Test_PythonKafka:
 
     @missing_feature(library="python")
     @missing_feature(library="java")
+    @missing_feature(library="golang")
     def test_consume_trace_equality(self):
         """This test relies on the setup for consume, it currently cannot be run on its own"""
         producer_span = self.get_span(interfaces.python_buddy, span_kind="producer", topic=self.BUDDY_TO_WEBLOG_TOPIC)

--- a/tests/integrations/test_crossed_integrations.py
+++ b/tests/integrations/test_crossed_integrations.py
@@ -154,9 +154,9 @@ class Test_PythonKafka:
         assert producer_span is not None
         assert consumer_span is not None
 
-        # java doesn't give us much to assert on
-        if "java" not in consumer_span["meta"]["component"]:
-            assert consumer_span["meta"]["kafka.received_message"] == "True"
+        consumed = consumer_span["meta"].get("kafka.received_message")
+        if consumed is not None:  # available only for python spans
+            assert consumed == "True"
 
         # Assert that the consumer span is not the root
         assert "parent_id" in consumer_span, "parent_id is missing in consumer span"

--- a/utils/build/docker/golang/app/go.mod
+++ b/utils/build/docker/golang/app/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/DataDog/go-libddwaf/v2 v2.1.0 // indirect
 	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
 	github.com/DataDog/sketches-go v1.4.2 // indirect
+	github.com/IBM/sarama v1.42.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/bytedance/sonic v1.10.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/utils/build/docker/golang/app/go.sum
+++ b/utils/build/docker/golang/app/go.sum
@@ -13,6 +13,8 @@ github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOA
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=
 github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjvVA/o=
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
+github.com/IBM/sarama v1.42.1 h1:wugyWa15TDEHh2kvq2gAy1IHLjEjuYOYgXz/ruC/OSQ=
+github.com/IBM/sarama v1.42.1/go.mod h1:Xxho9HkHd4K/MDUo/T/sOqwtX/17D33++E9Wib6hUdQ=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

This PR adds a`kafka.produce` and `kafka.consume` endpoint using the sarama integration in dd-trace-go.

Endpoints:
1. `/kafka/produce`
1. `/kafka/consume`


<img width="1013" alt="image" src="https://github.com/DataDog/system-tests/assets/26727996/69ef8951-4f15-4e32-badb-a4be64229af5">


## Motivation

<!-- What inspired you to submit this pull request? -->

Relates to the goals of https://github.com/DataDog/system-tests/pull/1757 and https://github.com/DataDog/system-tests/pull/1783 .

## Workflow

1. ⚠️⚠️ Create your PR as draft
3. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
4. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
5. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
