### PR TITLE
chore(python): enable more tests for fastapi

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -166,17 +166,18 @@ tests/:
       test_addresses.py:
         Test_BodyJson:
           '*': v1.4.0rc1.dev
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_BodyRaw:
           '*': missing_feature
           django-poc: v1.5.2
           python3.12: v1.5.2
+          fastapi: v2.4.0.dev1
         Test_BodyUrlEncoded:
           '*': v1.4.0rc1.dev
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_BodyXml:
           '*': v1.5.0rc1.dev
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_ClientIP: v1.5.0rc1.dev
         Test_Cookies:
           django-poc: v1.1.0rc2.dev
@@ -193,7 +194,7 @@ tests/:
         Test_Method: missing_feature
         Test_PathParams:
           django-poc: v1.1.0rc2.dev
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
           flask-poc: v1.4.0rc1.dev
           pylons: v1.1.0rc2.dev
           python3.12: v1.1.0rc2.dev
@@ -201,16 +202,16 @@ tests/:
           uwsgi-poc: v1.5.2
         Test_ResponseStatus:
           '*': v0.58.5
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_UrlQuery:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_UrlQueryKey:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_UrlRaw:
           '*': v0.58.5
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_gRPC: missing_feature
       test_blocking.py:
         Test_Blocking:
@@ -231,7 +232,7 @@ tests/:
         Test_Exclusions:
           '*': v1.16.1
           django-poc: v1.12
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
           flask-poc: v1.12
       test_miscs.py:
         Test_404: v1.1.0rc2.dev
@@ -251,54 +252,54 @@ tests/:
       test_rules.py:
         Test_CommandInjection:
           '*': v1.2.1
-          fastapi: missing_feature
+          ffastapi: v2.4.0.dev1
         Test_DiscoveryScan:
           '*': v0.58.5
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_HttpProtocol:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_JavaCodeInjection:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_JsInjection:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_LFI:
-          '*': missing_feature
+          '*': v2.4.0.dev1
           flask-poc: v1.5.2
           uds-flask: v1.5.2
         Test_NoSqli:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_PhpCodeInjection:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_RFI:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_SQLI:
           '*': v1.3.0
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_SSRF:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_Scanners:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_XSS:
           '*': v1.3.0
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
       test_telemetry.py:
         Test_TelemetryMetrics:
           '*': v1.14.0
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
     test_PII.py:
       Test_Scrubbing: missing_feature
     test_alpha.py:
       Test_Basic:
         '*': v1.1.0rc2.dev
-        fastapi: missing_feature
+        fastapi: v2.4.0.dev1
     test_automated_login_events.py:
       Test_Login_Events: missing_feature
       Test_Login_Events_Extended: missing_feature
@@ -360,10 +361,10 @@ tests/:
     test_conf.py:
       Test_ConfigurationVariables:
         '*': v1.1.2
-        fastapi: missing_feature
+        fastapi: v2.4.0.dev1
       Test_RuleSet_1_3_1:
         '*': v1.2.1
-        fastapi: missing_feature
+        fastapi: v2.4.0.dev1
       Test_StaticRuleSet: missing_feature
     test_customconf.py:
       Test_ConfRuleSet: v1.1.0rc2.dev
@@ -392,7 +393,7 @@ tests/:
     test_request_blocking.py:
       Test_AppSecRequestBlocking:
         '*': v1.10.0
-        fastapi: missing_feature
+        fastapi: v2.4.0.dev1
     test_runtime_activation.py:
       Test_RuntimeActivation: missing_feature
     test_shell_execution.py:
@@ -401,10 +402,10 @@ tests/:
       Test_AppSecEventSpanTags: v0.58.5
       Test_AppSecObfuscator:
         '*': v1.5.0rc1.dev
-        fastapi: missing_feature
+        fastapi: v2.4.0.dev1
       Test_CollectRespondHeaders:
         '*': v1.4.0rc1.dev
-        fastapi: missing_feature
+        fastapi: v2.4.0.dev1
       Test_RetainTraces: v1.1.0rc2.dev
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist:
@@ -491,7 +492,7 @@ tests/:
   test_scrubbing.py:
     Test_UrlField:
       '*': v1.7.1
