### PR TITLE
Update skipped tests for .NET for new propagation default

### DIFF
--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -87,7 +87,7 @@ def enable_tracecontext_datadog_b3multi_extract_first_true() -> Any:
 
 @scenarios.parametric
 class Test_Headers_Precedence:
-    @missing_feature(context.library == "dotnet", reason="New 'datadog' default hasn't been implemented yet")
+    @missing_feature(context.library == "dotnet", reason="Implements the new 'datadog,tracecontext' default")
     @missing_feature(context.library == "golang", reason="New 'datadog' default hasn't been implemented yet")
     @irrelevant(context.library >= "cpp@0.1.12", reason="Implements the new 'datadog,tracecontext' default")
     @irrelevant(context.library >= "java@1.24.0", reason="Implements the new 'datadog,tracecontext' default")
@@ -218,6 +218,7 @@ class Test_Headers_Precedence:
     @missing_feature(
         context.library == "ruby", reason="Issue: tracecontext,Datadog was never the default configuration"
     )
+    @irrelevant(context.library > "dotnet@2.46.0", reason="Implements the new 'datadog,tracecontext' default")
     def test_headers_precedence_propagationstyle_default_tracecontext_datadog(self, test_agent, test_library):
         self.test_headers_precedence_propagationstyle_tracecontext_datadog(test_agent, test_library)
 
@@ -485,7 +486,7 @@ class Test_Headers_Precedence:
     @missing_feature(context.library < "java@1.24.0", reason="Implemented from 1.24.0")
     @missing_feature(context.library == "ruby", reason="library does not yet implement this default configuration")
     @irrelevant(context.library == "cpp", reason="library does not implement this default configuration")
-    @irrelevant(context.library == "dotnet", reason="library does not implement this default configuration")
+    @irrelevant(context.library < "dotnet@2.47.0", reason="Implemented from 2.47.0")
     @irrelevant(context.library == "golang", reason="library does not implement this default configuration")
     @irrelevant(context.library == "nodejs", reason="library does not implement this default configuration")
     @irrelevant(context.library == "php", reason="library does not implement this default configuration")


### PR DESCRIPTION
## Motivation

Changing the default propagation style for the .NET Tracer to `datadog,tracecontext` so flipping around system tests to skip the `tracecontext,datadog` test and unskip the `datadog,tracecontext` test.

## Changes

- Skips `tracecontext,datadog` test for versions of the tracer below 2.47.0
- Runs `datadog,tracecontext` test for versions of the tracer 2.47.0 and above

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
