### PR TITLE
OnBoarding fix local installation amazon linux 2

### DIFF
--- a/utils/build/virtual_machine/provisions/container-auto-inject/auto-inject_container_manual.yml
+++ b/utils/build/virtual_machine/provisions/container-auto-inject/auto-inject_container_manual.yml
@@ -53,8 +53,7 @@
         aarch64) architecture="aarch64" ;;
     esac
 
-    if [ -e datadog-apm-inject-*.$architecture.rpm ]
-    then
+    if ls datadog-apm-inject-*.$architecture.rpm 1> /dev/null 2>&1; then
         echo "Instaling datadog-apm-inject from local folder"
           sudo yum -q list installed datadog-apm-inject &>/dev/null && sudo yum -y reinstall --disablerepo="*" datadog-apm-inject-*.$architecture.rpm || sudo yum -y install --disablerepo="*" datadog-apm-inject-*.$architecture.rpm
     else
@@ -62,8 +61,7 @@
         sudo yum -q list installed datadog-apm-inject &>/dev/null && sudo yum -y reinstall --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject || sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject
     fi
 
-    if [ -e datadog-apm-library-$DD_LANG-*.$architecture.rpm ]
-    then
+    if ls datadog-apm-library-$DD_LANG-*.$architecture.rpm 1> /dev/null 2>&1; then
         echo "Instaling datadog-apm-library-$DD_LANG from local folder"
         sudo yum -q list installed datadog-apm-library-$DD_LANG &>/dev/null && sudo yum -y reinstall --disablerepo="*" datadog-apm-library-$DD_LANG-*.$architecture.rpm || sudo yum -y install --disablerepo="*" datadog-apm-library-$DD_LANG-*.$architecture.rpm
     else

--- a/utils/build/virtual_machine/provisions/host-auto-inject/auto-inject_host_manual.yml
+++ b/utils/build/virtual_machine/provisions/host-auto-inject/auto-inject_host_manual.yml
@@ -53,8 +53,7 @@
         aarch64) architecture="aarch64" ;;
     esac
 
-    if [ -e datadog-apm-inject-*.$architecture.rpm ]
-    then
+    if ls datadog-apm-inject-*.$architecture.rpm 1> /dev/null 2>&1; then
         echo "Instaling datadog-apm-inject from local folder"
         sudo yum -q list installed datadog-apm-inject &>/dev/null && sudo yum -y reinstall --disablerepo="*" datadog-apm-inject-*.$architecture.rpm || sudo yum -y install --disablerepo="*" datadog-apm-inject-*.$architecture.rpm
     else
@@ -62,8 +61,7 @@
         sudo yum -q list installed datadog-apm-inject &>/dev/null && sudo yum -y reinstall --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject || sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject
     fi
 
-    if [ -e datadog-apm-library-$DD_LANG-*.$architecture.rpm ]
-    then
+    if ls datadog-apm-library-$DD_LANG-*.$architecture.rpm 1> /dev/null 2>&1; then
         echo "Instaling datadog-apm-library-$DD_LANG from local folder"
         sudo yum -q list installed datadog-apm-library-$DD_LANG &>/dev/null && sudo yum -y reinstall --disablerepo="*" datadog-apm-library-$DD_LANG-*.$architecture.rpm || sudo yum -y install --disablerepo="*" datadog-apm-library-$DD_LANG-*.$architecture.rpm
     else
@@ -71,10 +69,14 @@
         sudo yum -q list installed datadog-apm-library-$DD_LANG &>/dev/null && sudo yum -y reinstall --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-library-$DD_LANG || sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-library-$DD_LANG
     fi
 
-
     dd-host-install
     sudo cp debug_config.yaml /etc/datadog-agent/inject/debug_config.yaml
-    echo "Verify package signature. Fails if it isn't V4"
-    yumdownloader datadog-apm-inject
-    rpm -v --checksig *.rpm | grep -q "Header V4 RSA/SHA256 Signature"
-    echo "Package signature verified!"
+
+    if ls datadog-apm-inject-*.$architecture.rpm 1> /dev/null 2>&1; then
+        echo "Skipping package signature verification for local package"
+    else
+        echo "Verify package signature. Fails if it isn't V4"
+        yumdownloader datadog-apm-inject
+        rpm -v --checksig *.rpm | grep -q "Header V4 RSA/SHA256 Signature"
+        echo "Package signature verified!"
+    fi


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
OnBooarding tests were failing for Amazon linux 2 in local installation.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
