### PR TITLE
[ASM[ Tainted path system tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -84,7 +84,7 @@ tests/:
         test_parameter_value.py:
           TestParameterValue: v2.28.0
         test_path.py:
-          TestPath: missing_feature
+          TestPath: v2.39.0
         test_uri.py:
           TestURI: irrelevant     
     waf/:

--- a/tests/appsec/iast/sink/test_hsts_missing_header.py
+++ b/tests/appsec/iast/sink/test_hsts_missing_header.py
@@ -18,6 +18,7 @@ class Test_HstsMissingHeader(BaseSinkTest):
     headers = {"X-Forwarded-Proto": "https"}
 
     @missing_feature(context.library < "java@1.22.0", reason="Metrics not implemented")
+    @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 

--- a/tests/appsec/iast/source/test_path.py
+++ b/tests/appsec/iast/source/test_path.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import features
+from utils import features, missing_feature
 from .._test_iast_fixtures import BaseSourceTest
 
 
@@ -15,3 +15,7 @@ class TestPath(BaseSourceTest):
     source_names = None
     source_value = "/iast/source/path/test"
     requests_kwargs = [{"method": "GET"}]
+
+    @missing_feature(library="dotnet", reason="Not implemented")
+    def test_telemetry_metric_instrumented_source(self):
+        super().test_telemetry_metric_instrumented_source()

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -135,6 +135,21 @@ namespace weblog
                 return StatusCode(500, "NotOk");
             }
         }
+        
+        [HttpGet("/iast/source/path/test")]
+        public IActionResult pathTest()
+        {
+            try
+            {
+                System.Diagnostics.Process.Start(Request.Path);
+                
+                return Content("Ok");
+            }
+            catch
+            {
+                return StatusCode(500, "NotOk");
+            }
+        }
 
         [HttpGet("insecure_cipher/test_insecure_algorithm")]
         public IActionResult test_insecure_weakCipher()


### PR DESCRIPTION
## Motivation

This PR adds the system tests for IAST - .Net that check if the path of a query has been tainted. For instance, if a controller has the attribute [HttpGet("/iast/source/path/test")], "/iast/source/path/test" should be tainted.

## Changes

It is a feature that we already support.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
