### PR TITLE
Fix integrations dsm tests in replay mode

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -496,14 +496,6 @@ jobs:
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
 
-    - name: Run Integration in replay mode
-      if: always() 
-      run: ./run.sh INTEGRATIONS --replay
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-        DD_APP_KEY: ${{ secrets.DD_APPLICATION_KEY }}
-
     - name: Run all scenarios in replay mode
       if: always() && steps.build.outcome == 'success' && inputs.run_replay
       run: |

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -495,6 +495,15 @@ jobs:
       run: ./run.sh DEBUGGER_MIX_LOG_PROBE
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
+
+    - name: Run Integration in replay mode
+      if: always() 
+      run: ./run.sh INTEGRATIONS --replay
+      env:
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        DD_APPLICATION_KEY: ${{ secrets.DD_APPLICATION_KEY }}
+        DD_APP_KEY: ${{ secrets.DD_APPLICATION_KEY }}
+
     - name: Run all scenarios in replay mode
       if: always() && steps.build.outcome == 'success' && inputs.run_replay
       run: |

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -420,8 +420,11 @@ class Test_DsmContext_Extraction_Base64:
         queue = "dsm-propagation-test-v2-encoding-queue"
         exchange = "dsm-propagation-test-v2-encoding-exchange"
 
-        # send initial message with v2 pathway context encoding
-        self.produce_response = DsmHelper.produce_rabbitmq_message_base64_propagation(queue, exchange)
+        if not context.scenario.replay:
+            # send initial message with v2 pathway context encoding
+            self.produce_response = DsmHelper.produce_rabbitmq_message_base64_propagation(queue, exchange)
+        else:
+            self.produce_response = "ok"
 
         self.r = weblog.get(f"/rabbitmq/consume?queue={queue}&exchange={exchange}&timeout=60", timeout=61,)
 

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -347,8 +347,11 @@ class Test_DsmContext_Injection_Base64:
         # send initial message with via weblog
         self.r = weblog.get(f"/rabbitmq/produce?queue={queue}&exchange={exchange}&timeout=60", timeout=61,)
 
-        # consume message using helper and check propagation type
-        self.consume_response = DsmHelper.consume_rabbitmq_injection(queue, exchange, 61)
+        if not context.scenario.replay:
+            # consume message using helper and check propagation type
+            self.consume_response = DsmHelper.consume_rabbitmq_injection(queue, exchange, 61)
+        else:
+            self.consume_response = "ok"
 
     def test_dsmcontext_injection_base64(self):
         assert self.r.status_code == 200

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -350,13 +350,14 @@ class Test_DsmContext_Injection_Base64:
         if not context.scenario.replay:
             # consume message using helper and check propagation type
             self.consume_response = DsmHelper.consume_rabbitmq_injection(queue, exchange, 61)
-        else:
-            self.consume_response = "ok"
 
     def test_dsmcontext_injection_base64(self):
         assert self.r.status_code == 200
 
         assert "error" not in self.r.text
+        if context.scenario.replay:
+            # This test doesn't work in replay mode
+            return
         assert "error" not in self.consume_response
 
         language_hashes = {


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
There is massive failure when we run in replay mode for integrations scenario. The problems resides on test_dsm.py

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
