### PR TITLE
support http header tags tracing in parametric test server and enable its test

### DIFF
--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -97,6 +97,77 @@ def assert_sampling_rate(trace: List[Dict], rate: float):
 ENV_SAMPLING_RULE_RATE = 0.55
 
 
+@scenarios.parametric
+@features.dynamic_configuration
+class TestDynamicConfigV0:
+    @missing_feature(context.library in ["java", "dotnet", "golang", "nodejs"], reason="RPC not implemented yet")
+    @parametrize(
+        "library_env",
+        [
+            {
+                **DEFAULT_ENVVARS,
+                "DD_TRACE_HEADER_TAGS": "X-Test-Header:test_header_env,X-Test-Header-2:test_header_env2,Content-Length:content_length_env",
+            },
+        ],
+    )
+    def test_tracing_client_http_header_tags(
+        self, library_env, test_agent, test_library, test_agent_hostname, test_agent_port
+    ):
+        """Ensure the tracing http header tags can be set via RC.
+
+        Testing is done using a http client request RPC and asserting the span tags.
+
+        Requests are made to the test agent.
+        """
+
+        # Test without RC.
+        test_library.http_client_request(
+            method="GET",
+            url=f"http://{test_agent_hostname}:{test_agent_port}",
+            headers=[("X-Test-Header", "test-value"), ("X-Test-Header-2", "test-value-2"), ("Content-Length", "35"),],
+        )
+        trace = test_agent.wait_for_num_traces(num=1, clear=True)
+        assert trace[0][0]["meta"]["test_header_env"] == "test-value"
+        assert trace[0][0]["meta"]["test_header_env2"] == "test-value-2"
+        assert int(trace[0][0]["meta"]["content_length_env"]) > 0
+
+        # Set and test with RC.
+        set_and_wait_rc(
+            test_agent,
+            config_overrides={
+                "tracing_header_tags": [
+                    {"header": "X-Test-Header", "tag_name": "test_header_rc"},
+                    {"header": "X-Test-Header-2", "tag_name": "test_header_rc2"},
+                    {"header": "Content-Length", "tag_name": ""},
+                ]
+            },
+        )
+        test_library.http_client_request(
+            method="GET",
+            url=f"http://{test_agent_hostname}:{test_agent_port}",
+            headers=[("X-Test-Header", "test-value"), ("X-Test-Header-2", "test-value-2"), ("Content-Length", "0")],
+        )
+        trace = test_agent.wait_for_num_traces(num=1, clear=True)
+        assert trace[0][0]["meta"]["test_header_rc"] == "test-value"
+        assert trace[0][0]["meta"]["test_header_rc2"] == "test-value-2"
+        assert trace[0][0]["meta"]["http.request.headers.content-length"] == "0"
+        assert trace[0][0]["meta"]["http.response.headers.content-length"] == "14"
+        assert "test_header_env" not in trace[0][0]["meta"]
+        assert "test_header_env2" not in trace[0][0]["meta"]
+
+        # Unset RC.
+        set_and_wait_rc(test_agent, config_overrides={"tracing_header_tags": None})
+        test_library.http_client_request(
+            method="GET",
+            url=f"http://{test_agent_hostname}:{test_agent_port}",
+            headers=[("X-Test-Header", "test-value"), ("X-Test-Header-2", "test-value-2"), ("Content-Length", "35"),],
+        )
+        trace = test_agent.wait_for_num_traces(num=1, clear=True)
+        assert trace[0][0]["meta"]["test_header_env"] == "test-value"
+        assert trace[0][0]["meta"]["test_header_env2"] == "test-value-2"
+        assert int(trace[0][0]["meta"]["content_length_env"]) > 0
+
+
 @rfc("https://docs.google.com/document/d/1SVD0zbbAAXIsobbvvfAEXipEUO99R9RMsosftfe9jx0")
 @scenarios.parametric
 @features.dynamic_configuration
