### PR TITLE
Enable more Java tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -58,14 +58,16 @@ tests/:
             uds-spring-boot: v1.27.0
         test_hsts_missing_header.py:
           Test_HstsMissingHeader:
-            '*': missing_feature
-            spring-boot: v1.20.0
-            spring-boot-jetty: v1.20.0
-            spring-boot-openliberty: bug (not working as expected)
-            spring-boot-payara: v1.20.0
-            spring-boot-undertow: v1.20.0
-            spring-boot-wildfly: v1.20.0
-            uds-spring-boot: v1.20.0
+            '*': v1.20.0
+            akka-http: missing_feature
+            jersey-grizzly2: missing_feature
+            play: missing_feature
+            ratpack: missing_feature
+            resteasy-netty3: missing_feature
+            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-openliberty: bug (APPSEC-51483)
+            vertx3: missing_feature
+            vertx4: missing_feature
         test_insecure_cookie.py:
           TestInsecureCookie:
             '*': v1.18.0
@@ -75,11 +77,11 @@ tests/:
             spring-boot-3-native: missing_feature
         test_ldap_injection.py:
           TestLDAPInjection:
-            '*': v1.7.0
+            '*': v1.3.0
             akka-http: v1.12.0
             jersey-grizzly2: v1.11.0
-            play: missing_feature
-            ratpack: missing_feature
+            play: missing_feature (endpoint not implemented)
+            ratpack: missing_feature (endpoint not implemented)
             resteasy-netty3: v1.11.0
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
             vertx3: v1.12.0
@@ -122,7 +124,7 @@ tests/:
             vertx3: v1.12.0
         test_ssrf.py:
           TestSSRF:
-            '*': v1.14.0
+            '*': v1.13.0
             akka-http: missing_feature (No endpoint implemented)
             play: missing_feature (No endpoint implemented)
             ratpack: missing_feature (No endpoint implemented)
@@ -133,15 +135,16 @@ tests/:
             "*": "bug (APPSEC-12201)"
         test_unvalidated_redirect.py:
           TestUnvalidatedHeader: 
-            '*': v1.16.0
+            '*': v1.15.0
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
             spring-boot-jetty: v1.17.0
+            vertx3: v1.16.0
             vertx4: v1.17.0
           TestUnvalidatedRedirect:
-            '*': v1.16.0
+            '*': v1.15.0
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
@@ -150,13 +153,14 @@ tests/:
             vertx4: v1.17.0
         test_unvalidated_redirect_forward.py:
           TestUnvalidatedForward:
-            '*': v1.16.0
+            '*': v1.15.0
             akka-http: irrelevant (No forward)
             jersey-grizzly2: irrelevant (No forward)
             play: missing_feature (No endpoint implemented)
             ratpack: irrelevant (No forward)
             resteasy-netty3: irrelevant (No forward)
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            vertx3: v1.16.0
             vertx4: v1.17.0
         test_weak_cipher.py:
           TestWeakCipher:
@@ -175,14 +179,16 @@ tests/:
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         test_xcontent_sniffing.py:
           Test_XContentSniffing:
-            "*": "missing_feature"
-            spring-boot: v1.22.0
-            spring-boot-jetty: v1.22.0
+            '*': v1.22.0
+            akka-http: missing_feature
+            jersey-grizzly2: missing_feature
+            play: missing_feature
+            ratpack: missing_feature
+            resteasy-netty3: missing_feature
+            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
             spring-boot-openliberty: bug (not working as expected)
-            spring-boot-payara: v1.22.0
-            spring-boot-undertow: v1.22.0
-            spring-boot-wildfly: v1.22.0
-            uds-spring-boot: v1.22.0
+            vertx3: missing_feature
+            vertx4: missing_feature
         test_xpath_injection.py:
           TestXPathInjection:
             '*': v1.18.0
@@ -191,14 +197,15 @@ tests/:
             spring-boot-3-native: missing_feature
         test_xss.py:
           TestXSS:
-            '*': missing_feature
-            spring-boot: v1.19.0
-            spring-boot-jetty: v1.19.0
-            spring-boot-openliberty: v1.19.0
-            spring-boot-payara: v1.19.0
-            spring-boot-undertow: v1.19.0
-            spring-boot-wildfly: v1.19.0
-            uds-spring-boot: v1.19.0
+            '*': v1.19.0
+            akka-http: missing_feature
+            jersey-grizzly2: missing_feature
+            play: missing_feature
+            ratpack: missing_feature
+            resteasy-netty3: missing_feature
+            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            vertx3: missing_feature
+            vertx4: missing_feature
       source/:
         test_body.py:
           TestRequestBody:
