### PR TITLE
[Ruby 1.17.0] Parametric missing feature: test_headers_precedence_propagationstyle_default

### DIFF
--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -96,8 +96,8 @@ class Test_Headers_Precedence:
     @missing_feature(context.library == "python", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "python_http", reason="New 'datadog' default hasn't been implemented yet")
     @irrelevant(context.library < "java@1.24.0", reason="Newer versions include tracecontext as a default propagator")
-    @missing_feature(context.library <= "ruby@1.17.0", reason="Missing feature for version 1.17.0")
-    def test_headers_precedence_propagationstyle_default(self, test_agent, test_library):
+    @irrelevant(context.library >= "ruby@1.17.0", reason="Implements the new 'datadog,tracecontext' default")
+    def test_headers_precedence_propagationstyle_legacy(self, test_agent, test_library):
         self.test_headers_precedence_propagationstyle_datadog(test_agent, test_library)
 
     @enable_datadog()

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -96,7 +96,7 @@ class Test_Headers_Precedence:
     @missing_feature(context.library == "python", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "python_http", reason="New 'datadog' default hasn't been implemented yet")
     @irrelevant(context.library < "java@1.24.0", reason="Newer versions include tracecontext as a default propagator")
-    @missing_feature(context.library == "ruby@1.17.0", reason="Missing feature for version 1.17.0")
+    @missing_feature(context.library <= "ruby@1.17.0", reason="Missing feature for version 1.17.0")
     def test_headers_precedence_propagationstyle_default(self, test_agent, test_library):
         self.test_headers_precedence_propagationstyle_datadog(test_agent, test_library)
 

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -96,6 +96,7 @@ class Test_Headers_Precedence:
     @missing_feature(context.library == "python", reason="New 'datadog' default hasn't been implemented yet")
     @missing_feature(context.library == "python_http", reason="New 'datadog' default hasn't been implemented yet")
     @irrelevant(context.library < "java@1.24.0", reason="Newer versions include tracecontext as a default propagator")
+    @missing_feature(context.library == "ruby@1.17.0", reason="Missing feature for version 1.17.0")
     def test_headers_precedence_propagationstyle_default(self, test_agent, test_library):
         self.test_headers_precedence_propagationstyle_datadog(test_agent, test_library)
 

--- a/utils/build/docker/ruby/parametric/Gemfile
+++ b/utils/build/docker/ruby/parametric/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-sha = '7ddd68a8cd772de30d4810231446d27e338aa893'
+sha = ENV['RUBY_DDTRACE_SHA']
 if sha && !sha.empty?
   gem 'ddtrace', git: 'https://github.com/Datadog/dd-trace-rb.git', ref: sha
 else

--- a/utils/build/docker/ruby/parametric/Gemfile
+++ b/utils/build/docker/ruby/parametric/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 sha = ENV['RUBY_DDTRACE_SHA']
 if sha && !sha.empty?
-  gem 'ddtrace', git: 'https://github.com/Datadog/dd-trace-rb.git', ref: sha
+  gem 'ddtrace', git: 'https://github.com/Datadog/dd-trace-rb.git', ref: '7ddd68a8cd772de30d4810231446d27e338aa893'
 else
   gem 'ddtrace'
 end

--- a/utils/build/docker/ruby/parametric/Gemfile
+++ b/utils/build/docker/ruby/parametric/Gemfile
@@ -1,8 +1,8 @@
 source "https://rubygems.org"
 
-sha = ENV['RUBY_DDTRACE_SHA']
+sha = '7ddd68a8cd772de30d4810231446d27e338aa893'
 if sha && !sha.empty?
-  gem 'ddtrace', git: 'https://github.com/Datadog/dd-trace-rb.git', ref: '7ddd68a8cd772de30d4810231446d27e338aa893'
+  gem 'ddtrace', git: 'https://github.com/Datadog/dd-trace-rb.git', ref: sha
 else
   gem 'ddtrace'
 end


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
