### PR TITLE
golang/parametric: dont restart tracer on span creation

### DIFF
--- a/utils/build/docker/golang/parametric/datadog.go
+++ b/utils/build/docker/golang/parametric/datadog.go
@@ -3,14 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 func (s *apmClientServer) StartSpan(ctx context.Context, args *StartSpanArgs) (*StartSpanReturn, error) {
-	if !s.tracerStarted {
-		s.tracerStarted = true
-		tracer.Start()
-	}
 	var opts []tracer.StartSpanOption
 	if args.GetParentId() > 0 {
 		parent := s.spans[*args.ParentId]

--- a/utils/build/docker/golang/parametric/main.go
+++ b/utils/build/docker/golang/parametric/main.go
@@ -19,11 +19,10 @@ import (
 
 type apmClientServer struct {
 	UnimplementedAPMClientServer
-	spans         map[uint64]tracer.Span
-	otelSpans     map[uint64]spanContext
-	tp            *ddotel.TracerProvider
-	tracer        otel_trace.Tracer
-	tracerStarted bool
+	spans     map[uint64]tracer.Span
+	otelSpans map[uint64]spanContext
+	tp        *ddotel.TracerProvider
+	tracer    otel_trace.Tracer
 }
 
 type spanContext struct {


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

Don't restart the Go tracer on span creation.

## Motivation

Seems to be a regression in https://github.com/DataDog/system-tests/pull/1381/ - the tracer is already started by the `NewTracerProvider` call in main.go.

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
