### PR TITLE
[HotFix] Skip loading WAF rule set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,11 +259,13 @@ jobs:
     - name: Build proxy image
       if: contains(github.event.pull_request.labels.*.name, 'build-proxy-image')
       run: ./build.sh -i proxy
-    - name: Load WAF rules
-      if: ${{ matrix.version == 'dev' }}
-      run: ./utils/scripts/load-binary.sh waf_rule_set
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #### appsec-event-rules is now a private repo. The GH_TOKEN provided can't read private repos.
+    #### skipping this, waiting for a proper solution
+    # - name: Load WAF rules
+    #   if: ${{ matrix.version == 'dev' }}
+    #   run: ./utils/scripts/load-binary.sh waf_rule_set
+    #   env:
+    #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Load library binary
       if: ${{ matrix.version == 'dev' }}
       run: ./utils/scripts/load-binary.sh ${{ matrix.variant.library }}

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -242,10 +242,9 @@ elif [ "$TARGET" = "waf_rule_set_v2" ]; then
 
 elif [ "$TARGET" = "waf_rule_set" ]; then
     assert_version_is_dev
-    curl --silent \
+    curl --fail --output "waf_rule_set.json" \
         -H "Authorization: token $GH_TOKEN" \
         -H "Accept: application/vnd.github.v3.raw" \
-        --output "waf_rule_set.json" \
         https://api.github.com/repos/DataDog/appsec-event-rules/contents/build/recommended.json
 
 else


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/appsec-event-rules is now private, we can't load the last set anymore

## Changes

Waiting for a proper solution, skip loading the rule set
Also change the script to make it fail on `404`, (it was a silent fail)

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
](https://github.com/DataDog/appsec-event-rules)