### PR TITLE
Fix pr labels: generate docker images lib-injeciton

### DIFF
--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -15,7 +15,6 @@ env:
 
 jobs:
   manual-lib-injection-tests:
-    if: ${{ false }} 
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -161,7 +160,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build weblog base images
+      - name: Build weblog base images (PR)
         if: inputs.build_lib_injection_app_images
         env:
           DOCKER_IMAGE_WEBLOG_TAG: ${{ github.sha }}
@@ -172,9 +171,7 @@ jobs:
           cd ..
 
       - name: Build weblog latest base images
-        #if github.ref_name == ''
-        #if github.ref == 'refs/heads/main'
-        if: github.ref == 'refs/pull/2207/merge'
+        if: github.ref == 'refs/heads/main'
         env:
           DOCKER_IMAGE_WEBLOG_TAG: latest
           APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ matrix.variant.weblog-variant }}
@@ -194,10 +191,7 @@ jobs:
       - name: Kubernetes lib-injection tests
         if: inputs.build_lib_injection_app_images != true
         id: k8s-lib-injection-tests
-        run: |
-          echo " github.event.workflow_run.head_commit.message: ${{ github.event.workflow_run.head_commit.message }}"
-          echo "github.event.head_commit.message: ${{ github.event.head_commit.message }}"
-          ./run.sh K8S_LIB_INJECTION 
+        run: ./run.sh K8S_LIB_INJECTION 
 
 
         

--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -170,6 +170,16 @@ jobs:
           LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:${{ github.sha }} ./build.sh
           cd ..
 
+      - name: Build weblog latest base images
+        if: github.ref == 'refs/heads/robertomonteromiguel/fix_pr_labels_lib_injection'
+        env:
+          DOCKER_IMAGE_WEBLOG_TAG: latest
+          APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ matrix.variant.weblog-variant }}
+        run: |
+          cd lib-injection/build/docker/$TEST_LIBRARY/$WEBLOG_VARIANT 
+          LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
+          cd ..
+
       - name: Install runner
         uses: ./.github/actions/install_runner       
 

--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -173,7 +173,8 @@ jobs:
 
       - name: Build weblog latest base images
         #if github.ref_name == ''
-        if: github.ref == 'refs/heads/robertomonteromiguel/fix_pr_labels_lib_injection'
+        #if github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/pull/2207/merge'
         env:
           DOCKER_IMAGE_WEBLOG_TAG: latest
           APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ matrix.variant.weblog-variant }}
@@ -194,8 +195,8 @@ jobs:
         if: inputs.build_lib_injection_app_images != true
         id: k8s-lib-injection-tests
         run: |
-          echo "THE REFFFFFFFFFFFF: ${{github.ref}}"
-          echo "THE NAME: ${{github.ref.name}}"
+          echo " github.event.workflow_run.head_commit.message: ${{ github.event.workflow_run.head_commit.message }}"
+          echo "github.event.head_commit.message: ${{ github.event.head_commit.message }}"
           ./run.sh K8S_LIB_INJECTION 
 
 

--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -171,7 +171,7 @@ jobs:
           cd ..
 
       - name: Build weblog latest base images
-        if: github.ref_name == 'robertomonteromiguel/fix_pr_labels_lib_injection'
+        if: github.ref_name == 'fix_pr_labels_lib_injection'
         env:
           DOCKER_IMAGE_WEBLOG_TAG: latest
           APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ matrix.variant.weblog-variant }}

--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -171,7 +171,7 @@ jobs:
           cd ..
 
       - name: Build weblog latest base images
-        if: github.ref == 'refs/heads/robertomonteromiguel/fix_pr_labels_lib_injection'
+        if: github.ref_name == 'robertomonteromiguel/fix_pr_labels_lib_injection'
         env:
           DOCKER_IMAGE_WEBLOG_TAG: latest
           APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ matrix.variant.weblog-variant }}

--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   manual-lib-injection-tests:
+    if: ${{ false }} 
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -171,7 +172,8 @@ jobs:
           cd ..
 
       - name: Build weblog latest base images
-        if: github.ref_name == 'fix_pr_labels_lib_injection'
+        #if github.ref_name == ''
+        if: github.ref == 'refs/heads/robertomonteromiguel/fix_pr_labels_lib_injection'
         env:
           DOCKER_IMAGE_WEBLOG_TAG: latest
           APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ matrix.variant.weblog-variant }}
@@ -191,7 +193,10 @@ jobs:
       - name: Kubernetes lib-injection tests
         if: inputs.build_lib_injection_app_images != true
         id: k8s-lib-injection-tests
