### PR TITLE
fix ruby image docker build on macos M1 system

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -329,7 +329,7 @@ def ruby_library_factory() -> APMLibraryTestServer:
         container_name="ruby-test-client",
         container_tag="ruby-test-client",
         container_img=f"""
-            FROM ruby:3.2.1-bullseye
+            FROM --platform=linux/amd64 ruby:3.2.1-bullseye
             WORKDIR /app
             COPY {ruby_reldir} .           
             COPY {ruby_reldir}/../install_ddtrace.sh binaries* /binaries/


### PR DESCRIPTION
## Motivation

Inability to run system-tests locally due to the following error:

## Changes

Added `--platform=linux/amd64` parameter to `FROM ruby:3.2.1-bullseye` as suggested by ...

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
