### PR TITLE
[nodejs] Re-enable API Sec sampling test for Node

### DIFF
--- a/tests/appsec/api_security/test_apisec_sampling.py
+++ b/tests/appsec/api_security/test_apisec_sampling.py
@@ -38,7 +38,7 @@ class Test_API_Security_sampling:
             for _ in range(self.N ** 2)
         ]
 
-    @irrelevant(context.library !== 'nodejs', reason="RFC is deprecated by a newer RFC. New tests will be implemented")
+    @irrelevant(context.library not in ["nodejs"], reason="RFC is deprecated by a newer RFC. New tests will be implemented")
     def test_sampling_rate(self):
         """can provide request header schema"""
         N = self.N

--- a/tests/appsec/api_security/test_apisec_sampling.py
+++ b/tests/appsec/api_security/test_apisec_sampling.py
@@ -1,4 +1,5 @@
 from utils import (
+    context,
     features,
     interfaces,
     irrelevant,

--- a/tests/appsec/api_security/test_apisec_sampling.py
+++ b/tests/appsec/api_security/test_apisec_sampling.py
@@ -39,8 +39,7 @@ class Test_API_Security_sampling:
         ]
 
     @irrelevant(
-        context.library not in ["nodejs"],
-        reason="RFC is deprecated by a newer RFC. New tests will be implemented"
+        context.library not in ["nodejs"], reason="RFC is deprecated by a newer RFC. New tests will be implemented"
     )
     def test_sampling_rate(self):
         """can provide request header schema"""

--- a/tests/appsec/api_security/test_apisec_sampling.py
+++ b/tests/appsec/api_security/test_apisec_sampling.py
@@ -38,7 +38,10 @@ class Test_API_Security_sampling:
             for _ in range(self.N ** 2)
         ]
 
-    @irrelevant(context.library not in ["nodejs"], reason="RFC is deprecated by a newer RFC. New tests will be implemented")
+    @irrelevant(
+        context.library not in ["nodejs"],
+        reason="RFC is deprecated by a newer RFC. New tests will be implemented"
+    )
     def test_sampling_rate(self):
         """can provide request header schema"""
         N = self.N

--- a/tests/appsec/api_security/test_apisec_sampling.py
+++ b/tests/appsec/api_security/test_apisec_sampling.py
@@ -38,7 +38,7 @@ class Test_API_Security_sampling:
             for _ in range(self.N ** 2)
         ]
 
-    @irrelevant(True, reason="RFC is deprecated by a newer RFC. New tests will be implemented")
+    @irrelevant(context.library !== 'nodejs', reason="RFC is deprecated by a newer RFC. New tests will be implemented")
     def test_sampling_rate(self):
         """can provide request header schema"""
         N = self.N


### PR DESCRIPTION
## Motivation

Revert a change made in #2166 to re-enable API Security sampling tests in Node.js
