### PR TITLE
Change API Security test to use float instead of int

### DIFF
--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -147,7 +147,7 @@ class Test_Schema_Request_Json_Body:
 
     def setup_request_method(self):
         payload = {
-            "main": [{"key": "id001", "value": 1345}, {"value": 1567, "key": "id002"}],
+            "main": [{"key": "id001", "value": 1345.67}, {"value": 1567.89, "key": "id002"}],
             "nullable": None,
         }
         self.request = weblog.post("/tag_value/api_match_AS004/200", json=payload)
@@ -156,7 +156,7 @@ class Test_Schema_Request_Json_Body:
         """can provide request request body schema"""
         schema = get_schema(self.request, "req.body")
         assert self.request.status_code == 200
-        assert contains(schema, [{"main": [[[{"key": [8], "value": [4]}]], {"len": 2}], "nullable": [1]}],)
+        assert contains(schema, [{"main": [[[{"key": [8], "value": [16]}]], {"len": 2}], "nullable": [1]}],)
 
 
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")


### PR DESCRIPTION
## Motivation

Javascript doesn't have a distinction between integers and floats (all numbers are floats).
I propose this change instead of having a dirty special case for nodejs.

btw JSON means Javascript Object Notation. Not C Object Notation. Although I agree the JSON spec doesn't even define ints nor floats, only a series of digits.

## Changes

Change the API Security JSON body test to use floats instead of ints.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
