### PR TITLE
[parametric] Update test skips in test_headers_precedence.py for language tracers

### DIFF
--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -89,14 +89,20 @@ def enable_tracecontext_datadog_b3multi_extract_first_true() -> Any:
 @scenarios.parametric
 @features.datadog_headers_propagation
 class Test_Headers_Precedence:
-    @irrelevant(context.library == "dotnet", reason="Implements the new 'datadog,tracecontext' default")
-    @missing_feature(context.library == "golang", reason="New 'datadog' default hasn't been implemented yet")
+    @irrelevant(
+        context.library >= "dotnet@2.22.0", reason="Newer versions include tracecontext as a default propagator"
+    )
+    @irrelevant(
+        context.library >= "golang@1.47.0", reason="Newer versions include tracecontext as a default propagator"
+    )
+    @irrelevant(
+        context.library >= "nodejs@3.14.0",
+        reason="Newer versions include tracecontext as a default propagator (2.27.0 and 3.14.0)",
+    )
+    @irrelevant(context.library >= "php@0.84.0", reason="Newer versions include tracecontext as a default propagator")
+    @irrelevant(context.library >= "python@1.7.0", reason="Newer versions include tracecontext as a default propagator")
     @irrelevant(context.library >= "cpp@0.1.12", reason="Implements the new 'datadog,tracecontext' default")
     @irrelevant(context.library >= "java@1.24.0", reason="Implements the new 'datadog,tracecontext' default")
-    @missing_feature(context.library == "nodejs", reason="New 'datadog' default hasn't been implemented yet")
-    @missing_feature(context.library == "php", reason="New 'datadog' default hasn't been implemented yet")
-    @missing_feature(context.library == "python", reason="New 'datadog' default hasn't been implemented yet")
-    @irrelevant(context.library < "java@1.24.0", reason="Newer versions include tracecontext as a default propagator")
     @irrelevant(context.library >= "ruby@1.17.0", reason="Implements the new 'datadog,tracecontext' default")
     def test_headers_precedence_propagationstyle_legacy(self, test_agent, test_library):
         self.test_headers_precedence_propagationstyle_datadog(test_agent, test_library)
@@ -212,12 +218,12 @@ class Test_Headers_Precedence:
         assert "traceparent" not in headers6
         assert "tracestate" not in headers6
 
-    @irrelevant(context.library == "cpp", reason="Issue: tracecontext,Datadog was never the default configuration")
     @irrelevant(context.library >= "nodejs@5.0.0", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library >= "php@0.97.0", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library >= "python@2.6.0", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library >= "golang@1.61.0.dev", reason="Default value was switched to datadog,tracecontext")
-    @irrelevant(context.library > "dotnet@2.47.0", reason="Implements the new 'datadog,tracecontext' default")
+    @irrelevant(context.library > "dotnet@2.47.0", reason="Default value was switched to datadog,tracecontext")
+    @irrelevant(context.library == "cpp", reason="Issue: tracecontext,Datadog was never the default configuration")
     @irrelevant(context.library == "java", reason="Issue: tracecontext,Datadog was never the default configuration")
     @irrelevant(context.library == "ruby", reason="Issue: tracecontext,Datadog was never the default configuration")
     def test_headers_precedence_propagationstyle_default_tracecontext_datadog(self, test_agent, test_library):

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -212,18 +212,14 @@ class Test_Headers_Precedence:
         assert "traceparent" not in headers6
         assert "tracestate" not in headers6
 
-    @bug(context.library == "cpp", reason="Issue: traceparent not being injected")
-    @bug(context.library == "nodejs", reason="Issue: headers4 is incorrectly using the x-datadog-trace-id by default")
-    @missing_feature(
-        context.library == "java", reason="Issue: tracecontext,Datadog was never the default configuration"
-    )
-    @missing_feature(
-        context.library == "ruby", reason="Issue: tracecontext,Datadog was never the default configuration"
-    )
+    @irrelevant(context.library == "cpp", reason="Issue: tracecontext,Datadog was never the default configuration")
+    @irrelevant(context.library >= "nodejs@5.0.0", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library >= "php@0.97.0", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library >= "python@2.6.0", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library >= "golang@1.61.0.dev", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library > "dotnet@2.47.0", reason="Implements the new 'datadog,tracecontext' default")
+    @irrelevant(context.library == "java", reason="Issue: tracecontext,Datadog was never the default configuration")
+    @irrelevant(context.library == "ruby", reason="Issue: tracecontext,Datadog was never the default configuration")
     def test_headers_precedence_propagationstyle_default_tracecontext_datadog(self, test_agent, test_library):
         self.test_headers_precedence_propagationstyle_tracecontext_datadog(test_agent, test_library)
 
