### PR TITLE
[dotnet][IAST] Add NoSQL MongoDB Injection tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -44,7 +44,7 @@ tests/:
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie: v2.39.0
         test_nosql_mongodb_injection.py:
-          TestNoSqlMongodbInjection: missing_feature
+          TestNoSqlMongodbInjection: v2.47.0
         test_path_traversal.py:
           TestPathTraversal: v2.31.0
         test_sql_injection.py:

--- a/tests/appsec/iast/sink/test_nosql_mongodb_injection.py
+++ b/tests/appsec/iast/sink/test_nosql_mongodb_injection.py
@@ -28,6 +28,7 @@ class TestNoSqlMongodbInjection(BaseSinkTest):
     @missing_feature(context.library < "java@1.13.0", reason="Not implemented yet")
     @missing_feature(library="nodejs", reason="Not implemented yet")
     @missing_feature(library="python", reason="Not implemented yet")
+    @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -543,5 +543,41 @@ namespace weblog
                 return StatusCode(500, "Error executing query.");
             }               
         }
+
+        [HttpPost("mongodb-nosql-injection/test_insecure")]
+        public IActionResult test_insecure_mongodb_injection([FromForm]string key)
+        {
+            try
+            {
+                var mongoDbHelper = new MongoDbHelper("mongodb://localhost:27017", "test-db");
+                var filter = "{ \"user\": \"" + key + "\" }";
+                mongoDbHelper.Find("users", filter);
+                
+                return Content("Executed injection");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                return StatusCode(500, "Error executing query.");
+            }
+        }
+        
+        [HttpPost("mongodb-nosql-injection/test_secure")]
+        public IActionResult test_secure_mongodb_injection([FromForm]string key)
+        {
+            try
+            {
+                var mongoDbHelper = new MongoDbHelper("mongodb://localhost:27017", "test-db");
+                var filter = MongoDbHelper.CreateSimpleDocument("user", key);
+                mongoDbHelper.Find("users", filter);
+                
+                return Content("Executed secure injection");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                return StatusCode(500, "Error executing query.");
+            }
+        }
     }
 }

--- a/utils/build/docker/dotnet/Dependencies/MongoDbHelper.cs
+++ b/utils/build/docker/dotnet/Dependencies/MongoDbHelper.cs
@@ -1,0 +1,33 @@
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace weblog;
+
+public class MongoDbHelper
+{
+    private IMongoClient _client;
+    private readonly IMongoDatabase _database;
+
+    public MongoDbHelper(string connectionString, string databaseName)
+    {
+        _client = new MongoClient(connectionString);
+        _database = _client.GetDatabase(databaseName);
+    }
+    
+    public BsonDocument Find(string collectionName, string json)
+    {
+        var collection = _database.GetCollection<BsonDocument>(collectionName);
+        return collection.Find(json).FirstOrDefault();
+    }
+    
+    public BsonDocument Find(string collectionName, BsonDocument filter)
+    {
+        var collection = _database.GetCollection<BsonDocument>(collectionName);
+        return collection.Find(filter).FirstOrDefault();
+    }
+    
+    public static BsonDocument CreateSimpleDocument(string key, string value)
+    {
+        return new BsonDocument(key, value);
+    }
+}

--- a/utils/build/docker/dotnet/app.csproj
+++ b/utils/build/docker/dotnet/app.csproj
@@ -25,5 +25,6 @@
 		<Reference Include="Datadog.Trace">
 			<HintPath>/opt/datadog/netcoreapp3.1/Datadog.Trace.dll</HintPath>
 		</Reference>
+		<PackageReference Include="MongoDB.Driver" Version="2.23.1" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Motivation

Add the dotnet tests for the NoSQL MongoDB Injection IAST vulnerability.

## Changes

- Enable the 2 available tests for mongodb
- Integrate into the dotnet IastController the 2 endpoints.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
