### PR TITLE
Add tests to insecure auth protocol

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -15,6 +15,7 @@ tests/:
         test_hardcoded_secrets.py: irrelevant (ASM is not implemented in C++)
         test_header_injection.py: irrelevant (ASM is not implemented in C++)
         test_hsts_missing_header.py: irrelevant (ASM is not implemented in C++)
+        test_insecure_auth_protocol.py: irrelevant (ASM is not implemented in C++)
         test_insecure_cookie.py: irrelevant (ASM is not implemented in C++)
         test_ldap_injection.py: irrelevant (ASM is not implemented in C++)
         test_no_httponly_cookie.py: irrelevant (ASM is not implemented in C++)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -33,6 +33,8 @@ tests/:
           TestHeaderInjection: v2.46.0
         test_hsts_missing_header.py: 
           Test_HstsMissingHeader: v2.44.0
+        test_insecure_auth_protocol.py:
+          Test_InsecureAuthProtocol: missing_feature
         test_insecure_cookie.py:
           TestInsecureCookie: v2.39.0
         test_ldap_injection.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -48,6 +48,8 @@ tests/:
           TestHeaderInjection: missing_feature
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: missing_feature
+        test_insecure_auth_protocol.py:
+          Test_InsecureAuthProtocol: missing_feature
         test_insecure_cookie.py:
           TestInsecureCookie: missing_feature
         test_ldap_injection.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -79,6 +79,9 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             spring-boot-3-native: missing_feature
+        test_insecure_auth_protocol.py:
+          Test_InsecureAuthProtocol:
+            '*': v1.29.0
         test_ldap_injection.py:
           TestLDAPInjection:
             '*': v1.3.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -79,6 +79,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-openliberty: bug (not working as expected)
         test_insecure_cookie.py:
           TestInsecureCookie:
             '*': v1.18.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -72,6 +72,9 @@ tests/:
             spring-boot-openliberty: bug (APPSEC-51483)
             vertx3: missing_feature
             vertx4: missing_feature
+        test_insecure_auth_protocol.py:
+          Test_InsecureAuthProtocol:
+            '*': v1.29.0
         test_insecure_cookie.py:
           TestInsecureCookie:
             '*': v1.18.0
@@ -79,9 +82,6 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             spring-boot-3-native: missing_feature
-        test_insecure_auth_protocol.py:
-          Test_InsecureAuthProtocol:
-            '*': v1.29.0
         test_ldap_injection.py:
           TestLDAPInjection:
             '*': v1.3.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -74,7 +74,11 @@ tests/:
             vertx4: missing_feature
         test_insecure_auth_protocol.py:
           Test_InsecureAuthProtocol:
-            '*': v1.29.0
+            '*': v1.30.0
+            akka-http: missing_feature
+            play: missing_feature
+            ratpack: missing_feature
+            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         test_insecure_cookie.py:
           TestInsecureCookie:
             '*': v1.18.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -48,6 +48,8 @@ tests/:
             '*': missing_feature
             express4: v4.8.0
             express4-typescript: v4.8.0
+        test_insecure_auth_protocol.py:
+          Test_InsecureAuthProtocol: missing_feature
         test_insecure_cookie.py:
           TestInsecureCookie:
             '*': missing_feature

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -33,6 +33,8 @@ tests/:
           TestHeaderInjection: missing_feature
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: missing_feature
+        test_insecure_auth_protocol.py:
+          Test_InsecureAuthProtocol: missing_feature
         test_insecure_cookie.py:
           TestInsecureCookie: missing_feature
         test_ldap_injection.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -101,6 +101,8 @@ tests/:
           TestHeaderInjection: missing_feature
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: missing_feature
+        test_insecure_auth_protocol.py:
+          Test_InsecureAuthProtocol: missing_feature
         test_insecure_cookie.py:
           TestInsecureCookie:
             '*': v1.19.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -35,6 +35,8 @@ tests/:
           TestHeaderInjection: missing_feature
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: missing_feature
+        test_insecure_auth_protocol.py:
+          Test_InsecureAuthProtocol: missing_feature
         test_insecure_cookie.py:
           TestInsecureCookie: missing_feature
         test_ldap_injection.py:

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -68,6 +68,8 @@ class BaseSinkTestWithoutTelemetry:
     params = None
     data = None
     headers = None
+    secure_headers = None
+    insecure_headers = None
     location_map = None
     evidence_map = None
 
@@ -95,7 +97,7 @@ class BaseSinkTestWithoutTelemetry:
                 path=self.insecure_endpoint,
                 params=self.params,
                 data=self.data,
-                headers=self.headers,
+                headers=self.insecure_headers if self.insecure_headers is not None else self.headers,
             )
 
         self.insecure_request = self.__class__.insecure_request
@@ -123,7 +125,7 @@ class BaseSinkTestWithoutTelemetry:
                 path=self.secure_endpoint,
                 params=self.params,
                 data=self.data,
-                headers=self.headers,
+                headers=self.secure_headers if self.secure_headers is not None else self.headers,
             )
 
         self.secure_request = self.__class__.secure_request

