### PR TITLE
OnBoarding tests - FPD reports

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,8 +34,12 @@ stages:
     - pulumi plugin install resource aws 5.41.0
   artifacts:
     when: always
-    paths:
-      - logs_$SCENARIO_SUFIX/  
+    reports:
+      # using the https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportsdotenv trick to fill a job variable for downstream of successor job
+      dotenv: generate.env
+    paths: 
+      - logs_$SCENARIO_SUFIX/
+ 
 variables:
     # Do not modify this - must be the repository name for Kubernetes gitlab runners to run
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: system-tests #helm-charts
@@ -63,6 +67,7 @@ onboarding_nodejs:
          
   script:
       - export SCENARIO_SUFIX=$(echo "$SCENARIO" | tr '[:upper:]' '[:lower:]')
+      - echo "SCENARIO_SUFIX=${SCENARIO_SUFIX}" >> generate.env
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY} 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,6 +163,8 @@ onboarding_parse_results:
   script:
       - |
         for folder in reports/logs*/ ; do
+          cat ${folder}feature_parity.json
+          echo "------------"
           curl -X POST ${FP_IMPORT_URL} \
             --fail \
             --header "Content-Type: application/json" \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ stages:
     - pulumi plugin install resource command 0.7.2
     - pulumi plugin install resource aws 5.41.0
   after_script:
-    - SCENARIO_SUFIX=$(echo "$SCENARIO" | tr '[:upper:]' '[:lower:]')
+    - export SCENARIO_SUFIX=$(echo "$SCENARIO" | tr '[:upper:]' '[:lower:]')
   artifacts:
     when: always
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,16 @@ stages:
     - pulumi login --local #"s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
     - pulumi plugin install resource command 0.7.2
     - pulumi plugin install resource aws 5.41.0
-
+  after_script:
+    - SCENARIO_SUFIX=$(echo "$SCENARIO" | tr '[:upper:]' '[:lower:]')
+    - REPORTS_PATH="reports/"
+    - mkdir -p "$REPORTS_PATH"
+    - cp -R logs_"${SCENARIO_SUFIX}" $REPORTS_PATH/
+    - cp logs_"${SCENARIO_SUFIX}"/feature_parity.json "$REPORTS_PATH"/"${SCENARIO_SUFIX}".json
+  artifacts:
+      when: always
+      paths:
+        - reports/
  
 variables:
     # Do not modify this - must be the repository name for Kubernetes gitlab runners to run
@@ -60,17 +69,9 @@ onboarding_nodejs:
        #   SCENARIO: [ONBOARDING_CONTAINER_INSTALL_MANUAL, ONBOARDING_CONTAINER_INSTALL_SCRIPT, ONBOARDING_CONTAINER_UNINSTALL] 
          
   script:
-      - export SCENARIO_SUFIX=$(echo "$SCENARIO" | tr '[:upper:]' '[:lower:]')
-      - echo "SCENARIO_SUFIX=${SCENARIO_SUFIX}" >> generate.env
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY} 
-  artifacts:
-    when: always
-    reports:
-      # using the https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportsdotenv trick to fill a job variable for downstream of successor job
-      dotenv: generate.env
-    paths: 
-      - logs_$SCENARIO_SUFIX/
+
 .onboarding_java:
   extends: .base_job_onboarding
   stage: java_tracer
@@ -161,7 +162,7 @@ onboarding_parse_results:
     - export FP_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.fp-api-key --with-decryption --query "Parameter.Value" --out text) 
   script:
       - |
-        for folder in logs*/ ; do
+        for folder in reports/logs*/ ; do
           curl -X POST ${FP_IMPORT_URL} \
             --fail \
             --header "Content-Type: application/json" \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
 stages:
-  - ruby_tracer
+  #- ruby_tracer
   - nodejs_tracer
-  - java_tracer
-  - python_tracer
-  - dotnet_tracer
+  #- java_tracer
+  #- python_tracer
+  #- dotnet_tracer
   - parse_results
   - before_tests
 
@@ -32,16 +32,11 @@ stages:
     - pulumi login --local #"s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
     - pulumi plugin install resource command 0.7.2
     - pulumi plugin install resource aws 5.41.0
