### PR TITLE
Parametric: Add client: nodejs version: dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
     secrets: inherit
 
   main:
-    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     needs:
     - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@parametric_use_load_binary_nodejs
+    uses: datadog/system-tests/.github/workflows/parametric.yml@robertomonteromiguel/parametric_use_load_binary_nodejs
     secrets: inherit
 
   experimental:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@robertomonteromiguel/parametric_use_load_binary_nodejs
+    uses: datadog/system-tests/.github/workflows/parametric.yml@main
     secrets: inherit
 
   experimental:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@main
+    uses: datadog/system-tests/.github/workflows/parametric.yml@parametric_use_load_binary_nodejs
     secrets: inherit
 
   experimental:
@@ -76,6 +76,7 @@ jobs:
     secrets: inherit
 
   main:
+    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     needs:
     - lint

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -13,29 +13,29 @@ jobs:
       matrix:
           variant:
             #Updated with dev version 
-           # - client: java
-           #   version: dev
-           # - client: java
-           #   version: prod
+            - client: java
+              version: dev
+            - client: java
+              version: prod
             - client: nodejs
               version: prod
             - client: nodejs
               version: dev
             #Pending to update with dev version  
-           # - client: php
-           #   version: prod
-           # - client: python
-           #   version: prod
-           # - client: python_http
-           #   version: prod
-           # - client: dotnet
-           #   version: prod
-           # - client: golang
-           #   version: prod
-           # - client: ruby
-           #   version: prod
-           # - client: cpp
-           #   version: prod
+            - client: php
+              version: prod
+            - client: python
+              version: prod
+            - client: python_http
+              version: prod
+            - client: dotnet
+              version: prod
+            - client: golang
+              version: prod
+            - client: ruby
+              version: prod
+            - client: cpp
+              version: prod
  
       fail-fast: false
     env:

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -13,28 +13,29 @@ jobs:
       matrix:
           variant:
             #Updated with dev version 
-            - client: java
-              version: dev
-            - client: java
-              version: prod
-
-            #Pending to update with dev version  
-            - client: php
-              version: prod
-            - client: python
-              version: prod
-            - client: python_http
-              version: prod
-            - client: dotnet
-              version: prod
-            - client: golang
-              version: prod
+           # - client: java
+           #   version: dev
+           # - client: java
+           #   version: prod
             - client: nodejs
               version: prod
-            - client: ruby
-              version: prod
-            - client: cpp
-              version: prod
+            - client: nodejs
+              version: dev
+            #Pending to update with dev version  
+           # - client: php
+           #   version: prod
+           # - client: python
+           #   version: prod
+           # - client: python_http
+           #   version: prod
+           # - client: dotnet
+           #   version: prod
+           # - client: golang
+           #   version: prod
+           # - client: ruby
+           #   version: prod
+           # - client: cpp
+           #   version: prod
  
       fail-fast: false
     env:

--- a/docs/scenarios/parametric.md
+++ b/docs/scenarios/parametric.md
@@ -146,12 +146,9 @@ TEST_LIBRARY=python PYTHON_DDTRACE_PACKAGE=git+https://github.com/Datadog/dd-tra
 #### NodeJS
 
 There is two ways for running the NodeJS tests with a custom tracer:
-- Place the ddtrace NPM package in the folder `utils/build/docker/nodejs/parametric/npm` and then set the environment variable `NODEJS_DDTRACE_MODULE`
-with the filename placed in the aforementioned folder. For example:
-  - `TEST_LIBRARY=nodejs NODEJS_DDTRACE_MODULE="dd-trace-2.22.3.tgz" ./run.sh PARAMETRIC`
-- Set the environment variable `NODEJS_DDTRACE_MODULE` to hold a commit in a remote branch. The following example will run
-the tests with a specific commit:
-  - `TEST_LIBRARY=nodejs NODEJS_DDTRACE_MODULE=datadog/dd-trace-js#687cb813289e19bfcc884a2f9f634470cf138143 ./run.sh PARAMETRIC`
+1. Create a file `nodejs-load-from-npm` in `binaries/`, the content will be installed by `npm install`. Content example:
+    * `DataDog/dd-trace-js#master`
+2. Clone the dd-trace-js repo inside `binaries`
 
 #### Ruby
 

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -153,7 +153,8 @@ RUN python3.9 -m pip install %s
 def node_library_factory() -> APMLibraryTestServer:
     nodejs_appdir = os.path.join("utils", "build", "docker", "nodejs", "parametric")
     nodejs_absolute_appdir = os.path.join(_get_base_directory(), nodejs_appdir)