@@ -489,13 +485,13 @@ class Test_Headers_Precedence:
         assert "x-datadog-sampling-priority" not in headers6
 
     @missing_feature(context.library < "java@1.24.0", reason="Implemented from 1.24.0")
-    @irrelevant(context.library == "cpp", reason="library does not implement this default configuration")
-    @irrelevant(context.library < "dotnet@2.48.0", reason="Default value was updated in 2.48.0")
-    @irrelevant(context.library < "python@2.6.0", reason="Default value was switched to datadog,tracecontext")
-    @irrelevant(context.library < "golang@1.62.0", reason="Default value was updated in v1.62.0 (w3c phase 2)")
-    @irrelevant(context.library == "nodejs", reason="library does not implement this default configuration")
-    @irrelevant(context.library < "php@0.98.0", reason="Default value was updated in v0.98.0 (w3c phase 2)")
-    @irrelevant(context.library == "python", reason="library does not implement this default configuration")
+    @missing_feature(context.library < "cpp@0.1.12", reason="Implemented in 0.1.12")
+    @missing_feature(context.library < "dotnet@2.48.0", reason="Default value was updated in 2.48.0")
+    @missing_feature(context.library < "python@2.6.0", reason="Default value was switched to datadog,tracecontext")
+    @missing_feature(context.library < "golang@1.62.0", reason="Default value was updated in v1.62.0 (w3c phase 2)")
+    @missing_feature(context.library < "nodejs@4.20.0", reason="Implemented in 4.20.0 (and 3.41.0)")
+    @missing_feature(context.library < "php@0.98.0", reason="Default value was updated in v0.98.0 (w3c phase 2)")
+    @missing_feature(context.library < "ruby@1.17.0", reason="Implemented from 1.17.0")
     def test_headers_precedence_propagationstyle_default_datadog_tracecontext(self, test_agent, test_library):
         self.test_headers_precedence_propagationstyle_datadog_tracecontext(test_agent, test_library)
 
@@ -923,9 +919,12 @@ class Test_Headers_Precedence:
 
     @enable_datadog_b3multi_tracecontext_extract_first_false()
     @missing_feature(context.library < "cpp@0.1.12", reason="Implemented in 0.1.12")
-    @missing_feature(context.library <= "dotnet@2.41.0", reason="Implemented in 2.42.0")
-    @missing_feature(context.library < "python@2.3.3", reason="python must implement new tracestate propagation")
-    @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")
+    @missing_feature(context.library < "dotnet@2.42.0", reason="Implemented in 2.42.0")
+    @missing_feature(context.library < "python@2.3.3", reason="Implemented in 2.3.3")
+    @missing_feature(context.library < "java@1.24.0", reason="Implemented in 1.24.0")
+    @missing_feature(context.library < "nodejs@4.20.0", reason="Implemented in 4.20.0 (and 3.41.0)")
+    @missing_feature(context.library < "php@0.94.0", reason="Implemented in 0.94.0")
+    @missing_feature(context.library < "ruby@1.17.0", reason="Implemented in 1.17.0")
     def test_headers_precedence_propagationstyle_tracecontext_last_extract_first_false_correctly_propagates_tracestate(
         self, test_agent, test_library
     ):
@@ -934,8 +933,8 @@ class Test_Headers_Precedence:
         )
 
     @enable_datadog_b3multi_tracecontext_extract_first_true()
-    @bug(context.library == "cpp", reason="Legacy behaviour")
-    @bug(context.library == "php", reason="Legacy behaviour: Fixed order instead of order of definition")
+    @missing_feature(context.library == "cpp", reason="DD_TRACE_PROPAGATION_EXTRACT_FIRST is not yet implemented")
+    @missing_feature(context.library == "php", reason="DD_TRACE_PROPAGATION_EXTRACT_FIRST is not yet implemented")
     @bug(
         context.library < "golang@1.57.0",
         reason="Legacy behaviour: tracecontext propagator would always take precedence",


### PR DESCRIPTION
## Description

Updates test skips in `tests/parametric/test_headers_precedence.py` with more accurate versions for test skips. This is to help improve the version tracking for our tracer's propagation behaviors.

## Motivation

Improve version tracking for each tracing library's implementation of propagation behaviors

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
