### PR TITLE
[APPSEC-51301] Add HTTP headers to collect

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -186,6 +186,7 @@ tests/:
       Test_AppSecObfuscator: v2.7.0
       Test_CollectRespondHeaders: v2.5.1
       Test_DistributedTraceInfo: missing_feature (test not implemented)
+      Test_ExternalWafRequestsIdentification: missing_feature
       Test_RetainTraces: v1.29.0
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist: v2.30.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -301,6 +301,7 @@ tests/:
         '*': v1.36.2
         gin: v1.37.0
       Test_DistributedTraceInfo: missing_feature (test not implemented)
+      Test_ExternalWafRequestsIdentification: missing_feature
       Test_RetainTraces:
         '*': v1.36.0
         gin: v1.37.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -792,6 +792,7 @@ tests/:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         spring-boot-payara: missing_feature (No AppSec support)
       Test_DistributedTraceInfo: missing_feature (test not implemented)
+      Test_ExternalWafRequestsIdentification: missing_feature
       Test_RetainTraces:
         '*': v0.92.0
         akka-http: v1.22.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -269,6 +269,7 @@ tests/:
       Test_AppSecObfuscator: v2.6.0
       Test_CollectRespondHeaders: v2.0.0
       Test_DistributedTraceInfo: missing_feature (test not implemented)
+      Test_ExternalWafRequestsIdentification: missing_feature
       Test_RetainTraces: v2.0.0
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -157,6 +157,7 @@ tests/:
       Test_ShellExecution: v0.95.0
     test_traces.py:
       Test_DistributedTraceInfo: missing_feature (test not implemented)
+      Test_ExternalWafRequestsIdentification: missing_feature
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist: v0.86.3
   debugger/:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -437,6 +437,7 @@ tests/:
         '*': v1.4.0rc1.dev
         fastapi: v2.4.0.dev1
       Test_DistributedTraceInfo: missing_feature (test not implemented)
+      Test_ExternalWafRequestsIdentification: missing_feature
       Test_RetainTraces: v1.1.0rc2.dev
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -191,6 +191,7 @@ tests/:
       Test_AppSecObfuscator: v1.0.0
       Test_CollectRespondHeaders: v1.0.0.beta1
       Test_DistributedTraceInfo: missing_feature (test not implemented)
+      Test_ExternalWafRequestsIdentification: missing_feature
       Test_RetainTraces: v0.54.2
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist: missing_feature (Ruby supported denylists of 2500 entries but it fails to block this those 15000)

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -126,7 +126,12 @@ class Test_AppSecEventSpanTags:
         interfaces.library.validate_spans(self.r, validate_request_headers)
         interfaces.library.validate_spans(self.r, validate_response_headers)
 
