### PR TITLE
Fix parametric http docs

### DIFF
--- a/docs/scenarios/parametric.md
+++ b/docs/scenarios/parametric.md
@@ -271,10 +271,10 @@ service APMClient {
 An HTTP interface can be used instead of the GRPC. To view the interface run
 
 ```
-PORT=8000 ./run_reference_http.sh
+PORT=8000 ./utils/scripts/parametric/run_reference_http.sh
 ```
 
-and navigate to http://localhost:8000. The OpenAPI schema can be downloaded at
+and navigate to http://localhost:8000/docs. The OpenAPI schema can be downloaded at
 http://localhost:8000/openapi.json. The schema can be imported
 into [Postman](https://learning.postman.com/docs/integrations/available-integrations/working-with-openAPI/) or
 other tooling to assist in development.

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,8 +35,6 @@ ddsketch==2.0.4
 ddtrace==2.3.0
 filelock==3.12.2
 Flask==2.0.0
-opentelemetry-distro
-opentelemetry-exporter-otlp
 frozenlist==1.3.1
 grpcio==1.51.3
 idna==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,9 +32,11 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
 ddapm-test-agent==1.14.0
 ddsketch==2.0.4
-ddtrace==1.10.2
+ddtrace==2.3.0
 filelock==3.12.2
 Flask==2.0.0
+opentelemetry-distro
+opentelemetry-exporter-otlp
 frozenlist==1.3.1
 grpcio==1.51.3
 idna==3.4
@@ -75,4 +77,3 @@ pulumi-tls==5.0.0a0
 pulumi-command==0.7.2
 pyyaml==6.0.0
 pyyaml-include==1.3
-

--- a/utils/build/docker/python_http/parametric/requirements.txt
+++ b/utils/build/docker/python_http/parametric/requirements.txt
@@ -1,2 +1,4 @@
 fastapi==0.89.1
 uvicorn==0.20.0
+opentelemetry-distro
+opentelemetry-exporter-otlp

--- a/utils/build/docker/python_http/parametric/requirements.txt
+++ b/utils/build/docker/python_http/parametric/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.89.1
 uvicorn==0.20.0
-opentelemetry-distro
-opentelemetry-exporter-otlp
+opentelemetry-distro==0.42b0
+opentelemetry-exporter-otlp==1.21.0

--- a/utils/scripts/parametric/run_reference_http.sh
+++ b/utils/scripts/parametric/run_reference_http.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1091
 
 
 PORT="${PORT:=8000}"

--- a/utils/scripts/parametric/run_reference_http.sh
+++ b/utils/scripts/parametric/run_reference_http.sh
@@ -3,8 +3,8 @@
 
 PORT="${PORT:=8000}"
 
-source $PWD/venv/bin/activate
+source "$PWD/venv/bin/activate"
 
-pushd $PWD/utils/build/docker/python_http/parametric || exit
+pushd "$PWD/utils/build/docker/python_http/parametric" || exit
     APM_TEST_CLIENT_SERVER_PORT=$PORT python -m apm_test_client
 popd || exit

--- a/utils/scripts/parametric/run_reference_http.sh
+++ b/utils/scripts/parametric/run_reference_http.sh
@@ -3,6 +3,8 @@
 
 PORT="${PORT:=8000}"
 
-pushd ../../../utils/build/docker/python_http/parametric || exit
+source $PWD/venv/bin/activate
+
+pushd $PWD/utils/build/docker/python_http/parametric || exit
     APM_TEST_CLIENT_SERVER_PORT=$PORT python -m apm_test_client
 popd || exit


### PR DESCRIPTION
prep for the incoming http revolution

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
