### PR TITLE
[OTEL-1734][opentelemetry] Extend test to OTLP metrics intake

### DIFF
--- a/tests/otel_tracing_e2e/_test_validator_metric.py
+++ b/tests/otel_tracing_e2e/_test_validator_metric.py
@@ -3,15 +3,19 @@
 import dictdiffer
 
 # Validates the JSON logs from backend and returns the OTel log trace attributes
-def validate_metrics(metrics_agent: list[dict], metrics_collector: list[dict]):
-    diff = list(dictdiffer.diff(metrics_agent[0], metrics_collector[0]))
-    assert len(diff) == 0, f"Diff between count metrics from Agent vs. from Collector: {diff}"
-    validate_example_counter(metrics_agent[0])
+def validate_metrics(
+    metrics_1: list[dict], metrics_2: list[dict], metrics_source1: str, metrics_source2: str,
+):
+    diff = list(dictdiffer.diff(metrics_1[0], metrics_2[0]))
+    assert len(diff) == 0, f"Diff between count metrics from {metrics_source1} vs. from {metrics_source2}: {diff}"
+    validate_example_counter(metrics_1[0])
     idx = 1
     for histogram_suffix in ["", ".sum", ".count"]:
-        diff = list(dictdiffer.diff(metrics_agent[idx], metrics_collector[idx]))
-        assert len(diff) == 0, f"Diff between histogram{histogram_suffix} metrics from Agent vs. from Collector: {diff}"
-        validate_example_histogram(metrics_agent[idx], histogram_suffix)
+        diff = list(dictdiffer.diff(metrics_1[idx], metrics_2[idx]))
+        assert (
+            len(diff) == 0
+        ), f"Diff between histogram{histogram_suffix} metrics from {metrics_source1} vs. from {metrics_source2}: {diff}"
+        validate_example_histogram(metrics_1[idx], histogram_suffix)
         idx += 1
 
 

--- a/tests/otel_tracing_e2e/test_e2e.py
+++ b/tests/otel_tracing_e2e/test_e2e.py
@@ -101,6 +101,19 @@ class Test_OTelMetricE2E:
                 for metric in self.expected_metrics
             ]
 
+            # The 2nd account has metrics via the backend OTLP intake endpoint
+            metrics_intake = [
+                interfaces.backend.query_timeseries(
+                    start=self.start,
+                    end=end,
+                    rid=rid,
+                    metric=metric,
+                    dd_api_key=os.environ["DD_API_KEY_2"],
+                    dd_app_key=os.environ.get("DD_APP_KEY_2"),
+                )
+                for metric in self.expected_metrics
+            ]
+
             # The 3rd account has metrics sent by OTel Collector
             metrics_collector = [
                 interfaces.backend.query_timeseries(
@@ -118,7 +131,8 @@ class Test_OTelMetricE2E:
             logger.warning("Backend does not provide series")
             return
 
-        validate_metrics(metrics_agent, metrics_collector)
+        validate_metrics(metrics_agent, metrics_collector, "Agent", "Collector")
+        validate_metrics(metrics_agent, metrics_intake, "Agent", "Intake")
 
 
 @scenarios.otel_log_e2e

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1580,7 +1580,7 @@ class scenarios:
     )
 
     otel_tracing_e2e = OpenTelemetryScenario("OTEL_TRACING_E2E", doc="")
-    otel_metric_e2e = OpenTelemetryScenario("OTEL_METRIC_E2E", include_intake=False, doc="")
+    otel_metric_e2e = OpenTelemetryScenario("OTEL_METRIC_E2E", doc="")
     otel_log_e2e = OpenTelemetryScenario("OTEL_LOG_E2E", include_intake=False, doc="")
 
     library_conf_custom_header_tags = EndToEndScenario(

--- a/utils/build/docker/java_otel/spring-boot-native/src/main/java/com/datadoghq/springbootnative/App.java
+++ b/utils/build/docker/java_otel/spring-boot-native/src/main/java/com/datadoghq/springbootnative/App.java
@@ -67,7 +67,7 @@ public class App {
                     .setEndpoint("http://proxy:8126/api/v0.2/traces")  // send to the proxy first
                     .addHeader("dd-protocol", "otlp")
                     .addHeader("dd-api-key", System.getenv("DD_API_KEY"))
-                    .addHeader("dd-otlp-path", "intake")
+                    .addHeader("dd-otlp-path", "intake-traces")
                     .addHeader("dd-otlp-source", "datadog")
                     .build());
         }
@@ -102,6 +102,17 @@ public class App {
                             .setEndpoint("http://proxy:8126/v1/metrics")
                             .addHeader("dd-protocol", "otlp")
                             .addHeader("dd-otlp-path", "agent")
+                            .setAggregationTemporalitySelector(AggregationTemporalitySelector.deltaPreferred())
+                            .build());
+        }
+        if (isIntakeEnabled()) {
+            metricExporters.add(
+                    OtlpHttpMetricExporter.builder()
+                            .setEndpoint("http://proxy:8126/api/intake/otlp/v1/metrics")  // send to the proxy first
+                            .addHeader("dd-protocol", "otlp")
+                            .addHeader("dd-api-key", System.getenv("DD_API_KEY"))
+                            .addHeader("dd-otlp-path", "intake-metrics")
+                            .addHeader("dd-otel-metric-config", "{\"histograms\": {\"send_aggregation_metrics\": true}}")
                             .setAggregationTemporalitySelector(AggregationTemporalitySelector.deltaPreferred())
                             .build());
         }

--- a/utils/build/docker/java_otel/spring-boot-native/src/main/java/com/datadoghq/springbootnative/WebController.java
+++ b/utils/build/docker/java_otel/spring-boot-native/src/main/java/com/datadoghq/springbootnative/WebController.java
@@ -47,6 +47,7 @@ public class WebController {
               .addLink(spanContext, Attributes.of(AttributeKey.stringKey("messaging.operation"), "publish"))
               .setAttribute(SemanticAttributes.HTTP_ROUTE, "/")
               .setAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+              .setAttribute(AttributeKey.booleanKey("bool_key"), false)
               .setAttribute("http.request.headers.user-agent", headers.get("User-Agent").get(0))
               .startSpan();
       try (Scope ignored = span.makeCurrent()) {

--- a/utils/proxy/core.py
+++ b/utils/proxy/core.py
@@ -96,8 +96,12 @@ class _RequestLogger:
                     flow.request.host = "system-tests-collector"
                     flow.request.port = 4318
                     flow.request.scheme = "http"
-                elif otlp_path == "intake":
+                elif otlp_path == "intake-traces":
                     flow.request.host = "trace.agent." + os.environ.get("DD_SITE", "datad0g.com")
+                    flow.request.port = 443
+                    flow.request.scheme = "https"
+                elif otlp_path == "intake-metrics":
+                    flow.request.host = "api." + os.environ.get("DD_SITE", "datad0g.com")
                     flow.request.port = 443
                     flow.request.scheme = "https"
                 else:


### PR DESCRIPTION
## Motivation

Cover OTLP metrics intake in OTel system test.

## Changes

Extend system test `OTEL_METRIC_E2E` to cover the OTLP metrics intake scenario.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
