### PR TITLE
Fix Open-Telemetry-Manual scenario

### DIFF
--- a/tests/otel_tracing_e2e/_test_validator_log.py
+++ b/tests/otel_tracing_e2e/_test_validator_log.py
@@ -1,7 +1,8 @@
 # Util functions to validate JSON logs from OTel system tests
 
-# Validates the JSON logs from backend and returns the OTel log trace attributes
+
 def validate_log(log: dict, rid: str, otel_source: str) -> dict:
+    """ Validates the JSON logs from backend and returns the OTel log trace attributes """
     assert log["type"] == "log"
     expected_attributes_tags = [
         "datadog.submission_auth:private_api_key",

--- a/tests/otel_tracing_e2e/_test_validator_log.py
+++ b/tests/otel_tracing_e2e/_test_validator_log.py
@@ -9,7 +9,7 @@ def validate_log(log: dict, rid: str, otel_source: str) -> dict:
         "env:system-tests",
         f"otel_source:{otel_source}",
         "service:otel-system-tests-spring-boot",
-        "source:undefined",
+        "source:otlp_log_ingestion",
     ]
     assert expected_attributes_tags <= log["attributes"]["tags"]
     expected_attributes_attributes = {


### PR DESCRIPTION
## Motivation

The open telemetry manual started failing when we validate the "OTel log trace attributes". This PR fixes this problem

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
