### PR TITLE
Add NodeJS to the Crossed Tracer integration tests

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -277,7 +277,10 @@ tests/:
       Test_Debugger_Probe_Statuses: irrelevant
   integrations/:
     test_crossed_integrations.py:
-      Test_PythonKafka: missing_feature
+      Test_PythonKafka:
+        '*': v0.1
+        express4-typescript: missing_feature (Endpoint not implemented)
+        nextjs: missing_feature (Endpoint not implemented)
     test_db_integrations_sql.py:
       Test_MsSql:
         '*': missing_feature

--- a/tests/integrations/test_crossed_integrations.py
+++ b/tests/integrations/test_crossed_integrations.py
@@ -24,14 +24,13 @@ class _PythonBuddy(_Weblog):
 @coverage.basic
 @features.kafkaspan_creationcontext_propagation_with_dd_trace_py
 class Test_PythonKafka:
-    """ Test kafka compatibility with datadog python tracer """
+    """Test kafka compatibility with datadog python tracer"""
 
     WEBLOG_TO_BUDDY_TOPIC = "Test_PythonKafka_weblog_to_buddy"
     BUDDY_TO_WEBLOG_TOPIC = "Test_PythonKafka_buddy_to_weblog"
 
     @classmethod
     def get_span(cls, interface, span_kind, topic):
-
         logger.debug(f"Trying to find traces with span kind: {span_kind} and topic: {topic} in {interface}")
 
         for data, trace in interface.get_traces():
@@ -50,7 +49,7 @@ class Test_PythonKafka:
 
     @staticmethod
     def get_topic(span) -> str | None:
-        """ Extracts the topic from a span by trying various fields """
+        """Extracts the topic from a span by trying various fields"""
         topic = span["meta"].get("kafka.topic")  # this is in python
         if topic is None:
             if "Topic" in span["resource"]:
@@ -63,8 +62,8 @@ class Test_PythonKafka:
 
     def setup_produce(self):
         """
-            send request A to weblog : this request will produce a kafka message
-            send request B to python buddy, this request will consume kafka message
+        send request A to weblog : this request will produce a kafka message
+        send request B to python buddy, this request will consume kafka message
         """
 
         python_buddy = _PythonBuddy()
@@ -73,7 +72,7 @@ class Test_PythonKafka:
         self.consume_response = python_buddy.get("/kafka/consume", params={"topic": self.WEBLOG_TO_BUDDY_TOPIC})
 
     def test_produce(self):
-        """ Check that a message produced to kafka is correctly ingested by a Datadog python tracer"""
+        """Check that a message produced to kafka is correctly ingested by a Datadog python tracer"""
 
         assert self.production_response.status_code == 200
 
@@ -84,10 +83,18 @@ class Test_PythonKafka:
             topic=self.WEBLOG_TO_BUDDY_TOPIC,
         )
 
-    @missing_feature(library="nodejs", reason="Expected to fail, one end is always Python which does not currently propagate context")
-    @missing_feature(library="python", reason="Expected to fail, one end is always Python which does not currently propagate context")
-    @missing_feature(library="java", reason="Expected to fail, one end is always Python which does not currently propagate context")
-    @missing_feature(library="golang", reason="Expected to fail, one end is always Python which does not currently propagate context")
+    @missing_feature(
+        library="nodejs", reason="Expected to fail, one end is always Python which does not currently propagate context"
+    )
+    @missing_feature(
+        library="python", reason="Expected to fail, one end is always Python which does not currently propagate context"
+    )
+    @missing_feature(
+        library="java", reason="Expected to fail, one end is always Python which does not currently propagate context"
+    )
+    @missing_feature(
+        library="golang", reason="Expected to fail, one end is always Python which does not currently propagate context"
+    )
     def test_produce_trace_equality(self):
         """This test relies on the setup for produce, it currently cannot be run on its own"""
         producer_span = self.get_span(interfaces.library, span_kind="producer", topic=self.WEBLOG_TO_BUDDY_TOPIC)
