### PR TITLE
Hide some expected error logs

### DIFF
--- a/utils/build/docker/nodejs/express4/iast/sources.js
+++ b/utils/build/docker/nodejs/express4/iast/sources.js
@@ -3,7 +3,11 @@ const { readFileSync } = require('fs')
 
 function init (app, tracer) {
   app.post('/iast/source/body/test', (req, res) => {
-    readFileSync(req.body.name)
+    try {
+      readFileSync(req.body.name)
+    } catch {
+      // do nothing
+    }
     res.send('OK')
   })
 
@@ -12,7 +16,11 @@ function init (app, tracer) {
     Object.keys(req.headers).forEach((key) => {
       vulnParam += key
     })
-    readFileSync(vulnParam)
+    try {
+      readFileSync(vulnParam)
+    } catch {
+      // do nothing
+    }
     res.send('OK')
   })
 
@@ -21,7 +29,11 @@ function init (app, tracer) {
     Object.keys(req.headers).forEach((key) => {
       vulnParam += req.headers[key]
     })
-    readFileSync(vulnParam)
+    try {
+      readFileSync(vulnParam)
+    } catch {
+      // do nothing
+    }
     res.send('OK')
   })
 
@@ -30,7 +42,11 @@ function init (app, tracer) {
     Object.keys(req.query).forEach((key) => {
       vulnParam += key
     })
-    readFileSync(vulnParam)
+    try {
+      readFileSync(vulnParam)
+    } catch {
+      // do nothing
+    }
     res.send('OK')
   })
 
@@ -39,7 +55,11 @@ function init (app, tracer) {
     Object.keys(req.body).forEach((key) => {
       vulnParam += req.body[key]
     })
-    readFileSync(vulnParam)
+    try {
+      readFileSync(vulnParam)
+    } catch {
+      // do nothing
+    }
     res.send('OK')
   })
 
@@ -48,7 +68,11 @@ function init (app, tracer) {
     Object.keys(req.query).forEach((key) => {
       vulnParam += req.query[key]
     })
-    readFileSync(vulnParam)
+    try {
+      readFileSync(vulnParam)
+    } catch {
+      // do nothing
+    }
     res.send('OK')
   })
 
@@ -57,7 +81,11 @@ function init (app, tracer) {
     Object.keys(req.cookies).forEach((key) => {
       vulnParam += key
     })
-    readFileSync(vulnParam)
+    try {
+      readFileSync(vulnParam)
+    } catch {
+      // do nothing
+    }
     res.send('OK')
   })
 
@@ -66,7 +94,11 @@ function init (app, tracer) {
     Object.keys(req.cookies).forEach((key) => {
       vulnParam += req.cookies[key]
     })
-    readFileSync(vulnParam)
+    try {
+      readFileSync(vulnParam)
+    } catch {
+      // do nothing
+    }
     res.send('OK')
   })
 }


### PR DESCRIPTION
## Description

<!-- A brief description of the change being made with this pull request. -->
Hide errors when weblog is trying to read some files that do not exist. 
We are not testing that the reading is working, we are testing that the vulnerability is in the request, an the result of the operation does not matter.


## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
