### PR TITLE
[parametric] Add system-test for client libraries to generate 128 bit trace-id's by default

### DIFF
--- a/tests/parametric/test_128_bit_traceids.py
+++ b/tests/parametric/test_128_bit_traceids.py
@@ -63,7 +63,7 @@ class Test_128_Bit_Traceids:
         assert trace_id == 1234567890123456789
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
-        assert "_dd.p.tid=" not in headers["x-datadog-tags"]
+        assert "x-datadog-tags" not in headers or "_dd.p.tid=" not in headers["x-datadog-tags"]
 
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "python_http", reason="not implemented")
@@ -91,7 +91,7 @@ class Test_128_Bit_Traceids:
         assert trace_id == 1234567890123456789
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
-        assert "_dd.p.tid=" not in headers["x-datadog-tags"]
+        assert "x-datadog-tags" not in headers or "_dd.p.tid=" not in headers["x-datadog-tags"]
 
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "python_http", reason="not implemented")
@@ -119,7 +119,7 @@ class Test_128_Bit_Traceids:
         assert trace_id == 1234567890123456789
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
-        assert "_dd.p.tid=" not in headers["x-datadog-tags"]
+        assert "x-datadog-tags" not in headers or "_dd.p.tid=" not in headers["x-datadog-tags"]
 
     @missing_feature(context.library == "dotnet", reason="Optional feature not implemented")
     @missing_feature(context.library == "golang", reason="Optional feature not implemented")
@@ -162,7 +162,7 @@ class Test_128_Bit_Traceids:
         assert trace_id == 1234567890123456789
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
-        assert "_dd.p.tid=" not in headers["x-datadog-tags"]
+        assert "x-datadog-tags" not in headers or "_dd.p.tid=" not in headers["x-datadog-tags"]
 
     @pytest.mark.parametrize(
         "library_env",
@@ -181,7 +181,7 @@ class Test_128_Bit_Traceids:
         assert trace_id < POWER_2_64
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
-        assert "_dd.p.tid=" not in headers["x-datadog-tags"]
+        assert "x-datadog-tags" not in headers or "_dd.p.tid=" not in headers["x-datadog-tags"]
 
     @missing_feature(context.library == "python_http", reason="not implemented")
     @missing_feature(context.library == "ruby", reason="not implemented")

--- a/tests/parametric/test_128_bit_traceids.py
+++ b/tests/parametric/test_128_bit_traceids.py
@@ -197,6 +197,32 @@ class Test_128_Bit_Traceids:
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         validate_dd_p_tid(dd_p_tid)
 
+    @missing_feature(context.library == "cpp", reason="not implemented")
+    @missing_feature(context.library == "dotnet", reason="not implemented")
+    @missing_feature(context.library == "golang", reason="not implemented")
+    @missing_feature(context.library == "java", reason="not implemented")
+    @missing_feature(context.library == "nodejs", reason="not implemented")
+    @missing_feature(context.library == "php", reason="not implemented")
+    @missing_feature(context.library == "python", reason="not implemented")
+    @missing_feature(context.library == "python_http", reason="not implemented")
+    @missing_feature(context.library == "ruby", reason="not implemented")
+    @pytest.mark.parametrize(
+        "library_env", [{"DD_TRACE_PROPAGATION_STYLE": "Datadog"}],
+    )
+    def test_datadog_128_bit_generation_enabled_by_default(self, test_agent, test_library):
+        """Ensure that 128-bit TraceIds are properly generated, propagated in
+        datadog headers, and populated in trace data.
+        """
+        with test_library:
+            headers = make_single_request_and_get_inject_headers(test_library, [])
+        span = get_span(test_agent)
+        trace_id = span.get("trace_id")
+        dd_p_tid = span["meta"].get("_dd.p.tid")
+
+        assert trace_id < POWER_2_64
+        assert int(headers["x-datadog-trace-id"], 10) == trace_id
+        validate_dd_p_tid(dd_p_tid)
+
     @missing_feature(context.library == "cpp", reason="propagation style not supported")
     @missing_feature(context.library == "python_http", reason="not implemented")
     @missing_feature(context.library == "ruby", reason="not implemented")

--- a/tests/parametric/test_128_bit_traceids.py
+++ b/tests/parametric/test_128_bit_traceids.py
@@ -195,6 +195,7 @@ class Test_128_Bit_Traceids:
 
         assert trace_id < POWER_2_64
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
+        assert "_dd.p.tid=" + dd_p_tid in headers["x-datadog-tags"]
         validate_dd_p_tid(dd_p_tid)
 
     @missing_feature(context.library == "cpp", reason="not implemented")
@@ -221,6 +222,7 @@ class Test_128_Bit_Traceids:
 
         assert trace_id < POWER_2_64
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
+        assert "_dd.p.tid=" + dd_p_tid in headers["x-datadog-tags"]
         validate_dd_p_tid(dd_p_tid)
 
     @missing_feature(context.library == "cpp", reason="propagation style not supported")

--- a/tests/parametric/test_128_bit_traceids.py
+++ b/tests/parametric/test_128_bit_traceids.py
@@ -35,6 +35,7 @@ class Test_128_Bit_Traceids:
         assert trace_id == 1234567890123456789
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid == "640cfd8d00000000"
+        assert "_dd.p.tid=" + dd_p_tid in headers["x-datadog-tags"]
 
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "python_http", reason="not implemented")
@@ -62,6 +63,7 @@ class Test_128_Bit_Traceids:
         assert trace_id == 1234567890123456789
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
+        assert "_dd.p.tid=" not in headers["x-datadog-tags"]
 
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "python_http", reason="not implemented")
@@ -89,6 +91,7 @@ class Test_128_Bit_Traceids:
         assert trace_id == 1234567890123456789
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
+        assert "_dd.p.tid=" not in headers["x-datadog-tags"]
 
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "python_http", reason="not implemented")
@@ -116,6 +119,7 @@ class Test_128_Bit_Traceids:
         assert trace_id == 1234567890123456789
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
+        assert "_dd.p.tid=" not in headers["x-datadog-tags"]
 
     @missing_feature(context.library == "dotnet", reason="Optional feature not implemented")
     @missing_feature(context.library == "golang", reason="Optional feature not implemented")
@@ -158,6 +162,7 @@ class Test_128_Bit_Traceids:
         assert trace_id == 1234567890123456789
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
+        assert "_dd.p.tid=" not in headers["x-datadog-tags"]
 
     @pytest.mark.parametrize(
         "library_env",
@@ -176,6 +181,7 @@ class Test_128_Bit_Traceids:
         assert trace_id < POWER_2_64
         assert int(headers["x-datadog-trace-id"], 10) == trace_id
         assert dd_p_tid is None
+        assert "_dd.p.tid=" not in headers["x-datadog-tags"]
 
     @missing_feature(context.library == "python_http", reason="not implemented")
     @missing_feature(context.library == "ruby", reason="not implemented")


### PR DESCRIPTION
## Description

Adds test to assert that tracing client libraries generate 128-bit trace-id's by default. The test behavior is identical to the enabled case.

## Motivation

This test asserts that all libraries implement the new behavior.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
