### PR TITLE
[dotnet] Fix dotnet project for arm64 architecture

### DIFF
--- a/utils/build/docker/dotnet/app.csproj
+++ b/utils/build/docker/dotnet/app.csproj
@@ -17,7 +17,8 @@
 		<PackageReference Include="MySql.Data" Version="8.0.30" />
 		<PackageReference Include="Npgsql" Version="4.0.10" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
-		<PackageReference Include="Microsoft.Data.Sqlite " />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="7.0.15" />
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.8" />
 		<PackageReference Include="System.DirectoryServices" Version="6.0.0" />
 		<PackageReference Include="NodaTime" Version="3.1.6"/>
                 <PackageReference Include="Confluent.Kafka" Version="1.9.3" />

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -148,18 +148,6 @@ get_github_release_asset() {
     curl -H "Authorization: token $GH_TOKEN" --output $name -L $url 
 }
 
-get_dotnet_tracer_latest_artifact() {
-    ARCH=$1
-    VERSION=$(curl --silent https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/version.txt)
-    SHA=$(curl --silent https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/sha.txt)
-    ARTIFACT="datadog-dotnet-apm-$VERSION.$ARCH.tar.gz"
-    URL="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/$SHA/$ARTIFACT"
-
-    echo "Load $URL"
-
-    curl --silent -L $URL --output $ARTIFACT
-}
-
 if test -f ".env"; then
     source .env
 fi
@@ -182,8 +170,6 @@ elif [ "$TARGET" = "dotnet" ]; then
         ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot .
     elif [ $VERSION = 'prod' ]; then
         ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest .
-    elif [ $VERSION = 'dev-arm64' ]; then
-       get_dotnet_tracer_latest_artifact "arm64"
     else
         echo "Don't know how to load version $VERSION for $TARGET"
     fi

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -148,6 +148,18 @@ get_github_release_asset() {
     curl -H "Authorization: token $GH_TOKEN" --output $name -L $url 
 }
 
+get_dotnet_tracer_latest_artifact() {
+    ARCH=$1
+    VERSION=$(curl --silent https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/version.txt)
+    SHA=$(curl --silent https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/sha.txt)
+    ARTIFACT="datadog-dotnet-apm-$VERSION.$ARCH.tar.gz"
+    URL="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/$SHA/$ARTIFACT"
+
+    echo "Load $URL"
+
+    curl --silent -L $URL --output $ARTIFACT
+}
+
 if test -f ".env"; then
     source .env
 fi
@@ -170,6 +182,8 @@ elif [ "$TARGET" = "dotnet" ]; then
         ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot .
     elif [ $VERSION = 'prod' ]; then
         ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest .
+    elif [ $VERSION = 'dev-arm64' ]; then
+       get_dotnet_tracer_latest_artifact "arm64"
     else
         echo "Don't know how to load version $VERSION for $TARGET"
     fi


### PR DESCRIPTION
## Motivation

Fix the run for the arm64 version. The weblog was failing because, the project was lacking of the arm64 version of the SQLite binaries.

## Changes

- Change the SQLite dependency (that doesn't provide an arm64 version)

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
