### PR TITLE
Support minified AppSec rules in Java

### DIFF
--- a/utils/build/docker/java/install_ddtrace.sh
+++ b/utils/build/docker/java/install_ddtrace.sh
@@ -30,8 +30,9 @@ if [[ $SYSTEM_TESTS_LIBRARY_VERSION == 0.96* ]]; then
   echo "1.2.5" > /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 else
   jar xf /dd-tracer/dd-java-agent.jar appsec/default_config.json
-  grep rules_version appsec/default_config.json | head -n 1 | awk -F'"' '{print $4;}' \
-    > /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
+  curl -Lf -o jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+  chmod +x jq
+  ./jq -r .metadata.rules_version appsec/default_config.json > /binaries/SYSTEM_TESTS_APPSEC_EVENT_RULES_VERSION
 fi
 
 echo "dd-trace version: $(cat /binaries/SYSTEM_TESTS_LIBRARY_VERSION)"


### PR DESCRIPTION
## Motivation

We'll probably start shipping minified AppSec rules in Java. This requires tweaking the way we extract our AppSec rules version during build.

## Changes

Use `jq` to extract AppSec rules version, regardless of whether it's pretty printed or minified.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
