### PR TITLE
Debug parametric tests ports conflicts

### DIFF
--- a/utils/parametric/tcp_ports.py
+++ b/utils/parametric/tcp_ports.py
@@ -1,0 +1,66 @@
+import fasteners
+import threading
+
+
+class BindFreePort(object):
+    def __init__(self, start, stop):
+        self.port = None
+
+        import random, socket
+
+        self.sock = socket.socket()
+
+        while True:
+            port = random.randint(start, stop)
+            try:
+                self.sock.bind(("", port))
+                self.port = port
+                break
+            except Exception:
+                continue
+
+    def release(self):
+        assert self.port is not None
+        self.sock.close()
+
+
+class FreePort(object):
+    used_ports = set()
+
+    def __init__(self, start=1024, stop=65000):
+        self.lock = None
+        self.bind = None
+        self.port = None
+
+        from fasteners.process_lock import InterProcessLock
+        import time
+
+        while True:
+            bind = BindFreePort(start, stop)
+
+            if bind.port in self.used_ports:
+                bind.release()
+                continue
+
+            """
+            Since we cannot be certain the user will bind the port 'immediately' (actually it is not possible using
+            this flow. We must ensure that the port will not be reacquired even it is not bound to anything
+            """
+            lock = InterProcessLock(path="/tmp/socialdna/port_{}_lock".format(bind.port))
+            success = lock.acquire(blocking=False)
+
+            if success:
+                self.lock = lock
+                self.port = bind.port
+                self.used_ports.add(bind.port)
+                bind.release()
+                break
+
+            bind.release()
+            time.sleep(0.01)
+
+    def release(self):
+        assert self.lock is not None
+        assert self.port is not None
+        self.used_ports.remove(self.port)
+        self.lock.release()


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
