### PR TITLE
Update python app to use ddtrace-run

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -109,9 +109,10 @@ def python_library_factory() -> APMLibraryTestServer:
 FROM ghcr.io/datadog/dd-trace-py/testrunner:7ce49bd78b0d510766fc5db12756a8840724febc
 WORKDIR /app
 RUN pyenv global 3.9.11
-RUN python3.9 -m pip install fastapi==0.89.1 uvicorn==0.20.0 requests
+RUN python3.9 -m pip install fastapi==0.89.1 uvicorn==0.20.0
 COPY utils/build/docker/python/install_ddtrace.sh utils/build/docker/python/get_appsec_rules_version.py binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
+ENV DD_PATCH_MODULES="fastapi:false"
 """,
         container_cmd="ddtrace-run python3.9 -m apm_test_client".split(" "),
         container_build_dir=python_absolute_appdir,

--- a/utils/build/docker/python/parametric/Dockerfile
+++ b/utils/build/docker/python/parametric/Dockerfile
@@ -2,6 +2,7 @@
 FROM ghcr.io/datadog/dd-trace-py/testrunner:7ce49bd78b0d510766fc5db12756a8840724febc
 WORKDIR /app
 RUN pyenv global 3.9.11
-RUN python3.9 -m pip install fastapi==0.89.1 uvicorn==0.20.0 requests
+RUN python3.9 -m pip install fastapi==0.89.1 uvicorn==0.20.0
 COPY utils/build/docker/python/install_ddtrace.sh utils/build/docker/python/get_appsec_rules_version.py binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
+ENV DD_PATCH_MODULES="fastapi:false"

--- a/utils/parametric/spec/remoteconfig.py
+++ b/utils/parametric/spec/remoteconfig.py
@@ -1,5 +1,6 @@
 import enum
 from typing import Literal
+from typing import Tuple
 
 
 # Remote Configuration apply status is used by clients to report the application status of a Remote Configuration
@@ -28,3 +29,7 @@ class Capabilities(enum.IntEnum):
     APM_TRACING_LOGS_INJECTION = 13
     APM_TRACING_HTTP_HEADER_TAGS = 14
     APM_TRACING_CUSTOM_TAGS = 15
+
+
+def human_readable_capabilities(caps: int) -> Tuple[str]:
+    return tuple(c.name for c in Capabilities if caps >> c & 1)


### PR DESCRIPTION
This is the recommended approach to instrumenting Python applications and the same code path that is used with Single Step APM.


## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
