### PR TITLE
tests scanners for api security

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -7,6 +7,7 @@ tests/:
   appsec/:
     api_security/:
       test_schemas.py:
+        Test_Scanners: missing_feature
         Test_Schema_Request_Body: missing_feature
         Test_Schema_Request_Cookies: missing_feature
         Test_Schema_Request_Headers: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -11,6 +11,7 @@ tests/:
   appsec/:
     api_security/:
       test_schemas.py:
+        Test_Scanners: missing_feature
         Test_Schema_Request_Body: missing_feature
         Test_Schema_Request_Cookies: missing_feature
         Test_Schema_Request_Headers: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -11,6 +11,7 @@ tests/:
   appsec/:
     api_security/:
       test_schemas.py:
+        Test_Scanners: missing_feature
         Test_Schema_Request_Body: missing_feature
         Test_Schema_Request_Cookies: missing_feature
         Test_Schema_Request_Headers: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -7,6 +7,7 @@ tests/:
   appsec/:
     api_security/:
       test_schemas.py:
+        Test_Scanners: missing_feature
         Test_Schema_Request_Body: missing_feature
         Test_Schema_Request_Cookies: missing_feature
         Test_Schema_Request_Headers: missing_feature

--- a/manifests/php_appsec.yml
+++ b/manifests/php_appsec.yml
@@ -2,6 +2,7 @@ tests/:
   appsec/:
     api_security/:
       test_schemas.py:
+        Test_Scanners: missing_feature
         Test_Schema_Request_Body: missing_feature
         Test_Schema_Request_Cookies: missing_feature
         Test_Schema_Request_Headers: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -42,6 +42,11 @@ tests/:
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
+        Test_Scanners:
+          '*': missing_feature
+          django-poc: v2.4.0.dev
+          flask-poc: v2.4.0.dev
+          python3.12: v2.4.0.dev
     iast/:
       sink/:
         test_command_injection.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -7,6 +7,11 @@ tests/:
   appsec/:
     api_security/:
       test_schemas.py:
+        Test_Scanners:
+          '*': missing_feature
+          django-poc: v2.4.0.dev
+          flask-poc: v2.4.0.dev
+          python3.12: v2.4.0.dev
         Test_Schema_Request_Body:
           '*': missing_feature
           django-poc: v2.1.0.dev
@@ -42,11 +47,6 @@ tests/:
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-        Test_Scanners:
-          '*': missing_feature
-          django-poc: v2.4.0.dev
-          flask-poc: v2.4.0.dev
-          python3.12: v2.4.0.dev
     iast/:
       sink/:
         test_command_injection.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -7,6 +7,7 @@ tests/:
   appsec/:
     api_security/:
       test_schemas.py:
+        Test_Scanners: missing_feature
         Test_Schema_Request_Body: v1.15.0
         Test_Schema_Request_Cookies: v1.15.0
         Test_Schema_Request_Headers: v1.15.0

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -25,7 +25,7 @@ def get_schema(request, address):
 
 
 def contains(t1, t2):
-    """validate that schema t1 contains all keys and values from t2"""
+    """validate that schema t1 contains all keys and values from t2 """
     if t1 is None or t2 is None:
         return False
     return equal_value(t1[0], t2[0])
@@ -72,7 +72,7 @@ class Test_Schema_Request_Cookies:
 
     def setup_request_method(self):
         self.request = weblog.get(
-            "/tag_value/api_match_AS001/200", cookies={"secret": "any_value", "cache": "any_other_value"},
+            "/tag_value/api_match_AS001/200", cookies={"secret": "any_value", "cache": "any_other_value"}
         )
 
     @missing_feature(context.library < "python@1.19.0.dev")
@@ -138,17 +138,14 @@ class Test_Schema_Request_Body:
     """Test API Security - Request Body and list length"""
 
     def setup_request_method(self):
-        payload = {
-            "main": [{"key": "id001", "value": 1345}, {"value": 1567, "key": "id002"}],
-            "nullable": None,
-        }
+        payload = {"main": [{"key": "id001", "value": 1345}, {"value": 1567, "key": "id002"}], "nullable": None}
         self.request = weblog.post("/tag_value/api_match_AS004/200", json=payload)
 
     def test_request_method(self):
         """can provide request request body schema"""
         schema = get_schema(self.request, "req.body")
         assert self.request.status_code == 200
-        assert contains(schema, [{"main": [[[{"key": [8], "value": [4]}]], {"len": 2}], "nullable": [1]}],)
+        assert contains(schema, [{"main": [[[{"key": [8], "value": [4]}]], {"len": 2}], "nullable": [1]}])
 
 
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
@@ -181,7 +178,7 @@ class Test_Schema_Response_Body:
     def setup_request_method(self):
         self.request = weblog.post(
             "/tag_value/payload_in_response_body_001/200",
-            data={"test_int": 1, "test_str": "anything", "test_bool": True, "test_float": 1.5234,},
+            data={"test_int": 1, "test_str": "anything", "test_bool": True, "test_float": 1.5234},
         )
 
     def test_request_method(self):

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -2,7 +2,16 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, coverage, interfaces, missing_feature, rfc, scenarios, weblog
+from utils import (
+    context,
+    coverage,
+    interfaces,
+    missing_feature,
+    rfc,
+    scenarios,
+    weblog,
+    features,
+)
 
 
 def get_schema(request, address):
@@ -16,7 +25,7 @@ def get_schema(request, address):
 
 
 def contains(t1, t2):
-    """validate that schema t1 contains all keys and values from t2 """
+    """validate that schema t1 contains all keys and values from t2"""
     if t1 is None or t2 is None:
         return False
     return equal_value(t1[0], t2[0])
