### PR TITLE
Feb2024 Extended Sampling API Revision Tests

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -116,8 +116,10 @@ tests/:
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: missing_feature
       Test_Trace_Sampling_Globs: missing_feature
+      Test_Trace_Sampling_Globs_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_Resource: missing_feature
       Test_Trace_Sampling_Tags: missing_feature
+      Test_Trace_Sampling_Tags_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_With_W3C: missing_feature
     test_tracer.py:
       Test_TracerSCITagging: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -235,8 +235,10 @@ tests/:
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: missing_feature
       Test_Trace_Sampling_Globs: missing_feature
+      Test_Trace_Sampling_Globs_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_Resource: missing_feature
       Test_Trace_Sampling_Tags: missing_feature
+      Test_Trace_Sampling_Tags_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_With_W3C: missing_feature
     test_tracer.py:
       Test_TracerSCITagging: bug (Both env vars are not independent; injected tags are duplicated in all spans)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -374,8 +374,10 @@ tests/:
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.37.0 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: v1.60.0
+      Test_Trace_Sampling_Globs_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_Resource: v1.60.0
       Test_Trace_Sampling_Tags: v1.60.0
+      Test_Trace_Sampling_Tags_Feb2024_Revision: missing_feature
     test_tracer.py:
       Test_TracerSCITagging: v1.48.0
     test_tracer_flare.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -922,7 +922,7 @@ tests/:
       Test_Trace_Sampling_Globs_Feb2024_Revision: v1.30.0
       Test_Trace_Sampling_Resource: v1.25.0
       Test_Trace_Sampling_Tags: v1.26.0
-      Test_Trace_Tag_Sampling_Feb2024_Revision: v1.30.0
+      Test_Trace_Sampling_Tags_Feb2024_Revision: v1.30.0
       Test_Trace_Sampling_With_W3C: missing_feature
     test_tracer.py:
       Test_TracerSCITagging: v1.12.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -919,8 +919,10 @@ tests/:
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.111.0
       Test_Trace_Sampling_Globs: v1.25.0
+      Test_Trace_Sampling_Globs_Feb2024_Revision: v1.30.0
       Test_Trace_Sampling_Resource: v1.25.0
       Test_Trace_Sampling_Tags: v1.26.0
+      Test_Trace_Tag_Sampling_Feb2024_Revision: v1.30.0
       Test_Trace_Sampling_With_W3C: missing_feature
     test_tracer.py:
       Test_TracerSCITagging: v1.12.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -371,8 +371,10 @@ tests/:
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: missing_feature
       Test_Trace_Sampling_Globs: missing_feature
+      Test_Trace_Sampling_Globs_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_Resource: missing_feature
       Test_Trace_Sampling_Tags: missing_feature
+      Test_Trace_Sampling_Tags_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_With_W3C: missing_feature
     test_tracer.py:
       Test_TracerSCITagging: v3.21.0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -219,8 +219,10 @@ tests/:
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.68.3 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: v0.96.0
+      Test_Trace_Sampling_Globs_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_Resource: v0.96.0
       Test_Trace_Sampling_Tags: v0.96.0
+      Test_Trace_Sampling_Tags_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_With_W3C: missing_feature
     test_tracer.py:
       Test_TracerSCITagging: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -534,8 +534,10 @@ tests/:
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.9.0 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: missing_feature
+      Test_Trace_Sampling_Globs_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_Resource: missing_feature
       Test_Trace_Sampling_Tags: missing_feature
+      Test_Trace_Sampling_Tags_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_With_W3C: missing_feature
     test_tracer.py:
       Test_TracerSCITagging: v1.12.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -270,8 +270,10 @@ tests/:
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.0.0 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: missing_feature
+      Test_Trace_Sampling_Globs_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_Resource: missing_feature
       Test_Trace_Sampling_Tags: missing_feature
+      Test_Trace_Sampling_Tags_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_With_W3C: missing_feature
     test_tracer.py:
       Test_TracerSCITagging: missing_feature

