### PR TITLE
Allow the main workflow to be called in a distant workflow

### DIFF
--- a/.github/actions/install_runner/action.yaml
+++ b/.github/actions/install_runner/action.yaml
@@ -3,7 +3,7 @@ description: "Install python virtual env, and system dependencies, using github 
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.9"
     - uses: actions/cache@v3

--- a/.github/actions/install_runner/action.yaml
+++ b/.github/actions/install_runner/action.yaml
@@ -6,7 +6,7 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.9"
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: runner_cache
       with:
         path: venv

--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -8,6 +8,23 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Let's free some place
+      shell: bash
+      run: |
+        if [[ "${{ inputs.pull-all }}" == "true" ]]; then
+          df -h
+
+          echo "Removing docker images, dotnet, android, ghc, and CodeQL cache to free space"
+
+          sudo rm -rf /usr/local/lib/android  # 9Gb!
+          sudo rm -rf /opt/hostedtoolcache/CodeQL  # 5Gb !
+          sudo rm -rf /usr/share/dotnet # 1Gb
+
+          # sudo docker image prune --all --force  # if ever needed, but it's slow. Only 3Gb
+
+          df -h
+        fi
+
     - name: Pull images needed for default scenario
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Run lints
       uses: ./.github/actions/lint_code
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install runner
         uses: ./.github/actions/install_runner
       # force /bin/bash in order to test against bash 3.2 on macOS
@@ -85,7 +85,7 @@ jobs:
     if: always() && github.ref == 'refs/heads/main'
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Update CI Dashboard
       run: ./utils/scripts/update_dashboard_CI_visibility.sh system-tests ${{ github.run_id }}-${{ github.run_attempt }}
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,26 @@ jobs:
       uses: ./.github/actions/lint_code
 
   test_the_test:
+    name: Test the test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install runner
+        uses: ./.github/actions/install_runner
+      # force /bin/bash in order to test against bash 3.2 on macOS
+      - name: Test the test (direct)
+        run: /bin/bash run.sh TEST_THE_TEST
+      - name: Test group parsing
+        run: |
+          /bin/bash run.sh ++dry APPSEC_SCENARIOS
+          /bin/bash run.sh ++dry TRACER_RELEASE_SCENARIOS
+
+  test_the_test_platforms:
     strategy:
       matrix:
         os:
           - macos-latest
-          - ubuntu-latest
     name: Test the test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -496,7 +496,7 @@ jobs:
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
     - name: Run all scenarios in replay mode
-      if: always() && steps.build.outcome == 'success' && (inputs.run_replay || inputs.run_all)
+      if: always() && steps.build.outcome == 'success' && inputs.run_replay
       run: |
         ./run.sh DEFAULT --replay
         ./run.sh PROFILING --replay

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -229,7 +229,7 @@ jobs:
       SYSTEM_TESTS_REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: Pull images

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -232,6 +232,20 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: 'DataDog/system-tests'
+    - name: Free up Disk Space
+      run: |
+        # List of image that will be removed
+        docker images -f "dangling=true"
+
+        # Remove specific Docker images that are no longer needed
+        docker rmi $(docker images -f "dangling=true" -q) || true
+        
+        # Prune unused Docker objects (images, containers, volumes, and networks)
+        # docker system prune -f || true
+
+        # Show disk space usage
+        df -h
+
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: Pull images

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -68,7 +68,7 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  main:
+  end-to-end:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -230,6 +230,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        repository: 'DataDog/system-tests'
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: Pull images

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -565,11 +565,6 @@ jobs:
         FP_API_KEY: ${{ secrets.FP_API_KEY }}
         FP_IMPORT_URL: ${{ secrets.FP_IMPORT_URL }}
 
