### PR TITLE
[dotnet][IAST] Add Insecure Auth Protocol tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -34,7 +34,7 @@ tests/:
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: v2.44.0
         test_insecure_auth_protocol.py:
-          Test_InsecureAuthProtocol: missing_feature
+          Test_InsecureAuthProtocol: v2.49.0
         test_insecure_cookie.py:
           TestInsecureCookie: v2.39.0
         test_ldap_injection.py:

--- a/tests/appsec/iast/sink/test_insecure_auth_protocol.py
+++ b/tests/appsec/iast/sink/test_insecure_auth_protocol.py
@@ -18,6 +18,7 @@ class Test_InsecureAuthProtocol(BaseSinkTest):
     insecure_headers = {"Authorization": "Basic dGVzd"}
 
     @missing_feature(library="java", reason="Not implemented yet")
+    @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -610,6 +610,11 @@ namespace weblog
                 return StatusCode(500, "Error executing safe reflection.");
             }
         }
-
+        
+        [HttpGet("insecure-auth-protocol/test")]
+        public IActionResult test_insecure_auth_protocol()
+        {
+            return StatusCode(200);
+        }
     }
 }


### PR DESCRIPTION
## Motivation

Add the dotnet tests for the Insecure Auth Protocol IAST vulnerability.

## Changes

- Enable the available test for the Insecure Auth Protocol
- Integrate into the dotnet IastController the endpoint.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
