### PR TITLE
Use Nginx Opentracing 0.34

### DIFF
--- a/utils/build/docker/cpp/nginx/install_ddtrace.sh
+++ b/utils/build/docker/cpp/nginx/install_ddtrace.sh
@@ -8,10 +8,7 @@ get_latest_release() {
 
 NGINX_VERSION=1.17.3
 
-# https://github.com/opentracing-contrib/nginx-opentracing/issues/586
-# ot16 file are missing from the latest release of nginx-opentracing
-# OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
-OPENTRACING_NGINX_VERSION="v0.34.0"
+OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
 
 DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
 

--- a/utils/build/docker/cpp/nginx/install_ddtrace.sh
+++ b/utils/build/docker/cpp/nginx/install_ddtrace.sh
@@ -11,7 +11,7 @@ NGINX_VERSION=1.17.3
 # https://github.com/opentracing-contrib/nginx-opentracing/issues/586
 # ot16 file are missing from the latest release of nginx-opentracing
 # OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
-OPENTRACING_NGINX_VERSION="v0.33.0"
+OPENTRACING_NGINX_VERSION="v0.34.0"
 
 DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
 
@@ -23,7 +23,7 @@ echo "0.0.0" > SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 
 # Install NGINX plugin for OpenTracing
 wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz
-tar zxf linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
+tar zxf linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
 # Install Datadog Opentracing C++ Plugin
 wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz
 gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so


### PR DESCRIPTION
## Motivation

In new version of Nginx Opentracing modules, there is no anymore modules for Opentracing 1.5.
It means default modules built against only with Opentracing 1.6.0

References: https://github.com/opentracing-contrib/nginx-opentracing/pull/528

Solves problem https://github.com/DataDog/system-tests/pull/2162

cc: @cbeauchesne 

## Changes

Use latest Nginx Opentracing modules

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
