### PR TITLE
Parametric: Add client: cpp version: dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@robertomonteromiguel/parametric_use_load_binary_cpp
+    uses: datadog/system-tests/.github/workflows/parametric.yml@main
     secrets: inherit
 
   experimental:
@@ -76,7 +76,6 @@ jobs:
     secrets: inherit
 
   main:
-    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     needs:
     - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - lint
     - test_the_test
     - scenarios
-    uses: datadog/system-tests/.github/workflows/parametric.yml@main
+    uses: datadog/system-tests/.github/workflows/parametric.yml@robertomonteromiguel/parametric_use_load_binary_cpp
     secrets: inherit
 
   experimental:
@@ -76,6 +76,7 @@ jobs:
     secrets: inherit
 
   main:
+    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     needs:
     - lint

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -13,30 +13,30 @@ jobs:
       matrix:
           variant:
             #Updated with dev version 
-            #- client: java
-            #  version: dev
-            #- client: java
-            #  version: prod
-            #- client: nodejs
-            #  version: dev
-            #- client: nodejs
-            #  version: prod
-            #- client: golang
-            #  version: dev
-            #- client: golang
-            #  version: prod
-            #- client: python
-            #  version: dev
-            #- client: python
-            #  version: prod
-            #- client: ruby
-            #  version: dev
-            #- client: ruby
-            #  version: prod
-            #- client: dotnet
-            #  version: dev
-            #- client: dotnet
-            #  version: prod
+            - client: java
+              version: dev
+            - client: java
+              version: prod
+            - client: nodejs
+              version: dev
+            - client: nodejs
+              version: prod
+            - client: golang
+              version: dev
+            - client: golang
+              version: prod
+            - client: python
+              version: dev
+            - client: python
+              version: prod
+            - client: ruby
+              version: dev
+            - client: ruby
+              version: prod
+            - client: dotnet
+              version: dev
+            - client: dotnet
+              version: prod
             - client: cpp
               version: dev
             - client: cpp

--- a/.github/workflows/parametric.yml
+++ b/.github/workflows/parametric.yml
@@ -13,33 +13,35 @@ jobs:
       matrix:
           variant:
             #Updated with dev version 
-            - client: java
+            #- client: java
+            #  version: dev
+            #- client: java
+            #  version: prod
+            #- client: nodejs
+            #  version: dev
+            #- client: nodejs
+            #  version: prod
+            #- client: golang
+            #  version: dev
+            #- client: golang
+            #  version: prod
+            #- client: python
+            #  version: dev
+            #- client: python
+            #  version: prod
+            #- client: ruby
+            #  version: dev
+            #- client: ruby
+            #  version: prod
+            #- client: dotnet
+            #  version: dev
+            #- client: dotnet
+            #  version: prod
+            - client: cpp
               version: dev
-            - client: java
-              version: prod
-            - client: nodejs
-              version: dev
-            - client: nodejs
-              version: prod
-            - client: golang
-              version: dev
-            - client: golang
-              version: prod
-            - client: python
-              version: dev
-            - client: python
-              version: prod
-            - client: ruby
-              version: dev
-            - client: ruby
-              version: prod
-            - client: dotnet
-              version: dev
-            - client: dotnet
-              version: prod
-            #Pending to update with dev version  
             - client: cpp
               version: prod
+            #Pending to update with dev version 
             - client: php
               version: prod
  

--- a/docs/scenarios/parametric.md
+++ b/docs/scenarios/parametric.md
@@ -157,6 +157,12 @@ gem 'ddtrace', git: "https://github.com/Datadog/dd-trace-rb", branch: "master", 
 
 #### C++
 
