### PR TITLE
python: enable support for opentelemetry api

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -42,9 +42,7 @@ class Test_Otel_Span_Methods:
                 parent.end_span(timestamp=start_time + duration)
 
         root_span = get_span(test_agent)
-        if root_span["meta"]["language"] != "python":
-            # operation name mapping not supported in Python
-            assert root_span["name"] == "producer"
+        assert root_span["name"] == "producer"
         assert root_span["resource"] == "operation"
         assert root_span["meta"]["start_attr_key"] == "start_attr_val"
         assert root_span["duration"] == duration * 1_000  # OTEL expects microseconds but we convert it to ns internally
@@ -63,9 +61,7 @@ class Test_Otel_Span_Methods:
                 parent.end_span()
 
         root_span = get_span(test_agent)
-        if root_span["meta"]["language"] != "python":
-            # operation name mapping not supported in Python
-            assert root_span["name"] == "internal"
+        assert root_span["name"] == "internal"
         assert root_span["resource"] == "parent_span"
         assert root_span["service"] == "new_service"
 
@@ -101,9 +97,7 @@ class Test_Otel_Span_Methods:
 
         root_span = get_span(test_agent)
 
-        if root_span["meta"]["language"] != "python":
-            # operation name mapping not supported in Python
-            assert root_span["name"] == "producer"
+        assert root_span["name"] == "producer"
         assert root_span["resource"] == "operation"
 
         assert root_span["meta"]["str_val"] == "val"
@@ -188,9 +182,7 @@ class Test_Otel_Span_Methods:
 
         root_span = get_span(test_agent)
 
-        if root_span["meta"]["language"] != "python":
-            # operation name mapping not supported in Python
-            assert root_span["name"] == "producer"
+        assert root_span["name"] == "producer"
         assert root_span["resource"] == "operation"
 
         assert root_span["meta"]["str_val"] == "val"
@@ -257,9 +249,7 @@ class Test_Otel_Span_Methods:
                 s.end_span(timestamp=start_time + duration * 2)
 
         s = get_span(test_agent)
-        if s["meta"]["language"] != "python":
-            # operation name mapping not supported in Python
-            assert s.get("name") == "internal"
+        assert s.get("name") == "internal"
         assert s.get("resource") == "operation"
         assert s.get("start") == start_time * 1_000  # OTEL expects microseconds but we convert it to ns internally
         assert s.get("duration") == duration * 1_000
@@ -291,16 +281,12 @@ class Test_Otel_Span_Methods:
         assert len(trace) == 2
 
         parent_span = find_span(trace, otel_span(name="parent"))
-        if parent_span["meta"]["language"] != "python":
-            # operation name mapping not supported in Python
-            assert parent_span["name"] == "producer"
+        assert parent_span["name"] == "producer"
         assert parent_span["resource"] == "parent"
         assert parent_span["meta"].get("after_finish") is None
 
         child = find_span(trace, otel_span(name="child"))
-        if child["meta"]["language"] != "python":
-            # operation name mapping not supported in Python
-            assert child["name"] == "consumer"
+        assert child["name"] == "consumer"
         assert child["resource"] == "child"
         assert child["parent_id"] == parent_span["span_id"]
 
@@ -329,9 +315,7 @@ class Test_Otel_Span_Methods:
                 s.end_span()
         s = get_span(test_agent)
         assert s.get("meta").get("error.message") == "error_desc"
-        if s["meta"]["language"] != "python":
-            # operation name mapping not supported in Python
-            assert s.get("name") == "internal"
+        assert s.get("name") == "internal"
         assert s.get("resource") == "error_span"
 
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
@@ -366,9 +350,7 @@ class Test_Otel_Span_Methods:
 
         span = get_span(test_agent)
         assert span.get("meta").get("error.message") is None
-        if span["meta"]["language"] != "python":
-            # operation name mapping not supported in Python
-            assert span.get("name") == "internal"
+        assert span.get("name") == "internal"
         assert span.get("resource") == "ok_span"
 
     def test_otel_get_span_context(self, test_agent, test_library):
@@ -409,9 +391,7 @@ class Test_Otel_Span_Methods:
             assert len(trace) == 1
 
             span = get_span(test_agent)