@@ -100,11 +107,11 @@ class Test_PythonKafka:
 
     def setup_consume(self):
         """
-            send request A to python buddy : this request will produce a kafka message
-            send request B to weblog, this request will consume kafka message
+        send request A to python buddy : this request will produce a kafka message
+        send request B to weblog, this request will consume kafka message
 
-            request A: GET /python_buddy/produce_kafka_message
-            request B: GET /weblog/consume_kafka_message 
+        request A: GET /python_buddy/produce_kafka_message
+        request B: GET /weblog/consume_kafka_message
         """
         python_buddy = _PythonBuddy()
 
@@ -112,7 +119,7 @@ class Test_PythonKafka:
         self.consume_response = weblog.get("/kafka/consume", params={"topic": self.BUDDY_TO_WEBLOG_TOPIC})
 
     def test_consume(self):
-        """ Check that a message by an app instrumented by a Datadog python tracer is correctly ingested """
+        """Check that a message by an app instrumented by a Datadog python tracer is correctly ingested"""
 
         assert self.production_response.status_code == 200
         assert self.consume_response.status_code == 200
@@ -124,10 +131,18 @@ class Test_PythonKafka:
             topic=self.BUDDY_TO_WEBLOG_TOPIC,
         )
 
-    @missing_feature(library="nodejs", reason="Expected to fail, one end is always Python which does not currently propagate context")
-    @missing_feature(library="python", reason="Expected to fail, one end is always Python which does not currently propagate context")
-    @missing_feature(library="java", reason="Expected to fail, one end is always Python which does not currently propagate context")
-    @missing_feature(library="golang", reason="Expected to fail, one end is always Python which does not currently propagate context")
+    @missing_feature(
+        library="nodejs", reason="Expected to fail, one end is always Python which does not currently propagate context"
+    )
+    @missing_feature(
+        library="python", reason="Expected to fail, one end is always Python which does not currently propagate context"
+    )
+    @missing_feature(
+        library="java", reason="Expected to fail, one end is always Python which does not currently propagate context"
+    )
+    @missing_feature(
+        library="golang", reason="Expected to fail, one end is always Python which does not currently propagate context"
+    )
     def test_consume_trace_equality(self):
         """This test relies on the setup for consume, it currently cannot be run on its own"""
         producer_span = self.get_span(interfaces.python_buddy, span_kind="producer", topic=self.BUDDY_TO_WEBLOG_TOPIC)
@@ -140,8 +155,8 @@ class Test_PythonKafka:
 
     def validate_kafka_spans(self, producer_interface, consumer_interface, topic):
         """
-            Validates production/consumption of kafka message.
-            It works the same for both test_produce and test_consume
+        Validates production/consumption of kafka message.
+        It works the same for both test_produce and test_consume
         """
 
         # Check that the producer did not created any consumer span

--- a/tests/integrations/test_crossed_integrations.py
+++ b/tests/integrations/test_crossed_integrations.py
@@ -84,10 +84,10 @@ class Test_PythonKafka:
             topic=self.WEBLOG_TO_BUDDY_TOPIC,
         )
 
-    @missing_feature(library="python")
-    @missing_feature(library="java")
-    @missing_feature(library="nodejs")
-    @missing_feature(library="golang")
+    @missing_feature(library="nodejs", reason="Expected to fail, one end is always Python which does not currently propagate context")
+    @missing_feature(library="python", reason="Expected to fail, one end is always Python which does not currently propagate context")
+    @missing_feature(library="java", reason="Expected to fail, one end is always Python which does not currently propagate context")
+    @missing_feature(library="golang", reason="Expected to fail, one end is always Python which does not currently propagate context")
     def test_produce_trace_equality(self):
         """This test relies on the setup for produce, it currently cannot be run on its own"""
         producer_span = self.get_span(interfaces.library, span_kind="producer", topic=self.WEBLOG_TO_BUDDY_TOPIC)
