### PR TITLE
[.Net] IAST header injection system tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -26,7 +26,7 @@ tests/:
         test_hardcoded_secrets.py:
           Test_HardcodedSecrets: missing_feature
         test_header_injection.py:
-          TestHeaderInjection: missing_feature
+          TestHeaderInjection: v2.46.0
         test_hsts_missing_header.py: 
           Test_HstsMissingHeader: missing_feature
         test_insecure_cookie.py:

--- a/tests/appsec/iast/sink/test_header_injection.py
+++ b/tests/appsec/iast/sink/test_header_injection.py
@@ -19,6 +19,7 @@ class TestHeaderInjection(BaseSinkTest):
     location_map = {"nodejs": {"express4": "iast/index.js", "express4-typescript": "iast.ts"}}
 
     @missing_feature(context.library < "java@1.22.0", reason="Metrics not implemented")
+    @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -317,6 +317,20 @@ namespace weblog
                 return Content($"Error creating connection");
             }                
         }
+
+        [HttpPost("header_injection/test_insecure")]
+        public IActionResult test_insecure_header_injection([FromForm] string test)
+        {
+            Response.Headers.Add("returnedHeaderKey", test);
+            return Content("Ok");
+        }
+        
+        [HttpPost("header_injection/test_secure")]
+        public IActionResult test_secure_header_injection([FromForm] string test)
+        {
+            Response.Headers.Add("returnedHeaderKey", "notTainted");
+            return Content("Ok");
+        }        
         
         [HttpPost("sqli/test_insecure")]
         public IActionResult test_insecure_sqlI([FromForm] string username, [FromForm] string password)


### PR DESCRIPTION
This PR adds the IAST system tests for the header injection vulnerability.

## Motivation

To test a feature that we already support.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