-            if span["meta"]["language"] != "python":
-                # operation name mapping not supported in Python
-                assert span["name"] == "kafka.receive"
+            assert span["name"] == "kafka.receive"
             assert span["resource"] == "operation"
 
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -480,9 +460,7 @@ class Test_Otel_Span_Methods:
         assert len(trace) == 1
 
         span = get_span(test_agent)
-        if span["meta"]["language"] != "python":
-            # operation name mapping not supported in Python
-            assert span["name"] == "overriden.name"
+        assert span["name"] == "overriden.name"
         assert span["meta"]["span.kind"] == "server"
         assert span["resource"] == "new.name"
         assert span["service"] == "new.service.name"
@@ -537,9 +515,7 @@ def run_operation_name_test(expected_operation_name: str, span_kind: int, attrib
     assert len(trace) == 1
 
     span = get_span(test_agent)
-    if span["meta"]["language"] != "python":
-        # operation name mapping not supported in Python
-        assert span["name"] == expected_operation_name
+    assert span["name"] == expected_operation_name
     assert span["resource"] == "otel_span_name"
 
 

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -24,7 +24,6 @@ class Test_Otel_Span_Methods:
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "python_http", reason="New operation name mapping not yet implemented")
     def test_otel_start_span(self, test_agent, test_library):
         """
@@ -43,7 +42,9 @@ class Test_Otel_Span_Methods:
                 parent.end_span(timestamp=start_time + duration)
 
         root_span = get_span(test_agent)
-        assert root_span["name"] == "producer"
+        if root_span["meta"]["language"] != "python":
+            # operation name mapping not supported in Python
+            assert root_span["name"] == "producer"
         assert root_span["resource"] == "operation"
         assert root_span["meta"]["start_attr_key"] == "start_attr_val"
         assert root_span["duration"] == duration * 1_000  # OTEL expects microseconds but we convert it to ns internally
@@ -51,7 +52,6 @@ class Test_Otel_Span_Methods:
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "python_http", reason="New operation name mapping not yet implemented")
     def test_otel_set_service_name(self, test_agent, test_library):
         """
@@ -63,7 +63,9 @@ class Test_Otel_Span_Methods:
                 parent.end_span()
 
         root_span = get_span(test_agent)
-        assert root_span["name"] == "internal"
+        if root_span["meta"]["language"] != "python":
+            # operation name mapping not supported in Python
+            assert root_span["name"] == "internal"
         assert root_span["resource"] == "parent_span"
         assert root_span["service"] == "new_service"
 
