### PR TITLE
OnBoarding: Push results to FPD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
   - java_tracer
   - python_tracer
   - dotnet_tracer
-  #- parse_results
+  - parse_results
 
 .base_job_onboarding:
   only:
@@ -146,7 +146,7 @@ onboarding_ruby:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY}
 
-.onboarding_parse_results:
+onboarding_parse_results:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
   tags: ["arch:amd64"]
   stage: parse_results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ allow_no_feature_nodes = [
     "tests/apm_tracing_e2e/test_otel.py",
     "tests/apm_tracing_e2e/test_single_span.py",
     "tests/apm_tracing_e2e/test_smoke.py",
-    "tests/onboarding/test_onboarding_install.py",
     "tests/otel_tracing_e2e/test_e2e.py",
     "tests/parametric/test_128_bit_traceids.py",
     "tests/parametric/test_headers_none.py",

--- a/tests/onboarding/test_onboarding_install.py
+++ b/tests/onboarding/test_onboarding_install.py
@@ -2,9 +2,8 @@ import os
 
 import pytest
 
-from utils import scenarios, context
+from utils import scenarios, context, features
 from utils.tools import logger
-
 from utils.onboarding.weblog_interface import make_get_request
 from utils.onboarding.backend_interface import wait_backend_trace_id
 from utils.onboarding.wait_for_tcp_port import wait_for_port
@@ -44,21 +43,25 @@ class _OnboardingUninstallBaseTest:
             pass
 
 
+@features.container_auto_instrumentation
 @scenarios.onboarding_container_install_manual
 class TestOnboardingInstallManualContainer(_OnboardingInstallBaseTest):
     pass
 
 
+@features.host_auto_instrumentation
 @scenarios.onboarding_host_install_manual
 class TestOnboardingInstallManualHost(_OnboardingInstallBaseTest):
     pass
 
 
+@features.host_auto_instrumentation
 @scenarios.onboarding_host_install_script
 class TestOnboardingInstallScriptHost(_OnboardingInstallBaseTest):
     pass
 
 
+@features.container_auto_instrumentation
 @scenarios.onboarding_container_install_script
 class TestOnboardingInstallScriptContainer(_OnboardingInstallBaseTest):
     pass
@@ -69,11 +72,13 @@ class TestOnboardingInstallScriptContainer(_OnboardingInstallBaseTest):
 #########################
 
 
+@features.container_auto_instrumentation
 @scenarios.onboarding_container_uninstall
 class TestOnboardingUninstallContainer(_OnboardingUninstallBaseTest):
     pass
 
 
+@features.host_auto_instrumentation
 @scenarios.onboarding_host_uninstall
 class TestOnboardingUninstallHost(_OnboardingUninstallBaseTest):
     pass


### PR DESCRIPTION
## Motivation

Enable gitlab job that pushes the tests results to system-tests-dashboard
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