@@ -106,7 +177,6 @@ class TestDynamicConfigV1:
     v1 includes support for:
         - tracing_sampling_rate
         - log_injection_enabled
-        - tracing_header_tags
     """
 
     @parametrize("library_env", [{"DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1"}])
@@ -269,75 +339,6 @@ class TestDynamicConfigV1:
         """
         cfg_state = set_and_wait_rc(test_agent, config_overrides={"tracing_sample_rate": None})
         assert cfg_state["apply_state"] == 2
-
-    @missing_feature(
-        context.library in ["java", "dotnet", "python", "golang", "nodejs"], reason="RPC not implemented yet"
-    )
-    @parametrize(
-        "library_env",
-        [
-            {
-                **DEFAULT_ENVVARS,
-                "DD_TRACE_HEADER_TAGS": "X-Test-Header:test_header_env,X-Test-Header-2:test_header_env2,Content-Length:content_length_env",
-            },
-        ],
-    )
-    def test_tracing_client_http_header_tags(
-        self, library_env, test_agent, test_library, test_agent_hostname, test_agent_port
-    ):
-        """Ensure the tracing http header tags can be set via RC.
-
-        Testing is done using a http client request RPC and asserting the span tags.
-
-        Requests are made to the test agent.
-        """
-
-        # Test without RC.
-        test_library.http_client_request(
-            method="GET",
-            url=f"http://{test_agent_hostname}:{test_agent_port}",
-            headers=[("X-Test-Header", "test-value"), ("X-Test-Header-2", "test-value-2"), ("Content-Length", "35"),],
-        )
-        trace = test_agent.wait_for_num_traces(num=1, clear=True)
-        assert trace[0][0]["meta"]["test_header_env"] == "test-value"
-        assert trace[0][0]["meta"]["test_header_env2"] == "test-value-2"
-        assert int(trace[0][0]["meta"]["content_length_env"]) > 0
-
-        # Set and test with RC.
-        set_and_wait_rc(
-            test_agent,
-            config_overrides={
-                "tracing_header_tags": [
-                    {"header": "X-Test-Header", "tag_name": "test_header_rc",},
-                    {"header": "X-Test-Header-2", "tag_name": "test_header_rc2",},
-                    {"header": "Content-Length", "tag_name": "",},
-                ]
-            },
-        )
-        test_library.http_client_request(
-            method="GET",
-            url=f"http://{test_agent_hostname}:{test_agent_port}",
-            headers=[("X-Test-Header", "test-value"), ("X-Test-Header-2", "test-value-2"), ("Content-Length", "0")],
-        )
-        trace = test_agent.wait_for_num_traces(num=1, clear=True)
-        assert trace[0][0]["meta"]["test_header_rc"] == "test-value"
-        assert trace[0][0]["meta"]["test_header_rc2"] == "test-value-2"
-        assert trace[0][0]["meta"]["http.request.headers.content-length"] == "0"
-        assert trace[0][0]["meta"]["http.response.headers.content-length"] == "14"
-        assert "test_header_env" not in trace[0][0]["meta"]
-        assert "test_header_env2" not in trace[0][0]["meta"]
-
-        # Unset RC.
-        set_and_wait_rc(test_agent, config_overrides={"tracing_header_tags": None})
-        test_library.http_client_request(
-            method="GET",
-            url=f"http://{test_agent_hostname}:{test_agent_port}",
-            headers=[("X-Test-Header", "test-value"), ("X-Test-Header-2", "test-value-2"), ("Content-Length", "35"),],
-        )
-        trace = test_agent.wait_for_num_traces(num=1, clear=True)
-        assert trace[0][0]["meta"]["test_header_env"] == "test-value"
-        assert trace[0][0]["meta"]["test_header_env2"] == "test-value-2"
-        assert int(trace[0][0]["meta"]["content_length_env"]) > 0
 
 
 @rfc("https://docs.google.com/document/d/1V4ZBsTsRPv8pAVG5WCmONvl33Hy3gWdsulkYsE4UZgU/edit")

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -249,6 +249,7 @@ class HttpClientRequestReturn(BaseModel):
 
 @app.post("/http/client/request")
 def http_client_request(args: HttpClientRequestArgs) -> HttpClientRequestReturn:
