### PR TITLE
Command execution for PHP

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -151,7 +151,7 @@ tests/:
       Test_ExtraTagsFromRule: v0.88.0
       Test_Info: v0.68.3  # probably 0.68.2, but was flaky
     test_shell_execution.py:
-      Test_ShellExecution: missing_feature
+      Test_ShellExecution: v0.95.0
     test_traces.py:
       Test_DistributedTraceInfo: missing_feature (test not implemented)
     test_user_blocking_full_denylist.py:

--- a/tests/appsec/test_shell_execution.py
+++ b/tests/appsec/test_shell_execution.py
@@ -3,13 +3,27 @@
 # Copyright 2021 Datadog, Inc.
 
 import json
-from utils import coverage, interfaces, weblog, features
+from utils import coverage, interfaces, weblog, features, irrelevant
+from utils._context.core import context
 
 
 @features.appsec_shell_execution_tracing
 @coverage.basic
 class Test_ShellExecution:
     """Test shell execution tracing"""
+
+    @staticmethod
+    def fetch_command_execution_span(r):
+        for _, trace in interfaces.library.get_traces(request=r):
+            for span in trace:
+                if span["name"] == "command_execution":
+                    command_exec_span = span
+
+        assert r.status_code == 200
+        assert command_exec_span is not None, f"command execution span hasn't be found for {r.url}"
+        assert command_exec_span["name"] == "command_execution"
+        assert command_exec_span["meta"]["component"] == "subprocess"
+        return command_exec_span
 
     def setup_track_cmd_exec(self):
         self.r_cmd_exec = weblog.post(
@@ -18,77 +32,101 @@ class Test_ShellExecution:
             data=json.dumps({"command": "echo", "options": {"shell": False}, "args": "foo"}),
         )
 
+    @irrelevant(
+        context.library == "php"
+        and context.weblog_variant.contains("-7.")
+        and not context.weblog_variant.contains("7.4"),
+        reason="For PHP 7.4+",
+    )
     def test_track_cmd_exec(self):
-        for _, trace in interfaces.library.get_traces(request=self.r_cmd_exec):
-            for span in trace:
-                if span["name"] == "command_execution":
-                    shell_exec_span = span
-
-        assert self.r_cmd_exec.status_code == 200
-        assert shell_exec_span is not None, f"shell_exec_span hasn't be found for {self.r_cmd_exec.request.url}"
-        assert shell_exec_span["name"] == "command_execution"
-        assert shell_exec_span["meta"]["component"] == "subprocess"
+        shell_exec_span = self.fetch_command_execution_span(self.r_cmd_exec)
         assert shell_exec_span["meta"]["cmd.exec"] == '["echo","foo"]'
         assert shell_exec_span["meta"]["cmd.exit_code"] == "0"
 
     def setup_track_shell_exec(self):
