### PR TITLE
Decorate few missing tests with feature ids

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,21 +44,12 @@ allow_no_feature_nodes = [
     "tests/parametric/test_sampling_span_tags.py",
     "tests/parametric/test_span_links.py",
     "tests/parametric/test_tracer.py",
-    "tests/perfs/test_performances.py",
-    "tests/remote_config/test_remote_configuration.py",
-    "tests/test_data_integrity.py",
-    "tests/test_distributed.py",
-    "tests/test_library_logs.py",
-    "tests/test_miscs.py",
-    "tests/test_schemas.py",
-    "tests/test_semantic_conventions.py",
-    "tests/test_smoke.py",
-    "tests/test_telemetry.py",
-    "tests/test_library_conf.py",
-    "tests/test_remote_config.py",
-    "tests/test_scrubbing.py",
-    "tests/test_no_ip_is_reported.py",
-    "tests/test_the_test/",
+    "tests/perfs/test_performances.py",  # exotic scenario, not really used
+    "tests/test_library_logs.py",  # we do not have a real feature to attach
+    "tests/test_miscs.py",  # we do not have a real feature to attach
+    "tests/test_schemas.py",  # Too broad test, can't attach to a feature
+    "tests/test_smoke.py",  # Too broad test, can't attach to a feature
+    "tests/test_the_test/",  # Not a real test
 ]
 
 [tool.pylint]

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -30,6 +30,7 @@ with open("tests/remote_config/rc_expected_requests_asm_dd.json", encoding="utf-
     ASM_DD_EXPECTED_REQUESTS = json.load(f)
 
 
+@features.agent_remote_configuration
 class Test_Agent:
     """misc test on agent/remote config features"""
 
@@ -48,6 +49,7 @@ class Test_Agent:
 
 
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
+@features.remote_config_object_supported
 class RemoteConfigurationFieldsBasicTests:
     """Misc tests on fields and values on remote configuration requests"""
 
@@ -283,6 +285,7 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
 
 @coverage.basic
 @scenarios.remote_config_mocked_backend_asm_features
+@features.remote_config_object_supported
 class Test_RemoteConfigurationExtraServices:
     """Tests that extra services are sent in the RC message"""
 
@@ -325,6 +328,7 @@ class Test_RemoteConfigurationExtraServices:
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_live_debugging
+@features.remote_config_object_supported
 class Test_RemoteConfigurationUpdateSequenceLiveDebugging(RemoteConfigurationFieldsBasicTests):
     """Tests that over a sequence of related updates, tracers follow the RFC for the Live Debugging product"""
 
@@ -355,6 +359,7 @@ class Test_RemoteConfigurationUpdateSequenceLiveDebugging(RemoteConfigurationFie
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_asm_dd
+@features.remote_config_object_supported
 class Test_RemoteConfigurationUpdateSequenceASMDD(RemoteConfigurationFieldsBasicTests):
     """Tests that over a sequence of related updates, tracers follow the RFC for the ASM DD product"""
 
@@ -415,6 +420,7 @@ class Test_RemoteConfigurationUpdateSequenceFeaturesNoCache(RemoteConfigurationF
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_live_debugging_nocache
+@features.remote_config_object_supported
 class Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache(RemoteConfigurationFieldsBasicTests):
     """Tests that over a sequence of related updates, tracers follow the RFC for the Live Debugging product"""
 
@@ -442,6 +448,7 @@ class Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache(RemoteConfigura
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @coverage.basic
 @scenarios.remote_config_mocked_backend_asm_dd_nocache
+@features.remote_config_object_supported
 class Test_RemoteConfigurationUpdateSequenceASMDDNoCache(RemoteConfigurationFieldsBasicTests):
     """Tests that over a sequence of related updates, tracers follow the RFC for the ASM DD product"""
 

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -3,11 +3,12 @@
 # Copyright 2021 Datadog, Inc.
 
 """Misc checks around data integrity during components' lifetime"""
-from utils import weblog, interfaces, context, bug, rfc, missing_feature
+from utils import weblog, interfaces, context, bug, rfc, missing_feature, features
 from utils.tools import logger
 from utils.cgroup_info import get_container_id
 
 
+@features.data_integrity
 class Test_TraceUniqueness:
     """All trace ids are uniques"""
 
@@ -16,6 +17,7 @@ class Test_TraceUniqueness:
 
 
 @rfc("https://github.com/DataDog/architecture/blob/master/rfcs/apm/integrations/submitting-traces-to-agent/rfc.md")
+@features.data_integrity
 class Test_TraceHeaders:
     """All required headers are present in all traces submitted to the agent"""
 
@@ -122,6 +124,7 @@ class Test_TraceHeaders:
         interfaces.library.add_traces_validation(validator, success_by_default=True)
 
 
+@features.data_integrity
 class Test_LibraryHeaders:
     """Misc test around headers sent by libraries"""
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -2,10 +2,11 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2022 Datadog, Inc.
 
-from utils import weblog, interfaces, scenarios
+from utils import weblog, interfaces, scenarios, features
 
 
 @scenarios.trace_propagation_style_w3c
+@features.w3c_headers_injection_and_extraction
 class Test_DistributedHttp:
     """ Verify behavior of http clients and distributed traces """
 

--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -21,6 +21,7 @@ class Test_HeaderTags:
 
 @coverage.basic
 @scenarios.library_conf_custom_header_tags
+@features.http_headers_as_tags_dd_trace_header_tags
 class Test_HeaderTags_Short:
     """Validates that the short, header name only, format for specifying headers correctly tags spans"""
 
@@ -38,6 +39,7 @@ class Test_HeaderTags_Short:
 
 @coverage.basic
 @scenarios.library_conf_custom_header_tags
+@features.http_headers_as_tags_dd_trace_header_tags
 class Test_HeaderTags_Long:
     """Validates that input in `<header>:<tag_name>` format correctly tags spans"""
 
@@ -55,6 +57,7 @@ class Test_HeaderTags_Long:
 
 @coverage.basic
 @scenarios.library_conf_custom_header_tags
+@features.http_headers_as_tags_dd_trace_header_tags
 class Test_HeaderTags_Whitespace_Header:
     """Validates that leading/trailing whitespaces are trimmed on the header values given to DD_TRACE_HEADER_TAGS
     e.g, ' header ' in DD_TRACE_HEADER_TAGS=' header ' becomes 'header' and is expected to match req.header of 'header' """
@@ -73,6 +76,7 @@ class Test_HeaderTags_Whitespace_Header:
 
 @coverage.basic
 @scenarios.library_conf_custom_header_tags
+@features.http_headers_as_tags_dd_trace_header_tags
 class Test_HeaderTags_Whitespace_Tag:
     """Validates that leading/trailing whitespaces on the Input to DD_TRACE_HEADER_TAGS are 
     trimmed on mapping parts, but whitespaces in between non-whitespace chars are left in-tact."""
@@ -91,6 +95,7 @@ class Test_HeaderTags_Whitespace_Tag:
 
 @coverage.basic
 @scenarios.library_conf_custom_header_tags
+@features.http_headers_as_tags_dd_trace_header_tags
 class Test_HeaderTags_Whitespace_Val_Short:
     """Validates that between-char whitespaces in header values are not removed,
     but leading/trailing whitespace is stripped, using short form input"""
@@ -109,6 +114,7 @@ class Test_HeaderTags_Whitespace_Val_Short:
 
 @coverage.basic
 @scenarios.library_conf_custom_header_tags
+@features.http_headers_as_tags_dd_trace_header_tags
 class Test_HeaderTags_Whitespace_Val_Long:
     """Validates that between-char whitespaces in header values are not removed,
     but leading/trailing whitespace is stripped, using long form input"""
@@ -127,6 +133,7 @@ class Test_HeaderTags_Whitespace_Val_Long:
 
 @coverage.basic
 @scenarios.library_conf_custom_header_tags_invalid
+@features.http_headers_as_tags_dd_trace_header_tags
 class Test_HeaderTags_Colon_Leading:
     """ Validates that Input to DD_TRACE_HEADER_TAGS with leading colon results in 0 additional span tags """
 
@@ -149,6 +156,7 @@ class Test_HeaderTags_Colon_Leading:
 
 @coverage.basic
 @scenarios.library_conf_custom_header_tags_invalid
+@features.http_headers_as_tags_dd_trace_header_tags
 class Test_HeaderTags_Colon_Trailing:
     """ Validates that DD_TRACE_HEADER_TAGS input that contains a leading or trailing colon results in 0 additional span tags """
 

--- a/tests/test_no_ip_is_reported.py
+++ b/tests/test_no_ip_is_reported.py
@@ -4,7 +4,7 @@
 
 """Misc checks around data integrity during components' lifetime"""
 import socket
-from utils import interfaces, coverage, scenarios
+from utils import interfaces, coverage, scenarios, features
 
 
 def is_ip(value):
@@ -17,6 +17,7 @@ def is_ip(value):
 
 @coverage.good
 @scenarios.todo
+@features.library_scrubbing
 class Test_NoIpIsReported:
     """ Used to check that no IP is reported by agent """
 

--- a/tests/test_remote_config.py
+++ b/tests/test_remote_config.py
@@ -2,11 +2,12 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import rfc, coverage, interfaces
+from utils import rfc, coverage, interfaces, features
 
 
 @rfc("https://docs.google.com/document/d/1bUVtEpXNTkIGvLxzkNYCxQzP2X9EK9HMBLHWXr_5KLM/edit#heading=h.vy1jegxy7cuc")
 @coverage.basic
+@features.remote_config_object_supported
 class Test_NoError:
     """A library should apply with no error all remote config payload."""
 

--- a/tests/test_scrubbing.py
+++ b/tests/test_scrubbing.py
@@ -3,7 +3,7 @@
 # Copyright 2022 Datadog, Inc.
 
 import re
-from utils import bug, context, coverage, interfaces, rfc, weblog, missing_feature
+from utils import bug, context, coverage, interfaces, rfc, weblog, missing_feature, features
 from utils.tools import logger
 
 
@@ -30,6 +30,7 @@ def validate_no_leak(needle, whitelist_pattern=None):
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2490990623/QueryString+-+Sensitive+Data+Obfuscation")
 @coverage.good
+@features.library_scrubbing
 class Test_UrlQuery:
     """ PII values in query parameter are all removed"""
 
@@ -62,6 +63,7 @@ class Test_UrlQuery:
 
 
 @coverage.basic
+@features.library_scrubbing
 class Test_UrlField:
     """ PII in url field is removed on client HTTP calls """
 
@@ -100,6 +102,7 @@ class Test_UrlField:
 
 
 @coverage.good
+@features.library_scrubbing
 class Test_EnvVar:
     """ Environnement variables are not leaked """
 

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -316,6 +316,7 @@ class Test_MetaDatadogTags:
         interfaces.library.validate_spans(validator=validator)
 
 
+@features.data_integrity
 class Test_MetricsStandardTags:
     """metrics object in spans respect all conventions regarding basic tags"""
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -542,6 +542,7 @@ class Test_Telemetry:
             raise Exception("app-product-change is not emitted when product change is enabled")
 
 
+@features.telemetry_instrumentation
 class Test_APMOnboardingInstallID:
     """Tests that APM onboarding install information is correctly propagated"""
 

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -1864,3 +1864,73 @@ class features:
         """
         pytest.mark.features(feature_id=258)(test_object)
         return test_object
+
+    @staticmethod
+    def decisionless_trace_context_extraction(test_object):
+        """
+        Decisionless Trace Context Extraction
+
+        https://feature-parity.us1.prod.dog/#/?feature=261
+        """
+        pytest.mark.features(feature_id=261)(test_object)
+        return test_object
+
+    @staticmethod
+    def semantic_core_validations(test_object):
+        """
+        Semantic Core Validations
+
+        https://feature-parity.us1.prod.dog/#/?feature=262
+        """
+        pytest.mark.features(feature_id=262)(test_object)
+        return test_object
+
+    @staticmethod
+    def aws_sqsspan_creationcontext_propagationaws_x_ray_with_dd_trace(test_object):
+        """
+        [AWS-SQS][Span Creation][Context Propagation][AWS X-Ray] with dd-trace
+
+        https://feature-parity.us1.prod.dog/#/?feature=263
+        """
+        pytest.mark.features(feature_id=263)(test_object)
+        return test_object
+
+    @staticmethod
+    def aws_sqsspan_creationcontext_propagationaws_message_attributes_with_dd_trace(test_object):
+        """
+        [AWS-SQS][Span Creation][Context Propagation][AWS Message Attributes] with dd-trace
+
+        https://feature-parity.us1.prod.dog/#/?feature=264
+        """
+        pytest.mark.features(feature_id=264)(test_object)
+        return test_object
+
+    @staticmethod
+    def agent_remote_configuration(test_object):
+        """
+        Agent supports remote configuration
+
+        https://feature-parity.us1.prod.dog/#/?feature=265
+        """
+        pytest.mark.features(feature_id=265)(test_object)
+        return test_object
+
+    @staticmethod
+    def data_integrity(test_object):
+        """
+        Data integrity
+
+        https://feature-parity.us1.prod.dog/#/?feature=266
+        """
+        pytest.mark.features(feature_id=266)(test_object)
+        return test_object
+
+    @staticmethod
+    def library_scrubbing(test_object):
+        """
+        Library scrubbing
+
+        https://feature-parity.us1.prod.dog/#/?feature=267
+        """
+        pytest.mark.features(feature_id=267)(test_object)
+        return test_object


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
