### PR TITLE
fix(otel): Strict attributes and tracestate comparisons

### DIFF
--- a/tests/parametric/test_otel_api_interoperability.py
+++ b/tests/parametric/test_otel_api_interoperability.py
@@ -255,7 +255,7 @@ class Test_Otel_API_Interoperability:
         assert link["trace_id_high"] == TEST_TRACE_ID_HIGH
         assert link["span_id"] == TEST_SPAN_ID_INT
         assert "t.dm:-0" in link["tracestate"]
-        assert link["attributes"] == {"arg1": "val1", "_dd.p.dm": "-0"}
+        assert link["attributes"]["arg1"] == "val1"
 
     def test_concurrent_traces_in_order(self, test_agent, test_library):
         """
@@ -410,7 +410,7 @@ class Test_Otel_API_Interoperability:
                 otel_context = otel_span.span_context()
 
                 assert otel_context.get("trace_id") == trace_id
-                assert otel_context.get("trace_state") == "dd=t.dm:-0,foo=1"
+                assert "foo=1" in otel_context.get("trace_state")
                 assert otel_context.get("trace_flags") == "01"
 
         traces = test_agent.wait_for_num_traces(1)
@@ -441,9 +441,12 @@ class Test_Otel_API_Interoperability:
             with test_library.start_span(name="dd_span", http_headers=headers,) as dd_span:
                 otel_span = test_library.otel_current_span()
                 otel_context = otel_span.span_context()
+                otel_trace_state = otel_context.get("trace_state")
 
                 assert otel_context.get("trace_id") == "000000000000000000000000075bcd15"
-                assert otel_context.get("trace_state") == "dd=o:synthetics;s:-2;t.foo:bar"
+                assert "o:synthetics" in otel_trace_state
+                assert "s:-2" in otel_trace_state
+                assert "t.foo:bar" in otel_trace_state
                 assert otel_context.get("trace_flags") == "00"
 
         traces = test_agent.wait_for_num_traces(1)

--- a/tests/parametric/test_otel_sdk_interoperability.py
+++ b/tests/parametric/test_otel_sdk_interoperability.py
@@ -39,7 +39,7 @@ class Test_Otel_SDK_Interoperability:
         assert link["trace_id_high"] == TEST_TRACE_ID_HIGH
         assert link["span_id"] == TEST_SPAN_ID_INT
         assert "t.dm:-0" in link["tracestate"]
-        assert link["attributes"] == {"arg1": "val1", "_dd.p.dm": "-0"}
+        assert link["attributes"]["arg1"] == "val1"
 
     def test_set_update_remove_meta(self, test_agent, test_library):
         """
@@ -197,7 +197,7 @@ class Test_Otel_SDK_Interoperability:
                 assert otel_link["trace_id"] == TEST_TRACE_ID
                 assert otel_link["parent_id"] == TEST_SPAN_ID
                 assert otel_link["tracestate"] == TEST_TRACESTATE
-                assert otel_link["attributes"] == {"arg1": "val1", "_dd.p.dm": "-0"}
+                assert otel_link["attributes"]["arg1"] == "val1"
 
         traces = test_agent.wait_for_num_traces(1)
         trace = find_trace_by_root(traces, Span(name="dd.span"))
@@ -227,7 +227,7 @@ class Test_Otel_SDK_Interoperability:
                 assert otel_link["trace_id"] == TEST_TRACE_ID
                 assert otel_link["parent_id"] == TEST_SPAN_ID
                 assert otel_link["tracestate"] == TEST_TRACESTATE
-                assert otel_link["attributes"] == {"arg1": "val1", "_dd.p.dm": "-0"}
+                assert otel_link["attributes"]["arg1"] == "val1"
 
                 otel_span.end_span()
 


### PR DESCRIPTION
## Motivation

Motivated by this [PR](https://github.com/DataDog/dd-trace-php/pull/2549) (e.g., [failure](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/15214/workflows/d67c3fa0-58a9-4584-87c1-cb3cffe343c4/jobs/4022316?invite=true#step-110-431)) - The Parametric Tests are failing because the comparison are too strict in some places.

## Changes

Allow for more flexibility in the comparisons, and only test what's relevant. This will prevent test failures from unrelated features.

The Span Links's tracestate comparisons were purposefully left strict.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
