### PR TITLE
[PHP] Add documentation for testing parametric tests locally for PHP

### DIFF
--- a/docs/scenarios/parametric.md
+++ b/docs/scenarios/parametric.md
@@ -112,7 +112,19 @@ TEST_LIBRARY=java ./run.sh test_span_sampling.py::test_single_rule_match_span_sa
 
 #### PHP
 
-If you are seeing DNS resolution issues when running the tests locally, add the following config to the Docker daemon:
+##### To run with a custom build
+
+- Download `datadog-setup.php` in `build packages/package extension` job on CI
+- Copy it in the binaries folder
+
+##### Then run the tests
+
+From the repo root folder:
+
+- `./build.sh -i runner`
+- `TEST_LIBRARY=php ./run.sh PARAMETRIC` or `TEST_LIBRARY=php ./run.sh PARAMETRIC -k <my_test>`
+
+> :warning: **If you are seeing DNS resolution issues when running the tests locally**, add the following config to the Docker daemon:
 
 ```json
   "dns-opts": [


### PR DESCRIPTION
## Description

Add documentation for testing parametric tests locally for PHP

## Motivation

Love your neighbor :)

## Workflow

1. ⚠️⚠️ Create your PR as draft
2. Follow the style guidelines of this project (See [how to easily lint the code](https://github.com/DataDog/system-tests/blob/main/docs/edit/lint.md))
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review

Once your PR is reviewed, you can merge it! :heart:

## Reviewer checklist

* [ ] Check what scenarios are modified. If needed, add the relevant label (`run-parametric-scenario`, `run-profiling-scenario`...). If this PR modifies any system-tests internal, then add the `run-all-scenarios` label ([more info](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md)). 
* [ ] CI is green
   * [ ] If not, failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] if any of `build-some-image` label is present
  1. is the image labl have been updated ? 
  2. just before merging, locally build and push the image to hub.docker.com
* [ ] if a scenario is added (or removed), add (or remove) it in system-test-dasboard nightly
