### PR TITLE
Update Java tracer parametric tests 

### DIFF
--- a/tests/parametric/test_128_bit_traceids.py
+++ b/tests/parametric/test_128_bit_traceids.py
@@ -207,7 +207,7 @@ class Test_128_Bit_Traceids:
     @missing_feature(context.library == "cpp", reason="not implemented")
     @missing_feature(context.library == "dotnet", reason="not implemented")
     @missing_feature(context.library == "golang", reason="not implemented")
-    @missing_feature(context.library == "java", reason="not implemented")
+    @missing_feature(context.library < "java@1.24.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "php", reason="not implemented")
     @missing_feature(context.library == "python", reason="not implemented")

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -89,6 +89,7 @@ def enable_tracecontext_datadog_b3multi_extract_first_true() -> Any:
 class Test_Headers_Precedence:
     @missing_feature(context.library == "dotnet", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "golang", reason="New 'datadog' default hasn't been implemented yet")
+    @irrelevant(context.library >= "java@1.24.0", reason="Implements the new 'datadog,tracecontext' default")
     @missing_feature(context.library == "nodejs", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "php", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "python", reason="New 'datadog' default hasn't been implemented yet")
@@ -479,8 +480,8 @@ class Test_Headers_Precedence:
         assert "x-datadog-parent-id" not in headers6
         assert "x-datadog-sampling-priority" not in headers6
 
+    @missing_feature(context.library < "java@1.24.0", reason="Implemented from 1.24.0")
     @missing_feature(context.library == "ruby", reason="library does not yet implement this default configuration")
-    @missing_feature(context.library == "java", reason="library does not yet implement this default configuration")
     @irrelevant(context.library == "cpp", reason="library does not implement this default configuration")
     @irrelevant(context.library == "dotnet", reason="library does not implement this default configuration")
     @irrelevant(context.library == "golang", reason="library does not implement this default configuration")
@@ -636,11 +637,11 @@ class Test_Headers_Precedence:
     @enable_datadog_b3multi_tracecontext_extract_first_false()
     @missing_feature(context.library == "cpp", reason="c++ must implement new tracestate propagation")
     @missing_feature(context.library == "dotnet", reason="dotnet must implement new tracestate propagation")
-    @missing_feature(context.library == "java", reason="java must implement new tracestate propagation")
     @missing_feature(context.library == "nodejs", reason="NodeJS must implement new tracestate propagation")
     @missing_feature(context.library == "php", reason="php must implement new tracestate propagation")
     @missing_feature(context.library == "python", reason="python must implement new tracestate propagation")
     @missing_feature(context.library == "python_http", reason="python must implement new tracestate propagation")
+    @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "ruby", reason="ruby must implement new tracestate propagation")
     def test_headers_precedence_propagationstyle_tracecontext_last_extract_first_false_correctly_propagates_tracestate(
         self, test_agent, test_library

--- a/tests/parametric/test_headers_tracestate_dd.py
+++ b/tests/parametric/test_headers_tracestate_dd.py
@@ -651,7 +651,7 @@ class Test_Headers_Tracestate_DD:
     @temporary_enable_propagationstyle_default()
     @bug(library="cpp", reason="c++ is not dropping the 33rd (last) list-member")
     @bug(library="dotnet", reason="dotnet is not dropping the 33rd (last) list-member")
-    @bug(library="java", reason="java is not dropping the 33rd (last) list-member")
+    @bug(context.library < "java@1.24.0", reason="java is not dropping the 33rd (last) list-member")
     @bug(library="nodejs", reason="NodeJS is not dropping the 33rd (last) list-member")
     @bug(library="python", reason="python is not dropping the 33rd (last) list-member")
     @bug(library="python_http", reason="python is not dropping the 33rd (last) list-member")

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -66,7 +66,7 @@ class Test_Otel_Span_Methods:
         assert root_span["resource"] == "parent_span"
         assert root_span["service"] == "new_service"
 
-    @missing_feature(
+    @irrelevant(
         context.library == "java",
         reason="Old array encoding was removed in 1.22.0 and new span naming introduced in 1.24.0: no version elligible for this test.",
     )
@@ -439,7 +439,7 @@ class Test_Otel_Span_Methods:
             test_agent=test_agent,
         )
 
-    @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
+    @missing_feature(context.library < "java@1.25.0", reason="Implemented in 1.25.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")

--- a/tests/parametric/test_otel_span_with_w3c.py
+++ b/tests/parametric/test_otel_span_with_w3c.py
@@ -22,7 +22,7 @@ class Test_Otel_Span_With_W3c:
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library <= "java@1.23.0", reason="OTel resource naming implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     def test_otel_start_span_with_w3c(self, test_agent, test_library):

--- a/tests/parametric/test_otel_tracer.py
+++ b/tests/parametric/test_otel_tracer.py
@@ -61,7 +61,7 @@ class Test_Otel_Tracer:
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library <= "java@1.23.0", reason="OTel resource naming implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     def test_otel_force_flush(self, test_agent, test_library):

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/OpenTelemetryClient.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/OpenTelemetryClient.java
@@ -22,6 +22,8 @@ import com.datadoghq.client.ApmTestClient.OtelSetStatusArgs;
 import com.datadoghq.client.ApmTestClient.OtelSetStatusReturn;
 import com.datadoghq.client.ApmTestClient.OtelSpanContextArgs;
 import com.datadoghq.client.ApmTestClient.OtelSpanContextReturn;
+import com.datadoghq.client.ApmTestClient.OtelStartSpanArgs;
+import com.datadoghq.client.ApmTestClient.OtelStartSpanReturn;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import io.grpc.stub.StreamObserver;
@@ -140,7 +142,7 @@ public class OpenTelemetryClient extends APMClientGrpc.APMClientImplBase {
     }
 
     @Override
-    public void otelStartSpan(ApmTestClient.OtelStartSpanArgs request, StreamObserver<ApmTestClient.OtelStartSpanReturn> responseObserver) {
+    public void otelStartSpan(OtelStartSpanArgs request, StreamObserver<OtelStartSpanReturn> responseObserver) {
         LOGGER.info("Starting OTel span: {}", request);
         try {
             // Build span from request
@@ -191,7 +193,7 @@ public class OpenTelemetryClient extends APMClientGrpc.APMClientImplBase {
             long traceId = DDTraceId.fromHex(span.getSpanContext().getTraceId()).toLong();
             this.spans.put(spanId, span);
             // Complete request
-            responseObserver.onNext(ApmTestClient.OtelStartSpanReturn.newBuilder()
+            responseObserver.onNext(OtelStartSpanReturn.newBuilder()
                     .setSpanId(spanId)
                     .setTraceId(traceId)
                     .build());


### PR DESCRIPTION
## Description

This PR enables the latest parametric test for the Java tracer.

## Motivation

Java tracer recently implement new features that system-tests cover.

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
