### PR TITLE
Refine shell tracing tests

### DIFF
--- a/tests/appsec/test_shell_execution.py
+++ b/tests/appsec/test_shell_execution.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, coverage, interfaces, weblog, features, irrelevant, rfc
+from utils import bug, context, coverage, interfaces, weblog, features, irrelevant, rfc
 
 
 @rfc("https://docs.google.com/document/d/1YYxOB1nM032H-lgXrVml9mukMhF4eHVIzyK9H_PvrSY/edit#heading=h.o5gstqo08gu5")

--- a/tests/appsec/test_shell_execution.py
+++ b/tests/appsec/test_shell_execution.py
@@ -50,10 +50,10 @@ class Test_ShellExecution:
         )
 
     @irrelevant(library="java", reason="No method for shell execution in Java")
+    @bug(library="nodejs", reason="resource name handling is inconsistent with the RFC")
     def test_track_shell_exec(self):
         span = self.fetch_command_execution_span(self.r_shell_exec)
-        # Some implementations will compute the shell command as "sh -c echo foo".
-        assert span["resource"] in ("echo", "sh")
+        assert span["resource"] == "sh"
         assert span["meta"]["cmd.shell"] == "echo foo"
         assert span["meta"]["cmd.exit_code"] == "0"
 

--- a/tests/appsec/test_shell_execution.py
+++ b/tests/appsec/test_shell_execution.py
@@ -2,11 +2,10 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-import json
-from utils import coverage, interfaces, weblog, features, irrelevant
-from utils._context.core import context
+from utils import context, coverage, interfaces, weblog, features, irrelevant, rfc
 
 
+@rfc("https://docs.google.com/document/d/1YYxOB1nM032H-lgXrVml9mukMhF4eHVIzyK9H_PvrSY/edit#heading=h.o5gstqo08gu5")
 @features.appsec_shell_execution_tracing
 @coverage.basic
 class Test_ShellExecution:
@@ -14,22 +13,25 @@ class Test_ShellExecution:
 
     @staticmethod
     def fetch_command_execution_span(r):
-        for _, trace in interfaces.library.get_traces(request=r):
-            for span in trace:
-                if span["name"] == "command_execution":
-                    command_exec_span = span
-
         assert r.status_code == 200
-        assert command_exec_span is not None, f"command execution span hasn't be found for {r.url}"
-        assert command_exec_span["name"] == "command_execution"
-        assert command_exec_span["meta"]["component"] == "subprocess"
-        return command_exec_span
+
+        traces = [t for _, t in interfaces.library.get_traces(request=r)]
+        assert traces, "No traces found"
+        assert len(traces) == 1
+        spans = traces[0]
+        spans = [s for s in spans if s["name"] == "command_execution"]
+        assert spans, "No command_execution span found"
+        assert len(spans) == 1, "More than one command_execution span found"
+
+        span = spans[0]
+        assert span["name"] == "command_execution"
+        assert span["type"] == "system"
+        assert span["meta"]["component"] == "subprocess"
+        return span
 
     def setup_track_cmd_exec(self):
         self.r_cmd_exec = weblog.post(
-            "/shell_execution",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"command": "echo", "options": {"shell": False}, "args": "foo"}),
+            "/shell_execution", json={"command": "echo", "options": {"shell": False}, "args": "foo"},
         )
 
     @irrelevant(
@@ -37,30 +39,28 @@ class Test_ShellExecution:
         reason="For PHP 7.4+",
     )
     def test_track_cmd_exec(self):
-        shell_exec_span = self.fetch_command_execution_span(self.r_cmd_exec)
-        assert shell_exec_span["meta"]["cmd.exec"] == '["echo","foo"]'
-        assert shell_exec_span["meta"]["cmd.exit_code"] == "0"
+        span = self.fetch_command_execution_span(self.r_cmd_exec)
+        assert span["resource"] == "echo"
+        assert span["meta"]["cmd.exec"] == '["echo","foo"]'
+        assert span["meta"]["cmd.exit_code"] == "0"
 
     def setup_track_shell_exec(self):
         self.r_shell_exec = weblog.post(
-            "/shell_execution",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"command": "echo", "options": {"shell": True}, "args": "foo"}),
+            "/shell_execution", json={"command": "echo", "options": {"shell": True}, "args": "foo"},
         )
 
     @irrelevant(library="java", reason="No method for shell execution in Java")
     def test_track_shell_exec(self):
-        shell_exec_span = self.fetch_command_execution_span(self.r_shell_exec)
-
-        assert shell_exec_span["meta"]["cmd.shell"] == "echo foo"
-        assert shell_exec_span["meta"]["cmd.exit_code"] == "0"
+        span = self.fetch_command_execution_span(self.r_shell_exec)
+        # Some implementations will compute the shell command as "sh -c echo foo".
+        assert span["resource"] in ("echo", "sh")
+        assert span["meta"]["cmd.shell"] == "echo foo"
+        assert span["meta"]["cmd.exit_code"] == "0"
 
     def setup_truncated(self):
         args = ["a" * 4096, "arg"]
         self.r_truncation = weblog.post(
-            "/shell_execution",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"command": "echo", "options": {"shell": False}, "args": args}),
+            "/shell_execution", json={"command": "echo", "options": {"shell": False}, "args": args},
         )
 
     @irrelevant(
@@ -68,17 +68,16 @@ class Test_ShellExecution:
         reason="For PHP 7.4+",
     )
     def test_truncated(self):
-        shell_exec_span = self.fetch_command_execution_span(self.r_truncation)
-        assert shell_exec_span["meta"]["cmd.exec"] == '["echo","' + "a" * 4092 + '",""]'
-        assert shell_exec_span["meta"]["cmd.truncated"] == "true"
-        assert shell_exec_span["meta"]["cmd.exit_code"] == "0"
+        span = self.fetch_command_execution_span(self.r_truncation)
+        assert span["resource"] == "echo"
+        assert span["meta"]["cmd.exec"] == '["echo","' + "a" * 4092 + '",""]'
+        assert span["meta"]["cmd.truncated"] == "true"
+        assert span["meta"]["cmd.exit_code"] == "0"
 
     def setup_obfuscation(self):
         args = "password 1234"
         self.r_obfuscation = weblog.post(
-            "/shell_execution",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"command": "echo", "options": {"shell": False}, "args": args}),
+            "/shell_execution", json={"command": "echo", "options": {"shell": False}, "args": args},
         )
 
     @irrelevant(
@@ -86,7 +85,7 @@ class Test_ShellExecution:
         reason="For PHP 7.4+",
     )
     def test_obfuscation(self):
-        shell_exec_span = self.fetch_command_execution_span(self.r_obfuscation)
-
-        assert shell_exec_span["meta"]["cmd.exec"] == '["echo","password","?"]'
-        assert shell_exec_span["meta"]["cmd.exit_code"] == "0"
+        span = self.fetch_command_execution_span(self.r_obfuscation)
+        assert span["resource"] == "echo"
+        assert span["meta"]["cmd.exec"] == '["echo","password","?"]'
+        assert span["meta"]["cmd.exit_code"] == "0"


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

* Make initial asserts more explicit.
* Assert `resource`.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)

