### PR TITLE
Fix format.sh (unbound variable DOCKER_HOST)

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -20,7 +20,8 @@ fi
 # To determine whether docker is rootless, examine the permissions of the file
 # referred to by DOCKER_HOST. If it's owned by the current user, then assume
 # that docker is rootless.
-if [[ "$DOCKER_HOST" == unix://* && -O "${DOCKER_HOST#unix://}" ]]; then
+DOCKER_HOST="${DOCKER_HOST:-}"
+if [[ "${DOCKER_HOST}" == unix://* && -O "${DOCKER_HOST#unix://}" ]]; then
   user_arg=""
 else
   user_arg="--user=$(id -u):$(id -g)"


### PR DESCRIPTION

## Motivation

`format.sh` previously broken by https://github.com/DataDog/system-tests/pull/2005

The script would fail in systems without DOCKER_HOST env var defined.

## Changes

Ensure `DOCKER_HOST` is defined within the script before referencing it.

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)

