### PR TITLE
activate api security tests for python fastapi

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -34,6 +34,7 @@ tests/:
         Test_Schema_Request_Json_Body:
           '*': missing_feature
           django-poc: v2.1.0.dev
+          fastapi: v2.5.0.dev1
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
         Test_Schema_Request_Path_Parameters:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -12,41 +12,49 @@ tests/:
           django-poc: v2.4.0.dev
           flask-poc: v2.4.0.dev
           python3.12: v2.4.0.dev
+          fastapi: v2.4.0.dev1
         Test_Schema_Request_Body:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
+          fastapi: v2.4.0.dev1
         Test_Schema_Request_Cookies:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
+          fastapi: v2.4.0.dev1
         Test_Schema_Request_Headers:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
+          fastapi: v2.4.0.dev1
         Test_Schema_Request_Path_Parameters:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
+          fastapi: v2.4.0.dev1
         Test_Schema_Request_Query_Parameters:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
+          fastapi: v2.4.0.dev1
         Test_Schema_Response_Body:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
+          fastapi: v2.4.0.dev1
         Test_Schema_Response_Headers:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
+          fastapi: v2.4.0.dev1
     iast/:
       sink/:
         test_command_injection.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -12,49 +12,49 @@ tests/:
           django-poc: v2.4.0.dev
           flask-poc: v2.4.0.dev
           python3.12: v2.4.0.dev
-          fastapi: v2.4.0.dev1
+          fastapi: v2.5.0.dev1
         Test_Schema_Request_Body:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.4.0.dev1
+          fastapi: v2.5.0.dev1
         Test_Schema_Request_Cookies:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.4.0.dev1
+          fastapi: v2.5.0.dev1
         Test_Schema_Request_Headers:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.4.0.dev1
+          fastapi: v2.5.0.dev1
         Test_Schema_Request_Path_Parameters:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.4.0.dev1
+          fastapi: v2.5.0.dev1
         Test_Schema_Request_Query_Parameters:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.4.0.dev1
+          fastapi: v2.5.0.dev1
         Test_Schema_Response_Body:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.4.0.dev1
+          fastapi: v2.5.0.dev1
         Test_Schema_Response_Headers:
           '*': missing_feature
           django-poc: v2.1.0.dev
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.4.0.dev1
+          fastapi: v2.5.0.dev1
     iast/:
       sink/:
         test_command_injection.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -10,51 +10,51 @@ tests/:
         Test_Scanners:
           '*': missing_feature
           django-poc: v2.4.0.dev
+          fastapi: v2.5.0.dev1
           flask-poc: v2.4.0.dev
           python3.12: v2.4.0.dev
-          fastapi: v2.5.0.dev1
         Test_Schema_Request_Body:
           '*': missing_feature
           django-poc: v2.1.0.dev
+          fastapi: v2.5.0.dev1
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.5.0.dev1
         Test_Schema_Request_Cookies:
           '*': missing_feature
           django-poc: v2.1.0.dev
+          fastapi: v2.5.0.dev1
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.5.0.dev1
         Test_Schema_Request_Headers:
           '*': missing_feature
           django-poc: v2.1.0.dev
+          fastapi: v2.5.0.dev1
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.5.0.dev1
         Test_Schema_Request_Path_Parameters:
           '*': missing_feature
           django-poc: v2.1.0.dev
+          fastapi: v2.5.0.dev1
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.5.0.dev1
         Test_Schema_Request_Query_Parameters:
           '*': missing_feature
           django-poc: v2.1.0.dev
+          fastapi: v2.5.0.dev1
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.5.0.dev1
         Test_Schema_Response_Body:
           '*': missing_feature
           django-poc: v2.1.0.dev
+          fastapi: v2.5.0.dev1
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.5.0.dev1
         Test_Schema_Response_Headers:
           '*': missing_feature
           django-poc: v2.1.0.dev
+          fastapi: v2.5.0.dev1
           flask-poc: v2.1.0.dev
           python3.12: v2.1.0.dev
-          fastapi: v2.5.0.dev1
     iast/:
       sink/:
         test_command_injection.py:

--- a/utils/build/docker/python/install_ddtrace.sh
+++ b/utils/build/docker/python/install_ddtrace.sh
@@ -15,8 +15,9 @@ elif [ $(ls python-load-from-pip | wc -l) = 1 ]; then
     echo "Install ddtrace from $(cat python-load-from-pip)"
     pip install "$(cat python-load-from-pip)"
 elif [ $(ls *.whl | wc -l) = 0 ]; then
-    echo "Install ddtrace from pypi"
-    pip install ddtrace
+    echo "Install ddtrace from pypi@"
+    # pip install ddtrace
+    pip install git+https://github.com/Datadog/dd-trace-py.git@main
 else
     echo "ERROR: Found several wheel files in binaries/, abort."
     exit 1

--- a/utils/build/docker/python/install_ddtrace.sh
+++ b/utils/build/docker/python/install_ddtrace.sh
@@ -15,9 +15,8 @@ elif [ $(ls python-load-from-pip | wc -l) = 1 ]; then
     echo "Install ddtrace from $(cat python-load-from-pip)"
     pip install "$(cat python-load-from-pip)"
 elif [ $(ls *.whl | wc -l) = 0 ]; then
-    echo "Install ddtrace from pypi@"
-    # pip install ddtrace
-    pip install git+https://github.com/Datadog/dd-trace-py.git@main
+    echo "Install ddtrace from pypi"
+    pip install ddtrace
 else
     echo "ERROR: Found several wheel files in binaries/, abort."
     exit 1


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/dd-trace-py/pull/7954 add api security support for fastapi.
This PR activates the tests for the corresponding weblog (PR7954 is now merged)

## Changes

Also fix a fastapi endpoint to accept urlencoded payload.

Add an `ANY` value for api sec tests to match any value.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
