### PR TITLE
Julio/fix shell execution test

### DIFF
--- a/tests/appsec/test_shell_execution.py
+++ b/tests/appsec/test_shell_execution.py
@@ -67,6 +67,7 @@ class Test_ShellExecution:
         reason="For PHP 7.4+",
     )
     @bug(library="java", reason="Truncation method not aligned with the RFC")
+    @bug(library="php", reason="Truncation method not aligned with the RFC")
     def test_truncate_1st_argument(self):
         span = self.fetch_command_execution_span(self.r_truncation)
         assert span["resource"] == "echo"
@@ -85,6 +86,7 @@ class Test_ShellExecution:
         reason="For PHP 7.4+",
     )
     @bug(library="java", reason="Truncation method not aligned with the RFC")
+    @bug(library="php", reason="Truncation method not aligned with the RFC")
     def test_truncate_blank_2nd_argument(self):
         span = self.fetch_command_execution_span(self.r_truncation)
         assert span["resource"] == "echo"

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -195,11 +195,18 @@ app.all('/tag_value/:tag/:status', (req: Request, res: Response) => {
 });
 
 app.post('/shell_execution', (req: Request, res: Response) => {
-  const options = { shell: req?.body?.options?.shell ? true : false}
-  const args = req?.body?.args.split(' ')
+  const options = { shell: !!req?.body?.options?.shell }
+  const reqArgs = req?.body?.args
+
+  let args
+  if (typeof reqArgs === 'string') {
+    args = reqArgs.split(' ')
+  } else {
+    args = reqArgs
+  }
 
   const response = spawnSync(req?.body?.command, args, options)
-  
+
   res.send(response)
 })
 

--- a/utils/build/docker/nodejs/express4/app.js
+++ b/utils/build/docker/nodejs/express4/app.js
@@ -288,7 +288,14 @@ app.get('/db', async (req, res) => {
 
 app.post('/shell_execution', (req, res) => {
   const options = { shell: !!req?.body?.options?.shell }
-  const args = req?.body?.args.split(' ')
+  const reqArgs = req?.body?.args
+
+  let args
+  if (typeof reqArgs === 'string') {
+    args = reqArgs.split(' ')
+  } else {
+    args = reqArgs
+  }
 
   const response = spawnSync(req?.body?.command, args, options)
 


### PR DESCRIPTION
## Motivation

Fix some misalignments with RFC specification.
## Changes

Fixes:
- Command truncation tests.
- Express and TS application

Adds:
- New truncation test in order to test edge case.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
