### PR TITLE
fix debugger tests with new EMITTING probe status

### DIFF
--- a/tests/debugger/test_debugger.py
+++ b/tests/debugger/test_debugger.py
@@ -204,10 +204,10 @@ class Test_Debugger_Method_Probe_Snaphots(_Base_Debugger_Snapshot_Test):
         assert self.span_decoration_probe_response.status_code == 200
 
         expected_probes = {
-            "log170aa-acda-4453-9111-1478a6method": "INSTALLED",
-            "metricaa-acda-4453-9111-1478a6method": "INSTALLED",
-            "span70aa-acda-4453-9111-1478a6method": "INSTALLED",
-            "decor0aa-acda-4453-9111-1478a6method": "INSTALLED",
+            "log170aa-acda-4453-9111-1478a6method": "EMITTING",
+            "metricaa-acda-4453-9111-1478a6method": "EMITTING",
+            "span70aa-acda-4453-9111-1478a6method": "EMITTING",
+            "decor0aa-acda-4453-9111-1478a6method": "EMITTING",
         }
         expected_snapshots = ["log170aa-acda-4453-9111-1478a6method"]
         expected_spans = ["span70aa-acda-4453-9111-1478a6method", "decor0aa-acda-4453-9111-1478a6method"]

--- a/tests/debugger/test_debugger.py
+++ b/tests/debugger/test_debugger.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import scenarios, interfaces, weblog, features, missing_feature
+from utils import scenarios, interfaces, weblog, features, missing_feature, context
 from utils.tools import logger
 
 

--- a/tests/debugger/test_debugger.py
+++ b/tests/debugger/test_debugger.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import scenarios, interfaces, weblog, features
+from utils import scenarios, interfaces, weblog, features, missing_feature
 from utils.tools import logger
 
 
@@ -194,6 +194,7 @@ class Test_Debugger_Method_Probe_Snaphots(_Base_Debugger_Snapshot_Test):
         self.span_probe_response = weblog.get("/debugger/span")
         self.span_decoration_probe_response = weblog.get("/debugger/span-decoration/asd/1")
 
+    @missing_feature(context.library >= "java@1.27", reason="introduction of new EMITTING probe status")
     def test_method_probe_snaphots(self):
         self.assert_remote_config_is_sent()
         self.assert_all_probes_are_installed()
@@ -204,10 +205,10 @@ class Test_Debugger_Method_Probe_Snaphots(_Base_Debugger_Snapshot_Test):
         assert self.span_decoration_probe_response.status_code == 200
 
         expected_probes = {
-            "log170aa-acda-4453-9111-1478a6method": "EMITTING",
-            "metricaa-acda-4453-9111-1478a6method": "EMITTING",
-            "span70aa-acda-4453-9111-1478a6method": "EMITTING",
-            "decor0aa-acda-4453-9111-1478a6method": "EMITTING",
+            "log170aa-acda-4453-9111-1478a6method": "INSTALLED",
+            "metricaa-acda-4453-9111-1478a6method": "INSTALLED",
+            "span70aa-acda-4453-9111-1478a6method": "INSTALLED",
+            "decor0aa-acda-4453-9111-1478a6method": "INSTALLED",
         }
         expected_snapshots = ["log170aa-acda-4453-9111-1478a6method"]
         expected_spans = ["span70aa-acda-4453-9111-1478a6method", "decor0aa-acda-4453-9111-1478a6method"]

--- a/tests/debugger/test_debugger.py
+++ b/tests/debugger/test_debugger.py
@@ -238,6 +238,7 @@ class Test_Debugger_Line_Probe_Snaphots(_Base_Debugger_Snapshot_Test):
         self.metric_probe_response = weblog.get("/debugger/metric/1")
         self.span_decoration_probe_response = weblog.get("/debugger/span-decoration/asd/1")
 
+    @missing_feature(context.library >= "java@1.27", reason="introduction of new EMITTING probe status")
     def test_line_probe_snaphots(self):
         self.assert_remote_config_is_sent()
         self.assert_all_probes_are_installed()
@@ -274,6 +275,7 @@ class Test_Debugger_Mix_Log_Probe(_Base_Debugger_Snapshot_Test):
         interfaces.agent.wait_for(self.wait_for_all_probes_installed, timeout=30)
         self.multi_probe_response = weblog.get("/debugger/mix/asd/1")
 
+    @missing_feature(context.library >= "java@1.27", reason="introduction of new EMITTING probe status")
     def test_mix_probe(self):
         self.assert_remote_config_is_sent()
         self.assert_all_probes_are_installed()


### PR DESCRIPTION
## Motivation

Following https://github.com/DataDog/dd-trace-java/pull/6365 a new probe status was introduced, requiring to update those tests

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
