### PR TITLE
Java OpenTelemetry Auto: Fix for 2.2.0 and obfuscation test issues

### DIFF
--- a/tests/integrations/test_open_telemetry.py
+++ b/tests/integrations/test_open_telemetry.py
@@ -109,7 +109,7 @@ class _BaseOtelDbIntegrationTestClass(BaseDbIntegrationsTestClass):
         """ All queries come out obfuscated from agent """
         for db_operation, request in self.get_requests():
             span = self.get_span_from_agent(request)
-            if db_operation in ["update", "delete", "procedure", "select_error"]:
+            if db_operation in ["update", "delete", "procedure", "select_error", "select"]:
                 assert (
                     span["meta"]["db.statement"].count("?") == 2
                 ), f"The query is not properly obfuscated for operation {db_operation}"
@@ -203,6 +203,10 @@ class Test_MsSql(_BaseOtelDbIntegrationTestClass):
             if db_operation in ["insert", "select"]:
                 expected_obfuscation_count = 3
             else:
+                expected_obfuscation_count = 2
+
+            # Fix for Java otel 2.2.0
+            if db_operation == "select" and context.library == "java_otel":
                 expected_obfuscation_count = 2
 
             observed_obfuscation_count = span["meta"]["db.statement"].count("?")


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

open telemetry 2.2.0 released, and causes test failures for the obfuscation feature. The failure resides on the test. There are not detected any problem with the agent or collector.

https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
