### PR TITLE
k8s-lib-injection: run in parallel

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -322,6 +322,13 @@ function main() {
       done
     fi
 
+    # evaluate max pytest number of process for K8s_lib_injection
+    for scenario in "${scenarios[@]}"; do
+        if [[ "${scenario}" == "K8S_LIB_INJECTION" ]]; then
+            pytest_numprocesses=$(nproc)
+        fi
+    done
+    
     case "${pytest_numprocesses}" in
         0|1)
             ;;

--- a/tests/k8s_lib_injection/conftest.py
+++ b/tests/k8s_lib_injection/conftest.py
@@ -27,9 +27,9 @@ def test_k8s_instance(request):
     logger.info("K8sInstance created")
     yield k8s_instance
     logger.info("K8sInstance Exporting debug info")
-    # k8s_instance.export_debug_info(test_name)
+    k8s_instance.export_debug_info(test_name)
     logger.info("K8sInstance destroying")
-    # k8s_instance.destroy_instance()
+    k8s_instance.destroy_instance()
     logger.info("K8sInstance destroyed")
 
 

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -337,11 +337,8 @@ class TestConfigMapAutoInject:
         logger.debug(f"Traces: {traces_json}")
         assert len(traces_json) > 0, "No traces found"
 
-        logger.debug(" _check_for_env_vars")
         self._check_for_env_vars(test_k8s_instance, expected_env_vars)
-        logger.debug(" _check_for_pod_metadata")
         self._check_for_pod_metadata(test_k8s_instance)
-        logger.debug(" _check_for_deploy_metadata")
         self._check_for_deploy_metadata(test_k8s_instance)
 
         logger.debug(" Trigger unrelated rolling-update")
@@ -433,11 +430,8 @@ class TestConfigMapAutoInject:
         test_k8s_instance.deploy_weblog_as_deployment()
         test_agent = test_k8s_instance.deploy_test_agent()
         test_agent.deploy_operator_auto()
-        default_config_data = self._get_default_auto_inject_config(test_k8s_instance)
 
         expected_env_vars = [{"name": "DD_TRACE_SAMPLE_RATE", "value": "0.90"}]
-
-        #  test_k8s_instance.apply_config_auto_inject(json.dumps(default_config_data))
 
         all_config_data = self._get_default_auto_inject_config_all_libraries(test_k8s_instance)
         test_k8s_instance.apply_config_auto_inject(json.dumps(all_config_data), timeout=300)

--- a/tests/k8s_lib_injection/test_k8s_manual_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_manual_inject.py
@@ -10,10 +10,10 @@ from utils import scenarios, context, features
 @features.k8s_admission_controller
 @scenarios.k8s_lib_injection
 class TestAdmisionController:
-    def _get_dev_agent_traces(self, retry=10):
+    def _get_dev_agent_traces(self, agent_port, retry=10):
         for _ in range(retry):
             logger.info(f"[Check traces] Checking traces:")
-            response = requests.get("http://localhost:18126/test/traces")
+            response = requests.get(f"http://localhost:{agent_port}/test/traces")
             traces_json = response.json()
             if len(traces_json) > 0:
                 logger.debug(f"Test traces response: {traces_json}")
@@ -22,26 +22,32 @@ class TestAdmisionController:
         return []
 
     def test_inject_admission_controller(self, test_k8s_instance):
-        logger.info(f"Launching test _test_inject_admission_controller")
+        logger.info(
+            f"Launching test _test_inject_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
+        )
         test_agent = test_k8s_instance.deploy_test_agent()
         test_agent.deploy_operator_manual()
         test_k8s_instance.deploy_weblog_as_pod()
-        traces_json = self._get_dev_agent_traces()
+        traces_json = self._get_dev_agent_traces(test_k8s_instance.k8s_kind_cluster.agent_port)
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_admission_controller finished")
 
     def test_inject_without_admission_controller(self, test_k8s_instance):
-        logger.info(f"Launching test _test_inject_without_admission_controller")
+        logger.info(
+            f"Launching test _test_inject_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
+        )
         test_agent = test_k8s_instance.deploy_test_agent()
         test_k8s_instance.deploy_weblog_as_pod(with_admission_controller=False)
