### PR TITLE
Provide the new way to fetch the sources for PHP

### DIFF
--- a/utils/build/docker/php/apache-mod/build.sh
+++ b/utils/build/docker/php/apache-mod/build.sh
@@ -54,5 +54,5 @@ sed -i s/80/7777/ /etc/apache2/ports.conf
 SYSTEM_TESTS_LIBRARY_VERSION=$(cat /binaries/SYSTEM_TESTS_LIBRARY_VERSION)
 
 if [[ -f "/etc/php/98-ddtrace.ini" ]]; then
-    grep datadog.trace.request_init_hook /etc/php/98-ddtrace.ini >> /etc/php/php.ini
+    grep -E 'datadog.trace.request_init_hook|datadog.trace.sources_path' /etc/php/98-ddtrace.ini >> /etc/php/php.ini
 fi

--- a/utils/build/docker/php/php-fpm/build.sh
+++ b/utils/build/docker/php/php-fpm/build.sh
@@ -57,3 +57,4 @@ rm -rf /etc/php/$PHP_VERSION/fpm/conf.d/98-ddappsec.ini
 
 SYSTEM_TESTS_LIBRARY_VERSION=$(cat /binaries/SYSTEM_TESTS_LIBRARY_VERSION)
 echo "datadog.trace.request_init_hook = /opt/datadog/dd-library/$SYSTEM_TESTS_LIBRARY_VERSION/dd-trace-sources/bridge/dd_wrap_autoloader.php" >> /etc/php/$PHP_VERSION/fpm/php.ini
+echo "datadog.trace.sources_path = /opt/datadog/dd-library/$SYSTEM_TESTS_LIBRARY_VERSION/dd-trace-sources/src" >> /etc/php/$PHP_VERSION/fpm/php.ini


### PR DESCRIPTION
In dd-trace-php-1.0.0 we'll change the way how it's configured. It doesn't do any harm to have both in the INI, so until dd-trace-php-1.0.0 is release we'll just have both. That way system tests can still run on that branch.