### PR TITLE
Enable PHP RC ASM_FEATURES scenarios

### DIFF
--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -55,7 +55,6 @@ class RemoteConfigurationFieldsBasicTests:
     @bug(context.library < "golang@1.36.0")
     @bug(context.library < "java@0.93.0")
     @bug(context.library >= "nodejs@3.14.1")
-    @bug(context.library == "php")
     def test_schemas(self):
         """Test all library schemas"""
         interfaces.library.assert_schemas()
@@ -88,11 +87,6 @@ class RemoteConfigurationFieldsBasicTests:
             allowed_errors = (
                 # value is missing in configuration object in telemetry payloads
                 r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-            )
-        elif context.library == "php":
-            allowed_errors = (
-                r"'interval' is a required property on instance \['payload'\]\['series'\]\[\d+\]",
-                r"'namespace' is a required property on instance \['payload'\]",
             )
 
         interfaces.library.assert_schemas(allowed_errors=allowed_errors)

--- a/utils/build/docker/php/apache-mod/entrypoint.sh
+++ b/utils/build/docker/php/apache-mod/entrypoint.sh
@@ -21,4 +21,4 @@ export -p | sed 's@declare -x@export@' | tee /dev/stderr >> /etc/apache2/envvars
 
 service apache2 start
 
-exec tail -f "${LOGS_PHP[@]}" "${LOGS_APACHE[@]}"
+exec tail -f "${LOGS_PHP[@]}" "${LOGS_APACHE[@]}" "/tmp/appsec.log" "/tmp/helper.log"

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -21,18 +21,21 @@ if [ "$PKG" == "" ]; then
   unset PKG
 fi
 
+INI_FILE=/etc/php/php.ini
 echo "Installing php package ${PKG-"{default}"} with setup script $SETUP"
 if [[ $IS_APACHE -eq 0 ]]; then
       php $SETUP --php-bin all ${PKG+"--file=$PKG"}
+      PHP_VERSION=$(php -r "echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;")
+      INI_FILE=/etc/php/$PHP_VERSION/fpm/conf.d/98-ddtrace.ini
 else
       PHP_INI_SCAN_DIR="/etc/php" php $SETUP --php-bin all ${PKG+"--file=$PKG"}
- fi
+fi
 
 #There is a bug on 0.98.1 which config when it shouldnt. Delete this line when hotfix
-sed -i "/datadog.appsec.enabled/s/^/;/g" /etc/php/php.ini
-
+sed -i "/datadog.appsec.enabled/s/^/;/g" $INI_FILE
 #Parametric tests don't need appsec
-[ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> /etc/php/php.ini
+[ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> $INI_FILE
+
 #Ensure parametric test compatibility
 [ ! -z ${NO_EXTRACT_VERSION+x} ] && exit 0
 

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -8,9 +8,6 @@ cd /binaries
 
 PKG=$(find /binaries -maxdepth 1 -name 'dd-library-php-*-linux-gnu.tar.gz')
 SETUP=/binaries/datadog-setup.php
-ENABLE_APPSEC_ARG="--enable-appsec"
-#Parametric tests don't need appsec
-[ ! -z ${NO_EXTRACT_VERSION+x} ] && ENABLE_APPSEC_ARG=""
 
 if [ "$PKG" != "" ] && [ ! -f "$SETUP" ]; then
   echo "local install failed: package located in /binaries but datadog-setup.php not present, please include it"
@@ -26,11 +23,13 @@ fi
 
 echo "Installing php package ${PKG-"{default}"} with setup script $SETUP"
 if [[ $IS_APACHE -eq 0 ]]; then
-      php $SETUP --php-bin all ${PKG+"--file=$PKG"} $ENABLE_APPSEC_ARG
+      php $SETUP --php-bin all ${PKG+"--file=$PKG"}
 else
-      PHP_INI_SCAN_DIR="/etc/php" php $SETUP --php-bin all ${PKG+"--file=$PKG"} $ENABLE_APPSEC_ARG
+      PHP_INI_SCAN_DIR="/etc/php" php $SETUP --php-bin all ${PKG+"--file=$PKG"}
  fi
 
+#Parametric tests don't need appsec
+[ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> /etc/php/php.ini
 #Ensure parametric test compatibility
 [ ! -z ${NO_EXTRACT_VERSION+x} ] && exit 0
 

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -32,7 +32,7 @@ else
 fi
 
 if test -f $INI_FILE; then
-  #There is a bug on 0.98.1 which config when it shouldnt. Delete this line when hotfix
+  #There is a bug on 0.98.1 which disable explicitly appsec when it shouldnt. Delete this line when hotfix
   sed -i "/datadog.appsec.enabled/s/^/;/g" $INI_FILE
   #Parametric tests don't need appsec
   [ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> $INI_FILE

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -31,10 +31,12 @@ else
       PHP_INI_SCAN_DIR="/etc/php" php $SETUP --php-bin all ${PKG+"--file=$PKG"}
 fi
 
-#There is a bug on 0.98.1 which config when it shouldnt. Delete this line when hotfix
-sed -i "/datadog.appsec.enabled/s/^/;/g" $INI_FILE
-#Parametric tests don't need appsec
-[ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> $INI_FILE
+if test -f $INI_FILE; then
+  #There is a bug on 0.98.1 which config when it shouldnt. Delete this line when hotfix
+  sed -i "/datadog.appsec.enabled/s/^/;/g" $INI_FILE
+  #Parametric tests don't need appsec
+  [ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> $INI_FILE
+fi
 
 #Ensure parametric test compatibility
 [ ! -z ${NO_EXTRACT_VERSION+x} ] && exit 0

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -28,6 +28,9 @@ else
       PHP_INI_SCAN_DIR="/etc/php" php $SETUP --php-bin all ${PKG+"--file=$PKG"}
  fi
 
+#There is a bug on 0.98.1 which config when it shouldnt. Delete this line when hotfix
+sed -i "/datadog.appsec.enabled/s/^/;/g" /etc/php/php.ini
+
 #Parametric tests don't need appsec
 [ ! -z ${NO_EXTRACT_VERSION+x} ] && echo "datadog.appsec.enabled = Off" >> /etc/php/php.ini
 #Ensure parametric test compatibility


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