-    @missing_feature(reason="Not implemented yet")
+    @missing_feature(library="java", reason="Not implemented yet")
+    @missing_feature(library="dotnet", reason="Not implemented yet")
+    @missing_feature(library="python", reason="Not implemented yet")
+    @missing_feature(library="ruby", reason="Not implemented yet")
+    @missing_feature(library="php", reason="Not implemented yet")
+    @missing_feature(library="cpp", reason="Not implemented yet")
     def test_extra_header_collection(self):
         """
         Collect extra headers when AppSec is enabled.

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -91,7 +91,7 @@ class Test_AppSecEventSpanTags:
         interfaces.library.validate_spans(validator=validate_custom_span_tags)
 
     def setup_header_collection(self):
-        self.r = weblog.get("/headers", headers={"User-Agent": "Arachni/v1", "Content-Type": "text/plain",},)
+        self.r = weblog.get("/headers", headers={"User-Agent": "Arachni/v1", "Content-Type": "text/plain"})
 
     @bug(context.library < f"python@{PYTHON_RELEASE_GA_1_1}", reason="a PR was not included in the release")
     @bug(context.library < "java@1.2.0", weblog_variant="spring-boot-openliberty", reason="APPSEC-6734")

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -370,7 +370,7 @@ class Test_ExternalWafRequestsIdentification:
                 "cf-ray",
                 "x-cloud-trace-context",
                 "x-appgw-trace-id",
-                "x-sigsci-request-id",
+                "x-sigsci-requestid",
                 "x-sigsci-tags",
                 "akamai-user-risk",
             ]:

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -120,8 +120,9 @@ class Test_AppSecEventSpanTags:
         interfaces.library.validate_spans(self.r, validate_response_headers)
 
     def setup_test_x_amzn_trace_id_header_collection(self):
-        self.r = weblog.get("/headers", headers={"X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027",},)
+        self.r2 = weblog.get("/headers", headers={"X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027",},)
 
+    @missing_feature(library="go", reason="Not implemented yet")
     @missing_feature(library="java", reason="Not implemented yet")
     @missing_feature(library="dotnet", reason="Not implemented yet")
     @missing_feature(library="python", reason="Not implemented yet")
@@ -142,7 +143,7 @@ class Test_AppSecEventSpanTags:
                 assertHeaderInSpanMeta(span, f"http.request.headers.{header}")
             return True
 
-        interfaces.library.validate_spans(self.r, validate_request_headers)
+        interfaces.library.validate_spans(self.r2, validate_request_headers)
 
     @bug(context.library < "java@0.93.0")
     def test_root_span_coherence(self):

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -119,33 +119,6 @@ class Test_AppSecEventSpanTags:
         interfaces.library.validate_spans(self.r, validate_request_headers)
         interfaces.library.validate_spans(self.r, validate_response_headers)
 
-    def setup_x_amzn_trace_id_header_collection(self):
-        self.r2 = weblog.get("/headers", headers={"X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027",})
-
-    @missing_feature(library="golang", reason="Not implemented yet")
-    @missing_feature(library="java", reason="Not implemented yet")
-    @missing_feature(library="dotnet", reason="Not implemented yet")
-    @missing_feature(library="python", reason="Not implemented yet")
-    @missing_feature(library="ruby", reason="Not implemented yet")
-    @missing_feature(library="php", reason="Not implemented yet")
-    @missing_feature(library="cpp", reason="Not implemented yet")
-    @missing_feature(context.library < "nodejs@5.1.0")
-    def test_x_amzn_trace_id_header_collection(self):
-        """
-        Collect X-Amzn-Trace-Id when appsec is enabled.
-        """
-
-        def assertHeaderInSpanMeta(span, header):
-            if header not in span["meta"]:
-                raise Exception(f"Can't find {header} in span's meta")
-
-        def validate_request_headers(span):
-            for header in ["x-amzn-trace-id"]:
-                assertHeaderInSpanMeta(span, f"http.request.headers.{header}")
-            return True
-
-        interfaces.library.validate_spans(self.r2, validate_request_headers)
-
     @bug(context.library < "java@0.93.0")
     def test_root_span_coherence(self):
         """Appsec tags are not on span where type is not web"""
@@ -361,3 +334,33 @@ class Test_DistributedTraceInfo:
 
     def test_main(self):
         assert False, "Test not implemented"
+
+@rfc("https://docs.google.com/document/d/1xf-s6PtSr6heZxmO_QLUtcFzY_X_rT94lRXNq6-Ghws/edit?pli=1")
+class Test_ExternalWafRequestsIdentification:
+    def setup_external_wafs_header_collection(self):
+        self.r = weblog.get("/headers", headers={"X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027","CloudFront-Viewer-Ja3-Fingerprint":"e7d705a3286e19ea42f587b344ee6865" ,
+                                                  "Cf-Ray":"230b030023ae2822-SJC","X-Cloud-Trace-Context":"105445aa7843bc8bf206b12000100000/1","X-Appgw-Trace-id":"ac882cd65a2712a0fe1289ec2bb6aee7",
+                                                  "X-SigSci-RequestID":"55c24b96ca84c02201000001","X-SigSci-Tags":"SQLI, XSS", "Akamai-User-Risk": "uuid=913c4545-757b-4d8d-859d-e1361a828361;status=0"})
+    
+    @missing_feature(library="golang", reason="Not implemented yet")
+    @missing_feature(library="java", reason="Not implemented yet")
+    @missing_feature(library="dotnet", reason="Not implemented yet")
+    @missing_feature(library="python", reason="Not implemented yet")
+    @missing_feature(library="ruby", reason="Not implemented yet")
+    @missing_feature(library="php", reason="Not implemented yet")
+    @missing_feature(library="nodejs", reason="Not supported yet")
+    def test_external_wafs_header_collection(self):
+        """
+        Collect external wafs request identifier and other security info when appsec is enabled.
+        """
+
+        def assertHeaderInSpanMeta(span, header):
+            if header not in span["meta"]:
+                raise Exception(f"Can't find {header} in span's meta")
+
+        def validate_request_headers(span):
+            for header in ["x-amzn-trace-id","cloudfront-viewer-ja3-fingerprint","cf-ray", "x-cloud-trace-context","x-appgw-trace-id","x-sigsci-request-id","x-sigsci-tags", "akamai-user-risk"]:
+                assertHeaderInSpanMeta(span, f"http.request.headers.{header}")
+            return True
+
+        interfaces.library.validate_spans(self.r, validate_request_headers)

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -122,7 +122,7 @@ class Test_AppSecEventSpanTags:
     def setup_test_x_amzn_trace_id_header_collection(self):
         self.r2 = weblog.get("/headers", headers={"X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027",},)
 
-    @missing_feature(library="go", reason="Not implemented yet")
+    @missing_feature(library="golang", reason="Not implemented yet")
     @missing_feature(library="java", reason="Not implemented yet")
     @missing_feature(library="dotnet", reason="Not implemented yet")
     @missing_feature(library="python", reason="Not implemented yet")

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -337,6 +337,7 @@ class Test_DistributedTraceInfo:
 
 
 @rfc("https://docs.google.com/document/d/1xf-s6PtSr6heZxmO_QLUtcFzY_X_rT94lRXNq6-Ghws/edit?pli=1")
+@features.security_events_metadata
 class Test_ExternalWafRequestsIdentification:
     def setup_external_wafs_header_collection(self):
         self.r = weblog.get(

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -96,7 +96,6 @@ class Test_AppSecEventSpanTags:
             headers={
                 "User-Agent": "Arachni/v1",
                 "Content-Type": "text/plain",
-                "X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027",
             },
         )
 
@@ -126,15 +125,23 @@ class Test_AppSecEventSpanTags:
         interfaces.library.validate_spans(self.r, validate_request_headers)
         interfaces.library.validate_spans(self.r, validate_response_headers)
 
+    def setup_test_x_amzn_trace_id_header_collection(self):
+        self.r = weblog.get(
+            "/headers",
+            headers={
+                "X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027",
+            },
+        )
+
     @missing_feature(library="java", reason="Not implemented yet")
     @missing_feature(library="dotnet", reason="Not implemented yet")
     @missing_feature(library="python", reason="Not implemented yet")
     @missing_feature(library="ruby", reason="Not implemented yet")
     @missing_feature(library="php", reason="Not implemented yet")
     @missing_feature(library="cpp", reason="Not implemented yet")
-    def test_extra_header_collection(self):
+    def test_x_amzn_trace_id_header_collection(self):
         """
