### PR TITLE
Use require function in main js file instead of --require

### DIFF
--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -25,7 +25,7 @@ ENV DD_DATA_STREAMS_ENABLED=true
 ENV PORT=7777
 ENV HOSTNAME=0.0.0.0
 ENV DD_TRACE_DEBUG=true
-RUN echo '#!/bin/bash\nnode .next/standalone/server.js' > app.sh
+RUN echo '#!/bin/bash\nnode app.js' > app.sh
 RUN chmod +x app.sh
-ENV NODE_OPTIONS="--require dd-trace/init.js"
+
 CMD ./app.sh

--- a/utils/build/docker/nodejs/nextjs/app.js
+++ b/utils/build/docker/nodejs/nextjs/app.js
@@ -1,0 +1,2 @@
+require('dd-trace/init.js')
+require('./.next/standalone/server.js')


### PR DESCRIPTION
## Description
Prevent the use `--require` in nextjs system tests to require the tracer.
<!-- A brief description of the change being made with this pull request. -->

## Motivation
In node +20, ESM hooks run in new thread, if tracer is required with `--require`, new instance of the tracer is started in the new thread and that causes unexpected RC messages and system test failures.
In this nodejs PR we are adding new ESM hook, and it causes some failures related with RC: 
- PR: https://github.com/DataDog/dd-trace-js/pull/3783
- Failing test: https://github.com/DataDog/dd-trace-js/actions/runs/6826265563/job/18617269855
- The same PR now is running system test in this PR, it works: https://github.com/DataDog/dd-trace-js/actions/runs/6882226389/job/18720299625?pr=3783



<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
