### PR TITLE
trace-stats: fix hostname validator

### DIFF
--- a/utils/interfaces/schemas/library/v0.6/stats-request.json
+++ b/utils/interfaces/schemas/library/v0.6/stats-request.json
@@ -4,7 +4,7 @@
   "properties": {
     "Version": { "type": "string", "minLength": 1 },
     "Env": { "type": "string", "minLength": 1 },
-    "Hostname": { "type": "string", "minLength": 1 },
+    "Hostname": { "type": "string" },
     "Stats": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## Motivation

`utils/interfaces/schemas/library/v0.6/stats-request.json` requires stats payloads to contain hostnames. This is incorrect. Hostnames should only be set if  `DD_TRACE_REPORT_HOSTNAME=True` is set. By default hostnames should be resolved by the Datadog Agent. This will reduce cardinality in trace stats.

Fixes the following tests for the python tracer: `tests/test_schemas.py::Test_Library::test_full` and `tests/test_schemas.py::Test_Library::test_non_regression` ([link](https://github.com/DataDog/dd-trace-py/actions/runs/7559749497/job/20584254662?pr=8130)).

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
