### PR TITLE
Fix telemetry v2 client-configuration-change schema

### DIFF
--- a/utils/interfaces/schemas/miscs/telemetry/v2/events/client-configuration-change.json
+++ b/utils/interfaces/schemas/miscs/telemetry/v2/events/client-configuration-change.json
@@ -6,10 +6,7 @@
   "type": "object",
   "properties": {
     "configuration": {
-      "type": "array",
-      "items": {
-        "$ref": "/miscs/telemetry/v2/objects/configuration.json"
-      }
+      "$ref": "/miscs/telemetry/v2/objects/configuration.json"
     },
     "remote_config": {
       "$ref": "/miscs/telemetry/common/objects/remote_config.json"


### PR DESCRIPTION
## Motivation

The `configuration` property is an array of items, but it was incorrectly typed as an array of arrays of items, which is incorrect.

## Changes

Fixes the schema to match what is expected by the Telemetry API.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [X] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [X] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
