### PR TITLE
Fix OnBoarding container from binaries folder

### DIFF
--- a/utils/build/virtual_machine/provisions/container-auto-inject/auto-inject_container_manual.yml
+++ b/utils/build/virtual_machine/provisions/container-auto-inject/auto-inject_container_manual.yml
@@ -23,7 +23,16 @@
         echo "Instaling datadog-apm-inject from remote repository"
         sudo apt install -y --reinstall -t $DD_deb_repo_name datadog-apm-inject
     fi
-    sudo apt-get install -y --reinstall -t $DD_deb_repo_name datadog-apm-library-$DD_LANG
+
+    if [ -e datadog-apm-library-$DD_LANG_*_$architecture.deb ]
+    then
+        echo "Instaling datadog-apm-library-$DD_LANG from local folder"
+        sudo apt install -y --reinstall ./datadog-apm-library-$DD_LANG_*_$architecture.deb
+    else
+        echo "Instaling datadog-apm-library-$DD_LANG from remote repository"
+        sudo apt install -y --reinstall -t $DD_deb_repo_name datadog-apm-library-$DD_LANG
+    fi
+
     dd-container-install
     sudo cp docker_config.yaml /etc/datadog-agent/inject/docker_config.yaml
     sudo cp debug_config.yaml /etc/datadog-agent/inject/debug_config.yaml
@@ -52,7 +61,15 @@
         echo "Instaling datadog-apm-inject from remote repository"
         sudo yum -q list installed datadog-apm-inject &>/dev/null && sudo yum -y reinstall --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject || sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject
     fi
-    sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-library-$DD_LANG
+
+    if [ -e datadog-apm-library-$DD_LANG-*.$architecture.rpm ]
+    then
+        echo "Instaling datadog-apm-library-$DD_LANG from local folder"
+        sudo yum -q list installed datadog-apm-library-$DD_LANG &>/dev/null && sudo yum -y reinstall --disablerepo="*" datadog-apm-library-$DD_LANG-*.$architecture.rpm || sudo yum -y install --disablerepo="*" datadog-apm-library-$DD_LANG-*.$architecture.rpm
+    else
+        echo "Instaling datadog-apm-library-$DD_LANG from remote repository"
+        sudo yum -q list installed datadog-apm-library-$DD_LANG &>/dev/null && sudo yum -y reinstall --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-library-$DD_LANG || sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-library-$DD_LANG
+    fi
     dd-container-install
     sudo cp docker_config.yaml /etc/datadog-agent/inject/docker_config.yaml
     sudo cp debug_config.yaml /etc/datadog-agent/inject/debug_config.yaml


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Load installation "datadog-apm-library-lang" from binaries folder if exists

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
