### PR TITLE
Lib injection: auto lib-injection

### DIFF
--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -107,5 +107,5 @@ jobs:
         if: always() && steps.compress_logs.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
-          name: logs_k82_lib_injection_${{ matrix.variant.library}}_${{matrix.variant.weblog-variant}}_${{ matrix.version }}
+          name: logs_k8s_lib_injection_${{ matrix.variant.library}}_${{matrix.variant.weblog-variant}}_${{ matrix.version }}
           path: artifact.tar.gz

--- a/tests/k8s_lib_injection/conftest.py
+++ b/tests/k8s_lib_injection/conftest.py
@@ -72,9 +72,13 @@ class K8sInstance:
 
     def start_instance(self):
         self.k8s_kind_cluster = ensure_cluster()
-        config.load_kube_config()
         self.test_agent.configure(self.k8s_kind_cluster)
         self.test_weblog.configure(self.k8s_kind_cluster)
+        try:
+            config.load_kube_config()
+            logger.info(f"kube config loaded")
+        except Exception as e:
+            logger.error(f"Error loading kube config: {e}")
 
     def destroy_instance(self):
         destroy_cluster(self.k8s_kind_cluster)
@@ -95,8 +99,8 @@ class K8sInstance:
         self.test_weblog.deploy_app_auto()
         return self.test_weblog
 
-    def apply_config_auto_inject(self, config_data, timeout=200):
-        self.test_agent.apply_config_auto_inject(config_data)
+    def apply_config_auto_inject(self, config_data, rev=0, timeout=200):
+        self.test_agent.apply_config_auto_inject(config_data, rev=rev)
         self.test_weblog.wait_for_weblog_after_apply_configmap(f"{self.library}-app", timeout=timeout)
         return self.test_agent
 

--- a/tests/k8s_lib_injection/conftest.py
+++ b/tests/k8s_lib_injection/conftest.py
@@ -21,6 +21,7 @@ def test_k8s_instance(request):
         context.scenario._weblog_variant_image,
         context.scenario._library_init_image,
         context.scenario._library_init_image_tag,
+        context.scenario._prefix_library_init_image,
     )
     logger.info(f"K8sInstance creating -- {test_name}")
     k8s_instance.start_instance()
@@ -34,15 +35,28 @@ def test_k8s_instance(request):
 
 
 class K8sInstance:
-    def __init__(self, library, weblog_variant, weblog_variant_image, library_init_image, library_init_image_tag):
+    def __init__(
+        self,
+        library,
+        weblog_variant,
+        weblog_variant_image,
+        library_init_image,
+        library_init_image_tag,
+        prefix_library_init_image,
+    ):
         self.library = library
         self.weblog_variant = weblog_variant
         self.weblog_variant_image = weblog_variant_image
         self.library_init_image = library_init_image
         self.library_init_image_tag = library_init_image_tag
+        # If we inject the library using configmap and cluster agent, we need to use the prefix_library_init_image
+        # only for snapshot images. The agent builds image names like “gcr.io/datadoghq/dd-lib-python-init:latest_snapshot”
+        # but we need gcr.io/datadoghq/dd-trace-py/dd-lib-python-init:latest_snapshot
+        # We use this prefix with the env prop "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY"
+        self.prefix_library_init_image = prefix_library_init_image
 
-        self.test_agent = K8sDatadogClusterTestAgent()
-        self.test_weblog = K8sWeblog()
+        self.test_agent = K8sDatadogClusterTestAgent(prefix_library_init_image)
+        self.test_weblog = K8sWeblog(weblog_variant_image, library, library_init_image)
         self.k8s_kind_cluster = None
 
     def start_instance(self):
@@ -60,22 +74,18 @@ class K8sInstance:
 
     def deploy_weblog_as_pod(self, with_admission_controller=True, use_uds=False):
         if with_admission_controller:
-            self.test_weblog.install_weblog_pod_with_admission_controller(
-                self.weblog_variant_image, self.library, self.library_init_image
-            )
+            self.test_weblog.install_weblog_pod_with_admission_controller()
         else:
-            self.test_weblog.install_weblog_pod_without_admission_controller(
-                self.weblog_variant_image, self.library, self.library_init_image, use_uds
-            )
+            self.test_weblog.install_weblog_pod_without_admission_controller(use_uds)
 
         return self.test_weblog
 
     def deploy_weblog_as_deployment(self):
-        self.test_weblog.deploy_app_auto(self.weblog_variant_image, self.library)
+        self.test_weblog.deploy_app_auto()
         return self.test_weblog
 
     def apply_config_auto_inject(self, config_data, timeout=200):
-        self.test_agent.apply_config_auto_inject(self.library, config_data)
+        self.test_agent.apply_config_auto_inject(config_data)
         self.test_weblog.wait_for_weblog_after_apply_configmap(f"{self.library}-app", timeout=timeout)
         return self.test_agent
 
@@ -86,4 +96,4 @@ class K8sInstance:
             os.makedirs(output_folder)
 
         self.test_agent.export_debug_info(output_folder, test_name)
-        self.test_weblog.export_debug_info(output_folder, test_name, self.library)
+        self.test_weblog.export_debug_info(output_folder, test_name)

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -266,12 +266,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case1 finished")
 
-    @irrelevant(
-        condition=not hasattr(context.scenario, "_library_init_image_tag")
-        or context.scenario._library_init_image_tag != "latest",
-        reason="We only can test the latest release of the library",
-    )
-    def _test_fileprovider_configmap_case2(self, test_k8s_instance):
+    def test_fileprovider_configmap_case2(self, test_k8s_instance):
         """ Config change:
                - deploy app & agent
                - apply config
@@ -303,12 +298,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case2 finished")
 
-    @irrelevant(
-        condition=not hasattr(context.scenario, "_library_init_image_tag")
-        or context.scenario._library_init_image_tag != "latest",
-        reason="We only can test the latest release of the library",
-    )
-    def _test_fileprovider_configmap_case3(self, test_k8s_instance):
+    def test_fileprovider_configmap_case3(self, test_k8s_instance):
         """  Config persistence:
                - deploy app & agent
                - apply config
@@ -350,12 +340,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case3 finished")
 
-    @irrelevant(
-        condition=not hasattr(context.scenario, "_library_init_image_tag")
-        or context.scenario._library_init_image_tag != "latest",
-        reason="We only can test the latest release of the library",
-    )
-    def _test_fileprovider_configmap_case4(self, test_k8s_instance):
+    def test_fileprovider_configmap_case4(self, test_k8s_instance):
         """  Mismatching config:
                - deploy app & agent
                - apply config with non-matching cluster name
@@ -374,12 +359,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case4 finished")
 
-    @irrelevant(
-        condition=not hasattr(context.scenario, "_library_init_image_tag")
-        or context.scenario._library_init_image_tag != "latest",
-        reason="We only can test the latest release of the library",
-    )
-    def _test_fileprovider_configmap_case5(self, test_k8s_instance):
+    def test_fileprovider_configmap_case5(self, test_k8s_instance):
         """ Config change to action:disable
                 - deploy app & agent
                 - apply matching config