+There is two ways for running the C++ library tests with a custom tracer:
+1. Create a file `cpp-load-from-git` in `binaries/`. Content examples:
+    * `https://github.com/DataDog/dd-trace-cpp@main`
+    * `https://github.com/DataDog/dd-trace-cpp@<COMMIT HASH>`
+2. Clone the dd-trace-cpp repo inside `binaries`
+
 The parametric shared tests can be run against the C++ library,
 [dd-trace-cpp][1], this way:
 ```console

--- a/utils/build/docker/cpp/parametric/ddtracer_version.Dockerfile
+++ b/utils/build/docker/cpp/parametric/ddtracer_version.Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.14
+
+RUN apk add --no-cache curl git bash jq
+
+
+WORKDIR /usr/app
+COPY utils/build/docker/cpp/parametric/CMakeLists.txt .
+COPY utils/build/docker/cpp/parametric/install_ddtrace.sh binaries* /binaries/
+
+RUN sh /binaries/install_ddtrace.sh
+
+CMD cat SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/cpp/parametric/http/Dockerfile
+++ b/utils/build/docker/cpp/parametric/http/Dockerfile
@@ -1,19 +1,12 @@
+
 FROM datadog/docker-library:dd-trace-cpp-ci AS build
 
-RUN apt-get update && apt-get -y install pkg-config libabsl-dev
-WORKDIR /cpp-parametric-test
-ADD CMakeLists.txt \
-    developer_noise.cpp \
-    developer_noise.h \
-    httplib.h \
-    json.hpp \
-    main.cpp \
-    manual_scheduler.h \
-    request_handler.cpp \
-    request_handler.h \
-    utils.h \
-    /cpp-parametric-test/
+RUN apt-get update && apt-get -y install pkg-config libabsl-dev curl jq
+WORKDIR /usr/app
+COPY utils/build/docker/cpp/parametric/http/../install_ddtrace.sh binaries* /binaries/
+ADD utils/build/docker/cpp/parametric/http/CMakeLists.txt     utils/build/docker/cpp/parametric/http/developer_noise.cpp     utils/build/docker/cpp/parametric/http/developer_noise.h     utils/build/docker/cpp/parametric/http/httplib.h     utils/build/docker/cpp/parametric/http/json.hpp     utils/build/docker/cpp/parametric/http/main.cpp     utils/build/docker/cpp/parametric/http/manual_scheduler.h     utils/build/docker/cpp/parametric/http/request_handler.cpp     utils/build/docker/cpp/parametric/http/request_handler.h     utils/build/docker/cpp/parametric/http/utils.h     /usr/app
+RUN sh /binaries/install_ddtrace.sh
 RUN cmake -B .build -DCMAKE_BUILD_TYPE=Release . && cmake --build .build -j $(nproc) && cmake --install .build --prefix dist
 
 FROM ubuntu:22.04
-COPY --from=build /cpp-parametric-test/dist/bin/cpp-parametric-http-test /usr/local/bin/cpp-parametric-test
+COPY --from=build /usr/app/dist/bin/cpp-parametric-http-test /usr/local/bin/cpp-parametric-test

--- a/utils/build/docker/cpp/parametric/install_ddtrace.sh
+++ b/utils/build/docker/cpp/parametric/install_ddtrace.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -eu
+
+git_clone(){
+    url_to_clone=$1
+    branch_to_clone=$2
+    git clone --branch "$branch_to_clone" "$url_to_clone" /binaries/dd-trace-cpp
+}
+
+git_clone_latest_release (){
+   url_to_clone="https://github.com/DataDog/dd-trace-cpp"
+   latest_release=$(curl -s  https://api.github.com/repos/DataDog/dd-trace-cpp/releases/latest | jq '.tag_name'| tr -d '"')
+   echo "$latest_release" > SYSTEM_TESTS_LIBRARY_VERSION
+   git_clone "$url_to_clone" "$latest_release"    
+}
+
+get_version_from_binaries() {
+    # shellcheck disable=SC2002
+    version_line=$(cat /binaries/dd-trace-cpp/src/datadog/version.cpp | grep '^#define VERSION *')
+    current_version=$(echo "$version_line" |  awk -F'VERSION' '{ print $2 }')
+    echo "$current_version" | tr -d '"'> SYSTEM_TESTS_LIBRARY_VERSION
+}
+
+configure_cmake_to_fetch_from_dir() {
+    sed -i 's@GIT_REPOSITORY@SOURCE_DIR "/binaries/dd-trace-cpp" #GIT_REPOSITORY@g' /usr/app/CMakeLists.txt
+    sed -i "s/GIT_TAG/#GIT_TAG/g" /usr/app/CMakeLists.txt
+    sed -i "s/GIT_SHALLOW/#GIT_SHALLOW/g" /usr/app/CMakeLists.txt
+    sed -i "s/GIT_PROGRESS/#GIT_PROGRESS/g" /usr/app/CMakeLists.txt
+}
+
+
+cd /usr/app
+
+if [ -e /binaries/cpp-load-from-git ]; then
+    echo "install from file cpp-load-from-git"
+    target=$(cat /binaries/cpp-load-from-git) 
+    url=$(echo "$target" | cut -d "@" -f 1)
+    branch=$(echo "$target" | cut -d "@" -f 2)
+    #Clone from git, get version from file version.cpp and configure make to use binaries/dd-trace-cpp folder
+    git_clone "$url" "$branch"
+    get_version_from_binaries
+elif [ -e /binaries/dd-trace-cpp ]; then
+    echo "install from local folder /binaries/dd-trace-cpp"
+    get_version_from_binaries
+else
+    echo "install from latest tracer release"
+    git_clone_latest_release
+fi
+configure_cmake_to_fetch_from_dir

--- a/utils/build/docker/cpp/parametric/install_ddtrace.sh
+++ b/utils/build/docker/cpp/parametric/install_ddtrace.sh
@@ -5,7 +5,10 @@ set -eu
 git_clone(){
     url_to_clone=$1
     branch_to_clone=$2
-    git clone --branch "$branch_to_clone" "$url_to_clone" /binaries/dd-trace-cpp
+    current_dir=$(pwd)
+    #git clone --branch "$branch_to_clone" "$url_to_clone" /binaries/dd-trace-cpp
+    git clone "$url_to_clone" /binaries/dd-trace-cpp
+    cd /binaries/dd-trace-cpp && git checkout "$branch_to_clone" && cd "$current_dir"
 }
 
 git_clone_latest_release (){

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -218,7 +218,9 @@ elif [ "$TARGET" = "cpp" ]; then
     assert_version_is_dev
     # get_circleci_artifact "gh/DataDog/dd-opentracing-cpp" "build_test_deploy" "build" "TBD"
     # PROFILER: The main version is stored in s3, though we can not access this in CI
-    # Not handled for now
+    # Not handled for now for system-tests. this handles artifact for parametric
+    echo "Using https://github.com/DataDog/dd-trace-cpp@main"
+    echo "https://github.com/DataDog/dd-trace-cpp@main" > cpp-load-from-git
 elif [ "$TARGET" = "agent" ]; then
     assert_version_is_dev
     echo "datadog/agent-dev:master-py3" > agent-image


### PR DESCRIPTION
## Motivation

Adapt parametric test to use the script load-binary.sh to test snapshot and release versions.
The idea behind this is to retrieve tracer versions in similar way as other tracer. Also we try to use the same mechanism in system-tests and in parametric tests

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