-        traces_json = self._get_dev_agent_traces()
+        traces_json = self._get_dev_agent_traces(test_k8s_instance.k8s_kind_cluster.agent_port)
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_without_admission_controller finished")
 
     def test_inject_uds_without_admission_controller(self, test_k8s_instance):
-        logger.info(f"Launching test test_inject_uds_without_admission_controller")
+        logger.info(
+            f"Launching test test_inject_uds_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
+        )
         test_agent = test_k8s_instance.deploy_test_agent()
         test_k8s_instance.deploy_weblog_as_pod(with_admission_controller=False, use_uds=True)
-        traces_json = self._get_dev_agent_traces()
+        traces_json = self._get_dev_agent_traces(test_k8s_instance.k8s_kind_cluster.agent_port)
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test test_inject_uds_without_admission_controller finished")

--- a/tests/k8s_lib_injection/test_k8s_manual_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_manual_inject.py
@@ -36,7 +36,7 @@ class TestAdmisionController:
         logger.info(
             f"Launching test _test_inject_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )
-        test_agent = test_k8s_instance.deploy_test_agent()
+        test_k8s_instance.deploy_test_agent()
         test_k8s_instance.deploy_weblog_as_pod(with_admission_controller=False)
         traces_json = self._get_dev_agent_traces(test_k8s_instance.k8s_kind_cluster.agent_port)
         assert len(traces_json) > 0, "No traces found"
@@ -46,7 +46,7 @@ class TestAdmisionController:
         logger.info(
             f"Launching test test_inject_uds_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )
-        test_agent = test_k8s_instance.deploy_test_agent()
+        test_k8s_instance.deploy_test_agent()
         test_k8s_instance.deploy_weblog_as_pod(with_admission_controller=False, use_uds=True)
         traces_json = self._get_dev_agent_traces(test_k8s_instance.k8s_kind_cluster.agent_port)
         assert len(traces_json) > 0, "No traces found"

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -1,5 +1,6 @@
 import subprocess, datetime, os, time, signal
 from utils.tools import logger
+from utils.k8s_lib_injection.k8s_sync_kubectl import KubectlLock
 
 
 def execute_command(command, timeout=None):
@@ -42,34 +43,32 @@ def execute_command(command, timeout=None):
     return output
 
 
-def ensure_cluster():
-    execute_command(
-        "kind create cluster --image=kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1 --name lib-injection-testing --config utils/k8s_lib_injection/resources/kind-config.yaml"
-    )
-    execute_command("kubectl wait --for=condition=Ready nodes --all --timeout=5m")
+def helm_add_repo(name, url, k8s_kind_cluster, update=False):
+
+    with KubectlLock():
+        execute_command(f"kubectl config use-context {k8s_kind_cluster.context_name}")
+        execute_command(f"helm repo add {name} {url}")
+        if update:
+            execute_command(f"helm repo update")
 
 
-def destroy_cluster():
-    execute_command("kind delete cluster --name lib-injection-testing")
-    execute_command("docker rm -f lib-injection-testing-control-plane")
+def helm_install_chart(k8s_kind_cluster, name, chart, set_dict={}, value_file=None):
+    with KubectlLock():
+        execute_command(f"kubectl config use-context {k8s_kind_cluster.context_name}")
+        set_str = ""
+        if set_dict:
+            for key, value in set_dict.items():
+                set_str += f" --set {key}={value}"
+
+        command = f"helm install {name} --wait {set_str} {chart}"
+        if value_file:
+            # command = f"helm install {name} --wait {set_str} -f {value_file} {chart}"
+            command = f"helm install {name} {set_str} -f {value_file} {chart}"
+
+        execute_command(command, timeout=90)
 
 
-def helm_add_repo(name, url, update=False):
-
-    execute_command(f"helm repo add {name} {url}")
-    if update:
-        execute_command(f"helm repo update")
-
-
-def helm_install_chart(name, chart, set_dict={}, value_file=None):
-    set_str = ""
-    if set_dict:
-        for key, value in set_dict.items():
-            set_str += f" --set {key}={value}"
-
-    command = f"helm install {name} --wait {set_str} {chart}"
-    if value_file:
-        # command = f"helm install {name} --wait {set_str} -f {value_file} {chart}"
-        command = f"helm install {name} {set_str} -f {value_file} {chart}"
-
-    execute_command(command, timeout=90)
+def path_clusterrole(k8s_kind_cluster):
+    with KubectlLock():
+        execute_command(f"kubectl config use-context {k8s_kind_cluster.context_name}")
+        execute_command("sh utils/k8s_lib_injection/resources/operator/scripts/path_clusterrole.sh")

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -1,5 +1,6 @@
 import subprocess, datetime, os, time, signal
 from utils.tools import logger
+from utils import context
 from utils.k8s_lib_injection.k8s_sync_kubectl import KubectlLock
 
 
@@ -43,6 +44,13 @@ def execute_command(command, timeout=None):
     return output
 
 
+def execute_command_sync(command, k8s_kind_cluster, timeout=None):
+
+    with KubectlLock():
+        execute_command(f"kubectl config use-context {k8s_kind_cluster.context_name}")
+        execute_command(command, timeout=timeout)
+
+
 def helm_add_repo(name, url, k8s_kind_cluster, update=False):
 
     with KubectlLock():
@@ -53,6 +61,20 @@ def helm_add_repo(name, url, k8s_kind_cluster, update=False):
 
 
 def helm_install_chart(k8s_kind_cluster, name, chart, set_dict={}, value_file=None):
+    # Copy and replace cluster name in the value file
+    custom_value_file = None
+    if value_file:
+        with open(value_file, "r") as file:
+            value_data = file.read()
+
+        value_data = value_data.replace("$$CLUSTER_NAME$$", str(k8s_kind_cluster.cluster_name))
+
+        custom_value_file = f"{context.scenario.host_log_folder}/{k8s_kind_cluster.cluster_name}_help_values.yaml"
+
+        with open(custom_value_file, "w") as fp:
+            fp.write(value_data)
+            fp.seek(0)
+
     with KubectlLock():
         execute_command(f"kubectl config use-context {k8s_kind_cluster.context_name}")
         set_str = ""
@@ -61,14 +83,15 @@ def helm_install_chart(k8s_kind_cluster, name, chart, set_dict={}, value_file=No
                 set_str += f" --set {key}={value}"
 
         command = f"helm install {name} --wait {set_str} {chart}"
-        if value_file:
+        if custom_value_file:
             # command = f"helm install {name} --wait {set_str} -f {value_file} {chart}"
-            command = f"helm install {name} {set_str} -f {value_file} {chart}"
+            command = f"helm install {name} {set_str} -f {custom_value_file} {chart}"
 
         execute_command(command, timeout=90)
 
 
 def path_clusterrole(k8s_kind_cluster):
+    """ This is a hack until the patching permission is added in the official helm chart."""
     with KubectlLock():
         execute_command(f"kubectl config use-context {k8s_kind_cluster.context_name}")
         execute_command("sh utils/k8s_lib_injection/resources/operator/scripts/path_clusterrole.sh")

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -1,8 +1,13 @@
 import time
-from kubernetes import client, watch
+from kubernetes import client, config, watch
 from kubernetes.utils import create_from_yaml
 from utils.tools import logger
-from utils.k8s_lib_injection.k8s_command_utils import helm_add_repo, helm_install_chart, execute_command
+from utils.k8s_lib_injection.k8s_command_utils import (
+    helm_add_repo,
+    helm_install_chart,
+    execute_command,
+    path_clusterrole,
+)
 from utils.k8s_lib_injection.k8s_logger import k8s_logger
 
 import os
@@ -10,11 +15,20 @@ import json
 
 
 class K8sDatadogClusterTestAgent:
+    def __init__(self):
+        self.k8s_kind_cluster = None
+
+    def configure(self, k8s_kind_cluster):
+        self.k8s_kind_cluster = k8s_kind_cluster
+
     def desploy_test_agent(self):
         """ Installs the test agent pod."""
 
-        logger.info("[Test agent] Deploying Datadog test agent")
-        apps_api = client.AppsV1Api()
+        logger.info(f"[Test agent] Deploying Datadog test agent on the cluster: {self.k8s_kind_cluster.cluster_name}")
+
+        apps_api = client.AppsV1Api(
+            api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name)
+        )
         container = client.V1Container(
             name="trace-agent",
             image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest",
@@ -83,7 +97,7 @@ class K8sDatadogClusterTestAgent:
         """ Installs the Datadog Cluster Agent via helm for manual library injection testing.
             It returns when the Cluster Agent pod is ready."""
 
-        v1 = client.CoreV1Api()
+        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
 
         logger.info("[Deploy operator] Deploying Datadog Operator")
 
@@ -93,11 +107,12 @@ class K8sDatadogClusterTestAgent:
             operator_file = "utils/k8s_lib_injection/resources/operator/operator-helm-values-uds.yaml"
 
         logger.info("[Deploy operator] Configuring helm repository")
-        helm_add_repo("datadog", "https://helm.datadoghq.com", update=True)
+        helm_add_repo("datadog", "https://helm.datadoghq.com", self.k8s_kind_cluster, update=True)
 
         logger.info(f"[Deploy operator] helm install datadog with config file [{operator_file}]")
 
         helm_install_chart(
+            self.k8s_kind_cluster,
             "datadog",
             "datadog/datadog",
             value_file=operator_file,
@@ -121,11 +136,12 @@ class K8sDatadogClusterTestAgent:
 
         self.create_configmap_auto_inject()
         logger.info("[Deploy operator] Configuring helm repository")
-        helm_add_repo("datadog", "https://helm.datadoghq.com", update=True)
+        helm_add_repo("datadog", "https://helm.datadoghq.com", self.k8s_kind_cluster, update=True)
 
         logger.info(f"[Deploy operator] helm install datadog with config file [{operator_file}]")
 
         helm_install_chart(
+            self.k8s_kind_cluster,
             "datadog",
             "datadog/datadog",
             value_file=operator_file,
@@ -135,9 +151,7 @@ class K8sDatadogClusterTestAgent:
 
         # TODO: This is a hack until the patching permission is added in the official helm chart.
         logger.info("[Deploy operator] adding patch permissions to the datadog-cluster-agent clusterrole")
-        execute_command("sh utils/k8s_lib_injection/resources/operator/scripts/path_clusterrole.sh")
-
-        v1 = client.CoreV1Api()
+        path_clusterrole(self.k8s_kind_cluster)
 
         self._wait_for_operator_ready()
 
@@ -146,7 +160,7 @@ class K8sDatadogClusterTestAgent:
             It returns when the targeted deployment finishes the rollout."""
 
         logger.info(f"[Auto Config] Applying config for auto-inject: {config_data}")
-        v1 = client.CoreV1Api()
+        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
         metadata = client.V1ObjectMeta(name="auto-instru", namespace="default",)
         configmap = client.V1ConfigMap(kind="ConfigMap", data={"auto-instru.json": config_data,}, metadata=metadata)
         r = v1.replace_namespaced_config_map(name="auto-instru", namespace="default", body=configmap)
@@ -156,7 +170,7 @@ class K8sDatadogClusterTestAgent:
     def create_configmap_auto_inject(self):
         """ Minimal configuration needed when we install operator auto """
         logger.info("[Auto Config] Creating configmap for auto-inject")
-        v1 = client.CoreV1Api()
+        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
         metadata = client.V1ObjectMeta(name="auto-instru", namespace="default",)
         configmap = client.V1ConfigMap(
             kind="ConfigMap",
@@ -174,8 +188,10 @@ class K8sDatadogClusterTestAgent:
         time.sleep(5)
 
     def wait_for_test_agent(self):
-        v1 = client.CoreV1Api()
-        apps_api = client.AppsV1Api()
+        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
+        apps_api = client.AppsV1Api(
+            api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name)
+        )
         daemonset_created = False
         daemonset_status = None
         # Wait for the daemonset to be created
@@ -207,7 +223,7 @@ class K8sDatadogClusterTestAgent:
                 break
 
     def _wait_for_operator_ready(self):
-        v1 = client.CoreV1Api()
+        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
         pods = v1.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
         datadog_cluster_name = pods.items[0].metadata.name
 
@@ -238,8 +254,8 @@ class K8sDatadogClusterTestAgent:
 
     def export_debug_info(self, output_folder, test_name):
         """ Exports debug information for the test agent and the operator."""
-        v1 = client.CoreV1Api()
-        api = client.AppsV1Api()
+        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
+        api = client.AppsV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
 
         # Get all pods
         ret = v1.list_pod_for_all_namespaces(watch=False)

--- a/utils/k8s_lib_injection/k8s_kind_cluster.py
+++ b/utils/k8s_lib_injection/k8s_kind_cluster.py
@@ -27,10 +27,10 @@ def ensure_cluster():
         fp.write(kind_data)
         fp.seek(0)
         execute_command(
-            f"kind create cluster --image=kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1 --name {k8s_kind_cluster.cluster_name} --config {cluster_config}"
+            f"kind create cluster --image=kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1 --name {k8s_kind_cluster.cluster_name} --config {cluster_config} --wait 1m"
         )
 
-        time.sleep(20)
+        # time.sleep(20)
 
     return k8s_kind_cluster
 

--- a/utils/k8s_lib_injection/k8s_kind_cluster.py
+++ b/utils/k8s_lib_injection/k8s_kind_cluster.py
@@ -1,0 +1,67 @@
+import time
+import os
+import socket
+import random
+import tempfile
+from uuid import uuid4
+
+from utils.k8s_lib_injection.k8s_command_utils import execute_command
+from utils.tools import logger
+from utils import context
+
+
+def ensure_cluster():
+    k8s_kind_cluster = K8sKindCluster()
+    k8s_kind_cluster.confiure_ports()
+
+    kind_data = ""
+    with open("utils/k8s_lib_injection/resources/kind-config-template.yaml", "r") as file:
+        kind_data = file.read()
+
+    kind_data = kind_data.replace("$$AGENT_PORT$$", str(k8s_kind_cluster.agent_port))
+    kind_data = kind_data.replace("$$WEBLOG_PORT$$", str(k8s_kind_cluster.weblog_port))
+
+    cluster_config = f"{context.scenario.host_log_folder}/{k8s_kind_cluster.cluster_name}_kind-config.yaml"
+
+    with open(cluster_config, "w") as fp:
+        fp.write(kind_data)
+        fp.seek(0)
+        execute_command(
+            f"kind create cluster --image=kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1 --name {k8s_kind_cluster.cluster_name} --config {cluster_config}"
+        )
+
+        time.sleep(20)
+
+    return k8s_kind_cluster
+
+
+def destroy_cluster(k8s_kind_cluster):
+    execute_command(f"kind delete cluster --name {k8s_kind_cluster.cluster_name}")
+    execute_command(f"docker rm -f {k8s_kind_cluster.cluster_name}-control-plane")
+
+
+def get_free_port():
+    last_allowed_port = 65535
+    port = random.randint(1100, 65100)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    while port <= last_allowed_port:
+        try:
+            sock.bind(("", port))
+            sock.close()
+            return port
+        except OSError:
+            port += 1
+    raise IOError("no free ports")
+
+
+class K8sKindCluster:
+    def __init__(self):
+        self.cluster_name = f"lib-injection-testing-{str(uuid4())[:8]}"
+        self.context_name = f"kind-{self.cluster_name}"
+        self.agent_port = 18126
+        self.weblog_port = 18080
+
+    def confiure_ports(self):
+        # Get random free ports
+        self.agent_port = get_free_port()
+        self.weblog_port = get_free_port()

--- a/utils/k8s_lib_injection/k8s_sync_kubectl.py
+++ b/utils/k8s_lib_injection/k8s_sync_kubectl.py
@@ -1,0 +1,81 @@
+import os
+import time
+import errno
+from utils import context
+
+
+class KubectlLockException(Exception):
+    pass
+
+
+class KubectlLock(object):
+    """ A file locking mechanism that has context-manager support so 
+        you can use it in a with statement. This should be relatively cross
+        compatible as it doesn't rely on msvcrt or fcntl for the locking.
+    """
+
+    def __init__(self, file_name=f"{context.scenario.host_log_folder}/kubectl.sync", timeout=60, delay=0.05):
+        """ Prepare the file locker. Specify the file to lock and optionally
+            the maximum timeout and the delay between each attempt to lock.
+        """
+        if timeout is not None and delay is None:
+            raise ValueError("If timeout is not None, then delay must not be None.")
+        self.is_locked = False
+        self.lockfile = os.path.join(os.getcwd(), "%s.lock" % file_name)
+        self.file_name = file_name
+        self.timeout = timeout
+        self.delay = delay
+
+    def acquire(self):
+        """ Acquire the lock, if possible. If the lock is in use, it check again
+            every `wait` seconds. It does this until it either gets the lock or
+            exceeds `timeout` number of seconds, in which case it throws 
+            an exception.
+        """
+        start_time = time.time()
+        while True:
+            try:
+                self.fd = os.open(self.lockfile, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+                self.is_locked = True  # moved to ensure tag only when locked
+                break
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+                if self.timeout is None:
+                    raise KubectlLockException("Could not acquire lock on {}".format(self.file_name))
+                if (time.time() - start_time) >= self.timeout:
+                    raise KubectlLockException("Timeout occured.")
+                time.sleep(self.delay)
+
+    #        self.is_locked = True
+
+    def release(self):
+        """ Get rid of the lock by deleting the lockfile. 
+            When working in a `with` statement, this gets automatically 
+            called at the end.
+        """
+        if self.is_locked:
+            os.close(self.fd)
+            os.unlink(self.lockfile)
+            self.is_locked = False
+
+    def __enter__(self):
+        """ Activated when used in the with statement. 
+            Should automatically acquire a lock to be used in the with block.
+        """
+        if not self.is_locked:
+            self.acquire()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        """ Activated at the end of the with statement.
+            It automatically releases the lock if it isn't locked.
+        """
+        if self.is_locked:
+            self.release()
+
+    def __del__(self):
+        """ Make sure that the FileLock instance doesn't leave a lockfile
+            lying around.
+        """
+        self.release()

--- a/utils/k8s_lib_injection/resources/kind-config-template.yaml
+++ b/utils/k8s_lib_injection/resources/kind-config-template.yaml
@@ -6,7 +6,7 @@ nodes:
     extraPortMappings:
       # agent port
       - containerPort: 8126
-        hostPort: 18126
+        hostPort: $$AGENT_PORT$$
         # optional: set the bind address on the host
         # 0.0.0.0 is the current default
         listenAddress: "127.0.0.1"
@@ -15,7 +15,7 @@ nodes:
         protocol: TCP
       # app port
       - containerPort: 18080
-        hostPort: 18080
+        hostPort: $$WEBLOG_PORT$$
         # optional: set the bind address on the host
         # 0.0.0.0 is the current default
         listenAddress: "127.0.0.1"

--- a/utils/k8s_lib_injection/resources/operator/operator-helm-values-auto.yaml
+++ b/utils/k8s_lib_injection/resources/operator/operator-helm-values-auto.yaml
@@ -1,7 +1,7 @@
 agents:
   enabled: false
 datadog:
-  clusterName: lib-injection-testing
+  clusterName: $$CLUSTER_NAME$$
   logLevel: DEBUG
   apm:
     enabled: true
@@ -22,8 +22,8 @@ clusterAgent:
   image:
     #tag: master
     #repository: datadog/cluster-agent-dev
-    tag: liliya-belaus-7-52-0-rc2-test
-    repository: datadog/cluster-agent-dev
+    #tag: liliya-belaus-7-52-0-rc2-test
+    #repository: datadog/cluster-agent-dev
     pullPolicy: Always
     doNotCheckTag: true
   env:

--- a/utils/k8s_lib_injection/resources/operator/operator-helm-values-uds.yaml
+++ b/utils/k8s_lib_injection/resources/operator/operator-helm-values-uds.yaml
@@ -2,7 +2,7 @@ targetSystem: "linux"
 agents:
   enabled: false
 datadog:
-  clusterName: lib-injection-testing
+  clusterName: $$CLUSTER_NAME$$
   tags: []
   # datadog.kubelet.tlsVerify should be `false` on kind and minikube
   # to establish communication with the kubelet
@@ -27,9 +27,9 @@ clusterAgent:
     
   image:
    #comment name, tag and repository to test cluster-agent for local Mac M1
-    name: ""
-    tag: master
-    repository: datadog/cluster-agent-dev
+   # name: ""
+   # tag: master
+   # repository: datadog/cluster-agent-dev
     pullPolicy: Always
     doNotCheckTag: true
   admissionController:

--- a/utils/k8s_lib_injection/resources/operator/operator-helm-values.yaml
+++ b/utils/k8s_lib_injection/resources/operator/operator-helm-values.yaml
@@ -3,7 +3,7 @@ targetSystem: "linux"
 agents:
   enabled: false
 datadog:
-  clusterName: lib-injection-testing
+  clusterName: $$CLUSTER_NAME$$
   tags: []
   logLevel: DEBUG
   # datadog.kubelet.tlsVerify should be `false` on kind and minikube


### PR DESCRIPTION
## Motivation

Run k8s-lib-injection tests in parallel

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
