### PR TITLE
Fix open telemetry manual logs validator

### DIFF
--- a/tests/otel_tracing_e2e/_test_validator_log.py
+++ b/tests/otel_tracing_e2e/_test_validator_log.py
@@ -5,7 +5,7 @@ def validate_log(log: dict, rid: str, otel_source: str) -> dict:
     """ Validates the JSON logs from backend and returns the OTel log trace attributes """
     assert log["type"] == "log"
     expected_attributes_tags = [
-        "datadog.submission_auth:private_api_key",
+        "datadog.submission_auth:api_key",
         "datadog.index:main",
         "env:system-tests",
         f"otel_source:{otel_source}",


### PR DESCRIPTION
## Motivation

Fix log validator for open telemetry manual
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