-        run: ./run.sh K8S_LIB_INJECTION 
+        run: |
+          echo "THE REFFFFFFFFFFFF: ${{github.ref}}"
+          echo "THE NAME: ${{github.ref.name}}"
+          ./run.sh K8S_LIB_INJECTION 
 
 
         

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,7 +201,7 @@ check_merge_labels:
     - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text) 
   script:
-    - apt install default-jdk
+    - apt install -y default-jdk
     - ./utils/scripts/get_pr_merged_labels.sh
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "robertomonteromiguel/fix_pr_labels_lib_injection"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,7 +201,7 @@ check_merge_labels:
     - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text) 
   script:
-    - sudo apt install default-jdk
+    - apt install default-jdk
     - ./utils/scripts/get_pr_merged_labels.sh
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "robertomonteromiguel/fix_pr_labels_lib_injection"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,6 +201,7 @@ check_merge_labels:
     - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text) 
   script:
+    - apt-get update
     - apt install -y default-jdk
     - ./utils/scripts/get_pr_merged_labels.sh
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,19 +193,19 @@ onboarding_parse_results:
         done
 
 check_merge_labels:
-  tags: ["arch:amd64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal
-  #image: registry.ddbuild.io/images/ci_docker_base
+  #tags: ["arch:amd64"]
+  #image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal
+  image: registry.ddbuild.io/images/ci_docker_base
   #image: ghcr.io/datadog/dd-trace-java-docker-build:v23.10-base
-  #tags: ["runner:docker"]
+  tags: ["runner:docker"]
   stage: before_tests
   before_script:
     - export GH_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.gh-token --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text) 
   script:
-    #- apt-get update
-    #- apt install -y default-jdk
+    - apt-get update
+    - apt install -y default-jdk
     - ./utils/scripts/get_pr_merged_labels.sh
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "robertomonteromiguel/fix_pr_labels_lib_injection"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,7 +193,8 @@ onboarding_parse_results:
         done
 
 check_merge_labels:
-  image: registry.ddbuild.io/images/ci_docker_base
+  #image: registry.ddbuild.io/images/ci_docker_base
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
   tags: ["runner:docker"]
   stage: before_tests
   before_script:
@@ -201,8 +202,8 @@ check_merge_labels:
     - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text) 
   script:
-    - apt-get update
-    - apt install -y default-jdk
+   # - apt-get update
+   # - apt install -y default-jdk
     - ./utils/scripts/get_pr_merged_labels.sh
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "robertomonteromiguel/fix_pr_labels_lib_injection"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,10 +193,7 @@ onboarding_parse_results:
         done
 
 check_merge_labels:
-  #tags: ["arch:amd64"]
-  #image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal
   image: registry.ddbuild.io/images/ci_docker_base
-  #image: ghcr.io/datadog/dd-trace-java-docker-build:v23.10-base
   tags: ["runner:docker"]
   stage: before_tests
   before_script:
@@ -204,8 +201,6 @@ check_merge_labels:
     - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text) 
   script:
-    - apt-get update
-    - apt install -y default-jdk
     - ./utils/scripts/get_pr_merged_labels.sh
   rules:
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "robertomonteromiguel/fix_pr_labels_lib_injection"
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,7 +194,7 @@ onboarding_parse_results:
 
 check_merge_labels:
   #image: registry.ddbuild.io/images/ci_docker_base
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
+  image: ghcr.io/datadog/dd-trace-java-docker-build:v23.10-base
   tags: ["runner:docker"]
   stage: before_tests
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,16 +194,16 @@ onboarding_parse_results:
 
 check_merge_labels:
   #image: registry.ddbuild.io/images/ci_docker_base
-  image: ghcr.io/datadog/dd-trace-java-docker-build:v23.10-base
-  tags: ["runner:docker"]
+  #image: ghcr.io/datadog/dd-trace-java-docker-build:v23.10-base
+  #tags: ["runner:docker"]
   stage: before_tests
   before_script:
     - export GH_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.gh-token --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text) 
   script:
-   # - apt-get update
-   # - apt install -y default-jdk
+    #- apt-get update
+    #- apt install -y default-jdk
     - ./utils/scripts/get_pr_merged_labels.sh
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "robertomonteromiguel/fix_pr_labels_lib_injection"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,6 +193,8 @@ onboarding_parse_results:
         done
 
 check_merge_labels:
+  tags: ["arch:amd64"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal
   #image: registry.ddbuild.io/images/ci_docker_base
   #image: ghcr.io/datadog/dd-trace-java-docker-build:v23.10-base
   #tags: ["runner:docker"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -200,7 +200,8 @@ check_merge_labels:
     - export GH_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.gh-token --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text) 
     - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text) 
