### PR TITLE
Fix tracing_enabled RC value type

### DIFF
--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -178,7 +178,7 @@ class TestDynamicConfigTracingEnabled:
         test_agent.wait_for_rc_capabilities([Capabilities.APM_TRACING_ENABLED])
 
     @parametrize(
-        "library_env", [{**DEFAULT_ENVVARS}, {**DEFAULT_ENVVARS, "DD_TRACE_ENABLED": "false"},],
+        "library_env", [{**DEFAULT_ENVVARS}, {**DEFAULT_ENVVARS, "DD_TRACE_ENABLED": false},],
     )
     def test_tracing_client_tracing_enabled(self, library_env, test_agent, test_library):
         if library_env.get("DD_TRACE_ENABLED", True):
@@ -191,7 +191,7 @@ class TestDynamicConfigTracingEnabled:
                 "wait_for_num_traces does not raise an exception."
             )
 
-        set_and_wait_rc(test_agent, config_overrides={"tracing_enabled": "false"})
+        set_and_wait_rc(test_agent, config_overrides={"tracing_enabled": false})
         with test_library:
             with test_library.start_span("test"):
                 pass


### PR DESCRIPTION
The type in the config should be a boolean not a string.

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
