### PR TITLE
Add a kafka endpoint to the dotnet weblog

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -212,7 +212,7 @@ tests/:
   integrations/:
     crossed_integrations/:
       test_kafka.py:
-        Test_Kafka: missing_feature
+        Test_Kafka: v2.0.0
       test_kinesis.py:
         Test_Kinesis_PROPAGATION_VIA_MESSAGE_ATTRIBUTES: missing_feature
       test_rabbitmq.py:

--- a/utils/build/docker/dotnet/Dependencies/KafkaHelper.cs
+++ b/utils/build/docker/dotnet/Dependencies/KafkaHelper.cs
@@ -4,10 +4,10 @@ using Confluent.Kafka.Admin;
 using System.Collections.Generic;
 
 public class KafkaHelper {
+    private static IProducer<Null, string> producer;
 
-    private static IProducer<long, string> producer;
-
-    public static IProducer<long, string> GetProducer(string bootstrapServers){
+    public static IProducer<Null, string> GetProducer(string bootstrapServers)
+    {
         if (producer == null) {
             var config = new ProducerConfig
                 {
@@ -20,8 +20,7 @@ public class KafkaHelper {
                     RetryBackoffMs = 1000
                 };
 
-            producer = new ProducerBuilder<long, string>(config).
-                SetKeySerializer(Serializers.Int64).
+            producer = new ProducerBuilder<Null, string>(config).
                 SetValueSerializer(Serializers.Utf8).
                 Build();
         }
@@ -29,7 +28,8 @@ public class KafkaHelper {
         return producer;
     }
 
-    public static IConsumer<long, string> GetConsumer(string bootstrapServers, string group = "default") {
+    public static IConsumer<Ignore, string> GetConsumer(string bootstrapServers, string group = "default")
+    {
         var config = new ConsumerConfig
         {
             BootstrapServers = bootstrapServers,
@@ -38,7 +38,7 @@ public class KafkaHelper {
             AutoOffsetReset = AutoOffsetReset.Earliest
         };
 
-        return new ConsumerBuilder<long, string>(config).Build();
+        return new ConsumerBuilder<Ignore, string>(config).Build();
     }
 
     public static void CreateTopics(string bootstrapServers, IEnumerable<string> topics) {

--- a/utils/build/docker/dotnet/Endpoints/DsmEndpoint.cs
+++ b/utils/build/docker/dotnet/Endpoints/DsmEndpoint.cs
@@ -48,8 +48,8 @@ namespace weblog
             KafkaHelper.CreateTopics("kafka:9092", new List<string>{"dsm-system-tests-queue"});
             using (var producer = KafkaHelper.GetProducer("kafka:9092")) {
                 using (Datadog.Trace.Tracer.Instance.StartActive("KafkaProduce")) {
-                    producer.Produce("dsm-system-tests-queue", new Message<long, string>{
-                        Key = DateTime.UtcNow.Ticks,
+                    producer.Produce("dsm-system-tests-queue", new Message<Null, string>
+                    {
                         Value = "Produced to dsm-system-tests-queue"
                     });
                     producer.Flush();

--- a/utils/build/docker/dotnet/Endpoints/MessagingEndpoints.cs
+++ b/utils/build/docker/dotnet/Endpoints/MessagingEndpoints.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using Confluent.Kafka;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+namespace weblog;
+
+public class MessagingEndpoints : ISystemTestEndpoint
+{
+    public void Register(IEndpointRouteBuilder routeBuilder)
+    {
+        routeBuilder.MapGet("/kafka/produce", async context =>
+        {
+            var topic = context.Request.Query["topic"].ToString();
+            KafkaProduce(topic);
+            await context.Response.CompleteAsync();
+        });
+        routeBuilder.MapGet("/kafka/consume", async context =>
+        {
+            var topic = context.Request.Query["topic"].ToString();
+            TimeSpan timeout;
+            try
+            {
+                timeout = TimeSpan.FromSeconds(Int32.Parse(context.Request.Query["timeout"].ToString()));
+            }
+            catch // I don't want to deal with the different ways this can fail, I'm catching all to set the default.
+            {
+                Console.WriteLine("timeout set to default value");
+                timeout = TimeSpan.FromMinutes(1);
+            }
+
+            var success = KafkaConsume(topic, timeout);
+            if (!success)
+                context.Response.StatusCode = 500;
+            await context.Response.CompleteAsync();
+        });
+    }
+
+    private static void KafkaProduce(string topic)
+    {
+        using var producer = KafkaHelper.GetProducer("kafka:9092");
+        producer.Produce(topic, new Message<Null, string> { Value = "message produced from dotnet" });
+        producer.Flush();
+        Console.WriteLine("kafka message produced to topic " + topic);
+    }
+
+    private static bool KafkaConsume(string topic, TimeSpan timeout)
+    {
+        Console.WriteLine("consuming one message from topic " + topic);
+        using var consumer = KafkaHelper.GetConsumer("kafka:9092", "apm_test");
+        consumer.Subscribe(new List<string> { topic });
+        var result = consumer.Consume((int)timeout.TotalMilliseconds);
+        return result != null;
+    }
+}


### PR DESCRIPTION
## Motivation

ability to run Kafka tests with dotnet

## Changes

Added 2 endpoints, `/kafka/produce` and `/kafka/consume`. The class where those lie will be extended in future PRs to integrate other messaging systems like RabbitMQ or SQS.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
