### PR TITLE
Add Reflection Injection tests

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -22,6 +22,7 @@ tests/:
         test_no_samesite_cookie.py: irrelevant (ASM is not implemented in C++)
         test_nosql_mongodb_injection.py: irrelevant (ASM is not implemented in C++)
         test_path_traversal.py: irrelevant (ASM is not implemented in C++)
+        test_reflection_injection.py: irrelevant (ASM is not implemented in C++)
         test_sql_injection.py: irrelevant (ASM is not implemented in C++)
         test_ssrf.py: irrelevant (ASM is not implemented in C++)
         test_trust_boundary_violation.py: irrelevant (ASM is not implemented in C++)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -47,6 +47,8 @@ tests/:
           TestNoSqlMongodbInjection: v2.47.0
         test_path_traversal.py:
           TestPathTraversal: v2.31.0
+        test_reflection_injection.py:
+          TestReflectionInjection: missing_feature
         test_sql_injection.py:
           TestSqlInjection:
              '*': v2.23.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -62,6 +62,8 @@ tests/:
           TestNoSqlMongodbInjection: missing_feature
         test_path_traversal.py:
           TestPathTraversal: missing_feature
+        test_reflection_injection.py:
+          TestReflectionInjection: missing_feature
         test_sql_injection.py:
           TestSqlInjection: missing_feature
         test_ssrf.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -126,7 +126,7 @@ tests/:
             vertx3: v1.12.0
         test_reflection_injection.py:
           TestReflectionInjection:
-            '*': v1.30.0
+            '*': v1.31.0
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -124,6 +124,13 @@ tests/:
             resteasy-netty3: v1.11.0
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
             vertx3: v1.12.0
+        test_reflection_injection.py:
+          TestReflectionInjection:
+            '*': v1.30.0
+            akka-http: missing_feature
+            play: missing_feature
+            ratpack: missing_feature
+            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         test_sql_injection.py:
           TestSqlInjection:
             '*': v1.1.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -82,6 +82,8 @@ tests/:
             '*': missing_feature
             express4: v3.19.0
             express4-typescript: v3.19.0
+        test_reflection_injection.py:
+          TestReflectionInjection: missing_feature
         test_sql_injection.py:
           TestSqlInjection:
             '*': missing_feature

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -47,6 +47,8 @@ tests/:
           TestNoSqlMongodbInjection: missing_feature
         test_path_traversal.py:
           TestPathTraversal: missing_feature
+        test_reflection_injection.py:
+          TestReflectionInjection: missing_feature
         test_sql_injection.py:
           TestSqlInjection: missing_feature
         test_ssrf.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -153,6 +153,8 @@ tests/:
             '*': v2.1.0
             fastapi: missing_feature
             python3.12: missing_feature
+        test_reflection_injection.py:
+          TestReflectionInjection: missing_feature
         test_sql_injection.py:
           TestSqlInjection:
             django-poc: v1.18.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -49,6 +49,8 @@ tests/:
           TestNoSqlMongodbInjection: missing_feature
         test_path_traversal.py:
           TestPathTraversal: missing_feature
+        test_reflection_injection.py:
+          TestReflectionInjection: missing_feature
         test_sql_injection.py:
           TestSqlInjection: missing_feature
         test_ssrf.py:

--- a/tests/appsec/iast/sink/test_reflection_injection.py
+++ b/tests/appsec/iast/sink/test_reflection_injection.py
@@ -1,0 +1,26 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+from utils import missing_feature, features
+from .._test_iast_fixtures import BaseSinkTest
+
+
+@features.iast_sink_reflection_injection
+class TestReflectionInjection(BaseSinkTest):
+    """Test Reflection Injection detection."""
+
+    vulnerability_type = "REFLECTION_INJECTION"
+    http_method = "POST"
+    insecure_endpoint = "/iast/reflection_injection/test_insecure"
+    secure_endpoint = "/iast/reflection_injection/test_secure"
+    data = {"param": "ReflectionInjection"}
+    location_map = {"java": "com.datadoghq.system_tests.iast.utils.ReflectionExamples"}
+
+    @missing_feature(library="java", reason="Not implemented yet")
+    def test_telemetry_metric_instrumented_sink(self):
+        super().test_telemetry_metric_instrumented_sink()
+
+    @missing_feature(library="java", reason="Not implemented yet")
+    def test_telemetry_metric_executed_sink(self):
+        super().test_telemetry_metric_executed_sink()

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2026,3 +2026,13 @@ class features:
         """
         pytest.mark.features(feature_id=280)(test_object)
         return test_object
+
+    @staticmethod
+    def iast_sink_reflection_injection(test_object):
+        """
+        IAST Sink: Reflection Injection
+
+        https://feature-parity.us1.prod.dog/#/?feature=276
+        """
+        pytest.mark.features(feature_id=279)(test_object)
+        return test_object

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2032,7 +2032,7 @@ class features:
         """
         IAST Sink: Reflection Injection
 
