### PR TITLE
Fix dynamic config v2 tests and enable for .net

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -206,7 +206,7 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigV1: v2.33.0
-      TestDynamicConfigV2: missing_feature
+      TestDynamicConfigV2: v2.44.0
     test_span_links.py: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: missing_feature

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -701,7 +701,7 @@ class _TestAgentAPI:
                             if message["request_type"] == event_name:
                                 if clear:
                                     self.clear()
-                                return event["payload"]
+                                return message
                     elif event["request_type"] == event_name:
                         if clear:
                             self.clear()

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -368,7 +368,7 @@ class TestDynamicConfigV2:
         assert_trace_has_tags(traces[0], {"rc_key1": "val1", "rc_key2": "val2"})
 
         # Ensure previous tags are restored.
-        set_and_wait_rc(test_agent, config_overrides={"tracing_tags": None})
+        set_and_wait_rc(test_agent, config_overrides={})
         with test_library:
             with test_library.start_span("test") as span:
                 with test_library.start_span("test2", parent_id=span.span_id):


### PR DESCRIPTION
## Motivation

Enable dynamic configuration v2 tests for .NET.

## Changes

 - Enable dynamic configuration v2 tests for .NET
 - message-batch messages weren't handled properly
 - In test_tracing_client_tracing_tags, remove the tracing_tags key instead of setting an empty value (mimicking the behavior in production)

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