-        self.r_cmd_exec = weblog.post(
+        self.r_shell_exec = weblog.post(
             "/shell_execution",
             headers={"Content-Type": "application/json"},
             data=json.dumps({"command": "echo", "options": {"shell": True}, "args": "foo"}),
         )
 
+    # This test is wrong. cmd.shell should not be in array notation. Citing the RFC:
+    # > As an example, subprocess.run(["ls", "-l"], shell=True) will produce
+    # > "cmd.shell": "ls -a" [sic]
+    @irrelevant(library="php", reason="The test is wrong")
     def test_track_shell_exec(self):
-        for _, trace in interfaces.library.get_traces(request=self.r_cmd_exec):
-            for span in trace:
-                if span["name"] == "command_execution":
-                    shell_exec_span = span
+        shell_exec_span = self.fetch_command_execution_span(self.r_shell_exec)
 
-        assert self.r_cmd_exec.status_code == 200
-        assert shell_exec_span is not None, f"shell_exec_span hasn't be found for {self.r_cmd_exec.request.url}"
-        assert shell_exec_span["name"] == "command_execution"
-        assert shell_exec_span["meta"]["component"] == "subprocess"
         assert shell_exec_span["meta"]["cmd.shell"] == '["echo","foo"]'
+        assert shell_exec_span["meta"]["cmd.exit_code"] == "0"
+
+    def setup_track_shell_exec_correct(self):
+        self.r_shell_exec_correct = weblog.post(
+            "/shell_execution",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps({"command": "echo", "options": {"shell": True}, "args": "foo"}),
+        )
+
+    @bug(
+        context.library != "php" and context.library != "java",
+        reason="Possible reliance on wrong test. See " "test_track_shell_exec",
+    )
+    @irrelevant(library="java", reason="No method for shell execution in Java")
+    def test_track_shell_exec_correct(self):
+        shell_exec_span = self.fetch_command_execution_span(self.r_shell_exec_correct)
+
+        assert shell_exec_span["meta"]["cmd.shell"] == "echo foo"
         assert shell_exec_span["meta"]["cmd.exit_code"] == "0"
 
     def setup_truncation(self):
         args = "foo".ljust(32000, "o")
-        self.r_cmd_exec = weblog.post(
+        self.r_truncation = weblog.post(
             "/shell_execution",
             headers={"Content-Type": "application/json"},
             data=json.dumps({"command": "echo", "options": {"shell": False}, "args": args}),
         )
 
+    # The RFC never says the argument should be truncated to 2 characters. It says
+    # the argument should be truncated **by** 2 characters (the length of "ls"
+    # in the example in the RFC).
+    @irrelevant(library="php", reason="The test is wrong")
     def test_truncation(self):
-        for _, trace in interfaces.library.get_traces(request=self.r_cmd_exec):
-            for span in trace:
-                if span["name"] == "command_execution":
-                    shell_exec_span = span
+        shell_exec_span = self.fetch_command_execution_span(self.r_truncation)
 
-        assert self.r_cmd_exec.status_code == 200
-        assert shell_exec_span is not None, f"shell_exec_span hasn't be found for {self.r_cmd_exec.request.url}"
-        assert shell_exec_span["name"] == "command_execution"
-        assert shell_exec_span["meta"]["component"] == "subprocess"
         assert shell_exec_span["meta"]["cmd.exec"] == '["echo","fo"]'
+        assert shell_exec_span["meta"]["cmd.exit_code"] == "0"
+
+    def setup_truncated_correct(self):
+        args = ["a" * 4096, "arg"]
+        self.r_truncation_correct = weblog.post(
+            "/shell_execution",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps({"command": "echo", "options": {"shell": False}, "args": args}),
+        )
+
+    @bug(context.library != "php", reason="Possible reliance on wrong test. See comment in test_truncation")
+    @irrelevant(
+        context.library == "php"
+        and context.weblog_variant.contains("-7.")
+        and not context.weblog_variant.contains("7.4"),
+        reason="For PHP 7.4+",
+    )
+    def test_truncated_correct(self):
+        shell_exec_span = self.fetch_command_execution_span(self.r_truncation_correct)
+
+        assert shell_exec_span["meta"]["cmd.exec"] == '["echo","' + "a" * 4092 + '",""]'
         assert shell_exec_span["meta"]["cmd.exit_code"] == "0"
 
     def setup_obfuscation(self):
         args = "password 1234"
-        self.r_cmd_exec = weblog.post(
+        self.r_obfuscation = weblog.post(
             "/shell_execution",
             headers={"Content-Type": "application/json"},
             data=json.dumps({"command": "echo", "options": {"shell": False}, "args": args}),
         )
 
     def test_obfuscation(self):
-        for _, trace in interfaces.library.get_traces(request=self.r_cmd_exec):
-            for span in trace:
-                if span["name"] == "command_execution":
-                    shell_exec_span = span
+        shell_exec_span = self.fetch_command_execution_span(self.r_obfuscation)
 
-        assert self.r_cmd_exec.status_code == 200
-        assert shell_exec_span is not None, f"shell_exec_span hasn't be found for {self.r_cmd_exec.request.url}"
-        assert shell_exec_span["name"] == "command_execution"
-        assert shell_exec_span["meta"]["component"] == "subprocess"
         assert shell_exec_span["meta"]["cmd.exec"] == '["echo","password","?"]'
         assert shell_exec_span["meta"]["cmd.exit_code"] == "0"

--- a/utils/build/docker/php/apache-mod/php.conf
+++ b/utils/build/docker/php/apache-mod/php.conf
@@ -15,6 +15,7 @@
         RewriteRule "^/user_login_success_event$" "/user_login_success_event/"
         RewriteRule "^/dbm$" "/dbm/"
         RewriteRule "^/login$" "/login/"
+        RewriteRule "^/shell_execution$" "/shell_execution/"
         RewriteCond /var/www/html/%{REQUEST_URI} !-f
         RewriteRule "^/([^/]+)/(.*)" "/$1.php/$2" [L]
         ErrorDocument 404 /404.php

--- a/utils/build/docker/php/common/shell_execution.php
+++ b/utils/build/docker/php/common/shell_execution.php
@@ -1,0 +1,41 @@
+<?php
+
+$spec = json_decode(stream_get_contents(fopen('php://input', 'rb')), true);
+
+$command = $spec['command'];
+$options = $spec['options'] ?? [];
+$args = $spec['args'] ?? [];
+
+$isShell = !empty($options['shell']);
+
+if (!$isShell && PHP_VERSION_ID < 70400) {
+    http_send_status(500);
+    error_log('PHP version must be at least 7.4.0 to run this command in non-shell mode');
+    die('PHP version must be at least 7.4.0 to run this command in non-shell mode');
+}
+
+if (is_string($args)) {
+    $args = preg_split('/\s+/', $args);
+}
+
+$c = array_merge([$command], $args);
+if ($isShell) {
+    $c = implode(' ', $c); // purposefully not escaped
+}
+
+$p = proc_open($c, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+if (!is_resource($p)) {
+    http_send_status(500);
+    error_log("Failed to open process: $p");
+    die('Failed to open process');
+}
+
+$stdout = stream_get_contents($pipes[1]);
+fclose($pipes[1]);
+$stderr = stream_get_contents($pipes[2]);
+fclose($pipes[2]);
+
+echo "STDOUT:\n$stdout\n";
+echo "STDERR:\n$stderr\n";
+
+echo "exit code: " . proc_close($p), "\n";

--- a/utils/build/docker/php/php-fpm/php-fpm.conf
+++ b/utils/build/docker/php/php-fpm/php-fpm.conf
@@ -21,6 +21,7 @@
         RewriteRule "^/user_login_success_event$" "/user_login_success_event/"
         RewriteRule "^/dbm$" "/dbm/"
         RewriteRule "^/login$" "/login/"
+        RewriteRule "^/shell_execution$" "/shell_execution/"
         RewriteCond /var/www/html/%{REQUEST_URI} !-f
         RewriteRule "^/([^/]+)/(.*)" "/$1.php/$2" [L]
         ErrorDocument 404 /404.php


### PR DESCRIPTION
## Description

Command execution spans for PHP. Requires the version 0.95 of the tracer.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [x] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