@@ -407,12 +387,7 @@ class TestConfigMapAutoInject:
         self._check_for_disabled_pod_metadata(test_k8s_instance)
         logger.info(f"Test _test_fileprovider_configmap_case5 finished")
 
-    @irrelevant(
-        condition=not hasattr(context.scenario, "_library_init_image_tag")
-        or context.scenario._library_init_image_tag != "latest",
-        reason="We only can test the latest release of the library",
-    )
-    def _test_fileprovider_configmap_case6(self, test_k8s_instance):
+    def test_fileprovider_configmap_case6(self, test_k8s_instance):
         """  Inject-all case (for batch instrumentation)
            - use language name "all" in RC config
            - all supported language libraries should be injected into the container

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -61,7 +61,7 @@ class TestConfigMapAutoInject:
                 "action": "enable",
                 "lib_config": {
                     "library_language": "all",
-                    "library_version": "latest",
+                    "library_version": f"{test_k8s_instance.library_init_image_tag}",
                     "service_name": "test-service",
                     "env": "dev",
                     "tracing_enabled": True,
@@ -81,7 +81,7 @@ class TestConfigMapAutoInject:
                 "action": "enable",
                 "lib_config": {
                     "library_language": "all",
-                    "library_version": "latest",
+                    "library_version": f"{test_k8s_instance.library_init_image_tag}",
                     "service_name": "test-service",
                     "env": "dev",
                     "tracing_enabled": True,
@@ -101,7 +101,7 @@ class TestConfigMapAutoInject:
                 "action": "enable",
                 "lib_config": {
                     "library_language": "all",
-                    "library_version": "latest",
+                    "library_version": f"{test_k8s_instance.library_init_image_tag}",
                     "service_name": "test-service",
                     "env": "dev",
                     "tracing_enabled": True,
@@ -238,7 +238,7 @@ class TestConfigMapAutoInject:
             pods.items[0].metadata.labels["admission.datadoghq.com/enabled"] == "false"
         ), "annotation 'admission.datadoghq.com/enabled' wasn't 'false'"
 
-    def test_fileprovider_configmap_case1(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case1(self, test_k8s_instance):
         """ Nominal case:
            - deploy app & agent
            - apply config
@@ -266,7 +266,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case1 finished")
 
-    def test_fileprovider_configmap_case2(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case2(self, test_k8s_instance):
         """ Config change:
                - deploy app & agent
                - apply config
@@ -298,7 +298,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case2 finished")
 
-    def test_fileprovider_configmap_case3(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case3(self, test_k8s_instance):
         """  Config persistence:
                - deploy app & agent
                - apply config
@@ -340,7 +340,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case3 finished")
 
-    def test_fileprovider_configmap_case4(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case4(self, test_k8s_instance):
         """  Mismatching config:
                - deploy app & agent
                - apply config with non-matching cluster name
@@ -359,7 +359,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case4 finished")
 
-    def test_fileprovider_configmap_case5(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case5(self, test_k8s_instance):
         """ Config change to action:disable
                 - deploy app & agent
                 - apply matching config

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -238,7 +238,7 @@ class TestConfigMapAutoInject:
             pods.items[0].metadata.labels["admission.datadoghq.com/enabled"] == "false"
         ), "annotation 'admission.datadoghq.com/enabled' wasn't 'false'"
 
-    def _test_fileprovider_configmap_case1(self, test_k8s_instance):
+    def test_fileprovider_configmap_case1(self, test_k8s_instance):
         """ Nominal case:
            - deploy app & agent
            - apply config
@@ -266,7 +266,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case1 finished")
 
-    def _test_fileprovider_configmap_case2(self, test_k8s_instance):
+    def test_fileprovider_configmap_case2(self, test_k8s_instance):
         """ Config change:
                - deploy app & agent
                - apply config
@@ -298,7 +298,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case2 finished")
 
-    def _test_fileprovider_configmap_case3(self, test_k8s_instance):
+    def test_fileprovider_configmap_case3(self, test_k8s_instance):
         """  Config persistence:
                - deploy app & agent
                - apply config
@@ -340,7 +340,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case3 finished")
 
-    def _test_fileprovider_configmap_case4(self, test_k8s_instance):
+    def test_fileprovider_configmap_case4(self, test_k8s_instance):
         """  Mismatching config:
                - deploy app & agent
                - apply config with non-matching cluster name
@@ -359,7 +359,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case4 finished")
 
-    def _test_fileprovider_configmap_case5(self, test_k8s_instance):
+    def test_fileprovider_configmap_case5(self, test_k8s_instance):
         """ Config change to action:disable
                 - deploy app & agent
                 - apply matching config
@@ -387,6 +387,11 @@ class TestConfigMapAutoInject:
         self._check_for_disabled_pod_metadata(test_k8s_instance)
         logger.info(f"Test _test_fileprovider_configmap_case5 finished")
 
+    @irrelevant(
+        condition=not hasattr(context.scenario, "_library_init_image_tag")
+        or context.scenario._library_init_image_tag != "latest",
+        reason="We only can test the latest release of the library",
+    )
     def test_fileprovider_configmap_case6(self, test_k8s_instance):
         """  Inject-all case (for batch instrumentation)
            - use language name "all" in RC config
@@ -404,7 +409,6 @@ class TestConfigMapAutoInject:
         expected_env_vars = [{"name": "DD_TRACE_SAMPLE_RATE", "value": "0.90"}]
 
         all_config_data = self._get_default_auto_inject_config_all_libraries(test_k8s_instance)
-        logger.info(f"RMM all config data: {all_config_data}")
         test_k8s_instance.apply_config_auto_inject(json.dumps(all_config_data), timeout=300)
 
         traces_json = self._get_dev_agent_traces(test_k8s_instance.k8s_kind_cluster.agent_port)

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -404,6 +404,7 @@ class TestConfigMapAutoInject:
         expected_env_vars = [{"name": "DD_TRACE_SAMPLE_RATE", "value": "0.90"}]
 
         all_config_data = self._get_default_auto_inject_config_all_libraries(test_k8s_instance)
+        logger.info(f"RMM all config data: {all_config_data}")
         test_k8s_instance.apply_config_auto_inject(json.dumps(all_config_data), timeout=300)
 
         traces_json = self._get_dev_agent_traces(test_k8s_instance.k8s_kind_cluster.agent_port)

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -238,7 +238,7 @@ class TestConfigMapAutoInject:
             pods.items[0].metadata.labels["admission.datadoghq.com/enabled"] == "false"
         ), "annotation 'admission.datadoghq.com/enabled' wasn't 'false'"
 
