### PR TITLE
Generate buddies on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
     secrets: inherit
 
   main:
-    if: ${{ false }}  # disable for now3-10
     runs-on: ubuntu-latest
     needs:
     - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
     secrets: inherit
 
   main:
+    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     needs:
     - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     secrets: inherit
 
   main:
-    if: ${{ false }}  # disable for now
+    if: ${{ false }}  # disable for now1
     runs-on: ubuntu-latest
     needs:
     - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     secrets: inherit
 
   main:
-    if: ${{ false }}  # disable for now3
+    if: ${{ false }}  # disable for now3-10
     runs-on: ubuntu-latest
     needs:
     - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     secrets: inherit
 
   main:
-    if: ${{ false }}  # disable for now1
+    if: ${{ false }}  # disable for now3
     runs-on: ubuntu-latest
     needs:
     - lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,5 +164,5 @@ job1-test_merge:
   stage: test_stage
   script:
     - echo "This job runs in merge request pipelines"
-  only:
-    - merge_requests
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,3 +159,8 @@ onboarding_parse_results:
     - export GITHUB_MAIL=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.gh-mail --with-decryption --query "Parameter.Value" --out text) 
   script:
       - sh utils/scripts/push_reports_dashboard.sh
+job1-test_merge:
+  script:
+    - echo "This job runs in merge request pipelines"
+  only:
+    - merge_requests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,51 +160,18 @@ onboarding_parse_results:
     - export GITHUB_MAIL=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.gh-mail --with-decryption --query "Parameter.Value" --out text) 
   script:
       - sh utils/scripts/push_reports_dashboard.sh
-job1-test_merge:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
-  tags: ["arch:amd64"]
+
+
+check_merge_labels:
+  image: registry.ddbuild.io/images/ci_docker_base
+  tags: ["runner:docker"]
   stage: test_stage
-  script:
-    - echo "This job runs in merge request pipelines"
+  before_script:
+    - export GH_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.gh-token --with-decryption --query "Parameter.Value" --out text) 
+    - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text) 
+    - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text) 
+  script:  
+    - ./utils/scripts/get_pr_merged_labels.sh
   rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "robertomonteromiguel/auto_generate_buddies"
 
-job1-test_push:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
-  tags: ["arch:amd64"]
-  stage: test_stage
-  script:
-    - echo "This job runs in merge request pipelines"
-    - git rev-parse HEAD^2 >/dev/null 2>/dev/null && echo "is merge" || echo "regular commit" 
-    - echo "EL COMMIT BRANCH --- $CI_COMMIT_BRANCH"
-    - echo "EL COMMIT MESSAGE --- $CI_COMMIT_MESSAGE"
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "push"
-
-on-pull-requests:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
-  tags: ["arch:amd64"]
-  stage: test_stage
-  script: echo 'this should run on pull requests'
-  only:
-    - external_pull_requests
-
-job2-test_merge:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
-  tags: ["arch:amd64"]
-  stage: test_stage
-  script:
-    - echo "This job runs in merge request pipelines"
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event"'
-      when: always
-
-
-job4-test_merge:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
-  tags: ["arch:amd64"]
-  stage: test_stage
-  script:
-    - echo "This job runs in merge request pipelines"
-  only:
-    - merge_requests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ stages:
   - python_tracer
   - dotnet_tracer
   - parse_results
+  - test_stage
 
 .base_job_onboarding:
   only:
@@ -160,6 +161,7 @@ onboarding_parse_results:
   script:
       - sh utils/scripts/push_reports_dashboard.sh
 job1-test_merge:
+  stage: test_stage
   script:
     - echo "This job runs in merge request pipelines"
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -176,6 +176,8 @@ job1-test_push:
   script:
     - echo "This job runs in merge request pipelines"
     - git rev-parse HEAD^2 >/dev/null 2>/dev/null && echo "is merge" || echo "regular commit" 
+    - echo "EL COMMIT BRANCH --- $CI_COMMIT_BRANCH"
+    - echo "EL COMMIT MESSAGE --- $CI_COMMIT_MESSAGE"
   rules:
     - if: $CI_PIPELINE_SOURCE == "push"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,3 +177,21 @@ job1-test_push:
     - echo "This job runs in merge request pipelines"
   rules:
     - if: $CI_PIPELINE_SOURCE == "push"
+
+on-pull-requests:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
+  tags: ["arch:amd64"]
+  stage: test_stage
+  script: echo 'this should run on pull requests'
+  only:
+    - external_pull_requests
+
+job2-test_merge:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
+  tags: ["arch:amd64"]
+  stage: test_stage
+  script:
+    - echo "This job runs in merge request pipelines"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event"'
+      when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,6 +175,7 @@ job1-test_push:
   stage: test_stage
   script:
     - echo "This job runs in merge request pipelines"
+    - git rev-parse "HEAD^2" >nul 2>nul && echo "is merge" || echo "regular commit"
   rules:
     - if: $CI_PIPELINE_SOURCE == "push"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
   - python_tracer
   - dotnet_tracer
   - parse_results
-  - test_stage
+  - before_tests
 
 .base_job_onboarding:
   only:
@@ -161,11 +161,10 @@ onboarding_parse_results:
   script:
       - sh utils/scripts/push_reports_dashboard.sh
 
-
 check_merge_labels:
   image: registry.ddbuild.io/images/ci_docker_base
   tags: ["runner:docker"]
-  stage: test_stage
+  stage: before_tests
   before_script:
     - export GH_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.gh-token --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text) 
@@ -173,5 +172,5 @@ check_merge_labels:
   script:  
     - ./utils/scripts/get_pr_merged_labels.sh
   rules:
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "robertomonteromiguel/auto_generate_buddies"
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,8 +161,19 @@ onboarding_parse_results:
   script:
       - sh utils/scripts/push_reports_dashboard.sh
 job1-test_merge:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
