### PR TITLE
Avoid alarming exceptions log pattern for Exception Debugging logger in .NET

### DIFF
--- a/tests/test_library_logs.py
+++ b/tests/test_library_logs.py
@@ -14,6 +14,6 @@ class Test_NoExceptions:
             pattern=r"[A-Za-z]+\.[A-Za-z]*Exception",
             allowed_patterns=[
                 r"System.DllNotFoundException: Unable to load shared library 'Datadog.AutoInstrumentation.Profiler.Native.x64'",  # pylint: disable=line-too-long
-                r"Logger retrieved for: Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ExceptionDebugging", # pylint: disable=line-too-long
+                r"Logger retrieved for: Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ExceptionDebugging",  # pylint: disable=line-too-long
             ],
         )

--- a/tests/test_library_logs.py
+++ b/tests/test_library_logs.py
@@ -14,5 +14,6 @@ class Test_NoExceptions:
             pattern=r"[A-Za-z]+\.[A-Za-z]*Exception",
             allowed_patterns=[
                 r"System.DllNotFoundException: Unable to load shared library 'Datadog.AutoInstrumentation.Profiler.Native.x64'",  # pylint: disable=line-too-long
+                r"Logger retrieved for: Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ExceptionDebugging", # pylint: disable=line-too-long
             ],
         )


### PR DESCRIPTION
## Motivation
The [.NET Exception Debugging PR](https://github.com/DataDog/dd-trace-dotnet/pull/5163) has just been merged into [dd-trace-dotnet](https://github.com/DataDog/dd-trace-dotnet), and the [system-tests has started to fail](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=154612&view=logs&j=c26e76bd-da46-50ee-4755-0e58d94fc624&t=92993314-6f81-5dd3-7188-86548f340d7b) because it found a log pattern that contains the word 'Exception'. All the code of Exception Debugging in .NET is under a new namespace `ExceptionAutoInstrumentation`, so it falsely reporting it.

## Changes
Added `Logger retrieved for: Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ExceptionDebugging` to the `allowed_patterns` list.