### PR TITLE
nodejs: going to drop instrumentation v1 support

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -428,6 +428,7 @@ class Test_Telemetry:
     @irrelevant(library="python")
     @irrelevant(library="php")
     @irrelevant(library="java")
+    @irrelevant(library="nodejs")
     def test_api_still_v1(self):
         """Test that the telemetry api is still at version v1
         If this test fails, please mark Test_TelemetryV2 as released for the current version of the tracer,


### PR DESCRIPTION
## Description

- node.js tracer is working on dropping v1 support
- https://github.com/DataDog/dd-trace-js/pull/3827

## Motivation

- v2 > v1

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [x] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [x] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [x] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
