### PR TITLE
php: datadog_tracecontext will be the default in 1.0

### DIFF
--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -492,7 +492,7 @@ class Test_Headers_Precedence:
     @irrelevant(context.library < "python@2.6.0", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library < "golang@1.62.0", reason="Default value was updated in v1.62.0 (w3c phase 2)")
     @irrelevant(context.library == "nodejs", reason="library does not implement this default configuration")
-    @irrelevant(context.library < "php@1.0.0", reason="Default value was updated in v0.98.0 (w3c phase 2)")
+    @irrelevant(context.library < "php@1.0.0", reason="Default value will be updated in v1.0.0 (w3c phase 2)")
     @irrelevant(context.library == "python", reason="library does not implement this default configuration")
     def test_headers_precedence_propagationstyle_default_datadog_tracecontext(self, test_agent, test_library):
         self.test_headers_precedence_propagationstyle_datadog_tracecontext(test_agent, test_library)

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -492,7 +492,7 @@ class Test_Headers_Precedence:
     @irrelevant(context.library < "python@2.6.0", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library < "golang@1.62.0", reason="Default value was updated in v1.62.0 (w3c phase 2)")
     @irrelevant(context.library == "nodejs", reason="library does not implement this default configuration")
-    @irrelevant(context.library < "php@0.98.0", reason="Default value was updated in v0.98.0 (w3c phase 2)")
+    @irrelevant(context.library < "php@1.0.0", reason="Default value was updated in v0.98.0 (w3c phase 2)")
     @irrelevant(context.library == "python", reason="library does not implement this default configuration")
     def test_headers_precedence_propagationstyle_default_datadog_tracecontext(self, test_agent, test_library):
         self.test_headers_precedence_propagationstyle_datadog_tracecontext(test_agent, test_library)


### PR DESCRIPTION
## Motivation

Addresses:  https://github.com/DataDog/dd-trace-php/pull/2510#pullrequestreview-1871823057

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
