### PR TITLE
add a rabbitmq endpoint to dotnet weblog

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -216,7 +216,7 @@ tests/:
       test_kinesis.py:
         Test_Kinesis_PROPAGATION_VIA_MESSAGE_ATTRIBUTES: missing_feature
       test_rabbitmq.py:
-        Test_RabbitMQ_Trace_Context_Propagation: missing_feature
+        Test_RabbitMQ_Trace_Context_Propagation: v2.0.0
       test_sns_to_sqs.py:
         Test_SNS_Propagation: missing_feature (Endpoint not implemented)
       test_sqs.py:

--- a/tests/integrations/crossed_integrations/test_rabbitmq.py
+++ b/tests/integrations/crossed_integrations/test_rabbitmq.py
@@ -39,11 +39,11 @@ class _Test_RabbitMQ:
                     continue
 
                 meta = span.get("meta")
-                component = meta.get("component", "")
                 if (
                     queue.lower() not in span.get("resource").lower()
                     and exchange.lower() not in span.get("resource").lower()
-                    and queue.lower() not in meta.get(f"{component}.routing_key", "").lower()
+                    and queue.lower() not in meta.get(f"rabbitmq.routing_key", "").lower()
+                    and queue.lower() not in meta.get(f"amqp.routing_key", "").lower()  # this is where we find the queue name in dotnet
                 ):
                     continue
 
@@ -172,7 +172,7 @@ class _Test_RabbitMQ:
         It works the same for both test_produce and test_consume
         """
 
-        # Check that the producer did not created any consumer span
+        # Check that the producer did not create any consumer span
         assert (
             self.get_span(
                 producer_interface,
@@ -184,7 +184,7 @@ class _Test_RabbitMQ:
             is None
         )
 
-        # Check that the consumer did not created any producer span
+        # Check that the consumer did not create any producer span
         assert (
             self.get_span(
                 consumer_interface, span_kind="producer", queue=queue, exchange=exchange, operation=["publish"],


### PR DESCRIPTION
## Motivation

more coverage

## Changes

Added produce and consume endpoints to the dotnet weblog.
I had to change a little bit the way the spans are fetched, because dotnet tags the spans with `component:RabbitMQ`, but the specific properties are under `amqp.***`

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
