### PR TITLE
Create prune-image-registry.yml

### DIFF
--- a/.github/workflows/prune-image-registry.yml
+++ b/.github/workflows/prune-image-registry.yml
@@ -1,0 +1,34 @@
+name: Prune Injection images
+on:
+  schedule:
+    - cron: '15 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  prune-init-images:
+    name: Prune dd-lib-java-init docker images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        weblog-variant: 
+          - dd-lib-java-init-test-app
+          - sample-app
+          - dd-lib-python-init-test-django
+      fail-fast: false
+    steps:
+    - name: Prune registry
+      uses: vlaurin/action-ghcr-prune@0a539594d122b915e71c59733a5b115bfaaf5d52 #v0.5.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        organization: Datadog
+        container: system-tests/${{ matrix.weblog-variant }}
+        keep-younger-than: 7 # days
+        keep-last: 10
+        keep-tags: |
+          latest
+        prune-tags-regexes: |
+          ^[a-z0-9]{40}$
+        prune-untagged: true


### PR DESCRIPTION
## Motivation

There are ~38,000 python images and ~2,700 java images in system-tests for lib injection

## Changes

This adds a github action workflow to prune the number of images in the repo. It is mirrored after: https://github.com/DataDog/dd-trace-java/blob/master/.github/workflows/lib-injection-prune-registry.yaml

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
