### PR TITLE
New Lib Injection: Generate weblog images

### DIFF
--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   manual-lib-injection-tests:
+    if:  ${{ false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -161,25 +162,24 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build weblog base images
-        if: inputs.build_lib_injection_app_images
         env:
-          DOCKER_IMAGE_WEBLOG_TAG: ${{ github.sha }}
+          DOCKER_IMAGE_WEBLOG_TAG: latest
           APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ matrix.variant.weblog-variant }}
         run: |
           cd lib-injection/build/docker/$TEST_LIBRARY/$WEBLOG_VARIANT 
-          LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:${{ github.sha }} ./build.sh
+          LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
           cd ..
 
       - name: Install runner
         uses: ./.github/actions/install_runner       
 
       - name: Kubernetes lib-injection tests (using custom weblog image tag)
-        if: inputs.build_lib_injection_app_images
+        if:  ${{ false }}
         id: k8s-lib-injection-tests-custom-weblog-tag
         run: DOCKER_IMAGE_WEBLOG_TAG=${{ github.sha }} ./run.sh K8S_LIB_INJECTION 
 
       - name: Kubernetes lib-injection tests
-        if: inputs.build_lib_injection_app_images != true
+        if:  ${{ false }}
         id: k8s-lib-injection-tests
         run: ./run.sh K8S_LIB_INJECTION 
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