@@ -36,6 +45,7 @@ def equal_value(t1, t2):
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @coverage.basic
 @scenarios.appsec_api_security
+@features.api_security_schemas
 class Test_Schema_Request_Headers:
     """Test API Security - Request Headers Schema"""
 
@@ -56,12 +66,13 @@ class Test_Schema_Request_Headers:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @coverage.basic
 @scenarios.appsec_api_security
+@features.api_security_schemas
 class Test_Schema_Request_Cookies:
     """Test API Security - Request Cookies Schema"""
 
     def setup_request_method(self):
         self.request = weblog.get(
-            "/tag_value/api_match_AS001/200", cookies={"secret": "any_value", "cache": "any_other_value"}
+            "/tag_value/api_match_AS001/200", cookies={"secret": "any_value", "cache": "any_other_value"},
         )
 
     @missing_feature(context.library < "python@1.19.0.dev")
@@ -79,6 +90,7 @@ class Test_Schema_Request_Cookies:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @coverage.basic
 @scenarios.appsec_api_security
+@features.api_security_schemas
 class Test_Schema_Request_Query_Parameters:
     """Test API Security - Request Query Parameters Schema"""
 
@@ -99,6 +111,7 @@ class Test_Schema_Request_Query_Parameters:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @coverage.basic
 @scenarios.appsec_api_security
+@features.api_security_schemas
 class Test_Schema_Request_Path_Parameters:
     """Test API Security - Request Path Parameters Schema"""
 
@@ -120,23 +133,28 @@ class Test_Schema_Request_Path_Parameters:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @coverage.basic
 @scenarios.appsec_api_security
+@features.api_security_schemas
 class Test_Schema_Request_Body:
     """Test API Security - Request Body and list length"""
 
     def setup_request_method(self):
-        payload = {"main": [{"key": "id001", "value": 1345}, {"value": 1567, "key": "id002"}], "nullable": None}
+        payload = {
+            "main": [{"key": "id001", "value": 1345}, {"value": 1567, "key": "id002"}],
+            "nullable": None,
+        }
         self.request = weblog.post("/tag_value/api_match_AS004/200", json=payload)
 
     def test_request_method(self):
         """can provide request request body schema"""
         schema = get_schema(self.request, "req.body")
         assert self.request.status_code == 200
-        assert contains(schema, [{"main": [[[{"key": [8], "value": [4]}]], {"len": 2}], "nullable": [1]}])
+        assert contains(schema, [{"main": [[[{"key": [8], "value": [4]}]], {"len": 2}], "nullable": [1]}],)
 
 
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @coverage.basic
 @scenarios.appsec_api_security
+@features.api_security_schemas
 class Test_Schema_Response_Headers:
     """Test API Security - Response Header Schema"""
 
@@ -156,13 +174,14 @@ class Test_Schema_Response_Headers:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @coverage.basic
 @scenarios.appsec_api_security
+@features.api_security_schemas
 class Test_Schema_Response_Body:
     """Test API Security - Response Body Schema with urlencoded body"""
 
     def setup_request_method(self):
         self.request = weblog.post(
             "/tag_value/payload_in_response_body_001/200",
-            data={"test_int": 1, "test_str": "anything", "test_bool": True, "test_float": 1.5234},
+            data={"test_int": 1, "test_str": "anything", "test_bool": True, "test_float": 1.5234,},
         )
 
     def test_request_method(self):
@@ -176,3 +195,44 @@ class Test_Schema_Response_Body:
         payload_schema = schema[0]["payload"][0]
         for key in ("test_bool", "test_int", "test_str", "test_float"):
             assert key in payload_schema
+
+
+@rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
+@coverage.basic
+@scenarios.appsec_api_security
+@features.api_security_schemas
+class Test_Scanners:
+    """Test API Security - Scanners"""
+
+    def setup_request_method(self):
+        self.request = weblog.get(
+            "/tag_value/api_match_AS001/200",
+            cookies={"mastercard": "5123456789123456", "authorization": "digest a0b1c2", "SSN": "123-45-6789",},
+            headers={"authorization": "digest a0b1c2",},
+        )
+
+    @missing_feature(context.library < "python@1.19.0.dev")
+    def test_request_method(self):
+        """can provide request header schema"""
+        schema_cookies = get_schema(self.request, "req.cookies")
+        schema_headers = get_schema(self.request, "req.headers")
+        assert self.request.status_code == 200
+        assert schema_cookies
+        assert isinstance(schema_cookies, list)
+        EXPECTED_COOKIES = {
+            "SSN": [8, {"category": "pii", "type": "us_ssn"}],
+            "authorization": [8],
+            "mastercard": [8, {"card_type": "mastercard", "type": "card", "category": "payment"},],
+        }
+        EXPECTED_HEADERS = {"authorization": [8, {"category": "credentials", "type": "digest_auth"}]}
+
+        for schema, expected in [
+            (schema_cookies[0], EXPECTED_COOKIES),
+            (schema_headers[0], EXPECTED_HEADERS),
+        ]:
+            for key in expected:
+                assert key in schema
+                assert isinstance(schema[key], list)
+                assert len(schema[key]) == len(expected[key])
+                if len(schema[key]) == 2:
+                    assert schema[key][1] == expected[key][1]

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -1328,3 +1328,13 @@ class features:
         """
         pytest.mark.features(feature_id=203)(test_object)
         return test_object
+
+    @staticmethod
+    def api_security_schemas(test_object):
+        """
+        Schema extraction for API Security
+
+        https://feature-parity.us1.prod.dog/#/?feature=204
+        """
+        pytest.mark.features(feature_id=204)(test_object)
+        return test_object


### PR DESCRIPTION
Add tests to check scanners for api security are working as expected

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
