### PR TITLE
[DEBUGGER] Restore java tests

### DIFF
--- a/tests/debugger/test_debugger.py
+++ b/tests/debugger/test_debugger.py
@@ -2,15 +2,13 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import scenarios, interfaces, weblog, features, missing_feature, context
-from utils.tools import logger
+from utils import scenarios, interfaces, weblog, features
 import test_debugger_base as base
 
 
 @features.debugger
 @scenarios.debugger_probes_status
 class Test_Debugger_Probe_Statuses:
-    @missing_feature(context.library >= "java@1.27", reason="Sending probe status to DEBUGGER track")
     def test_method_probe_status(self):
         expected_probes = {
             "loga0cf2-meth-45cf-9f39-591received": "RECEIVED",
@@ -25,7 +23,6 @@ class Test_Debugger_Probe_Statuses:
 
         base.validate_probes(expected_probes)
 
-    @missing_feature(context.library >= "java@1.27", reason="Sending probe status to DEBUGGER track")
     def test_line_probe_status(self):
         expected_probes = {
             "loga0cf2-line-45cf-9f39-59installed": "INSTALLED",
@@ -59,7 +56,6 @@ class Test_Debugger_Method_Probe_Snaphots(base._Base_Debugger_Snapshot_Test):
         self.span_probe_response = weblog.get("/debugger/span")
         self.span_decoration_probe_response = weblog.get("/debugger/span-decoration/asd/1")
 
-    @missing_feature(context.library >= "java@1.27", reason="introduction of new EMITTING probe status")
     def test_method_probe_snaphots(self):
         self.assert_remote_config_is_sent()
         self.assert_all_probes_are_installed()
@@ -103,7 +99,6 @@ class Test_Debugger_Line_Probe_Snaphots(base._Base_Debugger_Snapshot_Test):
         self.metric_probe_response = weblog.get("/debugger/metric/1")
         self.span_decoration_probe_response = weblog.get("/debugger/span-decoration/asd/1")
 
-    @missing_feature(context.library >= "java@1.27", reason="introduction of new EMITTING probe status")
     def test_line_probe_snaphots(self):
         self.assert_remote_config_is_sent()
         self.assert_all_probes_are_installed()
@@ -140,7 +135,6 @@ class Test_Debugger_Mix_Log_Probe(base._Base_Debugger_Snapshot_Test):
         interfaces.agent.wait_for(self.wait_for_all_probes_installed, timeout=30)
         self.multi_probe_response = weblog.get("/debugger/mix/asd/1")
 
-    @missing_feature(context.library >= "java@1.27", reason="introduction of new EMITTING probe status")
     def test_mix_probe(self):
         self.assert_remote_config_is_sent()
         self.assert_all_probes_are_installed()

--- a/tests/debugger/test_debugger_base.py
+++ b/tests/debugger/test_debugger_base.py
@@ -12,19 +12,21 @@ _DEBUGER_PATH = "/api/v2/debugger"
 _LOGS_PATH = "/api/v2/logs"
 _TRACES_PATH = "/api/v0.2/traces"
 
+
 def read_data():
     tracer = list(interfaces.library.get_data(_CONFIG_PATH))[0]["request"]["content"]["client"]["client_tracer"]
-    
+
     if tracer["language"] == "java":
-        tracer_version = version.parse(tracer["tracer_version"].split('+')[0])
+        tracer_version = version.parse(tracer["tracer_version"].split("+")[0])
         if tracer_version > version.parse("1.27.0"):
             path = _DEBUGER_PATH
         else:
             path = _LOGS_PATH
     else:
         path = _LOGS_PATH
-        
+
     return list(interfaces.agent.get_data(path))
+
 
 def get_probes_map(data_set):
     probe_hash = {}
@@ -48,11 +50,9 @@ def get_probes_map(data_set):
 
     return probe_hash
 
+
 def validate_probes(expected_probes):
-
     def check_probe_status(expected_id, expected_status, probe_status_map):
-        print(probe_status_map)
-
         if expected_id not in probe_status_map:
             raise ValueError("Probe " + expected_id + " was not received.")
 
@@ -66,7 +66,6 @@ def validate_probes(expected_probes):
                 + ", but expected for "
                 + expected_status
             )
-
 
     probe_map = get_probes_map(read_data())
     for expected_id, expected_status in expected_probes.items():
@@ -125,6 +124,7 @@ def validate_spans(expected_spans):
     for expected_trace in expected_spans:
         check_trace(expected_trace, span_map)
 
+
 class _Base_Debugger_Snapshot_Test:
     expected_probe_ids = []
     all_probes_installed = False
@@ -136,7 +136,7 @@ class _Base_Debugger_Snapshot_Test:
                 return
 
         raise ValueError("I was expecting a remote config")
-    
+
     def _is_all_probes_installed(self, probes_map):
         if probes_map is None:
             return False
@@ -161,7 +161,7 @@ class _Base_Debugger_Snapshot_Test:
                 self.all_probes_installed = True
 
         return self.all_probes_installed
-    
+
     def assert_all_probes_are_installed(self):
         if not self.all_probes_installed:
             raise ValueError("At least one probe is missing")

--- a/tests/debugger/test_debugger_base.py
+++ b/tests/debugger/test_debugger_base.py
@@ -2,32 +2,62 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import scenarios, interfaces, weblog, features, missing_feature, context
+from utils import interfaces
 from utils.tools import logger
+from packaging import version
+import json
 
+_CONFIG_PATH = "/v0.7/config"
+_DEBUGER_PATH = "/api/v2/debugger"
+_LOGS_PATH = "/api/v2/logs"
+_TRACES_PATH = "/api/v0.2/traces"
 
-def validate_probes(expected_probes):
-    def get_probes_map():
-        agent_logs_endpoint_requests = list(interfaces.agent.get_data(path_filters="/api/v2/logs"))
-        probe_hash = {}
+def read_data():
+    tracer = list(interfaces.library.get_data(_CONFIG_PATH))[0]["request"]["content"]["client"]["client_tracer"]
+    
+    if tracer["language"] == "java":
+        tracer_version = version.parse(tracer["tracer_version"].split('+')[0])
+        if tracer_version > version.parse("1.27.0"):
+            path = _DEBUGER_PATH
+        else:
+            path = _LOGS_PATH
+    else:
+        path = _LOGS_PATH
+        
+    return list(interfaces.agent.get_data(path))
 
-        for request in agent_logs_endpoint_requests:
-            content = request["request"]["content"]
-            if content is not None:
-                for content in content:
+def get_probes_map(data_set):
+    probe_hash = {}
+
+    for data in data_set:
+        contents = data["request"].get("content", [])
+        if contents is not None:
+            for content in contents:
+                if "content" in content:
+                    d_contents = json.loads(content["content"])
+                    for d_content in d_contents:
+                        debugger = d_content["debugger"]
+                        if "diagnostics" in debugger:
+                            probe_id = debugger["diagnostics"]["probeId"]
+                            probe_hash[probe_id] = debugger["diagnostics"]
+                else:
                     debugger = content["debugger"]
                     if "diagnostics" in debugger:
                         probe_id = debugger["diagnostics"]["probeId"]
                         probe_hash[probe_id] = debugger["diagnostics"]
 
-        return probe_hash
+    return probe_hash
+
+def validate_probes(expected_probes):
 
     def check_probe_status(expected_id, expected_status, probe_status_map):
+        print(probe_status_map)
+
         if expected_id not in probe_status_map:
             raise ValueError("Probe " + expected_id + " was not received.")
 
         actual_status = probe_status_map[expected_id]["status"]
-        if actual_status != expected_status:
+        if actual_status != expected_status and not (expected_status == "INSTALLED" and actual_status == "EMITTING"):
             raise ValueError(
                 "Received probe "
                 + expected_id
@@ -37,14 +67,15 @@ def validate_probes(expected_probes):
                 + expected_status
             )
 
-    probe_map = get_probes_map()
+
+    probe_map = get_probes_map(read_data())
     for expected_id, expected_status in expected_probes.items():
         check_probe_status(expected_id, expected_status, probe_map)
 
 
 def validate_snapshots(expected_snapshots):
     def get_snapshot_map():
-        agent_logs_endpoint_requests = list(interfaces.agent.get_data(path_filters="/api/v2/logs"))
+        agent_logs_endpoint_requests = list(interfaces.agent.get_data(_LOGS_PATH))
         snapshot_hash = {}
 
         for request in agent_logs_endpoint_requests:
@@ -69,7 +100,7 @@ def validate_snapshots(expected_snapshots):
 
 def validate_spans(expected_spans):
     def get_span_map():
-        agent_logs_endpoint_requests = list(interfaces.agent.get_data(path_filters="/api/v0.2/traces"))
+        agent_logs_endpoint_requests = list(interfaces.agent.get_data(_TRACES_PATH))
         span_hash = {}
         for request in agent_logs_endpoint_requests:
             content = request["request"]["content"]
@@ -94,31 +125,27 @@ def validate_spans(expected_spans):
     for expected_trace in expected_spans:
         check_trace(expected_trace, span_map)
 
-
 class _Base_Debugger_Snapshot_Test:
     expected_probe_ids = []
+    all_probes_installed = False
 
     def assert_remote_config_is_sent(self):
-        for data in interfaces.library.get_data("/v0.7/config"):
+        for data in interfaces.library.get_data(_CONFIG_PATH):
             logger.debug(f"Found config in {data['log_filename']}")
             if "client_configs" in data.get("response", {}).get("content", {}):
                 return
 
         raise ValueError("I was expecting a remote config")
-
-    def _is_all_probes_installed(self, data):
-        contents = data.get("request", {}).get("content", [])
-
-        if contents is None:
+    
+    def _is_all_probes_installed(self, probes_map):
+        if probes_map is None:
             return False
 
         installed_ids = set()
-        for content in contents:
-            diagnostics = content.get("debugger", {}).get("diagnostics", {})
-            if diagnostics.get("status") == "INSTALLED":
-                installed_ids.add(diagnostics.get("probeId"))
-
-        logger.debug(f"Found probes in {data['log_filename']}:\n    {installed_ids}")
+        for expected_id in self.expected_probe_ids:
+            if expected_id in probes_map:
+                if probes_map[expected_id]["status"] == "INSTALLED":
+                    installed_ids.add(expected_id)
 
         if set(self.expected_probe_ids).issubset(installed_ids):
             logger.debug(f"Succes: found probes {installed_ids}")
@@ -128,17 +155,13 @@ class _Base_Debugger_Snapshot_Test:
 
         logger.debug(f"Found some probes, but not all of them. Missing probes are {missings_ids}")
 
-    def assert_all_probes_are_installed(self):
-        logger.debug(f"Checking if I found all my probes:\n    {self.expected_probe_ids}")
-        for data in interfaces.agent.get_data("/api/v2/logs"):
-            if self._is_all_probes_installed(data):
-                return
-
-        raise ValueError("At least one probe is missing")
-
     def wait_for_all_probes_installed(self, data):
-        if data["path"] == "/api/v2/logs":
-            if self._is_all_probes_installed(data):
-                return True
+        if data["path"] == _DEBUGER_PATH or data["path"] == _LOGS_PATH:
+            if self._is_all_probes_installed(get_probes_map([data])):
+                self.all_probes_installed = True
 
-        return False
+        return self.all_probes_installed
+    
+    def assert_all_probes_are_installed(self):
+        if not self.all_probes_installed:
+            raise ValueError("At least one probe is missing")

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/DebuggerController.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/DebuggerController.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 // Dummy line
 // Dummy line
 // Dummy line
+// Dummy line
 
 @RestController
 @RequestMapping("/debugger")


### PR DESCRIPTION
## Motivation
Restore java tests

## Changes
`Java` has introduced a new EMITTING status and a different endpoint for sending probe statuses. This PR updates the system tests to work with the new statuses for Java, and old statuses for `dotnet`.