-    - name: Upload results CI Visibility
-      if: ${{ always() }}
-      run: ./utils/scripts/upload_results_CI_visibility.sh ${{ matrix.version }} system-tests ${{ github.run_id }}-${{ github.run_attempt }}
-      env:
-        DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}
     - name: Print fancy log report
       if: ${{ always() }}
       run: python utils/scripts/markdown_logs.py >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -545,7 +545,7 @@ jobs:
       run: tar -czvf artifact.tar.gz $(ls | grep logs)
     - name: Upload artifact
       if: always() && steps.compress_logs.outcome == 'success'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: logs_endtoend_${{ matrix.variant.library }}_${{ matrix.variant.weblog }}_${{ matrix.version }}
         path: artifact.tar.gz

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -232,20 +232,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: 'DataDog/system-tests'
-    - name: Free up Disk Space
-      run: |
-        # List of image that will be removed
-        docker images -f "dangling=true"
-
-        # Remove specific Docker images that are no longer needed
-        docker rmi $(docker images -f "dangling=true" -q) || true
-        
-        # Prune unused Docker objects (images, containers, volumes, and networks)
-        # docker system prune -f || true
-
-        # Show disk space usage
-        df -h
-
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: Pull images
@@ -290,6 +276,10 @@ jobs:
       run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
     - name: Build agent
       run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i agent
+
+    - name: Print free space
+      run: df -h
+
     - name: Build weblog
       id: build
       run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i weblog

--- a/.github/workflows/run-exotics.yml
+++ b/.github/workflows/run-exotics.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   peformances:
     runs-on: ubuntu-latest
-    if: inputs.run_all
     env:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
@@ -27,7 +26,6 @@ jobs:
 
   fuzzer:
     runs-on: ubuntu-latest
-    if: inputs.run_all
     env:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:

--- a/.github/workflows/run-exotics.yml
+++ b/.github/workflows/run-exotics.yml
@@ -1,0 +1,45 @@
+name: Exotic scenarios
+
+on:
+  workflow_call:
+
+jobs:
+  peformances:
+    runs-on: ubuntu-latest
+    if: inputs.run_all
+    env:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        repository: 'DataDog/system-tests'
+    - name: Setup python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Run
+      run: ./tests/perfs/run.sh golang
+    - name: Display
+      run: |
+        source venv/bin/activate
+        python tests/perfs/process.py
+
+  fuzzer:
+    runs-on: ubuntu-latest
+    if: inputs.run_all
+    env:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        repository: 'DataDog/system-tests'
+    - name: Install runner
+      uses: ./.github/actions/install_runner
+    - name: Build
+      run: |
+        ./build.sh -i agent
+        ./build.sh golang -i weblog
+    - name: Run
+      run: ./tests/fuzzer/run.sh

--- a/.github/workflows/run-exotics.yml
+++ b/.github/workflows/run-exotics.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         repository: 'DataDog/system-tests'
     - name: Setup python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - name: Run

--- a/.github/workflows/run-graphql.yml
+++ b/.github/workflows/run-graphql.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          repository: 'DataDog/system-tests'
       - name: Install runner
         uses: ./.github/actions/install_runner
 

--- a/.github/workflows/run-graphql.yml
+++ b/.github/workflows/run-graphql.yml
@@ -81,7 +81,7 @@ jobs:
         run: tar -czvf artifact.tar.gz $(ls | grep logs)
       - name: Upload artifact
         if: always() && steps.compress_logs.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: logs_graphql_${{ matrix.variant.library }}_${{ matrix.variant.weblog }}_${{ matrix.version }}
           path: artifact.tar.gz

--- a/.github/workflows/run-graphql.yml
+++ b/.github/workflows/run-graphql.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install runner
         uses: ./.github/actions/install_runner
 

--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -1,4 +1,4 @@
-name: Experimental tests
+name: Lib-injection tests
 
 on:
   workflow_call:

--- a/.github/workflows/run-open-telemetry.yml
+++ b/.github/workflows/run-open-telemetry.yml
@@ -71,7 +71,7 @@ jobs:
       if: always() && steps.build.outcome == 'success'
       uses: actions/upload-artifact@v4
       with:
-        name: logs_java-otel_prod
+        name: logs_otelmanual_java-otel_spring-boot-native_prod
         path: artifact.tar.gz
 
   open-telemetry-automatic:
@@ -126,6 +126,6 @@ jobs:
       if: always() && steps.build_otel.outcome == 'success'
       uses: actions/upload-artifact@v4
       with:
-        name: logs_${{ matrix.variant.library }}_${{ matrix.variant.version }}
+        name: logs_otelautomatic_${{ matrix.variant.library }}_${{ matrix.variant.weblog }}_${{ matrix.version }}
         path: artifact.tar.gz
 

