### PR TITLE
Rename dynamic config tests to remote configuration

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -103,9 +103,9 @@ tests/:
       Test_DsmRabbitmq_TopicExchange: missing_feature
       Test_DsmSQS: missing_feature
   parametric/:
-    test_dynamic_configuration.py:
-      TestDynamicConfigV1: missing_feature
-      TestDynamicConfigV2: missing_feature
+    test_library_remote_configuration.py:
+      Test_RemoteConfigurationTracingV1: missing_feature
+      Test_RemoteConfigurationTracingV2: missing_feature
     test_otel_span_methods.py: irrelevant (library does not implement OpenTelemetry)
     test_span_links.py: missing_feature
     test_telemetry.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -220,9 +220,9 @@ tests/:
       Test_DsmRabbitmq_TopicExchange: missing_feature
       Test_DsmSQS: missing_feature
   parametric/:
-    test_dynamic_configuration.py:
-      TestDynamicConfigV1: v2.33.0
-      TestDynamicConfigV2: v2.44.0
+    test_library_remote_configuration.py:
+      Test_RemoteConfigurationTracingV1: v2.33.0
+      Test_RemoteConfigurationTracingV2: v2.44.0
     test_span_links.py: missing_feature
     test_telemetry.py:
       Test_TelemetryInstallSignature: v2.45.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -353,9 +353,9 @@ tests/:
       Test_DsmRabbitmq_TopicExchange: missing_feature
       Test_DsmSQS: missing_feature
   parametric/:
-    test_dynamic_configuration.py:
-      TestDynamicConfigV1: v1.59.0-dev
-      TestDynamicConfigV2: v1.59.0-dev
+    test_library_remote_configuration.py:
+      Test_RemoteConfigurationTracingV1: v1.59.0-dev
+      Test_RemoteConfigurationTracingV2: v1.59.0-dev
     test_span_links.py: missing_feature
     test_telemetry.py:
       Test_TelemetryInstallSignature: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -891,9 +891,9 @@ tests/:
     test_sql.py:
       Test_Sql: bug (Endpoint is probably improperly implemented on weblog)
   parametric/:
-    test_dynamic_configuration.py:
-      TestDynamicConfigV1: v1.17.0
-      TestDynamicConfigV2: missing_feature
+    test_library_remote_configuration.py:
+      Test_RemoteConfigurationTracingV1: v1.17.0
+      Test_RemoteConfigurationTracingV2: missing_feature
     test_span_links.py: missing_feature
     test_telemetry.py:
       Test_TelemetryInstallSignature: v1.27.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -330,9 +330,9 @@ tests/:
       Test_DsmSQS: 
         '*': missing_feature
   parametric/:
-    test_dynamic_configuration.py:
-      TestDynamicConfigV1: v4.11.0
-      TestDynamicConfigV2: missing_feature
+    test_library_remote_configuration.py:
+      Test_RemoteConfigurationTracingV1: v4.11.0
+      Test_RemoteConfigurationTracingV2: missing_feature
     test_span_links.py: missing_feature
     test_telemetry.py:
       Test_TelemetryInstallSignature: v4.23.0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -192,9 +192,9 @@ tests/:
       Test_DsmRabbitmq_TopicExchange: missing_feature
       Test_DsmSQS: missing_feature
   parametric/:
-    test_dynamic_configuration.py:
-      TestDynamicConfigV1: missing_feature
-      TestDynamicConfigV2: missing_feature
+    test_library_remote_configuration.py:
+      Test_RemoteConfigurationTracingV1: missing_feature
+      Test_RemoteConfigurationTracingV2: missing_feature
     test_otel_span_methods.py:
         Test_Otel_Span_Methods: v0.94.0
     test_otel_span_with_w3c.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -502,9 +502,9 @@ tests/:
         '*': missing_feature
         flask-poc: v1.20.3
   parametric/:
-    test_dynamic_configuration.py:
-      TestDynamicConfigV1: missing_feature
-      TestDynamicConfigV2: missing_feature
+    test_library_remote_configuration.py:
+      Test_RemoteConfigurationTracingV1: v2.6.0
+      Test_RemoteConfigurationTracingV2: v2.6.0
     test_sampling_delegation.py:
       Test_Decisionless_Extraction: >-
         missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -239,9 +239,9 @@ tests/:
       Test_DsmRabbitmq_TopicExchange: missing_feature
       Test_DsmSQS: missing_feature
   parametric/:
