### PR TITLE
Add sevice+env case-insensitivity test to TestDynamicConfigV1

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -109,6 +109,7 @@ tests/:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: missing_feature
+      TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_otel_span_methods.py: irrelevant (library does not implement OpenTelemetry)
     test_span_links.py: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -232,6 +232,7 @@ tests/:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: v2.33.0
+      TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v2.44.0
     test_span_links.py: missing_feature
     test_telemetry.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -370,6 +370,7 @@ tests/:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: v1.59.0
+      TestDynamicConfigV1_ServiceTargets: v1.59.0
       TestDynamicConfigV2: v1.59.0
     test_span_links.py: missing_feature
     test_telemetry.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -921,8 +921,8 @@ tests/:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: v1.17.0
+      TestDynamicConfigV1_ServiceTargets: v1.31.0
       TestDynamicConfigV2: missing_feature
-      
     test_span_links.py: missing_feature
     test_telemetry.py:
       Test_Defaults: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -379,6 +379,7 @@ tests/:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: v4.11.0
+      TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v4.23.0
     test_span_links.py: missing_feature
     test_telemetry.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -204,6 +204,7 @@ tests/:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: missing_feature
+      TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_otel_span_methods.py:
         Test_Otel_Span_Methods: v0.94.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -548,6 +548,7 @@ tests/:
       TestDynamicConfigHeaderTags: v2.6.0
       TestDynamicConfigTracingEnabled: v2.6.0
       TestDynamicConfigV1: missing_feature
+      TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_sampling_delegation.py:
       Test_Decisionless_Extraction: >-

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -257,6 +257,7 @@ tests/:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: v1.13.0
+      TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_otel_span_methods.py:
       Test_Otel_Span_Methods: v1.17.0


### PR DESCRIPTION
## Motivation

The backend normalizes service and env values, so we need a test case that verifies such a scenario to make sure that a Tracer is case-insensitive of env or service name values.

## Changes

Add sevice+env case-insensitivity test.
Extract service+env test to TestDynamicConfigV1_ServiceTargets.
Enable TestDynamicConfigV1_ServiceTargets for [the Java Tracer v1.30+](https://github.com/DataDog/dd-trace-java/pull/6636).

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [x] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
