### PR TITLE
Add insecure auth protocol test for dotnet

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -34,7 +34,7 @@ tests/:
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: v2.44.0
         test_insecure_auth_protocol.py:
-          Test_InsecureAuthProtocol: missing_feature
+          Test_InsecureAuthProtocol: v2.49.0
         test_insecure_cookie.py:
           TestInsecureCookie: v2.39.0
         test_ldap_injection.py:

--- a/tests/appsec/iast/sink/test_insecure_auth_protocol.py
+++ b/tests/appsec/iast/sink/test_insecure_auth_protocol.py
@@ -15,7 +15,7 @@ class Test_InsecureAuthProtocol(BaseSinkTest):
     insecure_endpoint = "/iast/insecure-auth-protocol/test"
     secure_endpoint = "/iast/insecure-auth-protocol/test"
     data = {}
-    insecure_headers = {"Authorization": "Digest dGVzd"}
+    insecure_headers = {"Authorization": "Basic dGVzd"}
 
     @missing_feature(library="java", reason="Not implemented yet")
     @missing_feature(library="dotnet", reason="Not implemented yet")

--- a/tests/appsec/iast/sink/test_insecure_auth_protocol.py
+++ b/tests/appsec/iast/sink/test_insecure_auth_protocol.py
@@ -18,6 +18,7 @@ class Test_InsecureAuthProtocol(BaseSinkTest):
     insecure_headers = {"Authorization": "Basic dGVzd"}
 
     @missing_feature(library="java", reason="Not implemented yet")
+    @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
 

--- a/tests/appsec/iast/sink/test_insecure_auth_protocol.py
+++ b/tests/appsec/iast/sink/test_insecure_auth_protocol.py
@@ -15,7 +15,7 @@ class Test_InsecureAuthProtocol(BaseSinkTest):
     insecure_endpoint = "/iast/insecure-auth-protocol/test"
     secure_endpoint = "/iast/insecure-auth-protocol/test"
     data = {}
-    insecure_headers = {"Authorization": "Basic dGVzd"}
+    insecure_headers = {"Authorization": "Digest dGVzd"}
 
     @missing_feature(library="java", reason="Not implemented yet")
     @missing_feature(library="dotnet", reason="Not implemented yet")

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -630,6 +630,11 @@ namespace weblog
                 return StatusCode(500, "Error executing safe reflection.");
             }
         }
-
+        
+        [HttpGet("insecure-auth-protocol/test")]
+        public IActionResult test_insecure_auth_protocol()
+        {
+            return StatusCode(200);
+        }
     }
 }

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -634,7 +634,10 @@ namespace weblog
         [HttpGet("insecure-auth-protocol/test")]
         public IActionResult test_insecure_auth_protocol()
         {
-            return StatusCode(200);
+            // Print Authorization header
+            var authHeader = Request.Headers["Authorization"];
+            Console.WriteLine("Authorization header: " + authHeader);
+            return Content("Executed insecure auth protocol");
         }
     }
 }

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -634,6 +634,12 @@ namespace weblog
         [HttpGet("insecure-auth-protocol/test")]
         public IActionResult test_insecure_auth_protocol()
         {
+            // Reset the deduplication of vulnerabilities using reflection
+            var type = Type.GetType("Datadog.Trace.Iast.HashBasedDeduplication, Datadog.Trace")!;
+            var instance = type.GetProperty("Instance")!.GetValue(null);
+            var field = type.GetField("_vulnerabilityHashes", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            field!.SetValue(instance, new HashSet<int>());
+            
             return StatusCode(200);
         }
     }

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -634,10 +634,7 @@ namespace weblog
         [HttpGet("insecure-auth-protocol/test")]
         public IActionResult test_insecure_auth_protocol()
         {
-            // Print Authorization header
-            var authHeader = Request.Headers["Authorization"];
-            Console.WriteLine("Authorization header: " + authHeader);
-            return Content("Executed insecure auth protocol");
+            return StatusCode(200);
         }
     }
 }


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
