### PR TITLE
[dotnet] Unvalidated Redirect implementation

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -46,8 +46,8 @@ tests/:
         test_trust_boundary_violation.py:
           Test_TrustBoundaryViolation: v2.43.0
         test_unvalidated_redirect.py:
-          TestUnvalidatedHeader: missing_feature
-          TestUnvalidatedRedirect: missing_feature
+          TestUnvalidatedHeader: v2.44.0
+          TestUnvalidatedRedirect: v2.44.0
         test_unvalidated_redirect_forward.py:
           TestUnvalidatedForward: missing_feature
         test_weak_cipher.py:

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -410,6 +410,35 @@ namespace weblog
             return Content("Nothing added to session");
         }
         
+        [HttpPost("unvalidated_redirect/test_insecure_header")]
+        public IActionResult test_insecure_redirect_header([FromForm]string location)
+        {
+            Response.Headers["location"] = location;
+            return Content("Redirected to " + location);
+        }
+
+        [HttpPost("unvalidated_redirect/test_secure_header")]
+        public IActionResult test_secure_redirect_header()
+        {
+            var location = "http://dummy.location.com";
+            Response.Headers["location"] = location;
+            return Content("Redirected to " + location);
+        }
+
+        [HttpPost("unvalidated_redirect/test_insecure_redirect")]
+        public IActionResult test_insecure_redirect([FromForm]string location)
+        {
+            Response.Redirect(location);
+            return Content("Redirected to " + location);
+        }
+
+        [HttpPost("unvalidated_redirect/test_secure_redirect")]
+        public IActionResult test_secure_redirect()
+        {
+            var location = "http://dummy.location.com";
+            Response.Redirect(location);
+            return Content("Redirected to " + location);
+        }
 
         [HttpGet("source/cookievalue/test")]
         public IActionResult test_cookie_value()


### PR DESCRIPTION
## Motivation

Unvalidated Redirect implementation for dotnet

## Changes

Redirect method and Location header tests

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
