### PR TITLE
enable/fix more DSM and Context Propagation Messaging Tests

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -481,7 +481,7 @@ tests/:
           flask-poc: v0.1 # real version not known
         Test_SQS_PROPAGATION_VIA_MESSAGE_ATTRIBUTES:
           '*': irrelevant
-          flask-poc: v2.6.0
+          flask-poc: v2.6.0.dev
     test_db_integrations_sql.py:
       Test_MsSql:
         '*': missing_feature

--- a/tests/integrations/crossed_integrations/test_kafka.py
+++ b/tests/integrations/crossed_integrations/test_kafka.py
@@ -207,14 +207,10 @@ class Test_Kafka(_Test_Kafka):
     WEBLOG_TO_BUDDY_TOPIC = "Test_Kafka_weblog_to_buddy"
     BUDDY_TO_WEBLOG_TOPIC = "Test_Kafka_buddy_to_weblog"
 
-    @missing_feature(library="golang", reason="Expected to fail, Golang does not propagate context")
     @missing_feature(library="ruby", reason="Expected to fail, Ruby does not propagate context")
-    @missing_feature(library="python", reason="Expected to fail, Python does not propagate context")
     def test_produce_trace_equality(self):
         super().test_produce_trace_equality()
 
-    @missing_feature(library="golang", reason="Expected to fail, Golang does not propagate context")
     @missing_feature(library="ruby", reason="Expected to fail, Ruby does not propagate context")
-    @missing_feature(library="python", reason="Expected to fail, Python does not propagate context")
     def test_consume_trace_equality(self):
         super().test_consume_trace_equality()

--- a/tests/integrations/crossed_integrations/test_sqs.py
+++ b/tests/integrations/crossed_integrations/test_sqs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from tests.integrations.crossed_integrations.test_kafka import _python_buddy, _java_buddy
+from tests.integrations.crossed_integrations.test_kafka import _nodejs_buddy, _java_buddy
 from utils import interfaces, scenarios, weblog, missing_feature, features
 from utils.tools import logger
 
@@ -35,6 +35,16 @@ class _Test_SQS:
                     continue
 
                 if queue != cls.get_queue(span):
+                    continue
+
+                if operation.lower() == "receivemessage" and span["meta"].get("language", "") == "javascript":
+                    # for nodejs we propagate from aws.response span which does not have the queue included on the span
+                    if span["resource"] != "aws.response":
+                        continue
+                    # this is a bit hacky. The only way we can identify the NodeJS 'aws.response' span is by using pathway hash
+                    if span["meta"].get("pathway.hash", "") not in ["3798979665392115457", "476120775804749364"]:
+                        continue
+                elif queue != cls.get_queue(span):
                     continue
 
                 logger.debug(f"span found in {data['log_filename']}:\n{json.dumps(span, indent=2)}")
@@ -70,6 +80,11 @@ class _Test_SQS:
             "/sqs/consume", params={"queue": self.WEBLOG_TO_BUDDY_QUEUE, "timeout": 60}, timeout=61
         )
 
+    @missing_feature(
+        library="java",
+        reason="Expected to fail, Java defaults to using Xray headers to propagate context. \
+        NodeJS cannot extract from Xray and will not create an 'aws.response' span if no context is extracted.",
+    )
     def test_produce(self):
         """Check that a message produced to sqs is correctly ingested by a Datadog tracer"""
 
@@ -85,9 +100,10 @@ class _Test_SQS:
 
     @missing_feature(library="golang", reason="Expected to fail, Golang does not propagate context")
     @missing_feature(library="ruby", reason="Expected to fail, Ruby does not propagate context")
