### PR TITLE
Parametric: Add client: dotnet version: dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@parametric_use_load_binary_dotnet
+    uses: datadog/system-tests/.github/workflows/parametric.yml@robertomonteromiguel/parametric_use_load_binary_dotnet
     secrets: inherit
 
   experimental:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@robertomonteromiguel/parametric_use_load_binary_dotnet
+    uses: datadog/system-tests/.github/workflows/parametric.yml@main
     secrets: inherit
 
   experimental:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@main
+    uses: datadog/system-tests/.github/workflows/parametric.yml@parametric_use_load_binary_dotnet
     secrets: inherit
 
   experimental:

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -38,8 +38,6 @@ jobs:
             - client: dotnet
               version: prod
             #Pending to update with dev version  
-            - client: dotnet
-              version: prod
             - client: cpp
               version: prod
             - client: php

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -13,33 +13,37 @@ jobs:
       matrix:
           variant:
             #Updated with dev version 
-            - client: java
+            #- client: java
+            #  version: dev
+            #- client: java
+            #  version: prod
+            #- client: nodejs
+            #  version: dev
+            #- client: nodejs
+            #  version: prod
+            #- client: golang
+            #  version: dev
+            #- client: golang
+            #  version: prod
+            #- client: python
+            #  version: dev
+            #- client: python
+            #  version: prod
+            #- client: ruby
+            #  version: dev
+            #- client: ruby
+            #  version: prod
+            - client: dotnet
               version: dev
-            - client: java
-              version: prod
-            - client: nodejs
-              version: dev
-            - client: nodejs
-              version: prod
-            - client: golang
-              version: dev
-            - client: golang
-              version: prod
-            - client: python
-              version: dev
-            - client: python
-              version: prod
-            - client: ruby
-              version: dev
-            - client: ruby
-              version: prod
-            #Pending to update with dev version  
-            - client: php
-              version: prod
             - client: dotnet
               version: prod
-            - client: cpp
-              version: prod
+            #Pending to update with dev version  
+            #- client: dotnet
+            #  version: prod
+            #- client: cpp
+            #  version: prod
+            #- client: php
+            #  version: prod
  
       fail-fast: false
     env:

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -13,37 +13,37 @@ jobs:
       matrix:
           variant:
             #Updated with dev version 
-            #- client: java
-            #  version: dev
-            #- client: java
-            #  version: prod
-            #- client: nodejs
-            #  version: dev
-            #- client: nodejs
-            #  version: prod
-            #- client: golang
-            #  version: dev
-            #- client: golang
-            #  version: prod
-            #- client: python
-            #  version: dev
-            #- client: python
-            #  version: prod
-            #- client: ruby
-            #  version: dev
-            #- client: ruby
-            #  version: prod
+            - client: java
+              version: dev
+            - client: java
+              version: prod
+            - client: nodejs
+              version: dev
+            - client: nodejs
+              version: prod
+            - client: golang
+              version: dev
+            - client: golang
+              version: prod
+            - client: python
+              version: dev
+            - client: python
+              version: prod
+            - client: ruby
+              version: dev
+            - client: ruby
+              version: prod
             - client: dotnet
               version: dev
             - client: dotnet
               version: prod
             #Pending to update with dev version  
-            #- client: dotnet
-            #  version: prod
-            #- client: cpp
-            #  version: prod
-            #- client: php
-            #  version: prod
+            - client: dotnet
+              version: prod
+            - client: cpp
+              version: prod
+            - client: php
+              version: prod
  
       fail-fast: false
     env:

--- a/docs/scenarios/parametric.md
+++ b/docs/scenarios/parametric.md
@@ -83,10 +83,7 @@ go mod tidy
 
 #### dotnet
 
-To test unmerged PRs locally, do the following:
-- In your local dd-trace-dotnet repo, build the `Datadog.Trace` NuGet package. The easiest way to do this is to run `dotnet pack` from the `/tracer/src/Datadog.Trace` directory.
-- Copy the resulting `.nupkg` file into the `apps/dotnet` directory
-- In `apps/dotnet/ApmTestClient.csproj`, update the version of the `Datadog.Trace` package reference to the dev version
+Add a file datadog-dotnet-apm-<VERSION>.tar.gz in binaries/. <VERSION> must be a valid version number.
 
 #### Java
 

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -192,37 +192,38 @@ RUN go install
 def dotnet_library_factory():
     dotnet_appdir = os.path.join("utils", "build", "docker", "dotnet", "parametric")
     dotnet_absolute_appdir = os.path.join(_get_base_directory(), dotnet_appdir)
