### PR TITLE
Paullgdc/telemetry/add install tags to onboarding event

### DIFF
--- a/utils/interfaces/schemas/miscs/telemetry/common/events/apm-onboarding.json
+++ b/utils/interfaces/schemas/miscs/telemetry/common/events/apm-onboarding.json
@@ -45,6 +45,15 @@
         },
         "script_version": {
           "type": "string"
+        },
+        "install_id": {
+          "type": "string"
+        },
+        "install_type": {
+          "type": "string"
+        },
+        "install_time": {
+          "type": "integer"
         }
       }
     },

--- a/utils/interfaces/schemas/miscs/telemetry/common/events/apm-onboarding.json
+++ b/utils/interfaces/schemas/miscs/telemetry/common/events/apm-onboarding.json
@@ -55,7 +55,10 @@
         "install_time": {
           "type": "integer"
         }
-      }
+      },
+      "$comment": "TODO: add install_id, install_type, install_time to required properties once the next agent is released",
+      "required": ["agent_version", "agent_hostname", "env"],
+      "additionalProperties": false
     },
     "error": {
       "type": "object",


### PR DESCRIPTION
## Description

Add install_* fields to onboarding events emitted by the agent, and mark some fields as required

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
