### PR TITLE
OnBoarding create a minimal scenario

### DIFF
--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -129,6 +129,22 @@ class TestHostAutoInjectManual(_AutoInjectBaseTest):
         logger.info(f"Done test_uninstall for : [{virtual_machine.name}]...")
 
 
+@features.host_auto_installation_script
+@scenarios.host_auto_injection_install_script
+class TestHostAutoInjectInstallScript(_AutoInjectBaseTest):
+    def test_install(self, virtual_machine):
+        self._test_install(virtual_machine)
+
+
+@features.host_auto_instrumentation
+@scenarios.simple_host_auto_injection
+class TestSimpleHostAutoInjectManual(_AutoInjectBaseTest):
+    def test_install(self, virtual_machine):
+        logger.info(f"Launching test_install for : [{virtual_machine.name}]...")
+        self._test_install(virtual_machine)
+        logger.info(f"Done test_install for : [{virtual_machine.name}]")
+
+
 @features.container_auto_instrumentation
 @scenarios.container_auto_injection
 class TestContainerAutoInjectManual(_AutoInjectBaseTest):
@@ -145,16 +161,16 @@ class TestContainerAutoInjectManual(_AutoInjectBaseTest):
         )
 
 
-@features.host_auto_installation_script
-@scenarios.host_auto_injection_install_script
-class TestHostAutoInjectInstallScript(_AutoInjectBaseTest):
+@features.container_auto_installation_script
+@scenarios.container_auto_injection_install_script
+class TestContainerAutoInjectInstallScript(_AutoInjectBaseTest):
     def test_install(self, virtual_machine):
         self._test_install(virtual_machine)
 
 
-@features.container_auto_installation_script
-@scenarios.container_auto_injection_install_script
-class TestContainerAutoInjectInstallScript(_AutoInjectBaseTest):
+@features.container_auto_instrumentation
+@scenarios.simple_container_auto_injection
+class TestSimpleContainerAutoInjectManual(_AutoInjectBaseTest):
     def test_install(self, virtual_machine):
         self._test_install(virtual_machine)
 

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1064,6 +1064,38 @@ class _VirtualMachineScenario(_Scenario):
             test["description"] = test["path"][last_index:]
 
 
+class HostAutoInjectionScenario(_VirtualMachineScenario):
+    def __init__(self, name, doc, vm_provision="host-auto-inject") -> None:
+        super().__init__(
+            name,
+            vm_provision=vm_provision,
+            doc=doc,
+            include_ubuntu_22_amd64=True,
+            include_ubuntu_22_arm64=True,
+            include_ubuntu_18_amd64=True,
+            include_amazon_linux_2_amd64=True,
+            include_amazon_linux_2_dotnet_6=True,
+            include_amazon_linux_2023_amd64=True,
+            include_amazon_linux_2023_arm64=True,
+        )
+
+
+class ContainerAutoInjectionScenario(_VirtualMachineScenario):
+    def __init__(self, name, doc, vm_provision="container-auto-inject") -> None:
+        super().__init__(
+            name,
+            vm_provision=vm_provision,
+            doc=doc,
+            include_ubuntu_22_amd64=True,
+            include_ubuntu_22_arm64=True,
+            include_ubuntu_18_amd64=True,
+            include_amazon_linux_2_amd64=False,
+            include_amazon_linux_2_dotnet_6=False,
+            include_amazon_linux_2023_amd64=True,
+            include_amazon_linux_2023_arm64=True,
+        )
+
+
 class scenarios:
     todo = _Scenario("TODO", doc="scenario that skips tests not yet executed")
     test_the_test = TestTheTestScenario("TEST_THE_TEST", doc="Small scenario that check system-tests internals")
@@ -1493,66 +1525,33 @@ class scenarios:
 
     fuzzer = _DockerScenario("_FUZZER", doc="Fake scenario for fuzzing (launch without pytest)")
 