-  script:  
+  script:
+    - sudo apt install default-jdk
     - ./utils/scripts/get_pr_merged_labels.sh
   rules:
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "robertomonteromiguel/fix_pr_labels_lib_injection"

--- a/utils/scripts/get_pr_merged_labels.sh
+++ b/utils/scripts/get_pr_merged_labels.sh
@@ -6,7 +6,7 @@
 
 ##################################################
         echo "TESTTTTTTTTTTTTT"
-        docker buildx create --name multiarch --driver docker-container --use
+        #docker buildx create --name multiarch --driver docker-container --use
 
         echo "$DOCKER_LOGIN_PASS" | docker login --username "$DOCKER_LOGIN" --password-stdin
         export DOCKER_IMAGE_WEBLOG_TAG="latest"

--- a/utils/scripts/get_pr_merged_labels.sh
+++ b/utils/scripts/get_pr_merged_labels.sh
@@ -4,34 +4,6 @@
 #We extract the PR number and using GitHub API we check the PR labels.
 #If the PR contains the label "build-buddies-images" we launch the build and push process
 
-##################################################
-        echo "TESTTTTTTTTTTTTT"
-        docker buildx create --name multiarch --driver docker-container --use
-
-        echo "$DOCKER_LOGIN_PASS" | docker login --username "$DOCKER_LOGIN" --password-stdin
-        export DOCKER_IMAGE_WEBLOG_TAG="latest"
-
-        echo "Building and pushing the lib-injection apps for java"
-        export APP_DOCKER_IMAGE_REPO=ghcr.io/datadog/system-tests/dd-lib-java-init-test-app
-        cd lib-injection/build/docker/java/dd-lib-java-init-test-app
-        LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
-        cd ../../../../..
-
-        echo "Building and pushing the lib-injection apps for nodejs"
-        export APP_DOCKER_IMAGE_REPO=ghcr.io/datadog/system-tests/sample-app
-        cd lib-injection/build/docker/nodejs/sample-app
-        LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
-        cd ../../../../..
-
-        echo "Building and pushing the lib-injection apps for python"
-        export APP_DOCKER_IMAGE_REPO=ghcr.io/datadog/system-tests/dd-lib-python-init-test-django
-        cd lib-injection/build/docker/python/dd-lib-python-init-test-django
-        LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
-        cd ../../../../..
-
-##################################################
-
-
 
 PR_PATTERN='#[0-9]+'
 
@@ -48,7 +20,6 @@ if [[ $CI_COMMIT_MESSAGE =~ ($PR_PATTERN) ]]; then
     echo "We found PR labels: $PR_DATA"    
 
     is_build_buddies=$(echo "$PR_DATA" | jq -c '.[] | select(.name | contains("build-buddies-images"))');
-    is_build_lib_injections_apps=$(echo "$PR_DATA" | jq -c '.[] | select(.name | contains("build-lib-injection-app-images"))');
 
     if [ -z "$is_build_buddies" ]
     then
@@ -57,34 +28,6 @@ if [[ $CI_COMMIT_MESSAGE =~ ($PR_PATTERN) ]]; then
         echo "The PR $PR_NUMBER contains the 'build-buddies-images' label. Launching the images generation process "
         echo "$DOCKER_LOGIN_PASS" | docker login --username "$DOCKER_LOGIN" --password-stdin
         ./utils/build/build_tracer_buddies.sh --push
-    fi
-
-
-    if [ -z "$is_build_lib_injections_apps" ]
-    then
-        echo "The PR $PR_NUMBER doesn't contain the 'build-lib-injection-app-images' label "
-    else
-        echo "The PR $PR_NUMBER contains the 'build-lib-injection-app-images' label. Launching the images generation process "
-        echo "$DOCKER_LOGIN_PASS" | docker login --username "$DOCKER_LOGIN" --password-stdin
-        export DOCKER_IMAGE_WEBLOG_TAG="latest"
-
-        echo "Building and pushing the lib-injection apps for java"
-        export APP_DOCKER_IMAGE_REPO=ghcr.io/datadog/system-tests/dd-lib-java-init-test-app
-        cd lib-injection/build/docker/java/dd-lib-java-init-test-app
-        LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
-        cd ../../../../..
-
-        echo "Building and pushing the lib-injection apps for nodejs"
-        export APP_DOCKER_IMAGE_REPO=ghcr.io/datadog/system-tests/sample-app
-        cd lib-injection/build/docker/nodejs/sample-app
-        LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
-        cd ../../../../..
-
-        echo "Building and pushing the lib-injection apps for python"
-        export APP_DOCKER_IMAGE_REPO=ghcr.io/datadog/system-tests/dd-lib-python-init-test-django
-        cd lib-injection/build/docker/python/dd-lib-python-init-test-django
-        LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
-        cd ../../../../..
     fi
 else
     echo "The commit message $CI_COMMIT_MESSAGE doesn't contain the PR number."