@@ -213,7 +220,7 @@ tests/:
             vertx4: v1.12.0
         test_cookie_name.py:
           TestCookieName:
-            '*': v1.5.0
+            '*': v1.4.0
             akka-http: v1.12.0
             play: missing_feature
             ratpack: missing_feature
@@ -223,7 +230,7 @@ tests/:
             vertx4: v1.12.0
         test_cookie_value.py:
           TestCookieValue:
-            '*': v1.5.0
+            '*': v1.10.0
             akka-http: v1.12.0
             jersey-grizzly2: v1.11.0
             play: missing_feature
@@ -234,7 +241,7 @@ tests/:
             vertx4: v1.12.0
         test_header_name.py:
           TestHeaderName:
-            '*': v1.5.0
+            '*': v1.3.0
             akka-http: v1.12.0
             jersey-grizzly2: v1.15.0
             play: missing_feature
@@ -245,7 +252,7 @@ tests/:
             vertx4: v1.12.0
         test_header_value.py:
           TestHeaderValue:
-            '*': v1.5.0
+            '*': v1.3.0
             akka-http: v1.12.0
             jersey-grizzly2: v1.11.0
             play: missing_feature
@@ -256,16 +263,18 @@ tests/:
             vertx4: v1.12.0
         test_multipart.py:
           TestMultipart:
-            '*': missing_feature
-            spring-boot: v1.22.0
-            spring-boot-jetty: v1.22.0
-            spring-boot-openliberty: v1.22.0
-            spring-boot-payara: v1.22.0
-            spring-boot-undertow: v1.22.0
-            uds-spring-boot: v1.22.0
+            '*': v1.22.0
+            akka-http: missing_feature
+            jersey-grizzly2: missing_feature
+            play: missing_feature
+            ratpack: missing_feature
+            resteasy-netty3: missing_feature
+            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            vertx3: missing_feature
+            vertx4: missing_feature
         test_parameter_name.py:
           TestParameterName:
-            '*': v1.5.0
+            '*': v1.1.0
             akka-http: v1.12.0
             jersey-grizzly2: v1.15.0
             play: missing_feature
@@ -275,7 +284,7 @@ tests/:
             vertx4: v1.12.0
         test_parameter_value.py:
           TestParameterValue:
-            '*': v1.5.0
+            '*': v1.1.0
             akka-http: v1.12.0
             jersey-grizzly2: v1.11.0
             play: missing_feature
@@ -286,24 +295,26 @@ tests/:
             vertx4: v1.12.0
         test_path.py:
           TestPath:
-            '*': missing_feature
-            spring-boot: v1.22.0
-            spring-boot-jetty: v1.22.0
-            spring-boot-openliberty: v1.22.0
-            spring-boot-payara: v1.22.0
-            spring-boot-undertow: v1.22.0
-            spring-boot-wildfly: v1.22.0
-            uds-spring-boot: v1.22.0
+            '*': v1.22.0
+            akka-http: missing_feature
+            jersey-grizzly2: missing_feature
+            play: missing_feature
+            ratpack: missing_feature
+            resteasy-netty3: missing_feature
+            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            vertx3: missing_feature
+            vertx4: missing_feature
         test_uri.py:
           TestURI:
-            '*': missing_feature
-            spring-boot: v1.22.0
-            spring-boot-jetty: v1.22.0
-            spring-boot-openliberty: v1.22.0
-            spring-boot-payara: v1.22.0
-            spring-boot-undertow: v1.22.0
-            spring-boot-wildfly: v1.22.0
-            uds-spring-boot: v1.22.0
+            '*': v1.23.0
+            akka-http: missing_feature
+            jersey-grizzly2: missing_feature
+            play: missing_feature
+            ratpack: missing_feature
+            resteasy-netty3: missing_feature
+            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            vertx3: missing_feature
+            vertx4: missing_feature
     waf/:
       test_addresses.py:
         Test_BodyJson:
@@ -399,20 +410,15 @@ tests/:
           vertx4: irrelevant
       test_blocking.py:
         Test_Blocking:
-          '*': missing_feature
+          '*': v0.112.0
           akka-http: v1.22.0
           jersey-grizzly2: v1.7.0
           play: v1.22.0
           ratpack: v1.7.0
           resteasy-netty3: v1.7.0
-          spring-boot: v0.112.0
           spring-boot-3-native: missing_feature
-          spring-boot-jetty: v0.112.0
           spring-boot-openliberty: v1.3.0
           spring-boot-payara: missing_feature (No AppSec support)
-          spring-boot-undertow: v0.112.0
-          spring-boot-wildfly: v0.112.0
-          uds-spring-boot: v0.112.0
           vertx3: v1.7.0
         Test_CustomBlockingResponse:
           '*': v1.11.0
@@ -538,20 +544,15 @@ tests/:
       Test_Login_Events_Extended: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses:
-        '*': missing_feature
+        '*': v0.111.0
         akka-http: v1.22.0
         jersey-grizzly2: v1.7.0
         play: v1.22.0
         ratpack: v1.6.0
         resteasy-netty3: v1.7.0
-        spring-boot: v0.111.0  # initially v0.110.0, but was bugged
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-jetty: v0.111.0
         spring-boot-openliberty: v0.115.0
         spring-boot-payara: missing_feature (Missing support)
-        spring-boot-undertow: v0.111.0
-        spring-boot-wildfly: v0.111.0
-        uds-spring-boot: v0.110.0
         vertx3: v1.7.0
         vertx4: v1.7.0
       Test_BlockingGraphqlResolvers: missing_feature
@@ -966,7 +967,7 @@ tests/:
   test_semantic_conventions.py:
     Test_Meta:
       play: irrelevant (top span is akka-http-server)
-    Test_MetricsStandardTags: v1.6.0
+    Test_MetricsStandardTags: v1.3.0
   test_standard_tags.py:
     Test_StandardTagsClientIp:
       '*': v0.114.0

--- a/tests/appsec/iast/sink/test_command_injection.py
+++ b/tests/appsec/iast/sink/test_command_injection.py
@@ -26,13 +26,13 @@ class TestCommandInjection(BaseSinkTest):
     def test_secure(self):
         super().test_secure()
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
     @missing_feature(library="dotnet", reason="Not implemented yet")
     @missing_feature(library="python", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
     @missing_feature(library="python", reason="Not implemented yet")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()

--- a/tests/appsec/iast/sink/test_ldap_injection.py
+++ b/tests/appsec/iast/sink/test_ldap_injection.py
@@ -21,11 +21,11 @@ class TestLDAPInjection(BaseSinkTest):
         "nodejs": {"express4": "iast/index.js", "express4-typescript": "iast.ts"},
     }
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
     @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.11.0", reason="Metrics not implemented")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()

--- a/tests/appsec/iast/sink/test_no_samesite_cookie.py
+++ b/tests/appsec/iast/sink/test_no_samesite_cookie.py
@@ -28,13 +28,13 @@ class TestNoSamesiteCookie(BaseSinkTest):
     def test_empty_cookie(self):
         self.assert_no_iast_event(self.request_empty_cookie)
 
-    @missing_feature(context.library <= "java@1.22.0", reason="Metrics not implemented")
+    @missing_feature(context.library < "java@1.22.0", reason="Metrics not implemented")
     @missing_feature(library="python", reason="Metrics not implemented")
     @missing_feature(library="dotnet", reason="Metrics not implemented")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 
-    @missing_feature(context.library <= "java@1.22.0", reason="Metrics not implemented")
+    @missing_feature(context.library < "java@1.22.0", reason="Metrics not implemented")
     @missing_feature(weblog_variant="vertx4", reason="Metrics not implemented")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()

--- a/tests/appsec/iast/sink/test_path_traversal.py
+++ b/tests/appsec/iast/sink/test_path_traversal.py
@@ -22,11 +22,11 @@ class TestPathTraversal(BaseSinkTest):
         "python": {"flask-poc": "app.py", "django-poc": "app/urls.py"},
     }
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
     @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.11.0", reason="Metrics not implemented")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()