--- a/tests/parametric/test_trace_sampling.py
+++ b/tests/parametric/test_trace_sampling.py
@@ -9,6 +9,7 @@ from utils.parametric.spec.trace import find_span_in_traces
 from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, SAMPLING_RULE_PRIORITY_RATE
 from utils import rfc, scenarios, features
 
+
 @features.trace_sampling
 @scenarios.parametric
 @rfc("https://docs.google.com/document/d/1HRbi1DrBjL_KGeONrPgH7lblgqSLGlV5Ox1p4RL97xM/")
@@ -397,15 +398,9 @@ def tag_sampling_env(tag_glob_pattern):
     return {
         "DD_TRACE_SAMPLE_RATE": 0,
         "DD_TRACE_SAMPLING_RULES_FORMAT": "glob",
-        "DD_TRACE_SAMPLING_RULES": json.dumps(
-            [
-                {
-                    "tags": {"tag": tag_glob_pattern},
-                    "sample_rate": 1.0
-                }
-            ]
-        )
+        "DD_TRACE_SAMPLING_RULES": json.dumps([{"tags": {"tag": tag_glob_pattern}, "sample_rate": 1.0}]),
     }
+
 
 @scenarios.parametric
 @rfc("https://docs.google.com/document/d/1S9pufnJjrsxH6pRbpigdYFwA5JjSdZ6iLZ-9E7PoAic/")
@@ -420,8 +415,8 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             tag_sampling_env("?o*"),
             tag_sampling_env("???"),
             tag_sampling_env("*"),
-            tag_sampling_env("**")
-        ]
+            tag_sampling_env("**"),
+        ],
     )
     def test_globs_same_casing(self, test_agent, test_library):
         """Test tag matching with string of matching case"""
@@ -429,19 +424,16 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", "foo")
 
-        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+        matching_span = find_span_in_traces(
+            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
+        )
 
         assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
         assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
 
     @pytest.mark.parametrize(
         "library_env",
-        [
-            tag_sampling_env("Foo"),
-            tag_sampling_env("Fo*"),
-            tag_sampling_env("F??"),
-            tag_sampling_env("?O*")
-        ]
+        [tag_sampling_env("Foo"), tag_sampling_env("Fo*"), tag_sampling_env("F??"), tag_sampling_env("?O*")],
     )
     def test_globs_different_casing(self, test_agent, test_library):
         """Test tag matching with string of matching case"""
@@ -449,7 +441,9 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", "foo")
 
-        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+        matching_span = find_span_in_traces(
+            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
+        )
 
         assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
         assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
@@ -461,7 +455,9 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", "[abc]")
 
-        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+        matching_span = find_span_in_traces(
+            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
+        )
 
         assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
         assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
@@ -473,7 +469,9 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", "[a-c]")
 
-        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+        matching_span = find_span_in_traces(
+            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
+        )
 
         assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
         assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
@@ -485,7 +483,9 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", "^(foo|bar)[]\\$")
 
-        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+        matching_span = find_span_in_traces(
+            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
+        )
 
         assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
         assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
@@ -497,7 +497,9 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", random.choice(["foo", "bar", "baz", "quux"]))
 
-        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+        matching_span = find_span_in_traces(
+            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
+        )
 
         assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
         assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
@@ -509,19 +511,25 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_metric("tag", random.choice([-100, -0.5, 0, 5, 1000]))
 
-        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+        matching_span = find_span_in_traces(
+            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
+        )
 
         assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
         assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
 
-    @pytest.mark.parametrize("library_env", [tag_sampling_env("20"), tag_sampling_env("2*"), tag_sampling_env("2?"), tag_sampling_env("*")])
+    @pytest.mark.parametrize(
+        "library_env", [tag_sampling_env("20"), tag_sampling_env("2*"), tag_sampling_env("2?"), tag_sampling_env("*")]
+    )
     def test_metric_matching(self, test_agent, test_library):
         """Tests that any patterns are equivalent to an existence check for metrics"""
         with test_library:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_metric("tag", 20.0)
 
