### PR TITLE
Enable tracer-flare system-tests for Java tracer 1.25.0 and later

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -879,7 +879,7 @@ tests/:
     test_tracer.py:
       Test_TracerSCITagging: v1.12.0
     test_tracer_flare.py:
-      TestTracerFlareV1: missing_feature
+      TestTracerFlareV1: v1.25.0
   remote_config/:
     test_remote_configuration.py:
       Test_RemoteConfigurationExtraServices: missing_feature


### PR DESCRIPTION
## Description

Enable tracer-flare system-tests for Java tracer 1.25.0 and later

## Motivation

We've merged enough of the tracer-flare work to begin system-testing it as of the upcoming 1.25.0 release.

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [x] CI is green
   * [x] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
