### PR TITLE
The 'tracing_enabled' value in 'config_overrides' JSON should be a Boolean, not a String

### DIFF
--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -219,7 +219,7 @@ class TestDynamicConfigTracingEnabled:
     )
     @irrelevant(library="golang")
     def test_tracing_client_tracing_disable_one_way(self, library_env, test_agent, test_library):
-        set_and_wait_rc(test_agent, config_overrides={"tracing_enabled": "false"})
+        set_and_wait_rc(test_agent, config_overrides={"tracing_enabled": False})
         _set_rc(test_agent, _create_rc_config({}))
         with test_library:
             with test_library.start_span("test"):


### PR DESCRIPTION
## Motivation

The "apm-tracing" schema says `tracing_enabled` should be a boolean: https://github.com/DataDog/dd-go/blob/master/remote-config/apps/rc-product/schemas/apm-tracing.json#L73

Setting a string value in the `config_overrides` JSON for this field means the override will be rejected by tracers that strictly follow the expected schema.

## Changes

This changes the one place where the JSON is constructed directly in the code.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