-  after_script:
-    - SCENARIO_SUFIX=$(echo "$SCENARIO" | tr '[:upper:]' '[:lower:]')
-    - REPORTS_PATH="reports/$ONBOARDING_FILTER_ENV/$TEST_LIBRARY/$ONBOARDING_FILTER_WEBLOG"
-    - mkdir -p "$REPORTS_PATH"
-    - cp -R logs_"${SCENARIO_SUFIX}" $REPORTS_PATH/
-    - cp logs_"${SCENARIO_SUFIX}"/feature_parity.json "$REPORTS_PATH"/"${SCENARIO_SUFIX}".json
+
   artifacts:
       when: always
       paths:
-        - reports/
+        - logs_*/
 variables:
     # Do not modify this - must be the repository name for Kubernetes gitlab runners to run
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: system-tests #helm-charts
@@ -58,18 +53,20 @@ onboarding_nodejs:
     TEST_LIBRARY: "nodejs"
   parallel:
       matrix:
-        - ONBOARDING_FILTER_ENV: [dev, prod]
+        #- ONBOARDING_FILTER_ENV: [dev, prod]
+        - ONBOARDING_FILTER_ENV: [dev]
           ONBOARDING_FILTER_WEBLOG: [test-app-nodejs]
-          SCENARIO: [ONBOARDING_HOST_INSTALL_MANUAL,ONBOARDING_CONTAINER_INSTALL_MANUAL, ONBOARDING_HOST_INSTALL_SCRIPT, ONBOARDING_CONTAINER_INSTALL_SCRIPT, ONBOARDING_HOST_UNINSTALL,ONBOARDING_CONTAINER_UNINSTALL, ONBOARDING_HOST_BLOCK_LIST] 
-        - ONBOARDING_FILTER_ENV: [dev, prod]
-          ONBOARDING_FILTER_WEBLOG: [test-app-nodejs-alpine]
-          SCENARIO: [ONBOARDING_CONTAINER_INSTALL_MANUAL, ONBOARDING_CONTAINER_INSTALL_SCRIPT, ONBOARDING_CONTAINER_UNINSTALL] 
+          SCENARIO: [ONBOARDING_HOST_INSTALL_MANUAL] 
+        #  SCENARIO: [ONBOARDING_HOST_INSTALL_MANUAL,ONBOARDING_CONTAINER_INSTALL_MANUAL, ONBOARDING_HOST_INSTALL_SCRIPT, ONBOARDING_CONTAINER_INSTALL_SCRIPT, ONBOARDING_HOST_UNINSTALL,ONBOARDING_CONTAINER_UNINSTALL, ONBOARDING_HOST_BLOCK_LIST] 
+       # - ONBOARDING_FILTER_ENV: [dev, prod]
+       #   ONBOARDING_FILTER_WEBLOG: [test-app-nodejs-alpine]
+       #   SCENARIO: [ONBOARDING_CONTAINER_INSTALL_MANUAL, ONBOARDING_CONTAINER_INSTALL_SCRIPT, ONBOARDING_CONTAINER_UNINSTALL] 
          
   script:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY} 
       
-onboarding_java:
+.onboarding_java:
   extends: .base_job_onboarding
   stage: java_tracer
   allow_failure: true
@@ -90,7 +87,7 @@ onboarding_java:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY}
 
-onboarding_python:
+.onboarding_python:
   extends: .base_job_onboarding
   stage: python_tracer
   allow_failure: true
@@ -111,7 +108,7 @@ onboarding_python:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY} 
 
-onboarding_dotnet:
+.onboarding_dotnet:
   extends: .base_job_onboarding
   stage: dotnet_tracer
   allow_failure: true
@@ -129,7 +126,7 @@ onboarding_dotnet:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY}
 
-onboarding_ruby:
+.onboarding_ruby:
   extends: .base_job_onboarding
   stage: ruby_tracer
   allow_failure: true
@@ -153,13 +150,22 @@ onboarding_parse_results:
   stage: parse_results
   only:
     - schedules
+  rules:
+    - if: $CI_COMMIT_BRANCH == "robertomonteromiguel/onboarding_feature_parity_dashboard"
   before_script:
-    - export GITHUB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.gh-token --with-decryption --query "Parameter.Value" --out text) 
     #We need authenticate on git repository