-    host_auto_injection = _VirtualMachineScenario(
-        "HOST_AUTO_INJECTION",
-        vm_provision="host-auto-inject",
-        doc="Onboarding Host Single Step Instrumentation scenario",
-        include_ubuntu_22_amd64=True,
-        include_ubuntu_22_arm64=True,
-        include_ubuntu_18_amd64=True,
-        include_amazon_linux_2_amd64=True,
-        include_amazon_linux_2_dotnet_6=True,
-        include_amazon_linux_2023_amd64=True,
-        include_amazon_linux_2023_arm64=True,
+    host_auto_injection = HostAutoInjectionScenario(
+        "HOST_AUTO_INJECTION", "Onboarding Host Single Step Instrumentation scenario",
     )
-    host_auto_injection_block_list = _VirtualMachineScenario(
+    simple_host_auto_injection = HostAutoInjectionScenario(
+        "SIMPLE_HOST_AUTO_INJECTION", "Onboarding Host Single Step Instrumentation scenario (minimal test scenario)",
+    )
+    host_auto_injection_block_list = HostAutoInjectionScenario(
         "HOST_AUTO_INJECTION_BLOCK_LIST",
-        vm_provision="host-auto-inject",
-        doc="Onboarding Host Single Step Instrumentation scenario: Test user defined blocking lists",
-        include_ubuntu_22_amd64=True,
-        include_ubuntu_22_arm64=True,
-        include_ubuntu_18_amd64=True,
-        include_amazon_linux_2_amd64=True,
-        include_amazon_linux_2_dotnet_6=True,
-        include_amazon_linux_2023_amd64=True,
-        include_amazon_linux_2023_arm64=True,
+        "Onboarding Host Single Step Instrumentation scenario: Test user defined blocking lists",
     )
-    host_auto_injection_install_script = _VirtualMachineScenario(
+    host_auto_injection_install_script = HostAutoInjectionScenario(
         "HOST_AUTO_INJECTION_INSTALL_SCRIPT",
+        "Onboarding Host Single Step Instrumentation scenario using agent auto install script",
         vm_provision="host-auto-inject-install-script",
-        doc="Onboarding Host Single Step Instrumentation scenario using agent auto install script",
-        include_ubuntu_22_amd64=True,
-        include_ubuntu_22_arm64=True,
-        include_ubuntu_18_amd64=True,
-        include_amazon_linux_2_amd64=True,
-        include_amazon_linux_2_dotnet_6=True,
-        include_amazon_linux_2023_amd64=True,
-        include_amazon_linux_2023_arm64=True,
     )
 
-    container_auto_injection = _VirtualMachineScenario(
-        "CONTAINER_AUTO_INJECTION",
-        vm_provision="container-auto-inject",
-        doc="Onboarding Container Single Step Instrumentation scenario",
-        include_ubuntu_22_amd64=True,
-        include_ubuntu_22_arm64=True,
-        include_ubuntu_18_amd64=True,
-        include_amazon_linux_2_amd64=False,
-        include_amazon_linux_2_dotnet_6=False,
-        include_amazon_linux_2023_amd64=True,
-        include_amazon_linux_2023_arm64=True,
+    container_auto_injection = ContainerAutoInjectionScenario(
+        "CONTAINER_AUTO_INJECTION", "Onboarding Container Single Step Instrumentation scenario",
     )
-    container_auto_injection_install_script = _VirtualMachineScenario(
+    simple_container_auto_injection = ContainerAutoInjectionScenario(
+        "SIMPLE_CONTAINER_AUTO_INJECTION",
+        "Onboarding Container Single Step Instrumentation scenario (minimal test scenario)",
+    )
+    container_auto_injection_install_script = ContainerAutoInjectionScenario(
         "CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT",
-        vm_provision="container-auto-inject",
-        doc="Onboarding Container Single Step Instrumentation scenario",
-        include_ubuntu_22_amd64=True,
-        include_ubuntu_22_arm64=True,
-        include_ubuntu_18_amd64=True,
-        include_amazon_linux_2_amd64=False,
-        include_amazon_linux_2_dotnet_6=False,
-        include_amazon_linux_2023_amd64=True,
-        include_amazon_linux_2023_arm64=True,
+        "Onboarding Container Single Step Instrumentation scenario using agent auto install script",
+        vm_provision="container-auto-inject-install-script",
     )
 
 


### PR DESCRIPTION
## Motivation

Define minimal onboarding test scenario to be launched on the tracers pipelines
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
