### PR TITLE
OnBoarding tests: allow install datadog-apm-inject from file

### DIFF
--- a/tests/onboarding/infra_provision/includes/provision_lib_injection_host_manual.yml
+++ b/tests/onboarding/infra_provision/includes/provision_lib_injection_host_manual.yml
@@ -2,20 +2,60 @@
 - os_type: linux
   os_distro: deb
   copy_files:
+      - name: copy-binaries
+        local_path: binaries/
+
       - name: copy-tracer-debug-config
         local_path: tests/onboarding/autoinjection/tracer_debug/debug_config.yaml
   command: |
-    sudo apt install -y -t $DD_deb_repo_name datadog-apm-inject datadog-apm-library-$DD_LANG
+
+    architecture=""
+    case $(uname -m) in
+        x86_64) architecture="amd64" ;;
+        aarch64) architecture="arm64" ;;
+    esac
+
+    if [ -e datadog-apm-inject_*_$architecture.deb ]
+    then
+        echo "Instaling datadog-apm-inject from local folder"
+        sudo apt install ./datadog-apm-inject_*_$architecture.deb
+    else
+        echo "Instaling datadog-apm-inject from remote repository"
+        sudo apt install -y -t $DD_deb_repo_name datadog-apm-inject
+    fi
+
+    #sudo apt install -y -t $DD_deb_repo_name datadog-apm-inject datadog-apm-library-$DD_LANG
+    sudo apt install -y -t $DD_deb_repo_name datadog-apm-library-$DD_LANG
     dd-host-install
     sudo cp debug_config.yaml /etc/datadog-agent/inject/debug_config.yaml
 
 - os_type: linux
   os_distro: rpm
   copy_files:
+      - name: copy-binaries
+        local_path: binaries/
+
       - name: copy-tracer-debug-config
         local_path: tests/onboarding/autoinjection/tracer_debug/debug_config.yaml
   command: | 
-    sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject datadog-apm-library-$DD_LANG
+
+    architecture=""
+    case $(uname -m) in
+        x86_64) architecture="x86_64" ;;
+        aarch64) architecture="aarch64" ;;
+    esac
+
+    if [ -e datadog-apm-inject-*.$architecture.rpm ]
+    then
+        echo "Instaling datadog-apm-inject from local folder"
+        sudo yum -y install --disablerepo="*" datadog-apm-inject-*.$architecture.rpm
+    else
+        echo "Instaling datadog-apm-inject from remote repository"
+        sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject
+    fi
+
+    #sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject datadog-apm-library-$DD_LANG
+    sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-library-$DD_LANG
     dd-host-install
     sudo cp debug_config.yaml /etc/datadog-agent/inject/debug_config.yaml
     echo "Verify package signature. Fails if it isn't V4"


### PR DESCRIPTION
## Motivation

Onboarding test tweaks in order to allow install datadog-apm-inject from files.
The idea behind this is to allow to incorporate these tests on auto_inject pipeline.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
