### PR TITLE
OnBoarding: Use 128 bits trace_id and check dates on the backend resp…

### DIFF
--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -1,7 +1,7 @@
 import os
 import time
-
 import requests
+from datetime import datetime
 from utils.tools import logger
 
 
@@ -18,9 +18,18 @@ def _query_for_trace_id(trace_id):
         logger.debug(f" Backend response status for trace_id [{trace_id}]: [{r.status_code}]")
         if r.status_code == 200:
             logger.debug(f" Backend response for trace_id [{trace_id}]: [{r.text}]")
+            # Check if it's  not a old trace
+            trace_data = r.json()
+            root_id = trace_data["trace"]["root_id"]
+            start_time = trace_data["trace"]["spans"][root_id]["start"]
+            start_date = datetime.fromtimestamp(start_time)
+            now = datetime.now()
+            if (datetime.now() - start_date).days > 1:
+                logger.warn("Backend trace is too old")
+                return -1
         return r.status_code
-    except Exception:
-        logger.error(f"Error received connecting to host: [{host}] ")
+    except Exception as e:
+        logger.error(f"Error received connecting to host: [{host}] {e} ")
         return -1
 
 

--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -24,7 +24,7 @@ def _query_for_trace_id(trace_id):
             start_time = trace_data["trace"]["spans"][root_id]["start"]
             start_date = datetime.fromtimestamp(start_time)
             if (datetime.now() - start_date).days > 1:
-                logger.warn("Backend trace is too old")
+                logger.info("Backend trace is too old")
                 return -1
         return r.status_code
     except Exception as e:

--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -1,9 +1,8 @@
 import os
 import time
-import requests
 from datetime import datetime
+import requests
 from utils.tools import logger
-
 
 def _query_for_trace_id(trace_id):
     path = f"/api/v1/trace/{trace_id}"

--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import requests
 from utils.tools import logger
 
+
 def _query_for_trace_id(trace_id):
     path = f"/api/v1/trace/{trace_id}"
     host = "https://dd.datadoghq.com"

--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -23,7 +23,6 @@ def _query_for_trace_id(trace_id):
             root_id = trace_data["trace"]["root_id"]
             start_time = trace_data["trace"]["spans"][root_id]["start"]
             start_date = datetime.fromtimestamp(start_time)
-            now = datetime.now()
             if (datetime.now() - start_date).days > 1:
                 logger.warn("Backend trace is too old")
                 return -1

--- a/utils/onboarding/weblog_interface.py
+++ b/utils/onboarding/weblog_interface.py
@@ -4,7 +4,7 @@ import requests
 
 
 def make_get_request(app_url):
-    generated_uuid = str(randint(0, 10000000))
+    generated_uuid = str(randint(0, 100000000000000000))
     requests.get(
         app_url, headers={"x-datadog-trace-id": generated_uuid, "x-datadog-parent-id": generated_uuid}, timeout=10
     )


### PR DESCRIPTION
…onse

## Motivation

We rely on backend to check if we are sending traces to it from the auto instrumented app.
Sometimes the trace id is duplicated, and the backend returns a old trace id. this cause flakiness on our tests.
To mitigate this situation we implemented two actions:
- Use 128 bit trace id.
- Check start dates on the backend response

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