-      fastapi: missing_feature
+      fastapi: v2.4.0.dev1
     Test_UrlQuery: v1.6.0rc1.dev
   test_semantic_conventions.py:
     Test_Meta: v1.80.0
@@ -503,7 +504,7 @@ tests/:
     Test_StandardTagsStatusCode: v1.4.0rc1.dev
     Test_StandardTagsUrl:
       '*': v1.6.0rc1.dev
-      fastapi: missing_feature
+      fastapi: v2.4.0.dev1
     Test_StandardTagsUserAgent: v1.5.0rc1.dev
   test_telemetry.py:
     Test_DependencyEnable: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -238,17 +238,17 @@ tests/:
         Test_404: v1.1.0rc2.dev
         Test_CorrectOptionProcessing:
           '*': v1.1.0
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_MultipleAttacks:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
         Test_MultipleHighlight:
           '*': v1.2.1
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
       test_reports.py:
         Test_Monitoring:
           '*': v1.5.0rc1.dev
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
       test_rules.py:
         Test_CommandInjection:
           '*': v1.2.1

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -402,7 +402,7 @@ tests/:
       Test_AppSecEventSpanTags: v0.58.5
       Test_AppSecObfuscator:
         '*': v1.5.0rc1.dev
-        fastapi: v2.4.0.dev1
+        fastapi: bug (overwrite of waf reports, will be fixed with nested events)
       Test_CollectRespondHeaders:
         '*': v1.4.0rc1.dev
         fastapi: v2.4.0.dev1

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -252,7 +252,7 @@ tests/:
       test_rules.py:
         Test_CommandInjection:
           '*': v1.2.1
-          ffastapi: v2.4.0.dev1
+          fastapi: v2.4.0.dev1
         Test_DiscoveryScan:
           '*': v0.58.5
           fastapi: v2.4.0.dev1

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -181,7 +181,7 @@ tests/:
         Test_ClientIP: v1.5.0rc1.dev
         Test_Cookies:
           django-poc: v1.1.0rc2.dev
-          fastapi: missing_feature
+          fastapi: v2.4.0.dev1
           flask-poc: v1.4.0rc1.dev
           pylons: v1.1.0rc2.dev
           python3.12: v1.1.0rc2.dev

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -170,8 +170,8 @@ tests/:
         Test_BodyRaw:
           '*': missing_feature
           django-poc: v1.5.2
-          python3.12: v1.5.2
           fastapi: v2.4.0.dev1
+          python3.12: v1.5.2
         Test_BodyUrlEncoded:
           '*': v1.4.0rc1.dev
           fastapi: v2.4.0.dev1

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -25,7 +25,7 @@ class Test_StaticRuleSet:
     @missing_feature(library="php", reason="Rules file is not parsed")
     @missing_feature(library="nodejs", reason="Rules file is not parsed")
     def test_basic_hardcoded_ruleset(self):
-        """Library has loaded a hardcoded AppSec ruleset"""
+        """ Library has loaded a hardcoded AppSec ruleset"""
         stdout = interfaces.library_stdout if context.library != "dotnet" else interfaces.library_dotnet_managed
         stdout.assert_presence(r"AppSec loaded \d+ rules from file <?.*>?$", level="INFO")
 
@@ -33,7 +33,7 @@ class Test_StaticRuleSet:
 @coverage.basic
 @features.threats_configuration
 class Test_RuleSet_1_2_4:
-    """AppSec uses rule set 1.2.4 or higher"""
+    """ AppSec uses rule set 1.2.4 or higher """
 
     def test_main(self):
         assert context.appsec_rules_version >= "1.2.4"
@@ -42,7 +42,7 @@ class Test_RuleSet_1_2_4:
 @coverage.basic
 @features.threats_configuration
 class Test_RuleSet_1_2_5:
-    """AppSec uses rule set 1.2.5 or higher"""
+    """ AppSec uses rule set 1.2.5 or higher """
 
     def test_main(self):
         assert context.appsec_rules_version >= "1.2.5"
@@ -51,10 +51,10 @@ class Test_RuleSet_1_2_5:
 @coverage.good
 @features.threats_configuration
 class Test_RuleSet_1_3_1:
-    """AppSec uses rule set 1.3.1 or higher"""
+    """ AppSec uses rule set 1.3.1 or higher """
 
     def test_main(self):
