### PR TITLE
add rabbitmq cross integration tests for trace context propagation

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -83,6 +83,8 @@ tests/:
         Test_NodeJSKafka: missing_feature
         Test_PythonKafka: missing_feature
         Test_RubyKafka: missing_feature
+      test_rabbitmq.py:
+        Test_RabbitMQ_Trace_Context_Propagation: missing_feature
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -203,6 +203,8 @@ tests/:
         Test_NodeJSKafka: missing_feature
         Test_PythonKafka: missing_feature
         Test_RubyKafka: missing_feature
+      test_rabbitmq.py:
+        Test_RabbitMQ_Trace_Context_Propagation: missing_feature
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -334,6 +334,8 @@ tests/:
         Test_RubyKafka:
           "*": irrelevant
           net-http: v0.1 # real version not known
+      test_rabbitmq.py:
+        Test_RabbitMQ_Trace_Context_Propagation: missing_feature
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -846,6 +846,10 @@ tests/:
         Test_RubyKafka:
           "*": missing_feature (Endpoint not implemented)
           spring-boot: v0.1 # real version not known
+      test_rabbitmq.py:
+        Test_RabbitMQ_Trace_Context_Propagation:
+          "*": missing_feature (Endpoint not implemented)
+          spring-boot: v0.1 # real version not known
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -303,7 +303,7 @@ tests/:
       test_rabbitmq.py:
         Test_RabbitMQ_Trace_Context_Propagation:
           "*": missing_feature (Endpoint not implemented)
-          express4: v0.1 # real version not known
+          express4: missing_feature (Endpoint not implemented)
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -300,6 +300,10 @@ tests/:
         Test_RubyKafka:
           '*': missing_feature (Endpoint not implemented)
           express4: v0.1 # real version not known
+      test_rabbitmq.py:
+        Test_RabbitMQ_Trace_Context_Propagation:
+          "*": missing_feature (Endpoint not implemented)
+          express4: v0.1 # real version not known
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -303,7 +303,6 @@ tests/:
       test_rabbitmq.py:
         Test_RabbitMQ_Trace_Context_Propagation:
           "*": missing_feature (Endpoint not implemented)
-          express4: missing_feature (Endpoint not implemented)
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -173,6 +173,8 @@ tests/:
         Test_NodeJSKafka: missing_feature
         Test_PythonKafka: missing_feature
         Test_RubyKafka: missing_feature
+      test_rabbitmq.py:
+        Test_RabbitMQ_Trace_Context_Propagation: missing_feature
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -472,7 +472,6 @@ tests/:
       test_rabbitmq.py:
         Test_RabbitMQ_Trace_Context_Propagation:
           "*": missing_feature (Endpoint not implemented)
-          flask-poc: missing_feature (Endpoint not implemented)
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -472,7 +472,7 @@ tests/:
       test_rabbitmq.py:
         Test_RabbitMQ_Trace_Context_Propagation:
           "*": missing_feature (Endpoint not implemented)
-          flask-poc: v0.1 # real version not known
+          flask-poc: missing_feature (Endpoint not implemented)
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -469,6 +469,10 @@ tests/:
         Test_RubyKafka:
           '*': missing_feature (missing endpoint on weblog)
           flask-poc: v0.1 # real version unknown
+      test_rabbitmq.py:
+        Test_RabbitMQ_Trace_Context_Propagation:
+          "*": missing_feature (Endpoint not implemented)
+          flask-poc: v0.1 # real version not known
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -220,6 +220,9 @@ tests/:
         Test_RubyKafka:
           "*": missing_feature (Only requires one server -  rails70)
           rails70: v0.1 # real version unknown
+      test_rabbitmq.py:
+        Test_RabbitMQ_Trace_Context_Propagation:
+          "*": missing_feature (Endpoint not implemented)
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (Endpoint not implemented)

