### PR TITLE
Fix opentemetry distro version for python (due to a bug on opentelemt…

### DIFF
--- a/utils/build/docker/python_otel/flask-poc-otel.Dockerfile
+++ b/utils/build/docker/python_otel/flask-poc-otel.Dockerfile
@@ -15,7 +15,8 @@ RUN pip uninstall -y psycopg2-binary
 RUN pip install psycopg2
 #############
 
-RUN pip install opentelemetry-distro opentelemetry-exporter-otlp
+#Set to 0.42b0 due this bug: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2046
+RUN pip install opentelemetry-distro==0.42b0 opentelemetry-exporter-otlp
 
 RUN opentelemetry-bootstrap -a install
 

--- a/utils/build/docker/python_otel/flask-poc-otel.Dockerfile
+++ b/utils/build/docker/python_otel/flask-poc-otel.Dockerfile
@@ -15,7 +15,7 @@ RUN pip uninstall -y psycopg2-binary
 RUN pip install psycopg2
 #############
 
-#Set to 0.42b0 due this bug: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2046
+#Set opentelemetry-distro to 0.42b0 due this bug: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2046
 RUN pip install opentelemetry-distro==0.42b0 opentelemetry-exporter-otlp
 
 RUN opentelemetry-bootstrap -a install


### PR DESCRIPTION
…ry latest release)

## Motivation

There is a bug on the latest opentelemetry distribution for python.
We set the previous version, in order to avoid the docker build error.
We'll wait for the fix to remove the current version

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
