### PR TITLE
Enable telemetry tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 /utils/build/docker/python*/ @DataDog/apm-python @DataDog/asm-python @DataDog/system-tests-core
 /utils/build/docker/ruby*/ @DataDog/apm-ruby @DataDog/asm-ruby @DataDog/system-tests-core
 /parametric/ @Kyle-Verhoog @DataDog/system-tests-core
+/tests/parametric/ @Kyle-Verhoog @DataDog/system-tests-core
 /tests/otel_tracing_e2e/ @DataDog/opentelemetry @DataDog/system-tests-core
 /tests/remote_config/ @DataDog/system-tests-core @DataDog/remote-config @DataDog/system-tests-core
 /tests/appsec/ @DataDog/asm-libraries @DataDog/system-tests-core

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -249,8 +249,8 @@ tests/:
       TestDynamicConfigV2: v2.44.0
     test_span_links.py: missing_feature
     test_telemetry.py:
-      Test_Defaults: missing_feature
-      Test_Environment: missing_feature
+      Test_Defaults: v2.46.0
+      Test_Environment: v2.46.0
       Test_TelemetryInstallSignature: v2.45.0
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -249,8 +249,8 @@ tests/:
       TestDynamicConfigV2: v2.44.0
     test_span_links.py: missing_feature
     test_telemetry.py:
-      Test_Defaults: v2.46.0
-      Test_Environment: v2.46.0
+      Test_Defaults: v2.49.0
+      Test_Environment: v2.49.0
       Test_TelemetryInstallSignature: v2.45.0
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -399,8 +399,8 @@ tests/:
       TestDynamicConfigV2: v1.59.0
     test_span_links.py: missing_feature
     test_telemetry.py:
-      Test_Defaults: missing_feature
-      Test_Environment: missing_feature
+      Test_Defaults: v1.60.1
+      Test_Environment: v1.60.1
       Test_TelemetryInstallSignature: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.37.0 # TODO what is the earliest version?

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -399,8 +399,8 @@ tests/:
       TestDynamicConfigV2: v1.59.0
     test_span_links.py: missing_feature
     test_telemetry.py:
-      Test_Defaults: v1.60.1
-      Test_Environment: v1.60.1
+      Test_Defaults: v1.61.0
+      Test_Environment: v1.61.0
       Test_TelemetryInstallSignature: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.37.0 # TODO what is the earliest version?

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -955,8 +955,8 @@ tests/:
       TestDynamicConfigV2: v1.31.0      
     test_span_links.py: missing_feature
     test_telemetry.py:
-      Test_Defaults: v1.28.0
-      Test_Environment: v1.28.0
+      Test_Defaults: v1.31.0
+      Test_Environment: v1.31.0
       Test_TelemetryInstallSignature: v1.27.0
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.111.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -955,8 +955,8 @@ tests/:
       TestDynamicConfigV2: v1.31.0      
     test_span_links.py: missing_feature
     test_telemetry.py:
-      Test_Defaults: missing_feature
-      Test_Environment: missing_feature
+      Test_Defaults: v1.28.0
+      Test_Environment: v1.28.0
       Test_TelemetryInstallSignature: v1.27.0
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.111.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -299,7 +299,7 @@ tests/:
       Test_AppSecObfuscator: v2.6.0
       Test_CollectRespondHeaders: v2.0.0
       Test_DistributedTraceInfo: missing_feature (test not implemented)
-      Test_ExternalWafRequestsIdentification: missing_feature
+      Test_ExternalWafRequestsIdentification: v5.7.0
       Test_RetainTraces: v2.0.0
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -234,8 +234,8 @@ tests/:
         See <https://github.com/DataDog/system-tests/actions/runs/7629296312/job/20782699614?pr=2005>.)
     test_span_links.py: missing_feature
     test_telemetry.py:
-      Test_Defaults: missing_feature
-      Test_Environment: missing_feature
+      Test_Defaults: v0.98.1
+      Test_Environment: v0.98.1
       Test_TelemetryInstallSignature: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.68.3 # TODO what is the earliest version?

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -526,8 +526,8 @@ tests/:
     test_span_links.py:
       Test_Span_Links: v2.3.0
     test_telemetry.py:
-      Test_Defaults: missing_feature
-      Test_Environment: missing_feature
+      Test_Defaults: v2.7.3
+      Test_Environment: v2.7.3
       Test_TelemetryInstallSignature: v2.5.0
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.9.0 # TODO what is the earliest version?

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -82,7 +82,10 @@ class Test_Defaults:
                     cfg_item["value"] = _get_filtered_tags(cfg_item.get("value"))
                 assert cfg_item.get("value") in value, "Unexpected value for '{}'".format(apm_telemetry_name)
             else:
+                if apm_telemetry_name == "trace_tags":
+                    cfg_item["value"] = _get_filtered_tags(cfg_item.get("value"))
                 assert cfg_item.get("value") == value, "Unexpected value for '{}'".format(apm_telemetry_name)
+
             assert cfg_item.get("origin") == "default", "Unexpected origin for '{}'".format(apm_telemetry_name)
 
 
@@ -140,6 +143,7 @@ class Test_Environment:
             apm_telemetry_name = _mapped_telemetry_name(context, apm_telemetry_name)
             cfg_item = configuration_by_name.get(apm_telemetry_name)
             assert cfg_item is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
+
             if isinstance(environment_value, tuple):
                 if apm_telemetry_name == "trace_tags":
                     cfg_item["value"] = _get_filtered_tags(cfg_item.get("value"))
@@ -151,6 +155,7 @@ class Test_Environment:
                 assert cfg_item.get("value") == environment_value, "Unexpected value for '{}'".format(
                     apm_telemetry_name
                 )
+
             assert cfg_item.get("origin") == "env_var", "Unexpected origin for '{}'".format(apm_telemetry_name)
 
 

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -71,7 +71,15 @@ class Test_Defaults:
             cfg_item = configuration_by_name.get(apm_telemetry_name)
             assert cfg_item is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
             if isinstance(value, tuple):
-                assert cfg_item.get("value") in value, "Unexpected value for '{}'".format(apm_telemetry_name)
+                if apm_telemetry_name == "trace_tags" and len(cfg_item.get("value")) > 0 :
+                    for given_value in cfg_item.get("value"):
+                        if given_value.startswith('runtime'):
+                            continue
+                        assert given_value in value, "Unexpected value for '{}'".format(
+                            apm_telemetry_name
+                        )
+                else:
+                    assert cfg_item.get("value") in value, "Unexpected value for '{}'".format(apm_telemetry_name)
             else:
                 assert cfg_item.get("value") == value, "Unexpected value for '{}'".format(apm_telemetry_name)
             assert cfg_item.get("origin") == "default", "Unexpected origin for '{}'".format(apm_telemetry_name)
@@ -133,9 +141,17 @@ class Test_Environment:
             cfg_item = configuration_by_name.get(apm_telemetry_name)
             assert cfg_item is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
             if isinstance(environment_value, tuple):
-                assert cfg_item.get("value") in environment_value, "Unexpected value for '{}'".format(
-                    apm_telemetry_name
-                )
+                if apm_telemetry_name == "trace_tags":
+                    for given_value in cfg_item.get("value") and len(cfg_item.get("value")) > 0 :
+                        if given_value.startswith('runtime'):
+                            continue
+                        assert given_value in environment_value, "Unexpected value for '{}'".format(
+                            apm_telemetry_name
+                        )
+                else:
+                    assert cfg_item.get("value") in environment_value, "Unexpected value for '{}'".format(
+                        apm_telemetry_name
+                    )
             else:
                 assert cfg_item.get("value") == environment_value, "Unexpected value for '{}'".format(
                     apm_telemetry_name

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -69,8 +69,8 @@ class Test_Defaults:
             ("appsec_enabled", ("false", False, "inactive", None)),
             ("data_streams_enabled", ("false", False)),
         ]:
-            # The Go tracer does not support logs injection.
-            if context.library == "golang" and apm_telemetry_name in ("logs_injection_enabled",):
+            # The Go tracer does not support logs injection. It doesn't report the *_enabled values (except for trace_enabled).
+            if context.library == "golang" and apm_telemetry_name in ("logs_injection_enabled","profiling_enabled","appsec_enabled","data_streams_enabled",):
                 continue
             apm_telemetry_name = _mapped_telemetry_name(context, apm_telemetry_name)
 
@@ -136,8 +136,8 @@ class Test_Environment:
             ("appsec_enabled", ("false", False)),
             ("data_streams_enabled", ("false", False)),
         ]:
