### PR TITLE
Add a test to parametric test suit for OpenTelemetry -> Datadog name conventions

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -384,6 +384,32 @@ class Test_Otel_Span_Methods:
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
+    def test_otel_set_attributes_separately(self, test_agent, test_library):
+        """
+            This test verifies retrieving the span context of a span
+            accordingly to the Otel API spec
+            (https://opentelemetry.io/docs/reference/specification/trace/api/#get-context)
+        """
+        with test_library:
+            with test_library.otel_start_span(name="operation", span_kind=SK_CLIENT) as span:
+                span.set_attributes({"messaging.system": "Kafka"})
+                span.set_attributes({"messaging.operation": "Receive"})
+                span.end_span()
+
+            traces = test_agent.wait_for_num_traces(1)
+            trace = find_trace_by_root(traces, otel_span(name="operation"))
+            assert len(trace) == 1
+
+            span = get_span(test_agent)
+            assert span["name"] == "kafka.receive"
+            assert span["resource"] == "operation"
+
+    @missing_feature(context.library == "golang", reason="Not implemented")
+    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library == "python", reason="Not implemented")
+    @missing_feature(context.library == "python_http", reason="Not implemented")
     @pytest.mark.parametrize(
         "expected_operation_name,span_kind,attributes",
         [


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->
Added a test suit for a corner case in OTel operation remapping
## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