-    @missing_feature(library="python", reason="Expected to fail, Python does not propagate context")
-    @missing_feature(library="nodejs", reason="Expected to fail, Nodejs does not propagate context")
-    @missing_feature(library="java", reason="Expected to fail, Nodejs does not propagate context")
+    @missing_feature(
+        library="java", reason="Expected to fail, Java defaults to using Xray headers to propagate context"
+    )
+    @missing_feature(library="python", reason="Expected to fail. Python does not propagate context.")
     def test_produce_trace_equality(self):
         """This test relies on the setup for produce, it currently cannot be run on its own"""
         producer_span = self.get_span(
@@ -98,7 +114,7 @@ class _Test_SQS:
         )
         consumer_span = self.get_span(
             self.buddy_interface,
-            span_kind=["consumer", "client"],
+            span_kind=["consumer", "client", "server"],
             queue=self.WEBLOG_TO_BUDDY_QUEUE,
             operation="receiveMessage",
         )
@@ -139,9 +155,6 @@ class _Test_SQS:
 
     @missing_feature(library="golang", reason="Expected to fail, Golang does not propagate context")
     @missing_feature(library="ruby", reason="Expected to fail, Ruby does not propagate context")
-    @missing_feature(library="python", reason="Expected to fail, Python does not propagate context")
-    @missing_feature(library="nodejs", reason="Expected to fail, Nodejs does not propagate context")
-    @missing_feature(library="java", reason="Expected to fail, Nodejs does not propagate context")
     def test_consume_trace_equality(self):
         """This test relies on the setup for consume, it currently cannot be run on its own"""
         producer_span = self.get_span(
@@ -152,7 +165,7 @@ class _Test_SQS:
         )
         consumer_span = self.get_span(
             interfaces.library,
-            span_kind=["consumer", "client"],
+            span_kind=["consumer", "client", "server"],
             queue=self.BUDDY_TO_WEBLOG_QUEUE,
             operation="receiveMessage",
         )