-        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+        matching_span = find_span_in_traces(
+            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
+        )
 
         assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
         assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
@@ -533,7 +541,9 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="mismatching-span", service="test") as span:
                 span.set_metric("tag", 20.1)
 
-        mismatching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="mismatching-span", service="test"))
+        mismatching_span = find_span_in_traces(
+            test_agent.wait_for_num_traces(1), Span(name="mismatching-span", service="test")
+        )
 
         assert mismatching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == -1
         assert mismatching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 0.0
@@ -545,11 +555,12 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_metric("tag", 20.3)
 
-        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+        matching_span = find_span_in_traces(
+            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
+        )
 
         assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
         assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
-
 
 
 @scenarios.parametric

--- a/tests/parametric/test_trace_sampling.py
+++ b/tests/parametric/test_trace_sampling.py
@@ -406,6 +406,18 @@ def tag_sampling_env(tag_glob_pattern):
 @rfc("https://docs.google.com/document/d/1S9pufnJjrsxH6pRbpigdYFwA5JjSdZ6iLZ-9E7PoAic/")
 @features.trace_sampling
 class Test_Trace_Sampling_Tags_Feb2024_Revision:
+    def assert_matching_span(self, test_agent, **kwargs):
+        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(**kwargs))
+
+        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
+        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+
+    def assert_mismatching_span(self, test_agent, **kwargs):
+        mismatching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(**kwargs))
+
+        assert mismatching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == -1
+        assert mismatching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 0.0
+
     @pytest.mark.parametrize(
         "library_env",
         [
@@ -424,12 +436,7 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", "foo")
 
-        matching_span = find_span_in_traces(
-            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
-        )
-
-        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
-        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+        self.assert_matching_span(test_agent, name="matching-span", service="test")
 
     @pytest.mark.parametrize(
         "library_env",
@@ -441,12 +448,7 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", "foo")
 
-        matching_span = find_span_in_traces(
-            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
-        )
-
-        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
-        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+        self.assert_matching_span(test_agent, name="matching-span", service="test")
 
     @pytest.mark.parametrize("library_env", [tag_sampling_env("[abc]")])
     def test_no_set_support(self, test_agent, test_library):
@@ -455,12 +457,7 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", "[abc]")
 
-        matching_span = find_span_in_traces(
-            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
-        )
-
-        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
-        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+        self.assert_matching_span(test_agent, name="matching-span", service="test")
 
     @pytest.mark.parametrize("library_env", [tag_sampling_env("[a-c]")])
     def test_no_range_support(self, test_agent, test_library):
@@ -469,12 +466,7 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", "[a-c]")
 
-        matching_span = find_span_in_traces(
-            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
-        )
-
-        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
-        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+        self.assert_matching_span(test_agent, name="matching-span", service="test")
 
     @pytest.mark.parametrize("library_env", [tag_sampling_env("^(foo|bar)[]\\$")])
     def test_regex_special_chars(self, test_agent, test_library):
@@ -483,12 +475,7 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", "^(foo|bar)[]\\$")
 
-        matching_span = find_span_in_traces(
-            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
-        )
-
-        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
-        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+        self.assert_matching_span(test_agent, name="matching-span", service="test")
 
     @pytest.mark.parametrize("library_env", [tag_sampling_env("*"), tag_sampling_env("**"), tag_sampling_env("***")])
     def test_meta_existence(self, test_agent, test_library):
@@ -497,12 +484,7 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_meta("tag", random.choice(["foo", "bar", "baz", "quux"]))
 
-        matching_span = find_span_in_traces(
-            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
-        )
-
-        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
-        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+        self.assert_matching_span(test_agent, name="matching-span", service="test")
 
     @pytest.mark.parametrize("library_env", [tag_sampling_env("*"), tag_sampling_env("**"), tag_sampling_env("***")])
     def test_metric_existence(self, test_agent, test_library):
@@ -511,12 +493,7 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_metric("tag", random.choice([-100, -0.5, 0, 5, 1000]))
 
-        matching_span = find_span_in_traces(
-            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
-        )
-
-        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
-        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+        self.assert_matching_span(test_agent, name="matching-span", service="test")
 
     @pytest.mark.parametrize(
         "library_env", [tag_sampling_env("20"), tag_sampling_env("2*"), tag_sampling_env("2?"), tag_sampling_env("*")]
@@ -527,12 +504,7 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_metric("tag", 20.0)
 
-        matching_span = find_span_in_traces(
-            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
-        )
-
-        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
-        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+        self.assert_matching_span(test_agent, name="matching-span", service="test")
 
     @pytest.mark.parametrize("library_env", [tag_sampling_env("20"), tag_sampling_env("2*"), tag_sampling_env("2?")])
     def test_metric_mismatch_non_integer(self, test_agent, test_library):
@@ -541,12 +513,7 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="mismatching-span", service="test") as span:
                 span.set_metric("tag", 20.1)
 
-        mismatching_span = find_span_in_traces(
-            test_agent.wait_for_num_traces(1), Span(name="mismatching-span", service="test")
-        )
-
-        assert mismatching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == -1
-        assert mismatching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 0.0
+        self.assert_mismatching_span(test_agent, name="mismatching-span", service="test")
 
     @pytest.mark.parametrize("library_env", [tag_sampling_env("*"), tag_sampling_env("**"), tag_sampling_env("***")])
     def test_metric_matching(self, test_agent, test_library):
@@ -555,12 +522,7 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
             with test_library.start_span(name="matching-span", service="test") as span:
                 span.set_metric("tag", 20.3)
 
-        matching_span = find_span_in_traces(
-            test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test")
-        )
-
-        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
-        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+        self.assert_matching_span(test_agent, name="matching-span", service="test")
 
 
 @scenarios.parametric

--- a/tests/parametric/test_trace_sampling.py
+++ b/tests/parametric/test_trace_sampling.py
@@ -410,7 +410,7 @@ def tag_sampling_env(tag_glob_pattern):
 @scenarios.parametric
 @rfc("https://docs.google.com/document/d/1S9pufnJjrsxH6pRbpigdYFwA5JjSdZ6iLZ-9E7PoAic/")
 @features.trace_sampling
-class Test_Trace_Tag_Sampling_Feb2024_Revision:
+class Test_Trace_Sampling_Tags_Feb2024_Revision:
     @pytest.mark.parametrize(
         "library_env",
         [

--- a/tests/parametric/test_trace_sampling.py
+++ b/tests/parametric/test_trace_sampling.py
@@ -1,13 +1,13 @@
 import json
 
 import pytest
+import random
 
 from utils import rfc, scenarios, missing_feature, context
 from utils.parametric.spec.trace import Span
 from utils.parametric.spec.trace import find_span_in_traces
 from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, SAMPLING_RULE_PRIORITY_RATE
 from utils import rfc, scenarios, features
-
 
 @features.trace_sampling
 @scenarios.parametric
@@ -142,6 +142,51 @@ class Test_Trace_Sampling_Globs:
 
         assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == -1
         assert span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 0.0
+
+
+@features.trace_sampling
+@scenarios.parametric
+@rfc("https://docs.google.com/document/d/1S9pufnJjrsxH6pRbpigdYFwA5JjSdZ6iLZ-9E7PoAic/")
+class Test_Trace_Sampling_Globs_Feb2024_Revision:
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+                "DD_TRACE_SAMPLE_RATE": 0,
+                "DD_TRACE_SAMPLING_RULES_FORMAT": "glob",
+                "DD_TRACE_SAMPLING_RULES": json.dumps(
+                    [{"service": "web.non-matching*", "sample_rate": 0}, {"service": "web*", "sample_rate": 1},]
+                ),
+            },
+            {
+                "DD_TRACE_SAMPLE_RATE": 0,
+                "DD_TRACE_SAMPLING_RULES_FORMAT": "glob",
+                "DD_TRACE_SAMPLING_RULES": json.dumps(
+                    [{"name": "web.non-matching*", "sample_rate": 0}, {"name": "wEb.*", "sample_rate": 1}]
+                ),
+            },
+            {
+                "DD_TRACE_SAMPLE_RATE": 0,
+                "DD_TRACE_SAMPLING_RULES_FORMAT": "glob",
+                "DD_TRACE_SAMPLING_RULES": json.dumps(
+                    [
+                        {"service": "webserv?r.non-matching", "name": "wEb.req*", "sample_rate": 0},
+                        {"service": "webserv?r", "name": "web.req*.non-matching", "sample_rate": 0},
+                        {"service": "webserv?r", "name": "web.req*", "sample_rate": 1},
+                    ]
+                ),
+            },
+        ],
+    )
+    def test_trace_sampled_by_trace_sampling_rule_insensitive_glob_match(self, test_agent, test_library):
+        """Test that a trace is sampled by the glob matching trace sampling rule"""
+        with test_library:
+            with test_library.start_span(name="web.reqUEst", service="wEbServer"):
+                pass
+        span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="web.reqUEst", service="wEbServer"))
+
+        assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
+        assert span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
 
 
 @features.trace_sampling
