### PR TITLE
[PHP] Support unified package

### DIFF
--- a/utils/build/docker/php/apache-mod/build.sh
+++ b/utils/build/docker/php/apache-mod/build.sh
@@ -52,4 +52,7 @@ sed -i s/80/7777/ /etc/apache2/ports.conf
 /install_ddtrace.sh 1
 
 SYSTEM_TESTS_LIBRARY_VERSION=$(cat /binaries/SYSTEM_TESTS_LIBRARY_VERSION)
-grep datadog.trace.request_init_hook /etc/php/98-ddtrace.ini >> /etc/php/php.ini
+
+if [[ -f "/etc/php/98-ddtrace.ini" ]]; then
+    grep datadog.trace.request_init_hook /etc/php/98-ddtrace.ini >> /etc/php/php.ini
+fi

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -1,47 +1,68 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
 IS_APACHE=$1
 
-echo "Loading install script"
-curl -Lf -o /tmp/dd-library-php-setup.php \
-  https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php
-
 cd /binaries
 
-BINARIES_APPSEC_N=$(find . -name 'dd-appsec-php-*.tar.gz' | wc -l)
-BINARIES_TRACER_N=$(find . -name 'datadog-php-tracer*.tar.gz' | wc -l)
-INSTALLER_ARGS=()
-if [[ $BINARIES_APPSEC_N -eq 1 ]]; then
-  INSTALLER_ARGS+=(--appsec-file /binaries/dd-appsec-php-*.tar.gz)
-elif [[ $BINARIES_APPSEC_N -gt 1 ]]; then
-  echo "Too many appsec packages in /binaries" >&2
-  exit 1
-else
-  INSTALLER_ARGS+=(--appsec-version $APPSEC_VERSION)
-fi
+if [[ -f "datadog-setup.php" ]]; then
+    INSTALLER_ARGS=()
 
-if [[ $BINARIES_TRACER_N -eq 1 ]]; then
-  INSTALLER_ARGS+=(--tracer-file /binaries/datadog-php-tracer*.tar.gz)
-elif [[ $BINARIES_TRACER_N -gt 1 ]]; then
-  echo "Too many appsec packages in /binaries" >&2
-  exit 1
-else
-  INSTALLER_ARGS+=(--tracer-version $TRACER_VERSION)
-fi
+    BINARIES_COMBINED_N=$(find . -name 'dd-library-php-*-x86_64-linux-gnu.tar.gz' | wc -l)
+    if [[ $BINARIES_COMBINED_N -eq 1 ]]; then
+      INSTALLER_ARGS+=(--file dd-library-php-*-x86_64-linux-gnu.tar.gz)
+    elif [[ $BINARIES_COMBINED_N -gt 1 ]]; then
+      echo "Too many appsec packages in /binaries" >&2
+      exit 1
+    fi
 
-echo "Install args are ${INSTALLER_ARGS[@]}"
+    echo "Install args are ${INSTALLER_ARGS[@]}"
 
-export DD_APPSEC_ENABLED=0
-if [[ $IS_APACHE -eq 0 ]]; then
-  php /tmp/dd-library-php-setup.php \
-    "${INSTALLER_ARGS[@]}"\
-    --php-bin all
+    export DD_APPSEC_ENABLED=0
+    if [[ $IS_APACHE -eq 0 ]]; then
+      php datadog-setup --php-bin all "${INSTALLER_ARGS[@]}"
+    else
+      PHP_INI_SCAN_DIR="/etc/php" php datadog-setup.php --php-bin all "${INSTALLER_ARGS[@]}"
+    fi
 else
-  PHP_INI_SCAN_DIR="/etc/php" php /tmp/dd-library-php-setup.php \
-    "${INSTALLER_ARGS[@]}"\
-    --php-bin all
+    echo "Loading install script"
+    curl -Lf -o /tmp/dd-library-php-setup.php \
+      https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php
+
+    BINARIES_APPSEC_N=$(find . -name 'dd-appsec-php-*.tar.gz' | wc -l)
+    BINARIES_TRACER_N=$(find . -name 'datadog-php-tracer*.tar.gz' | wc -l)
+    INSTALLER_ARGS=()
+    if [[ $BINARIES_APPSEC_N -eq 1 ]]; then
+      INSTALLER_ARGS+=(--appsec-file /binaries/dd-appsec-php-*.tar.gz)
+    elif [[ $BINARIES_APPSEC_N -gt 1 ]]; then
+      echo "Too many appsec packages in /binaries" >&2
+      exit 1
+    else
+      INSTALLER_ARGS+=(--appsec-version $APPSEC_VERSION)
+    fi
+
+    if [[ $BINARIES_TRACER_N -eq 1 ]]; then
+      INSTALLER_ARGS+=(--tracer-file /binaries/datadog-php-tracer*.tar.gz)
+    elif [[ $BINARIES_TRACER_N -gt 1 ]]; then
+      echo "Too many appsec packages in /binaries" >&2
+      exit 1
+    else
+      INSTALLER_ARGS+=(--tracer-version $TRACER_VERSION)
+    fi
+
+    echo "Install args are ${INSTALLER_ARGS[@]}"
+
+    export DD_APPSEC_ENABLED=0
+    if [[ $IS_APACHE -eq 0 ]]; then
+      php /tmp/dd-library-php-setup.php \
+        "${INSTALLER_ARGS[@]}"\
+        --php-bin all
+    else
+      PHP_INI_SCAN_DIR="/etc/php" php /tmp/dd-library-php-setup.php \
+        "${INSTALLER_ARGS[@]}"\
+        --php-bin all
+    fi
 fi
 
 php -d error_reporting='' -d extension=ddtrace.so -d extension=ddappsec.so -r 'echo phpversion("ddtrace");' > \
@@ -52,8 +73,13 @@ php -d error_reporting='' -d extension=ddtrace.so -d extension=ddappsec.so -r 'e
 
 touch SYSTEM_TESTS_LIBDDWAF_VERSION
 
-appsec_version=$(<./SYSTEM_TESTS_PHP_APPSEC_VERSION)
-rule_file="/opt/datadog/dd-library/appsec-${appsec_version}/etc/dd-appsec/recommended.json"
+library_version=$(<././SYSTEM_TESTS_LIBRARY_VERSION)
+rule_file="/opt/datadog/dd-library/${library_version}/etc/recommended.json"
+if [[ ! -f "${rule_file}" ]]; then
+    appsec_version=$(<./SYSTEM_TESTS_PHP_APPSEC_VERSION)
+    rule_file="/opt/datadog/dd-library/appsec-${appsec_version}/etc/dd-appsec/recommended.json"
+fi
+
 jq -r '.metadata.rules_version // "1.2.5"' "${rule_file}" > SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 
 find /opt -name ddappsec-helper -exec ln -s '{}' /usr/local/bin/ \;


### PR DESCRIPTION
## Description

Currently the system tests (with the exception of the parametric tests) use the independent tracer and appsec packages, this PR adds support for the unified package to allow local testing and testing in the tracer's CI.

Related Jira: [APPSEC-4581]

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly


[APPSEC-4581]: https://datadoghq.atlassian.net/browse/APPSEC-4581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