### PR TITLE
Unskip .NET tests for OperationName and W3C

### DIFF
--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -638,7 +638,6 @@ class Test_Headers_Precedence:
 
     @enable_datadog_b3multi_tracecontext_extract_first_false()
     @missing_feature(context.library < "cpp@0.1.12", reason="Implemented in 0.1.12")
-    @missing_feature(context.library == "dotnet", reason="dotnet must implement new tracestate propagation")
     @missing_feature(context.library == "nodejs", reason="NodeJS must implement new tracestate propagation")
     @missing_feature(context.library == "php", reason="php must implement new tracestate propagation")
     @missing_feature(context.library == "python", reason="python must implement new tracestate propagation")

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -480,7 +480,10 @@ class Test_Otel_Span_Methods:
 
     @missing_feature(context.library < "java@1.25.0", reason="Implemented in 1.25.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(
+        context.library <= "dotnet",
+        reason=".NET does not honor 'something-else' as a 'false' value that would set 'analytics.event' as that would differ from the OTLP implementation.",
+    )
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @pytest.mark.parametrize(

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.parametrize(
 class Test_Otel_Span_Methods:
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
+    @missing_feature(context.library <= "dotnet@2.41.0", reason="New operation name in v2.42.0")
     @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "python_http", reason="New operation name mapping not yet implemented")
     def test_otel_start_span(self, test_agent, test_library):
@@ -50,7 +50,7 @@ class Test_Otel_Span_Methods:
 
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
+    @missing_feature(context.library <= "dotnet@2.41.0", reason="New operation name in v2.42.0")
     @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "python_http", reason="New operation name mapping not yet implemented")
     def test_otel_set_service_name(self, test_agent, test_library):
@@ -72,7 +72,7 @@ class Test_Otel_Span_Methods:
         reason="Old array encoding was removed in 1.22.0 and new span naming introduced in 1.24.0: no version elligible for this test.",
     )
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
+    @missing_feature(context.library <= "dotnet@2.41.0", reason="New operation name in v2.42.0")
     @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "python_http", reason="New operation name mapping not yet implemented")
     def test_otel_set_attributes_different_types(self, test_agent, test_library):
@@ -152,7 +152,8 @@ class Test_Otel_Span_Methods:
         context.library == "nodejs", reason="New operation name mapping & array encoding not yet implemented"
     )
     @missing_feature(
-        context.library == "dotnet", reason="New operation name mapping & array encoding not yet implemented"
+        context.library == "dotnet",
+        reason="Array encoding not yet implemented - new operaiton name mapping in v2.42.0",
     )
     @missing_feature(
         context.library == "python", reason="New operation name mapping & array encoding not yet implemented"
@@ -259,7 +260,7 @@ class Test_Otel_Span_Methods:
 
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library == "dotnet", reason="New operation name mapping not yet implemented")
+    @missing_feature(context.library <= "dotnet@2.41.0", reason="New operation name in v2.42.0")
     @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "python_http", reason="New operation name mapping not yet implemented")
     def test_otel_span_end(self, test_agent, test_library):
@@ -374,7 +375,7 @@ class Test_Otel_Span_Methods:
 
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library <= "dotnet@2.41.0", reason="New operation name in v2.42.0")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     def test_otel_set_attributes_separately(self, test_agent, test_library):
@@ -399,7 +400,7 @@ class Test_Otel_Span_Methods:
 
     @missing_feature(context.library == "java", reason="Not implemented")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library <= "dotnet@2.41.0", reason="New operation name in v2.42.0")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @pytest.mark.parametrize(
@@ -442,7 +443,7 @@ class Test_Otel_Span_Methods:
 
     @missing_feature(context.library < "java@1.25.0", reason="Implemented in 1.25.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library <= "dotnet@2.41.0", reason="Operation name wasn't lowercased until v2.42.0")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @bug(context.library == "java", reason="span.kind not set")

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -481,7 +481,7 @@ class Test_Otel_Span_Methods:
     @missing_feature(context.library < "java@1.25.0", reason="Implemented in 1.25.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(
-        context.library <= "dotnet",
+        context.library == "dotnet",
         reason=".NET does not honor 'something-else' as a 'false' value that would set 'analytics.event' as that would differ from the OTLP implementation.",
     )
     @missing_feature(context.library == "python", reason="Not implemented")

--- a/utils/build/docker/dotnet/parametric/ApmTestClient.csproj
+++ b/utils/build/docker/dotnet/parametric/ApmTestClient.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.34.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.42.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.52.0" />
     <PackageReference Include="LucasP.DuckTyping" Version="0.1.0" />
   </ItemGroup>

--- a/utils/build/docker/dotnet/parametric/Services/ApmTestClientService.Otel.cs
+++ b/utils/build/docker/dotnet/parametric/Services/ApmTestClientService.Otel.cs
@@ -74,9 +74,35 @@ public partial class ApmTestClientService
 
         var parentContext = localParentContext ?? remoteParentContext ?? default;
 
+        var kind = ActivityKind.Internal;
+        if (request.HasSpanKind)
+        {
+            switch (request.SpanKind)
+            {
+                case 1:
+                    kind = ActivityKind.Internal;
+                    break;
+                case 2:
+                    kind = ActivityKind.Server;
+                    break;
+                case 3:
+                    kind = ActivityKind.Client;
+                    break;
+                case 4:
+                    kind = ActivityKind.Producer;
+                    break;
+                case 5:
+                    kind = ActivityKind.Consumer;
+                    break;
+                default:
+                    kind = ActivityKind.Internal; // this is the default in Activity
+                    break;
+            }
+        }
+
         var activity = ApmTestClientActivitySource.StartActivity(
             request.Name,
-            ActivityKind.Internal,
+            kind,
             parentContext,
             tags: null,
             links: null,


### PR DESCRIPTION
## Description

**v2.42.0 is released, but NuGet has been degraded and the package we use for the parametric tests hasn't been listed yet on NuGet.**

Unskips the OpenTelemetry and W3C parametric tests for .NET, specifically to support the new operation name mapping and W3C propagation introduced in v2.42.0 of the .NET Tracer.

## Motivation

The tests were skipped before due to yet being supported by the .NET Tracer.

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