-        Collect extra headers when AppSec is enabled.
+        Collect X-Amzn-Trace-Id when appsec is enabled.
         """
 
         def assertHeaderInSpanMeta(span, header):

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -335,13 +335,24 @@ class Test_DistributedTraceInfo:
     def test_main(self):
         assert False, "Test not implemented"
 
+
 @rfc("https://docs.google.com/document/d/1xf-s6PtSr6heZxmO_QLUtcFzY_X_rT94lRXNq6-Ghws/edit?pli=1")
 class Test_ExternalWafRequestsIdentification:
     def setup_external_wafs_header_collection(self):
-        self.r = weblog.get("/headers", headers={"X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027","CloudFront-Viewer-Ja3-Fingerprint":"e7d705a3286e19ea42f587b344ee6865" ,
-                                                  "Cf-Ray":"230b030023ae2822-SJC","X-Cloud-Trace-Context":"105445aa7843bc8bf206b12000100000/1","X-Appgw-Trace-id":"ac882cd65a2712a0fe1289ec2bb6aee7",
-                                                  "X-SigSci-RequestID":"55c24b96ca84c02201000001","X-SigSci-Tags":"SQLI, XSS", "Akamai-User-Risk": "uuid=913c4545-757b-4d8d-859d-e1361a828361;status=0"})
-    
+        self.r = weblog.get(
+            "/headers",
+            headers={
+                "X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027",
+                "CloudFront-Viewer-Ja3-Fingerprint": "e7d705a3286e19ea42f587b344ee6865",
+                "Cf-Ray": "230b030023ae2822-SJC",
+                "X-Cloud-Trace-Context": "105445aa7843bc8bf206b12000100000/1",
+                "X-Appgw-Trace-id": "ac882cd65a2712a0fe1289ec2bb6aee7",
+                "X-SigSci-RequestID": "55c24b96ca84c02201000001",
+                "X-SigSci-Tags": "SQLI, XSS",
+                "Akamai-User-Risk": "uuid=913c4545-757b-4d8d-859d-e1361a828361;status=0",
+            },
+        )
+
     @missing_feature(library="golang", reason="Not implemented yet")
     @missing_feature(library="java", reason="Not implemented yet")
     @missing_feature(library="dotnet", reason="Not implemented yet")
@@ -359,7 +370,16 @@ class Test_ExternalWafRequestsIdentification:
                 raise Exception(f"Can't find {header} in span's meta")
 
         def validate_request_headers(span):
-            for header in ["x-amzn-trace-id","cloudfront-viewer-ja3-fingerprint","cf-ray", "x-cloud-trace-context","x-appgw-trace-id","x-sigsci-request-id","x-sigsci-tags", "akamai-user-risk"]:
+            for header in [
+                "x-amzn-trace-id",
+                "cloudfront-viewer-ja3-fingerprint",
+                "cf-ray",
+                "x-cloud-trace-context",
+                "x-appgw-trace-id",
+                "x-sigsci-request-id",
+                "x-sigsci-tags",
+                "akamai-user-risk",
+            ]:
                 assertHeaderInSpanMeta(span, f"http.request.headers.{header}")
             return True
 

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -354,13 +354,6 @@ class Test_ExternalWafRequestsIdentification:
             },
         )
 
-    @missing_feature(library="golang", reason="Not implemented yet")
-    @missing_feature(library="java", reason="Not implemented yet")
-    @missing_feature(library="dotnet", reason="Not implemented yet")
-    @missing_feature(library="python", reason="Not implemented yet")
-    @missing_feature(library="ruby", reason="Not implemented yet")
-    @missing_feature(library="php", reason="Not implemented yet")
-    @missing_feature(library="nodejs", reason="Not supported yet")
     def test_external_wafs_header_collection(self):
         """
         Collect external wafs request identifier and other security info when appsec is enabled.

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -119,8 +119,8 @@ class Test_AppSecEventSpanTags:
         interfaces.library.validate_spans(self.r, validate_request_headers)
         interfaces.library.validate_spans(self.r, validate_response_headers)
 