--- a/utils/scripts/get_pr_merged_labels.sh
+++ b/utils/scripts/get_pr_merged_labels.sh
@@ -6,6 +6,8 @@
 
 ##################################################
         echo "TESTTTTTTTTTTTTT"
+        docker buildx create --name multiarch --driver docker-container --use
+
         echo "$DOCKER_LOGIN_PASS" | docker login --username "$DOCKER_LOGIN" --password-stdin
         export DOCKER_IMAGE_WEBLOG_TAG="latest"
 

--- a/utils/scripts/get_pr_merged_labels.sh
+++ b/utils/scripts/get_pr_merged_labels.sh
@@ -4,6 +4,33 @@
 #We extract the PR number and using GitHub API we check the PR labels.
 #If the PR contains the label "build-buddies-images" we launch the build and push process
 
+##################################################
+        echo "TESTTTTTTTTTTTTT"
+        echo "$DOCKER_LOGIN_PASS" | docker login --username "$DOCKER_LOGIN" --password-stdin
+        export DOCKER_IMAGE_WEBLOG_TAG="latest"
+
+        echo "Building and pushing the lib-injection apps for java"
+        export APP_DOCKER_IMAGE_REPO=ghcr.io/datadog/system-tests/dd-lib-java-init-test-app
+        cd lib-injection/build/docker/java/dd-lib-java-init-test-app
+        LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
+        cd ../../../../..
+
+        echo "Building and pushing the lib-injection apps for nodejs"
+        export APP_DOCKER_IMAGE_REPO=ghcr.io/datadog/system-tests/sample-app
+        cd lib-injection/build/docker/nodejs/sample-app
+        LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
+        cd ../../../../..
+
+        echo "Building and pushing the lib-injection apps for python"
+        export APP_DOCKER_IMAGE_REPO=ghcr.io/datadog/system-tests/dd-lib-python-init-test-django
+        cd lib-injection/build/docker/python/dd-lib-python-init-test-django
+        LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
+        cd ../../../../..
+
+##################################################
+
+
+
 PR_PATTERN='#[0-9]+'
 
 if [[ $CI_COMMIT_MESSAGE =~ ($PR_PATTERN) ]]; then
@@ -20,7 +47,7 @@ if [[ $CI_COMMIT_MESSAGE =~ ($PR_PATTERN) ]]; then
 
     is_build_buddies=$(echo "$PR_DATA" | jq -c '.[] | select(.name | contains("build-buddies-images"))');
     is_build_lib_injections_apps=$(echo "$PR_DATA" | jq -c '.[] | select(.name | contains("build-lib-injection-app-images"))');
-    is_build_lib_injections_apps="true"
+
     if [ -z "$is_build_buddies" ]
     then
         echo "The PR $PR_NUMBER doesn't contain the 'build-buddies-images' label "

--- a/utils/scripts/get_pr_merged_labels.sh
+++ b/utils/scripts/get_pr_merged_labels.sh
@@ -6,7 +6,7 @@
 
 ##################################################
         echo "TESTTTTTTTTTTTTT"
-        #docker buildx create --name multiarch --driver docker-container --use
+        docker buildx create --name multiarch --driver docker-container --use
 
         echo "$DOCKER_LOGIN_PASS" | docker login --username "$DOCKER_LOGIN" --password-stdin
         export DOCKER_IMAGE_WEBLOG_TAG="latest"

--- a/utils/scripts/get_pr_merged_labels.sh
+++ b/utils/scripts/get_pr_merged_labels.sh
@@ -20,7 +20,7 @@ if [[ $CI_COMMIT_MESSAGE =~ ($PR_PATTERN) ]]; then
 
     is_build_buddies=$(echo "$PR_DATA" | jq -c '.[] | select(.name | contains("build-buddies-images"))');
     is_build_lib_injections_apps=$(echo "$PR_DATA" | jq -c '.[] | select(.name | contains("build-lib-injection-app-images"))');
-
+    is_build_lib_injections_apps="true"
     if [ -z "$is_build_buddies" ]
     then
         echo "The PR $PR_NUMBER doesn't contain the 'build-buddies-images' label "


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