+    """Creates and finishes a span similar to the ones created during HTTP request/response cycles"""
     # falcon config doesn't really matter here - any config object with http header tracing enabled will work
     integration_config = config.falcon
     request_headers = {k: v for k, v in args.headers}
@@ -258,6 +259,8 @@ def http_client_request(args: HttpClientRequestArgs) -> HttpClientRequestReturn:
             request_span, integration_config, request_headers=request_headers, response_headers=response_headers
         )
         spans[request_span.span_id] = request_span
+    # this cache invalidation happens in most web frameworks as a side effect of their multithread design
+    # it's made explicit here to allow test expectations to be precise
     config.http._reset()
     config._header_tag_name.invalidate()
     return HttpClientRequestReturn()

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -21,6 +21,8 @@ from ddtrace.opentelemetry import TracerProvider
 
 import ddtrace
 from ddtrace import Span
+from ddtrace import config
+from ddtrace.contrib.trace_utils import set_http_meta
 from ddtrace.context import Context
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
@@ -232,6 +234,33 @@ def trace_span_add_link(args: TraceSpanAddLinksArgs) -> TraceSpanAddLinkReturn:
     linked_span = spans[args.parent_id]
     span.link_span(linked_span.context, attributes=args.attributes)
     return TraceSpanAddLinkReturn()
+
+
+class HttpClientRequestArgs(BaseModel):
+    method: str
+    url: str
+    headers: List[Tuple[str, str]]
+    body: str
+
+
+class HttpClientRequestReturn(BaseModel):
+    pass
+
+
+@app.post("/http/client/request")
+def http_client_request(args: HttpClientRequestArgs) -> HttpClientRequestReturn:
+    # falcon config doesn't really matter here - any config object with http header tracing enabled will work
+    integration_config = config.falcon
+    request_headers = {k: v for k, v in args.headers}
+    response_headers = {"Content-Length": "14"}
+    with ddtrace.tracer.trace("fake-request") as request_span:
+        set_http_meta(
+            request_span, integration_config, request_headers=request_headers, response_headers=response_headers
+        )
+        spans[request_span.span_id] = request_span
+    config.http._reset()
+    config._header_tag_name.invalidate()
+    return HttpClientRequestReturn()
 
 
 class OtelStartSpanArgs(BaseModel):

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -241,13 +241,12 @@ class APMLibraryClientHTTP(APMLibraryClient):
         resp = self._session.post(self._url("/trace/otel/flush"), json={"seconds": timeout}).json()
         return resp["success"]
 
-    # TODO: test and implement this endpoint for test_dynamic_configuration tests
-    # def http_client_request(self, method: str, url: str, headers: List[Tuple[str, str]], body: bytes) -> int:
-    #     resp = self._session.post(
-    #         self._url("/http/client/request"),
-    #         json={"method": method, "url": url, "headers": headers or [], "body": body.decode()},
-    #     ).json()
-    #     return resp
+    def http_client_request(self, method: str, url: str, headers: List[Tuple[str, str]], body: bytes) -> int:
+        resp = self._session.post(
+            self._url("/http/client/request"),
+            json={"method": method, "url": url, "headers": headers or [], "body": body.decode()},
+        ).json()
+        return resp
 
 
 class _TestSpan:


### PR DESCRIPTION
## Motivation

My goal is to validate the functionality added to dd-trace-py in https://github.com/DataDog/dd-trace-py/pull/8144.

## Changes

This pull request implements a test server endpoint that generates spans similar to those generated by HTTP request/response cycles in the Datadog tracer. It also enables a test that uses that endpoint to validate the behavior of the `tracing_http_header_tags` remote configuration option.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
