### PR TITLE
add weblog container system information to startup messages

### DIFF
--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -409,9 +409,7 @@ class EndToEndScenario(_DockerScenario):
     def session_start(self):
         super().session_start()
         try:
-            code, (stdout, stderr) = self.weblog_container._container.exec_run(
-                "uname -a", demux=True
-            )
+            code, (stdout, stderr) = self.weblog_container._container.exec_run("uname -a", demux=True)
             if code:
                 message = f"Failed to get weblog system info: [{code}] {stderr.decode()} {stdout.decode()}"
             else:

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -115,8 +115,11 @@ class _Scenario:
 
         from utils._context.containers import _get_client
 
-        weblog_container = _get_client().containers.get("system-tests-weblog")
-        code, (stdout, stderr) = weblog_container.exec_run("uname -a", demux=True)
+        try:
+            weblog_container = _get_client().containers.get("system-tests-weblog")
+            code, (stdout, stderr) = weblog_container.exec_run("uname -a", demux=True)
+        except:
+            stdout = b"unknown"
         logger.stdout(f"Weblog system: {stdout.decode()}")
 
     def pytest_sessionfinish(self, session):

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -113,6 +113,12 @@ class _Scenario:
             self.close_targets()
             raise
 
+        from utils._context.containers import _get_client
+
+        weblog_container = _get_client().containers.get("system-tests-weblog")
+        code, (stdout, stderr) = weblog_container.exec_run("uname -a", demux=True)
+        logger.stdout(f"Weblog system: {stdout.decode()}")
+
     def pytest_sessionfinish(self, session):
         """ called at the end of the process  """
 


### PR DESCRIPTION
## Motivation

We may need to check architecture and platform used to run the weblog and the tracer. 

## Changes

This PR adds, just after the warmup phase, a call to the weblog container to print its current system information.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
