### PR TITLE
Revert PHP skips on ZTS/PHP 7.0/7.1

### DIFF
--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -319,7 +319,6 @@ class Test_Blocking_request_uri:
 @scenarios.appsec_blocking
 @features.appsec_request_blocking
 @bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
-@flaky(context.library > "php@0.96.0", reason="APPSEC-51448")
 class Test_Blocking_request_path_params:
     """Test if blocking is supported on server.request.path_params address"""
 
@@ -361,7 +360,6 @@ class Test_Blocking_request_path_params:
 @scenarios.appsec_blocking
 @features.appsec_request_blocking
 @bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
-@flaky(context.library > "php@0.96.0", reason="APPSEC-51448")
 class Test_Blocking_request_query:
     """Test if blocking is supported on server.request.query address"""
 
@@ -406,7 +404,6 @@ class Test_Blocking_request_query:
 @scenarios.appsec_blocking
 @features.appsec_request_blocking
 @bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
-@flaky(context.library > "php@0.96.0", reason="APPSEC-51448")
 class Test_Blocking_request_headers:
     """Test if blocking is supported on server.request.headers.no_cookies address"""
 

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -432,7 +432,6 @@ class Test_Blocking_request_headers:
         self.set_req1 = weblog.get("/tag_value/clean_value_3880/200")
         self.block_req2 = weblog.get("/tag_value/tainted_value_xyz/200", headers={"foo": "asldhkuqwgervf"})
 
-    @flaky(context.library > "php@0.96.0", reason="APPSEC-51448")
     def test_blocking_before(self):
         """Test that blocked requests are blocked before being processed"""
         # first request should not block and must set the tag in span accordingly
@@ -449,7 +448,6 @@ class Test_Blocking_request_headers:
 @scenarios.appsec_blocking
 @features.appsec_request_blocking
 @bug(context.library >= "java@1.20.0" and context.weblog_variant == "spring-boot-openliberty")
-@flaky(context.library > "php@0.96.0", reason="APPSEC-51448")
 class Test_Blocking_request_cookies:
     """Test if blocking is supported on server.request.cookies address"""
 

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -46,7 +46,6 @@ JSON_CONTENT_TYPES = {
 
 @scenarios.appsec_blocking
 @features.appsec_blocking_action
-@flaky(context.library > "php@0.96.0", reason="APPSEC-51448")
 class Test_Blocking:
     """Blocking response is obtained when triggering a blocking rule, test the default blocking response"""
 


### PR DESCRIPTION
Reverted commits adding flaky annotations now that [APPSEC-51448] has been resolved.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly


[APPSEC-51448]: https://datadoghq.atlassian.net/browse/APPSEC-51448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