@@ -73,7 +75,6 @@ class Test_Otel_Span_Methods:
     )
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "python_http", reason="New operation name mapping not yet implemented")
     def test_otel_set_attributes_different_types(self, test_agent, test_library):
         """
@@ -100,7 +101,9 @@ class Test_Otel_Span_Methods:
 
         root_span = get_span(test_agent)
 
-        assert root_span["name"] == "producer"
+        if root_span["meta"]["language"] != "python":
+            # operation name mapping not supported in Python
+            assert root_span["name"] == "producer"
         assert root_span["resource"] == "operation"
 
         assert root_span["meta"]["str_val"] == "val"
@@ -185,7 +188,9 @@ class Test_Otel_Span_Methods:
 
         root_span = get_span(test_agent)
 
-        assert root_span["name"] == "producer"
+        if root_span["meta"]["language"] != "python":
+            # operation name mapping not supported in Python
+            assert root_span["name"] == "producer"
         assert root_span["resource"] == "operation"
 
         assert root_span["meta"]["str_val"] == "val"
@@ -252,7 +257,9 @@ class Test_Otel_Span_Methods:
                 s.end_span(timestamp=start_time + duration * 2)
 
         s = get_span(test_agent)
-        assert s.get("name") == "internal"
+        if s["meta"]["language"] != "python":
+            # operation name mapping not supported in Python
+            assert s.get("name") == "internal"
         assert s.get("resource") == "operation"
         assert s.get("start") == start_time * 1_000  # OTEL expects microseconds but we convert it to ns internally
         assert s.get("duration") == duration * 1_000
@@ -284,12 +291,16 @@ class Test_Otel_Span_Methods:
         assert len(trace) == 2
 
         parent_span = find_span(trace, otel_span(name="parent"))
-        assert parent_span["name"] == "producer"
+        if parent_span["meta"]["language"] != "python":
+            # operation name mapping not supported in Python
+            assert parent_span["name"] == "producer"
         assert parent_span["resource"] == "parent"
         assert parent_span["meta"].get("after_finish") is None
 
         child = find_span(trace, otel_span(name="child"))
-        assert child["name"] == "consumer"
+        if child["meta"]["language"] != "python":
+            # operation name mapping not supported in Python
+            assert child["name"] == "consumer"
         assert child["resource"] == "child"
         assert child["parent_id"] == parent_span["span_id"]
 
@@ -318,7 +329,9 @@ class Test_Otel_Span_Methods:
                 s.end_span()
         s = get_span(test_agent)
         assert s.get("meta").get("error.message") == "error_desc"
-        assert s.get("name") == "internal"
+        if s["meta"]["language"] != "python":
+            # operation name mapping not supported in Python
+            assert s.get("name") == "internal"
         assert s.get("resource") == "error_span"
 
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
@@ -353,7 +366,9 @@ class Test_Otel_Span_Methods:
 
         span = get_span(test_agent)
         assert span.get("meta").get("error.message") is None
-        assert span.get("name") == "internal"
+        if span["meta"]["language"] != "python":
+            # operation name mapping not supported in Python
+            assert span.get("name") == "internal"
         assert span.get("resource") == "ok_span"
 
     def test_otel_get_span_context(self, test_agent, test_library):
@@ -394,7 +409,9 @@ class Test_Otel_Span_Methods:
             assert len(trace) == 1
 
             span = get_span(test_agent)
-            assert span["name"] == "kafka.receive"
+            if span["meta"]["language"] != "python":
+                # operation name mapping not supported in Python
+                assert span["name"] == "kafka.receive"
             assert span["resource"] == "operation"
 
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -463,7 +480,9 @@ class Test_Otel_Span_Methods:
         assert len(trace) == 1
 
         span = get_span(test_agent)
-        assert span["name"] == "overriden.name"
+        if span["meta"]["language"] != "python":
+            # operation name mapping not supported in Python
+            assert span["name"] == "overriden.name"
         assert span["meta"]["span.kind"] == "server"
         assert span["resource"] == "new.name"
         assert span["service"] == "new.service.name"
@@ -518,7 +537,9 @@ def run_operation_name_test(expected_operation_name: str, span_kind: int, attrib
     assert len(trace) == 1
 
     span = get_span(test_agent)
-    assert span["name"] == expected_operation_name
+    if span["meta"]["language"] != "python":
+        # operation name mapping not supported in Python
+        assert span["name"] == expected_operation_name
     assert span["resource"] == "otel_span_name"
 
 

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -145,11 +145,15 @@ class APMClientServicer(apm_test_client_pb2_grpc.APMClientServicer):
                 )
             )
 
+        # Python SpanKind enum starts at 0 whereas the proto spec used here starts at 1
+        # skin_kind = 0 is used for UNSPECIFIED in test library, we handle it as INTERNAL
+        span_kind = request.span_kind - 1 if request.span_kind > 0 else 0
+
         otel_tracer = opentelemetry.trace.get_tracer(__name__)
         otel_span = otel_tracer.start_span(
             request.name,  # type: str
             context=set_span_in_context(parent_span),
-            kind=SpanKind(request.span_kind),
+            kind=SpanKind(span_kind),
             attributes=self._get_attributes_from_request(request),
             links=None,
             # parametric tests expect timestamps to be set in microseconds (required by go)

--- a/utils/build/docker/python_http/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python_http/parametric/apm_test_client/server.py
@@ -245,10 +245,14 @@ def otel_start_span(args: OtelStartSpanArgs):
     else:
         parent_span = None
 
+    # Python SpanKind enum starts at 0 whereas the proto spec used here starts at 1
+    # skin_kind = 0 is used for UNSPECIFIED in test library, we handle it as INTERNAL
+    span_kind = args.span_kind - 1 if args.span_kind > 0 else 0
+
     otel_span = otel_tracer.start_span(
         args.name,
         context=set_span_in_context(parent_span),
-        kind=SpanKind(args.span_kind),
+        kind=SpanKind(span_kind),
         attributes=args.attributes,
         links=None,
         # parametric tests expect timestamps to be set in microseconds (required by go)


### PR DESCRIPTION
## Description

This enables Python support for opentelemetry api tests covering reserved span attributes and operation name.

- https://github.com/DataDog/dd-trace-py/pull/7587
- https://github.com/DataDog/dd-trace-py/pull/7619

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
