### PR TITLE
Run OTel parametric tests for PHP

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -73,6 +73,8 @@ tests/:
       TestDynamicConfigV1: missing_feature
       TestDynamicConfigV2: missing_feature
     test_otel_span_methods.py: v0.94.0
+    test_otel_tracer.py: v0.94.0
+    test_otel_span_with_w3c.py: v0.94.0
     test_span_links.py: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.68.3 # TODO what is the earliest version?

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -72,9 +72,12 @@ tests/:
     test_dynamic_configuration.py:
       TestDynamicConfigV1: missing_feature
       TestDynamicConfigV2: missing_feature
-    test_otel_span_methods.py: v0.94.0
-    test_otel_tracer.py: v0.94.0
-    test_otel_span_with_w3c.py: v0.94.0
+    test_otel_span_methods.py:
+        Test_Otel_Span_Methods: v0.94.0
+    test_otel_span_with_w3c.py:
+        Test_Otel_Span_With_W3c: v0.94.0
+    test_otel_tracer.py:
+        Test_Otel_Tracer: v0.94.0
     test_span_links.py: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.68.3 # TODO what is the earliest version?

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -72,6 +72,7 @@ tests/:
     test_dynamic_configuration.py:
       TestDynamicConfigV1: missing_feature
       TestDynamicConfigV2: missing_feature
+    test_otel_span_methods.py: v0.94.0
     test_span_links.py: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.68.3 # TODO what is the earliest version?

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -72,7 +72,6 @@ tests/:
     test_dynamic_configuration.py:
       TestDynamicConfigV1: missing_feature
       TestDynamicConfigV2: missing_feature
-    test_otel_span_methods.py: missing_feature
     test_span_links.py: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.68.3 # TODO what is the earliest version?

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -375,9 +375,17 @@ class Test_Otel_Span_Methods:
                     span.end_span()
                     context = span.span_context()
                     assert context.get("trace_id") == parent.span_context().get("trace_id")
-                    # Some languages e.g. Nodejs using express need to return as a string value
-                    # due to 64-bit integers being too large.
-                    assert context.get("span_id") == "{:016x}".format(int(span.span_id))
+                    if (
+                        isinstance(span.span_id, str)
+                        and len(span.span_id) == 16
+                        and all(c in "0123456789abcdef" for c in span.span_id)
+                    ):
+                        # Some languages e.g. PHP return a hexadecimal span id
+                        assert context.get("span_id") == span.span_id
+                    else:
+                        # Some languages e.g. Nodejs using express need to return as a string value
+                        # due to 64-bit integers being too large.
+                        assert context.get("span_id") == "{:016x}".format(int(span.span_id))
                     assert context.get("trace_flags") == "01"
 
     @missing_feature(context.library <= "java@1.23.0", reason="Implemented in 1.24.0")

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -493,6 +493,7 @@ class Test_Otel_Span_Methods:
 
     @missing_feature(context.library < "java@1.25.0", reason="Implemented in 1.25.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @missing_feature(context.library <= "php@0.95.0", reason="Implemented in 0.96.0")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @pytest.mark.parametrize(
@@ -525,6 +526,7 @@ class Test_Otel_Span_Methods:
         reason="Ruby tracer decided to always set _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0",
     )
     @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @missing_feature(context.library <= "php@0.95.0", reason="Implemented in 0.96.0")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @pytest.mark.parametrize(
@@ -547,6 +549,7 @@ class Test_Otel_Span_Methods:
     @irrelevant(context.library == "java", reason="Choose to not implement Go parsing logic")
     @irrelevant(context.library == "ruby", reason="Choose to not implement Go parsing logic")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @missing_feature(context.library <= "php@0.95.0", reason="Implemented in 0.96.0")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @pytest.mark.parametrize(

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -104,6 +104,7 @@ class Test_Otel_Span_Methods:
         assert len(trace) == 1
 
         root_span = get_span(test_agent)
+        print(root_span["meta"])
 
         assert root_span["name"] == "producer"
         assert root_span["resource"] == "operation"
@@ -132,6 +133,13 @@ class Test_Otel_Span_Methods:
             assert root_span["meta"]["d_bool_val"] == "false"
             assert root_span["meta"]["array_val_int"] == "[10,20]"
             assert root_span["meta"]["array_val_double"] == "[10.1,20.2]"
+        elif context.library == "php":
+            assert root_span["meta"]["bool_val"] == "true"
+            assert root_span["meta"]["array_val_bool"] == "[true,false]"
+            assert root_span["meta"]["array_val_str"] == '["val1", "val2"]'
+            assert root_span["meta"]["d_bool_val"] == "false"
+            assert root_span["meta"]["array_val_int"] == "[10, 20]"
+            assert root_span["meta"]["array_val_double"] == "[10.1, 20.2]"
         else:
             assert root_span["meta"]["bool_val"] == "True"
             assert root_span["meta"]["array_val_bool"] == "[True, False]"

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -398,9 +398,8 @@ class Test_Otel_Span_Methods:
     @missing_feature(context.library == "python_http", reason="Not implemented")
     def test_otel_set_attributes_separately(self, test_agent, test_library):
         """
-            This test verifies retrieving the span context of a span
-            accordingly to the Otel API spec
-            (https://opentelemetry.io/docs/reference/specification/trace/api/#get-context)
+            This test verifies that setting attributes separately
+            behaves accordingly to the naming conventions
         """
         with test_library:
             with test_library.otel_start_span(name="operation", span_kind=SK_CLIENT) as span:
@@ -408,13 +407,13 @@ class Test_Otel_Span_Methods:
                 span.set_attributes({"messaging.operation": "Receive"})
                 span.end_span()
 
-            traces = test_agent.wait_for_num_traces(1)
-            trace = find_trace_by_root(traces, otel_span(name="operation"))
-            assert len(trace) == 1
+        traces = test_agent.wait_for_num_traces(1)
+        trace = find_trace_by_root(traces, otel_span(name="operation"))
+        assert len(trace) == 1
 
-            span = get_span(test_agent)
-            assert span["name"] == "kafka.receive"
-            assert span["resource"] == "operation"
+        span = get_span(test_agent)
+        assert span["name"] == "kafka.receive"
+        assert span["resource"] == "operation"
 
     @missing_feature(context.library < "java@1.24.1", reason="Implemented in 1.24.1")
     @missing_feature(context.library == "nodejs", reason="Not implemented")

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -73,6 +73,7 @@ class Test_Otel_Span_Methods:
     )
     @irrelevant(context.library >= "golang@v1.59.0.dev0", reason="New span naming introduced in v1.59.0")
     @irrelevant(context.library == "ruby", reason="Old array encoding no longer supported")
+    @irrelevant(context.library == "php", reason="Old array encoding no longer supported")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library <= "dotnet@2.41.0", reason="Implemented in 2.42.0")
     @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -110,7 +110,7 @@ class Test_Otel_Span_Methods:
 
         assert root_span["meta"]["str_val"] == "val"
         assert root_span["meta"]["str_val_empty"] == ""
-        if root_span["meta"]["language"] == "go":
+        if "language" in root_span["meta"] and root_span["meta"]["language"] == "go":
             # in line with the standard Datadog tracing library tags
             assert root_span["meta"]["bool_val"] == "true"
             assert root_span["meta"]["d_bool_val"] == "false"
@@ -118,14 +118,14 @@ class Test_Otel_Span_Methods:
             assert root_span["meta"]["array_val_str"] == "[val1 val2]"
             assert root_span["meta"]["array_val_int"] == "[10 20]"
             assert root_span["meta"]["array_val_double"] == "[10.1 20.2]"
-        elif root_span["meta"]["language"] == "jvm":
+        elif "language" in root_span["meta"] and root_span["meta"]["language"] == "jvm":
             assert root_span["meta"]["bool_val"] == "true"
             assert root_span["meta"]["array_val_bool"] == "[true, false]"
             assert root_span["meta"]["array_val_str"] == "[val1, val2]"
             assert root_span["meta"]["d_bool_val"] == "false"
             assert root_span["meta"]["array_val_int"] == "[10, 20]"
             assert root_span["meta"]["array_val_double"] == "[10.1, 20.2]"
-        elif root_span["meta"]["language"] == "dotnet":
+        elif "language" in root_span["meta"] and root_span["meta"]["language"] == "dotnet":
             assert root_span["meta"]["bool_val"] == "true"
             assert root_span["meta"]["array_val_bool"] == "[true,false]"
             assert root_span["meta"]["array_val_str"] == '["val1","val2"]'

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -135,11 +135,15 @@ class Test_Otel_Span_Methods:
             assert root_span["meta"]["array_val_double"] == "[10.1,20.2]"
         elif context.library == "php":
             assert root_span["meta"]["bool_val"] == "true"
-            assert root_span["meta"]["array_val_bool"] == "[true,false]"
-            assert root_span["meta"]["array_val_str"] == '["val1", "val2"]'
+            assert root_span["meta"]["array_val_bool.0"] == "true"
+            assert root_span["meta"]["array_val_bool.1"] == "false"
+            assert root_span["meta"]["array_val_str.0"] == "val1"
+            assert root_span["meta"]["array_val_str.1"] == "val2"
             assert root_span["meta"]["d_bool_val"] == "false"