-    - export GITHUB_USER=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.gh-user --with-decryption --query "Parameter.Value" --out text) 
-    - export GITHUB_MAIL=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.gh-mail --with-decryption --query "Parameter.Value" --out text) 
+    - export FP_IMPORT_URL=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.fp-import-url --with-decryption --query "Parameter.Value" --out text) 
+    - export FP_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.fp-api-key --with-decryption --query "Parameter.Value" --out text) 
   script:
-      - sh utils/scripts/push_reports_dashboard.sh
+      - |
+        for folder in logs*/ ; do
+          curl -X POST ${FP_IMPORT_URL} \
+            --fail
+            --header "Content-Type: application/json" \
+            --header "FP_API_KEY: ${FP_API_KEY}" \
+            --data "@./${folder}feature_parity.json" \
+            --include
+        done
 
 check_merge_labels:
   image: registry.ddbuild.io/images/ci_docker_base

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,11 +32,12 @@ stages:
     - pulumi login --local #"s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
     - pulumi plugin install resource command 0.7.2
     - pulumi plugin install resource aws 5.41.0
-
+  after_script:
+    - SCENARIO_SUFIX=$(echo "$SCENARIO" | tr '[:upper:]' '[:lower:]')
   artifacts:
-      when: always
-      paths:
-        - logs_*/
+    when: always
+    paths:
+      - logs_$SCENARIO_SUFIX/  
 variables:
     # Do not modify this - must be the repository name for Kubernetes gitlab runners to run
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: system-tests #helm-charts
@@ -65,7 +66,7 @@ onboarding_nodejs:
   script:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY} 
-      
+
 .onboarding_java:
   extends: .base_job_onboarding
   stage: java_tracer
@@ -158,7 +159,8 @@ onboarding_parse_results:
       - |
         for folder in logs*/ ; do
           curl -X POST ${FP_IMPORT_URL} \
-            --fail
+            --fail \
+            --header "Content-Type: application/json" \
             --header "FP_API_KEY: ${FP_API_KEY}" \
             --data "@./${folder}feature_parity.json" \
             --include

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,8 +150,6 @@ onboarding_parse_results:
   stage: parse_results
   only:
     - schedules
-  rules:
-    - if: $CI_COMMIT_BRANCH == "robertomonteromiguel/onboarding_feature_parity_dashboard"
   before_script:
     #We need authenticate on git repository
     - export FP_IMPORT_URL=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.fp-import-url --with-decryption --query "Parameter.Value" --out text) 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,13 +32,7 @@ stages:
     - pulumi login --local #"s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
     - pulumi plugin install resource command 0.7.2
     - pulumi plugin install resource aws 5.41.0
-  artifacts:
-    when: always
-    reports:
-      # using the https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportsdotenv trick to fill a job variable for downstream of successor job
-      dotenv: generate.env
-    paths: 
-      - logs_$SCENARIO_SUFIX/
+
  
 variables:
     # Do not modify this - must be the repository name for Kubernetes gitlab runners to run
@@ -70,7 +64,13 @@ onboarding_nodejs:
       - echo "SCENARIO_SUFIX=${SCENARIO_SUFIX}" >> generate.env
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY} 
-
+  artifacts:
+    when: always
+    reports:
+      # using the https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportsdotenv trick to fill a job variable for downstream of successor job
+      dotenv: generate.env
+    paths: 
+      - logs_$SCENARIO_SUFIX/
 .onboarding_java:
   extends: .base_job_onboarding
   stage: java_tracer

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
 stages:
-  #- ruby_tracer
+  - ruby_tracer
   - nodejs_tracer
-  #- java_tracer
-  #- python_tracer
-  #- dotnet_tracer
+  - java_tracer
+  - python_tracer
+  - dotnet_tracer
   - parse_results
   - before_tests
 
@@ -59,20 +59,17 @@ onboarding_nodejs:
     TEST_LIBRARY: "nodejs"
   parallel:
       matrix:
-        #- ONBOARDING_FILTER_ENV: [dev, prod]
-        - ONBOARDING_FILTER_ENV: [dev]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
           ONBOARDING_FILTER_WEBLOG: [test-app-nodejs]