--- a/.github/workflows/run-open-telemetry.yml
+++ b/.github/workflows/run-open-telemetry.yml
@@ -1,0 +1,131 @@
+name: Open telemetry tests
+
+on:
+  workflow_call:
+    inputs:
+      build_proxy_image:
+        description: "Shall we build proxy image"
+        default: false
+        required: false
+        type: boolean
+
+jobs:
+  open-telemetry-manual:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        repository: 'DataDog/system-tests'
+    - name: Install runner
+      uses: ./.github/actions/install_runner
+    - name: Pull mitmproxy image
+      if: ${{ !inputs.build_proxy_image }}
+      run: docker pull datadog/system-tests:proxy-v1 || true
+    - name: Build proxy image
+      if: inputs.build_proxy_image
+      run: ./build.sh -i proxy
+    - name: Build agent
+      run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh java_otel -i agent
+    - name: Build weblog
+      id: build
+      run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh java_otel -i weblog
+    - name: Run OTEL_TRACING_E2E scenario
+      if: always() && steps.build.outcome == 'success'
+      run: ./run.sh OTEL_TRACING_E2E
+      env:
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
+        DD_APP_KEY: ${{ secrets.DD_APPLICATION_KEY }}
+        DD_API_KEY_2: ${{ secrets.DD_API_KEY_2 }}
+        DD_APP_KEY_2: ${{ secrets.DD_APP_KEY_2 }}
+        DD_API_KEY_3: ${{ secrets.DD_API_KEY_3 }}
+        DD_APP_KEY_3: ${{ secrets.DD_APP_KEY_3 }}
+    - name: Run OTEL_METRIC_E2E scenario
+      if: always() && steps.build.outcome == 'success'
+      run: ./run.sh OTEL_METRIC_E2E
+      env:
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
+        DD_APP_KEY: ${{ secrets.DD_APPLICATION_KEY }}
+        DD_API_KEY_2: ${{ secrets.DD_API_KEY_2 }}
+        DD_APP_KEY_2: ${{ secrets.DD_APP_KEY_2 }}
+        DD_API_KEY_3: ${{ secrets.DD_API_KEY_3 }}
+        DD_APP_KEY_3: ${{ secrets.DD_APP_KEY_3 }}
+    - name: Run OTEL_LOG_E2E scenario
+      if: always() && steps.build.outcome == 'success'
+      run: ./run.sh OTEL_LOG_E2E
+      env:
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
+        DD_APP_KEY: ${{ secrets.DD_APPLICATION_KEY }}
+        DD_API_KEY_2: ${{ secrets.DD_API_KEY_2 }}
+        DD_APP_KEY_2: ${{ secrets.DD_APP_KEY_2 }}
+        DD_API_KEY_3: ${{ secrets.DD_API_KEY_3 }}
+        DD_APP_KEY_3: ${{ secrets.DD_APP_KEY_3 }}
+
+    - name: Compress logs
+      if: always() && steps.build.outcome == 'success'
+      run: tar -czvf artifact.tar.gz $(ls | grep logs)
+    - name: Upload artifact
+      if: always() && steps.build.outcome == 'success'
+      uses: actions/upload-artifact@v3
+      with:
+        name: logs_java-otel_prod
+        path: artifact.tar.gz
+
+  open-telemetry-automatic:
+    runs-on: ubuntu-latest
+    if: inputs.run_open_telemetry || inputs.run_integration
+    strategy:
+      matrix:
+        variant:
+        - library: java_otel
+          weblog: spring-boot-otel
+        - library: python_otel
+          weblog: flask-poc-otel
+        - library: nodejs_otel
+          weblog: express4-otel
+        version:
+        - prod
+      fail-fast: false
+    env:
+      TEST_LIBRARY: ${{ matrix.variant.library }}
+      WEBLOG_VARIANT: ${{ matrix.variant.weblog }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        repository: 'DataDog/system-tests'
+    - name: Install runner
+      uses: ./.github/actions/install_runner
+    - name: Pull mitmproxy image
+      if: ${{ !inputs.build_proxy_image }}
+      run: docker pull datadog/system-tests:proxy-v1 || true
+    - name: Build proxy image
+      if: inputs.build_proxy_image
+      run: ./build.sh -i proxy
+    - name: Build agent
+      run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh ${{ matrix.variant.library }} -i agent
+
+    - name: Build weblog opentelemetry autoinstrumentation
+      if: always()
+      id: build_otel
+      run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh ${{ matrix.variant.library }} --weblog-variant ${{ matrix.variant.weblog }}
+    - name: Run OTEL_INTEGRATIONS scenario
+      if: always() && steps.build_otel.outcome == 'success'
+      run: ./run.sh OTEL_INTEGRATIONS
+      env:
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
+        DD_APP_KEY: ${{ secrets.DD_APPLICATION_KEY }}
+    - name: Compress logs
+      if: always() && steps.build_otel.outcome == 'success'
+      run: tar -czvf artifact.tar.gz $(ls | grep logs)
+    - name: Upload artifact
+      if: always() && steps.build_otel.outcome == 'success'
+      uses: actions/upload-artifact@v3
+      with:
+        name: logs_${{ matrix.variant.library }}_${{ matrix.variant.version }}
+        path: artifact.tar.gz
+

--- a/.github/workflows/run-open-telemetry.yml
+++ b/.github/workflows/run-open-telemetry.yml
@@ -76,7 +76,6 @@ jobs:
 
   open-telemetry-automatic:
     runs-on: ubuntu-latest
-    if: inputs.run_open_telemetry || inputs.run_integration
     strategy:
       matrix:
         variant:

--- a/.github/workflows/run-open-telemetry.yml
+++ b/.github/workflows/run-open-telemetry.yml
@@ -69,7 +69,7 @@ jobs:
       run: tar -czvf artifact.tar.gz $(ls | grep logs)
     - name: Upload artifact
       if: always() && steps.build.outcome == 'success'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: logs_java-otel_prod
         path: artifact.tar.gz
@@ -124,7 +124,7 @@ jobs:
       run: tar -czvf artifact.tar.gz $(ls | grep logs)
     - name: Upload artifact
       if: always() && steps.build_otel.outcome == 'success'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: logs_${{ matrix.variant.library }}_${{ matrix.variant.version }}
         path: artifact.tar.gz

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -70,7 +70,7 @@ jobs:
         if: always() && steps.compress_logs.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
-          name: logs_parametric_${{ matrix.library}}_${{ matrix.version }}
+          name: logs_parametric_${{ matrix.library}}_parametric_${{ matrix.version }}
           path: artifact.tar.gz
       - name: Upload results CI Visibility
         if: ${{ always() }}

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -68,7 +68,7 @@ jobs:
         run: tar -czvf artifact.tar.gz $(ls | grep logs)
       - name: Upload artifact
         if: always() && steps.compress_logs.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: logs_parametric_${{ matrix.library}}_${{ matrix.version }}
           path: artifact.tar.gz

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          repository: 'DataDog/system-tests'
       - name: Install runner
         uses: ./.github/actions/install_runner
       - name: Load library binary

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -30,7 +30,7 @@ jobs:
       SYSTEM_TESTS_REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install runner
         uses: ./.github/actions/install_runner
       - name: Load library binary

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -113,123 +113,12 @@ jobs:
       build_buddies_images: ${{ inputs.build_buddies_images }}
       build_proxy_image: ${{ inputs.build_proxy_image }}
 
-  open-telemetry-manual:
-    runs-on: ubuntu-latest
+  open-telemetry:
     if: inputs.run_open_telemetry || inputs.run_all
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        repository: 'DataDog/system-tests'
-    - name: Install runner
-      uses: ./.github/actions/install_runner
-    - name: Pull mitmproxy image
-      run: docker pull datadog/system-tests:proxy-v1 || true
-    - name: Build proxy image
-      if: inputs.build_proxy_image
-      run: ./build.sh -i proxy
-    - name: Build agent
-      run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh java_otel -i agent
-    - name: Build weblog
-      id: build
-      run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh java_otel -i weblog
-    - name: Run OTEL_TRACING_E2E scenario
-      if: always() && steps.build.outcome == 'success'
-      run: ./run.sh OTEL_TRACING_E2E
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-        DD_APP_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-        DD_API_KEY_2: ${{ secrets.DD_API_KEY_2 }}
-        DD_APP_KEY_2: ${{ secrets.DD_APP_KEY_2 }}
-        DD_API_KEY_3: ${{ secrets.DD_API_KEY_3 }}
-        DD_APP_KEY_3: ${{ secrets.DD_APP_KEY_3 }}
-    - name: Run OTEL_METRIC_E2E scenario
-      if: always() && steps.build.outcome == 'success'
-      run: ./run.sh OTEL_METRIC_E2E
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-        DD_APP_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-        DD_API_KEY_2: ${{ secrets.DD_API_KEY_2 }}
-        DD_APP_KEY_2: ${{ secrets.DD_APP_KEY_2 }}
-        DD_API_KEY_3: ${{ secrets.DD_API_KEY_3 }}
-        DD_APP_KEY_3: ${{ secrets.DD_APP_KEY_3 }}
-    - name: Run OTEL_LOG_E2E scenario
-      if: always() && steps.build.outcome == 'success'
-      run: ./run.sh OTEL_LOG_E2E
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-        DD_APP_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-        DD_API_KEY_2: ${{ secrets.DD_API_KEY_2 }}
-        DD_APP_KEY_2: ${{ secrets.DD_APP_KEY_2 }}
-        DD_API_KEY_3: ${{ secrets.DD_API_KEY_3 }}
-        DD_APP_KEY_3: ${{ secrets.DD_APP_KEY_3 }}
-
-    - name: Compress logs
-      if: always() && steps.build.outcome == 'success'
-      run: tar -czvf artifact.tar.gz $(ls | grep logs)
-    - name: Upload artifact
-      if: always() && steps.build.outcome == 'success'
-      uses: actions/upload-artifact@v3
-      with:
-        name: logs_java-otel_prod
-        path: artifact.tar.gz
-
-  open-telemetry-automatic:
-    runs-on: ubuntu-latest
-    if: inputs.run_open_telemetry || inputs.run_integration || inputs.run_all
-    strategy:
-      matrix:
-        variant:
-        - library: java_otel
-          weblog: spring-boot-otel
-        - library: python_otel
-          weblog: flask-poc-otel
-        - library: nodejs_otel
-          weblog: express4-otel
-        version:
-        - prod
-      fail-fast: false
-    env:
-      TEST_LIBRARY: ${{ matrix.variant.library }}
-      WEBLOG_VARIANT: ${{ matrix.variant.weblog }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        repository: 'DataDog/system-tests'
-    - name: Install runner
-      uses: ./.github/actions/install_runner
-    - name: Pull mitmproxy image
-      run: docker pull datadog/system-tests:proxy-v1 || true
-    - name: Build proxy image
-      if: inputs.build_proxy_image
-      run: ./build.sh -i proxy
-    - name: Build agent
-      run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh ${{ matrix.variant.library }} -i agent
-
-    - name: Build weblog opentelemetry autoinstrumentation
-      if: always()
-      id: build_otel
-      run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh ${{ matrix.variant.library }} --weblog-variant ${{ matrix.variant.weblog }}
-    - name: Run OTEL_INTEGRATIONS scenario
-      if: always() && steps.build_otel.outcome == 'success'
-      run: ./run.sh OTEL_INTEGRATIONS
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-        DD_APP_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-    - name: Compress logs
-      if: always() && steps.build_otel.outcome == 'success'
-      run: tar -czvf artifact.tar.gz $(ls | grep logs)
-    - name: Upload artifact
-      if: always() && steps.build_otel.outcome == 'success'
-      uses: actions/upload-artifact@v3
-      with:
-        name: logs_${{ matrix.variant.library }}_${{ matrix.variant.version }}
-        path: artifact.tar.gz
+    uses: ./.github/workflows/run-open-telemetry.yml
+    secrets: inherit
+    with:
+      build_proxy_image: ${{ inputs.build_proxy_image }}
 
   exotics:
     if: inputs.run_all

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -118,7 +118,7 @@ jobs:
     if: inputs.run_open_telemetry || inputs.run_all
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: Pull mitmproxy image
@@ -195,7 +195,7 @@ jobs:
       WEBLOG_VARIANT: ${{ matrix.variant.weblog }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: Pull mitmproxy image
@@ -234,7 +234,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup python 3.9
       uses: actions/setup-python@v4
       with:
@@ -253,7 +253,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: Build

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -91,7 +91,7 @@ jobs:
     secrets: inherit
 
   graphql:
-    if: inputs.run_graphql || run_all_end_to_end || inputs.run_all
+    if: inputs.run_graphql || inputs.run_all_end_to_end || inputs.run_all
     uses: ./.github/workflows/run-graphql.yml
     secrets: inherit
     with:
@@ -106,7 +106,7 @@ jobs:
     uses: ./.github/workflows/run-end-to-end.yml
     secrets: inherit
     with:
-      run_all: ${{ inputs.run_all || run_all_end_to_end }}
+      run_all: ${{ inputs.run_all || inputs.run_all_end_to_end }}
       run_replay: ${{ inputs.run_replay }}
       run_integration: ${{ inputs.run_integration }}
       run_sampling: ${{ inputs.run_sampling }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -7,6 +7,11 @@ on:
         default: false
         required: false
         type: boolean
+      run_all_end_to_end:
+        description: "Shall we run all end-to-end scenarios"
+        default: false
+        required: false
+        type: boolean
       run_replay:
         description: "Shall we run all scenarios in replay mode"
         default: false
@@ -86,7 +91,7 @@ jobs:
     secrets: inherit
 
   graphql:
-    if: inputs.run_graphql || inputs.run_all
+    if: inputs.run_graphql || run_all_end_to_end || inputs.run_all
     uses: ./.github/workflows/run-graphql.yml
     secrets: inherit
     with:
@@ -101,7 +106,7 @@ jobs:
     uses: ./.github/workflows/run-end-to-end.yml
     secrets: inherit
     with:
-      run_all: ${{ inputs.run_all }}
+      run_all: ${{ inputs.run_all || run_all_end_to_end }}
       run_replay: ${{ inputs.run_replay }}
       run_integration: ${{ inputs.run_integration }}
       run_sampling: ${{ inputs.run_sampling }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -231,42 +231,7 @@ jobs:
         name: logs_${{ matrix.variant.library }}_${{ matrix.variant.version }}
         path: artifact.tar.gz
 
-  peformances:
-    runs-on: ubuntu-latest
+  exotics:
     if: inputs.run_all
-    env:
-      DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        repository: 'DataDog/system-tests'
-    - name: Setup python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
-    - name: Run
-      run: ./tests/perfs/run.sh golang
-    - name: Display
-      run: |
-        source venv/bin/activate
-        python tests/perfs/process.py
-
-  fuzzer:
-    runs-on: ubuntu-latest
-    if: inputs.run_all
-    env:
-      DD_API_KEY: ${{ secrets.DD_API_KEY }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        repository: 'DataDog/system-tests'
-    - name: Install runner
-      uses: ./.github/actions/install_runner
-    - name: Build
-      run: |
-        ./build.sh -i agent
-        ./build.sh golang -i weblog
-    - name: Run
-      run: ./tests/fuzzer/run.sh
+    uses: ./.github/workflows/run-exotics.yml
+    secrets: inherit

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -119,6 +119,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        repository: 'DataDog/system-tests'
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: Pull mitmproxy image
@@ -196,6 +198,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        repository: 'DataDog/system-tests'
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: Pull mitmproxy image
@@ -235,6 +239,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        repository: 'DataDog/system-tests'
     - name: Setup python 3.9
       uses: actions/setup-python@v4
       with:
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        repository: 'DataDog/system-tests'
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: Build

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -92,12 +92,12 @@ jobs:
     with:
       build_proxy_image: ${{ inputs.build_proxy_image }}
 
-  experimental:
+  lib-injection:
     if: inputs.run_libinjection || inputs.run_all
-    uses: ./.github/workflows/run-experimental.yml
+    uses: ./.github/workflows/run-lib-injection.yml
     secrets: inherit
 
-  main:
+  end-to-end:
     uses: ./.github/workflows/run-end-to-end.yml
     secrets: inherit
     with:

--- a/.github/workflows/update-agent-protobuf.yml
+++ b/.github/workflows/update-agent-protobuf.yml
@@ -9,7 +9,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v2
       - run: sudo apt-get update
       - run: sudo apt-get -y install protobuf-compiler

--- a/docs/CI/github-actions.md
+++ b/docs/CI/github-actions.md
@@ -45,7 +45,7 @@ jobs:
         run: ./run.sh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: logs_${{ matrix.library }}_${{ matrix.weblog-variant }}

--- a/docs/CI/github-actions.md
+++ b/docs/CI/github-actions.md
@@ -28,7 +28,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Motivation

Allow `DataDog/system-tests/.github/workflows/system-tests.yml` to be called from a different repo

## Changes

* `checkout` -> force system-tests repo to be checkout, rather than the calling repo

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
