### PR TITLE
Parametric: Add client: ruby version: dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@robertomonteromiguel/parametric_use_load_binary_ruby
+    uses: datadog/system-tests/.github/workflows/parametric.yml@main
     secrets: inherit
 
   experimental:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@main
+    uses: datadog/system-tests/.github/workflows/parametric.yml@robertomonteromiguel/parametric_use_load_binary_ruby
     secrets: inherit
 
   experimental:

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -13,31 +13,33 @@ jobs:
       matrix:
           variant:
             #Updated with dev version 
-            - client: java
+            #- client: java
+            #  version: dev
+            #- client: java
+            #  version: prod
+            #- client: nodejs
+            #  version: dev
+            #- client: nodejs
+            #  version: prod
+            #- client: golang
+            #  version: dev
+            #- client: golang
+            #  version: prod
+            #- client: python
+            #  version: dev
+            #- client: python
+            #  version: prod
+            - client: ruby
               version: dev
-            - client: java
-              version: prod
-            - client: nodejs
-              version: dev
-            - client: nodejs
-              version: prod
-            - client: golang
-              version: dev
-            - client: golang
-              version: prod
-            - client: python
-              version: dev
-            - client: python
-              version: prod
-            #Pending to update with dev version  
-            - client: php
-              version: prod
-            - client: dotnet
-              version: prod
             - client: ruby
               version: prod
-            - client: cpp
-              version: prod
+            #Pending to update with dev version  
+            #- client: php
+            #  version: prod
+            #- client: dotnet
+            #  version: prod
+            #- client: cpp
+            #  version: prod
  
       fail-fast: false
     env:

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -13,33 +13,33 @@ jobs:
       matrix:
           variant:
             #Updated with dev version 
-            #- client: java
-            #  version: dev
-            #- client: java
-            #  version: prod
-            #- client: nodejs
-            #  version: dev
-            #- client: nodejs
-            #  version: prod
-            #- client: golang
-            #  version: dev
-            #- client: golang
-            #  version: prod
-            #- client: python
-            #  version: dev
-            #- client: python
-            #  version: prod
+            - client: java
+              version: dev
+            - client: java
+              version: prod
+            - client: nodejs
+              version: dev
+            - client: nodejs
+              version: prod
+            - client: golang
+              version: dev
+            - client: golang
+              version: prod
+            - client: python
+              version: dev
+            - client: python
+              version: prod
             - client: ruby
               version: dev
             - client: ruby
               version: prod
             #Pending to update with dev version  
-            #- client: php
-            #  version: prod
-            #- client: dotnet
-            #  version: prod
-            #- client: cpp
-            #  version: prod
+            - client: php
+              version: prod
+            - client: dotnet
+              version: prod
+            - client: cpp
+              version: prod
  
       fail-fast: false
     env:

--- a/docs/scenarios/parametric.md
+++ b/docs/scenarios/parametric.md
@@ -152,11 +152,11 @@ There is two ways for running the NodeJS tests with a custom tracer:
 
 #### Ruby
 
-To run the Ruby tests "locally" push your code GitHub and then specify `RUBY_DDTRACE_SHA`:
+There is two ways for running the Ruby tests with a custom tracer:
 
-```sh
-RUBY_DDTRACE_SHA=0552ebd49dc5b3bec4e739c2c74b214fb3102c2a ./run.sh ...
-```
+1. Create an file ruby-load-from-bundle-add in binaries/, the content will be installed by bundle add. Content example:
+gem 'ddtrace', git: "https://github.com/Datadog/dd-trace-rb", branch: "master", require: 'ddtrace/auto_instrument'
+2. Clone the dd-trace-rb repo inside binaries
 
 #### C++
 

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -993,12 +993,6 @@ class ParametricScenario(_Scenario):
         super().configure(config)
         assert "TEST_LIBRARY" in os.environ
 
-        # For some tracers we need a env variable present to use custom build of the tracer
-        lang_custom_build_param = {
-            "ruby": "RUBY_DDTRACE_SHA",
-        }
-        build_param = os.getenv(lang_custom_build_param.get(os.getenv("TEST_LIBRARY"), ""), "")
-
         # get tracer version info building and executing the ddtracer-version.docker file
         parametric_appdir = os.path.join("utils", "build", "docker", os.getenv("TEST_LIBRARY"), "parametric")
         tracer_version_dockerfile = os.path.join(parametric_appdir, "ddtracer_version.Dockerfile")
@@ -1014,8 +1008,6 @@ class ParametricScenario(_Scenario):
                         "-f",
                         f"{tracer_version_dockerfile}",
                         "--quiet",
-                        "--build-arg",
-                        f"BUILD_MODULE={build_param}",
                     ],
                     stdout=subprocess.DEVNULL,
                     # stderr=subprocess.DEVNULL,

--- a/utils/build/docker/ruby/parametric/Gemfile
+++ b/utils/build/docker/ruby/parametric/Gemfile
@@ -1,12 +1,6 @@
 source "https://rubygems.org"
 
-sha = ENV['RUBY_DDTRACE_SHA']
-if sha && !sha.empty?
-  gem 'ddtrace', git: 'https://github.com/Datadog/dd-trace-rb.git', ref: sha
-else
-  gem 'ddtrace'
-end
-
+gem 'ddtrace'
 gem 'grpc'
 gem 'grpc-tools'
 

--- a/utils/build/docker/ruby/parametric/ddtracer_version.Dockerfile
+++ b/utils/build/docker/ruby/parametric/ddtracer_version.Dockerfile
@@ -1,10 +1,8 @@
 FROM ruby:3.2.1-bullseye
 
-WORKDIR /client
-RUN gem install ddtrace # Install a baseline ddtrace version, to cache all dependencies
-COPY ./utils/build/docker/ruby/parametric/Gemfile /client/
-COPY ./utils/build/docker/ruby/parametric/install_dependencies.sh /client/
-ARG BUILD_MODULE=''
-ENV RUBY_DDTRACE_SHA=$BUILD_MODULE
-RUN bash install_dependencies.sh
-CMD bundle exec ruby -e 'puts Gem.loaded_specs["ddtrace"].version'
+WORKDIR /app
+COPY utils/build/docker/ruby/parametric/ .
+COPY utils/build/docker/ruby/install_ddtrace.sh binaries* /binaries/
+RUN bundle install
+RUN /binaries/install_ddtrace.sh
+CMD cat SYSTEM_TESTS_LIBRARY_VERSION


### PR DESCRIPTION
## Motivation

Currently Parametric only executes tests using latest tracer release. We add support to run snapshot version of the ruby tracer (dev).

The idea behind this is to use the same approach to install dd-trace-rb as is used by system-tests (maintainability reasons).

We are using the previously existing script to install the tracer: utils/build/docker/ruby/install_ddtrace.sh

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
