### PR TITLE
Add Ruby to the Crossed Tracer integration tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -215,6 +215,7 @@ tests/:
         sinatra14: missing_feature (Only requires one server -  rails70)
         sinatra20: missing_feature (Only requires one server -  rails70)
         sinatra21: missing_feature (Only requires one server -  rails70)
+        uds-sinatra: missing_feature (We do not support authentication framework for sinatra or rack)
     test_db_integrations_sql.py:
       Test_MsSql: missing_feature
       Test_MySql: missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -200,7 +200,21 @@ tests/:
       Test_Debugger_Probe_Statuses: irrelevant
   integrations/:
     test_crossed_integrations.py:
-      Test_PythonKafka: missing_feature
+      Test_PythonKafka:
+        '*': v0.1
+        rails32: missing_feature (Only requires one server -  rails70)
+        rails40: missing_feature (Only requires one server -  rails70)
+        rails41: missing_feature (Only requires one server -  rails70)
+        rails42: missing_feature (Only requires one server -  rails70)
+        rails50: missing_feature (Only requires one server -  rails70)
+        rails51: missing_feature (Only requires one server -  rails70)
+        rails52: missing_feature (Only requires one server -  rails70)
+        rails60: missing_feature (Only requires one server -  rails70)
+        rails61: missing_feature (Only requires one server -  rails70)
+        sinatra14: missing_feature (Only requires one server -  rails70)
+        sinatra20: missing_feature (Only requires one server -  rails70)
+        sinatra21: missing_feature (Only requires one server -  rails70)
+        rack: missing_feature (Only requires one server -  rails70)
     test_db_integrations_sql.py:
       Test_MsSql: missing_feature
       Test_MySql: missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -202,6 +202,7 @@ tests/:
     test_crossed_integrations.py:
       Test_PythonKafka:
         '*': v0.1
+        rack: missing_feature (Only requires one server -  rails70)
         rails32: missing_feature (Only requires one server -  rails70)
         rails40: missing_feature (Only requires one server -  rails70)
         rails41: missing_feature (Only requires one server -  rails70)
@@ -214,7 +215,6 @@ tests/:
         sinatra14: missing_feature (Only requires one server -  rails70)
         sinatra20: missing_feature (Only requires one server -  rails70)
         sinatra21: missing_feature (Only requires one server -  rails70)
-        rack: missing_feature (Only requires one server -  rails70)
     test_db_integrations_sql.py:
       Test_MsSql: missing_feature
       Test_MySql: missing_feature

--- a/tests/integrations/test_crossed_integrations.py
+++ b/tests/integrations/test_crossed_integrations.py
@@ -95,6 +95,9 @@ class Test_PythonKafka:
     @missing_feature(
         library="golang", reason="Expected to fail, one end is always Python which does not currently propagate context"
     )
+    @missing_feature(
+        library="ruby", reason="Expected to fail, one end is always Python which does not currently propagate context"
+    )
     def test_produce_trace_equality(self):
         """This test relies on the setup for produce, it currently cannot be run on its own"""
         producer_span = self.get_span(interfaces.library, span_kind="producer", topic=self.WEBLOG_TO_BUDDY_TOPIC)
@@ -142,6 +145,9 @@ class Test_PythonKafka:
     )
     @missing_feature(
         library="golang", reason="Expected to fail, one end is always Python which does not currently propagate context"
+    )
+    @missing_feature(
+        library="ruby", reason="Expected to fail, one end is always Python which does not currently propagate context"
     )
     def test_consume_trace_equality(self):
         """This test relies on the setup for consume, it currently cannot be run on its own"""

--- a/utils/build/docker/ruby/rails70/Gemfile
+++ b/utils/build/docker/ruby/rails70/Gemfile
@@ -27,6 +27,9 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
+# Talk with Kafka for propagation tests
+gem "ruby-kafka"
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
@@ -1,4 +1,5 @@
 require 'datadog/kit/appsec/events'
+require 'kafka'
 
 class SystemTestController < ApplicationController
   skip_before_action :verify_authenticity_token
@@ -168,4 +169,48 @@ class SystemTestController < ApplicationController
 
     render plain: 'Hello, world!'
   end
+
+
+  def kafka_produce
+    kafka_client = Kafka.new(["kafka:9092"], client_id: "system-tests-client-producer")
+    topic = request.params["topic"]
+    stop = false
+    while stop == false
+      begin
+        Datadog::Tracing.trace('kafka_produce') do |span|
+          kafka_client.deliver_message("Hello, world!", topic: topic)
+          # This has to be done manually for now, because ruby does not add the topic
+          # to the span at all
+          span.set_tag("span.kind", "producer")
+          span.set_tag("kafka.topic", topic)
+          stop = true
+        end
+      rescue Kafka::LeaderNotAvailable
+      end
+    end
+
+    render plain: "Done"
+  end
+
+
+  def kafka_consume
+    kafka_client = Kafka.new(["kafka:9092"], client_id: "system-tests-client-consumer")
+    topic = request.params["topic"]
+    consumer = kafka_client.consumer(group_id: "system-tests-group")
+    consumer.subscribe(topic)
+    begin
+      consumer.each_message do |message|
+        if not message.nil?
+          break
+        end
+      end
+    rescue Exception => e
+      puts "An error has occurred while consuming messages from Kafka: #{e}"
+    ensure
+      consumer.stop
+    end
+
+    render plain: "Done"
+  end
+
 end

--- a/utils/build/docker/ruby/rails70/config/routes.rb
+++ b/utils/build/docker/ruby/rails70/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
   get  '/waf/*other' => 'system_test#waf'
   post '/waf/*other' => 'system_test#waf'
 
+  get '/kafka/produce' => 'system_test#kafka_produce'
+  get '/kafka/consume' => 'system_test#kafka_consume'
+
   get '/params/:value' => 'system_test#handle_path_params'
   get '/spans' => 'system_test#generate_spans'
   get '/status' => 'system_test#status'


### PR DESCRIPTION
This change adds the 'produce' and 'consume' endpoints to the express4 integration in support of the crossed tracer integration tests.  These endpoints are used to produce/consume from Kafka queues.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
