### PR TITLE
Update test_telemetry.py after dd-trace-js migrates to telemetry v2

### DIFF
--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -224,7 +224,7 @@ def _validate_headers(headers, request_type):
     if context.library == "python":
         # APM Python migrates Telemetry to V2
         expected_headers["DD-Telemetry-API-Version"] = "v2"
-    if context.library == "nodejs":
+    elif context.library == "nodejs":
         # APM Node.js migrates Telemetry to V2
         expected_headers["DD-Telemetry-API-Version"] = "v2"
     elif context.library >= "java@1.23.0":

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -223,7 +223,7 @@ def _validate_headers(headers, request_type):
 
     if context.library == "python":
         # APM Python migrates Telemetry to V2
-        # test
+        # test again
         expected_headers["DD-Telemetry-API-Version"] = "v2"
     elif context.library >= "java@1.23.0":
         expected_headers["DD-Telemetry-API-Version"] = "v2"

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -223,7 +223,9 @@ def _validate_headers(headers, request_type):
 
     if context.library == "python":
         # APM Python migrates Telemetry to V2
-        # test again
+        expected_headers["DD-Telemetry-API-Version"] = "v2"
+    if context.library == "nodejs":
+        # APM Node.js migrates Telemetry to V2
         expected_headers["DD-Telemetry-API-Version"] = "v2"
     elif context.library >= "java@1.23.0":
         expected_headers["DD-Telemetry-API-Version"] = "v2"

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -221,8 +221,11 @@ def _validate_headers(headers, request_type):
         "DD-Client-Library-Version": "",
     }
 
-    if context.library == "python" or context.library == "nodejs":
-        # APM Python and Node.js migrate Telemetry to V2
+    if context.library == "python":
+        # APM Python migrates Telemetry to V2
+        expected_headers["DD-Telemetry-API-Version"] = "v2"
+    elif context.library == "nodejs":
+        # APM Node.js migrates Telemetry to V2
         expected_headers["DD-Telemetry-API-Version"] = "v2"
     elif context.library >= "java@1.23.0":
         expected_headers["DD-Telemetry-API-Version"] = "v2"

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -224,7 +224,7 @@ def _validate_headers(headers, request_type):
     if context.library == "python":
         # APM Python migrates Telemetry to V2
         expected_headers["DD-Telemetry-API-Version"] = "v2"
-    elif context.library == "nodejs":
+    elif context.library > "nodejs@4.20.0":
         # APM Node.js migrates Telemetry to V2
         expected_headers["DD-Telemetry-API-Version"] = "v2"
     elif context.library >= "java@1.23.0":

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -223,9 +223,7 @@ def _validate_headers(headers, request_type):
 
     if context.library == "python":
         # APM Python migrates Telemetry to V2
-        expected_headers["DD-Telemetry-API-Version"] = "v2"
-    elif context.library == "nodejs":
-        # APM Node.js migrates Telemetry to V2
+        # test
         expected_headers["DD-Telemetry-API-Version"] = "v2"
     elif context.library >= "java@1.23.0":
         expected_headers["DD-Telemetry-API-Version"] = "v2"

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -221,8 +221,8 @@ def _validate_headers(headers, request_type):
         "DD-Client-Library-Version": "",
     }
 
-    if context.library == "python":
-        # APM Python migrates Telemetry to V2
+    if context.library == "python" or context.library == "nodejs":
+        # APM Python and Node.js migrate Telemetry to V2
         expected_headers["DD-Telemetry-API-Version"] = "v2"
     elif context.library >= "java@1.23.0":
         expected_headers["DD-Telemetry-API-Version"] = "v2"


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
