### PR TITLE
tests/apm_tracing_e2e: increase retries in OTel tests from 5 to 10

### DIFF
--- a/tests/apm_tracing_e2e/test_otel.py
+++ b/tests/apm_tracing_e2e/test_otel.py
@@ -44,7 +44,7 @@ class Test_Otel_Span:
         assert child.get("meta").get("span.kind") == "internal"
 
         # Assert the spans received from the backend!
-        spans = interfaces.backend.assert_request_spans_exist(self.req, query_filter="")
+        spans = interfaces.backend.assert_request_spans_exist(self.req, query_filter="", retries=10)
         assert 2 == len(spans), _assert_msg(2, len(spans))
 
     def setup_distributed_otel_trace(self):
@@ -75,7 +75,7 @@ class Test_Otel_Span:
         assert handler_span.get("parentID") == roundtrip_span.get("spanID")
 
         # Assert the spans received from the backend!
-        spans = interfaces.backend.assert_request_spans_exist(self.req, query_filter="")
+        spans = interfaces.backend.assert_request_spans_exist(self.req, query_filter="", retries=10)
         assert 3 == len(spans), _assert_msg(3, len(spans))
 
 

--- a/utils/interfaces/_backend.py
+++ b/utils/interfaces/_backend.py
@@ -133,7 +133,7 @@ class _BackendInterfaceValidator(ProxyBasedInterfaceValidator):
         query_filter = f"service:weblog @single_span:true @http.useragent:*{rid}"
         return self.assert_request_spans_exist(request, query_filter, min_spans_len, limit)
 
-    def assert_request_spans_exist(self, request, query_filter, min_spans_len=1, limit=100):
+    def assert_request_spans_exist(self, request, query_filter, min_spans_len=1, limit=100, retries=5):
         """Attempts to fetch span events from the Event Platform using the given `query_filter`
         as part of the search query. The query should be what you would use in the `/apm/traces`
         page in the UI. When a valid request is provided we will restrict the span search to span
@@ -147,9 +147,9 @@ class _BackendInterfaceValidator(ProxyBasedInterfaceValidator):
         if rid:
             query_filter = f"{query_filter} @http.useragent:*{rid}"
 
-        return self.assert_spans_exist(query_filter, min_spans_len, limit)
+        return self.assert_spans_exist(query_filter, min_spans_len, limit, retries)
 
-    def assert_spans_exist(self, query_filter, min_spans_len=1, limit=100):
+    def assert_spans_exist(self, query_filter, min_spans_len=1, limit=100, retries=5):
         """Attempts to fetch span events from the Event Platform using the given `query_filter`
         as part of the search query. The query should be what you would use in the `/apm/traces`
         page in the UI.
@@ -159,7 +159,7 @@ class _BackendInterfaceValidator(ProxyBasedInterfaceValidator):
         """
 
         logger.debug(f"We will attempt to fetch span events with query filter: {query_filter}")
-        data = self._wait_for_event_platform_spans(query_filter, limit)
+        data = self._wait_for_event_platform_spans(query_filter, limit, retries)
 
         result = data["response"]["content"]["result"]
         assert result["count"] >= min_spans_len, f"Did not have the expected number of spans ({min_spans_len}): {data}"


### PR DESCRIPTION
## Motivation

The two following tests have been flaking since July. This PR aims to reduce the flakiness.

![image](https://github.com/DataDog/system-tests/assets/163009/ff95f639-ebea-4ebc-abac-badc6e3b6129)
![image](https://github.com/DataDog/system-tests/assets/163009/789201b0-d964-4d26-933b-88930a1ee67c)

## Changes

Added a new `retries` keyword argument in the caller methods that rely in `_wait_for_event_platform_spans`, that accepts this keyword with default value of 5.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