-    test_dynamic_configuration.py:
-      TestDynamicConfigV1: v1.13.0
-      TestDynamicConfigV2: missing_feature
+    test_library_remote_configuration.py:
+      Test_RemoteConfigurationTracingV1: v1.13.0
+      Test_RemoteConfigurationTracingV2: missing_feature
     test_otel_span_methods.py:
       Test_Otel_Span_Methods: v1.17.0
     test_otel_span_with_w3c.py:

--- a/tests/parametric/test_library_remote_configuration.py
+++ b/tests/parametric/test_library_remote_configuration.py
@@ -99,14 +99,17 @@ ENV_SAMPLING_RULE_RATE = 0.55
 
 @rfc("https://docs.google.com/document/d/1SVD0zbbAAXIsobbvvfAEXipEUO99R9RMsosftfe9jx0")
 @scenarios.parametric
-@features.dynamic_configuration
-class TestDynamicConfigV1:
+@features.remote_configuration_trace_v1_no_capabilities
+class Test_RemoteConfigurationV1:
     """Tests covering the v1 release of the dynamic configuration feature.
 
     v1 includes support for:
         - tracing_sampling_rate
         - log_injection_enabled
         - tracing_header_tags
+
+    Note that v1 of the feature does not require the tracer to report capabilities. It
+    is assumed in the UI/backend that each setting is supported in this case.
     """
 
     @parametrize("library_env", [{"DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1"}])
@@ -342,8 +345,16 @@ class TestDynamicConfigV1:
 
 @rfc("https://docs.google.com/document/d/1V4ZBsTsRPv8pAVG5WCmONvl33Hy3gWdsulkYsE4UZgU/edit")
 @scenarios.parametric
-@features.dynamic_configuration
-class TestDynamicConfigV2:
+@features.remote_configuration_trace_v2_capabilities
+class Test_RemoteConfigurationTracingV2:
+    """
+    Extension of the remote configuration settings introduced in v1.
+
+    v2 includes support for custom tags AND requires that the tracer report RC capabilities for each setting.
+
+    The capabilities are used in the UI to show which options are available for the given service.
+    """
+
     @parametrize(
         "library_env", [{**DEFAULT_ENVVARS}, {**DEFAULT_ENVVARS, "DD_TAGS": "key1:val1,key2:val2"},],
     )

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -1953,3 +1953,61 @@ class features:
         """
         pytest.mark.features(feature_id=269)(test_object)
         return test_object
+
+    @staticmethod
+    def remote_configuration_trace_sampling_rate(test_object):
+        """
+        https://feature-parity.us1.prod.dog/#/?feature=270
+        """
+        pytest.mark.features(feature_id=270)(test_object)
+        return test_object
+
+    @staticmethod
+    def remote_configuration_trace_logs_injection(test_object):
+        """
+        https://feature-parity.us1.prod.dog/#/?feature=271
+        """
+        pytest.mark.features(feature_id=271)(test_object)
+        return test_object
+
+    @staticmethod
+    def remote_configuration_trace_header_tagging(test_object):
+        """
+        https://feature-parity.us1.prod.dog/#/?feature=272
+        """
+        pytest.mark.features(feature_id=272)(test_object)
+        return test_object
+
+    @staticmethod
+    def remote_configuration_trace_custom_tagging(test_object):
+        """
+        https://feature-parity.us1.prod.dog/#/?feature=273
+        """
+        pytest.mark.features(feature_id=273)(test_object)
+        return test_object
+
+    @staticmethod
+    def remote_configuration_trace_v1_no_capabilities(test_object):
+        """
+        The initial implementation of tracing settings did not
+        require capabilities and assumes that if none are specified
+        that trace sample rate, logs injection and http header tagging
+        are implemented.
+
+        https://feature-parity.us1.prod.dog/#/?feature=274
+        """
+        pytest.mark.features(feature_id=274)(test_object)
+        return test_object
+
+    @staticmethod
+    def remote_configuration_trace_v2_capabilities(test_object):
+        """
+        The initial implementation of tracing settings did not
+        require capabilities and assumes that if none are specified
+        that trace sample rate, logs injection and http header tagging
+        are implemented.
+
+        https://feature-parity.us1.prod.dog/#/?feature=275
+        """
+        pytest.mark.features(feature_id=275)(test_object)
+        return test_object


### PR DESCRIPTION
Dynamic config was a contrived name for the project and we don't use it publicly and less and less internally.


## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