-            assert root_span["meta"]["array_val_int"] == "[10, 20]"
-            assert root_span["meta"]["array_val_double"] == "[10.1, 20.2]"
+            assert root_span["metrics"]["array_val_int.0"] == 10
+            assert root_span["metrics"]["array_val_int.1"] == 20
+            assert root_span["metrics"]["array_val_double.0"] == 10.1
+            assert root_span["metrics"]["array_val_double.1"] == 20.2
         else:
             assert root_span["meta"]["bool_val"] == "True"
             assert root_span["meta"]["array_val_bool"] == "[True, False]"

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -104,7 +104,6 @@ class Test_Otel_Span_Methods:
         assert len(trace) == 1
 
         root_span = get_span(test_agent)
-        print(root_span["meta"])
 
         assert root_span["name"] == "producer"
         assert root_span["resource"] == "operation"

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -110,7 +110,7 @@ class Test_Otel_Span_Methods:
 
         assert root_span["meta"]["str_val"] == "val"
         assert root_span["meta"]["str_val_empty"] == ""
-        if "language" in root_span["meta"] and root_span["meta"]["language"] == "go":
+        if root_span["meta"]["language"] == "go":
             # in line with the standard Datadog tracing library tags
             assert root_span["meta"]["bool_val"] == "true"
             assert root_span["meta"]["d_bool_val"] == "false"
@@ -118,31 +118,20 @@ class Test_Otel_Span_Methods:
             assert root_span["meta"]["array_val_str"] == "[val1 val2]"
             assert root_span["meta"]["array_val_int"] == "[10 20]"
             assert root_span["meta"]["array_val_double"] == "[10.1 20.2]"
-        elif "language" in root_span["meta"] and root_span["meta"]["language"] == "jvm":
+        elif root_span["meta"]["language"] == "jvm":
             assert root_span["meta"]["bool_val"] == "true"
             assert root_span["meta"]["array_val_bool"] == "[true, false]"
             assert root_span["meta"]["array_val_str"] == "[val1, val2]"
             assert root_span["meta"]["d_bool_val"] == "false"
             assert root_span["meta"]["array_val_int"] == "[10, 20]"
             assert root_span["meta"]["array_val_double"] == "[10.1, 20.2]"
-        elif "language" in root_span["meta"] and root_span["meta"]["language"] == "dotnet":
+        elif root_span["meta"]["language"] == "dotnet":
             assert root_span["meta"]["bool_val"] == "true"
             assert root_span["meta"]["array_val_bool"] == "[true,false]"
             assert root_span["meta"]["array_val_str"] == '["val1","val2"]'
             assert root_span["meta"]["d_bool_val"] == "false"
             assert root_span["meta"]["array_val_int"] == "[10,20]"
             assert root_span["meta"]["array_val_double"] == "[10.1,20.2]"
-        elif context.library == "php":
-            assert root_span["meta"]["bool_val"] == "true"
-            assert root_span["meta"]["array_val_bool.0"] == "true"
-            assert root_span["meta"]["array_val_bool.1"] == "false"
-            assert root_span["meta"]["array_val_str.0"] == "val1"
-            assert root_span["meta"]["array_val_str.1"] == "val2"
-            assert root_span["meta"]["d_bool_val"] == "false"
-            assert root_span["metrics"]["array_val_int.0"] == 10
-            assert root_span["metrics"]["array_val_int.1"] == 20
-            assert root_span["metrics"]["array_val_double.0"] == 10.1
-            assert root_span["metrics"]["array_val_double.1"] == 20.2
         else:
             assert root_span["meta"]["bool_val"] == "True"
             assert root_span["meta"]["array_val_bool"] == "[True, False]"

--- a/tests/parametric/test_otel_span_with_w3c.py
+++ b/tests/parametric/test_otel_span_with_w3c.py
@@ -46,7 +46,6 @@ class Test_Otel_Span_With_W3c:
         assert root_span["duration"] == duration_ns
 
     @irrelevant(context.library == "cpp", reason="library does not implement OpenTelemetry")