-    def setup_test_x_amzn_trace_id_header_collection(self):
-        self.r2 = weblog.get("/headers", headers={"X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027",},)
+    def setup_x_amzn_trace_id_header_collection(self):
+        self.r2 = weblog.get("/headers", headers={"X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027",})
 
     @missing_feature(library="golang", reason="Not implemented yet")
     @missing_feature(library="java", reason="Not implemented yet")

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -129,6 +129,7 @@ class Test_AppSecEventSpanTags:
     @missing_feature(library="ruby", reason="Not implemented yet")
     @missing_feature(library="php", reason="Not implemented yet")
     @missing_feature(library="cpp", reason="Not implemented yet")
+    @missing_feature(context.library < "nodejs@5.1.0")
     def test_x_amzn_trace_id_header_collection(self):
         """
         Collect X-Amzn-Trace-Id when appsec is enabled.

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -91,13 +91,7 @@ class Test_AppSecEventSpanTags:
         interfaces.library.validate_spans(validator=validate_custom_span_tags)
 
     def setup_header_collection(self):
-        self.r = weblog.get(
-            "/headers",
-            headers={
-                "User-Agent": "Arachni/v1",
-                "Content-Type": "text/plain",
-            },
-        )
+        self.r = weblog.get("/headers", headers={"User-Agent": "Arachni/v1", "Content-Type": "text/plain",},)
 
     @bug(context.library < f"python@{PYTHON_RELEASE_GA_1_1}", reason="a PR was not included in the release")
     @bug(context.library < "java@1.2.0", weblog_variant="spring-boot-openliberty", reason="APPSEC-6734")
@@ -126,12 +120,7 @@ class Test_AppSecEventSpanTags:
         interfaces.library.validate_spans(self.r, validate_response_headers)
 
     def setup_test_x_amzn_trace_id_header_collection(self):
-        self.r = weblog.get(
-            "/headers",
-            headers={
-                "X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027",
-            },
-        )
+        self.r = weblog.get("/headers", headers={"X-Amzn-Trace-Id": "Root=1-65ae48bc-04fb551979979b6c57973027",},)
 
     @missing_feature(library="java", reason="Not implemented yet")
     @missing_feature(library="dotnet", reason="Not implemented yet")


### PR DESCRIPTION
## Motivation

The goal for this pr is to collect various headers from incoming headers which will help ASM with linking logs and traces.
See [rfc](https://docs.google.com/document/d/1xf-s6PtSr6heZxmO_QLUtcFzY_X_rT94lRXNq6-Ghws/edit?pli=1#heading=h.u0e1mc4e24ms) for more context
Link to [JIRA](https://datadoghq.atlassian.net/jira/software/c/projects/APPSEC/boards/5991?selectedIssue=APPSEC-52097)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
