### PR TITLE
OnBoarding: Enable alpine arm tests for staging

### DIFF
--- a/utils/_context/virtual_machines.py
+++ b/utils/_context/virtual_machines.py
@@ -63,16 +63,17 @@ class TestedVirtualMachine:
 
     def _configure_pytest_mark(self):
         """ Mark test as skip. We won't create this ec2 instance """
-        # Skip arm platform for production
-        if self.env == "prod" and "os_arch" in self.ec2_data and self.ec2_data["os_arch"] == "arm":
-            logger.warn(f" Support for ARM architecture has not been released yet")
-            return "missing_feature: ARM features haven't released yet"
 
         if "os_arch" in self.ec2_data and self.ec2_data["os_arch"] == "arm" and "buildpack" in self.weblog_name:
             logger.warn(f" WEBLOG: {self.weblog_name} doesn't support ARM architecture")
             return "missing_feature: Buildpack is not supported for ARM"
-
-        if "os_arch" in self.ec2_data and self.ec2_data["os_arch"] == "arm" and "alpine" in self.weblog_name:
+        # TODO Enable prod when we release
+        if (
+            self.env == "prod"
+            and "os_arch" in self.ec2_data
+            and self.ec2_data["os_arch"] == "arm"
+            and "alpine" in self.weblog_name
+        ):
             logger.warn(f"[bug][WEBLOG:  {self.weblog_name}] doesn't support ARM architecture")
             return "bug: Error loading shared library ld-linux-aarch64.so"
 


### PR DESCRIPTION
## Motivation

The alpine arm support is fixed on the snapshot 0.12.3. Enable the tests
 
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
