### PR TITLE
enable Go parametric tests for OTel operation naming

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -20,7 +20,6 @@ pytestmark = pytest.mark.parametrize(
 
 @scenarios.parametric
 class Test_Otel_Span_Methods:
-    @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
@@ -48,7 +47,6 @@ class Test_Otel_Span_Methods:
         assert root_span["meta"]["start_attr_key"] == "start_attr_val"
         assert root_span["duration"] == duration * 1_000  # OTEL expects microseconds but we convert it to ns internally
 
-    @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
@@ -68,7 +66,6 @@ class Test_Otel_Span_Methods:
         assert root_span["resource"] == "parent_span"
         assert root_span["service"] == "new_service"
 
-    @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
     @irrelevant(
         context.library == "java",
         reason="Old array encoding was removed in 1.22.0 and new span naming introduced in 1.24.0: no version elligible for this test.",
@@ -231,7 +228,6 @@ class Test_Otel_Span_Methods:
                 parent.end_span()
                 assert not parent.is_recording()
 
-    @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(
@@ -260,7 +256,6 @@ class Test_Otel_Span_Methods:
         assert s.get("start") == start_time * 1_000  # OTEL expects microseconds but we convert it to ns internally
         assert s.get("duration") == duration * 1_000
 
-    @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
@@ -297,7 +292,6 @@ class Test_Otel_Span_Methods:
         assert child["resource"] == "child"
         assert child["parent_id"] == parent_span["span_id"]
 
-    @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(
@@ -326,7 +320,6 @@ class Test_Otel_Span_Methods:
         assert s.get("name") == "internal"
         assert s.get("resource") == "error_span"
 
-    @missing_feature(context.library == "golang", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(
@@ -378,7 +371,6 @@ class Test_Otel_Span_Methods:
                     assert context.get("span_id") == "{:016x}".format(span.span_id)
                     assert context.get("trace_flags") == "01"
 
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "dotnet", reason="Not implemented")
@@ -404,7 +396,6 @@ class Test_Otel_Span_Methods:
             assert span["name"] == "kafka.receive"
             assert span["resource"] == "operation"
 
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "dotnet", reason="Not implemented")
@@ -448,7 +439,6 @@ class Test_Otel_Span_Methods:
             test_agent=test_agent,
         )
 
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "dotnet", reason="Not implemented")

--- a/utils/build/docker/golang/parametric/go.mod
+++ b/utils/build/docker/golang/parametric/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.20.0
 	google.golang.org/grpc v1.57.1
 	google.golang.org/protobuf v1.30.0
-	gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20231110173431-9d1bda315720
+	gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20231113165927-c94b8bb0c8ce
 )
 
 require (

--- a/utils/build/docker/golang/parametric/go.sum
+++ b/utils/build/docker/golang/parametric/go.sum
@@ -173,8 +173,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20231110173431-9d1bda315720 h1:8nvQXtBl4nDmIuUzkrQQuCTJo0S0ARI2vbY1rkxb8wM=
-gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20231110173431-9d1bda315720/go.mod h1:DwITIMYF2/Q1sO/gJ80KTwCBRC1Z+u6MHjoTb220uJA=
+gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20231113165927-c94b8bb0c8ce h1:7CycoYXfo0eT1gd8V+3nDkNIWAjKrlL6ixURjW8TeJU=
+gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20231113165927-c94b8bb0c8ce/go.mod h1:DwITIMYF2/Q1sO/gJ80KTwCBRC1Z+u6MHjoTb220uJA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
