### PR TITLE
Ruby:Upgrade Ruby version for older apps

### DIFF
--- a/utils/build/docker/ruby/rails42.Dockerfile
+++ b/utils/build/docker/ruby/rails42.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/datadog/dd-trace-rb/ruby:2.3.8-dd
+FROM ghcr.io/datadog/dd-trace-rb/ruby:2.5.9-dd
 
 RUN curl -O https://rubygems.org/downloads/libv8-node-15.14.0.1-$(arch)-linux.gem && gem install libv8-node-15.14.0.1-$(arch)-linux.gem && rm libv8-node-15.14.0.1-$(arch)-linux.gem
 

--- a/utils/build/docker/ruby/rails42.Dockerfile
+++ b/utils/build/docker/ruby/rails42.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/datadog/dd-trace-rb/ruby:2.5.9-dd
+FROM ghcr.io/datadog/dd-trace-rb/ruby:2.3.8-dd
 
 RUN curl -O https://rubygems.org/downloads/libv8-node-15.14.0.1-$(arch)-linux.gem && gem install libv8-node-15.14.0.1-$(arch)-linux.gem && rm libv8-node-15.14.0.1-$(arch)-linux.gem
 

--- a/utils/build/docker/ruby/sinatra14.Dockerfile
+++ b/utils/build/docker/ruby/sinatra14.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/datadog/dd-trace-rb/ruby:2.4.10-dd
+FROM ghcr.io/datadog/dd-trace-rb/ruby:2.7.6-dd
 
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
## Description

As the Ruby Tracing team start the work to deprecate support for Ruby < 2.5, this PR upgrades the base version of two older Ruby apps (Sinatra 1.4 and Rails 4.2) as these applications can still work with Ruby >= 2.5 but `dd-trace-rb` won't install in their containers if they are running Ruby < 2.5.

This should have no impact in testing of the currently stable release of `dd-trace-rb`.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
