### PR TITLE
Fix Datadog-Entity-ID header asserions. 

### DIFF
--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -158,8 +158,12 @@ class Test_LibraryHeaders:
             if "datadog-entity-id" not in request_headers:
                 raise ValueError(f"Datadog-Entity-ID header is missing in request {data['log_filename']}")
             val = request_headers["datadog-entity-id"]
-            assert val.startswith("in-"), f"Datadog-Entity-ID header value {val} doesn't start with 'in-'"
-            assert val[3:].isdigit(), f"Datadog-Entity-ID header value {val} doesn't end with digits"
+            if val.startswith("in-"):
+                assert val[3:].isdigit(), f"Datadog-Entity-ID header value {val} doesn't end with digits"
+            elif val.startswith("cid-"):
+                assert val[4:].isxdigit(), f"Datadog-Entity-ID header value {val} doesn't end with hex digits"
+            else:
+                raise ValueError(f"Datadog-Entity-ID header value {val} doesn't start with either 'in-' or 'cid-'")
 
         interfaces.library.validate(validator, success_by_default=True)
 


### PR DESCRIPTION
It can be either `id-<digits>` or `cid-<hex-digits>`

## Motivation

The assertion in [the original test implementation](https://github.com/DataDog/system-tests/pull/2029) is too strict allowing only `id-<digits>` whereas in fact the spec allows it to be `cid-<hex-digits>` as well. See AIT-9279

## Changes


## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
