### PR TITLE
[dotnet][IAST] Add Reflection Injection tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -48,7 +48,7 @@ tests/:
         test_path_traversal.py:
           TestPathTraversal: v2.31.0
         test_reflection_injection.py:
-          TestReflectionInjection: missing_feature
+          TestReflectionInjection: v2.48.0
         test_sql_injection.py:
           TestSqlInjection:
              '*': v2.23.0

--- a/tests/appsec/iast/sink/test_reflection_injection.py
+++ b/tests/appsec/iast/sink/test_reflection_injection.py
@@ -18,6 +18,7 @@ class TestReflectionInjection(BaseSinkTest):
     location_map = {"java": "com.datadoghq.system_tests.iast.utils.ReflectionExamples"}
 
     @missing_feature(library="java", reason="Not implemented yet")
+    @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -579,5 +579,37 @@ namespace weblog
                 return StatusCode(500, "Error executing query.");
             }
         }
+        
+        [HttpPost("reflection_injection/test_insecure")]
+        public IActionResult test_insecure_reflection_injection([FromForm]string param)
+        {
+            try
+            {
+                var type = Type.GetType(param);
+                Activator.CreateInstance(type);
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            return Content("Executed reflection injection");
+        }
+        
+        [HttpPost("reflection_injection/test_secure")]
+        public IActionResult test_secure_reflection_injection([FromForm]string param)
+        {
+            try
+            {
+                var type = Type.GetType("System.String")!;
+                Activator.CreateInstance(type);
+                return Content("Executed secure injection");
+            }
+            catch (Exception)
+            {
+                return StatusCode(500, "Error executing safe reflection.");
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## Motivation

Add the dotnet tests for the Reflection Injection IAST vulnerability.

## Changes

- Enable the 2 available tests for the Reflection Injection
- Integrate into the dotnet IastController the 2 endpoints.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
