### PR TITLE
[Api Security] Test_Schema_Request_FormUrlEncoded_Body expect float for value and 1 for nullable property 

### DIFF
--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -177,7 +177,7 @@ class Test_Schema_Request_FormUrlEncoded_Body:
         assert self.request.status_code == 200
         assert (
             contains(schema, [{"main": [[[{"key": [8], "value": [8]}]], {"len": 2}], "nullable": [8]}],)
-            or contains(schema, [{"main": [[[{"key": [8], "value": [16]}]], {"len": 2}], "nullable": [8]}],)
+            or contains(schema, [{"main": [[[{"key": [8], "value": [16]}]], {"len": 2}], "nullable": [1]}],)
             or contains(
                 schema,
                 [

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -175,17 +175,21 @@ class Test_Schema_Request_FormUrlEncoded_Body:
         """can provide request request body schema"""
         schema = get_schema(self.request, "req.body")
         assert self.request.status_code == 200
-        assert contains(schema, [{"main": [[[{"key": [8], "value": [8]}]], {"len": 2}], "nullable": [8]}],) or contains(
-            schema,
-            [
-                {
-                    "main[0][key]": ANY,
-                    "main[0][value]": ANY,
-                    "main[1][key]": ANY,
-                    "main[1][value]": ANY,
-                    # "nullable": ANY,  # some frameworks may drop that value
-                }
-            ],
+        assert (
+            contains(schema, [{"main": [[[{"key": [8], "value": [8]}]], {"len": 2}], "nullable": [8]}],)
+            or contains(schema, [{"main": [[[{"key": [8], "value": [16]}]], {"len": 2}], "nullable": [8]}],)
+            or contains(
+                schema,
+                [
+                    {
+                        "main[0][key]": ANY,
+                        "main[0][value]": ANY,
+                        "main[1][key]": ANY,
+                        "main[1][value]": ANY,
+                        # "nullable": ANY,  # some frameworks may drop that value
+                    }
+                ],
+            )
         ), schema
 
 


### PR DESCRIPTION
## Motivation
Fix broken test:
in c#, the api security model for value is a float, as we sometimes send some decimals for it, and not a string
the nullable field is nullable so it's a 1. I cant make it a string as it wouldnt pass other tests

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
