### PR TITLE
Try catch nodejs kafka key consumer

### DIFF
--- a/utils/build/docker/nodejs/express4-typescript/iast.ts
+++ b/utils/build/docker/nodejs/express4-typescript/iast.ts
@@ -481,7 +481,11 @@ function initSourceRoutes (app: Express): void {
       await consumer.run({
         eachMessage: async ({ message }: { message: any }) => {
           const vulnKey = message.key.toString()
-          readFileSync(vulnKey)
+          try {
+            readFileSync(vulnKey)
+          } catch {
+            // do nothing
+          }
 
           deferred.resolve?.()
         }

--- a/utils/build/docker/nodejs/express4/iast/sources.js
+++ b/utils/build/docker/nodejs/express4/iast/sources.js
@@ -195,7 +195,11 @@ function init (app, tracer) {
       await consumer.run({
         eachMessage: async ({ topic, partition, message }) => {
           const vulnKey = message.key.toString()
-          readFileSync(vulnKey)
+          try {
+            readFileSync(vulnKey)
+          } catch {
+            // do nothing
+          }
 
           deferred.resolve()
         }


### PR DESCRIPTION
## Motivation

Missing try-catch in kafka key express4 and express4-typescript tests

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
