### PR TITLE
Shell execution enabled and added in nextjs

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -288,7 +288,7 @@ tests/:
     test_runtime_activation.py:
       Test_RuntimeActivation: v3.9.0
     test_shell_execution.py:
-      Test_ShellExecution: missing_feature
+      Test_ShellExecution: v5.3.0
     test_traces.py:
       Test_AppSecEventSpanTags: v2.0.0
       Test_AppSecObfuscator: v2.6.0

--- a/utils/build/docker/nodejs/nextjs/src/app/shell_execution/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/shell_execution/route.js
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { spawnSync } from 'child_process'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST (request) {
+  const body = await request.json()
+
+  const options = { shell: !!body?.options?.shell }
+  const reqArgs = body?.args
+
+  let args
+  if (typeof reqArgs === 'string') {
+    args = reqArgs.split(' ')
+  } else {
+    args = reqArgs
+  }
+
+  const response = spawnSync(body?.command, args, options)
+
+  return NextResponse.json({ mesage: 'OK', response })
+}


### PR DESCRIPTION
## Motivation
Shell execution feature merged in master, we are enabling the tests here. 
I saw that nextjs endpoint wasn't implemented, so I implemented it also.

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->
Enable test
Add new endpoint in nextjs
## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents

_(Modified tests are in default scenario)_
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