-        """Test rule set version number"""
+        """ Test rule set version number"""
         assert context.appsec_rules_version >= "1.3.1"
 
     def setup_nosqli_keys(self):
@@ -67,12 +67,8 @@ class Test_RuleSet_1_3_1:
     def setup_nosqli_keys_with_brackets(self):
         self.r_keys2 = weblog.get("/waf/", params={"[$ne]": "value"})
 
-    @irrelevant(
-        library="php", reason="The PHP runtime interprets brackets as arrays, so this is considered malformed",
-    )
-    @irrelevant(
-        library="nodejs", reason="Node interprets brackets as arrays, so they're truncated",
-    )
+    @irrelevant(library="php", reason="The PHP runtime interprets brackets as arrays, so this is considered malformed")
+    @irrelevant(library="nodejs", reason="Node interprets brackets as arrays, so they're truncated")
     def test_nosqli_keys_with_brackets(self):
         """Test a rule defined on this rules version: nosql on keys with brackets"""
         interfaces.library.assert_waf_attack(self.r_keys2, rules.nosql_injection.crs_942_290)
@@ -82,7 +78,7 @@ class Test_RuleSet_1_3_1:
 @coverage.basic
 @features.threats_configuration
 class Test_ConfigurationVariables:
-    """Configuration environment variables"""
+    """ Configuration environment variables """
 
     SECRET = "This-value-is-secret"
 
@@ -93,22 +89,20 @@ class Test_ConfigurationVariables:
         self.r_enabled = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
     def test_enabled(self):
-        """test DD_APPSEC_ENABLED = true"""
+        """ test DD_APPSEC_ENABLED = true """
         interfaces.library.assert_waf_attack(self.r_enabled)
 
     def setup_disabled(self):
         self.r_disabled = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
-    @irrelevant(
-        library="ruby", weblog_variant="rack", reason="it's not possible to auto instrument with rack",
-    )
+    @irrelevant(library="ruby", weblog_variant="rack", reason="it's not possible to auto instrument with rack")
     @missing_feature(
         context.weblog_variant in ["sinatra14", "sinatra20", "sinatra21", "uds-sinatra"],
         reason="Conf is done in weblog instead of library",
     )
     @scenarios.appsec_disabled
     def test_disabled(self):
-        """test DD_APPSEC_ENABLED = false"""
+        """ test DD_APPSEC_ENABLED = false """
         interfaces.library.assert_no_appsec_event(self.r_disabled)
 
     def setup_appsec_rules(self):
@@ -116,7 +110,7 @@ class Test_ConfigurationVariables:
 
     @scenarios.appsec_custom_rules
     def test_appsec_rules(self):
-        """test DD_APPSEC_RULES = custom rules file"""
+        """ test DD_APPSEC_RULES = custom rules file """
         interfaces.library.assert_waf_attack(self.r_appsec_rules, pattern="dedicated-value-for-testing-purpose")
 
     def setup_waf_timeout(self):
@@ -128,7 +122,7 @@ class Test_ConfigurationVariables:
     @missing_feature(context.library == "java" and context.weblog_variant == "spring-boot-wildfly")
     @scenarios.appsec_low_waf_timeout
     def test_waf_timeout(self):
-        """test DD_APPSEC_WAF_TIMEOUT = low value"""
+        """ test DD_APPSEC_WAF_TIMEOUT = low value """
         interfaces.library.assert_no_appsec_event(self.r_waf_timeout)
 
     def setup_obfuscation_parameter_key(self):
@@ -138,7 +132,7 @@ class Test_ConfigurationVariables:
     @missing_feature(context.library < f"python@{PYTHON_RELEASE_GA_1_1}")
     @scenarios.appsec_custom_obfuscation
     def test_obfuscation_parameter_key(self):
