### PR TITLE
Use v0.33.0 of opentracing-contrib/nginx-opentracing

### DIFF
--- a/utils/build/docker/cpp/nginx/install_ddtrace.sh
+++ b/utils/build/docker/cpp/nginx/install_ddtrace.sh
@@ -8,7 +8,11 @@ get_latest_release() {
 
 NGINX_VERSION=1.17.3
 
-OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
+# https://github.com/opentracing-contrib/nginx-opentracing/issues/586
+# ot16 file are missing from the latest release of nginx-opentracing
+# OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
+OPENTRACING_NGINX_VERSION="v0.33.0"
+
 DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
 
 echo "opentracing-contrib/nginx-opentracing version: $OPENTRACING_NGINX_VERSION"


### PR DESCRIPTION
## Motivation

See opentracing-contrib/nginx-opentracing#586 , some assets are missing from their last release

## Changes

Use v0.33 of opentracing-contrib/nginx-opentracing


## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
