### PR TITLE
Add scenario and cases

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -13,7 +13,7 @@ tests/:
       test_apisec_sampling.py:
         Test_API_Security_sampling: v2.46.0
       test_schemas.py:
-        Test_Scanners: missing_feature
+        Test_Scanners: v2.46.0
         Test_Schema_Request_Cookies: v2.46.0
         Test_Schema_Request_FormUrlEncoded_Body: v2.46.0
         Test_Schema_Request_Headers: v2.46.0

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -275,7 +275,7 @@ class Test_Scanners:
     def setup_request_method(self):
         self.request = weblog.get(
             "/tag_value/api_match_AS001/200",
-            cookies={"mastercard": "5123456789123456", "authorization": "digest a0b1c2", "SSN": "123-45-6789",},
+            cookies={"mastercard": "5123456789123456", "authorization": "digest_a0b1c2", "SSN": "123-45-6789",},
             headers={"authorization": "digest a0b1c2",},
         )
 
@@ -287,20 +287,33 @@ class Test_Scanners:
         assert self.request.status_code == 200
         assert schema_cookies
         assert isinstance(schema_cookies, list)
-        EXPECTED_COOKIES = {
-            "SSN": [8, {"category": "pii", "type": "us_ssn"}],
-            "authorization": [8],
-            "mastercard": [8, {"card_type": "mastercard", "type": "card", "category": "payment"},],
-        }
-        EXPECTED_HEADERS = {"authorization": [8, {"category": "credentials", "type": "digest_auth"}]}
+        # some tracers report headers / cookies values as lists even if there's just one element (frameworks do)
+        # in this case, the second case of expected variables below would pass
+        EXPECTED_COOKIES = [
+            {
+                "SSN": [8, {"category": "pii", "type": "us_ssn"}],
+                "authorization": [8],
+                "mastercard": [8, {"card_type": "mastercard", "type": "card", "category": "payment"},],
+            },
+            {
+                "SSN": [[[8, {"category": "pii", "type": "us_ssn"}]], {"len": 1}],
+                "authorization": [[[8]], {"len": 1}],
+                "mastercard": [[[8, {"card_type": "mastercard", "type": "card", "category": "payment"}]], {"len": 1}],
+            },
+        ]
+        EXPECTED_HEADERS = [
+            {"authorization": [8, {"category": "credentials", "type": "digest_auth"}]},
+            {"authorization": [[[8, {"category": "credentials", "type": "digest_auth"}]], {"len": 1}]},
+        ]
 
         for schema, expected in [
             (schema_cookies[0], EXPECTED_COOKIES),
             (schema_headers[0], EXPECTED_HEADERS),
         ]:
-            for key in expected:
+
+            for key in expected[0]:
                 assert key in schema
                 assert isinstance(schema[key], list)
-                assert len(schema[key]) == len(expected[key])
+                assert len(schema[key]) == len(expected[0][key]) or len(schema[key]) == len(expected[1][key])
                 if len(schema[key]) == 2:
-                    assert schema[key][1] == expected[key][1]
+                    assert schema[key][1] == expected[1][key][1] or schema[key][1] == expected[0][key][1]


### PR DESCRIPTION
## Motivation

Activate scanners test for api security in dotnet

## Changes

- activate the dotnet test in the scenario file
- cookies in dotnet can't contain spaces
- allow other values as in aspnet core (dotnet) headers come like key - values [] so it generates such an api security schema with nested arrays.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