-    node_module = os.getenv("NODEJS_DDTRACE_MODULE", "dd-trace")
+    nodejs_reldir = nodejs_appdir.replace("\\", "/")
+
     return APMLibraryTestServer(
         lang="nodejs",
         protocol="http",
@@ -161,17 +162,22 @@ def node_library_factory() -> APMLibraryTestServer:
         container_tag="node-test-client",
         container_img=f"""
 FROM node:18.10-slim
-WORKDIR /client
-COPY ./package.json /client/
-COPY ./package-lock.json /client/
-COPY ./*.js /client/
-COPY ./npm/* /client/
+RUN apt-get update && apt-get install -y jq git
+WORKDIR /usr/app
+COPY {nodejs_reldir}/package.json /usr/app/
+COPY {nodejs_reldir}/package-lock.json /usr/app/
+COPY {nodejs_reldir}/*.js /usr/app/
+COPY {nodejs_reldir}/npm/* /usr/app/
+
 RUN npm install
-RUN npm install {node_module}
+
+COPY {nodejs_reldir}/../install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh
+
 """,
         container_cmd=["node", "server.js"],
         container_build_dir=nodejs_absolute_appdir,
-        container_build_context=nodejs_absolute_appdir,
+        container_build_context=_get_base_directory(),
         env={},
         port="",
     )

--- a/utils/build/docker/nodejs/parametric/Dockerfile
+++ b/utils/build/docker/nodejs/parametric/Dockerfile
@@ -11,3 +11,4 @@ RUN npm install
 
 COPY utils/build/docker/nodejs/parametric/../install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
+

--- a/utils/build/docker/nodejs/parametric/Dockerfile
+++ b/utils/build/docker/nodejs/parametric/Dockerfile
@@ -1,9 +1,13 @@
 
 FROM node:18.10-slim
-WORKDIR /client
-COPY ./package.json /client/
-COPY ./package-lock.json /client/
-COPY ./*.js /client/
-COPY ./npm/* /client/
+RUN apt-get update && apt-get install -y jq git
+WORKDIR /usr/app
+COPY utils/build/docker/nodejs/parametric/package.json /usr/app/
+COPY utils/build/docker/nodejs/parametric/package-lock.json /usr/app/
+COPY utils/build/docker/nodejs/parametric/*.js /usr/app/
+COPY utils/build/docker/nodejs/parametric/npm/* /usr/app/
+
 RUN npm install
-RUN npm install dd-trace
+
+COPY utils/build/docker/nodejs/parametric/../install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh

--- a/utils/build/docker/nodejs/parametric/ddtracer_version.Dockerfile
+++ b/utils/build/docker/nodejs/parametric/ddtracer_version.Dockerfile
@@ -1,15 +1,11 @@
 
 FROM node:18.10-slim
 
-ARG BUILD_MODULE=''
-ENV NODEJS_DDTRACE_MODULE=$BUILD_MODULE
-RUN apt-get update && apt-get install -y jq
+RUN apt-get update && apt-get install -y jq git
 
-WORKDIR /client
-COPY ./utils/build/docker/nodejs/parametric/package.json /client/
-COPY ./utils/build/docker/nodejs/parametric/package-lock.json /client/
-COPY ./utils/build/docker/nodejs/parametric/*.js /client/
-COPY ./utils/build/docker/nodejs/parametric/npm/* /client/
-COPY ./utils/build/docker/nodejs/parametric/ddtracer_version.sh .
-RUN sh ddtracer_version.sh
+WORKDIR /usr/app
+
+COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
+RUN /binaries/install_ddtrace.sh
+
 CMD cat SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/nodejs/parametric/ddtracer_version.sh
+++ b/utils/build/docker/nodejs/parametric/ddtracer_version.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-if [ -z "${NODEJS_DDTRACE_MODULE}" ]; then NODEJS_DDTRACE_MODULE=dd-trace; fi
-
-npm install
-npm install "$NODEJS_DDTRACE_MODULE"
-npm list --json | jq -r '.dependencies."dd-trace".version' > SYSTEM_TESTS_LIBRARY_VERSION


### PR DESCRIPTION
## Motivation

Currently Parametric only executes tests using latest tracer release. We add support to run snapshot version of the nodejs tracer (dev).

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
