### PR TITLE
Fix telemetry v2 app-client-configuration-change schema

### DIFF
--- a/utils/interfaces/schemas/miscs/telemetry/v2/events/client-configuration-change.json
+++ b/utils/interfaces/schemas/miscs/telemetry/v2/events/client-configuration-change.json
@@ -5,7 +5,7 @@
   "title": "client-configuration-change v2",
   "type": "object",
   "properties": {
-    "conf_key_values": {
+    "configuration": {
       "type": "array",
       "items": {
         "$ref": "/miscs/telemetry/v2/objects/configuration.json"
@@ -15,5 +15,5 @@
       "$ref": "/miscs/telemetry/common/objects/remote_config.json"
     }
   },
-  "required": ["conf_key_values"]
+  "required": ["configuration"]
 }


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->


## Changes

As of the [schema reference](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/payload.md#if-request_type--app-client-configuration-change-we-add-the-following-to-payload), the configuration field is not expected as `conf_key_value` but `configuration`.

Fixes the failing system tests for https://github.com/DataDog/dd-trace-go/pull/2444

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