-    def test_fileprovider_configmap_case1(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case1(self, test_k8s_instance):
         """ Nominal case:
            - deploy app & agent
            - apply config
@@ -266,7 +266,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case1 finished")
 
-    def test_fileprovider_configmap_case2(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case2(self, test_k8s_instance):
         """ Config change:
                - deploy app & agent
                - apply config
@@ -298,7 +298,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case2 finished")
 
-    def test_fileprovider_configmap_case3(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case3(self, test_k8s_instance):
         """  Config persistence:
                - deploy app & agent
                - apply config
@@ -340,7 +340,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case3 finished")
 
-    def test_fileprovider_configmap_case4(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case4(self, test_k8s_instance):
         """  Mismatching config:
                - deploy app & agent
                - apply config with non-matching cluster name
@@ -392,7 +392,7 @@ class TestConfigMapAutoInject:
         or context.scenario._library_init_image_tag != "latest",
         reason="We only can test the latest release of the library",
     )
-    def test_fileprovider_configmap_case6(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case6(self, test_k8s_instance):
         """  Inject-all case (for batch instrumentation)
            - use language name "all" in RC config
            - all supported language libraries should be injected into the container

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -238,11 +238,11 @@ class TestConfigMapAutoInject:
             pods.items[0].metadata.labels["admission.datadoghq.com/enabled"] == "false"
         ), "annotation 'admission.datadoghq.com/enabled' wasn't 'false'"
 
-    @irrelevant(
-        condition=not hasattr(context.scenario, "_library_init_image_tag")
-        or context.scenario._library_init_image_tag != "latest",
-        reason="We only can test the latest release of the library",
-    )
+    # @irrelevant(
+    #     condition=not hasattr(context.scenario, "_library_init_image_tag")
+    #     or context.scenario._library_init_image_tag != "latest",
+    #     reason="We only can test the latest release of the library",
+    # )
     def test_fileprovider_configmap_case1(self, test_k8s_instance):
         """ Nominal case:
            - deploy app & agent
@@ -276,7 +276,7 @@ class TestConfigMapAutoInject:
         or context.scenario._library_init_image_tag != "latest",
         reason="We only can test the latest release of the library",
     )
-    def test_fileprovider_configmap_case2(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case2(self, test_k8s_instance):
         """ Config change:
                - deploy app & agent
                - apply config
@@ -313,7 +313,7 @@ class TestConfigMapAutoInject:
         or context.scenario._library_init_image_tag != "latest",
         reason="We only can test the latest release of the library",
     )
-    def test_fileprovider_configmap_case3(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case3(self, test_k8s_instance):
         """  Config persistence:
                - deploy app & agent
                - apply config
@@ -360,7 +360,7 @@ class TestConfigMapAutoInject:
         or context.scenario._library_init_image_tag != "latest",
         reason="We only can test the latest release of the library",
     )
-    def test_fileprovider_configmap_case4(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case4(self, test_k8s_instance):
         """  Mismatching config:
                - deploy app & agent
                - apply config with non-matching cluster name
@@ -384,7 +384,7 @@ class TestConfigMapAutoInject:
         or context.scenario._library_init_image_tag != "latest",
         reason="We only can test the latest release of the library",
     )
-    def test_fileprovider_configmap_case5(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case5(self, test_k8s_instance):
         """ Config change to action:disable
                 - deploy app & agent
                 - apply matching config
@@ -417,7 +417,7 @@ class TestConfigMapAutoInject:
         or context.scenario._library_init_image_tag != "latest",
         reason="We only can test the latest release of the library",
     )
-    def test_fileprovider_configmap_case6(self, test_k8s_instance):
+    def _test_fileprovider_configmap_case6(self, test_k8s_instance):
         """  Inject-all case (for batch instrumentation)
            - use language name "all" in RC config
            - all supported language libraries should be injected into the container

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -238,7 +238,7 @@ class TestConfigMapAutoInject:
             pods.items[0].metadata.labels["admission.datadoghq.com/enabled"] == "false"
         ), "annotation 'admission.datadoghq.com/enabled' wasn't 'false'"
 
-    def _test_fileprovider_configmap_case1(self, test_k8s_instance):
+    def test_fileprovider_configmap_case1(self, test_k8s_instance):
         """ Nominal case:
            - deploy app & agent
            - apply config
@@ -266,7 +266,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case1 finished")
 
-    def _test_fileprovider_configmap_case2(self, test_k8s_instance):
+    def test_fileprovider_configmap_case2(self, test_k8s_instance):
         """ Config change:
                - deploy app & agent
                - apply config
@@ -298,7 +298,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case2 finished")
 
-    def _test_fileprovider_configmap_case3(self, test_k8s_instance):
+    def test_fileprovider_configmap_case3(self, test_k8s_instance):
         """  Config persistence:
                - deploy app & agent
                - apply config
@@ -340,7 +340,7 @@ class TestConfigMapAutoInject:
 
         logger.info(f"Test test_fileprovider_configmap_case3 finished")
 
-    def _test_fileprovider_configmap_case4(self, test_k8s_instance):
+    def test_fileprovider_configmap_case4(self, test_k8s_instance):
         """  Mismatching config:
                - deploy app & agent
                - apply config with non-matching cluster name
@@ -392,7 +392,7 @@ class TestConfigMapAutoInject:
         or context.scenario._library_init_image_tag != "latest",
         reason="We only can test the latest release of the library",
     )
-    def _test_fileprovider_configmap_case6(self, test_k8s_instance):
+    def test_fileprovider_configmap_case6(self, test_k8s_instance):
         """  Inject-all case (for batch instrumentation)
            - use language name "all" in RC config
            - all supported language libraries should be injected into the container

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -138,7 +138,7 @@ class TestConfigMapAutoInject:
 
         app_name = f"{test_k8s_instance.library}-app"
         pods = v1.list_namespaced_pod(namespace="default", label_selector=f"app={app_name}")
-        assert len(pods.items) == 1, f"No pods found for app {app_name}"
+        assert len(pods.items) != 0, f"No pods found for app {app_name}"
 
         for expected_env_var in expected_env_vars:
             env_var_found = False
@@ -157,7 +157,7 @@ class TestConfigMapAutoInject:
         library_version = test_k8s_instance.library_init_image_tag
         app_name = f"{test_k8s_instance.library}-app"
         pods = v1.list_namespaced_pod(namespace="default", label_selector=f"app={app_name}")
-        assert len(pods.items) == 1, f"No pods found for app {app_name}"
+        assert len(pods.items) != 0, f"No pods found for app {app_name}"
 
         assert (
             pods.items[0].metadata.labels["admission.datadoghq.com/enabled"] == "true"
@@ -223,7 +223,7 @@ class TestConfigMapAutoInject:
         v1, _ = self.get_k8s_api(test_k8s_instance.k8s_kind_cluster)
         app_name = f"{test_k8s_instance.library}-app"
         pods = v1.list_namespaced_pod(namespace="default", label_selector=f"app={app_name}")
-        assert len(pods.items) == 1, f"No pods found for app {app_name}"
+        assert len(pods.items) != 0, f"No pods found for app {app_name}"
 
         assert (
             "admission.datadoghq.com/enabled" not in pods.items[0].metadata.labels
@@ -234,7 +234,7 @@ class TestConfigMapAutoInject:
         v1, _ = self.get_k8s_api(test_k8s_instance.k8s_kind_cluster)
         app_name = f"{test_k8s_instance.library}-app"
         pods = v1.list_namespaced_pod(namespace="default", label_selector=f"app={app_name}")
-        assert len(pods.items) == 1, f"No pods found for app {app_name}"
+        assert len(pods.items) != 0, f"No pods found for app {app_name}"
         assert (
             pods.items[0].metadata.labels["admission.datadoghq.com/enabled"] == "false"
         ), "annotation 'admission.datadoghq.com/enabled' wasn't 'false'"

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -238,11 +238,6 @@ class TestConfigMapAutoInject:
             pods.items[0].metadata.labels["admission.datadoghq.com/enabled"] == "false"
         ), "annotation 'admission.datadoghq.com/enabled' wasn't 'false'"
 
-    # @irrelevant(
-    #     condition=not hasattr(context.scenario, "_library_init_image_tag")
-    #     or context.scenario._library_init_image_tag != "latest",
-    #     reason="We only can test the latest release of the library",
-    # )
     def test_fileprovider_configmap_case1(self, test_k8s_instance):
         """ Nominal case:
            - deploy app & agent

--- a/tests/k8s_lib_injection/test_k8s_manual_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_manual_inject.py
@@ -21,7 +21,7 @@ class TestAdmisionController:
             time.sleep(2)
         return []
 
-    def test_inject_admission_controller(self, test_k8s_instance):
+    def _test_inject_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test _test_inject_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )
@@ -32,7 +32,7 @@ class TestAdmisionController:
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_admission_controller finished")
 
-    def test_inject_without_admission_controller(self, test_k8s_instance):
+    def _test_inject_without_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test _test_inject_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )
@@ -42,7 +42,7 @@ class TestAdmisionController:
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_without_admission_controller finished")
 
-    def test_inject_uds_without_admission_controller(self, test_k8s_instance):
+    def _test_inject_uds_without_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test test_inject_uds_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )

--- a/tests/k8s_lib_injection/test_k8s_manual_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_manual_inject.py
@@ -21,7 +21,7 @@ class TestAdmisionController:
             time.sleep(2)
         return []
 
-    def _test_inject_admission_controller(self, test_k8s_instance):
+    def test_inject_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test _test_inject_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )
@@ -32,7 +32,7 @@ class TestAdmisionController:
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_admission_controller finished")
 
-    def _test_inject_without_admission_controller(self, test_k8s_instance):
+    def test_inject_without_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test _test_inject_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )
@@ -42,7 +42,7 @@ class TestAdmisionController:
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_without_admission_controller finished")
 
-    def _test_inject_uds_without_admission_controller(self, test_k8s_instance):
+    def test_inject_uds_without_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test test_inject_uds_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1132,7 +1132,6 @@ class _KubernetesScenario(_Scenario):
         ), "DOCKER_REGISTRY_IMAGES_PATH is not set. IE: ghcr.io/datadog"
 
         prefix_library_injection_init_image, library_injection_init_image = self._get_library_injection_init_image()
-        logger.info(f"RMM PREFIX INITI IMAGE;:;;;;; {prefix_library_injection_init_image}")
         library_injection_test_app_image = self._get_library_injection_test_app_image()
 
         self._library = LibraryVersion(os.getenv("TEST_LIBRARY"), "0.0")

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1113,7 +1113,7 @@ class ContainerAutoInjectionScenario(_VirtualMachineScenario):
         )
 
 
-class _KubernetesMachineScenario(_Scenario):
+class _KubernetesScenario(_Scenario):
     """ Scenario that tests kubernetes lib injection """
 
     def __init__(self, name, doc) -> None:
@@ -1131,12 +1131,14 @@ class _KubernetesMachineScenario(_Scenario):
             "DOCKER_REGISTRY_IMAGES_PATH" in os.environ
         ), "DOCKER_REGISTRY_IMAGES_PATH is not set. IE: ghcr.io/datadog"
 
-        library_injection_init_image = self._get_library_injection_init_image()
+        prefix_library_injection_init_image, library_injection_init_image = self._get_library_injection_init_image()
+        logger.info(f"RMM PREFIX INITI IMAGE;:;;;;; {prefix_library_injection_init_image}")
         library_injection_test_app_image = self._get_library_injection_test_app_image()
 
         self._library = LibraryVersion(os.getenv("TEST_LIBRARY"), "0.0")
         self._weblog_variant = os.getenv("WEBLOG_VARIANT")
         self._weblog_variant_image = library_injection_test_app_image
+        self._prefix_library_init_image = prefix_library_injection_init_image
         self._library_init_image = library_injection_init_image
         self._library_init_image_tag = os.getenv("DOCKER_IMAGE_TAG")
 
@@ -1176,19 +1178,24 @@ class _KubernetesMachineScenario(_Scenario):
         docker_registry_images_path = os.getenv("DOCKER_REGISTRY_IMAGES_PATH")
 
         init_docker_image_repo = ""
+        prefix_init_docker_image_repo = ""
         if docker_image_tag == "latest":
             # Release version are published in docker.io
             init_docker_image_repo = f"docker.io/datadog/dd-lib-{init_image_alias}-init"
+            prefix_init_docker_image_repo = f"docker.io/datadog"
         elif docker_image_tag == "local":
             # Docker hub doesn't allow multi level repo paths
+            # TODO review this
             init_docker_image_repo = f"{docker_registry_images_path}/dd-lib-{init_image_alias}-init"
+            prefix_init_docker_image_repo = f"{docker_registry_images_path}"
         else:
             init_docker_image_repo = (
                 f"{docker_registry_images_path}/dd-trace-{init_image_repo_alias}/dd-lib-{init_image_alias}-init"
             )
+            prefix_init_docker_image_repo = f"{docker_registry_images_path}/dd-trace-{init_image_repo_alias}"
 
         library_injection_init_image = f"{init_docker_image_repo}:{docker_image_tag}"
-        return library_injection_init_image
+        return prefix_init_docker_image_repo, library_injection_init_image
 
     @property
     def library(self):
@@ -1657,7 +1664,7 @@ class scenarios:
         "Onboarding Container Single Step Instrumentation scenario using agent auto install script",
         vm_provision="container-auto-inject-install-script",
     )
-    k8s_lib_injection = _KubernetesMachineScenario("K8S_LIB_INJECTION", doc=" Kubernetes Instrumentation scenario")
+    k8s_lib_injection = _KubernetesScenario("K8S_LIB_INJECTION", doc=" Kubernetes Instrumentation scenario")
 
 
 def _main():

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -60,7 +60,7 @@ def helm_add_repo(name, url, k8s_kind_cluster, update=False):
             execute_command(f"helm repo update")
 
 
-def helm_install_chart(k8s_kind_cluster, name, chart, set_dict={}, value_file=None):
+def helm_install_chart(k8s_kind_cluster, name, chart, set_dict={}, value_file=None, prefix_library_init_image=None):
     # Copy and replace cluster name in the value file
     custom_value_file = None
     if value_file:
@@ -68,6 +68,8 @@ def helm_install_chart(k8s_kind_cluster, name, chart, set_dict={}, value_file=No
             value_data = file.read()
 
         value_data = value_data.replace("$$CLUSTER_NAME$$", str(k8s_kind_cluster.cluster_name))
+        if prefix_library_init_image:
+            value_data = value_data.replace("$$PREFIX_INIT_IMAGE$$", prefix_library_init_image)
 
         custom_value_file = f"{context.scenario.host_log_folder}/{k8s_kind_cluster.cluster_name}_help_values.yaml"
 

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -244,6 +244,9 @@ class K8sDatadogClusterTestAgent:
         """ Exports debug information for the test agent and the operator."""
         v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
         api = client.AppsV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
+        event_api = client.EventsV1Api(
+            api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name)
+        )
 
         # Get all pods
         ret = v1.list_pod_for_all_namespaces(watch=False)
@@ -289,3 +292,6 @@ class K8sDatadogClusterTestAgent:
             k8s_logger(output_folder, test_name, "daemon.set.describe").info(
                 "Exception when calling CoreV1Api->datadog-cluster-agent logs: %s\n" % e
             )
+
+        events = event_api.list_event_for_all_namespaces(pretty="pretty_example")
+        k8s_logger(output_folder, test_name, "pod.events").info(events)

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -275,13 +275,15 @@ class K8sDatadogClusterTestAgent:
 
                 # Export: Telemetry datadog-cluster-agent
                 execute_command_sync(
-                    f"kubectl exec -it {pods.items[0].metadata.name} -- agent telemetry > '{output_folder}/{pods.items[0].metadata.name}_telemetry.log'"
+                    f"kubectl exec -it {pods.items[0].metadata.name} -- agent telemetry > '{output_folder}/{pods.items[0].metadata.name}_telemetry.log'",
+                    self.k8s_kind_cluster,
                 )
 
                 # Export: Status datadog-cluster-agent
                 # Sometimes this command fails. Ignore this error
                 execute_command_sync(
-                    f"kubectl exec -it {pods.items[0].metadata.name} -- agent status > '{output_folder}/{pods.items[0].metadata.name}_status.log' || true "
+                    f"kubectl exec -it {pods.items[0].metadata.name} -- agent status > '{output_folder}/{pods.items[0].metadata.name}_status.log' || true ",
+                    self.k8s_kind_cluster,
                 )
         except Exception as e:
             k8s_logger(output_folder, test_name, "daemon.set.describe").info(

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -1,7 +1,6 @@
 import time
 from kubernetes import client, config, watch
 from kubernetes.utils import create_from_yaml
-from utils.tools import logger
 from utils.k8s_lib_injection.k8s_command_utils import (
     helm_add_repo,
     helm_install_chart,
@@ -20,18 +19,39 @@ class K8sDatadogClusterTestAgent:
         self.prefix_library_init_image = prefix_library_init_image
         self.output_folder = output_folder
         self.test_name = test_name
+        self.logger = None
 
     def configure(self, k8s_kind_cluster):
         self.k8s_kind_cluster = k8s_kind_cluster
+        self.logger = k8s_logger(self.output_folder, self.test_name, "k8s_logger")
+        self.logger.info(f"K8sDatadogClusterTestAgent configured with cluster: {self.k8s_kind_cluster.cluster_name}")
+
+    def get_k8s_api(self):
+        """ Get the k8s api. It retries 5 times if it fails. Sometimes there are 
+        collisions when we execute a lot of tests in parallel."""
+        for i in range(5):
+            try:
+                return self._k8s_api()
+            except Exception as e:
+                self.logger.info(f"Error getting k8s api: {e}")
+                time.sleep(2)
+        raise Exception("Error getting k8s api")
+
+    def _k8s_api(self):
+        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
+        apps_api = client.AppsV1Api(
+            api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name)
+        )
+        return v1, apps_api
 
     def desploy_test_agent(self):
         """ Installs the test agent pod."""
 
-        logger.info(f"[Test agent] Deploying Datadog test agent on the cluster: {self.k8s_kind_cluster.cluster_name}")
-
-        apps_api = client.AppsV1Api(
-            api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name)
+        self.logger.info(
+            f"[Test agent] Deploying Datadog test agent on the cluster: {self.k8s_kind_cluster.cluster_name}"
         )
+
+        _, apps_api = self.get_k8s_api()
         container = client.V1Container(
             name="trace-agent",
             image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest",
@@ -94,23 +114,23 @@ class K8sDatadogClusterTestAgent:
 
         apps_api.create_namespaced_daemon_set(namespace="default", body=daemonset)
         self.wait_for_test_agent()
-        logger.info("[Test agent] Daemonset created")
+        self.logger.info("[Test agent] Daemonset created")
 
     def deploy_operator_manual(self, use_uds=False):
         """ Installs the Datadog Cluster Agent via helm for manual library injection testing.
             It returns when the Cluster Agent pod is ready."""
 
-        logger.info("[Deploy operator] Deploying Datadog Operator")
+        self.logger.info("[Deploy operator] Deploying Datadog Operator")
 
         operator_file = "utils/k8s_lib_injection/resources/operator/operator-helm-values.yaml"
         if use_uds:
-            logger.info("[Deploy operator] Using UDS")
+            self.logger.info("[Deploy operator] Using UDS")
             operator_file = "utils/k8s_lib_injection/resources/operator/operator-helm-values-uds.yaml"
 
-        logger.info("[Deploy operator] Configuring helm repository")
+        self.logger.info("[Deploy operator] Configuring helm repository")
         helm_add_repo("datadog", "https://helm.datadoghq.com", self.k8s_kind_cluster, update=True)
 
-        logger.info(f"[Deploy operator] helm install datadog with config file [{operator_file}]")
+        self.logger.info(f"[Deploy operator] helm install datadog with config file [{operator_file}]")
 
         helm_install_chart(
             self.k8s_kind_cluster,
@@ -120,21 +140,21 @@ class K8sDatadogClusterTestAgent:
             set_dict={"datadog.apiKey": os.getenv("DD_API_KEY"), "datadog.appKey": os.getenv("DD_APP_KEY")},
         )
 
-        logger.info("[Deploy operator] Waiting for the operator to be ready")
+        self.logger.info("[Deploy operator] Waiting for the operator to be ready")
         self._wait_for_operator_ready()
 
     def deploy_operator_auto(self):
         """ Installs the Datadog Cluster Agent via helm for auto library injection testing.
             It returns when the Cluster Agent pod is ready."""
 
-        logger.info("[Deploy operator] Using Patcher")
+        self.logger.info("[Deploy operator] Using Patcher")
         operator_file = "utils/k8s_lib_injection/resources/operator/operator-helm-values-auto.yaml"
 
         self.create_configmap_auto_inject()
-        logger.info("[Deploy operator] Configuring helm repository")
+        self.logger.info("[Deploy operator] Configuring helm repository")
         helm_add_repo("datadog", "https://helm.datadoghq.com", self.k8s_kind_cluster, update=True)
 
-        logger.info(f"[Deploy operator] helm install datadog with config file [{operator_file}]")
+        self.logger.info(f"[Deploy operator] helm install datadog with config file [{operator_file}]")
 
         helm_install_chart(
             self.k8s_kind_cluster,
@@ -147,28 +167,28 @@ class K8sDatadogClusterTestAgent:
         self._wait_for_operator_ready()
 
         # TODO: This is a hack until the patching permission is added in the official helm chart.
-        logger.info("[Deploy operator] adding patch permissions to the datadog-cluster-agent clusterrole")
+        self.logger.info("[Deploy operator] adding patch permissions to the datadog-cluster-agent clusterrole")
         path_clusterrole(self.k8s_kind_cluster)
 
         self._wait_for_operator_ready()
 
-    def apply_config_auto_inject(self, config_data):
+    def apply_config_auto_inject(self, config_data, rev=0):
         """ Applies an configuration change for auto injection.
             It returns when the targeted deployment finishes the rollout."""
 
-        logger.info(f"[Auto Config] Applying config for auto-inject: {config_data}")
-        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
+        self.logger.info(f"[Auto Config] Applying config for auto-inject: {config_data}")
+        v1, _ = self.get_k8s_api()
         metadata = client.V1ObjectMeta(name="auto-instru", namespace="default",)
         configmap = client.V1ConfigMap(kind="ConfigMap", data={"auto-instru.json": config_data,}, metadata=metadata)
         r = v1.replace_namespaced_config_map(name="auto-instru", namespace="default", body=configmap)
-        logger.info(f"[Auto Config] Configmap replaced!")
+        self.logger.info(f"[Auto Config] Configmap replaced!")
         k8s_logger(self.output_folder, self.test_name, "applied_configmaps").info(r)
-        self.watch_configmap_auto_inject(timeout=100)
+        self.wait_configmap_auto_inject(timeout=100, rev=rev)
 
     def create_configmap_auto_inject(self):
         """ Minimal configuration needed when we install operator auto """
-        logger.info("[Auto Config] Creating configmap for auto-inject")
-        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
+        self.logger.info("[Auto Config] Creating configmap for auto-inject")
+        v1, _ = self.get_k8s_api()
         metadata = client.V1ObjectMeta(name="auto-instru", namespace="default",)
         configmap = client.V1ConfigMap(
             kind="ConfigMap",
@@ -181,18 +201,38 @@ class K8sDatadogClusterTestAgent:
         v1.create_namespaced_config_map(namespace="default", body=configmap)
         time.sleep(5)
 
-    def watch_configmap_auto_inject(self, timeout=90):
-        """ log events related with config maps for 90 seconds"""
-        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
+    def wait_configmap_auto_inject(self, timeout=90, rev=0):
+        """ wait for the configmap to be read by the datadog-cluster-agent."""
+        patch_id = "11777398274940883092"
+        self.logger.info("[Auto Config] Waiting for the configmap to be read by the datadog-cluster-agent.")
+        # First we need to wait for the configmap to be created
+        v1, _ = self.get_k8s_api()
         w = watch.Watch()
         for event in w.stream(func=v1.list_namespaced_config_map, namespace="default", timeout_seconds=timeout):
             k8s_logger(self.output_folder, self.test_name, "events_configmaps").info(event)
+            if event["type"] == "ADDED" and event["object"].metadata.name == "auto-instru":
+                self.logger.info("[Auto Config] Configmap applied!")
+                w.stop()
+                break
+
+        # Second wait for datadog-cluster-agent read the configmap
+        pods = v1.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
+        assert len(pods.items) > 0, "No pods found for app datadog-cluster-agent"
+        expected_log = f'Applying Remote Config ID "{patch_id}" with revision "{rev}" and action'
+        timeout = time.time() + timeout
+        while True:
+            api_response = v1.read_namespaced_pod_log(name=pods.items[0].metadata.name, namespace="default")
+            for log_line in api_response.splitlines():
+                if log_line.find(expected_log) != -1:
+                    self.logger.info(f"Configmap read by datadog-cluster-agent: {log_line}")
+                    return
+            if time.time() > timeout:
+                self.logger.error(f"Timeout waiting for the datadog-cluster-agent to read the configmap")
+                raise TimeoutError("Timeout waiting for the datadog-cluster-agent to read the configmap")
+            time.sleep(5)
 
     def wait_for_test_agent(self):
-        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
-        apps_api = client.AppsV1Api(
-            api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name)
-        )
+        v1, apps_api = self.get_k8s_api()
         daemonset_created = False
         daemonset_status = None
         # Wait for the daemonset to be created
@@ -200,16 +240,16 @@ class K8sDatadogClusterTestAgent:
             try:
                 daemonset_status = apps_api.read_namespaced_daemon_set_status(name="datadog", namespace="default")
                 if daemonset_status.status.number_ready > 0:
-                    logger.info(f"[Test agent] daemonset status datadog running!")
+                    self.logger.info(f"[Test agent] daemonset status datadog running!")
                     daemonset_created = True
                     break
                 time.sleep(5)
             except client.exceptions.ApiException as e:
-                logger.info(f"[Test agent] daemonset status error: {e}")
+                self.logger.info(f"[Test agent] daemonset status error: {e}")
                 time.sleep(5)
 
         if not daemonset_created:
-            logger.info("[Test agent] Daemonset not created. Last status: %s" % daemonset_status)
+            self.logger.info("[Test agent] Daemonset not created. Last status: %s" % daemonset_status)
             raise Exception("Daemonset not created")
 
         w = watch.Watch()
@@ -218,43 +258,43 @@ class K8sDatadogClusterTestAgent:
         ):
             if event["object"].status.phase == "Running":
                 w.stop()
-                logger.info("Datadog test agent started!")
+                self.logger.info("Datadog test agent started!")
                 break
 
     def _wait_for_operator_ready(self):
-        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
-        pods = v1.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
-        datadog_cluster_name = pods.items[0].metadata.name
-
+        datadog_cluster_name = None
+        v1, _ = self.get_k8s_api()
         operator_ready = False
         for i in range(15):
             try:
+                if datadog_cluster_name is None:
+                    pods = v1.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
+                    datadog_cluster_name = pods.items[0].metadata.name
                 operator_status = v1.read_namespaced_pod_status(name=datadog_cluster_name, namespace="default")
                 if (
                     operator_status.status.phase == "Running"
                     and operator_status.status.container_statuses[0].ready == True
                 ):
-                    logger.info(f"[Deploy operator] Operator datadog running!")
+                    self.logger.info(f"[Deploy operator] Operator datadog running!")
                     operator_ready = True
                     break
                 time.sleep(5)
             except client.exceptions.ApiException as e:
-                logger.info(f"Pod status error: {e}")
+                self.logger.info(f"Pod status error: {e}")
                 time.sleep(5)
 
         if not operator_ready:
-            logger.error("Operator not created. Last status: %s" % operator_status)
+            self.logger.error("Operator not created. Last status: %s" % operator_status)
             operator_logs = v1.read_namespaced_pod_log(name=datadog_cluster_name, namespace="default")
-            logger.error(f"Operator logs: {operator_logs}")
+            self.logger.error(f"Operator logs: {operator_logs}")
             raise Exception("Operator not created")
-        # At this point the operator should be ready, we are going to wait a little bit more to make sure the operator is ready (some times the operator is ready but the cluster agent is not ready yet)
+        # At this point the operator should be ready, we are going to wait a little bit more
+        # to make sure the operator is ready (some times the operator is ready but the cluster agent is not ready yet)
         time.sleep(5)
 
     def export_debug_info(self):
         """ Exports debug information for the test agent and the operator."""
-        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
-        api = client.AppsV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
-
+        v1, api = self.get_k8s_api()
         # Get all pods
         ret = v1.list_namespaced_pod(namespace="default", watch=False)
         for i in ret.items:
@@ -284,24 +324,24 @@ class K8sDatadogClusterTestAgent:
         # Cluster logs, admission controller
         try:
             pods = v1.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
-            if len(pods.items) > 0:
-                api_response = v1.read_namespaced_pod_log(name=pods.items[0].metadata.name, namespace="default")
-                k8s_logger(self.output_folder, self.test_name, "datadog-cluster-agent").info(api_response)
+            assert len(pods.items) > 0, "No pods found for app datadog-cluster-agent"
+            api_response = v1.read_namespaced_pod_log(name=pods.items[0].metadata.name, namespace="default")
+            k8s_logger(self.output_folder, self.test_name, "datadog-cluster-agent").info(api_response)
 
-                # Export: Telemetry datadog-cluster-agent
-                execute_command_sync(
-                    f"kubectl exec -it {pods.items[0].metadata.name} -- agent telemetry ",
-                    self.k8s_kind_cluster,
-                    logfile=f"{self.output_folder}/{pods.items[0].metadata.name}_telemetry.log",
-                )
+            # Export: Telemetry datadog-cluster-agent
+            execute_command_sync(
+                f"kubectl exec -it {pods.items[0].metadata.name} -- agent telemetry ",
+                self.k8s_kind_cluster,
+                logfile=f"{self.output_folder}/{pods.items[0].metadata.name}_telemetry.log",
+            )
 
-                # Export: Status datadog-cluster-agent
-                # Sometimes this command fails. Ignore this error
-                execute_command_sync(
-                    f"kubectl exec -it {pods.items[0].metadata.name} -- agent status || true ",
-                    self.k8s_kind_cluster,
-                    logfile=f"{self.output_folder}/{pods.items[0].metadata.name}_status.log",
-                )
+            # Export: Status datadog-cluster-agent
+            # Sometimes this command fails. Ignore this error
+            execute_command_sync(
+                f"kubectl exec -it {pods.items[0].metadata.name} -- agent status || true ",
+                self.k8s_kind_cluster,
+                logfile=f"{self.output_folder}/{pods.items[0].metadata.name}_status.log",
+            )
         except Exception as e:
             k8s_logger(self.output_folder, self.test_name, "daemon.set.describe").info(
                 "Exception when calling CoreV1Api->datadog-cluster-agent logs: %s\n" % e

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -163,8 +163,7 @@ class K8sDatadogClusterTestAgent:
         r = v1.replace_namespaced_config_map(name="auto-instru", namespace="default", body=configmap)
         logger.info(f"[Auto Config] Configmap replaced!")
         k8s_logger(self.output_folder, self.test_name, "applied_configmaps").info(r)
-        self.watch_configmap_auto_inject(timeout=90)
-        # time.sleep(90)
+        self.watch_configmap_auto_inject(timeout=100)
 
     def create_configmap_auto_inject(self):
         """ Minimal configuration needed when we install operator auto """
@@ -183,14 +182,12 @@ class K8sDatadogClusterTestAgent:
         time.sleep(5)
 
     def watch_configmap_auto_inject(self, timeout=90):
+        """ log events related with config maps for 90 seconds"""
         v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
         w = watch.Watch()
         for event in w.stream(func=v1.list_namespaced_config_map, namespace="default", timeout_seconds=timeout):
             k8s_logger(self.output_folder, self.test_name, "events_configmaps").info(event)
 
-    # w = watch.Watch()
-    # for event in w.stream(kube.coreV1.list_namespaced_config_map, namespace=TARGET_NS):
-    #   print("Event: %s %s" % (event['type'], event['object'].metadata.name))
     def wait_for_test_agent(self):
         v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
         apps_api = client.AppsV1Api(

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -15,8 +15,9 @@ import json
 
 
 class K8sDatadogClusterTestAgent:
-    def __init__(self):
+    def __init__(self, prefix_library_init_image):
         self.k8s_kind_cluster = None
+        self.prefix_library_init_image = prefix_library_init_image
 
     def configure(self, k8s_kind_cluster):
         self.k8s_kind_cluster = k8s_kind_cluster
@@ -120,7 +121,7 @@ class K8sDatadogClusterTestAgent:
         logger.info("[Deploy operator] Waiting for the operator to be ready")
         self._wait_for_operator_ready()
 
-    def deploy_operator_auto(self, use_uds=False):
+    def deploy_operator_auto(self):
         """ Installs the Datadog Cluster Agent via helm for auto library injection testing.
             It returns when the Cluster Agent pod is ready."""
 
@@ -139,6 +140,7 @@ class K8sDatadogClusterTestAgent:
             "datadog/datadog",
             value_file=operator_file,
             set_dict={"datadog.apiKey": os.getenv("DD_API_KEY"), "datadog.appKey": os.getenv("DD_APP_KEY")},
+            prefix_library_init_image=self.prefix_library_init_image,
         )
         self._wait_for_operator_ready()
 
@@ -148,7 +150,7 @@ class K8sDatadogClusterTestAgent:
 
         self._wait_for_operator_ready()
 
-    def apply_config_auto_inject(self, library, config_data):
+    def apply_config_auto_inject(self, config_data):
         """ Applies an configuration change for auto injection.
             It returns when the targeted deployment finishes the rollout."""
 

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -163,8 +163,8 @@ class K8sDatadogClusterTestAgent:
         r = v1.replace_namespaced_config_map(name="auto-instru", namespace="default", body=configmap)
         logger.info(f"[Auto Config] Configmap replaced!")
         k8s_logger(self.output_folder, self.test_name, "applied_configmaps").info(r)
-
-        time.sleep(90)
+        self.watch_configmap_auto_inject(timeout=90)
+        # time.sleep(90)
 
     def create_configmap_auto_inject(self):
         """ Minimal configuration needed when we install operator auto """
@@ -182,6 +182,15 @@ class K8sDatadogClusterTestAgent:
         v1.create_namespaced_config_map(namespace="default", body=configmap)
         time.sleep(5)
 
+    def watch_configmap_auto_inject(self, timeout=90):
+        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
+        w = watch.Watch()
+        for event in w.stream(func=v1.list_namespaced_config_map, namespace="default", timeout_seconds=timeout):
+            k8s_logger(self.output_folder, self.test_name, "events_configmaps").info(event)
+
+    # w = watch.Watch()
+    # for event in w.stream(kube.coreV1.list_namespaced_config_map, namespace=TARGET_NS):
+    #   print("Event: %s %s" % (event['type'], event['object'].metadata.name))
     def wait_for_test_agent(self):
         v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
         apps_api = client.AppsV1Api(

--- a/utils/k8s_lib_injection/k8s_kind_cluster.py
+++ b/utils/k8s_lib_injection/k8s_kind_cluster.py
@@ -11,6 +11,15 @@ from utils import context
 
 
 def ensure_cluster():
+    try:
+        return _ensure_cluster()
+    except Exception as e:
+        # It's difficult, but sometimes the cluster is not created correctly, releated to the ports conflicts
+        logger.error(f"Error ensuring cluster: {e}. trying again.")
+        return _ensure_cluster()
+
+
+def _ensure_cluster():
     k8s_kind_cluster = K8sKindCluster()
     k8s_kind_cluster.confiure_ports()
 

--- a/utils/k8s_lib_injection/k8s_logger.py
+++ b/utils/k8s_lib_injection/k8s_logger.py
@@ -3,6 +3,7 @@ import logging.config
 
 
 def k8s_logger(log_folder, test_name, log_name, level=logging.INFO):
+    logging.getLogger("kubernetes").setLevel(logging.ERROR)
     specified_logger = logging.getLogger(f"{test_name}_{log_name}")
     if len(specified_logger.handlers) == 0:
         formatter = logging.Formatter("%(message)s")

--- a/utils/k8s_lib_injection/k8s_weblog.py
+++ b/utils/k8s_lib_injection/k8s_weblog.py
@@ -297,20 +297,23 @@ class K8sWeblog:
         start = time.time()
         while time.time() - start < timeout:
             time.sleep(2)
-            response = api.read_namespaced_deployment_status(deployment_name, "default")
-            s = response.status
-            if (
-                s.updated_replicas == response.spec.replicas
-                and s.replicas == response.spec.replicas
-                and s.available_replicas == response.spec.replicas
-                and s.observed_generation >= response.metadata.generation
-            ):
-                return True
-            else:
-                self.logger.info(
-                    f"[updated_replicas:{s.updated_replicas},replicas:{s.replicas}"
-                    f"available_replicas:{s.available_replicas},observed_generation:{s.observed_generation}] waiting..."
-                )
+            try:
+                response = api.read_namespaced_deployment_status(deployment_name, "default")
+                s = response.status
+                if (
+                    s.updated_replicas == response.spec.replicas
+                    and s.replicas == response.spec.replicas
+                    and s.available_replicas == response.spec.replicas
+                    and s.observed_generation >= response.metadata.generation
+                ):
+                    return True
+                else:
+                    self.logger.info(
+                        f"[updated_replicas:{s.updated_replicas},replicas:{s.replicas}"
+                        f"available_replicas:{s.available_replicas},observed_generation:{s.observed_generation}] waiting..."
+                    )
+            except Exception as e:
+                self.logger.info(f"Error checking deployment status: {e}")
 
         raise RuntimeError(f"Waiting timeout for deployment {deployment_name}")
 

--- a/utils/k8s_lib_injection/k8s_weblog.py
+++ b/utils/k8s_lib_injection/k8s_weblog.py
@@ -106,7 +106,7 @@ class K8sWeblog:
         v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
         pod_body = self._get_base_weblog_pod()
         v1.create_namespaced_pod(namespace="default", body=pod_body)
-        self.wait_for_weblog_ready_by_label_app("my-app", timeout=120)
+        self.wait_for_weblog_ready_by_label_app("my-app", timeout=200)
 
     def install_weblog_pod_without_admission_controller(self, use_uds):
         v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
@@ -162,7 +162,7 @@ class K8sWeblog:
         pod_body.spec.volumes = volumes
 
         v1.create_namespaced_pod(namespace="default", body=pod_body)
-        self.wait_for_weblog_ready_by_label_app("my-app", timeout=120)
+        self.wait_for_weblog_ready_by_label_app("my-app", timeout=200)
 
     def deploy_app_auto(self):
         """ Installs a target app for auto library injection testing.

--- a/utils/k8s_lib_injection/resources/operator/operator-helm-values-auto.yaml
+++ b/utils/k8s_lib_injection/resources/operator/operator-helm-values-auto.yaml
@@ -33,6 +33,8 @@ clusterAgent:
       value: "true"
     - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PATCHER_FALLBACK_TO_FILE_PROVIDER
       value: "true"
+    - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY
+      value: "$$PREFIX_INIT_IMAGE$$"
   volumes:
     - name: auto-instru
       configMap:


### PR DESCRIPTION
## Motivation

Enable tests for lib-injeciton auto and snapshot versions

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