-        https://feature-parity.us1.prod.dog/#/?feature=276
+        https://feature-parity.us1.prod.dog/#/?feature=279
         """
         pytest.mark.features(feature_id=279)(test_object)
         return test_object

--- a/utils/build/docker/java/iast-common/src/main/java/com/datadoghq/system_tests/iast/utils/ReflectionExamples.java
+++ b/utils/build/docker/java/iast-common/src/main/java/com/datadoghq/system_tests/iast/utils/ReflectionExamples.java
@@ -1,0 +1,22 @@
+package com.datadoghq.system_tests.iast.utils;
+
+public class ReflectionExamples {
+
+    public String secureClassForName() {
+        try {
+            Class.forName("java.lang.String");
+        } catch (ClassNotFoundException e) {
+            // ignore it
+        }
+        return "Secure";
+    }
+
+    public String insecureClassForName(final String value) {
+        try {
+            Class.forName(value);
+        } catch (ClassNotFoundException e) {
+            // ignore it
+        }
+        return "Insecure";
+    }
+}

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/IastSinkResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/IastSinkResource.java
@@ -25,8 +25,8 @@ public class IastSinkResource {
     private final PathExamples path = new PathExamples();
     private final SsrfExamples ssrf = new SsrfExamples();
     private final WeakRandomnessExamples weakRandomness = new WeakRandomnessExamples();
-
     private final XPathExamples xPathExamples = new XPathExamples();
+    private final ReflectionExamples reflectionExamples = new ReflectionExamples();
 
     @GET
     @Path("/insecure_hashing/deduplicate")
@@ -255,6 +255,20 @@ public class IastSinkResource {
     @Path("/insecure-auth-protocol/test")
     public Response  insecureAuthProtocol() {
         return Response.status(Response.Status.OK).build();
+    }
+
+    @POST
+    @Path("/reflection_injection/test_secure")
+    public String secureReflection() {
+        reflectionExamples.secureClassForName();
+        return "Secure";
+    }
+
+    @POST
+    @Path("/reflection_injection/test_insecure")
+    public String insecureReflection(@FormParam("param") final String className) {
+        reflectionExamples.insecureClassForName(className);
+        return "Insecure";
     }
 
 }

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/IastSinkResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/IastSinkResource.java
@@ -20,7 +20,6 @@ import java.net.URISyntaxException;
 public class IastSinkResource {
 
     private final String superSecretAccessKey = "insecure";
-
     private final CryptoExamples crypto = new CryptoExamples();
     private final SqlExamples sql = new SqlExamples(DATA_SOURCE) ;
     private final LDAPExamples ldap = new LDAPExamples(LDAP_CONTEXT);
@@ -28,8 +27,8 @@ public class IastSinkResource {
     private final PathExamples path = new PathExamples();
     private final SsrfExamples ssrf = new SsrfExamples();
     private final WeakRandomnessExamples weakRandomness = new WeakRandomnessExamples();
-
     private final XPathExamples xPathExamples = new XPathExamples();
+    private final ReflectionExamples reflectionExamples = new ReflectionExamples();
 
     @GET
     @Path("/insecure_hashing/deduplicate")
@@ -257,5 +256,19 @@ public class IastSinkResource {
     @Path("/insecure-auth-protocol/test")
     public Response  insecureAuthProtocol() {
         return Response.status(Response.Status.OK).build();
+    }
+
+    @POST
+    @Path("/reflection_injection/test_secure")
+    public String secureReflection() {
+        reflectionExamples.secureClassForName();
+        return "Secure";
+    }
+
+    @POST
+    @Path("/reflection_injection/test_insecure")
+    public String insecureReflection(@FormParam("param") final String className) {
+        reflectionExamples.insecureClassForName(className);
+        return "Insecure";
     }
 }

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
@@ -354,12 +354,12 @@ public class AppSecIast {
         return "ok";
     }
 
-    @GetMapping(value = "/reflection_injection/test_secure")
+    @PostMapping(value = "/reflection_injection/test_secure")
     public String secureReflection() {
         return reflectionExamples.secureClassForName();
     }
 
-    @GetMapping(value = "/reflection_injection/test_insecure")
+    @PostMapping(value = "/reflection_injection/test_insecure")
     public String insecureReflection(HttpServletRequest request) {
         final String className = request.getParameter("param");
         return reflectionExamples.insecureClassForName(className);

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIast.java
@@ -35,8 +35,8 @@ public class AppSecIast {
     private final WeakRandomnessExamples weakRandomnessExamples;
     private final XPathExamples xPathExamples;
     private final XSSExamples xssExamples;
-
     private final HardcodedSecretExamples hardcodedSecretExamples;
+    private final ReflectionExamples reflectionExamples;
 
 
     public AppSecIast(final DataSource dataSource) {
@@ -49,6 +49,7 @@ public class AppSecIast {
         this.xPathExamples = new XPathExamples();
         this.xssExamples = new XSSExamples();
         this.hardcodedSecretExamples = new HardcodedSecretExamples();
+        this.reflectionExamples = new ReflectionExamples();
     }
 
     @RequestMapping("/hardcoded_secrets/test_insecure")
@@ -351,6 +352,17 @@ public class AppSecIast {
     public String insecureAuthProtocol(HttpServletResponse response) {
         response.setStatus(HttpStatus.OK.value());
         return "ok";
+    }
+
+    @GetMapping(value = "/reflection_injection/test_secure")
+    public String secureReflection() {
+        return reflectionExamples.secureClassForName();
+    }
+
+    @GetMapping(value = "/reflection_injection/test_insecure")
+    public String insecureReflection(HttpServletRequest request) {
+        final String className = request.getParameter("param");
+        return reflectionExamples.insecureClassForName(className);
     }
 
 

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
@@ -31,6 +31,7 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         final SsrfExamples ssrf = new SsrfExamples();
         final WeakRandomnessExamples weakRandomness = new WeakRandomnessExamples();
         final XPathExamples xpath = new XPathExamples();
+        final ReflectionExamples reflection = new ReflectionExamples();
 
         router.route("/iast/*").handler(BodyHandler.create());
 
@@ -150,5 +151,13 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         router.get("/iast/insecure-auth-protocol/test").handler(ctx ->
                 ctx.response().end("ok")
         );
+        router.post("/iast/reflection_injection/test_secure").handler(ctx -> {
+            ctx.response().end(reflection.secureClassForName());
+        });
+        router.post("/iast/reflection_injection/test_insecure").handler(ctx -> {
+            final HttpServerRequest request = ctx.request();
+            final String pathParam = request.getParam("param");
+            ctx.response().end(reflection.insecureClassForName(param));
+        });
     }
 }

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSinkRouteProvider.java
@@ -156,7 +156,7 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         });
         router.post("/iast/reflection_injection/test_insecure").handler(ctx -> {
             final HttpServerRequest request = ctx.request();
-            final String pathParam = request.getParam("param");
+            final String param = request.getParam("param");
             ctx.response().end(reflection.insecureClassForName(param));
         });
     }

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
@@ -30,6 +30,7 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         final SqlExamples sql = new SqlExamples(dataSource);
         final WeakRandomnessExamples weakRandomness = new WeakRandomnessExamples();
         final XPathExamples xpath = new XPathExamples();
+        final ReflectionExamples reflection = new ReflectionExamples();
 
         router.route("/iast/*").handler(BodyHandler.create());
 
@@ -155,6 +156,14 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         router.get("/iast/insecure-auth-protocol/test").handler(ctx ->
                 ctx.response().end("ok")
         );
+        router.post("/iast/reflection_injection/test_secure").handler(ctx -> {
+            ctx.response().end(reflection.secureClassForName());
+        });
+        router.post("/iast/reflection_injection/test_insecure").handler(ctx -> {
+            final HttpServerRequest request = ctx.request();
+            final String pathParam = request.getParam("param");
+            ctx.response().end(reflection.insecureClassForName(param));
+        });
 
     }
 }

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSinkRouteProvider.java
@@ -161,7 +161,7 @@ public class IastSinkRouteProvider implements Consumer<Router> {
         });
         router.post("/iast/reflection_injection/test_insecure").handler(ctx -> {
             final HttpServerRequest request = ctx.request();
-            final String pathParam = request.getParam("param");
+            final String param = request.getParam("param");
             ctx.response().end(reflection.insecureClassForName(param));
         });
 


### PR DESCRIPTION
## Motivation

Test REFLECTION_INJECTION detection in Java.

## Changes

Define a new iast_sink_reflection_injection feature
Add new test_reflection_injection.py
Add endpoints for java frameworks

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
