### PR TITLE
go: enable custom blocking response tests

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -156,7 +156,8 @@ tests/:
       test_blocking.py:
         Test_Blocking: v1.50.0-rc.1
         Test_CustomBlockingResponse:
-          '*': v1.53.0
+          '*': v1.62.0-dev
+          gin: bug (gin preprends to the original response)
           uds-echo: bug
       test_custom_rules.py:
         Test_CustomRules: v1.51.0

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -230,7 +230,6 @@ class Test_CustomBlockingResponse:
         context.library == "java" and context.weblog_variant not in ("akka-http", "play"),
         reason="Do not check the configured redirect status code",
     )
-    @bug(context.library == "golang", reason="Do not check the configured redirect status code")
     def test_custom_redirect_wrong_status_code(self):
         """Block with an HTTP redirection but default to 303 status code, because the configured status code is not a valid redirect status code"""
         assert self.r_cr.status_code == 303
@@ -240,7 +239,6 @@ class Test_CustomBlockingResponse:
         self.r_cr = weblog.get("/waf/", headers={"User-Agent": "Canary/v4"}, allow_redirects=False)
 
     @bug(context.library == "java", reason="Do not check the configured redirect location value")
-    @bug(context.library == "golang", reason="Do not check the configured redirect location value")
     def test_custom_redirect_missing_location(self):
         """Block with an default page because location parameter is missing from redirect request configuration"""
         assert self.r_cr.status_code == 403


### PR DESCRIPTION
## Motivation

Enable all custom blocking response tests for Go now that the lib is finally aligned with the RFC.
Gin variant is disabled due to a bug.


## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