@@ -124,10 +124,10 @@ class Test_PythonKafka:
             topic=self.BUDDY_TO_WEBLOG_TOPIC,
         )
 
-    @missing_feature(library="nodejs")
-    @missing_feature(library="python")
-    @missing_feature(library="java")
-    @missing_feature(library="golang")
+    @missing_feature(library="nodejs", reason="Expected to fail, one end is always Python which does not currently propagate context")
+    @missing_feature(library="python", reason="Expected to fail, one end is always Python which does not currently propagate context")
+    @missing_feature(library="java", reason="Expected to fail, one end is always Python which does not currently propagate context")
+    @missing_feature(library="golang", reason="Expected to fail, one end is always Python which does not currently propagate context")
     def test_consume_trace_equality(self):
         """This test relies on the setup for consume, it currently cannot be run on its own"""
         producer_span = self.get_span(interfaces.python_buddy, span_kind="producer", topic=self.BUDDY_TO_WEBLOG_TOPIC)

--- a/tests/integrations/test_crossed_integrations.py
+++ b/tests/integrations/test_crossed_integrations.py
@@ -76,7 +76,6 @@ class Test_PythonKafka:
         """ Check that a message produced to kafka is correctly ingested by a Datadog python tracer"""
 
         assert self.production_response.status_code == 200
-        # assert self.consume_response.status_code == 200
 
         # The weblog is the producer, the buddy is the consumer
         self.validate_kafka_spans(
@@ -87,6 +86,7 @@ class Test_PythonKafka:
 
     @missing_feature(library="python")
     @missing_feature(library="java")
+    @missing_feature(library="nodejs")
     @missing_feature(library="golang")
     def test_produce_trace_equality(self):
         """This test relies on the setup for produce, it currently cannot be run on its own"""
@@ -124,6 +124,7 @@ class Test_PythonKafka:
             topic=self.BUDDY_TO_WEBLOG_TOPIC,
         )
 
+    @missing_feature(library="nodejs")
     @missing_feature(library="python")
     @missing_feature(library="java")
     @missing_feature(library="golang")

--- a/utils/build/docker/nodejs/express4/app.js
+++ b/utils/build/docker/nodejs/express4/app.js
@@ -198,7 +198,7 @@ app.get('/kafka/produce', (req, res) => {
     await admin.connect()
     await producer.connect()
     await admin.createTopics({
-      waitForLeaders: true,
+      waitForLeaders: true,  // While the topic already exists we use this to wait for leadership election to finish
       topics: [
         { topic }
       ]

--- a/utils/build/docker/nodejs/express4/app.js
+++ b/utils/build/docker/nodejs/express4/app.js
@@ -198,7 +198,7 @@ app.get('/kafka/produce', (req, res) => {
     await admin.connect()
     await producer.connect()
     await admin.createTopics({
-      waitForLeaders: true,  // While the topic already exists we use this to wait for leadership election to finish
+      waitForLeaders: true, // While the topic already exists we use this to wait for leadership election to finish
       topics: [
         { topic }
       ]
@@ -236,7 +236,7 @@ app.get('/kafka/consume', (req, res) => {
     const consumer = kafka.consumer({ groupId: 'testgroup1' })
 
     await consumer.connect()
-    await consumer.subscribe({ topic: topic, fromBeginning: true })
+    await consumer.subscribe({ topic, fromBeginning: true })
 
     await consumer.run({
       eachMessage: ({ messageTopic, messagePartition, message }) => {


### PR DESCRIPTION

## Motivation

This request expands the crossed-tracer integration tests to include NodeJS

## Changes

This change adds the 'produce' and 'consume' endpoints to the express4 integration in support of the crossed tracer integration tests.  These endpoints are used to produce/consume from Kafka queues.



## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [x] A scenario is added (or removed)?
    * [x] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [x] Once merged, add (or remove) it in system-test-dasboard nightly
