### PR TITLE
Fix debugger tests for new Debugger track

### DIFF
--- a/tests/debugger/test_debugger.py
+++ b/tests/debugger/test_debugger.py
@@ -98,6 +98,7 @@ def validate_spans(expected_spans):
 @features.debugger
 @scenarios.debugger_probes_status
 class Test_Debugger_Probe_Statuses:
+    @missing_feature(context.library >= "java@1.27", reason="Sending probe status to DEBUGGER track")
     def test_method_probe_status(self):
         expected_probes = {
             "loga0cf2-meth-45cf-9f39-591received": "RECEIVED",
@@ -112,6 +113,7 @@ class Test_Debugger_Probe_Statuses:
 
         validate_probes(expected_probes)
 
+    @missing_feature(context.library >= "java@1.27", reason="Sending probe status to DEBUGGER track")
     def test_line_probe_status(self):
         expected_probes = {
             "loga0cf2-line-45cf-9f39-59installed": "INSTALLED",


### PR DESCRIPTION
## Motivation

dd-trace-java now upload probe statuses to new Debugger track. need to wait other tracers to switch system tests
to this new track

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
