### PR TITLE
Support for meta_struct payloads in traces

### DIFF
--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -638,10 +638,12 @@ class Test_BlockingGraphqlResolvers:
     def test_request_block_attack(self):
         assert self.r_attack.status_code == 403
         for _, span in interfaces.library.get_root_spans(request=self.r_attack):
-            meta = span.get("meta", {}) | span.get("meta_struct", {})
+            meta = span.get("meta", {})
+            meta_struct = span.get("meta_struct", {})
             assert meta["appsec.event"] == "true"
-            assert "_dd.appsec.json" in meta
-            rule_triggered = meta["_dd.appsec.json"]["triggers"][0]
+            assert ("_dd.appsec.json" in meta) ^ ("appsec" in meta_struct)
+            appsec = meta.get("_dd.appsec.json", {}) or meta_struct.get("appsec", {})
+            rule_triggered = appsec["triggers"][0]
             parameters = rule_triggered["rule_matches"][0]["parameters"][0]
             assert (
                 parameters["address"] == "graphql.server.all_resolvers"
@@ -675,10 +677,12 @@ class Test_BlockingGraphqlResolvers:
     def test_request_block_attack_directive(self):
         assert self.r_attack.status_code == 403
         for _, span in interfaces.library.get_root_spans(request=self.r_attack):
-            meta = span.get("meta", {}) | span.get("meta_struct", {})
+            meta = span.get("meta", {})
+            meta_struct = span.get("meta_struct", {})
             assert meta["appsec.event"] == "true"
-            assert "_dd.appsec.json" in meta
-            rule_triggered = meta["_dd.appsec.json"]["triggers"][0]
+            assert ("_dd.appsec.json" in meta) ^ ("appsec" in meta_struct)
+            appsec = meta.get("_dd.appsec.json", {}) or meta_struct.get("appsec", {})
+            rule_triggered = appsec["triggers"][0]
             assert rule_triggered["rule"]["id"] == "block-resolvers"
             parameters = rule_triggered["rule_matches"][0]["parameters"][0]
             assert (

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -638,7 +638,7 @@ class Test_BlockingGraphqlResolvers:
     def test_request_block_attack(self):
         assert self.r_attack.status_code == 403
         for _, span in interfaces.library.get_root_spans(request=self.r_attack):
-            meta = span.get("meta", {})
+            meta = span.get("meta", {}) | span.get("meta_struct", {})
             assert meta["appsec.event"] == "true"
             assert "_dd.appsec.json" in meta
             rule_triggered = meta["_dd.appsec.json"]["triggers"][0]
@@ -675,7 +675,7 @@ class Test_BlockingGraphqlResolvers:
     def test_request_block_attack_directive(self):
         assert self.r_attack.status_code == 403
         for _, span in interfaces.library.get_root_spans(request=self.r_attack):
-            meta = span.get("meta", {})
+            meta = span.get("meta", {}) | span.get("meta_struct", {})
             assert meta["appsec.event"] == "true"
             assert "_dd.appsec.json" in meta
             rule_triggered = meta["_dd.appsec.json"]["triggers"][0]

--- a/utils/interfaces/_agent.py
+++ b/utils/interfaces/_agent.py
@@ -39,11 +39,9 @@ class AgentInterfaceValidator(ProxyBasedInterfaceValidator):
             for payload in content:
                 for chunk in payload["chunks"]:
                     for span in chunk["spans"]:
-
-                        if "meta" not in span or "_dd.appsec.json" not in span["meta"]:
+                        appsec_data = span.get("meta",{}).get("_dd.appsec.json", None) or span.get("meta_struct",{}).get("_dd.appsec.json", None)
+                        if appsec_data is None:
                             continue
-
-                        appsec_data = span["meta"]["_dd.appsec.json"]
 
                         if rid is None:
                             yield data, payload, chunk, span, appsec_data

--- a/utils/interfaces/_agent.py
+++ b/utils/interfaces/_agent.py
@@ -41,7 +41,7 @@ class AgentInterfaceValidator(ProxyBasedInterfaceValidator):
                     for span in chunk["spans"]:
                         appsec_data = span.get("meta", {}).get("_dd.appsec.json", None) or span.get(
                             "meta_struct", {}
-                        ).get("_dd.appsec.json", None)
+                        ).get("appsec", None)
                         if appsec_data is None:
                             continue
 

--- a/utils/interfaces/_agent.py
+++ b/utils/interfaces/_agent.py
@@ -39,7 +39,9 @@ class AgentInterfaceValidator(ProxyBasedInterfaceValidator):
             for payload in content:
                 for chunk in payload["chunks"]:
                     for span in chunk["spans"]:
-                        appsec_data = span.get("meta",{}).get("_dd.appsec.json", None) or span.get("meta_struct",{}).get("_dd.appsec.json", None)
+                        appsec_data = span.get("meta", {}).get("_dd.appsec.json", None) or span.get(
+                            "meta_struct", {}
+                        ).get("_dd.appsec.json", None)
                         if appsec_data is None:
                             continue
 

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -92,12 +92,12 @@ class LibraryInterfaceValidator(ProxyBasedInterfaceValidator):
 
     def get_appsec_events(self, request=None, full_trace=False):
         for data, trace, span in self.get_spans(request=request, full_trace=full_trace):
-            if "_dd.appsec.json" in span.get("meta_struct", {}):
+            if "appsec" in span.get("meta_struct", {}):
 
                 if request:  # do not spam log if all data are sent to the validator
                     logger.debug(f"Try to find relevant appsec data in {data['log_filename']}; span #{span['span_id']}")
 
-                appsec_data = span["meta_struct"]["_dd.appsec.json"]
+                appsec_data = span["meta_struct"]["appsec"]
                 yield data, trace, span, appsec_data
             elif "_dd.appsec.json" in span.get("meta", {}):
 

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -92,7 +92,14 @@ class LibraryInterfaceValidator(ProxyBasedInterfaceValidator):
 
     def get_appsec_events(self, request=None, full_trace=False):
         for data, trace, span in self.get_spans(request=request, full_trace=full_trace):
-            if "_dd.appsec.json" in span.get("meta", {}):
+            if "_dd.appsec.json" in span.get("meta_struct", {}):
+
+                if request:  # do not spam log if all data are sent to the validator
+                    logger.debug(f"Try to find relevant appsec data in {data['log_filename']}; span #{span['span_id']}")
+
+                appsec_data = span["meta_struct"]["_dd.appsec.json"]
+                yield data, trace, span, appsec_data
+            elif "_dd.appsec.json" in span.get("meta", {}):
 
                 if request:  # do not spam log if all data are sent to the validator
                     logger.debug(f"Try to find relevant appsec data in {data['log_filename']}; span #{span['span_id']}")

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -211,16 +211,22 @@ def _deserialize_meta(span):
             meta[key] = json.loads(meta[key])
 
 
-def _convert_bytes_values(item):
+def _convert_bytes_values(item, path=""):
     if isinstance(item, dict):
         for key in item:
             if isinstance(item[key], bytes):
-                item[key] = item[key].decode("ascii")
+                try:
+                    item[key] = item[key].decode("ascii")
+                except UnicodeDecodeError as e:
+                    if path == "[][].meta_struct":
+                        item[key] = msgpack.unpackb(item[key], unicode_errors="replace", strict_map_key=False)
+                    else:
+                        raise ValueError(f"Error decoding {path}") from e
             elif isinstance(item[key], dict):
-                _convert_bytes_values(item[key])
+                _convert_bytes_values(item[key], f"{path}.{key}")
     elif isinstance(item, (list, tuple)):
         for value in item:
-            _convert_bytes_values(value)
+            _convert_bytes_values(value, f"{path}[]")
 
 
 def deserialize(data, key, content, interface):


### PR DESCRIPTION
## Motivation

Support new data format. DataDog/dd-trace-py#8474

## Changes

Support for msgpack in msgpack.

Decoded payload  (meta is collapsed in this screenshot) 

![image](https://github.com/DataDog/system-tests/assets/11915659/28ea1c51-f364-4df4-92c8-16d8b5534bfe)

Add support for appsec json structure in meta struct in all tests. Tracers moving the data from meta to meta struct should not see any changes in system tests.

Tested with https://github.com/DataDog/dd-trace-py/pull/8474, both on CI and locally with all appsec tests 

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
