### PR TITLE
[OTel] Test `analytics.event` override with respect to OTLP Code

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -483,7 +483,7 @@ class Test_Otel_Span_Methods:
         assert "span.type" not in span["meta"]
         assert "analytics.event" not in span["meta"]
 
-    @missing_feature(context.library == "java", reason="OTLP behavior not respected")
+    @missing_feature(context.library == "java", reason="Choose to not implement Go parsing logic")
     @missing_feature(context.library == "golang", reason="OTLP behavior not respected")
     @missing_feature(context.library == "ruby", reason="OTLP behavior not respected")
     @missing_feature(context.library == "nodejs", reason="Not implemented")

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -483,9 +483,10 @@ class Test_Otel_Span_Methods:
         assert "span.type" not in span["meta"]
         assert "analytics.event" not in span["meta"]
 
-    @missing_feature(context.library < "java@1.25.0", reason="Implemented in 1.25.0")
+    @missing_feature(context.library == "java", reason="OTLP behavior not respected")
+    @missing_feature(context.library == "golang", reason="OTLP behavior not respected")
+    @missing_feature(context.library == "ruby", reason="OTLP behavior not respected")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @missing_feature(context.library == "dotnet", reason=".NET dosn't treat 'something-else' as a valid input here.")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @pytest.mark.parametrize(

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -522,16 +522,7 @@ class Test_Otel_Span_Methods:
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @pytest.mark.parametrize(
         "analytics_event_value,expected_metric_value",
-        [
-            ("t", 1),
-            ("T", 1),
-            ("f", 0),
-            ("F", 0),
-            ("1", 1),
-            ("0", 0),
-            ("fAlse", None),
-            ("trUe", None),
-        ],
+        [("t", 1), ("T", 1), ("f", 0), ("F", 0), ("1", 1), ("0", 0), ("fAlse", None), ("trUe", None),],
     )
     def test_otel_span_extended_reserved_attributes_overrides_analytics_event(
         self, analytics_event_value: Union[bool, str], expected_metric_value: Union[int, None], test_agent, test_library
@@ -571,7 +562,7 @@ def run_otel_span_reserved_attributes_overrides_analytics_event(
     assert len(trace) == 1
 
     span = get_span(test_agent)
-    if (expected_metric_value is not None) or (context.library not in ['dotnet']):
+    if (expected_metric_value is not None) or (context.library not in ["dotnet"]):
         assert span["metrics"].get("_dd1.sr.eausr") == (0 if expected_metric_value is None else expected_metric_value)
     else:
         assert "_dd1.sr.eausr" not in span["metrics"]

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -537,6 +537,7 @@ class Test_Otel_Span_Methods:
             test_agent=test_agent,
         )
 
+
 def run_operation_name_test(expected_operation_name: str, span_kind: int, attributes: dict, test_library, test_agent):
     with test_library:
         with test_library.otel_start_span("otel_span_name", span_kind=span_kind, attributes=attributes) as span:

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -507,15 +507,15 @@ class Test_Otel_Span_Methods:
 
     @irrelevant(
         context.library == "java",
-        reason="Java tracer always sets _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0",
+        reason="Java tracer decided to always set _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0",
     )
     @irrelevant(
         context.library == "golang",
-        reason="Go tracer always sets _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0",
+        reason="Go tracer decided to always set _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0",
     )
     @irrelevant(
         context.library == "ruby",
-        reason="Ruby tracer always sets _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0",
+        reason="Ruby tracer decided to always set _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0",
     )
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -505,9 +505,18 @@ class Test_Otel_Span_Methods:
             test_agent=test_agent,
         )
 
-    @irrelevant(context.library == "java", reason="The expected metric value is zero")
-    @irrelevant(context.library == "golang", reason="The expected metric value is zero")
-    @irrelevant(context.library == "ruby", reason="The expected metric value is zero")
+    @irrelevant(
+        context.library == "java",
+        reason="Java tracer always sets _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0",
+    )
+    @irrelevant(
+        context.library == "golang",
+        reason="Go tracer always sets _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0",
+    )
+    @irrelevant(
+        context.library == "ruby",
+        reason="Ruby tracer always sets _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0",
+    )
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -505,9 +505,9 @@ class Test_Otel_Span_Methods:
             test_agent=test_agent,
         )
 
-    @missing_feature(context.library == "java", reason="The expected metric value is zero")
-    @missing_feature(context.library == "golang", reason="The expected metric value is zero")
-    @missing_feature(context.library == "ruby", reason="The expected metric value is zero")
+    @irrelevant(context.library == "java", reason="The expected metric value is zero")
+    @irrelevant(context.library == "golang", reason="The expected metric value is zero")
+    @irrelevant(context.library == "ruby", reason="The expected metric value is zero")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
@@ -528,8 +528,8 @@ class Test_Otel_Span_Methods:
             test_agent=test_agent,
         )
 
-    @missing_feature(context.library == "java", reason="Choose to not implement Go parsing logic")
-    @missing_feature(context.library == "ruby", reason="Choose to not implement Go parsing logic")
+    @irrelevant(context.library == "java", reason="Choose to not implement Go parsing logic")
+    @irrelevant(context.library == "ruby", reason="Choose to not implement Go parsing logic")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -484,28 +484,42 @@ class Test_Otel_Span_Methods:
         assert "analytics.event" not in span["meta"]
 
     @missing_feature(context.library < "java@1.25.0", reason="Implemented in 1.25.0")