+  tags: ["arch:amd64"]
   stage: test_stage
   script:
     - echo "This job runs in merge request pipelines"
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+
+job1-test_push:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
+  tags: ["arch:amd64"]
+  stage: test_stage
+  script:
+    - echo "This job runs in merge request pipelines"
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,3 +195,13 @@ job2-test_merge:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event"'
       when: always
+
+
+job4-test_merge:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
+  tags: ["arch:amd64"]
+  stage: test_stage
+  script:
+    - echo "This job runs in merge request pipelines"
+  only:
+    - merge_requests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,7 +175,7 @@ job1-test_push:
   stage: test_stage
   script:
     - echo "This job runs in merge request pipelines"
-    - git rev-parse "HEAD^2" >nul 2>nul && echo "is merge" || echo "regular commit"
+    - git rev-parse HEAD^2 >/dev/null 2>/dev/null && echo "is merge" || echo "regular commit" 
   rules:
     - if: $CI_PIPELINE_SOURCE == "push"
 

--- a/utils/build/build_tracer_buddies.sh
+++ b/utils/build/build_tracer_buddies.sh
@@ -9,9 +9,15 @@ docker buildx build --load --progress=plain -f utils/build/docker/java/spring-bo
 docker buildx build --load --progress=plain -f utils/build/docker/ruby/rails70.Dockerfile -t datadog/system-tests:ruby_buddy-v0 .
 docker buildx build --load --progress=plain -f utils/build/docker/golang/net-http.Dockerfile -t datadog/system-tests:golang_buddy-v0 .
 
-# Leave this line commented, it's only used when we need to push a new version of the buddy
-# docker push datadog/system-tests:python_buddy-v0
-# docker push datadog/system-tests:nodejs_buddy-v0
-# docker push datadog/system-tests:java_buddy-v0
-# docker push datadog/system-tests:ruby_buddy-v0
-# docker push datadog/system-tests:golang_buddy-v0
+
+if [ -z "$PUSH_IMAGES" ]
+then
+      echo "Skip pushing buddies images"
+else
+      docker push datadog/system-tests:python_buddy-v0
+      docker push datadog/system-tests:nodejs_buddy-v0
+      docker push datadog/system-tests:java_buddy-v0
+      docker push datadog/system-tests:ruby_buddy-v0
+      docker push datadog/system-tests:golang_buddy-v0
+fi
+

--- a/utils/build/build_tracer_buddies.sh
+++ b/utils/build/build_tracer_buddies.sh
@@ -10,10 +10,7 @@ docker buildx build --load --progress=plain -f utils/build/docker/ruby/rails70.D
 docker buildx build --load --progress=plain -f utils/build/docker/golang/net-http.Dockerfile -t datadog/system-tests:golang_buddy-v0 .
 
 
-if [ -z "$PUSH_IMAGES" ]
-then
-      echo "Skip pushing buddies images"
-else
+if [ "$1" = "--push" ]; then
       docker push datadog/system-tests:python_buddy-v0
       docker push datadog/system-tests:nodejs_buddy-v0
       docker push datadog/system-tests:java_buddy-v0

--- a/utils/scripts/get_pr_merged_labels.sh
+++ b/utils/scripts/get_pr_merged_labels.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#Check the commit message to figure out if we are merging a PR.
+#We extract the PR number and using GitHub API we check the PR labels.
+#If the PR contains the label "build-buddies-images" we launch the build and push process
+
+PR_PATTERN='#[0-9]+'
+
+if [[ $CI_COMMIT_MESSAGE =~ ($PR_PATTERN) ]]; then
+    PR_NUMBER=${BASH_REMATCH[1]:1}
+    echo "Merged the PR number: [$PR_NUMBER]"; 
+    #search for labels
+    PR_DATA=$(curl -L \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GH_TOKEN" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/DataDog/system-tests/issues/$PR_NUMBER/labels");
+
+    echo "We found PR labels: $PR_DATA"    
+
+    is_build_buddies=$(echo "$PR_DATA" | jq -c '.[] | select(.name | contains("build-buddies-images"))');
+
+    if [ -z "$is_build_buddies" ]
+    then
+        echo "The PR $PR_NUMBER doesn't contain the 'build-buddies-images' label "
+    else
+        echo "The PR $PR_NUMBER contains the 'build-buddies-images' label. Launching the images generation process "
+        echo "$DOCKER_LOGIN_PASS" | docker login --username "$DOCKER_LOGIN" --password-stdin
+        PUSH_IMAGES=true ./utils/build/build_tracer_buddies.sh
+    fi
+else
+    echo "The commit message $CI_COMMIT_MESSAGE doesn't contain the PR number."
+fi

--- a/utils/scripts/get_pr_merged_labels.sh
+++ b/utils/scripts/get_pr_merged_labels.sh
@@ -26,7 +26,7 @@ if [[ $CI_COMMIT_MESSAGE =~ ($PR_PATTERN) ]]; then
     else
         echo "The PR $PR_NUMBER contains the 'build-buddies-images' label. Launching the images generation process "
         echo "$DOCKER_LOGIN_PASS" | docker login --username "$DOCKER_LOGIN" --password-stdin
-        PUSH_IMAGES=true ./utils/build/build_tracer_buddies.sh
+        ./utils/build/build_tracer_buddies.sh --push
     fi
 else
     echo "The commit message $CI_COMMIT_MESSAGE doesn't contain the PR number."


### PR DESCRIPTION
## Motivation

We need to regenerate buddies if a PR with this label is merged to main branch.
Use gitlab job to trigger the buddies generation on merge if the labels has been set 

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
