### PR TITLE
[nodejs] Enable FormData address test for nextjs

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -163,7 +163,7 @@ tests/:
         Test_BodyRaw: missing_feature
         Test_BodyUrlEncoded:
           '*': v2.2.0
-          nextjs: missing_feature  # request.formData() method not supported yet
+          nextjs: v5.3.0
         Test_BodyXml:
           '*': v2.2.0
           nextjs: irrelevant  # Body xml is not converted to JSON in nextjs


### PR DESCRIPTION
## Motivation
Feature merged in dd-trace-js

## Changes

Test enabled in the manifest

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
    _(Only dotnet tests fail, when my change is only in `manifests/nodejs.yml`)_
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