+    dotnet_reldir = dotnet_appdir.replace("\\", "/")
     server = APMLibraryTestServer(
         lang="dotnet",
         protocol="grpc",
         container_name="dotnet-test-client",
         container_tag="dotnet7_0-test-client",
-        container_img="""
+        container_img=f"""
 FROM mcr.microsoft.com/dotnet/sdk:7.0
 RUN apt-get update && apt-get install dos2unix
-WORKDIR /client
+WORKDIR /app
 
 # Opt-out of .NET SDK CLI telemetry (prevent unexpected http client spans)
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 # ensure that the Datadog.Trace.dlls are installed from /binaries
-COPY /install_ddtrace.sh /binaries/
+COPY utils/build/docker/dotnet/install_ddtrace.sh utils/build/docker/dotnet/query-versions.fsx binaries* /binaries/
 RUN dos2unix /binaries/install_ddtrace.sh
 RUN /binaries/install_ddtrace.sh
 
 # restore nuget packages
-COPY ["./ApmTestClient.csproj", "./nuget.config", "./*.nupkg", "./"]
+COPY ["{dotnet_reldir}/ApmTestClient.csproj", "{dotnet_reldir}/nuget.config", "{dotnet_reldir}/*.nupkg", "./"]
 RUN dotnet restore "./ApmTestClient.csproj"
 
 # build and publish
-COPY . ./
+COPY {dotnet_reldir} ./
 RUN dotnet publish --no-restore --configuration Release --output out
-WORKDIR /client/out
+WORKDIR /app/out
 
 # Set up automatic instrumentation (required for OpenTelemetry tests),
 # but don't enable it globally
 ENV CORECLR_ENABLE_PROFILING=0
-ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+ENV CORECLR_PROFILER={{846F5F1C-F9AE-4B07-969E-05C26BC060D8}}
 ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 
@@ -234,7 +235,7 @@ ENV DD_TRACE_OTEL_ENABLED=false
 """,
         container_cmd=["./ApmTestClient"],
         container_build_dir=dotnet_absolute_appdir,
-        container_build_context=dotnet_absolute_appdir,
+        container_build_context=_get_base_directory(),
         volumes=[],
         env={},
         port="",

--- a/utils/build/docker/dotnet/parametric/Dockerfile
+++ b/utils/build/docker/dotnet/parametric/Dockerfile
@@ -1,24 +1,23 @@
-
 FROM mcr.microsoft.com/dotnet/sdk:7.0
 RUN apt-get update && apt-get install dos2unix
-WORKDIR /client
+WORKDIR /app
 
 # Opt-out of .NET SDK CLI telemetry (prevent unexpected http client spans)
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 # ensure that the Datadog.Trace.dlls are installed from /binaries
-COPY /install_ddtrace.sh /binaries/
+COPY utils/build/docker/dotnet/install_ddtrace.sh utils/build/docker/dotnet/query-versions.fsx binaries* /binaries/
 RUN dos2unix /binaries/install_ddtrace.sh
 RUN /binaries/install_ddtrace.sh
 
 # restore nuget packages
-COPY ["./ApmTestClient.csproj", "./nuget.config", "./*.nupkg", "./"]
+COPY ["utils/build/docker/dotnet/parametric/ApmTestClient.csproj", "utils/build/docker/dotnet/parametric/nuget.config", "utils/build/docker/dotnet/parametric/*.nupkg", "./"]
 RUN dotnet restore "./ApmTestClient.csproj"
 
 # build and publish
-COPY . ./
+COPY utils/build/docker/dotnet/parametric ./
 RUN dotnet publish --no-restore --configuration Release --output out
-WORKDIR /client/out
+WORKDIR /app/out
 
 # Set up automatic instrumentation (required for OpenTelemetry tests),
 # but don't enable it globally

--- a/utils/build/docker/dotnet/parametric/ddtracer_version.Dockerfile
+++ b/utils/build/docker/dotnet/parametric/ddtracer_version.Dockerfile
@@ -3,10 +3,10 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 RUN apt-get update && apt-get install dos2unix
 
-WORKDIR /client
+WORKDIR /app
 
-COPY utils/build/docker/dotnet/parametric/install_ddtrace.sh binaries* /binaries/
+COPY utils/build/docker/dotnet/install_ddtrace.sh utils/build/docker/dotnet/query-versions.fsx binaries* /binaries/
 RUN dos2unix /binaries/install_ddtrace.sh
 RUN /binaries/install_ddtrace.sh
 
-CMD echo $(cat /binaries/SYSTEM_TESTS_LIBRARY_VERSION)
+CMD cat SYSTEM_TESTS_LIBRARY_VERSION


### PR DESCRIPTION
## Motivation

Adapt parametric test to use the script load-binary.sh to test snapshot and release versions

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
