### PR TITLE
When no span.kind, name should default to `internal`

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -434,7 +434,7 @@ class Test_Otel_Span_Methods:
             ("internal", SK_INTERNAL, None),
             ("consumer", SK_CONSUMER, None),
             ("producer", SK_PRODUCER, None),
-            ("otel_unknown", None, None),
+            ("internal", None, None),
         ],
     )
     def test_otel_span_operation_name(


### PR DESCRIPTION
## Description

We should always be able to rely on `span.kind` for the operation name as it will always have a value - by default the `span.kind` is `SpanKind.Internal`.
This removes the possibility of having `otel_unknown` as the operation name as we can always fallback on `span.kind`.

## Motivation

We will always have a value for `span.kind` to fallback to for the operation name. 

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
