### PR TITLE
fix: rails42 with new ruby-2.3.8 image

### DIFF
--- a/utils/build/docker/ruby/rails42/Gemfile
+++ b/utils/build/docker/ruby/rails42/Gemfile
@@ -42,3 +42,6 @@ gem 'devise'
 gem 'ddtrace', '~> 1.0.0.a', require: 'ddtrace/auto_instrument'
 gem 'mini_racer', '~> 0.4.0', platforms: :ruby
 gem 'puma', '5.0.2'
+# Include fix for canonicalize glibc conflict: https://github.com/sparklemotion/nokogiri/issues/2105
+gem 'nokogiri', '1.10.10', git: 'https://github.com/swaseybridge/nokogiri',
+                           ref: '2e29fafd27322e8463a769d227e1ea40f6603bdf'

--- a/utils/build/docker/ruby/rails42/Gemfile.lock
+++ b/utils/build/docker/ruby/rails42/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/swaseybridge/nokogiri
+  revision: 2e29fafd27322e8463a769d227e1ea40f6603bdf
+  ref: 2e29fafd27322e8463a769d227e1ea40f6603bdf
+  specs:
+    nokogiri (1.10.10)
 GEM
   remote: https://rubygems.org/
   specs:
@@ -86,7 +92,6 @@ GEM
     minitest (5.15.0)
     msgpack (1.4.4)
     nio4r (2.5.8)
-    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -184,6 +189,7 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  nokogiri (= 1.10.10)!
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