-        """test DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP"""
+        """ test DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP """
 
         def validate_appsec_span_tags(span, appsec_data):  # pylint: disable=unused-argument
             assert not nested_lookup(
@@ -156,7 +150,7 @@ class Test_ConfigurationVariables:
     @missing_feature(context.library < f"python@{PYTHON_RELEASE_GA_1_1}")
     @scenarios.appsec_custom_obfuscation
     def test_obfuscation_parameter_value(self):
-        """test DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP"""
+        """ test DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP """
 
         def validate_appsec_span_tags(span, appsec_data):  # pylint: disable=unused-argument
             assert not nested_lookup(

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -2,7 +2,16 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import weblog, context, coverage, interfaces, missing_feature, irrelevant, rfc, scenarios
+from utils import (
+    weblog,
+    context,
+    coverage,
+    interfaces,
+    missing_feature,
+    irrelevant,
+    rfc,
+    scenarios,
+)
 from utils.tools import nested_lookup
 from tests.constants import PYTHON_RELEASE_GA_1_1
 from .waf.utils import rules
@@ -22,14 +31,14 @@ class Test_StaticRuleSet:
     @missing_feature(library="php", reason="Rules file is not parsed")
     @missing_feature(library="nodejs", reason="Rules file is not parsed")
     def test_basic_hardcoded_ruleset(self):
-        """ Library has loaded a hardcoded AppSec ruleset"""
+        """Library has loaded a hardcoded AppSec ruleset"""
         stdout = interfaces.library_stdout if context.library != "dotnet" else interfaces.library_dotnet_managed
         stdout.assert_presence(r"AppSec loaded \d+ rules from file <?.*>?$", level="INFO")
 
 
 @coverage.basic
 class Test_RuleSet_1_2_4:
-    """ AppSec uses rule set 1.2.4 or higher """
+    """AppSec uses rule set 1.2.4 or higher"""
 
     def test_main(self):
         assert context.appsec_rules_version >= "1.2.4"
@@ -37,7 +46,7 @@ class Test_RuleSet_1_2_4:
 
 @coverage.basic
 class Test_RuleSet_1_2_5:
-    """ AppSec uses rule set 1.2.5 or higher """
+    """AppSec uses rule set 1.2.5 or higher"""
 
     def test_main(self):
         assert context.appsec_rules_version >= "1.2.5"
@@ -45,10 +54,10 @@ class Test_RuleSet_1_2_5:
 
 @coverage.good
 class Test_RuleSet_1_3_1:
-    """ AppSec uses rule set 1.3.1 or higher """
+    """AppSec uses rule set 1.3.1 or higher"""
 
     def test_main(self):
-        """ Test rule set version number"""
+        """Test rule set version number"""
         assert context.appsec_rules_version >= "1.3.1"
 
     def setup_nosqli_keys(self):
@@ -61,8 +70,12 @@ class Test_RuleSet_1_3_1:
     def setup_nosqli_keys_with_brackets(self):
         self.r_keys2 = weblog.get("/waf/", params={"[$ne]": "value"})
 
-    @irrelevant(library="php", reason="The PHP runtime interprets brackets as arrays, so this is considered malformed")
-    @irrelevant(library="nodejs", reason="Node interprets brackets as arrays, so they're truncated")
+    @irrelevant(
+        library="php", reason="The PHP runtime interprets brackets as arrays, so this is considered malformed",
+    )
+    @irrelevant(
+        library="nodejs", reason="Node interprets brackets as arrays, so they're truncated",
+    )
     def test_nosqli_keys_with_brackets(self):
         """Test a rule defined on this rules version: nosql on keys with brackets"""
         interfaces.library.assert_waf_attack(self.r_keys2, rules.nosql_injection.crs_942_290)
@@ -71,7 +84,7 @@ class Test_RuleSet_1_3_1:
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2355333252/Environment+Variables")
 @coverage.basic
 class Test_ConfigurationVariables:
-    """ Configuration environment variables """
+    """Configuration environment variables"""
 
     SECRET = "This-value-is-secret"
 
@@ -82,20 +95,22 @@ class Test_ConfigurationVariables:
         self.r_enabled = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
     def test_enabled(self):
-        """ test DD_APPSEC_ENABLED = true """
+        """test DD_APPSEC_ENABLED = true"""
         interfaces.library.assert_waf_attack(self.r_enabled)
 
     def setup_disabled(self):
         self.r_disabled = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
-    @irrelevant(library="ruby", weblog_variant="rack", reason="it's not possible to auto instrument with rack")
+    @irrelevant(
+        library="ruby", weblog_variant="rack", reason="it's not possible to auto instrument with rack",
+    )
     @missing_feature(
         context.weblog_variant in ["sinatra14", "sinatra20", "sinatra21", "uds-sinatra"],
         reason="Conf is done in weblog instead of library",
     )
     @scenarios.appsec_disabled
     def test_disabled(self):
-        """ test DD_APPSEC_ENABLED = false """
+        """test DD_APPSEC_ENABLED = false"""
         interfaces.library.assert_no_appsec_event(self.r_disabled)
 
     def setup_appsec_rules(self):
@@ -103,11 +118,11 @@ class Test_ConfigurationVariables:
 
     @scenarios.appsec_custom_rules
     def test_appsec_rules(self):
-        """ test DD_APPSEC_RULES = custom rules file """
+        """test DD_APPSEC_RULES = custom rules file"""
         interfaces.library.assert_waf_attack(self.r_appsec_rules, pattern="dedicated-value-for-testing-purpose")
 
     def setup_waf_timeout(self):
-        long_payload = "?" + "&".join(f"{k}={v}" for k, v in ((f"key_{i}", f"value{i}") for i in range(1000)))
+        long_payload = "?" + "&".join(f"{k}={v}" for k, v in ((f"key_{i}", f"value{i}") for i in range(10_000)))
         self.r_waf_timeout = weblog.get(f"/waf/{long_payload}", headers={"User-Agent": "Arachni/v1"})
 
     @missing_feature(context.library < "java@0.113.0")
@@ -115,7 +130,7 @@ class Test_ConfigurationVariables:
     @missing_feature(context.library == "java" and context.weblog_variant == "spring-boot-wildfly")
     @scenarios.appsec_low_waf_timeout
     def test_waf_timeout(self):
-        """ test DD_APPSEC_WAF_TIMEOUT = low value """
+        """test DD_APPSEC_WAF_TIMEOUT = low value"""
         interfaces.library.assert_no_appsec_event(self.r_waf_timeout)
 
     def setup_obfuscation_parameter_key(self):
@@ -125,7 +140,7 @@ class Test_ConfigurationVariables:
     @missing_feature(context.library < f"python@{PYTHON_RELEASE_GA_1_1}")
     @scenarios.appsec_custom_obfuscation
     def test_obfuscation_parameter_key(self):
-        """ test DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP """
+        """test DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP"""
 
         def validate_appsec_span_tags(span, appsec_data):  # pylint: disable=unused-argument
             assert not nested_lookup(
@@ -143,7 +158,7 @@ class Test_ConfigurationVariables:
     @missing_feature(context.library < f"python@{PYTHON_RELEASE_GA_1_1}")
     @scenarios.appsec_custom_obfuscation
     def test_obfuscation_parameter_value(self):
-        """ test DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP """
+        """test DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP"""
 
         def validate_appsec_span_tags(span, appsec_data):  # pylint: disable=unused-argument
             assert not nested_lookup(

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -1,13 +1,4 @@
-from utils import (
-    interfaces,
-    rfc,
-    weblog,
-    scenarios,
-    context,
-    bug,
-    missing_feature,
-    flaky,
-)
+from utils import interfaces, rfc, weblog, scenarios, context, bug, missing_feature, flaky
 from utils.tools import logger
 
 TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
@@ -26,7 +17,7 @@ def _setup(self):
     r_triggered = weblog.get("/", headers={"x-forwarded-for": "80.80.80.80", "user-agent": "Arachni/v1"})
     r_blocked = weblog.get(
         "/",
-        headers={"x-forwarded-for": "80.80.80.80", "user-agent": "dd-test-scanner-log-block",},
+        headers={"x-forwarded-for": "80.80.80.80", "user-agent": "dd-test-scanner-log-block"},
         # XXX: hack to prevent rid inhibiting the dd-test-scanner-log-block rule
         rid_in_user_agent=False,
     )
@@ -34,7 +25,7 @@ def _setup(self):
 
 
 class Test_TelemetryResponses:
-    """Test response from backend/agent"""
+    """ Test response from backend/agent """
 
     setup_all_telemetry_requests_are_successful = _setup
 
@@ -77,10 +68,7 @@ class Test_TelemetryMetrics:
         }
         series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
         # TODO(Python). Gunicorn creates 2 process (main gunicorn process + X child workers). It generates two init
-        if context.library == "python" and context.weblog_variant not in [
-            "fastapi",
-            "uwsgi-poc",
-        ]:
+        if context.library == "python" and context.weblog_variant not in ("fastapi", "uwsgi-poc"):
             assert len(series) == 2
         else:
             assert len(series) == 1
@@ -92,7 +80,7 @@ class Test_TelemetryMetrics:
 
         full_tags = set(s["tags"])
         self._assert_valid_tags(
-            full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes,
+            full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes
         )
 
         assert len(s["points"]) == 1
@@ -126,7 +114,7 @@ class Test_TelemetryMetrics:
 
         full_tags = set(s["tags"])
         self._assert_valid_tags(
-            full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes,
+            full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes
         )
 
         assert len(s["points"]) == 1
@@ -174,7 +162,7 @@ class Test_TelemetryMetrics:
 
             full_tags = set(s["tags"])
             self._assert_valid_tags(
-                full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes,
+                full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes
             )
 
             if len(full_tags & {"request_blocked:false", "rule_triggered:false"}) == 2:

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -1,4 +1,13 @@
-from utils import interfaces, rfc, weblog, scenarios, context, bug, missing_feature, flaky
+from utils import (
+    interfaces,
+    rfc,
+    weblog,
+    scenarios,
+    context,
+    bug,
+    missing_feature,
+    flaky,
+)
 from utils.tools import logger
 
 TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
@@ -17,7 +26,7 @@ def _setup(self):
     r_triggered = weblog.get("/", headers={"x-forwarded-for": "80.80.80.80", "user-agent": "Arachni/v1"})
     r_blocked = weblog.get(
         "/",
-        headers={"x-forwarded-for": "80.80.80.80", "user-agent": "dd-test-scanner-log-block"},
+        headers={"x-forwarded-for": "80.80.80.80", "user-agent": "dd-test-scanner-log-block",},
         # XXX: hack to prevent rid inhibiting the dd-test-scanner-log-block rule
         rid_in_user_agent=False,
     )
@@ -25,7 +34,7 @@ def _setup(self):
 
 
 class Test_TelemetryResponses:
-    """ Test response from backend/agent """
+    """Test response from backend/agent"""
 
     setup_all_telemetry_requests_are_successful = _setup
 
@@ -68,7 +77,10 @@ class Test_TelemetryMetrics:
         }
         series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
         # TODO(Python). Gunicorn creates 2 process (main gunicorn process + X child workers). It generates two init
-        if context.library == "python" and context.weblog_variant != "uwsgi-poc":
+        if context.library == "python" and context.weblog_variant not in [
+            "fastapi",
+            "uwsgi-poc",
+        ]:
             assert len(series) == 2
         else:
             assert len(series) == 1
@@ -80,7 +92,7 @@ class Test_TelemetryMetrics:
 
         full_tags = set(s["tags"])
         self._assert_valid_tags(
-            full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes
+            full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes,
         )
 
         assert len(s["points"]) == 1
@@ -114,7 +126,7 @@ class Test_TelemetryMetrics:
 
         full_tags = set(s["tags"])
         self._assert_valid_tags(
-            full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes
+            full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes,
         )
 
         assert len(s["points"]) == 1
@@ -162,7 +174,7 @@ class Test_TelemetryMetrics:
 
             full_tags = set(s["tags"])
             self._assert_valid_tags(
-                full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes
+                full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes,
             )
 
             if len(full_tags & {"request_blocked:false", "rule_triggered:false"}) == 2:

--- a/tests/parametric/test_headers_tracestate_dd.py
+++ b/tests/parametric/test_headers_tracestate_dd.py
@@ -183,11 +183,12 @@ class Test_Headers_Tracestate_DD:
 
         traceparent8, tracestate8 = get_tracecontext(headers8)
         sampled8 = str(traceparent8).split("-")[3]
-        dd_items8 = tracestate8["dd"].split(";")
         assert "traceparent" in headers8
         assert sampled8 == "00"
         assert "tracestate" in headers8
-        assert "s:0" in dd_items8 or not any(item.startswith("s:") for item in dd_items8)
+        if "dd" in tracestate8:
+            dd_items8 = tracestate8["dd"].split(";")
+            assert "s:0" in dd_items8 or not any(item.startswith("s:") for item in dd_items8)
 
     @temporary_enable_propagationstyle_default()
     def test_headers_tracestate_dd_propagate_origin(self, test_agent, test_library):


### PR DESCRIPTION
## Description

With growing support of FastAPI for ASM, enable more tests on the FastAPI variant. 

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