@@ -168,23 +181,11 @@ class _Test_SQS:
         It works the same for both test_produce and test_consume
         """
 
-        # Check that the producer did not created any consumer span
-        assert (
-            self.get_span(producer_interface, span_kind=["consumer", "client"], queue=queue, operation="receiveMessage")
-            is None
-        )
-
-        # Check that the consumer did not created any producer span
-        assert (
-            self.get_span(consumer_interface, span_kind=["producer", "client"], queue=queue, operation="sendMessage")
-            is None
-        )
-
         producer_span = self.get_span(
             producer_interface, span_kind=["producer", "client"], queue=queue, operation="sendMessage"
         )
         consumer_span = self.get_span(
-            consumer_interface, span_kind=["consumer", "client"], queue=queue, operation="receiveMessage"
+            consumer_interface, span_kind=["consumer", "client", "server"], queue=queue, operation="receiveMessage"
         )
         # check that both consumer and producer spans exists
         assert producer_span is not None
@@ -200,10 +201,14 @@ class _Test_SQS:
 @scenarios.crossed_tracing_libraries
 @features.aws_sqs_span_creationcontext_propagation_via_message_attributes_with_dd_trace
 class Test_SQS_PROPAGATION_VIA_MESSAGE_ATTRIBUTES(_Test_SQS):
-    buddy_interface = interfaces.python_buddy
-    buddy = _python_buddy
+    buddy_interface = interfaces.nodejs_buddy
+    buddy = _nodejs_buddy
     WEBLOG_TO_BUDDY_QUEUE = "Test_SQS_propagation_via_message_attributes_weblog_to_buddy"
     BUDDY_TO_WEBLOG_QUEUE = "Test_SQS_propagation_via_message_attributes_buddy_to_weblog"
+
+    @missing_feature(library="python", reason="Expected to fail. Python and NodeJS are not compatible at the moment")
+    def test_produce(self):
+        super().test_produce()
 
 
 @scenarios.crossed_tracing_libraries
@@ -216,8 +221,6 @@ class Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS(_Test_SQS):
 
     @missing_feature(library="golang", reason="Expected to fail, Golang does not propagate context")
     @missing_feature(library="ruby", reason="Expected to fail, Ruby does not propagate context")
-    @missing_feature(library="python", reason="Expected to fail, Python does not propagate context")
-    @missing_feature(library="nodejs", reason="Expected to fail, Nodejs does not propagate context")
     def test_produce_trace_equality(self):
         super().test_produce_trace_equality()
 

--- a/tests/integrations/crossed_integrations/test_sqs.py
+++ b/tests/integrations/crossed_integrations/test_sqs.py
@@ -34,9 +34,6 @@ class _Test_SQS:
                 if operation.lower() != span["meta"].get("aws.operation", "").lower():
                     continue
 
-                if queue != cls.get_queue(span):
-                    continue
-
                 if operation.lower() == "receivemessage" and span["meta"].get("language", "") == "javascript":
                     # for nodejs we propagate from aws.response span which does not have the queue included on the span
                     if span["resource"] != "aws.response":
@@ -207,6 +204,7 @@ class Test_SQS_PROPAGATION_VIA_MESSAGE_ATTRIBUTES(_Test_SQS):
     BUDDY_TO_WEBLOG_QUEUE = "Test_SQS_propagation_via_message_attributes_buddy_to_weblog"
 
     @missing_feature(library="python", reason="Expected to fail. Python and NodeJS are not compatible at the moment")
+    @missing_feature(library="java", reason="Expected to fail. Java and NodeJS are not compatible at the moment")
     def test_produce(self):
         super().test_produce()
 

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -196,15 +196,14 @@ class Test_DsmSQS:
     def setup_dsm_sqs(self):
         self.r = weblog.get("/dsm?integration=sqs&timeout=60", timeout=61)
 
-    @bug(weblog_variant="flask-poc", reason="DSM checkpoints for AWS SQS from dd-trace-py are not being received.")
-    @bug(weblog_variant="express4", reason="DSM checkpoints for AWS SQS from dd-trace-js are not being received.")
     def test_dsm_sqs(self):
         assert self.r.text == "ok"
 
         language_hashes = {
+            # nodejs uses a different hashing algorithm and therefore has different hashes than the default
             "nodejs": {
                 "producer": 18206246330825886989,
-                "consumer": 271115008390912609,
+                "consumer": 5236533131035234664,
                 "topic": "dsm-system-tests-queue",
             },
             "java": {

--- a/utils/build/docker/nodejs/express4/app.js
+++ b/utils/build/docker/nodejs/express4/app.js
@@ -13,7 +13,7 @@ const iast = require('./iast')
 const { spawnSync } = require('child_process')
 
 const { kafkaProduce, kafkaConsume } = require('./integrations/messaging/kafka/kafka')
-const { produceMessage, consumeMessage } = require('./integrations/messaging/aws/sqs')
+const { sqsProduce, sqsConsume } = require('./integrations/messaging/aws/sqs')
 const { rabbitmqProduce, rabbitmqConsume } = require('./integrations/messaging/rabbitmq/rabbitmq')
 
 iast.initData().catch(() => {})
@@ -156,32 +156,32 @@ app.get('/dsm', (req, res) => {
           })
           .catch((error) => {
             console.log(error)
-            res.status(500).send('Internal Server Error during Kafka consume')
+            res.status(500).send('[Kafka] Internal Server Error during DSM Kafka consume')
           })
       })
       .catch((error) => {
         console.log(error)
-        res.status(500).send('Internal Server Error during Kafka produce')
+        res.status(500).send('[Kafka] Internal Server Error during DSM Kafka produce')
       })
   } else if (integration === 'sqs') {
     const queue = 'dsm-system-tests-queue'
     const message = 'hello from SQS DSM JS'
     const timeout = req.query.timeout ?? 5
 
-    produceMessage(queue, message)
+    sqsProduce(queue, message)
       .then(() => {
-        consumeMessage(queue, timeout)
+        sqsConsume(queue, timeout * 1000)
           .then(() => {
             res.send('ok')
           })
           .catch((error) => {
             console.log(error)
-            res.status(500).send('Internal Server Error during SQS consume')
+            res.status(500).send('[SQS] Internal Server Error during DSM SQS consume')
           })
       })
       .catch((error) => {
         console.log(error)
-        res.status(500).send('Internal Server Error during SQS produce')
+        res.status(500).send('[SQS] Internal Server Error during DSM SQS produce')
       })
   } else if (integration === 'rabbitmq') {
     const queue = 'dsm-system-tests-queue'
@@ -198,15 +198,15 @@ app.get('/dsm', (req, res) => {
           })
           .catch((error) => {
             console.error(error)
-            res.status(500).send('Internal Server Error during RabbitMQ DSM consume')
+            res.status(500).send('[RabbitMQ] Internal Server Error during RabbitMQ DSM consume')
           })
       })
       .catch((error) => {
         console.error(error)
-        res.status(500).send('Internal Server Error during RabbitMQ DSM produce')
+        res.status(500).send('[RabbitMQ] Internal Server Error during RabbitMQ DSM produce')
       })
   } else {
-    res.status(400).send('Wrong or missing integration, available integrations are [Kafka, RabbitMQ, SQS]')
+    res.status(400).send('[DSM] Wrong or missing integration, available integrations are [Kafka, RabbitMQ, SQS]')
   }
 })
 
@@ -215,7 +215,7 @@ app.get('/kafka/produce', (req, res) => {
 
   kafkaProduce(topic, 'Hello from Kafka JS')
     .then(() => {
-      res.status(200).send('produce ok')
+      res.status(200).send('[Kafka] produce ok')
     })
     .catch((error) => {
       console.error(error)
@@ -229,7 +229,7 @@ app.get('/kafka/consume', (req, res) => {
 
   kafkaConsume(topic, timeout)
     .then(() => {
-      res.status(200).send('consume ok')
+      res.status(200).send('[Kafka] consume ok')
     })
     .catch((error) => {
       console.error(error)
@@ -240,13 +240,13 @@ app.get('/kafka/consume', (req, res) => {
 app.get('/sqs/produce', (req, res) => {
   const queue = req.query.queue
 
-  produceMessage(queue)
+  sqsProduce(queue)
     .then(() => {
-      res.status(200).send('produce ok')
+      res.status(200).send('[SQS] produce ok')
     })
     .catch((error) => {
       console.error(error)
-      res.status(500).send('Internal Server Error during SQS produce')
+      res.status(500).send('[SQS] Internal Server Error during SQS produce')
     })
 })
 
@@ -254,13 +254,13 @@ app.get('/sqs/consume', (req, res) => {
   const queue = req.query.queue
   const timeout = parseInt(req.query.timeout) ?? 5
 
-  consumeMessage(queue, timeout)
+  sqsConsume(queue, timeout)
     .then(() => {
-      res.status(200).send('consume ok')
+      res.status(200).send('[SQS] consume ok')
     })
     .catch((error) => {
       console.error(error)
-      res.status(500).send('Internal Server Error during SQS consume')
+      res.status(500).send('[SQS] Internal Server Error during SQS consume')
     })
 })
 
@@ -271,11 +271,11 @@ app.get('/rabbitmq/produce', (req, res) => {
 
   rabbitmqProduce(queue, exchange, routingKey, 'NodeJS Produce Context Propagation Test RabbitMQ')
     .then(() => {
-      res.status(200).send('produce ok')
+      res.status(200).send('[RabbitMQ] produce ok')
     })
     .catch((error) => {
       console.error(error)
-      res.status(500).send('Internal Server Error during RabbitMQ produce')
+      res.status(500).send('[RabbitMQ] Internal Server Error during RabbitMQ produce')
     })
 })
 
@@ -285,11 +285,11 @@ app.get('/rabbitmq/consume', (req, res) => {
 
   rabbitmqConsume(queue, timeout * 1000)
     .then(() => {
-      res.status(200).send('consume ok')
+      res.status(200).send('[RabbitMQ] consume ok')
     })
     .catch((error) => {
       console.error(error)
-      res.status(500).send('Internal Server Error during RabbitMQ consume')
+      res.status(500).send('[RabbitMQ] Internal Server Error during RabbitMQ consume')
     })
 })
 

--- a/utils/build/docker/nodejs/express4/integrations/messaging/aws/sqs.js
+++ b/utils/build/docker/nodejs/express4/integrations/messaging/aws/sqs.js
@@ -1,6 +1,6 @@
 const AWS = require('aws-sdk')
 
-const produceMessage = (queue, message) => {
+const sqsProduce = (queue, message) => {
   // Create an SQS client
   const sqs = new AWS.SQS({
     endpoint: 'http://elasticmq:9324',
@@ -31,7 +31,7 @@ const produceMessage = (queue, message) => {
               resolve()
             }
           })
-          console.log('Produced a message')
+          console.log('[SQS] Produced a message')
         }
 
         // Start producing messages
@@ -41,7 +41,7 @@ const produceMessage = (queue, message) => {
   })
 }
 
-const consumeMessage = async (queue, timeout) => {
+const sqsConsume = async (queue, timeout) => {
   // Create an SQS client
   const sqs = new AWS.SQS({
     endpoint: 'http://elasticmq:9324',
@@ -51,38 +51,50 @@ const consumeMessage = async (queue, timeout) => {
   const queueUrl = `http://elasticmq:9324/000000000000/${queue}`
 
   return new Promise((resolve, reject) => {
-    sqs.receiveMessage({
-      QueueUrl: queueUrl,
-      MaxNumberOfMessages: 1
-    }, (err, response) => {
-      if (err) {
-        console.error('Error receiving message: ', err)
-        reject(err)
-      }
-
-      try {
-        console.log(response)
-        if (response && response.Messages) {
-          for (const message of response.Messages) {
-            const consumedMessage = message.Body
-            console.log('Consumed the following: ' + consumedMessage)
-          }
-          resolve()
-        } else {
-          console.log('No messages received')
+    const receiveMessage = () => {
+      sqs.receiveMessage({
+        QueueUrl: queueUrl,
+        MaxNumberOfMessages: 1,
+        MessageAttributeNames: ['.*']
+      }, (err, response) => {
+        if (err) {
+          console.error('[SQS] Error receiving message: ', err)
+          reject(err)
         }
-      } catch (error) {
-        console.error('Error while consuming messages: ', error)
-        reject(error)
-      }
-    })
+
+        try {
+          console.log('[SQS] Received the following: ')
+          console.log(response)
+          if (response && response.Messages && response.Messages.length > 0) {
+            for (const message of response.Messages) {
+              console.log(message)
+              console.log(message.MessageAttributes)
+              const consumedMessage = message.Body
+              console.log('[SQS] Consumed the following: ' + consumedMessage)
+            }
+            resolve()
+          } else {
+            console.log('[SQS] No messages received')
+            setTimeout(() => {
+              receiveMessage()
+            }, 1000)
+          }
+        } catch (error) {
+          console.error('[SQS] Error while consuming messages: ', error)
+          reject(error)
+        }
+      })
+    }
     setTimeout(() => {
-      reject(new Error('Message not received'))
+      console.error('[SQS] TimeoutError: Message not received')
+      reject(new Error('[SQS] TimeoutError: Message not received'))
     }, timeout) // Set a timeout of n seconds for message reception
+
+    receiveMessage()
   })
 }
 
 module.exports = {
-  produceMessage,
-  consumeMessage
+  sqsProduce,
+  sqsConsume
 }

--- a/utils/build/docker/python/flask-poc.Dockerfile
+++ b/utils/build/docker/python/flask-poc.Dockerfile
@@ -15,6 +15,10 @@ ENV DD_REMOTECONFIG_POLL_SECONDS=1
 ENV DD_DATA_STREAMS_ENABLED=True
 ENV _DD_APPSEC_DEDUPLICATION_ENABLED=false
 
+# Cross Tracer Integration Testing for Trace Context Propagation
+ENV DD_BOTOCORE_PROPAGATION_ENABLED=true
+ENV DD_KAFKA_PROPAGATION_ENABLED=true
+
 # docker startup
 # FIXME: Ensure gevent patching occurs before ddtrace
 


### PR DESCRIPTION
## Motivation

Enables more Kafka, and SQS tests for DSM and Trace Context Propagation.

## Changes

Updates a few weblogs to have better comments, switches AWS SQS Context Propagation tests to use NodeJS Buddy since it is the only tracer buddy with SQS Propagation implemented in prod release. Also adds a few other random fixes.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
