### PR TITLE
Ignore SIDECAR telemetry events

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -698,13 +698,15 @@ class _TestAgentAPI:
                     if event["request_type"] == "message-batch":
                         for message in event["payload"]:
                             if message["request_type"] == event_name:
-                                if clear:
-                                    self.clear()
-                                return message
+                                if message.get("application", {}).get("language_version") != "SIDECAR":
+                                    if clear:
+                                        self.clear()
+                                    return message
                     elif event["request_type"] == event_name:
-                        if clear:
-                            self.clear()
-                        return event
+                        if event.get("application", {}).get("language_version") != "SIDECAR":
+                            if clear:
+                                self.clear()
+                            return event
             time.sleep(0.01)
         raise AssertionError("Telemetry event %r not found" % event_name)
 


### PR DESCRIPTION
PHP spawns a sidecar which will have its own app lifecycle and send telemetry events itself. For the purpose of the system tests it's pure noise, which we have to ignore.

It leads to flakiness in some of our tests as ordering of these is not deterministic.