+    @missing_feature(context.library == "dotnet", reason=".NET dosn't treat 'something-else' as a valid input here.")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @pytest.mark.parametrize(
         "analytics_event_value,expected_metric_value",
-        [
-            ("true", 1),
-            ("TRUE", 1),
-            ("True", 1),
-            ("false", 0),
-            ("False", 0),
-            ("FALSE", 0),
-            ("something-else", None),
-            (True, 1),
-            (False, 0),
-        ],
+        [("true", 1), ("TRUE", 1), ("True", 1), ("false", 0), ("False", 0), ("FALSE", 0), (True, 1), (False, 0),],
     )
-    def test_otel_span_reserved_attributes_overrides_analytics_event(
+    def test_otel_span_basic_reserved_attributes_overrides_analytics_event(
         self, analytics_event_value: Union[bool, str], expected_metric_value: Union[int, None], test_agent, test_library
     ):
         """
-            Tests that the analytics.event reserved attribute override
+            Tests the analytics.event reserved attribute override with basic inputs
+        """
+        run_otel_span_reserved_attributes_overrides_analytics_event(
+            analytics_event_value=analytics_event_value,
+            expected_metric_value=expected_metric_value,
+            test_library=test_library,
+            test_agent=test_agent,
+        )
+
+    @missing_feature(context.library == "java", reason="The expected metric value is zero")
+    @missing_feature(context.library == "golang", reason="The expected metric value is zero")
+    @missing_feature(context.library == "ruby", reason="The expected metric value is zero")
+    @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @missing_feature(context.library == "python", reason="Not implemented")
+    @missing_feature(context.library == "python_http", reason="Not implemented")
+    @pytest.mark.parametrize(
+        "analytics_event_value,expected_metric_value", [("something-else", None), ("fAlse", None), ("trUe", None),],
+    )
+    def test_otel_span_strict_reserved_attributes_overrides_analytics_event(
+        self, analytics_event_value: Union[bool, str], expected_metric_value: Union[int, None], test_agent, test_library
+    ):
+        """
+            Tests that the analytics.event reserved attribute override doesn't set the _dd1.sr.eausr metric
+            for inputs that aren't accepted by strconv.ParseBool
         """
         run_otel_span_reserved_attributes_overrides_analytics_event(
             analytics_event_value=analytics_event_value,
@@ -515,20 +529,18 @@ class Test_Otel_Span_Methods:
         )
 
     @missing_feature(context.library == "java", reason="Choose to not implement Go parsing logic")
-    @missing_feature(context.library == "golang", reason="Choose to not implement Go parsing logic")
     @missing_feature(context.library == "ruby", reason="Choose to not implement Go parsing logic")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @pytest.mark.parametrize(
-        "analytics_event_value,expected_metric_value",
-        [("t", 1), ("T", 1), ("f", 0), ("F", 0), ("1", 1), ("0", 0), ("fAlse", None), ("trUe", None),],
+        "analytics_event_value,expected_metric_value", [("t", 1), ("T", 1), ("f", 0), ("F", 0), ("1", 1), ("0", 0),],
     )
     def test_otel_span_extended_reserved_attributes_overrides_analytics_event(
         self, analytics_event_value: Union[bool, str], expected_metric_value: Union[int, None], test_agent, test_library
     ):
         """
-            Tests that the analytics.event reserved attribute override with respect to Go's strconv.ParseBool
+            Tests that the analytics.event reserved attribute override accepts Go's strconv.ParseBool additional values
         """
         run_otel_span_reserved_attributes_overrides_analytics_event(
             analytics_event_value=analytics_event_value,
@@ -563,8 +575,8 @@ def run_otel_span_reserved_attributes_overrides_analytics_event(
     assert len(trace) == 1
 
     span = get_span(test_agent)
-    if (expected_metric_value is not None) or (context.library not in ["dotnet"]):
-        assert span["metrics"].get("_dd1.sr.eausr") == (0 if expected_metric_value is None else expected_metric_value)
+    if expected_metric_value is not None:
+        assert span["metrics"].get("_dd1.sr.eausr") == expected_metric_value
     else:
         assert "_dd1.sr.eausr" not in span["metrics"]
     assert "analytics.event" not in span["meta"]

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -500,14 +500,14 @@ class Test_Otel_Span_Methods:
             ("something-else", None),
             (True, 1),
             (False, 0),
-            ('t', 1),
-            ('T', 1),
-            ('f', 0),
-            ('F', 0),
-            ('1', 1),
-            ('0', 0),
+            ("t", 1),
+            ("T", 1),
+            ("f", 0),
+            ("F", 0),
+            ("1", 1),
+            ("0", 0),
             ("fAlse", None),
-            ("trUe", None)
+            ("trUe", None),
         ],
     )
     def test_otel_span_reserved_attributes_overrides_analytics_event(

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -484,7 +484,6 @@ class Test_Otel_Span_Methods:
         assert "analytics.event" not in span["meta"]
 
     @missing_feature(context.library < "java@1.25.0", reason="Implemented in 1.25.0")
-    @missing_feature(context.library == "dotnet", reason=".NET dosn't treat 'something-else' as a valid input here.")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")


### PR DESCRIPTION
## Motivation

The [RFC](https://docs.google.com/document/d/1KB6XQxZDUgSSQHp1TEk_0X6zgOzmB9-r8NKE9TVaRJw/edit#bookmark=id.44nna34oqd3j) states that the reserved span attributes must match the behavior of the [OTLP code](https://github.com/DataDog/datadog-agent/blob/ea1911d5618df80c1dd25b362369a2e0491910be/pkg/trace/api/otlp.go#L466-L483) which uses Go's [strconv.ParseBool](https://cs.opensource.google/go/go/+/refs/tags/go1.21.5:src/strconv/atob.go;l=10).
```
// ParseBool returns the boolean value represented by the string.
// It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False.
```

More specifically, this means that 1, t, T, 0, f, and F strings are also valid entries, while anything other than those listed above shouldn't set the `_dd1.sr.eausr` in the metrics. This PR tests this behavior.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