--- a/tests/appsec/iast/sink/test_insecure_auth_protocol.py
+++ b/tests/appsec/iast/sink/test_insecure_auth_protocol.py
@@ -1,0 +1,26 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+from utils import context, missing_feature, features
+from .._test_iast_fixtures import BaseSinkTest
+
+
+@features.iast_sink_insecure_auth_protocol
+class Test_InsecureAuthProtocol(BaseSinkTest):
+    """Test Insecure Auth Protocol detection."""
+
+    vulnerability_type = "INSECURE_AUTH_PROTOCOL"
+    http_method = "GET"
+    insecure_endpoint = "/iast/insecure-auth-protocol/test"
+    secure_endpoint = "/iast/insecure-auth-protocol/test"
+    data = {}
+    insecure_headers = {"Authorization": "Basic dGVzd"}
+
+    @missing_feature(library="java", reason="Not implemented yet")
+    def test_telemetry_metric_instrumented_sink(self):
+        super().test_telemetry_metric_instrumented_sink()
+
+    @missing_feature(library="java", reason="Not implemented yet")
+    def test_telemetry_metric_executed_sink(self):
+        super().test_telemetry_metric_executed_sink()

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -1928,6 +1928,16 @@ class features:
         return test_object
 
     @staticmethod
+    def iast_sink_insecure_auth_protocol(test_object):
+        """
+        IAST Sink: Insecure auth protocol
+
+        https://feature-parity.us1.prod.dog/#/?feature=272
+        """
+        pytest.mark.features(feature_id=272)(test_object)
+        return test_object
+
+    @staticmethod
     def container_auto_installation_script(test_object):
         """
         Agent installation script should allow us to install auto-injection software for containers
@@ -1956,3 +1966,4 @@ class features:
         """
         pytest.mark.features(feature_id=276)(test_object)
         return test_object
+

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -1966,4 +1966,3 @@ class features:
         """
         pytest.mark.features(feature_id=276)(test_object)
         return test_object
-

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/IastSinkResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/IastSinkResource.java
@@ -1,23 +1,16 @@
 package com.datadoghq.jersey;
 
-import com.datadoghq.system_tests.iast.utils.*;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
-
-import jakarta.ws.rs.*;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Request;
-import org.glassfish.grizzly.http.server.Session;
-
-
 import static com.datadoghq.jersey.Main.DATA_SOURCE;
 import static com.datadoghq.jersey.Main.LDAP_CONTEXT;
 
+import com.datadoghq.system_tests.iast.utils.*;
+import io.opentracing.Span;
+import io.opentracing.util.GlobalTracer;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.http.HttpRequest;
 
 @Path("/iast")
 @Produces(MediaType.TEXT_PLAIN)
@@ -256,6 +249,12 @@ public class IastSinkResource {
     @Path("/no-httponly-cookie/test_secure")
     public Response  noHttpOnlyCookieSecure() {
         return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").build();
+    }
+
+    @GET
+    @Path("/insecure-auth-protocol/test")
+    public Response  insecureAuthProtocol() {
+        return Response.status(Response.Status.OK).build();
     }
 
 }

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/IastSinkResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/IastSinkResource.java
@@ -252,4 +252,10 @@ public class IastSinkResource {
     public Response  noHttpOnlyCookieSecure() {
         return Response.status(Response.Status.OK).header("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").build();
     }
+
+    @GET
+    @Path("/insecure-auth-protocol/test")
+    public Response  insecureAuthProtocol() {
+        return Response.status(Response.Status.OK).build();
+    }
 }

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
@@ -347,6 +347,12 @@ public class AppSecIast {
       return "Ok";
     }
 
+    @GetMapping(value = "/insecure-auth-protocol/test")
+    public String insecureAuthProtocol(HttpServletResponse response) {
+        response.setStatus(HttpStatus.OK.value());
+        return "ok";
+    }
+
 
     /**
      * TODO: Ldap is failing to startup in native image this method ensures it's started lazily

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
@@ -147,5 +147,8 @@ public class IastSinkRouteProvider implements Consumer<Router> {
             xpath.secureXPath();
             ctx.response().end("Secure");
         });
+        router.get("/iast/insecure-auth-protocol/test").handler(ctx ->
+                ctx.response().end("ok")
+        );
     }
 }

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
@@ -152,6 +152,9 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         router.get("/iast/no-httponly-cookie/test_secure").handler(ctx ->
                 ctx.response().putHeader("Set-Cookie", "user-id=7;Secure;HttpOnly;SameSite=Strict").end()
         );
+        router.get("/iast/insecure-auth-protocol/test").handler(ctx ->
+                ctx.response().end("ok")
+        );
 
     }
 }


### PR DESCRIPTION
## Motivation

Test INSECURE_AUTH_PROTOCOL detection in Java.

## Changes

Define a new iast_sink_insecure_auth_protocol feature
Add new test_insecure_auth_protocol.py
Modify BaseSinkTestWithoutTelemetry to accept different headers for secure/insecure requests
Add endpoints for java frameworks

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
