### PR TITLE
disable api sec tests for python until fix for sampling

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -29,84 +29,24 @@ tests/:
       test_schemas.py:
         Test_Scanners:
           '*': missing_feature
-          django-poc: v2.4.0.dev
-          fastapi: v2.5.0.dev1
-          flask-poc: v2.4.0.dev
-          python3.12: v2.4.0.dev
-          uds-flask: v2.4.0dev
-          uwsgi-poc: v2.4.0dev
         Test_Schema_Request_Cookies:
           '*': missing_feature
-          django-poc: v2.1.0.dev
-          fastapi: v2.5.0.dev1
-          flask-poc: v2.1.0.dev
-          python3.12: v2.1.0.dev
-          uds-flask: v2.1.0dev
-          uwsgi-poc: v2.1.0dev
         Test_Schema_Request_FormUrlEncoded_Body:
           '*': missing_feature
-          django-poc: v2.1.0.dev
-          fastapi: v2.5.0.dev1
-          flask-poc: v2.1.0.dev
-          python3.12: v2.1.0.dev
-          uds-flask: v2.1.0dev
-          uwsgi-poc: v2.1.0dev
         Test_Schema_Request_Headers:
           '*': missing_feature
-          django-poc: v2.1.0.dev
-          fastapi: v2.5.0.dev1
-          flask-poc: v2.1.0.dev
-          python3.12: v2.1.0.dev
-          uds-flask: v2.1.0dev
-          uwsgi-poc: v2.1.0dev
         Test_Schema_Request_Json_Body:
           '*': missing_feature
-          django-poc: v2.1.0.dev
-          fastapi: v2.5.0.dev1
-          flask-poc: v2.1.0.dev
-          python3.12: v2.1.0.dev
-          uds-flask: v2.1.0dev
-          uwsgi-poc: v2.1.0dev
         Test_Schema_Request_Path_Parameters:
           '*': missing_feature
-          django-poc: v2.1.0.dev
-          fastapi: v2.5.0.dev1
-          flask-poc: v2.1.0.dev
-          python3.12: v2.1.0.dev
-          uds-flask: v2.1.0dev
-          uwsgi-poc: v2.1.0dev
         Test_Schema_Request_Query_Parameters:
           '*': missing_feature
-          django-poc: v2.1.0.dev
-          fastapi: v2.5.0.dev1
-          flask-poc: v2.1.0.dev
-          python3.12: v2.1.0.dev
-          uds-flask: v2.1.0dev
-          uwsgi-poc: v2.1.0dev
         Test_Schema_Response_Body:
           '*': missing_feature
-          django-poc: v2.1.0.dev
-          fastapi: v2.5.0.dev1
-          flask-poc: v2.1.0.dev
-          python3.12: v2.1.0.dev
-          uds-flask: v2.1.0dev
-          uwsgi-poc: v2.1.0dev
         Test_Schema_Response_Body_env_var:
           '*': missing_feature
-          django-poc: v2.6.0.dev
-          fastapi: v2.6.0.dev1
-          flask-poc: v2.6.0.dev
-          python3.12: v2.6.0.dev
-          uds-flask: v2.1.0dev
-          uwsgi-poc: v2.1.0dev
         Test_Schema_Response_Headers:
           '*': missing_feature
-          django-poc: v2.1.0.dev
-          fastapi: v2.5.0.dev1
-          flask-poc: v2.1.0.dev
-          python3.12: v2.1.0.dev
-          uds-flask: v2.1.0dev
-          uwsgi-poc: v2.1.0dev
     iast/:
       sink/:
         test_command_injection.py:


### PR DESCRIPTION
## Motivation

API Security sampling new algorithm prevents API Security tests from passing

## Changes

This PR disables the tests until a more permanent fix is merged.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
