### PR TITLE
[WIP] Enable Span Links for Node

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -306,7 +306,7 @@ tests/:
     test_dynamic_configuration.py:
       TestDynamicConfigV1: v4.11.0
       TestDynamicConfigV2: missing_feature
-    test_span_links.py: missing_feature
+    test_span_links.py: missing_feature # will likely either be 4.24.0 or 5.0.0 (whichever comes first)
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: missing_feature
       Test_Trace_Sampling_Globs: missing_feature

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -84,7 +84,9 @@ app.post('/trace/span/start', (req, res) => {
       childOf: parent,
       tags: {
           service: request.service
-      }
+      },
+      // parentId is spanId in the tracer
+      links: request.links.map(link => ({ spanId: link.parent_id, attributes: link.attributes }))
   })
   spans[span.context().toSpanId()] = span
   res.json({ span_id: span.context().toSpanId(), trace_id:span.context().toTraceId(), service:request.service, resource:request.resource,});
@@ -124,6 +126,16 @@ app.post('/trace/span/set_metric', (req, res) => {
   span.setTag(key, value);
   res.json({});
 });
+
+app.post('/trace/span/add_link', (req, res)=> {
+  const spanId = req.body.span_id;
+  const parentId = req.body.parent_id;
+  const attributes = req.body.attributes;
+
+  const span = spans[spanId];
+  span.addLink({ spanId: parentId, attributes });
+  res.json({});
+})
 
 app.post('/trace/stats/flush', (req, res) => {
   // TODO: implement once available in NodeJS Tracer


### PR DESCRIPTION
## Motivation

Enabling span links for the node tracer.

## Changes

Adds additional logic for the Node.js server to handle links as part of the `startSpan` request and adds the appropriate endpoint (`/trace/span/add_link`) for adding a link to a span.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
