### PR TITLE
[PHP] Fix typo on tracer installer

### DIFF
--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -21,7 +21,7 @@ if [[ -f "datadog-setup.php" ]]; then
 
     export DD_APPSEC_ENABLED=0
     if [[ $IS_APACHE -eq 0 ]]; then
-      php datadog-setup --php-bin all "${INSTALLER_ARGS[@]}"
+      php datadog-setup.php --php-bin all "${INSTALLER_ARGS[@]}"
     else
       PHP_INI_SCAN_DIR="/etc/php" php datadog-setup.php --php-bin all "${INSTALLER_ARGS[@]}"
     fi


### PR DESCRIPTION
## Description

Small typo introduced in the tracer installer, doesn't affect the system tests CI at the moment.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
