### PR TITLE
add sqs endpoints for dotnet

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -221,9 +221,9 @@ tests/:
         Test_SNS_Propagation: missing_feature (Endpoint not implemented)
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
-          "*": missing_feature (Endpoint not implemented)
+          "*": missing_feature (not read in dotnet)
         Test_SQS_PROPAGATION_VIA_MESSAGE_ATTRIBUTES:
-          "*": missing_feature (Endpoint not implemented)
+          "*": v2.0.0
     test_db_integrations_sql.py:
       Test_MsSql: missing_feature
       Test_MySql: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -236,7 +236,7 @@ tests/:
       Test_DsmRabbitmq_FanoutExchange: missing_feature
       Test_DsmRabbitmq_TopicExchange: missing_feature
       Test_DsmSNS: missing_feature
-      Test_DsmSQS: missing_feature
+      Test_DsmSQS: v2.48.0
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -223,7 +223,7 @@ tests/:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           "*": missing_feature (not read in dotnet)
         Test_SQS_PROPAGATION_VIA_MESSAGE_ATTRIBUTES:
-          "*": v2.0.0
+          "*": v2.48.0
     test_db_integrations_sql.py:
       Test_MsSql: missing_feature
       Test_MySql: missing_feature

--- a/tests/integrations/crossed_integrations/test_sqs.py
+++ b/tests/integrations/crossed_integrations/test_sqs.py
@@ -164,6 +164,8 @@ class _Test_SQS:
 
     @missing_feature(library="golang", reason="Expected to fail, Golang does not propagate context")
     @missing_feature(library="ruby", reason="Expected to fail, Ruby does not propagate context")
+    @missing_feature(library="dotnet", reason="Expected to fail, dotnet currently does not extract context on receive. "
+                                              "TODO: enable after https://github.com/DataDog/dd-trace-dotnet/pull/5159")
     def test_consume_trace_equality(self):
         """This test relies on the setup for consume, it currently cannot be run on its own"""
         producer_span = self.get_span(

--- a/tests/integrations/crossed_integrations/test_sqs.py
+++ b/tests/integrations/crossed_integrations/test_sqs.py
@@ -164,8 +164,11 @@ class _Test_SQS:
 
     @missing_feature(library="golang", reason="Expected to fail, Golang does not propagate context")
     @missing_feature(library="ruby", reason="Expected to fail, Ruby does not propagate context")
-    @missing_feature(library="dotnet", reason="Expected to fail, dotnet currently does not extract context on receive. "
-                                              "TODO: enable after https://github.com/DataDog/dd-trace-dotnet/pull/5159")
+    @missing_feature(
+        library="dotnet",
+        reason="Expected to fail, dotnet currently does not extract context on receive."
+        " TODO: enable after https://github.com/DataDog/dd-trace-dotnet/pull/5159",
+    )
     def test_consume_trace_equality(self):
         """This test relies on the setup for consume, it currently cannot be run on its own"""
         producer_span = self.get_span(

--- a/utils/build/docker/dotnet/app.csproj
+++ b/utils/build/docker/dotnet/app.csproj
@@ -14,6 +14,7 @@
 		<DefineConstants>$(DefineConstants);DDTRACE_2_23_0_OR_GREATER</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="AWSSDK.SQS" Version="3.7.300.52" />
 		<PackageReference Include="MySql.Data" Version="8.0.30" />
 		<PackageReference Include="Npgsql" Version="4.0.10" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.6.1" />


### PR DESCRIPTION
## Motivation

increase test coverage

## Changes

Adding support for SQS in the dotnet weblog, & enabling the test that goes with it.
SQS support was merged in https://github.com/DataDog/dd-trace-dotnet/pull/4973 and will be available from the next tracer version.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
