### PR TITLE
Add decode support for capability byte arrays

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -749,7 +749,16 @@ class _TestAgentAPI:
                 for req in rc_reqs:
                     raw_caps = req["body"]["client"].get("capabilities")
                     if raw_caps:
-                        decoded_capabilities = base64.b64decode(raw_caps)
+                        # Capabilities can be a base64 encoded string or an array of numbers. This is due
+                        # to the Go json library used in the trace agent accepting and being able to decode
+                        # both: https://go.dev/play/p/fkT5Q7GE5VD
+
+                        # byte-array:
+                        if isinstance(raw_caps, list):
+                            decoded_capabilities = bytes(raw_caps)
+                        # base64-encoded string:
+                        else:
+                            decoded_capabilities = base64.b64decode(raw_caps)
                         int_capabilities = int.from_bytes(decoded_capabilities, byteorder="big")
                         capabilities_seen.add(remoteconfig.human_readable_capabilities(int_capabilities))
                         if all((int_capabilities >> c) & 1 for c in capabilities):


### PR DESCRIPTION
Turns out due to an implementation detail in the go json library, byte arrays can be encoded equally as base64 or an array of numbers.

The Python, .NET and Node libraries (at least) use base64 encoding to encode the capabilities and it seems like the Java implementation uses an array of numbers.

Since both are currently accepted by the agent, both should be accepted by the tests.

In the future we should standardize to avoid further unexpected behaviour.


## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
