### PR TITLE
Java will report telemtry config settings in snake_case

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -472,7 +472,7 @@ class Test_Telemetry:
             "nodejs": {"hostname": "proxy", "port": 8126, "appsec.enabled": True},
             # to-do :need to add configuration keys once python bug is fixed
             "python": {},
-            "java": {"trace.agent.port": 8126, "telemetry.heartbeat.interval": 2},
+            "java": {"trace_agent_port": 8126, "telemetry_heartbeat_interval": 2},
         }
         configuration_map = test_configuration[context.library.library]
 
@@ -482,9 +482,12 @@ class Test_Telemetry:
                 configurations = content["payload"]["configuration"]
                 configurations_present = []
                 for cnf in configurations:
-                    if cnf["name"] in configuration_map:
-                        configuration_name = cnf["name"]
-                        expected_value = str(configuration_map.get(cnf["name"]))
+                    configuration_name = cnf["name"]
+                    if context.library.library == "java":
+                        # support for older versions of Java Tracer
+                        configuration_name = configuration_name.replace(".", "_")
+                    if configuration_name in configuration_map:
+                        expected_value = str(configuration_map.get(configuration_name))
                         configuration_value = str(cnf["value"])
                         if configuration_value != expected_value:
                             raise Exception(


### PR DESCRIPTION
## Motivation

Java will report telemetry config settings in snake_case. 

## Changes

Supports both new snake_case and old Java format for reported config settings. See https://github.com/DataDog/dd-trace-java/pull/6694 that introduced snake_case formats

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