@@ -346,6 +391,165 @@ class Test_Trace_Sampling_Tags:
 
         assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == -1
         assert span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 0.0
+
+
+def tag_sampling_env(tag_glob_pattern):
+    return {
+        "DD_TRACE_SAMPLE_RATE": 0,
+        "DD_TRACE_SAMPLING_RULES_FORMAT": "glob",
+        "DD_TRACE_SAMPLING_RULES": json.dumps(
+            [
+                {
+                    "tags": {"tag": tag_glob_pattern},
+                    "sample_rate": 1.0
+                }
+            ]
+        )
+    }
+
+@scenarios.parametric
+@rfc("https://docs.google.com/document/d/1S9pufnJjrsxH6pRbpigdYFwA5JjSdZ6iLZ-9E7PoAic/")
+@features.trace_sampling
+class Test_Trace_Tag_Sampling_Feb2024_Revision:
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            tag_sampling_env("foo"),
+            tag_sampling_env("fo*"),
+            tag_sampling_env("f??"),
+            tag_sampling_env("?o*"),
+            tag_sampling_env("???"),
+            tag_sampling_env("*"),
+            tag_sampling_env("**")
+        ]
+    )
+    def test_globs_same_casing(self, test_agent, test_library):
+        """Test tag matching with string of matching case"""
+        with test_library:
+            with test_library.start_span(name="matching-span", service="test") as span:
+                span.set_meta("tag", "foo")
+
+        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+
+        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
+        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            tag_sampling_env("Foo"),
+            tag_sampling_env("Fo*"),
+            tag_sampling_env("F??"),
+            tag_sampling_env("?O*")
+        ]
+    )
+    def test_globs_different_casing(self, test_agent, test_library):
+        """Test tag matching with string of matching case"""
+        with test_library:
+            with test_library.start_span(name="matching-span", service="test") as span:
+                span.set_meta("tag", "foo")
+
+        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+
+        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
+        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+
+    @pytest.mark.parametrize("library_env", [tag_sampling_env("[abc]")])
+    def test_no_set_support(self, test_agent, test_library):
+        """Test verifying that common glob set extension is NOT supported"""
+        with test_library:
+            with test_library.start_span(name="matching-span", service="test") as span:
+                span.set_meta("tag", "[abc]")
+
+        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+
+        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
+        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+
+    @pytest.mark.parametrize("library_env", [tag_sampling_env("[a-c]")])
+    def test_no_range_support(self, test_agent, test_library):
+        """Test verifying that common glob range extension is NOT supported"""
+        with test_library:
+            with test_library.start_span(name="matching-span", service="test") as span:
+                span.set_meta("tag", "[a-c]")
+
+        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+
+        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
+        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+
+    @pytest.mark.parametrize("library_env", [tag_sampling_env("^(foo|bar)[]\\$")])
+    def test_regex_special_chars(self, test_agent, test_library):
+        """Test verifying that regex special chars doesn't break glob matching"""
+        with test_library:
+            with test_library.start_span(name="matching-span", service="test") as span:
+                span.set_meta("tag", "^(foo|bar)[]\\$")
+
+        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+
+        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
+        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+
+    @pytest.mark.parametrize("library_env", [tag_sampling_env("*"), tag_sampling_env("**"), tag_sampling_env("***")])
+    def test_meta_existence(self, test_agent, test_library):
+        """Tests that any patterns are equivalent to an existence check for meta"""
+        with test_library:
+            with test_library.start_span(name="matching-span", service="test") as span:
+                span.set_meta("tag", random.choice(["foo", "bar", "baz", "quux"]))
+
+        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+
+        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
+        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+
+    @pytest.mark.parametrize("library_env", [tag_sampling_env("*"), tag_sampling_env("**"), tag_sampling_env("***")])
+    def test_metric_existence(self, test_agent, test_library):
+        """Tests that any patterns are equivalent to an existence check for metrics"""
+        with test_library:
+            with test_library.start_span(name="matching-span", service="test") as span:
+                span.set_metric("tag", random.choice([-100, -0.5, 0, 5, 1000]))
+
+        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+
+        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
+        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+
+    @pytest.mark.parametrize("library_env", [tag_sampling_env("20"), tag_sampling_env("2*"), tag_sampling_env("2?"), tag_sampling_env("*")])
+    def test_metric_matching(self, test_agent, test_library):
+        """Tests that any patterns are equivalent to an existence check for metrics"""
+        with test_library:
+            with test_library.start_span(name="matching-span", service="test") as span:
+                span.set_metric("tag", 20.0)
+
+        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+
+        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
+        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+
+    @pytest.mark.parametrize("library_env", [tag_sampling_env("20"), tag_sampling_env("2*"), tag_sampling_env("2?")])
+    def test_metric_mismatch_non_integer(self, test_agent, test_library):
+        """Tests that any non-integer metrics mismatch patterns -- other than any patterns"""
+        with test_library:
+            with test_library.start_span(name="mismatching-span", service="test") as span:
+                span.set_metric("tag", 20.1)
+
+        mismatching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="mismatching-span", service="test"))
+
+        assert mismatching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == -1
+        assert mismatching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 0.0
+
+    @pytest.mark.parametrize("library_env", [tag_sampling_env("*"), tag_sampling_env("**"), tag_sampling_env("***")])
+    def test_metric_matching(self, test_agent, test_library):
+        """Tests that any patterns are equivalent to an existence check for metrics"""
+        with test_library:
+            with test_library.start_span(name="matching-span", service="test") as span:
+                span.set_metric("tag", 20.3)
+
+        matching_span = find_span_in_traces(test_agent.wait_for_num_traces(1), Span(name="matching-span", service="test"))
+
+        assert matching_span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
+        assert matching_span["metrics"].get(SAMPLING_RULE_PRIORITY_RATE) == 1.0
+
 
 
 @scenarios.parametric


### PR DESCRIPTION
## Motivation

Updating Tests to include Feb 2024 revisions to the Extended Sampling API RFC
- glob case insensitivity
- glob extensions like set & range are forbidden
- glob special character handling
- matching of metrics in addition to meta

## Changes

Introduced test classes Test_Trace_Sampling_Globs_Feb2024_Revision & Test_Trace_Tag_Sampling_Feb2024_Revision

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
