### PR TITLE
Ensure that Datadog-Container-ID is not empty if present

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -365,6 +365,8 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
+  test_data_integrity.py:
+    Test_LibraryHeaders: missing_feature (Datadog-Container-ID is empty on telemetry payloads)
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 """Misc checks around data integrity during components' lifetime"""
-from utils import weblog, interfaces, context, bug, rfc, scenarios, missing_feature
+from utils import weblog, interfaces, context, bug, rfc, missing_feature
 from utils.tools import logger
 from utils.cgroup_info import get_container_id
 
@@ -41,7 +41,7 @@ class Test_TraceHeaders:
         )
 
     def test_trace_header_diagnostic_check(self):
-        """ x-datadog-diagnostic-check header is present iif content is empty """
+        """x-datadog-diagnostic-check header is present iif content is empty"""
 
         def validator(data):
             request_headers = {h[0].lower() for h in data["request"]["headers"]}
@@ -91,7 +91,6 @@ class Test_TraceHeaders:
         logger.info(f"cgroup: weblog container id is {weblog_container_id}")
 
         def validator(data):
-
             if "content" not in data["request"] or not data["request"]["content"]:
                 # RFC states "Once container ID is stored locally in the tracer,
                 # it must be sent to the Agent every time traces are sent."
@@ -121,3 +120,17 @@ class Test_TraceHeaders:
                     )
 
         interfaces.library.add_traces_validation(validator, success_by_default=True)
+
+
+class Test_LibraryHeaders:
+    """Misc test around headers sent by libraries"""
+
+    def test_datadog_container_id(self):
+        """Datadog-Container-ID header is not empty if present"""
+
+        def validator(data):
+            for header, value in data["request"]["headers"]:
+                if header.lower() == "datadog-container-id":
+                    assert value, "Datadog-Container-ID header is empty"
+
+        interfaces.library.validate(validator, success_by_default=True)


### PR DESCRIPTION
## Motivation

`Datadog-Container-ID` header should not be an empty string

## Changes

Test asserting that `Datadog-Container-ID` is not empty

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