-            # The Go tracer does not support logs injection.
-            if context.library == "golang" and apm_telemetry_name in ("logs_injection_enabled",):
+             # The Go tracer does not support logs injection. It doesn't report the *_enabled values (except for trace_enabled).
+            if context.library == "golang" and apm_telemetry_name in ("logs_injection_enabled","profiling_enabled","appsec_enabled","data_streams_enabled",):
                 continue
 
             apm_telemetry_name = _mapped_telemetry_name(context, apm_telemetry_name)

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -55,7 +55,7 @@ class Test_Defaults:
         configuration_by_name = {item["name"]: item for item in configuration}
         for (apm_telemetry_name, value) in [
             ("trace_sample_rate", (1.0, None, "1.0")),
-            ("logs_injection_enabled", ("false", False)),
+            ("logs_injection_enabled", ("false", False, "true", True)),
             ("trace_header_tags", ""),
             ("trace_tags", ""),
             ("trace_enabled", ("true", True)),

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -30,10 +30,12 @@ def _mapped_telemetry_name(context, apm_telemetry_name):
             return mapped_name
     return apm_telemetry_name
 
+
 def _get_filtered_tags(existing_value):
     if isinstance(existing_value, str):
-        return ','.join([tag for tag in existing_value.split(',') if not tag.startswith('runtime')])
+        return ",".join([tag for tag in existing_value.split(",") if not tag.startswith("runtime")])
     return existing_value
+
 
 @scenarios.parametric
 @rfc("https://docs.google.com/document/d/1In4TfVBbKEztLzYg4g0si5H56uzAbYB3OfqzRGP2xhg/edit")
@@ -77,7 +79,7 @@ class Test_Defaults:
 
             if isinstance(value, tuple):
                 if apm_telemetry_name == "trace_tags":
-                    cfg_item['value'] = _get_filtered_tags(cfg_item.get("value"))
+                    cfg_item["value"] = _get_filtered_tags(cfg_item.get("value"))
                 assert cfg_item.get("value") in value, "Unexpected value for '{}'".format(apm_telemetry_name)
             else:
                 assert cfg_item.get("value") == value, "Unexpected value for '{}'".format(apm_telemetry_name)
@@ -140,8 +142,8 @@ class Test_Environment:
             assert cfg_item is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
             if isinstance(environment_value, tuple):
                 if apm_telemetry_name == "trace_tags":
-                    cfg_item['value'] = _get_filtered_tags(cfg_item.get("value"))
-                
+                    cfg_item["value"] = _get_filtered_tags(cfg_item.get("value"))
+
                 assert cfg_item.get("value") in environment_value, "Unexpected value for '{}'".format(
                     apm_telemetry_name
                 )

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -70,6 +70,10 @@ class Test_Defaults:
 
             cfg_item = configuration_by_name.get(apm_telemetry_name)
             assert cfg_item is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
+            print('----')
+            print(apm_telemetry_name)
+            print(cfg_item.get("value"))
+            print(value)
             if isinstance(value, tuple):
                 if apm_telemetry_name == "trace_tags" and len(cfg_item.get("value")) > 0 :
                     for given_value in cfg_item.get("value"):
@@ -140,6 +144,10 @@ class Test_Environment:
             apm_telemetry_name = _mapped_telemetry_name(context, apm_telemetry_name)
             cfg_item = configuration_by_name.get(apm_telemetry_name)
             assert cfg_item is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
+            print('----')
+            print(apm_telemetry_name)
+            print(cfg_item.get("value"))
+            print(environment_value)
             if isinstance(environment_value, tuple):
                 if apm_telemetry_name == "trace_tags":
                     for given_value in cfg_item.get("value") and len(cfg_item.get("value")) > 0 :

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -55,7 +55,6 @@ class RemoteConfigurationFieldsBasicTests:
     @bug(context.library < "golang@1.36.0")
     @bug(context.library < "java@0.93.0")
     @bug(context.library >= "nodejs@3.14.1")
-    @bug(context.library == "php")
     def test_schemas(self):
         """Test all library schemas"""
         interfaces.library.assert_schemas()
@@ -88,11 +87,6 @@ class RemoteConfigurationFieldsBasicTests:
             allowed_errors = (
                 # value is missing in configuration object in telemetry payloads
                 r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-            )
-        elif context.library == "php":
-            allowed_errors = (
-                r"'interval' is a required property on instance \['payload'\]\['series'\]\[\d+\]",
-                r"'namespace' is a required property on instance \['payload'\]",
             )
 
         interfaces.library.assert_schemas(allowed_errors=allowed_errors)

--- a/utils/build/docker/php/apache-mod/entrypoint.sh
+++ b/utils/build/docker/php/apache-mod/entrypoint.sh
@@ -21,4 +21,4 @@ export -p | sed 's@declare -x@export@' | tee /dev/stderr >> /etc/apache2/envvars
 
 service apache2 start
 
-exec tail -f "${LOGS_PHP[@]}" "${LOGS_APACHE[@]}"
+exec tail -f "${LOGS_PHP[@]}" "${LOGS_APACHE[@]}" "/tmp/appsec.log" "/tmp/helper.log"

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -21,18 +21,21 @@ if [ "$PKG" == "" ]; then
   unset PKG
 fi
 
+INI_FILE=/etc/php/php.ini
 echo "Installing php package ${PKG-"{default}"} with setup script $SETUP"
 if [[ $IS_APACHE -eq 0 ]]; then
       php $SETUP --php-bin all ${PKG+"--file=$PKG"}
+      PHP_VERSION=$(php -r "echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;")
+      INI_FILE=/etc/php/$PHP_VERSION/fpm/conf.d/98-ddtrace.ini
 else
       PHP_INI_SCAN_DIR="/etc/php" php $SETUP --php-bin all ${PKG+"--file=$PKG"}
- fi
+fi
 
 #There is a bug on 0.98.1 which config when it shouldnt. Delete this line when hotfix
-sed -i "/datadog.appsec.enabled/s/^/;/g" /etc/php/php.ini
-
+sed -i "/datadog.appsec.enabled/s/^/;/g" $INI_FILE
 #Parametric tests don't need appsec
-[ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> /etc/php/php.ini
+[ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> $INI_FILE
+
 #Ensure parametric test compatibility
 [ ! -z ${NO_EXTRACT_VERSION+x} ] && exit 0
 

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -8,9 +8,6 @@ cd /binaries
 
 PKG=$(find /binaries -maxdepth 1 -name 'dd-library-php-*-linux-gnu.tar.gz')
 SETUP=/binaries/datadog-setup.php
-ENABLE_APPSEC_ARG="--enable-appsec"
-#Parametric tests don't need appsec
-[ ! -z ${NO_EXTRACT_VERSION+x} ] && ENABLE_APPSEC_ARG=""
 
 if [ "$PKG" != "" ] && [ ! -f "$SETUP" ]; then
   echo "local install failed: package located in /binaries but datadog-setup.php not present, please include it"
@@ -26,11 +23,13 @@ fi
 
 echo "Installing php package ${PKG-"{default}"} with setup script $SETUP"
 if [[ $IS_APACHE -eq 0 ]]; then
-      php $SETUP --php-bin all ${PKG+"--file=$PKG"} $ENABLE_APPSEC_ARG
+      php $SETUP --php-bin all ${PKG+"--file=$PKG"}
 else
-      PHP_INI_SCAN_DIR="/etc/php" php $SETUP --php-bin all ${PKG+"--file=$PKG"} $ENABLE_APPSEC_ARG
+      PHP_INI_SCAN_DIR="/etc/php" php $SETUP --php-bin all ${PKG+"--file=$PKG"}
  fi
 
+#Parametric tests don't need appsec
+[ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> /etc/php/php.ini
 #Ensure parametric test compatibility
 [ ! -z ${NO_EXTRACT_VERSION+x} ] && exit 0
 

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -32,7 +32,7 @@ else
 fi
 
 if test -f $INI_FILE; then
-  #There is a bug on 0.98.1 which config when it shouldnt. Delete this line when hotfix
+  #There is a bug on 0.98.1 which disable explicitly appsec when it shouldnt. Delete this line when hotfix
   sed -i "/datadog.appsec.enabled/s/^/;/g" $INI_FILE
   #Parametric tests don't need appsec
   [ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> $INI_FILE

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -31,10 +31,12 @@ else
       PHP_INI_SCAN_DIR="/etc/php" php $SETUP --php-bin all ${PKG+"--file=$PKG"}
 fi
 
-#There is a bug on 0.98.1 which config when it shouldnt. Delete this line when hotfix
-sed -i "/datadog.appsec.enabled/s/^/;/g" $INI_FILE
-#Parametric tests don't need appsec
-[ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> $INI_FILE
+if test -f $INI_FILE; then
+  #There is a bug on 0.98.1 which config when it shouldnt. Delete this line when hotfix
+  sed -i "/datadog.appsec.enabled/s/^/;/g" $INI_FILE
+  #Parametric tests don't need appsec
+  [ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> $INI_FILE
+fi
 
 #Ensure parametric test compatibility
 [ ! -z ${NO_EXTRACT_VERSION+x} ] && exit 0

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -28,6 +28,9 @@ else
       PHP_INI_SCAN_DIR="/etc/php" php $SETUP --php-bin all ${PKG+"--file=$PKG"}
  fi
 
+#There is a bug on 0.98.1 which config when it shouldnt. Delete this line when hotfix
+sed -i "/datadog.appsec.enabled/s/^/;/g" /etc/php/php.ini
+
 #Parametric tests don't need appsec
 [ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> /etc/php/php.ini
 #Ensure parametric test compatibility


### PR DESCRIPTION

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