--- a/tests/appsec/iast/sink/test_sql_injection.py
+++ b/tests/appsec/iast/sink/test_sql_injection.py
@@ -26,14 +26,14 @@ class TestSqlInjection(BaseSinkTest):
     def test_insecure(self):
         super().test_insecure()
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
     @missing_feature(library="nodejs", reason="Not implemented yet")
     @missing_feature(library="python", reason="Not implemented yet")
     @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.11.0", reason="Metrics not implemented")
     @missing_feature(library="nodejs", reason="Not implemented yet")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()

--- a/tests/appsec/iast/sink/test_ssrf.py
+++ b/tests/appsec/iast/sink/test_ssrf.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import coverage, missing_feature, features
+from utils import bug, context, coverage, missing_feature, features
 from .._test_iast_fixtures import BaseSinkTest
 
 
@@ -21,6 +21,10 @@ class TestSSRF(BaseSinkTest):
         "nodejs": {"express4": "iast/index.js", "express4-typescript": "iast.ts"},
         "python": {"flask-poc": "app.py", "django-poc": "app/urls.py"},
     }
+
+    @bug(context.library < "java@1.14.0", reason="https://github.com/DataDog/dd-trace-java/pull/5172")
+    def test_insecure(self):
+        super().test_insecure()
 
     @missing_feature(library="nodejs", reason="Endpoint not implemented")
     def test_secure(self):

--- a/tests/appsec/iast/sink/test_trust_boundary_violation.py
+++ b/tests/appsec/iast/sink/test_trust_boundary_violation.py
@@ -2,11 +2,12 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import coverage, missing_feature, features
+from utils import bug, context, coverage, missing_feature, features
 from .._test_iast_fixtures import BaseSinkTest
 
 
 @features.iast_sink_trustboundaryviolation
+@bug(context.library < "java@1.22.0", reason="APPSEC-12201")
 @coverage.basic
 class Test_TrustBoundaryViolation(BaseSinkTest):
     """Test Trust Boundary Violation detection."""
@@ -18,12 +19,12 @@ class Test_TrustBoundaryViolation(BaseSinkTest):
     params = {"username": "shaquille_oatmeal", "password": "123456"}
 
     @missing_feature(library="nodejs", reason="Metrics implemented")
-    @missing_feature(library="java", reason="Metrics implemented")
     @missing_feature(library="dotnet", reason="Metrics implemented")
+    @missing_feature(context.library < "java@1.22.0", reason="Metrics not implemented")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 
     @missing_feature(library="nodejs", reason="Metrics implemented")
-    @missing_feature(library="java", reason="Metrics implemented")
+    @missing_feature(context.library < "java@1.22.0", reason="Metrics not implemented")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()

--- a/tests/appsec/iast/sink/test_weak_cipher.py
+++ b/tests/appsec/iast/sink/test_weak_cipher.py
@@ -25,11 +25,11 @@ class TestWeakCipher(BaseSinkTest):
     def test_secure(self):
         super().test_secure()
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
     @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.11.0", reason="Metrics not implemented")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()

--- a/tests/appsec/iast/sink/test_weak_hash.py
+++ b/tests/appsec/iast/sink/test_weak_hash.py
@@ -75,12 +75,12 @@ class TestWeakHash(BaseSinkTest):
             expected_location=self.expected_location,
         )
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
     @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.11.0", reason="Metrics not implemented")
     @missing_feature(context.library < "dotnet@2.38.0", reason="Not implemented yet")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()

--- a/tests/appsec/iast/source/test_body.py
+++ b/tests/appsec/iast/source/test_body.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import coverage, missing_feature, bug, features
+from utils import context, coverage, missing_feature, bug, features
 from .._test_iast_fixtures import BaseSourceTest
 
 
@@ -22,12 +22,21 @@ class TestRequestBody(BaseSourceTest):
     def test_source_reported(self):
         super().test_source_reported()
 