--- a/tests/integrations/crossed_integrations/test_rabbitmq.py
+++ b/tests/integrations/crossed_integrations/test_rabbitmq.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+
+from tests.integrations.crossed_integrations.test_kafka import _python_buddy, _java_buddy
+from utils import interfaces, scenarios, coverage, weblog, missing_feature, features
+from utils.tools import logger
+
+
+class _Test_RabbitMQ:
+    """Test RabbitMQ compatibility with inputted datadog tracer"""
+
+    BUDDY_TO_WEBLOG_QUEUE = None
+    WEBLOG_TO_BUDDY_QUEUE = None
+    buddy = None
+    buddy_interface = None
+
+    @classmethod
+    def get_span(cls, interface, span_kind, queue, operation):
+        logger.debug(f"Trying to find traces with span kind: {span_kind} and queue: {queue} in {interface}")
+
+        for data, trace in interface.get_traces():
+            for span in trace:
+                if not span.get("meta"):
+                    continue
+
+                if span["meta"].get("span.kind") != span_kind:
+                    continue
+
+                if operation.lower() not in span.get("resource").lower():
+                    continue
+
+                if queue.lower() not in span.get("resource").lower():
+                    continue
+
+                logger.debug(f"span found in {data['log_filename']}:\n{json.dumps(span, indent=2)}")
+                return span
+
+        logger.debug("No span found")
+        return None
+
+    def setup_produce(self):
+        """
+        send request A to weblog : this request will produce a RabbitMQ message
+        send request B to library buddy, this request will consume RabbitMQ message
+        """
+
+        self.production_response = weblog.get(
+            "/rabbitmq/produce", params={"queue": self.WEBLOG_TO_BUDDY_QUEUE}, timeout=60
+        )
+        self.consume_response = self.buddy.get(
+            "/rabbitmq/consume", params={"queue": self.WEBLOG_TO_BUDDY_QUEUE, "timeout": 60}, timeout=61
+        )
+
+    def test_produce(self):
+        """Check that a message produced to RabbitMQ is correctly ingested by a Datadog tracer"""
+
+        assert self.production_response.status_code == 200
+        assert self.consume_response.status_code == 200
+
+        # The weblog is the producer, the buddy is the consumer
+        self.validate_rabbitmq_spans(
+            producer_interface=interfaces.library,
+            consumer_interface=self.buddy_interface,
+            queue=self.WEBLOG_TO_BUDDY_QUEUE,
+        )
+
+    @missing_feature(library="golang", reason="Expected to fail, Golang does not propagate context")
+    @missing_feature(library="ruby", reason="Expected to fail, Ruby does not propagate context")
+    @missing_feature(library="python", reason="Expected to fail, Python does not propagate context")
+    @missing_feature(library="nodejs", reason="Expected to fail, Nodejs does not propagate context")
+    def test_produce_trace_equality(self):
+        """This test relies on the setup for produce, it currently cannot be run on its own"""
+        producer_span = self.get_span(
+            interfaces.library, span_kind="producer", queue=self.WEBLOG_TO_BUDDY_QUEUE, operation="basic.publish",
+        )
+        consumer_span = self.get_span(
+            self.buddy_interface, span_kind="consumer", queue=self.WEBLOG_TO_BUDDY_QUEUE, operation="basic.deliver",
+        )
+
+        # Both producer and consumer spans should be part of the same trace
+        # Different tracers can handle the exact propagation differently, so for now, this test avoids
+        # asserting on direct parent/child relationships
+        assert producer_span["trace_id"] == consumer_span["trace_id"]
+
+    def setup_consume(self):
+        """
+        send request A to library buddy : this request will produce a RabbitMQ message
+        send request B to weblog, this request will consume RabbitMQ message
+
+        request A: GET /library_buddy/produce_rabbitmq_message
+        request B: GET /weblog/consume_rabbitmq_message
+        """
+
+        self.production_response = self.buddy.get(
+            "/rabbitmq/produce", params={"queue": self.BUDDY_TO_WEBLOG_QUEUE}, timeout=60
+        )
+        self.consume_response = weblog.get(
+            "/rabbitmq/consume", params={"queue": self.BUDDY_TO_WEBLOG_QUEUE, "timeout": 60}, timeout=61
+        )
+
+    def test_consume(self):
+        """Check that a message by an app instrumented by a Datadog tracer is correctly ingested"""
+
+        assert self.production_response.status_code == 200
+        assert self.consume_response.status_code == 200
+
+        # The buddy is the producer, the weblog is the consumer
+        self.validate_rabbitmq_spans(
+            producer_interface=self.buddy_interface,
+            consumer_interface=interfaces.library,
+            queue=self.BUDDY_TO_WEBLOG_QUEUE,
+        )
+
+    @missing_feature(library="golang", reason="Expected to fail, Golang does not propagate context")
+    @missing_feature(library="ruby", reason="Expected to fail, Ruby does not propagate context")
+    @missing_feature(library="python", reason="Expected to fail, Python does not propagate context")
+    @missing_feature(library="nodejs", reason="Expected to fail, Nodejs does not propagate context")
+    def test_consume_trace_equality(self):
+        """This test relies on the setup for consume, it currently cannot be run on its own"""
+        producer_span = self.get_span(
+            self.buddy_interface, span_kind="producer", queue=self.BUDDY_TO_WEBLOG_QUEUE, operation="basic.publish",
+        )
+        consumer_span = self.get_span(
+            interfaces.library, span_kind="consumer", queue=self.BUDDY_TO_WEBLOG_QUEUE, operation="basic.deliver",
+        )
+
+        # Both producer and consumer spans should be part of the same trace
+        # Different tracers can handle the exact propagation differently, so for now, this test avoids
+        # asserting on direct parent/child relationships
+        assert producer_span["trace_id"] == consumer_span["trace_id"]
+
+    def validate_rabbitmq_spans(self, producer_interface, consumer_interface, queue):
+        """
+        Validates production/consumption of RabbitMQ message.
+        It works the same for both test_produce and test_consume
+        """
+
+        # Check that the producer did not created any consumer span
+        assert self.get_span(producer_interface, span_kind="consumer", queue=queue, operation="basic.deliver") is None
+
+        # Check that the consumer did not created any producer span
+        assert self.get_span(consumer_interface, span_kind="producer", queue=queue, operation="basic.publish") is None
+
+        producer_span = self.get_span(producer_interface, span_kind="producer", queue=queue, operation="basic.publish")
+        consumer_span = self.get_span(consumer_interface, span_kind="consumer", queue=queue, operation="basic.deliver")
+        # check that both consumer and producer spans exists
+        assert producer_span is not None
+        assert consumer_span is not None
+
+        # Assert that the consumer span is not the root
+        assert "parent_id" in consumer_span, "parent_id is missing in consumer span"
+
+        # returns both span for any custom check
+        return producer_span, consumer_span
+
+
+@scenarios.crossed_tracing_libraries
+@coverage.basic
+@features.rabbitmq_span_creationcontext_propagation_with_dd_trace
+class Test_RabbitMQ_Trace_Context_Propagation(_Test_RabbitMQ):
+    buddy_interface = interfaces.java_buddy
+    buddy = _java_buddy
+    WEBLOG_TO_BUDDY_QUEUE = "Test_RabbitMQ_Propagation_weblog_to_buddy"
+    BUDDY_TO_WEBLOG_QUEUE = "Test_RabbitMQ_Propagation_buddy_to_weblog"

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1091,6 +1091,7 @@ class scenarios:
         include_kafka=True,
         include_buddies=True,
         include_elasticmq=True,
