### PR TITLE
fix python rabbitmq tests

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -506,10 +506,10 @@ tests/:
         flask-poc: v2.6.0
       Test_DsmRabbitmq_FanoutExchange:
         '*': irrelevant
-        flask-poc: v2.6.0
+        flask-poc: missing_feature (endpoint not implemented)
       Test_DsmRabbitmq_TopicExchange:
         '*': irrelevant
-        flask-poc: v2.6.0
+        flask-poc: missing_feature (endpoint not implemented)
       Test_DsmSQS:
         '*': irrelevant
         flask-poc: v1.16.0

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -81,23 +81,24 @@ class Test_DsmRabbitmq:
                 "has_routing_key:true",
                 "type:rabbitmq",
             )
-        elif context.library == "rabbitmq":
+        elif context.library == "python":
             producer_hash = 3519882823224826180
             consumer_hash = 13984784774671877513
-            edge_tags_in = ("direction:in", "topic:systemTestRabbitmqQueue", "type:rabbitmq")
-            edge_tags_out = (
-                "direction:out",
-                "exchange:systemTestDirectExchange",
-                "has_routing_key:true",
-                "type:rabbitmq",
-            )
-        else:
-            producer_hash = 6176024609184775446
-            consumer_hash = 1648106384315938543
             edge_tags_in = ("direction:in", "topic:dsm-system-tests-queue", "type:rabbitmq")
             edge_tags_out = (
                 "direction:out",
                 "exchange:dsm-system-tests-queue",
+                "has_routing_key:true",
+                "type:rabbitmq",
+            )
+
+        else:
+            producer_hash = 6176024609184775446
+            consumer_hash = 1648106384315938543
+            edge_tags_in = ("direction:in", "topic:systemTestRabbitmqQueue", "type:rabbitmq")
+            edge_tags_out = (
+                "direction:out",
+                "exchange:systemTestDirectExchange",
                 "has_routing_key:true",
                 "type:rabbitmq",
             )

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -74,20 +74,40 @@ class Test_DsmRabbitmq:
             producer_hash = 5080618047473654667
             consumer_hash = 12436096712734841122
             # node does not have access to the queue argument and defaults to using the routing key
-            edge_tags = ("direction:in", "topic:systemTestDirectRoutingKey", "type:rabbitmq")
+            edge_tags_in = ("direction:in", "topic:systemTestDirectRoutingKey", "type:rabbitmq")
+            edge_tags_out = (
+                "direction:out",
+                "exchange:systemTestDirectExchange",
+                "has_routing_key:true",
+                "type:rabbitmq",
+            )
+        elif context.library == "rabbitmq":
+            producer_hash = 3519882823224826180
+            consumer_hash = 13984784774671877513
+            edge_tags_in = ("direction:in", "topic:systemTestRabbitmqQueue", "type:rabbitmq")
+            edge_tags_out = (
+                "direction:out",
+                "exchange:systemTestDirectExchange",
+                "has_routing_key:true",
+                "type:rabbitmq",
+            )
         else:
             producer_hash = 6176024609184775446
             consumer_hash = 1648106384315938543
-            edge_tags = ("direction:in", "topic:systemTestRabbitmqQueue", "type:rabbitmq")
+            edge_tags_in = ("direction:in", "topic:dsm-system-tests-queue", "type:rabbitmq")
+            edge_tags_out = (
+                "direction:out",
+                "exchange:dsm-system-tests-queue",
+                "has_routing_key:true",
+                "type:rabbitmq",
+            )
 
         DsmHelper.assert_checkpoint_presence(
-            hash_=producer_hash,
-            parent_hash=0,
-            tags=("direction:out", "exchange:systemTestDirectExchange", "has_routing_key:true", "type:rabbitmq"),
+            hash_=producer_hash, parent_hash=0, tags=edge_tags_out,
         )
 
         DsmHelper.assert_checkpoint_presence(
-            hash_=consumer_hash, parent_hash=producer_hash, tags=edge_tags,
+            hash_=consumer_hash, parent_hash=producer_hash, tags=edge_tags_in,
         )
 
     def setup_dsm_rabbitmq_dotnet_legacy(self):


### PR DESCRIPTION
## Motivation

fix RabbitMQ DSM tests for dd-trace-py

## Changes

A few tests should've been disabled. Also, the hashes and DSM edge tags needed to be corrected.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
