### PR TITLE
[dotnet] IAST TrustBoundaryViolation implementation

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -44,7 +44,7 @@ tests/:
         test_ssrf.py:
           TestSSRF: v2.36.0
         test_trust_boundary_violation.py:
-          Test_TrustBoundaryViolation: missing_feature
+          Test_TrustBoundaryViolation: v2.43.0
         test_unvalidated_redirect.py:
           TestUnvalidatedHeader: missing_feature
           TestUnvalidatedRedirect: missing_feature

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -96,7 +96,11 @@ class BaseSinkTestWithoutTelemetry:
             assert self.insecure_endpoint is not None, f"{self}.insecure_endpoint must not be None"
 
             self.__class__.insecure_request = weblog.request(
-                method=self.http_method, path=self.insecure_endpoint, params=self.params, data=self.data, headers=self.headers
+                method=self.http_method,
+                path=self.insecure_endpoint,
+                params=self.params,
+                data=self.data,
+                headers=self.headers,
             )
 
         self.insecure_request = self.__class__.insecure_request
@@ -120,7 +124,11 @@ class BaseSinkTestWithoutTelemetry:
             assert isinstance(self.secure_endpoint, str), f"Please set {self}.secure_endpoint"
 
             self.__class__.insecure_request = weblog.request(
-                method=self.http_method, path=self.secure_endpoint, params=self.params, data=self.data, headers=self.headers
+                method=self.http_method,
+                path=self.secure_endpoint,
+                params=self.params,
+                data=self.data,
+                headers=self.headers,
             )
 
         self.secure_request = self.__class__.secure_request

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -123,7 +123,7 @@ class BaseSinkTestWithoutTelemetry:
             assert self.secure_endpoint is not None, f"Please set {self}.secure_endpoint"
             assert isinstance(self.secure_endpoint, str), f"Please set {self}.secure_endpoint"
 
