### PR TITLE
server.response.headers.no_cookes address go

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -226,9 +226,15 @@ tests/:
       Test_Blocking_request_uri:
         '*': v1.51.0
         net-http: irrelevant
-      Test_Blocking_response_headers: missing_feature
-      Test_Blocking_response_status: missing_feature
-      Test_Suspicious_Request_Blocking: missing_feature
+      Test_Blocking_response_headers:
+        '*': v1.59.0
+        net-http: irrelevant
+      Test_Blocking_response_status:
+        '*': v1.59.0
+        net-http: irrelevant
+      Test_Suspicious_Request_Blocking:
+        '*': v1.59.0
+        net-http: irrelevant
     test_client_ip.py:
       Test_StandardTagsClientIp: v1.44.1
     test_conf.py:

--- a/utils/build/docker/golang/chi.Dockerfile
+++ b/utils/build/docker/golang/chi.Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get -y install jq
 RUN mkdir -p /app
 COPY utils/build/docker/golang/app/go.mod utils/build/docker/golang/app/go.sum /app
 WORKDIR /app
+# Force default value for GOPROXY since the custom DD value proxy does not work for some old modules used here
+ENV GOPROXY=https://proxy.golang.org,direct 
 RUN go mod download && go mod verify
 
 # copy the app code

--- a/utils/build/docker/golang/echo.Dockerfile
+++ b/utils/build/docker/golang/echo.Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get -y install jq
 RUN mkdir -p /app
 COPY utils/build/docker/golang/app/go.mod utils/build/docker/golang/app/go.sum /app
 WORKDIR /app
+# Force default value for GOPROXY since the custom DD value proxy does not work for some old modules used here
+ENV GOPROXY=https://proxy.golang.org,direct 
 RUN go mod download && go mod verify
 
 # copy the app code

--- a/utils/build/docker/golang/gin.Dockerfile
+++ b/utils/build/docker/golang/gin.Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get -y install jq
 RUN mkdir -p /app
 COPY utils/build/docker/golang/app/go.mod utils/build/docker/golang/app/go.sum /app
 WORKDIR /app
+# Force default value for GOPROXY since the custom DD value proxy does not work for some old modules used here
+ENV GOPROXY=https://proxy.golang.org,direct 
 RUN go mod download && go mod verify
 
 # copy the app code

--- a/utils/build/docker/golang/net-http.Dockerfile
+++ b/utils/build/docker/golang/net-http.Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update && apt-get -y install jq
 RUN mkdir -p /app
 COPY utils/build/docker/golang/app/go.mod utils/build/docker/golang/app/go.sum /app
 WORKDIR /app
+
+# Force default value for GOPROXY since the custom DD value proxy does not work for some old modules used here
+ENV GOPROXY=https://proxy.golang.org,direct 
 RUN go mod download && go mod verify
 
 # copy the app code

--- a/utils/build/docker/golang/uds-echo.Dockerfile
+++ b/utils/build/docker/golang/uds-echo.Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get -y install jq socat
 RUN mkdir -p /app
 COPY utils/build/docker/golang/app/go.mod utils/build/docker/golang/app/go.sum /app
 WORKDIR /app
+# Force default value for GOPROXY since the custom DD value proxy does not work for some old modules used here
+ENV GOPROXY=https://proxy.golang.org,direct 
 RUN go mod download && go mod verify
 
 # copy the app code


### PR DESCRIPTION
## Description

Add missing tests for response blocking.

Add forced value to `GOPROXY` to skip `binaries.ddbuild.io` which may be unavailable

## Motivation

Enable more tests following DataDog/dd-trace-go#2347

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
