### PR TITLE
Parametric: Add client: java version: dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
     secrets: inherit
 
   main:
+    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     needs:
     - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@robertomonteromiguel/parametric_use_load_binary_java
+    uses: datadog/system-tests/.github/workflows/parametric.yml@main
     secrets: inherit
 
   experimental:
@@ -76,7 +76,6 @@ jobs:
     secrets: inherit
 
   main:
-    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     needs:
     - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@main
+    uses: datadog/system-tests/.github/workflows/parametric.yml@robertomonteromiguel/parametric_use_load_binary_java
     secrets: inherit
 
   experimental:

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -20,6 +20,10 @@ jobs:
           - nodejs
           - ruby
           - cpp
+        include:
+          - version: prod
+          - client: java
+            version: dev
       fail-fast: false
     env:
       TEST_LIBRARY: ${{ matrix.client }}
@@ -28,6 +32,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Install runner
         uses: ./.github/actions/install_runner
+      - name: Load library binary
+        if: ${{ matrix.version == 'dev' }}
+        run: ./utils/scripts/load-binary.sh ${{ matrix.client }}
       - name: Run
         run: ./run.sh PARAMETRIC
       - name: Compress logs
@@ -35,14 +42,14 @@ jobs:
         if: always()
         run: tar -czvf artifact.tar.gz $(ls | grep logs)
       - name: Upload artifact
-        if: always()
+        if: always() && steps.compress_logs.outcome == 'success'
         uses: actions/upload-artifact@v3
         with:
-          name: logs_${{  matrix.client }}_main
+          name: logs_${{ matrix.client}}_parametric_${{ matrix.version }}_main
           path: artifact.tar.gz
       - name: Upload results CI Visibility
         if: ${{ always() }}
-        run: ./utils/scripts/upload_results_CI_visibility.sh dev system-tests ${{ github.run_id }}-${{ github.run_attempt }}
+        run: ./utils/scripts/upload_results_CI_visibility.sh ${{ matrix.version }} system-tests ${{ github.run_id }}-${{ github.run_attempt }}
         env:
           DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}
       - name: Print fancy log report

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -5,34 +5,20 @@ on:
 env:
   REGISTRY: ghcr.io
 jobs:
+
   parametric:
     runs-on:
       group: "APM Larger Runners"
     strategy:
       matrix:
-        fruit: [apple, pear]
-        animal: [cat, dog]
-        include:
-          - color: green
-          - color: pink
-            animal: cat
-          - fruit: apple
-            shape: circle
-          - fruit: banana
-          - fruit: banana
-            animal: cat
-    steps:
-      - name: Test
-        run: echo "hola"
-  parametric2:
-    if: ${{ false }}  # disable for now
-    runs-on:
-      group: "APM Larger Runners"
-    strategy:
-      matrix:
           variant:
+            #Updated with dev version 
             - client: java
               version: dev
+            - client: java
+              version: prod
+
+            #Pending to update with dev version  
             - client: nodejs
               version: prod
 

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -10,7 +10,12 @@ jobs:
       group: "APM Larger Runners"
     strategy:
       matrix:
-        client: [nodejs, java]
+          variant:
+            - client: java
+              version: [dev,prod]
+            - client: [nodejs]
+              version: [prod]
+
          # - php
          # - python
          # - python_http
@@ -20,21 +25,19 @@ jobs:
          # - nodejs
          # - ruby
          # - cpp
-        include:
-          - version: prod
-          - client: java
-            version: dev
+
+
       fail-fast: false
     env:
-      TEST_LIBRARY: ${{ matrix.client }}
+      TEST_LIBRARY: ${{ matrix.variant.client }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install runner
         uses: ./.github/actions/install_runner
       - name: Load library binary
-        if: ${{ matrix.version == 'dev' }}
-        run: ./utils/scripts/load-binary.sh ${{ matrix.client }}
+        if: ${{ matrix.variant.version == 'dev' }}
+        run: ./utils/scripts/load-binary.sh ${{ matrix.variant.client }}
       - name: Run
         run: ./run.sh PARAMETRIC
       - name: Compress logs
@@ -45,11 +48,11 @@ jobs:
         if: always() && steps.compress_logs.outcome == 'success'
         uses: actions/upload-artifact@v3
         with:
-          name: logs_${{ matrix.client}}_parametric_${{ matrix.version }}_main
+          name: logs_${{ matrix.variant.client}}_parametric_${{ matrix.variant.version }}_main
           path: artifact.tar.gz
       - name: Upload results CI Visibility
         if: ${{ always() }}
-        run: ./utils/scripts/upload_results_CI_visibility.sh ${{ matrix.version }} system-tests ${{ github.run_id }}-${{ github.run_attempt }}
+        run: ./utils/scripts/upload_results_CI_visibility.sh ${{ matrix.variant.version }} system-tests ${{ github.run_id }}-${{ github.run_attempt }}
         env:
           DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}
       - name: Print fancy log report

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -10,11 +10,29 @@ jobs:
       group: "APM Larger Runners"
     strategy:
       matrix:
+        fruit: [apple, pear]
+        animal: [cat, dog]
+        include:
+          - color: green
+          - color: pink
+            animal: cat
+          - fruit: apple
+            shape: circle
+          - fruit: banana
+          - fruit: banana
+            animal: cat
+    steps:
+      - name: Test
+        run: echo "hola"
+  parametric2:
+    if: ${{ false }}  # disable for now
+    runs-on:
+      group: "APM Larger Runners"
+    strategy:
+      matrix:
           variant:
             - client: java
-              version: 
-                - dev
-                - prod
+              version: dev
             - client: nodejs
               version: prod
 

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -10,16 +10,16 @@ jobs:
       group: "APM Larger Runners"
     strategy:
       matrix:
-        client:
-          - php
-          - python
-          - python_http
-          - dotnet
-          - golang
-          - java
-          - nodejs
-          - ruby
-          - cpp
+        client: [nodejs, java]
+         # - php
+         # - python
+         # - python_http
+         # - dotnet
+         # - golang
+         # - java
+         # - nodejs
+         # - ruby
+         # - cpp
         include:
           - version: prod
           - client: java

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
           variant:
-            - client: java
+            - client: [java]
               version: [dev,prod]
             - client: [nodejs]
               version: [prod]

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -11,10 +11,12 @@ jobs:
     strategy:
       matrix:
           variant:
-            - client: [java]
-              version: [dev,prod]
-            - client: [nodejs]
-              version: [prod]
+            - client: java
+              version: 
+                - dev
+                - prod
+            - client: nodejs
+              version: prod
 
          # - php
          # - python

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -19,20 +19,23 @@ jobs:
               version: prod
 
             #Pending to update with dev version  
+            - client: php
+              version: prod
+            - client: python
+              version: prod
+            - client: python_http
+              version: prod
+            - client: dotnet
+              version: prod
+            - client: golang
+              version: prod
             - client: nodejs
               version: prod
-
-         # - php
-         # - python
-         # - python_http
-         # - dotnet
-         # - golang
-         # - java
-         # - nodejs
-         # - ruby
-         # - cpp
-
-
+            - client: ruby
+              version: prod
+            - client: cpp
+              version: prod
+ 
       fail-fast: false
     env:
       TEST_LIBRARY: ${{ matrix.variant.client }}


### PR DESCRIPTION
## Motivation

Currently Parametric only executes tests using latest tracer release. We add support to run snapshot version of the java tracer (dev).
In this case we only add the support adding "dev" parameter on the parametric.yml (CI)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
