### PR TITLE
[golang] Unskip parametric tests for injection/extraction of `p` in `tracestate`

### DIFF
--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -720,7 +720,6 @@ class Test_Headers_Tracecontext:
     @missing_feature(context.library == "java", reason="Not implemented")
     @missing_feature(context.library == "cpp", reason="Not implemented")
     @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     def test_tracestate_w3c_p_extract(self, test_agent, test_library):
         """
         Ensure the last parent id tag is set according to the W3C spec
@@ -790,7 +789,6 @@ class Test_Headers_Tracecontext:
     @missing_feature(context.library == "java", reason="Not implemented")
     @missing_feature(context.library == "cpp", reason="Not implemented")
     @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     def test_tracestate_w3c_p_inject(self, test_agent, test_library):
         """
         Ensure the last parent id is propagated according to the W3C spec

--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -720,6 +720,7 @@ class Test_Headers_Tracecontext:
     @missing_feature(context.library == "java", reason="Not implemented")
     @missing_feature(context.library == "cpp", reason="Not implemented")
     @missing_feature(context.library == "ruby", reason="Not implemented")
+    @missing_feature(context.library < "golang@1.62.0", reason="Implemented in v1.62.0")
     def test_tracestate_w3c_p_extract(self, test_agent, test_library):
         """
         Ensure the last parent id tag is set according to the W3C spec
@@ -789,6 +790,7 @@ class Test_Headers_Tracecontext:
     @missing_feature(context.library == "java", reason="Not implemented")
     @missing_feature(context.library == "cpp", reason="Not implemented")
     @missing_feature(context.library == "ruby", reason="Not implemented")
+    @missing_feature(context.library < "golang@1.62.0", reason="Implemented in v1.62.0")
     def test_tracestate_w3c_p_inject(self, test_agent, test_library):
         """
         Ensure the last parent id is propagated according to the W3C spec

--- a/utils/build/docker/golang/parametric/go.mod
+++ b/utils/build/docker/golang/parametric/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.20.0
 	google.golang.org/grpc v1.57.1
 	google.golang.org/protobuf v1.30.0
-	gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20240213201730-25d3eb55c06a
+	gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20240229010116-19d14921248a
 )
 
 require (

--- a/utils/build/docker/golang/parametric/go.sum
+++ b/utils/build/docker/golang/parametric/go.sum
@@ -173,8 +173,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20240213201730-25d3eb55c06a h1:oX/QGhwwYeZpQyadBd1zIJpaQvwPXYlqi8pOSaxpe8I=
-gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20240213201730-25d3eb55c06a/go.mod h1:NHKX1t9eKmajySb6H+zLdgZizCFzbt5iKvrTyxEyy8w=
+gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20240229010116-19d14921248a h1:sBI/3ndWwXcMkHXJwYLgpz2QN9y7Mh1jtG15CZhgSSM=
+gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20240229010116-19d14921248a/go.mod h1:NHKX1t9eKmajySb6H+zLdgZizCFzbt5iKvrTyxEyy8w=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=


### PR DESCRIPTION
## Motivation

Unskips the parametric tests for `golang` for asserting the functionality of the `p` key in the `tracestate`.

## Changes

- Unskips the tests.
- Target the correct commit version of go

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