+        include_rabbitmq=True,
         doc="Spawns a buddy for each supported language of APM",
     )
 

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -1954,3 +1954,13 @@ class features:
         """
         pytest.mark.features(feature_id=269)(test_object)
         return test_object
+
+    @staticmethod
+    def rabbitmq_span_creationcontext_propagation_with_dd_trace(test_object):
+        """
+        [RabbitMQ][Span Creation][Context Propagation] with dd-trace
+
+        https://feature-parity.us1.prod.dog/#/?feature=270
+        """
+        pytest.mark.features(feature_id=270)(test_object)
+        return test_object

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -4,6 +4,7 @@ import com.datadoghq.system_tests.springboot.aws.SqsConnector;
 import com.datadoghq.system_tests.springboot.grpc.WebLogInterface;
 import com.datadoghq.system_tests.springboot.grpc.SynchronousWebLogGrpc;
 import com.datadoghq.system_tests.springboot.kafka.KafkaConnector;
+import com.datadoghq.system_tests.springboot.rabbitmq.RabbitmqConnector;
 import com.datadoghq.system_tests.springboot.rabbitmq.RabbitmqConnectorForDirectExchange;
 import com.datadoghq.system_tests.springboot.rabbitmq.RabbitmqConnectorForFanoutExchange;
 import com.datadoghq.system_tests.springboot.rabbitmq.RabbitmqConnectorForTopicExchange;
@@ -343,6 +344,34 @@ public class App {
             return consumed ? new ResponseEntity<>("consume ok", HttpStatus.OK) : new ResponseEntity<>("consume timed out", HttpStatus.BAD_REQUEST);
         } catch (Exception e) {
             System.out.println("[SQS] Failed to start consuming message...");
+            e.printStackTrace();
+            return new ResponseEntity<>("failed to start consuming messages", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @RequestMapping("/rabbitmq/produce")
+    ResponseEntity<String> rabbitmqProduce(@RequestParam(required = true) String queue) {
+        RabbitmqConnector rabbitmq = new RabbitmqConnector();
+        try {
+            rabbitmq.startProducingMessageWithQueue("RabbitMQ Context Propagation Test", queue);
+        } catch (Exception e) {
+            System.out.println("[RabbitMQ] Failed to start producing message...");
+            e.printStackTrace();
+            return new ResponseEntity<>("failed to start producing messages", HttpStatus.BAD_REQUEST);
+        }
+        return new ResponseEntity<>("produce ok", HttpStatus.OK);
+    }
+
+    @RequestMapping("/rabbitmq/consume")
+    ResponseEntity<String> rabbitmqConsume(@RequestParam(required = true) String queue, @RequestParam(required = false) Integer timeout) {
+        RabbitmqConnector rabbitmq = new RabbitmqConnector();
+        if (timeout == null) timeout = 60;
+        boolean consumed = false;
+        try {
+            consumed = rabbitmq.startConsumingMessagesWithQueue(queue, timeout).get();
+            return consumed ? new ResponseEntity<>("consume ok", HttpStatus.OK) : new ResponseEntity<>("consume timed out", HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            System.out.println("[RabbitMQ] Failed to start consuming message...");
             e.printStackTrace();
             return new ResponseEntity<>("failed to start consuming messages", HttpStatus.BAD_REQUEST);
         }

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rabbitmq/RabbitmqConnector.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rabbitmq/RabbitmqConnector.java
@@ -23,9 +23,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
-public abstract class RabbitmqConnector {
+public class RabbitmqConnector {
 	private static final String DIRECT_EXCHANGE_NAME = "systemTestDirectExchange";
 	private static final String DIRECT_ROUTING_KEY = "systemTestDirectRoutingKey";
 	private static final String QUEUE = "systemTestRabbitmqQueue";
@@ -90,6 +92,26 @@ public abstract class RabbitmqConnector {
         thread.start();
     }
 
+
+    public void startProducingMessageWithQueue(String message, String queue) throws Exception {
+        Thread thread = new Thread("RabbitmqProduce") {
+            public void run() {
+                try {
+                    Channel channel = createChannel();
+                    channel.exchangeDeclare(DIRECT_EXCHANGE_NAME, BuiltinExchangeType.DIRECT, true);
+                    channel.queueDeclare(queue, /*durable=*/true, /*exclusive=*/false, /*autoDelete=*/false, /*arguments=*/null);
+                    channel.queueBind(queue, DIRECT_EXCHANGE_NAME, DIRECT_ROUTING_KEY.concat(queue));
+                    channel.basicPublish(DIRECT_EXCHANGE_NAME, DIRECT_ROUTING_KEY.concat(queue), null, message.getBytes("UTF-8"));
+                    System.out.println("[rabbitmq] Published " + message);
+                } catch (Exception e) {
+                    System.out.println("[rabbitmq] Unable to produce message");
+                    e.printStackTrace();
+                }
+            }
+        };
+        thread.start();
+    }
+
     public void startConsumingMessages() throws Exception {
         System.out.println("[rabbitmq] Start consuming messages");
         Thread thread = new Thread("RabbitmqConsume") {
@@ -111,5 +133,43 @@ public abstract class RabbitmqConnector {
             }
         };
         thread.start();
+    }
+
+    public CompletableFuture<Boolean> startConsumingMessagesWithQueue(String queue, Integer timeout) throws Exception {
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        
+        System.out.println("[rabbitmq] Start consuming messages");
+        Thread thread = new Thread("RabbitmqConsume") {
+            public void run() {
+                try {
+                    Channel channel = createChannel();
+
+                    channel.exchangeDeclare(DIRECT_EXCHANGE_NAME, BuiltinExchangeType.DIRECT, true);
+                    channel.queueDeclare(queue, /*durable=*/true, /*exclusive=*/false, /*autoDelete=*/false, /*arguments=*/null);
+                    channel.queueBind(queue, DIRECT_EXCHANGE_NAME, DIRECT_ROUTING_KEY.concat(queue));
+                    System.out.println("[rabbitmq] Start consume-side bindings");
+
+                    final Consumer consumer = createConsumer(channel, ThreadLocalRandom.current().nextInt(0, 200));
+                    channel.basicConsume(queue, /*autoAck=*/false, consumer);
+
+                    future.complete(true); // Message consumed successfully
+                } catch (Exception e) {
+                    System.out.println("[rabbitmq] Unable to consume message");
+                    e.printStackTrace();
+                    future.complete(false); // Error occurred
+                }
+            }
+        };
+        thread.start();
+
+        // Add timeout
+        if (timeout > 0) {
+            thread.join(TimeUnit.SECONDS.toMillis(timeout));
+            if (thread.isAlive()) {
+                future.complete(false); // Timeout occurred
+                thread.interrupt(); // Interrupt the thread if still running
+            }
+        }
+        return future;
     }
 }


### PR DESCRIPTION
## Motivation

More testing

## Changes

Adds new cross integration test class for rabbitmq, modifies java weblog to have a new rabbitmq consume and produce endpoints

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