-            self.__class__.insecure_request = weblog.request(
+            self.__class__.secure_request = weblog.request(
                 method=self.http_method,
                 path=self.secure_endpoint,
                 params=self.params,

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -68,6 +68,7 @@ class BaseSinkTestWithoutTelemetry:
     http_method = None
     insecure_endpoint = None
     secure_endpoint = None
+    params = None
     data = None
     headers = None
     location_map = None
@@ -94,14 +95,9 @@ class BaseSinkTestWithoutTelemetry:
         if self.__class__.insecure_request is None:
             assert self.insecure_endpoint is not None, f"{self}.insecure_endpoint must not be None"
 
-            if self.http_method == "GET":
-                self.__class__.insecure_request = weblog.request(
-                    method=self.http_method, path=self.insecure_endpoint, params=self.data, headers=self.headers
-                )
-            else:
-                self.__class__.insecure_request = weblog.request(
-                    method=self.http_method, path=self.insecure_endpoint, data=self.data, headers=self.headers
-                )
+            self.__class__.insecure_request = weblog.request(
+                method=self.http_method, path=self.insecure_endpoint, params=self.params, data=self.data, headers=self.headers
+            )
 
         self.insecure_request = self.__class__.insecure_request
 
@@ -123,14 +119,9 @@ class BaseSinkTestWithoutTelemetry:
             assert self.secure_endpoint is not None, f"Please set {self}.secure_endpoint"
             assert isinstance(self.secure_endpoint, str), f"Please set {self}.secure_endpoint"
 
-            if self.http_method == "GET":
-                self.__class__.insecure_request = weblog.request(
-                    method=self.http_method, path=self.secure_endpoint, params=self.data, headers=self.headers
-                )
-            else:
-                self.__class__.insecure_request = weblog.request(
-                    method=self.http_method, path=self.secure_endpoint, data=self.data, headers=self.headers
-                )
+            self.__class__.insecure_request = weblog.request(
+                method=self.http_method, path=self.secure_endpoint, params=self.params, data=self.data, headers=self.headers
+            )
 
         self.secure_request = self.__class__.secure_request
 

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -94,9 +94,14 @@ class BaseSinkTestWithoutTelemetry:
         if self.__class__.insecure_request is None:
             assert self.insecure_endpoint is not None, f"{self}.insecure_endpoint must not be None"
 
-            self.__class__.insecure_request = weblog.request(
-                method=self.http_method, path=self.insecure_endpoint, data=self.data, headers=self.headers
-            )
+            if self.http_method == "GET":
+                self.__class__.insecure_request = weblog.request(
+                    method=self.http_method, path=self.insecure_endpoint, params=self.data, headers=self.headers
+                )
+            else:
+                self.__class__.insecure_request = weblog.request(
+                    method=self.http_method, path=self.insecure_endpoint, data=self.data, headers=self.headers
+                )
 
         self.insecure_request = self.__class__.insecure_request
 
@@ -117,9 +122,15 @@ class BaseSinkTestWithoutTelemetry:
         if self.__class__.secure_request is None:
             assert self.secure_endpoint is not None, f"Please set {self}.secure_endpoint"
             assert isinstance(self.secure_endpoint, str), f"Please set {self}.secure_endpoint"
-            self.__class__.secure_request = weblog.request(
-                method=self.http_method, path=self.secure_endpoint, data=self.data, headers=self.headers
-            )
+
+            if self.http_method == "GET":
+                self.__class__.insecure_request = weblog.request(
+                    method=self.http_method, path=self.secure_endpoint, params=self.data, headers=self.headers
+                )
+            else:
+                self.__class__.insecure_request = weblog.request(
+                    method=self.http_method, path=self.secure_endpoint, data=self.data, headers=self.headers
+                )
 
         self.secure_request = self.__class__.secure_request
 

--- a/tests/appsec/iast/sink/test_trust_boundary_violation.py
+++ b/tests/appsec/iast/sink/test_trust_boundary_violation.py
@@ -14,7 +14,7 @@ class Test_TrustBoundaryViolation(BaseSinkTest):
     http_method = "GET"
     insecure_endpoint = "/iast/trust-boundary-violation/test_insecure"
     secure_endpoint = "/iast/trust-boundary-violation/test_secure"
-    data = {"username": "shaquille_oatmeal", "password": "123456"}
+    params = {"username": "shaquille_oatmeal", "password": "123456"}
     location_map = {"nodejs": "iast/index.js"}
 
     @missing_feature(library="nodejs", reason="Metrics implemented")

--- a/tests/appsec/iast/sink/test_trust_boundary_violation.py
+++ b/tests/appsec/iast/sink/test_trust_boundary_violation.py
@@ -19,6 +19,7 @@ class Test_TrustBoundaryViolation(BaseSinkTest):
 
     @missing_feature(library="nodejs", reason="Metrics implemented")
     @missing_feature(library="java", reason="Metrics implemented")
+    @missing_feature(library="dotnet", reason="Metrics implemented")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -386,17 +386,31 @@ namespace weblog
         }
 
         [HttpGet("weak_randomness/test_insecure")]
-        public IActionResult test_insecure_weakRandomness(string user)
+        public IActionResult test_insecure_weakRandomness()
         {
             return Content("Weak random number: " + (new Random()).Next().ToString(), "text/html");
         }
 
         [HttpGet("weak_randomness/test_secure")]
-        public IActionResult test_secure_weakRandomness(string user)
+        public IActionResult test_secure_weakRandomness()
         {
             return Content("Secure random number: " + RandomNumberGenerator.GetInt32(100).ToString(), "text/html");
         }
+
+        [HttpGet("trust-boundary-violation/test_insecure")]
+        public IActionResult test_insecure_trustBoundaryViolation([FromQuery]string username, [FromQuery]string password)
+        {
+            HttpContext.Session.SetString("UserData", username);
+            return Content("Parameter added to session. User : " + HttpContext.Session.GetString("UserData"));
+        }
+
+        [HttpGet("trust-boundary-violation/test_secure")]
+        public IActionResult test_secure_trustBoundaryViolation([FromQuery]string username, [FromQuery]string password)
+        {
+            return Content("Nothing added to session");
+        }
         
+
         [HttpGet("source/cookievalue/test")]
         public IActionResult test_cookie_value()
         {

--- a/utils/build/docker/dotnet/Startup.cs
+++ b/utils/build/docker/dotnet/Startup.cs
@@ -13,13 +13,14 @@ namespace weblog
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSession();
             services.AddRazorPages();
-           services.AddControllers(options =>
+            services.AddControllers(options =>
             {
                 options.ModelBinderProviders.Insert(0, new ModelBinderSwitcherProvider());
             }).AddXmlSerializerFormatters();
            
-           var identityBuilder = services.AddIdentity<IdentityUser, IdentityRole>(
+            var identityBuilder = services.AddIdentity<IdentityUser, IdentityRole>(
                o =>
                {
                    o.Password.RequireDigit = false;
@@ -43,6 +44,7 @@ namespace weblog
 
             Sql.Setup();
 
+            app.UseSession();
             app.UseRouting();
             app.UseAuthorization();
             app.UseAuthentication();


### PR DESCRIPTION
IAST TrustBoundaryViolation implementation for dotnet

## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

Set data as params when creating the secure and insecure requests when GET method is selected

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