-          SCENARIO: [ONBOARDING_HOST_INSTALL_MANUAL] 
-        #  SCENARIO: [ONBOARDING_HOST_INSTALL_MANUAL,ONBOARDING_CONTAINER_INSTALL_MANUAL, ONBOARDING_HOST_INSTALL_SCRIPT, ONBOARDING_CONTAINER_INSTALL_SCRIPT, ONBOARDING_HOST_UNINSTALL,ONBOARDING_CONTAINER_UNINSTALL, ONBOARDING_HOST_BLOCK_LIST] 
-       # - ONBOARDING_FILTER_ENV: [dev, prod]
-       #   ONBOARDING_FILTER_WEBLOG: [test-app-nodejs-alpine]
-       #   SCENARIO: [ONBOARDING_CONTAINER_INSTALL_MANUAL, ONBOARDING_CONTAINER_INSTALL_SCRIPT, ONBOARDING_CONTAINER_UNINSTALL] 
-         
+          SCENARIO: [ONBOARDING_HOST_INSTALL_MANUAL,ONBOARDING_CONTAINER_INSTALL_MANUAL, ONBOARDING_HOST_INSTALL_SCRIPT, ONBOARDING_CONTAINER_INSTALL_SCRIPT, ONBOARDING_HOST_UNINSTALL,ONBOARDING_CONTAINER_UNINSTALL, ONBOARDING_HOST_BLOCK_LIST] 
+        - ONBOARDING_FILTER_ENV: [dev, prod]
+          ONBOARDING_FILTER_WEBLOG: [test-app-nodejs-alpine]
+          SCENARIO: [ONBOARDING_CONTAINER_INSTALL_MANUAL, ONBOARDING_CONTAINER_INSTALL_SCRIPT, ONBOARDING_CONTAINER_UNINSTALL]      
   script:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY} 
 
-.onboarding_java:
+onboarding_java:
   extends: .base_job_onboarding
   stage: java_tracer
   allow_failure: true
@@ -93,7 +90,7 @@ onboarding_nodejs:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY}
 
-.onboarding_python:
+onboarding_python:
   extends: .base_job_onboarding
   stage: python_tracer
   allow_failure: true
@@ -114,7 +111,7 @@ onboarding_nodejs:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY} 
 
-.onboarding_dotnet:
+onboarding_dotnet:
   extends: .base_job_onboarding
   stage: dotnet_tracer
   allow_failure: true
@@ -132,7 +129,7 @@ onboarding_nodejs:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY}
 
-.onboarding_ruby:
+onboarding_ruby:
   extends: .base_job_onboarding
   stage: ruby_tracer
   allow_failure: true
@@ -163,8 +160,6 @@ onboarding_parse_results:
   script:
       - |
         for folder in reports/logs*/ ; do
-          cat ${folder}feature_parity.json
-          echo "------------"
           curl -X POST ${FP_IMPORT_URL} \
             --fail \
             --header "Content-Type: application/json" \
@@ -185,4 +180,3 @@ check_merge_labels:
     - ./utils/scripts/get_pr_merged_labels.sh
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,8 +32,6 @@ stages:
     - pulumi login --local #"s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
     - pulumi plugin install resource command 0.7.2
     - pulumi plugin install resource aws 5.41.0
-  after_script:
-    - export SCENARIO_SUFIX=$(echo "$SCENARIO" | tr '[:upper:]' '[:lower:]')
   artifacts:
     when: always
     paths:
@@ -64,6 +62,7 @@ onboarding_nodejs:
        #   SCENARIO: [ONBOARDING_CONTAINER_INSTALL_MANUAL, ONBOARDING_CONTAINER_INSTALL_SCRIPT, ONBOARDING_CONTAINER_UNINSTALL] 
          
   script:
+      - export SCENARIO_SUFIX=$(echo "$SCENARIO" | tr '[:upper:]' '[:lower:]')
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --obd-weblog ${ONBOARDING_FILTER_WEBLOG} --obd-env ${ONBOARDING_FILTER_ENV} --obd-library ${TEST_LIBRARY} 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,7 +159,6 @@ onboarding_parse_results:
         for folder in logs*/ ; do
           curl -X POST ${FP_IMPORT_URL} \
             --fail
-            --header "Content-Type: application/json" \
             --header "FP_API_KEY: ${FP_API_KEY}" \
             --data "@./${folder}feature_parity.json" \
             --include


### PR DESCRIPTION
## Motivation

Avoid commiting reports to system-tests-dashboard.
Push the results to FPD without commiting  on system-tests-dashboard

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
