### PR TITLE
Debug flakyness otel_tracing_e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
     secrets: inherit
 
   main:
-    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     needs:
     - lint
@@ -610,9 +609,8 @@ jobs:
         path: artifact.tar.gz
 
   open-telemetry-automatic:
-    if: ${{ false }}  
     runs-on: ubuntu-latest
-    #if: needs.scenarios.outputs.run_open_telemetry == 'true' || needs.scenarios.outputs.run_integration == 'true'
+    if: needs.scenarios.outputs.run_open_telemetry == 'true' || needs.scenarios.outputs.run_integration == 'true'
     needs:
     - lint
     - test_the_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
     secrets: inherit
 
   main:
+    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     needs:
     - lint
@@ -609,8 +610,9 @@ jobs:
         path: artifact.tar.gz
 
   open-telemetry-automatic:
+    if: ${{ false }}  
     runs-on: ubuntu-latest
-    if: needs.scenarios.outputs.run_open_telemetry == 'true' || needs.scenarios.outputs.run_integration == 'true'
+    #if: needs.scenarios.outputs.run_open_telemetry == 'true' || needs.scenarios.outputs.run_integration == 'true'
     needs:
     - lint
     - test_the_test

--- a/tests/otel_tracing_e2e/_test_validator_trace.py
+++ b/tests/otel_tracing_e2e/_test_validator_trace.py
@@ -2,6 +2,7 @@
 
 import json
 import dictdiffer
+from utils.tools import logger
 
 # Validates traces from Agent, Collector and Backend intake OTLP ingestion paths are consistent
 def validate_all_traces(
@@ -96,6 +97,8 @@ def validate_spans_from_all_paths(spans_agent: tuple, spans_intake: tuple, spans
 
 
 def validate_span_fields(span1: dict, span2: dict, name1: str, name2: str):
+    logger.debug(f"Validate span fields. [{name1}]:[{span1}]")
+    logger.debug(f"Validate span fields. [{name2}]:[{span2}]")
     assert span1["start"] == span2["start"]
     assert span1["end"] == span2["end"]
     assert span1["duration"] == span2["duration"]

--- a/tests/otel_tracing_e2e/_test_validator_trace.py
+++ b/tests/otel_tracing_e2e/_test_validator_trace.py
@@ -121,6 +121,10 @@ KNOWN_UNMATCHED_METAS = [
     "_dd.p.dm",
     "_dd.agent_hostname",
     "_dd.ingestion_reason",  # this is replaced by `ddtags: ingestion_reason:otel` in the latest version
+    "_dd.install.id",
+    "_dd.install.time",
+    "_dd.install.type",
+    "_dd.p.tid",
 ]
 KNOWN_UNMATCHED_METRICS = [
     "_dd.agent_errors_sampler.target_tps",


### PR DESCRIPTION
## Motivation

There are random tests failures on the otel_tracing_e2e scenario.
This PR tries to debug and fix these failures.
@songy23 I'm not sure if I'm fixing the root cause, or just hiding it.

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
