### PR TITLE
Parametric: Timeout to running subprocess

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -785,7 +785,9 @@ def docker_run(
 def docker() -> str:
     """Fixture to ensure docker is ready to use on the system."""
     # Redirect output to /dev/null since we just care if we get a successful response code.
-    r = subprocess.run(["docker", "info"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    r = subprocess.run(
+        ["docker", "info"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=default_subprocess_run_timeout
+    )
     if r.returncode != 0:
         pytest.fail(
             "Docker is not running and is required to run the shared APM library tests. Start docker and try running the tests again."
@@ -815,7 +817,7 @@ def docker_network(docker: str, docker_network_log_file: TextIO, docker_network_
     ]
     docker_network_log_file.write("$ " + " ".join(cmd) + "\n\n")
     docker_network_log_file.flush()
-    r = subprocess.run(cmd, stderr=docker_network_log_file)
+    r = subprocess.run(cmd, stderr=docker_network_log_file, timeout=default_subprocess_run_timeout)
     if r.returncode not in (0, 1):  # 0 = network exists, 1 = network does not exist
         pytest.fail(
             "Could not check for docker network %r, error: %r" % (docker_network_name, r.stderr), pytrace=False,
@@ -831,7 +833,9 @@ def docker_network(docker: str, docker_network_log_file: TextIO, docker_network_
         ]
         docker_network_log_file.write("$ " + " ".join(cmd) + "\n\n")
         docker_network_log_file.flush()
-        r = subprocess.run(cmd, stdout=docker_network_log_file, stderr=docker_network_log_file)
+        r = subprocess.run(
+            cmd, stdout=docker_network_log_file, stderr=docker_network_log_file, timeout=default_subprocess_run_timeout
+        )
         if r.returncode != 0:
             pytest.fail(
                 "Could not create docker network %r, see the log file %r"
@@ -847,7 +851,9 @@ def docker_network(docker: str, docker_network_log_file: TextIO, docker_network_
     ]
     docker_network_log_file.write("$ " + " ".join(cmd) + "\n\n")
     docker_network_log_file.flush()
-    r = subprocess.run(cmd, stdout=docker_network_log_file, stderr=docker_network_log_file)
+    r = subprocess.run(
+        cmd, stdout=docker_network_log_file, stderr=docker_network_log_file, timeout=default_subprocess_run_timeout
+    )
     if r.returncode != 0:
         pytest.fail(
             "Failed to remove docker network %r, see the log file %r"

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -28,6 +28,9 @@ import json
 
 from filelock import FileLock
 
+# Max timeout in seconds to keep a container running
+default_subprocess_run_timeout = 300
+
 
 @pytest.fixture
 def test_id():
@@ -458,6 +461,7 @@ def build_apm_test_server_image(apm_test_server_definition: APMLibraryTestServer
         stdout=log_file,
         stderr=log_file,
         env=env,
+        timeout=default_subprocess_run_timeout,
     )
 
     failure_text: str = None
@@ -751,7 +755,7 @@ def docker_run(
     docker = shutil.which("docker")
 
     # Run the docker container
-    r = subprocess.run(_cmd, stdout=log_file, stderr=log_file)
+    r = subprocess.run(_cmd, stdout=log_file, stderr=log_file, timeout=default_subprocess_run_timeout)
     if r.returncode != 0:
         log_file.flush()
         pytest.fail(
@@ -774,9 +778,7 @@ def docker_run(
         _cmd = [docker, "kill", name]
         log_file.write("\n\n\n$ %s\n" % " ".join(_cmd))
         log_file.flush()
-        subprocess.run(
-            _cmd, stdout=log_file, stderr=log_file, check=True,
-        )
+        subprocess.run(_cmd, stdout=log_file, stderr=log_file, check=True, timeout=default_subprocess_run_timeout)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Description

Set timeout for subprocess. trying to avoid CI blocked running the parametric tests.
This PR won't solve the root cause of the problem (I don't know which is), but at least we won't block for hours the build CI execution

Today was the first time that I managed to block the execution of parametric tests on my laptop.

So far I have only seen this problem in the CI:
1. It happens more times in system-tests-dashboard than in system-tests. Why? 
2. It happens more times in Java than in other languages. Why?

I used "py-spy dump" to see the blocked program. My output:

```
(venv) roberto.montero@COMP-WMH2MQLQFT 20231115 % ps -fea|grep python         
  503  3140  2924   0 Mon10AM ??         0:11.87 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python /Users/roberto.montero/.vscode/extensions/ms-python.isort-2023.10.1/bundled/tool/lsp_server.py
  503  3346  2924   0 Mon10AM ??        26:49.78 /Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) --ms-enable-electron-run-as-node /Users/roberto.montero/.vscode/extensions/ms-python.vscode-pylance-2023.11.10/dist/server.bundle.js --cancellationReceive=file:bc87d653becbf11c6493d66ad136a6016f3f8a6659 --node-ipc --clientProcessId=2924
  503 48679 48655   0  8:39AM ??         0:03.81 /Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) --ms-enable-electron-run-as-node /Users/roberto.montero/.vscode/extensions/ms-python.vscode-pylance-2023.11.10/dist/server.bundle.js --cancellationReceive=file:1c88ed365f8c4e0670c351d957692feabf8b2cd7bd --node-ipc --clientProcessId=48655
  503 48925 48655   0  8:40AM ??         0:00.40 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python /Users/roberto.montero/.vscode/extensions/ms-python.isort-2023.10.1/bundled/tool/lsp_server.py
  503 57925 57924   0  9:34AM ttys002    0:01.64 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python /Users/roberto.montero/Documents/development/system-tests/venv/bin/pytest -S PARAMETRIC -p no:warnings -n auto
  503 58002 57925   0  9:34AM ttys002    0:03.41 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -u -c import sys;exec(eval(sys.stdin.readline()))
  503 58003 57925   0  9:34AM ttys002    0:05.34 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -u -c import sys;exec(eval(sys.stdin.readline()))
  503 58004 57925   0  9:34AM ttys002    0:04.92 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -u -c import sys;exec(eval(sys.stdin.readline()))
  503 58005 57925   0  9:34AM ttys002    0:04.32 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -u -c import sys;exec(eval(sys.stdin.readline()))
  503 58006 57925   0  9:34AM ttys002    0:05.10 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -u -c import sys;exec(eval(sys.stdin.readline()))
  503 58007 57925   0  9:34AM ttys002    0:05.33 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -u -c import sys;exec(eval(sys.stdin.readline()))
  503 58012 57925   0  9:34AM ttys002    0:04.35 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -u -c import sys;exec(eval(sys.stdin.readline()))
  503 58014 57925   0  9:34AM ttys002    0:05.88 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -u -c import sys;exec(eval(sys.stdin.readline()))
  503 58017 57925   0  9:34AM ttys002    0:05.20 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -u -c import sys;exec(eval(sys.stdin.readline()))
  503 68617 61503   0 10:01AM ttys004    0:00.00 grep python
  503 11101 10777   0 Tue09AM ttys007    0:00.06 /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python
(venv) roberto.montero@COMP-WMH2MQLQFT 20231115 % sudo py-spy dump --pid 58005
Process 58005: /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -u -c import sys;exec(eval(sys.stdin.readline()))
```

And de stack:
```
venv) roberto.montero@COMP-WMH2MQLQFT 20231115 % sudo py-spy dump --pid 58002
Process 58002: /opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python -u -c import sys;exec(eval(sys.stdin.readline()))
Python v3.9.16 (/opt/homebrew/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python)

Thread 0x1DD346080 (idle): "MainThread"
    _execute_child (subprocess.py:1754)
    __init__ (subprocess.py:951)
    run (subprocess.py:505)
    docker_network (tests/parametric/conftest.py:816)
    call_fixture_func (_pytest/fixtures.py:893)
    pytest_fixture_setup (_pytest/fixtures.py:1121)
    _multicall (pluggy/_callers.py:39)
    _hookexec (pluggy/_manager.py:80)
    __call__ (pluggy/_hooks.py:265)
    execute (_pytest/fixtures.py:1067)
    _compute_fixture_value (_pytest/fixtures.py:669)
    _get_active_fixturedef (_pytest/fixtures.py:583)
    execute (_pytest/fixtures.py:1043)
    _compute_fixture_value (_pytest/fixtures.py:669)
    _get_active_fixturedef (_pytest/fixtures.py:583)
    getfixturevalue (_pytest/fixtures.py:564)
    _fillfixtures (_pytest/fixtures.py:551)
    setup (_pytest/python.py:1764)
    setup (_pytest/runner.py:491)
    pytest_runtest_setup (_pytest/runner.py:154)
    _multicall (pluggy/_callers.py:39)
    _hookexec (pluggy/_manager.py:80)
    __call__ (pluggy/_hooks.py:265)
    <lambda> (_pytest/runner.py:259)
    from_call (_pytest/runner.py:338)
    call_runtest_hook (_pytest/runner.py:258)
    call_and_report (_pytest/runner.py:219)
    runtestprotocol (_pytest/runner.py:124)
    pytest_runtest_protocol (_pytest/runner.py:111)
    _multicall (pluggy/_callers.py:39)
    _hookexec (pluggy/_manager.py:80)
    __call__ (pluggy/_hooks.py:265)
    run_one_test (xdist/remote.py:174)
    pytest_runtestloop (xdist/remote.py:157)
    _multicall (pluggy/_callers.py:39)
    _hookexec (pluggy/_manager.py:80)
    __call__ (pluggy/_hooks.py:265)
    _main (_pytest/main.py:322)
    wrap_session (_pytest/main.py:268)
    pytest_cmdline_main (_pytest/main.py:315)
    _multicall (pluggy/_callers.py:39)
    _hookexec (pluggy/_manager.py:80)
    __call__ (pluggy/_hooks.py:265)
    <module> (xdist/remote.py:355)
    executetask (execnet/gateway_base.py:1084)
    run (execnet/gateway_base.py:220)
    _perform_spawn (execnet/gateway_base.py:285)
    integrate_as_primary_thread (execnet/gateway_base.py:267)
    serve (execnet/gateway_base.py:1060)
    serve (execnet/gateway_base.py:1554)
    <module> (<string>:8)
    <module> (<string>:1)
Thread 0x170437000 (idle)
    read (execnet/gateway_base.py:400)
    from_io (execnet/gateway_base.py:432)
    _thread_receiver (execnet/gateway_base.py:967)
    run (execnet/gateway_base.py:220)
    _perform_spawn (execnet/gateway_base.py:285)
```


## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
4. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
5. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
6. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
