### PR TITLE
go: uds-echo: tag API Sec cookies schema test as bug

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -15,7 +15,7 @@ tests/:
         Test_Schema_Request_Cookies:
           '*': v1.60.0-dev
           net-http: irrelevant (net-http doesn't handle path params)        
-          uds-echo: bug
+          uds-echo: bug (APPSEC-18224)
         Test_Schema_Request_FormUrlEncoded_Body: missing_feature
         Test_Schema_Request_Headers:
           '*': v1.60.0-dev

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -15,6 +15,7 @@ tests/:
         Test_Schema_Request_Cookies:
           '*': v1.60.0-dev
           net-http: irrelevant (net-http doesn't handle path params)        
+          uds-echo: bug
         Test_Schema_Request_FormUrlEncoded_Body: missing_feature
         Test_Schema_Request_Headers:
           '*': v1.60.0-dev


### PR DESCRIPTION
## Motivation

This test is failing. Disabling it and logging APPSEC-18224 to investigate.

## Changes

Mark API Security Test_Schema_Request_Cookies as bug for uds-echo in the golang manifest

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