-    @missing_feature(library="java", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
+    @missing_feature(
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
+    )
+    @bug(context.library >= "java@1.13.0" and context.library < "java@1.17.0", reason="Not reported")
     @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
-    @missing_feature(library="java", reason="Not implemented yet")
+    @missing_feature(context.library < "java@1.17.0", reason="Metrics not implemented")
+    @missing_feature(
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
+    )
     @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_executed_source(self):
         super().test_telemetry_metric_executed_source()

--- a/tests/appsec/iast/source/test_cookie_name.py
+++ b/tests/appsec/iast/source/test_cookie_name.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import coverage, bug, missing_feature, features
+from utils import context, coverage, bug, missing_feature, features
 from .._test_iast_fixtures import BaseSourceTest
 
 
@@ -18,10 +18,17 @@ class TestCookieName(BaseSourceTest):
     source_value = "user"
 
     @missing_feature(library="dotnet", reason="Not implemented")
-    @bug(library="java", reason="Not working as expected")
+    @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
+    @missing_feature(
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
+    )
+    @bug(context.library >= "java@1.16.0" and context.library < "java@1.22.0", reason="Not working as expected")
+    @missing_feature(weblog_variant="akka-http", reason="Not working as expected")
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
-    @bug(library="java", reason="Not working as expected")
+    @missing_feature(context.library < "java@1.22.0", reason="Metrics not implemented")
+    @missing_feature(weblog_variant="akka-http", reason="Not working as expected")
     def test_telemetry_metric_executed_source(self):
         super().test_telemetry_metric_executed_source()

--- a/tests/appsec/iast/source/test_cookie_value.py
+++ b/tests/appsec/iast/source/test_cookie_value.py
@@ -22,10 +22,18 @@ class TestCookieValue(BaseSourceTest):
         super().test_source_reported()
 
     @missing_feature(library="dotnet", reason="Not implemented")
-    @bug(library="java", reason="Not working as expected")
+    @missing_feature(context.library < "java@1.17.0", reason="Metrics not implemented")
+    @missing_feature(
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
+    )
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
-    @bug(library="java", reason="Not working as expected")
+    @missing_feature(context.library < "java@1.17.0", reason="Metrics not implemented")
+    @missing_feature(
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
+    )
     def test_telemetry_metric_executed_source(self):
         super().test_telemetry_metric_executed_source()

--- a/tests/appsec/iast/source/test_header_name.py
+++ b/tests/appsec/iast/source/test_header_name.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, coverage, bug, features
+from utils import context, coverage, missing_feature, features
 from .._test_iast_fixtures import BaseSourceTest
 
 
@@ -18,10 +18,20 @@ class TestHeaderName(BaseSourceTest):
     source_type = "http.request.header.name"
     source_value = None
 
-    @bug(library="java", reason="Not working as expected")
+    @missing_feature(context.library < "java@1.16.0", reason="Not working as expected")
+    @missing_feature(
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
+    )
+    @missing_feature(context.weblog_variant in ("jersey-grizzly2", "vertx4"), reason="Metrics not implemented")
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
-    @bug(library="java", reason="Not working as expected")
+    @missing_feature(context.library < "java@1.16.0", reason="Not working as expected")
+    @missing_feature(
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
+    )
+    @missing_feature(context.weblog_variant in ("jersey-grizzly2", "vertx4"), reason="Metrics not implemented")
     def test_telemetry_metric_executed_source(self):
         super().test_telemetry_metric_executed_source()

--- a/tests/appsec/iast/source/test_header_value.py
+++ b/tests/appsec/iast/source/test_header_value.py
@@ -24,15 +24,19 @@ class TestHeaderValue(BaseSourceTest):
     def test_source_reported(self):
         super().test_source_reported()
 
+    @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
     @missing_feature(
-        context.library < "java@1.13.0"
-        or (context.library.library == "java" and not context.weblog_variant.startswith("spring-boot")),
-        reason="Not implemented",
+        context.library.library == "java" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
     )
     @missing_feature(library="dotnet", reason="Not implemented")
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
-    @bug(library="java", reason="Not working as expected")
+    @missing_feature(context.library < "java@1.16.0", reason="Metrics not implemented")
+    @missing_feature(
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
+    )
     def test_telemetry_metric_executed_source(self):
         super().test_telemetry_metric_executed_source()

--- a/tests/appsec/iast/source/test_parameter_name.py
+++ b/tests/appsec/iast/source/test_parameter_name.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import coverage, missing_feature, bug, features
+from utils import context, coverage, missing_feature, bug, features
 from .._test_iast_fixtures import BaseSourceTest
 
 
@@ -47,10 +47,26 @@ class TestParameterName(BaseSourceTest):
         super().test_source_reported()
 
     @missing_feature(library="dotnet", reason="Not implemented")
-    @bug(library="java", reason="Not working as expected")
+    @missing_feature(context.library < "java@1.16.0", reason="Metrics not implemented")
+    @missing_feature(
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
+    )
+    @missing_feature(
+        context.weblog_variant in ("akka-http", "jersey-grizzly2", "resteasy-netty3", "vertx4"),
+        reason="Metrics not implemented",
+    )
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
-    @bug(library="java", reason="Not working as expected")
+    @missing_feature(context.library < "java@1.16.0", reason="Metrics not implemented")
+    @missing_feature(
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
+    )
+    @missing_feature(
+        context.weblog_variant in ("akka-http", "jersey-grizzly2", "resteasy-netty3", "vertx4"),
+        reason="Metrics not implemented",
+    )
     def test_telemetry_metric_executed_source(self):
         super().test_telemetry_metric_executed_source()

--- a/tests/appsec/iast/source/test_parameter_value.py
+++ b/tests/appsec/iast/source/test_parameter_value.py
@@ -42,17 +42,22 @@ class TestParameterValue(BaseSourceTest):
     def test_source_get_reported(self):
         self.validate_request_reported(self.requests["GET"], source_type="http.request.parameter")
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented")
+    @missing_feature(context.library < "java@1.9.0", reason="Not implemented")
     @missing_feature(
         context.library == "java" and not context.weblog_variant.startswith("spring-boot"), reason="Not implemented"
+    )
+    @missing_feature(
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
     )
     @missing_feature(library="dotnet", reason="Not implemented")
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
-    @missing_feature(context.library < "java@1.13.0", reason="Not implemented")
+    @missing_feature(context.library < "java@1.11.0", reason="Not implemented")
     @missing_feature(
-        context.library == "java" and not context.weblog_variant.startswith("spring-boot"), reason="Not implemented"
+        context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,
+        reason="Metrics not implemented",
     )
     def test_telemetry_metric_executed_source(self):
         super().test_telemetry_metric_executed_source()

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -230,7 +230,8 @@ class Test_Meta:
 
     @bug(library="cpp", reason="language tag not implemented")
     @bug(library="php", reason="language tag not implemented")
-    @bug(library="java", reason="language tag implemented but not for all spans")
+    # TODO: Versions previous to 1.1.0 might be ok, but were not tested so far.
+    @bug(context.library < "java@1.1.0", reason="language tag implemented but not for all spans")
     @bug(library="dotnet", reason="AIT-8735")
     @missing_feature(context.library < "dotnet@2.6.0")
     def test_meta_language_tag(self):
@@ -321,15 +322,10 @@ class Test_MetricsStandardTags:
     """metrics object in spans respect all conventions regarding basic tags"""
 
     @bug(library="cpp", reason="Not implemented")
+    @bug(context.library >= "java@1.3.0", reason="process_id set as tag, not metric")
     def test_metrics_process_id(self):
         """Validates that root spans from traces contain a process_id field"""
-
-        def validator(span):
-            if span.get("parent_id") not in (0, None):  # do nothing if not root span
-                return
-
+        spans = [s for _, s in interfaces.library.get_root_spans()]
+        assert spans, "Did not recieve any root spans to validate."
+        for span in spans:
             assert "process_id" in span["metrics"], "Root span expect a process_id metrics tag"
-
-        interfaces.library.validate_spans(validator=validator, success_by_default=True)
-        # checking that we have at least one root span
-        assert len(list(interfaces.library.get_root_spans())) != 0, "Did not recieve any root spans to validate."

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -280,6 +280,10 @@ class Test_StandardTagsClientIp:
         self._setup_with_attack()
 
     @bug(library="python", reason="cf-connecting-ipv6 seems to have higher precedence than it should")
+    @bug(
+        context.library < "java@1.11.0",
+        reason="X-Client-Ip not supported, see https://github.com/DataDog/dd-trace-java/pull/4878",
+    )
     def test_client_ip(self):
         """Test http.client_ip is always reported in the default scenario which has ASM enabled"""
         meta = self._get_root_span_meta(self.request_with_attack)
@@ -292,6 +296,9 @@ class Test_StandardTagsClientIp:
         self._setup_without_attack()
 
     @bug(library="golang", reason="missing cf-connecting-ipv6")
+    @bug(
+        context.library < "java@1.11.0", reason="not supported, see https://github.com/DataDog/dd-trace-java/pull/4878"
+    )
     def test_client_ip_vendor(self):
         """Test http.client_ip is always reported in the default scenario which has ASM enabled when using vendor headers"""
         self._test_client_ip(self.FORWARD_HEADERS_VENDOR)


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
