### PR TITLE
Add .net mapping for telemetry reporting tests

### DIFF
--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -12,20 +12,20 @@ from utils import context, scenarios, rfc, features
 
 
 telemetry_name_mapping = {
-    "trace_sample_rate": {"dotnet": "TODO",},
-    "logs_injection_enabled": {"dotnet": "TODO",},
-    "trace_header_tags": {"dotnet": "TODO",},
-    "trace_tags": {"dotnet": "TODO",},
-    "trace_enabled": {"dotnet": "TODO",},
-    "profiling_enabled": {"dotnet": "TODO",},
-    "appsec_enabled": {"dotnet": "TODO",},
-    "data_streams_enabled": {"dotnet": "TODO",},
+    "trace_sample_rate": {"dotnet": "DD_TRACE_SAMPLE_RATE",},
+    "logs_injection_enabled": {"dotnet": "DD_LOGS_INJECTION",},
+    "trace_header_tags": {"dotnet": "DD_TRACE_HEADER_TAGS",},
+    "trace_tags": {"dotnet": "DD_TAGS",},
+    "trace_enabled": {"dotnet": "DD_TRACE_ENABLED",},
+    "profiling_enabled": {"dotnet": "DD_PROFILING_ENABLED",},
+    "appsec_enabled": {"dotnet": "DD_APPSEC_ENABLED",},
+    "data_streams_enabled": {"dotnet": "DD_DATA_STREAMS_ENABLED",},
 }
 
 
 def _mapped_telemetry_name(context, apm_telemetry_name):
     if apm_telemetry_name in telemetry_name_mapping:
-        mapped_name = telemetry_name_mapping[apm_telemetry_name].get(context.library)
+        mapped_name = telemetry_name_mapping[apm_telemetry_name].get(context.library.library)
         if mapped_name is not None:
             return mapped_name
     return apm_telemetry_name
@@ -112,8 +112,8 @@ class Test_Environment:
             ("logs_injection_enabled", ("true", True)),
             (
                 "trace_header_tags",
-                "X-Header-Tag-1:header_tag_1,X-Header-Tag-2:header_tag_2",
-                "x-header-tag-1:header_tag_1,x-header-tag-2:header_tag_2",
+                ("X-Header-Tag-1:header_tag_1,X-Header-Tag-2:header_tag_2",
+                "x-header-tag-1:header_tag_1,x-header-tag-2:header_tag_2")
             ),
             ("trace_tags", ("team:apm,component:web", "component:web,team:apm")),
             ("trace_enabled", ("true", True)),


### PR DESCRIPTION
## Motivation

Add .NET mappings to https://github.com/DataDog/system-tests/pull/2172, and a few fixes.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
