### PR TITLE
Remove false positive in telemetry test

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -608,13 +608,19 @@ class Test_ProductsDisabled:
     @scenarios.telemetry_app_started_products_disabled
     def test_app_started_product_disabled(self):
 
-        telemetry_data = list(interfaces.library.get_telemetry_data())
-        if len(telemetry_data) == 0:
-            raise Exception("No telemetry data to validate on")
+        data_found = False
+        app_started_found = False
+
+        telemetry_data = interfaces.library.get_telemetry_data()
 
         for data in telemetry_data:
+            data_found = True
+
             if get_request_type(data) != "app-started":
                 continue
+
+            app_started_found = True
+
             payload = data["request"]["content"]["payload"]
 
             assert (
@@ -625,6 +631,12 @@ class Test_ProductsDisabled:
                 assert (
                     details.get("enabled") is False
                 ), f"Product information expected to indicate {product} is disabled, but found enabled"
+
+        if not data_found:
+            raise ValueError("No telemetry data to validate on")
+
+        if not app_started_found:
+            raise ValueError("app-started event not found in telemetry data")
 
 
 @features.dd_telemetry_dependency_collection_enabled_supported


### PR DESCRIPTION
## Motivation

Reduces flakyness

## Changes

This tests was checking something on app-started event. But if there is no `app-started`, the test was ok, leading to fan xpass if the feature is not implemented at all.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