-    @missing_feature(context.library == "php", reason="Not implemented")
     def test_otel_span_with_w3c_headers(self, test_agent, test_library):
         with test_library:
             with test_library.otel_start_span(

--- a/tests/parametric/test_otel_span_with_w3c.py
+++ b/tests/parametric/test_otel_span_with_w3c.py
@@ -18,7 +18,6 @@ pytestmark = pytest.mark.parametrize(
 @scenarios.parametric
 class Test_Otel_Span_With_W3c:
     @irrelevant(context.library == "cpp", reason="library does not implement OpenTelemetry")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="OTel resource naming implemented in 1.24.0")

--- a/tests/parametric/test_otel_tracer.py
+++ b/tests/parametric/test_otel_tracer.py
@@ -17,7 +17,6 @@ pytestmark = pytest.mark.parametrize(
 @scenarios.parametric
 class Test_Otel_Tracer:
     @irrelevant(context.library == "cpp", reason="library does not implement OpenTelemetry")
-    @missing_feature(context.library == "php", reason="Not implemented")
     def test_otel_simple_trace(self, test_agent, test_library):
         """
             Perform two traces
@@ -56,7 +55,6 @@ class Test_Otel_Tracer:
         assert child_span["resource"] == "child"
 
     @irrelevant(context.library == "cpp", reason="library does not implement OpenTelemetry")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library == "python_http", reason="Not implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="OTel resource naming implemented in 1.24.0")

--- a/tests/parametric/test_otel_tracer.py
+++ b/tests/parametric/test_otel_tracer.py
@@ -10,7 +10,7 @@ from utils import missing_feature, irrelevant, context, scenarios
 #   DD_TRACE_OTEL_ENABLED=true is required in some tracers (.NET, Python?)
 #   CORECLR_ENABLE_PROFILING=1 is required in .NET to enable auto-instrumentation
 pytestmark = pytest.mark.parametrize(
-    "library_env", [{"DD_TRACE_OTEL_ENABLED": "true", "CORECLR_ENABLE_PROFILING": "1", "OTEL_PHP_FIBERS_ENABLED": "1"}],
+    "library_env", [{"DD_TRACE_OTEL_ENABLED": "true", "CORECLR_ENABLE_PROFILING": "1"}],
 )
 
 

--- a/tests/parametric/test_otel_tracer.py
+++ b/tests/parametric/test_otel_tracer.py
@@ -10,7 +10,7 @@ from utils import missing_feature, irrelevant, context, scenarios
 #   DD_TRACE_OTEL_ENABLED=true is required in some tracers (.NET, Python?)
 #   CORECLR_ENABLE_PROFILING=1 is required in .NET to enable auto-instrumentation
 pytestmark = pytest.mark.parametrize(
-    "library_env", [{"DD_TRACE_OTEL_ENABLED": "true", "CORECLR_ENABLE_PROFILING": "1", "OTEL_PHP_FIBERS_ENABLED": "0"}],
+    "library_env", [{"DD_TRACE_OTEL_ENABLED": "true", "CORECLR_ENABLE_PROFILING": "1", "OTEL_PHP_FIBERS_ENABLED": "1"}],
 )
 
 

--- a/tests/parametric/test_otel_tracer.py
+++ b/tests/parametric/test_otel_tracer.py
@@ -10,7 +10,7 @@ from utils import missing_feature, irrelevant, context, scenarios
 #   DD_TRACE_OTEL_ENABLED=true is required in some tracers (.NET, Python?)
 #   CORECLR_ENABLE_PROFILING=1 is required in .NET to enable auto-instrumentation
 pytestmark = pytest.mark.parametrize(
-    "library_env", [{"DD_TRACE_OTEL_ENABLED": "true", "CORECLR_ENABLE_PROFILING": "1"}],
+    "library_env", [{"DD_TRACE_OTEL_ENABLED": "true", "CORECLR_ENABLE_PROFILING": "1", "OTEL_PHP_FIBERS_ENABLED": "0"}],
 )
 
 

--- a/utils/build/docker/php/parametric/composer.json
+++ b/utils/build/docker/php/parametric/composer.json
@@ -5,7 +5,7 @@
     "amphp/http-server": "3.x-dev",
     "amphp/http-server-router": "2.x-dev",
     "amphp/log": "2.x-dev",
-    "open-telemetry/sdk": "^1.0.0RC2",
+    "open-telemetry/sdk": "^1.0.0",
     "symfony/http-client": "6.4.x-dev",
     "nyholm/psr7": "^1.8@dev"
   },

--- a/utils/build/docker/php/parametric/composer.json
+++ b/utils/build/docker/php/parametric/composer.json
@@ -4,6 +4,14 @@
     "league/uri-components": "^2",
     "amphp/http-server": "3.x-dev",
     "amphp/http-server-router": "2.x-dev",
-    "amphp/log": "2.x-dev"
+    "amphp/log": "2.x-dev",
+    "open-telemetry/sdk": "^1.0.0RC2",
+    "symfony/http-client": "6.4.x-dev",
+    "nyholm/psr7": "^1.8@dev"
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": true
+    }
   }
 }

--- a/utils/build/docker/php/parametric/composer.lock
+++ b/utils/build/docker/php/parametric/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73b432099bb6b2480073eb6b4ba02c54",
+    "content-hash": "efc3f414de56139b8fd7d169f8771f5b",
     "packages": [
         {
             "name": "amphp/amp",
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "6f1da17ac5f8ac15f520d945bcff2a279b34737e"
+                "reference": "b6e3a6a63dc87a6926bc61a42500573408441931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/6f1da17ac5f8ac15f520d945bcff2a279b34737e",
-                "reference": "6f1da17ac5f8ac15f520d945bcff2a279b34737e",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/b6e3a6a63dc87a6926bc61a42500573408441931",
+                "reference": "b6e3a6a63dc87a6926bc61a42500573408441931",
                 "shasum": ""
             },
             "require": {
@@ -86,7 +86,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-31T04:30:33+00:00"
+            "time": "2023-08-18T18:40:59+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -94,12 +94,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "7e7a77579f3e90c6fbd56e49628e6ace02d8f88a"
+                "reference": "3a4a0faa5aa63d0d76f41b1665d7a8a9137139ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/7e7a77579f3e90c6fbd56e49628e6ace02d8f88a",
-                "reference": "7e7a77579f3e90c6fbd56e49628e6ace02d8f88a",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/3a4a0faa5aa63d0d76f41b1665d7a8a9137139ce",
+                "reference": "3a4a0faa5aa63d0d76f41b1665d7a8a9137139ce",
                 "shasum": ""
             },
             "require": {
@@ -121,7 +121,8 @@
             "type": "library",
             "autoload": {
                 "files": [
-                    "src/functions.php"
+                    "src/functions.php",
+                    "src/Internal/functions.php"
                 ],
                 "psr-4": {
                     "Amp\\ByteStream\\": "src"
@@ -153,7 +154,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/byte-stream/issues",
-                "source": "https://github.com/amphp/byte-stream/tree/v2.0.1"
+                "source": "https://github.com/amphp/byte-stream/tree/2.x"
             },
             "funding": [
                 {
@@ -161,7 +162,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T04:06:20+00:00"
+            "time": "2023-09-03T22:18:50+00:00"
         },
         {
             "name": "amphp/cache",
@@ -324,21 +325,22 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/hpack.git",
-                "reference": "cf4f1663e9fd58f60258c06177098655ca6377a5"
+                "reference": "95895d29ae577a3a5995b46d16def04e11e39947"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/hpack/zipball/cf4f1663e9fd58f60258c06177098655ca6377a5",
-                "reference": "cf4f1663e9fd58f60258c06177098655ca6377a5",
+                "url": "https://api.github.com/repos/amphp/hpack/zipball/95895d29ae577a3a5995b46d16def04e11e39947",
+                "reference": "95895d29ae577a3a5995b46d16def04e11e39947",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/php-cs-fixer-config": "^2",
                 "http2jp/hpack-test-case": "^1",
-                "phpunit/phpunit": "^6 | ^7"
+                "nikic/php-fuzzer": "^0.0.10",
+                "phpunit/phpunit": "^7 | ^8 | ^9"
             },
             "default-branch": true,
             "type": "library",
@@ -382,7 +384,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/hpack/issues",
-                "source": "https://github.com/amphp/hpack/tree/v3.1.1"
+                "source": "https://github.com/amphp/hpack/tree/v3.2.0"
             },
             "funding": [
                 {
@@ -390,7 +392,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-11T20:03:34+00:00"
+            "time": "2023-09-05T19:59:20+00:00"
         },
         {
             "name": "amphp/http",
@@ -398,21 +400,24 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/http.git",
-                "reference": "9c53bd482445ffa29365bcc2bf01fcb6fe2ce2b1"
+                "reference": "9f3500bef4bb15cf41987f21136539c0a06555a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/http/zipball/9c53bd482445ffa29365bcc2bf01fcb6fe2ce2b1",
-                "reference": "9c53bd482445ffa29365bcc2bf01fcb6fe2ce2b1",
+                "url": "https://api.github.com/repos/amphp/http/zipball/9f3500bef4bb15cf41987f21136539c0a06555a3",
+                "reference": "9f3500bef4bb15cf41987f21136539c0a06555a3",
                 "shasum": ""
             },
             "require": {
                 "amphp/hpack": "^3",
                 "amphp/parser": "^1.1",
-                "php": ">=8.1"
+                "league/uri-components": "^2.4.2 | ^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1 | ^2"
             },
             "require-dev": {
                 "amphp/php-cs-fixer-config": "^2",
+                "league/uri": "^6.8 | ^7.1",
                 "phpunit/phpunit": "^9",
                 "psalm/phar": "^5.4"
             },
@@ -435,12 +440,16 @@
                 {
                     "name": "Niklas Keller",
                     "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
                 }
             ],
             "description": "Basic HTTP primitives which can be shared by servers and clients.",
             "support": {
                 "issues": "https://github.com/amphp/http/issues",
-                "source": "https://github.com/amphp/http/tree/2.x"
+                "source": "https://github.com/amphp/http/tree/v2.1.0"
             },
             "funding": [
                 {
@@ -448,7 +457,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-21T16:54:23+00:00"
+            "time": "2023-08-22T19:50:46+00:00"
         },
         {
             "name": "amphp/http-server",
@@ -456,12 +465,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/http-server.git",
-                "reference": "61ca5c67f62286fdb08d642d6c55d5605556d6af"
+                "reference": "e984728667de7394629618e4f603a962981a4f91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/http-server/zipball/61ca5c67f62286fdb08d642d6c55d5605556d6af",
-                "reference": "61ca5c67f62286fdb08d642d6c55d5605556d6af",
+                "url": "https://api.github.com/repos/amphp/http-server/zipball/e984728667de7394629618e4f603a962981a4f91",
+                "reference": "e984728667de7394629618e4f603a962981a4f91",
                 "shasum": ""
             },
             "require": {
@@ -469,24 +478,24 @@
                 "amphp/byte-stream": "^2",
                 "amphp/cache": "^2",
                 "amphp/hpack": "^3",
-                "amphp/http": "^2-dev",
+                "amphp/http": "^2",
                 "amphp/pipeline": "^1",
-                "amphp/socket": "^2",
+                "amphp/socket": "^2.1",
                 "amphp/sync": "^2",
-                "league/uri": "^6",
-                "league/uri-interfaces": "^2.3",
+                "league/uri": "^6.8 | ^7.1",
+                "league/uri-interfaces": "^2.3 | ^7.1",
                 "php": ">=8.1",
-                "psr/http-message": "^1",
-                "psr/log": "^1|^2|^3",
+                "psr/http-message": "^1 | ^2",
+                "psr/log": "^1 | ^2 | ^3",
                 "revolt/event-loop": "^1"
             },
             "require-dev": {
-                "amphp/http-client": "^5-dev",
+                "amphp/http-client": "^5",
                 "amphp/log": "^2",
-                "amphp/php-cs-fixer-config": "^2-dev",
+                "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
-                "league/uri-components": "^2",
-                "monolog/monolog": "^2 || ^1.23",
+                "league/uri-components": "^2.4.2 | ^7.1",
+                "monolog/monolog": "^3",
                 "phpunit/phpunit": "^9",
                 "psalm/phar": "^5.4"
             },
@@ -495,11 +504,6 @@
             },
             "default-branch": true,
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "src/Driver/functions.php",
@@ -551,38 +555,42 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-02T00:53:17+00:00"
+            "time": "2023-09-04T04:43:25+00:00"
         },
         {
             "name": "amphp/http-server-router",
-            "version": "v2.x-dev",
+            "version": "2.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/http-server-router.git",
-                "reference": "7fc0a47beb40886e312cb3934aaae92cbdbb8965"
+                "reference": "8a166efa10bc3fc887a7a42b8a55c7b16bc9fc61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/http-server-router/zipball/7fc0a47beb40886e312cb3934aaae92cbdbb8965",
-                "reference": "7fc0a47beb40886e312cb3934aaae92cbdbb8965",
+                "url": "https://api.github.com/repos/amphp/http-server-router/zipball/8a166efa10bc3fc887a7a42b8a55c7b16bc9fc61",
+                "reference": "8a166efa10bc3fc887a7a42b8a55c7b16bc9fc61",
                 "shasum": ""
             },
             "require": {
+                "amphp/amp": "^3",
                 "amphp/cache": "^2",
-                "amphp/http": "^2-dev",
+                "amphp/http": "^2",
                 "amphp/http-server": "^3",
                 "amphp/socket": "^2",
                 "nikic/fast-route": "^1",
-                "php": ">=8.1"
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3"
             },
             "require-dev": {
                 "amphp/log": "^2",
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
+                "colinodell/psr-testlogger": "^1.2",
                 "league/uri": "^6",
                 "phpunit/phpunit": "^9",
                 "psalm/phar": "^5.6"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -610,7 +618,7 @@
                     "email": "aaron@trowski.com"
                 }
             ],
-            "description": "Router responder for Amp's HTTP server.",
+            "description": "Routes to request handlers based on HTTP method and path for amphp/http-server.",
             "homepage": "https://github.com/amphp/http-server-router",
             "keywords": [
                 "http",
@@ -619,7 +627,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/http-server-router/issues",
-                "source": "https://github.com/amphp/http-server-router/tree/v2"
+                "source": "https://github.com/amphp/http-server-router/tree/v2.0.0"
             },
             "funding": [
                 {
@@ -627,7 +635,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-02T01:07:46+00:00"
+            "time": "2023-08-05T19:16:57+00:00"
         },
         {
             "name": "amphp/log",
@@ -635,12 +643,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/log.git",
-                "reference": "f65226ffa4dfe0dd63805f2af31aced9ed27efb6"
+                "reference": "bf1562b8a18a3f30efa069ed740f412ac70a8a6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/log/zipball/f65226ffa4dfe0dd63805f2af31aced9ed27efb6",
-                "reference": "f65226ffa4dfe0dd63805f2af31aced9ed27efb6",
+                "url": "https://api.github.com/repos/amphp/log/zipball/bf1562b8a18a3f30efa069ed740f412ac70a8a6c",
+                "reference": "bf1562b8a18a3f30efa069ed740f412ac70a8a6c",
                 "shasum": ""
             },
             "require": {
@@ -694,7 +702,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/log/issues",
-                "source": "https://github.com/amphp/log/tree/v2.0.0-beta.2"
+                "source": "https://github.com/amphp/log/tree/v2.0.0"
             },
             "funding": [
                 {
@@ -702,7 +710,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T03:34:16+00:00"
+            "time": "2023-08-05T18:59:54+00:00"
         },
         {
             "name": "amphp/parser",
@@ -841,12 +849,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/process.git",
-                "reference": "a65d3bc1f36ef12d44df42a68f0f0643183f1052"
+                "reference": "943352b1c12e19ed14b9def671a98197e0121d0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/process/zipball/a65d3bc1f36ef12d44df42a68f0f0643183f1052",
-                "reference": "a65d3bc1f36ef12d44df42a68f0f0643183f1052",
+                "url": "https://api.github.com/repos/amphp/process/zipball/943352b1c12e19ed14b9def671a98197e0121d0e",
+                "reference": "943352b1c12e19ed14b9def671a98197e0121d0e",
                 "shasum": ""
             },
             "require": {
@@ -902,7 +910,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-15T16:00:57+00:00"
+            "time": "2023-08-22T21:49:13+00:00"
         },
         {
             "name": "amphp/serialization",
@@ -910,12 +918,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/serialization.git",
-                "reference": "d10194efb7a1d1f755f8fbb64c919d66b51043c2"
+                "reference": "21116dcd1221e0d1817e02a6e2b0c52a9a317327"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/serialization/zipball/d10194efb7a1d1f755f8fbb64c919d66b51043c2",
-                "reference": "d10194efb7a1d1f755f8fbb64c919d66b51043c2",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/21116dcd1221e0d1817e02a6e2b0c52a9a317327",
+                "reference": "21116dcd1221e0d1817e02a6e2b0c52a9a317327",
                 "shasum": ""
             },
             "require": {
@@ -970,7 +978,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T05:28:22+00:00"
+            "time": "2023-08-29T20:22:27+00:00"
         },
         {
             "name": "amphp/socket",
@@ -978,12 +986,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/socket.git",
-                "reference": "d43bbbe10164ebf2ecd96f1084a63af0ac4d1a69"
+                "reference": "3418a0c5c0d4978b0e8e0619ce1da0851c4053d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/socket/zipball/d43bbbe10164ebf2ecd96f1084a63af0ac4d1a69",
-                "reference": "d43bbbe10164ebf2ecd96f1084a63af0ac4d1a69",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/3418a0c5c0d4978b0e8e0619ce1da0851c4053d3",
+                "reference": "3418a0c5c0d4978b0e8e0619ce1da0851c4053d3",
                 "shasum": ""
             },
             "require": {
@@ -992,7 +1000,8 @@
                 "amphp/dns": "^2",
                 "ext-openssl": "*",
                 "kelunik/certificate": "^1.1",
-                "league/uri": "^6.5",
+                "league/uri": "^6.5 | ^7",
+                "league/uri-interfaces": "^2.3 | ^7",
                 "php": ">=8.1",
                 "revolt/event-loop": "^1 || ^0.2"
             },
@@ -1046,7 +1055,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/socket/issues",
-                "source": "https://github.com/amphp/socket/tree/v2.0.0"
+                "source": "https://github.com/amphp/socket/tree/v2.2.0"
             },
             "funding": [
                 {
@@ -1054,7 +1063,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-31T20:58:10+00:00"
+            "time": "2023-08-19T15:28:34+00:00"
         },
         {
             "name": "amphp/sync",
@@ -1062,12 +1071,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/sync.git",
-                "reference": "ad8a0e80cc586cece4f8ce57460f8bbf442ba8fc"
+                "reference": "c10c5f86afa0a043d82709e2d84831ade1e22304"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/sync/zipball/ad8a0e80cc586cece4f8ce57460f8bbf442ba8fc",
-                "reference": "ad8a0e80cc586cece4f8ce57460f8bbf442ba8fc",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/c10c5f86afa0a043d82709e2d84831ade1e22304",
+                "reference": "c10c5f86afa0a043d82709e2d84831ade1e22304",
                 "shasum": ""
             },
             "require": {
@@ -1122,7 +1131,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/sync/issues",
-                "source": "https://github.com/amphp/sync/tree/v2.0.0"
+                "source": "https://github.com/amphp/sync/tree/2.x"
             },
             "funding": [
                 {
@@ -1130,7 +1139,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-30T22:11:37+00:00"
+            "time": "2023-09-07T22:00:32+00:00"
         },
         {
             "name": "amphp/windows-registry",
@@ -1235,12 +1244,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/kelunik/certificate.git",
-                "reference": "47dcc659fe73ae040ae17d068a4fc8777813f0fb"
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kelunik/certificate/zipball/47dcc659fe73ae040ae17d068a4fc8777813f0fb",
-                "reference": "47dcc659fe73ae040ae17d068a4fc8777813f0fb",
+                "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
                 "shasum": ""
             },
             "require": {
@@ -1248,8 +1257,8 @@
                 "php": ">=7.0"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "phpunit/phpunit": "^6 | 7"
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
             },
             "default-branch": true,
             "type": "library",
@@ -1260,7 +1269,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Kelunik\\Certificate\\": "lib"
+                    "Kelunik\\Certificate\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1284,22 +1293,22 @@
             ],
             "support": {
                 "issues": "https://github.com/kelunik/certificate/issues",
-                "source": "https://github.com/kelunik/certificate/tree/master"
+                "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
             },
-            "time": "2020-01-29T20:07:08+00:00"
+            "time": "2023-02-03T21:26:53+00:00"
         },
         {
             "name": "league/uri",
-            "version": "dev-master",
+            "version": "6.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "c3417981f6d9e465b4058b3bd3db7e8d7fabbad2"
+                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/c3417981f6d9e465b4058b3bd3db7e8d7fabbad2",
-                "reference": "c3417981f6d9e465b4058b3bd3db7e8d7fabbad2",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/a700b4656e4c54371b799ac61e300ab25a2d1d39",
+                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39",
                 "shasum": ""
             },
             "require": {
@@ -1311,13 +1320,24 @@
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.9.5",
+                "nyholm/psr7": "^1.5.1",
+                "php-http/psr7-integration-tests": "^1.1.1",
+                "phpbench/phpbench": "^1.2.6",
+                "phpstan/phpstan": "^1.8.5",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.1.1",
+                "phpstan/phpstan-strict-rules": "^1.4.3",
+                "phpunit/phpunit": "^9.5.24",
+                "psr/http-factory": "^1.0.1"
+            },
             "suggest": {
                 "ext-fileinfo": "Needed to create Data URI from a filepath",
                 "ext-intl": "Needed to improve host validation",
                 "league/uri-components": "Needed to easily manipulate URI objects",
                 "psr/http-factory": "Needed to use the URI factory"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -1326,7 +1346,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "League\\Uri\\": ""
+                    "League\\Uri\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1366,8 +1386,8 @@
             "support": {
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
-                "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/master"
+                "issues": "https://github.com/thephpleague/uri/issues",
+                "source": "https://github.com/thephpleague/uri/tree/6.8.0"
             },
             "funding": [
                 {
@@ -1375,28 +1395,38 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-04T04:49:09+00:00"
+            "time": "2022-09-13T19:58:47+00:00"
         },
         {
             "name": "league/uri-components",
-            "version": "dev-master",
+            "version": "2.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-components.git",
-                "reference": "a81784b56f7d0a32f627c6b49c22bb46172b728f"
+                "reference": "c93837294fe9021d518fd3ea4c5f3fbba8b8ddeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-components/zipball/a81784b56f7d0a32f627c6b49c22bb46172b728f",
-                "reference": "a81784b56f7d0a32f627c6b49c22bb46172b728f",
+                "url": "https://api.github.com/repos/thephpleague/uri-components/zipball/c93837294fe9021d518fd3ea4c5f3fbba8b8ddeb",
+                "reference": "c93837294fe9021d518fd3ea4c5f3fbba8b8ddeb",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "league/uri": "dev-master",
-                "league/uri-interfaces": "dev-master",
-                "php": "^8.1",
-                "psr/http-message": "^1.0.1"
+                "league/uri-interfaces": "^2.3",
+                "php": "^7.4 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.22.0",
+                "guzzlehttp/psr7": "^2.2",
+                "laminas/laminas-diactoros": "^2.11",
+                "league/uri": "^6.0",
+                "phpstan/phpstan": "^1.10.28",
+                "phpstan/phpstan-deprecation-rules": "^1.1.4",
+                "phpstan/phpstan-phpunit": "^1.3.13",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^9.6.10"
             },
             "suggest": {
                 "ext-fileinfo": "Needed to create Data URI from a filepath",
@@ -1407,7 +1437,6 @@
                 "php-64bit": "to improve handle IPV4 parsing",
                 "psr/http-message-implementation": "to allow manipulating PSR-7 Uri objects"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -1416,7 +1445,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "League\\Uri\\": ""
+                    "League\\Uri\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1447,10 +1476,7 @@
                 "userinfo"
             ],
             "support": {
-                "docs": "https://uri.thephpleague.com",
-                "forum": "https://thephpleague.slack.com",
-                "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-components/tree/master"
+                "source": "https://github.com/thephpleague/uri-components/tree/2.4.x"
             },
             "funding": [
                 {
@@ -1458,30 +1484,37 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-26T11:53:58+00:00"
+            "time": "2023-08-13T19:53:57+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "dev-master",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "daaa23c9f595582b16ecdd796986be6ea28abdc2"
+                "reference": "00e7e2943f76d8cb50c7dfdc2f6dee356e15e383"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/daaa23c9f595582b16ecdd796986be6ea28abdc2",
-                "reference": "daaa23c9f595582b16ecdd796986be6ea28abdc2",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/00e7e2943f76d8cb50c7dfdc2f6dee356e15e383",
+                "reference": "00e7e2943f76d8cb50c7dfdc2f6dee356e15e383",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "ext-json": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.19",
+                "phpstan/phpstan": "^0.12.90",
+                "phpstan/phpstan-phpunit": "^0.12.19",
+                "phpstan/phpstan-strict-rules": "^0.12.9",
+                "phpunit/phpunit": "^8.5.15 || ^9.5"
             },
             "suggest": {
                 "ext-intl": "to use the IDNA feature",
-                "symfony/polyfill-intl-idn": "to use the IDNA feature via Symfony Polyfill"
+                "symfony/intl": "to use the IDNA feature via Symfony Polyfill"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -1490,7 +1523,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "League\\Uri\\": ""
+                    "League\\Uri\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1504,28 +1537,17 @@
                     "homepage": "https://nyamsprod.com"
                 }
             ],
-            "description": "Common interfaces and classes for URI representation and interaction",
-            "homepage": "https://uri.thephpleague.com",
+            "description": "Common interface for URI representation",
+            "homepage": "http://github.com/thephpleague/uri-interfaces",
             "keywords": [
-                "authority",
-                "components",
-                "fragment",
-                "host",
-                "idna",
-                "path",
-                "port",
-                "query",
                 "rfc3986",
-                "scheme",
+                "rfc3987",
                 "uri",
-                "url",
-                "userinfo"
+                "url"
             ],
             "support": {
-                "docs": "https://uri.thephpleague.com",
-                "forum": "https://thephpleague.slack.com",
-                "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/master"
+                "issues": "https://github.com/thephpleague/uri-interfaces/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/2.3.0"
             },
             "funding": [
                 {
@@ -1533,7 +1555,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-03T19:17:06+00:00"
+            "time": "2021-06-28T04:27:21+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1541,12 +1563,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "e68c00670e310e276da9624d75965f5d2f28aa80"
+                "reference": "9546d94bdc212214e23aa7ea5a3734417e33e5e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e68c00670e310e276da9624d75965f5d2f28aa80",
-                "reference": "e68c00670e310e276da9624d75965f5d2f28aa80",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/9546d94bdc212214e23aa7ea5a3734417e33e5e1",
+                "reference": "9546d94bdc212214e23aa7ea5a3734417e33e5e1",
                 "shasum": ""
             },
             "require": {
@@ -1561,15 +1583,15 @@
                 "doctrine/couchdb": "~1.0@dev",
                 "elasticsearch/elasticsearch": "^7 || ^8",
                 "ext-json": "*",
-                "graylog2/gelf-php": "^1.4.2 || ^2@dev",
-                "guzzlehttp/guzzle": "^7.4",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
                 "mongodb/mongodb": "^1.8",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
-                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan": "^1.9",
                 "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-strict-rules": "^1.1",
-                "phpunit/phpunit": "^9.5.16",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
                 "predis/predis": "^1.1 || ^2",
                 "ruflin/elastica": "^7",
                 "symfony/mailer": "^5.4 || ^6",
@@ -1635,7 +1657,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-20T13:21:44+00:00"
+            "time": "2023-08-03T12:04:37+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -1688,27 +1710,616 @@
             "time": "2019-12-20T12:15:33+00:00"
         },
         {
-            "name": "psr/http-message",
+            "name": "nyholm/psr7",
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "efd67d1dc14a7ef4fc4e518e7dee91c271d524e4"
+                "url": "https://github.com/Nyholm/psr7.git",
+                "reference": "3cb4d163b58589e47b35103e8e5e6a6a475b47be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/efd67d1dc14a7ef4fc4e518e7dee91c271d524e4",
-                "reference": "efd67d1dc14a7ef4fc4e518e7dee91c271d524e4",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/3cb4d163b58589e47b35103e8e5e6a6a475b47be",
+                "reference": "3cb4d163b58589e47b35103e8e5e6a6a475b47be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.2",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "php-http/message-factory-implementation": "1.0",
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "http-interop/http-factory-tests": "^0.9",
+                "php-http/message-factory": "^1.0",
+                "php-http/psr7-integration-tests": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
+                "symfony/error-handler": "^4.4"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "A fast PHP7 implementation of PSR-7",
+            "homepage": "https://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/Nyholm/psr7/issues",
+                "source": "https://github.com/Nyholm/psr7/tree/1.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-05-02T11:26:24+00:00"
+        },
+        {
+            "name": "open-telemetry/api",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/api.git",
+                "reference": "d577d732333d38a9a6c16936363ee25f1e3f1c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/d577d732333d38a9a6c16936363ee25f1e3f1c3c",
+                "reference": "d577d732333d38a9a6c16936363ee25f1e3f1c3c",
+                "shasum": ""
+            },
+            "require": {
+                "open-telemetry/context": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "psr/log": "^1.1|^2.0|^3.0",
+                "symfony/polyfill-php80": "^1.26",
+                "symfony/polyfill-php81": "^1.26",
+                "symfony/polyfill-php82": "^1.26"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Trace/functions.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\API\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "API for OpenTelemetry PHP.",
+            "keywords": [
+                "Metrics",
+                "api",
+                "apm",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2023-09-27T23:15:51+00:00"
+        },
+        {
+            "name": "open-telemetry/context",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/context.git",
+                "reference": "99f3d54fa9f9ff67421774feeef5e5b1f209ea21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/context/zipball/99f3d54fa9f9ff67421774feeef5e5b1f209ea21",
+                "reference": "99f3d54fa9f9ff67421774feeef5e5b1f209ea21",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "symfony/polyfill-php80": "^1.26",
+                "symfony/polyfill-php81": "^1.26",
+                "symfony/polyfill-php82": "^1.26"
+            },
+            "suggest": {
+                "ext-ffi": "To allow context switching in Fibers"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "fiber/initialize_fiber_handler.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\Context\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "Context implementation for OpenTelemetry PHP.",
+            "keywords": [
+                "Context",
+                "opentelemetry",
+                "otel"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2023-09-05T03:38:44+00:00"
+        },
+        {
+            "name": "open-telemetry/sdk",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/sdk.git",
+                "reference": "793ae3f887ff244bb079cdcba8c908dcc0319048"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/793ae3f887ff244bb079cdcba8c908dcc0319048",
+                "reference": "793ae3f887ff244bb079cdcba8c908dcc0319048",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "open-telemetry/api": "^1.0",
+                "open-telemetry/context": "^1.0",
+                "open-telemetry/sem-conv": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "php-http/discovery": "^1.14",
+                "psr/http-client": "^1.0",
+                "psr/http-client-implementation": "^1.0",
+                "psr/http-factory-implementation": "^1.0",
+                "psr/http-message": "^1.0.1|^2.0",
+                "psr/log": "^1.1|^2.0|^3.0",
+                "symfony/polyfill-mbstring": "^1.23",
+                "symfony/polyfill-php80": "^1.26",
+                "symfony/polyfill-php81": "^1.26",
+                "symfony/polyfill-php82": "^1.26"
+            },
+            "suggest": {
+                "ext-gmp": "To support unlimited number of synchronous metric readers",
+                "ext-mbstring": "To increase performance of string operations"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Common/Util/functions.php",
+                    "Logs/Exporter/_register.php",
+                    "Metrics/MetricExporter/_register.php",
+                    "Propagation/_register.php",
+                    "Trace/SpanExporter/_register.php",
+                    "Common/Dev/Compatibility/_load.php",
+                    "_autoload.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\SDK\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "SDK for OpenTelemetry PHP.",
+            "keywords": [
+                "Metrics",
+                "apm",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "sdk",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2023-10-13T00:48:23+00:00"
+        },
+        {
+            "name": "open-telemetry/sem-conv",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/sem-conv.git",
+                "reference": "45c77006786510ed05d59b61ce253c07afc54d32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/45c77006786510ed05d59b61ce253c07afc54d32",
+                "reference": "45c77006786510ed05d59b61ce253c07afc54d32",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenTelemetry\\SemConv\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "Semantic conventions for OpenTelemetry PHP.",
+            "keywords": [
+                "Metrics",
+                "apm",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "semantic conventions",
+                "semconv",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2023-09-05T03:38:44+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "57f3de01d32085fea20865f9b16fb0e69347c39e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/57f3de01d32085fea20865f9b16fb0e69347c39e",
+                "reference": "57f3de01d32085fea20865f9b16fb0e69347c39e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "symfony/phpunit-bridge": "^6.2"
+            },
+            "default-branch": true,
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.19.1"
+            },
+            "time": "2023-07-11T07:02:26+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "707984727bd5b2b670e59559d3ed2500240cf875"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/707984727bd5b2b670e59559d3ed2500240cf875",
+                "reference": "707984727bd5b2b670e59559d3ed2500240cf875",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container"
+            },
+            "time": "2023-09-22T11:11:30+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "7037f4b0950474e9d1350e8df89b15f1842085f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/7037f4b0950474e9d1350e8df89b15f1842085f6",
+                "reference": "7037f4b0950474e9d1350e8df89b15f1842085f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2023-09-22T11:16:44+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -1737,9 +2348,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2019-08-29T13:16:46+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/log",
@@ -1798,12 +2409,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "81dd825a0a7fa7a39cae25ef731bb944f3e18295"
+                "reference": "0fe2d31e1cddd26664e55d383d3d5da613334c03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/81dd825a0a7fa7a39cae25ef731bb944f3e18295",
-                "reference": "81dd825a0a7fa7a39cae25ef731bb944f3e18295",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/0fe2d31e1cddd26664e55d383d3d5da613334c03",
+                "reference": "0fe2d31e1cddd26664e55d383d3d5da613334c03",
                 "shasum": ""
             },
             "require": {
@@ -1861,9 +2472,660 @@
             ],
             "support": {
                 "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.0"
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.3"
             },
-            "time": "2022-11-02T21:46:22+00:00"
+            "time": "2023-07-29T17:07:12+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-23T14:45:45+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "6.4.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "bea130754ee8a62ae5845a4356cbc07f841544da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/bea130754ee8a62ae5845a4356cbc07f841544da",
+                "reference": "bea130754ee8a62ae5845a4356cbc07f841544da",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "^3",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.3"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.5",
+                "amphp/http-client": "^4.2.1",
+                "amphp/http-tunnel": "^1.0",
+                "amphp/socket": "^1.1",
+                "guzzlehttp/promises": "^1.4",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/6.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-10-07T07:34:26+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "c58b55bbca7422e19ed51667313834b67b098517"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/c58b55bbca7422e19ed51667313834b67b098517",
+                "reference": "c58b55bbca7422e19ed51667313834b67b098517",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/main"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-29T13:12:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-28T09:04:16+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/7581cd600fa9fd681b797d00b02f068e2f13263b",
+                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php82",
+            "version": "1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php82.git",
+                "reference": "b74818475a404db4219d49aca4ea8a1626b22a6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/b74818475a404db4219d49aca4ea8a1626b22a6b",
+                "reference": "b74818475a404db4219d49aca4ea8a1626b22a6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php82\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php82/tree/1.x"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-28T10:07:24+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "a4025a1c812c231d88ed0780e866b0cc644f4a84"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/a4025a1c812c231d88ed0780e866b0cc644f4a84",
+                "reference": "a4025a1c812c231d88ed0780e866b0cc644f4a84",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^2.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/main"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-29T13:12:44+00:00"
         }
     ],
     "packages-dev": [],

--- a/utils/build/docker/php/parametric/composer.lock
+++ b/utils/build/docker/php/parametric/composer.lock
@@ -1563,12 +1563,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "9546d94bdc212214e23aa7ea5a3734417e33e5e1"
+                "reference": "bd1758df12540ddd5a3f00bf06cdf6dfc6fe8b11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/9546d94bdc212214e23aa7ea5a3734417e33e5e1",
-                "reference": "9546d94bdc212214e23aa7ea5a3734417e33e5e1",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bd1758df12540ddd5a3f00bf06cdf6dfc6fe8b11",
+                "reference": "bd1758df12540ddd5a3f00bf06cdf6dfc6fe8b11",
                 "shasum": ""
             },
             "require": {
@@ -1657,7 +1657,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-03T12:04:37+00:00"
+            "time": "2023-10-25T13:15:33+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -1921,12 +1921,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sdk.git",
-                "reference": "793ae3f887ff244bb079cdcba8c908dcc0319048"
+                "reference": "1c6020b4f1b85fdd647538ee46f6c83360d7c11e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/793ae3f887ff244bb079cdcba8c908dcc0319048",
-                "reference": "793ae3f887ff244bb079cdcba8c908dcc0319048",
+                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/1c6020b4f1b85fdd647538ee46f6c83360d7c11e",
+                "reference": "1c6020b4f1b85fdd647538ee46f6c83360d7c11e",
                 "shasum": ""
             },
             "require": {
@@ -1997,7 +1997,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2023-10-13T00:48:23+00:00"
+            "time": "2023-10-18T20:53:08+00:00"
         },
         {
             "name": "open-telemetry/sem-conv",
@@ -2005,12 +2005,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sem-conv.git",
-                "reference": "45c77006786510ed05d59b61ce253c07afc54d32"
+                "reference": "e582b874ee89bec544f962db212b3966fe9310a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/45c77006786510ed05d59b61ce253c07afc54d32",
-                "reference": "45c77006786510ed05d59b61ce253c07afc54d32",
+                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/e582b874ee89bec544f962db212b3966fe9310a7",
+                "reference": "e582b874ee89bec544f962db212b3966fe9310a7",
                 "shasum": ""
             },
             "require": {
@@ -2055,7 +2055,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2023-09-05T03:38:44+00:00"
+            "time": "2023-10-19T20:10:44+00:00"
         },
         {
             "name": "php-http/discovery",
@@ -2409,12 +2409,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "0fe2d31e1cddd26664e55d383d3d5da613334c03"
+                "reference": "40292c18e53d9a1b7e6c807f4fda5908552e1ba5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/0fe2d31e1cddd26664e55d383d3d5da613334c03",
-                "reference": "0fe2d31e1cddd26664e55d383d3d5da613334c03",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/40292c18e53d9a1b7e6c807f4fda5908552e1ba5",
+                "reference": "40292c18e53d9a1b7e6c807f4fda5908552e1ba5",
                 "shasum": ""
             },
             "require": {
@@ -2472,9 +2472,9 @@
             ],
             "support": {
                 "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.3"
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.4"
             },
-            "time": "2023-07-29T17:07:12+00:00"
+            "time": "2023-10-22T03:19:00+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3134,11 +3134,13 @@
     "stability-flags": {
         "amphp/http-server": 20,
         "amphp/http-server-router": 20,
-        "amphp/log": 20
+        "amphp/log": 20,
+        "symfony/http-client": 20,
+        "nyholm/psr7": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/utils/build/docker/php/parametric/composer.lock
+++ b/utils/build/docker/php/parametric/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "efc3f414de56139b8fd7d169f8771f5b",
+    "content-hash": "9596c1fae76bc9b026bb905fa7915420",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1563,12 +1563,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "bd1758df12540ddd5a3f00bf06cdf6dfc6fe8b11"
+                "reference": "c412c2e0d6c98525e55746294dc40413f6ffebf3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bd1758df12540ddd5a3f00bf06cdf6dfc6fe8b11",
-                "reference": "bd1758df12540ddd5a3f00bf06cdf6dfc6fe8b11",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c412c2e0d6c98525e55746294dc40413f6ffebf3",
+                "reference": "c412c2e0d6c98525e55746294dc40413f6ffebf3",
                 "shasum": ""
             },
             "require": {
@@ -1657,7 +1657,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-25T13:15:33+00:00"
+            "time": "2023-11-10T12:29:35+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -1715,12 +1715,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nyholm/psr7.git",
-                "reference": "3cb4d163b58589e47b35103e8e5e6a6a475b47be"
+                "reference": "aa5fc277a4f5508013d571341ade0c3886d4d00e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/3cb4d163b58589e47b35103e8e5e6a6a475b47be",
-                "reference": "3cb4d163b58589e47b35103e8e5e6a6a475b47be",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/aa5fc277a4f5508013d571341ade0c3886d4d00e",
+                "reference": "aa5fc277a4f5508013d571341ade0c3886d4d00e",
                 "shasum": ""
             },
             "require": {
@@ -1774,7 +1774,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Nyholm/psr7/issues",
-                "source": "https://github.com/Nyholm/psr7/tree/1.8.0"
+                "source": "https://github.com/Nyholm/psr7/tree/1.8.1"
             },
             "funding": [
                 {
@@ -1786,7 +1786,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-02T11:26:24+00:00"
+            "time": "2023-11-13T09:31:12+00:00"
         },
         {
             "name": "open-telemetry/api",
@@ -1921,12 +1921,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sdk.git",
-                "reference": "1c6020b4f1b85fdd647538ee46f6c83360d7c11e"
+                "reference": "a6ba62857154ff7207711e9dcb3f5cda73c8c3e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/1c6020b4f1b85fdd647538ee46f6c83360d7c11e",
-                "reference": "1c6020b4f1b85fdd647538ee46f6c83360d7c11e",
+                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/a6ba62857154ff7207711e9dcb3f5cda73c8c3e8",
+                "reference": "a6ba62857154ff7207711e9dcb3f5cda73c8c3e8",
                 "shasum": ""
             },
             "require": {
@@ -1997,7 +1997,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2023-10-18T20:53:08+00:00"
+            "time": "2023-11-13T22:04:22+00:00"
         },
         {
             "name": "open-telemetry/sem-conv",
@@ -2005,12 +2005,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sem-conv.git",
-                "reference": "e582b874ee89bec544f962db212b3966fe9310a7"
+                "reference": "211039aa4667f3fbf56f970fad8bf78b6c7d5b33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/e582b874ee89bec544f962db212b3966fe9310a7",
-                "reference": "e582b874ee89bec544f962db212b3966fe9310a7",
+                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/211039aa4667f3fbf56f970fad8bf78b6c7d5b33",
+                "reference": "211039aa4667f3fbf56f970fad8bf78b6c7d5b33",
                 "shasum": ""
             },
             "require": {
@@ -2055,7 +2055,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2023-10-19T20:10:44+00:00"
+            "time": "2023-11-07T23:26:31+00:00"
         },
         {
             "name": "php-http/discovery",
@@ -2409,12 +2409,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "40292c18e53d9a1b7e6c807f4fda5908552e1ba5"
+                "reference": "136e9736450e1ae6dc58e93c486e2c21a11a1214"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/40292c18e53d9a1b7e6c807f4fda5908552e1ba5",
-                "reference": "40292c18e53d9a1b7e6c807f4fda5908552e1ba5",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/136e9736450e1ae6dc58e93c486e2c21a11a1214",
+                "reference": "136e9736450e1ae6dc58e93c486e2c21a11a1214",
                 "shasum": ""
             },
             "require": {
@@ -2472,9 +2472,9 @@
             ],
             "support": {
                 "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.4"
+                "source": "https://github.com/revoltphp/event-loop/tree/main"
             },
-            "time": "2023-10-22T03:19:00+00:00"
+            "time": "2023-10-31T12:54:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2526,7 +2526,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -2550,12 +2550,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "bea130754ee8a62ae5845a4356cbc07f841544da"
+                "reference": "2e2dff5212ab9834f331060a126e7564ed7f3722"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/bea130754ee8a62ae5845a4356cbc07f841544da",
-                "reference": "bea130754ee8a62ae5845a4356cbc07f841544da",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/2e2dff5212ab9834f331060a126e7564ed7f3722",
+                "reference": "2e2dff5212ab9834f331060a126e7564ed7f3722",
                 "shasum": ""
             },
             "require": {
@@ -2635,7 +2635,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-07T07:34:26+00:00"
+            "time": "2023-11-07T10:18:57+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -2643,12 +2643,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "c58b55bbca7422e19ed51667313834b67b098517"
+                "reference": "1ee70e699b41909c209a0c930f11034b93578654"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/c58b55bbca7422e19ed51667313834b67b098517",
-                "reference": "c58b55bbca7422e19ed51667313834b67b098517",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/1ee70e699b41909c209a0c930f11034b93578654",
+                "reference": "1ee70e699b41909c209a0c930f11034b93578654",
                 "shasum": ""
             },
             "require": {
@@ -2698,7 +2698,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/main"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -2714,7 +2714,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-29T13:12:44+00:00"
+            "time": "2023-07-30T20:28:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -3050,12 +3050,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "a4025a1c812c231d88ed0780e866b0cc644f4a84"
+                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/a4025a1c812c231d88ed0780e866b0cc644f4a84",
-                "reference": "a4025a1c812c231d88ed0780e866b0cc644f4a84",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
                 "shasum": ""
             },
             "require": {
@@ -3109,7 +3109,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/main"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -3125,7 +3125,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-29T13:12:44+00:00"
+            "time": "2023-07-30T20:28:31+00:00"
         }
     ],
     "packages-dev": [],

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -200,6 +200,9 @@ $router->addRoute('POST', '/trace/otel/start_span', new ClosureRequestHandler(fu
         print(json_encode($httpHeaders, JSON_PRETTY_PRINT) . "\n");
         $remoteContext = TraceContextPropagator::getInstance()->extract($httpHeaders);
         print(get_class($remoteContext) . "\n");
+        print(Span::fromContext($remoteContext)->getContext()->getTraceState());
+        print(Span::fromContext($remoteContext)->getContext()->getTraceId());
+        print(Span::fromContext($remoteContext)->getContext()->getSpanId());
         $spanBuilder->setParent($remoteContext);
     } else {
         print("No headers\n");

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -24,6 +24,7 @@ use OpenTelemetry\API\Trace\NonRecordingSpan;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Context\ScopeInterface;
 use OpenTelemetry\SDK\Trace as SDK;
 use OpenTelemetry\SDK\Trace\TracerProvider;
@@ -257,6 +258,18 @@ $router->addRoute('POST', '/trace/otel/set_status', new ClosureRequestHandler(fu
     $code = arg($req, 'code');
     $description = arg($req, 'description');
 
+    switch ($code) {
+        case 'UNSET':
+            $code = StatusCode::STATUS_UNSET;
+            break;
+        case 'OK':
+            $code = StatusCode::STATUS_OK;
+            break;
+        case 'ERROR':
+            $code = StatusCode::STATUS_ERROR;
+            break;
+    }
+
     /** @var ?Span $span */
     $span = $spans[$spanId];
     if ($span) {
@@ -295,7 +308,7 @@ $router->addRoute('POST', '/trace/otel/span_context', new ClosureRequestHandler(
         return jsonResponse([
             'trace_id' => $spanContext->getTraceId(),
             'span_id' => $spanContext->getSpanId(),
-            'trace_flags' => $spanContext->getTraceFlags(),
+            'trace_flags' => $spanContext->getTraceFlags() ? '01' : '00',
             'trace_state' => (string) $spanContext->getTraceState(), // Implements __toString()
             'remote' => $spanContext->isRemote()
         ]);

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -196,9 +196,14 @@ $router->addRoute('POST', '/trace/otel/start_span', new ClosureRequestHandler(fu
     }
 
     if ($httpHeaders) {
+        $carrier = [];
+        foreach ($httpHeaders as $header => $value) {
+            $carrier[strtolower($header)] = $value;
+        }
         print("Extracting context from headers\n");
         print(json_encode($httpHeaders, JSON_PRETTY_PRINT) . "\n");
-        $remoteContext = TraceContextPropagator::getInstance()->extract($httpHeaders);
+        print(json_encode($carrier, JSON_PRETTY_PRINT) . "\n");
+        $remoteContext = TraceContextPropagator::getInstance()->extract($carrier);
         print(get_class($remoteContext) . "\n");
         print(Span::fromContext($remoteContext)->getContext()->getTraceState());
         print(Span::fromContext($remoteContext)->getContext()->getTraceId());

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -199,7 +199,7 @@ $router->addRoute('POST', '/trace/otel/start_span', new ClosureRequestHandler(fu
     print("Pre $spanKind");
     $spanKind = remappedSpanKind($spanKind);
     print("Post $spanKind");
-    if ($spanKind) {
+    if ($spanKind !==  null) {
         $spanBuilder->setSpanKind($spanKind);
     }
 

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -196,8 +196,13 @@ $router->addRoute('POST', '/trace/otel/start_span', new ClosureRequestHandler(fu
     }
 
     if ($httpHeaders) {
+        print("Extracting context from headers\n");
+        print(json_encode($httpHeaders, JSON_PRETTY_PRINT) . "\n");
         $remoteContext = TraceContextPropagator::getInstance()->extract($httpHeaders);
+        print(get_class($remoteContext) . "\n");
         $spanBuilder->setParent($remoteContext);
+    } else {
+        print("No headers\n");
     }
 
     if ($attributes) {
@@ -272,9 +277,7 @@ $router->addRoute('POST', '/trace/otel/set_status', new ClosureRequestHandler(fu
 
     /** @var ?Span $span */
     $span = $spans[$spanId];
-    if ($span) {
-        $span->setStatus($code, $description);
-    }
+    $span?->setStatus($code, $description);
 
     return jsonResponse([]);
 }));

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -197,8 +197,8 @@ $router->addRoute('POST', '/trace/otel/start_span', new ClosureRequestHandler(fu
 
     if ($httpHeaders) {
         $carrier = [];
-        foreach ($httpHeaders as $header => $value) {
-            $carrier[strtolower($header)] = $value;
+        foreach ($httpHeaders as $headers) {
+            $carrier[$headers[0]] = $headers[1];
         }
         print("Extracting context from headers\n");
         print(json_encode($httpHeaders, JSON_PRETTY_PRINT) . "\n");

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -200,17 +200,8 @@ $router->addRoute('POST', '/trace/otel/start_span', new ClosureRequestHandler(fu
         foreach ($httpHeaders as $headers) {
             $carrier[$headers[0]] = $headers[1];
         }
-        print("Extracting context from headers\n");
-        print(json_encode($httpHeaders, JSON_PRETTY_PRINT) . "\n");
-        print(json_encode($carrier, JSON_PRETTY_PRINT) . "\n");
         $remoteContext = TraceContextPropagator::getInstance()->extract($carrier);
-        print(get_class($remoteContext) . "\n");
-        print(Span::fromContext($remoteContext)->getContext()->getTraceState());
-        print(Span::fromContext($remoteContext)->getContext()->getTraceId());
-        print(Span::fromContext($remoteContext)->getContext()->getSpanId());
         $spanBuilder->setParent($remoteContext);
-    } else {
-        print("No headers\n");
     }
 
     if ($attributes) {

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -281,7 +281,8 @@ $router->addRoute('POST', '/trace/otel/set_status', new ClosureRequestHandler(fu
     return jsonResponse([]);
 }));
 $router->addRoute('POST', '/trace/otel/flush', new ClosureRequestHandler(function (Request $req) use (&$spans) {
-     dd_trace_close_all_spans_and_flush();
+    \DDTrace\flush();
+    dd_trace_internal_fn("synchronous_flush");
      return jsonResponse([
          'success' => true
      ]);

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -196,9 +196,7 @@ $router->addRoute('POST', '/trace/otel/start_span', new ClosureRequestHandler(fu
         $spanBuilder->setParent($contextWithParentSpan);
     }
 
-    print("Pre $spanKind");
     $spanKind = remappedSpanKind($spanKind);
-    print("Post $spanKind");
     if ($spanKind !==  null) {
         $spanBuilder->setSpanKind($spanKind);
     }

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -265,7 +265,9 @@ $router->addRoute('POST', '/trace/otel/set_status', new ClosureRequestHandler(fu
 }));
 $router->addRoute('POST', '/trace/otel/flush', new ClosureRequestHandler(function (Request $req) use (&$spans) {
      dd_trace_close_all_spans_and_flush();
-     return jsonResponse([]);
+     return jsonResponse([
+         'success' => true
+     ]);
 }));
 $router->addRoute('POST', '/trace/otel/is_recording', new ClosureRequestHandler(function (Request $req) use (&$spans) {
     $spanId = arg($req, 'span_id');

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -196,7 +196,9 @@ $router->addRoute('POST', '/trace/otel/start_span', new ClosureRequestHandler(fu
         $spanBuilder->setParent($contextWithParentSpan);
     }
 
+    print("Pre $spanKind");
     $spanKind = remappedSpanKind($spanKind);
+    print("Post $spanKind");
     if ($spanKind) {
         $spanBuilder->setSpanKind($spanKind);
     }

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -7,7 +7,6 @@ require __DIR__ . "/vendor/autoload.php";
 
 use Amp\ByteStream;
 use Amp\Http\Server\DefaultErrorHandler;
-use Amp\Http\Server\Driver\SocketClientFactory;
 use Amp\Http\Server\Request;
 use Amp\Http\Server\RequestHandler\ClosureRequestHandler;
 use Amp\Http\Server\Response;
@@ -15,12 +14,8 @@ use Amp\Http\Server\Router;
 use Amp\Http\Server\SocketHttpServer;
 use Amp\Log\ConsoleFormatter;
 use Amp\Log\StreamHandler;
-use Amp\Socket\ResourceServerSocketFactory;
-use DDTrace\OpenTelemetry\API\Trace\SpanContext;
-use League\Uri\Components\Query;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
-use OpenTelemetry\API\Trace\NonRecordingSpan;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanKind;
@@ -36,10 +31,7 @@ $logHandler->setFormatter(new ConsoleFormatter);
 $logger = new Logger('server');
 $logger->pushHandler($logHandler);
 
-$serverSocketFactory = new ResourceServerSocketFactory();
-$clientFactory = new SocketClientFactory($logger);
-
-$server = new SocketHttpServer($logger, $serverSocketFactory, $clientFactory);
+$server = SocketHttpServer::createForDirectAccess($logger);
 
 $port = getenv('APM_TEST_CLIENT_SERVER_PORT');
 $server->expose("0.0.0.0:" . $port);

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -178,14 +178,16 @@ $router->addRoute('POST', '/trace/otel/start_span', new ClosureRequestHandler(fu
         $spanBuilder->setParent($contextWithParentSpan);
     }
 
-    if ($spanKind && in_array($spanKind, [
+    if ($spanKind && in_array($spanKind - 1, [
             SpanKind::KIND_INTERNAL,
             SpanKind::KIND_CLIENT,
             SpanKind::KIND_SERVER,
             SpanKind::KIND_PRODUCER,
             SpanKind::KIND_CONSUMER
         ])) {
-        $spanBuilder->setSpanKind($spanKind);
+        // otel_trace.py SK_.* ranges from 0 to 5, with 0 being SK_UNSPECIFIED, which doesn't exist in
+        // OpenTelemetry\API\Trace\SpanKind
+        $spanBuilder->setSpanKind($spanKind - 1);
     }
 
     if ($timestamp) {

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -263,6 +263,10 @@ $router->addRoute('POST', '/trace/otel/set_status', new ClosureRequestHandler(fu
 
     return jsonResponse([]);
 }));
+$router->addRoute('POST', '/trace/otel/flush', new ClosureRequestHandler(function (Request $req) use (&$spans) {
+     dd_trace_close_all_spans_and_flush();
+     return jsonResponse([]);
+}));
 $router->addRoute('POST', '/trace/otel/is_recording', new ClosureRequestHandler(function (Request $req) use (&$spans) {
     $spanId = arg($req, 'span_id');
 

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -14,9 +14,15 @@ use Amp\Http\Server\Router;
 use Amp\Http\Server\SocketHttpServer;
 use Amp\Log\ConsoleFormatter;
 use Amp\Log\StreamHandler;
+use DDTrace\OpenTelemetry\API\Trace\SpanContext;
 use League\Uri\Components\Query;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
+use OpenTelemetry\API\Trace\NonRecordingSpan;
+use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\SDK\Trace\TracerProvider;
 use function Amp\trapSignal;
 
 $logHandler = new StreamHandler(ByteStream\getStdout());
@@ -142,7 +148,141 @@ $router->addRoute('POST', '/trace/span/flush', new ClosureRequestHandler(functio
     dd_trace_internal_fn("synchronous_flush");
     return jsonResponse([]);
 }));
+$router->addRoute('POST', '/trace/otel/start_span', new ClosureRequestHandler(function (Request $req) use (&$spans) {
+    $name = arg($req, 'name');
+    $timestamp = arg($req, 'timestamp');
+    $spanKind = arg($req, 'span_kind');
+    $parentId = arg($req, 'parent_id');
+    $httpHeaders = arg($req, 'http_headers');
+    $attributes = arg($req, 'attributes');
 
+    $tracer = (new TracerProvider())->getTracer('OpenTelemetry.PHPTestTracer');
+
+    $spanBuilder = $tracer->spanBuilder($name);
+    if ($parentId) {
+        /** @var ?Span $parentSpan */
+        $parentSpan = $spans[$parentId];
+        if ($parentSpan === null) {
+            return;
+        }
+        $contextWithParentSpan = $parentSpan->storeInContext(OpenTelemetry\Context\Context::getRoot());
+        $spanBuilder->setParent($contextWithParentSpan);
+    }
+
+    if ($spanKind && in_array($spanKind, [
+            SpanKind::KIND_INTERNAL,
+            SpanKind::KIND_CLIENT,
+            SpanKind::KIND_SERVER,
+            SpanKind::KIND_PRODUCER,
+            SpanKind::KIND_CONSUMER
+        ])) {
+        $spanBuilder->setSpanKind($spanKind);
+    }
+
+    if ($timestamp) {
+        $spanBuilder->setStartTimestamp($timestamp * 1000); // ms -> ns
+    }
+
+    if ($httpHeaders) {
+        $remoteContext = TraceContextPropagator::getInstance()->extract($httpHeaders);
+        $spanBuilder->setParent($remoteContext);
+    }
+
+    if ($attributes) {
+        $spanBuilder->setAttributes($attributes);
+    }
+
+    $span = $spanBuilder->startSpan();
+    $spanId = $span->getContext()->getSpanId();
+    $traceId = $span->getContext()->getTraceId();
+    $spans[$spanId] = $span;
+
+    return jsonResponse([
+        'span_id' => $spanId,
+        'trace_id' => $traceId
+    ]);
+}));
+$router->addRoute('POST', '/trace/otel/end_span', new ClosureRequestHandler(function (Request $req) use (&$spans) {
+    $spanId = arg($req, 'id');
+    $timestamp = arg($req, 'timestamp');
+
+    /** @var ?Span $span */
+    $span = $spans[$spanId];
+    if ($span) {
+        $span->end($timestamp ? $timestamp * 1000 : null);
+    }
+
+    return jsonResponse([]);
+}));
+$router->addRoute('POST', '/trace/otel/set_attributes', new ClosureRequestHandler(function (Request $req) use (&$spans) {
+    $spanId = arg($req, 'span_id');
+    $attributes = arg($req, 'attributes');
+
+    /** @var ?Span $span */
+    $span = $spans[$spanId];
+    if ($span) {
+        $span->setAttributes($attributes);
+    }
+
+    return jsonResponse([]);
+}));
+$router->addRoute('POST', '/trace/otel/set_name', new ClosureRequestHandler(function (Request $req) use (&$spans) {
+    $spanId = arg($req, 'span_id');
+    $name = arg($req, 'name');
+
+    /** @var ?Span $span */
+    $span = $spans[$spanId];
+    if ($span) {
+        $span->updateName($name);
+    }
+
+    return jsonResponse([]);
+}));
+$router->addRoute('POST', '/trace/otel/set_status', new ClosureRequestHandler(function (Request $req) use (&$spans) {
+    $spanId = arg($req, 'span_id');
+    $code = arg($req, 'code');
+    $description = arg($req, 'description');
+
+    /** @var ?Span $span */
+    $span = $spans[$spanId];
+    if ($span) {
+        $span->setStatus($code, $description);
+    }
+
+    return jsonResponse([]);
+}));
+$router->addRoute('POST', '/trace/otel/is_recording', new ClosureRequestHandler(function (Request $req) use (&$spans) {
+    $spanId = arg($req, 'span_id');
+
+    /** @var ?Span $span */
+    $span = $spans[$spanId];
+    if ($span) {
+        return jsonResponse([
+            'is_recording' => $span->isRecording()
+        ]);
+    }
+
+    return jsonResponse([]);
+}));
+$router->addRoute('POST', '/trace/otel/span_context', new ClosureRequestHandler(function (Request $req) use (&$spans) {
+    $spanId = arg($req, 'span_id');
+
+    /** @var ?Span $span */
+    $span = $spans[$spanId];
+    if ($span) {
+        $spanContext = $span->getContext();
+
+        return jsonResponse([
+            'trace_id' => $spanContext->getTraceId(),
+            'span_id' => $spanContext->getSpanId(),
+            'trace_flags' => $spanContext->getTraceFlags(),
+            'trace_state' => (string) $spanContext->getTraceState(), // Implements __toString()
+            'remote' => $spanContext->isRemote()
+        ]);
+    }
+
+    return jsonResponse([]);
+}));
 $server->start($router, $errorHandler);
 
 $signal = trapSignal([SIGINT, SIGTERM]);


### PR DESCRIPTION
## Motivation

Run OTel parametric tests for PHP

## Changes

- Unskip OTel PHP tests
- A new `composer.lock` file was created as a result of the changes in the `composer.json`. I generated this file in my buster container. If this is not the way to do it, please advice me.
- `test_otel_get_span_context`: Allow hexadecimal span id, as span identifiers generated by OTel are hexadecimal

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
