### PR TITLE
k8s lib injection: api wrapper

### DIFF
--- a/tests/k8s_lib_injection/conftest.py
+++ b/tests/k8s_lib_injection/conftest.py
@@ -76,7 +76,7 @@ class K8sInstance:
         self.k8s_kind_cluster = ensure_cluster()
         self.k8s_wrapper = K8sWrapper(self.k8s_kind_cluster)
         self.test_agent.configure(self.k8s_kind_cluster, self.k8s_wrapper)
-        self.test_weblog.configure(self.k8s_kind_cluster)
+        self.test_weblog.configure(self.k8s_kind_cluster, self.k8s_wrapper)
         try:
             config.load_kube_config()
             logger.info(f"kube config loaded")

--- a/tests/k8s_lib_injection/conftest.py
+++ b/tests/k8s_lib_injection/conftest.py
@@ -8,6 +8,7 @@ import json
 from utils.k8s_lib_injection.k8s_kind_cluster import ensure_cluster, destroy_cluster
 from utils.k8s_lib_injection.k8s_datadog_cluster_agent import K8sDatadogClusterTestAgent
 from utils.k8s_lib_injection.k8s_weblog import K8sWeblog
+from utils.k8s_lib_injection.k8s_wrapper import K8sWrapper
 from kubernetes import config
 
 
@@ -69,10 +70,12 @@ class K8sInstance:
         self.test_agent = K8sDatadogClusterTestAgent(prefix_library_init_image, output_folder, test_name)
         self.test_weblog = K8sWeblog(weblog_variant_image, library, library_init_image, output_folder, test_name)
         self.k8s_kind_cluster = None
+        self.k8s_wrapper = None
 
     def start_instance(self):
         self.k8s_kind_cluster = ensure_cluster()
-        self.test_agent.configure(self.k8s_kind_cluster)
+        self.k8s_wrapper = K8sWrapper(self.k8s_kind_cluster)
+        self.test_agent.configure(self.k8s_kind_cluster, self.k8s_wrapper)
         self.test_weblog.configure(self.k8s_kind_cluster)
         try:
             config.load_kube_config()

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -156,42 +156,10 @@ class TestConfigMapAutoInject:
             },
         ]
 
-    def get_k8s_api(self, k8s_kind_cluster):
-        """ Get the k8s api. It retries 5 times if it fails. Sometimes there are 
-        collisions when we execute a lot of tests in parallel."""
-        for i in range(5):
-            try:
-                return self._k8s_api(k8s_kind_cluster)
-            except Exception as e:
-                self.logger.info(f"Error getting k8s api: {e}")
-                time.sleep(2)
-        raise Exception("Error getting k8s api")
-
-    def _k8s_api(self, k8s_kind_cluster):
-        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=k8s_kind_cluster.context_name))
-        apps_api = client.AppsV1Api(api_client=config.new_client_from_config(context=k8s_kind_cluster.context_name))
-        return v1, apps_api
-
-    def list_namespaced_pod(self, test_k8s_instance, namespace="default", label_selector=None):
-        """ Get list namespace pod and retry if it fails. """
-        v1, _ = self.get_k8s_api(test_k8s_instance.k8s_kind_cluster)
-        try:
-            return v1.list_namespaced_pod(namespace=namespace, label_selector=label_selector)
-        except Exception as e:
-            return v1.list_namespaced_pod(namespace=namespace, label_selector=label_selector)
-
-    def read_namespaced_deployment(self, test_k8s_instance, deployment_name=None):
-        """ Get deployment and retry if it fails."""
-        _, api = self.get_k8s_api(test_k8s_instance.k8s_kind_cluster)
-        try:
-            return api.read_namespaced_deployment(deployment_name, "default")
-        except Exception as e:
-            return api.read_namespaced_deployment(deployment_name, "default")
-
     def _check_for_env_vars(self, test_k8s_instance, expected_env_vars):
         """ evaluates whether the expected tracer config is reflected in the env vars of the targeted pod. """
         app_name = f"{test_k8s_instance.library}-app"
-        pods = self.list_namespaced_pod(test_k8s_instance, label_selector=f"app={app_name}")
+        pods = test_k8s_instance.k8s_wrapper.list_namespaced_pod("default", label_selector=f"app={app_name}")
         assert len(pods.items) != 0, f"No pods found for app {app_name}"
 
         for expected_env_var in expected_env_vars:
@@ -209,7 +177,7 @@ class TestConfigMapAutoInject:
         """evaluates whether the expected admission labels and annotations are applied to the targeted pod."""
         library_version = test_k8s_instance.library_init_image_tag
         app_name = f"{test_k8s_instance.library}-app"
-        pods = self.list_namespaced_pod(test_k8s_instance, label_selector=f"app={app_name}")
+        pods = test_k8s_instance.k8s_wrapper.list_namespaced_pod("default", label_selector=f"app={app_name}")
         assert len(pods.items) != 0, f"No pods found for app {app_name}"
 
         assert (
@@ -227,7 +195,7 @@ class TestConfigMapAutoInject:
         """evaluates whether the expected admission labels and annotations are applied to the targeted pod."""
         library_version = test_k8s_instance.library_init_image_tag
         app_name = f"{test_k8s_instance.library}-app"
-        pods = self.list_namespaced_pod(test_k8s_instance, label_selector=f"app={app_name}")
+        pods = test_k8s_instance.k8s_wrapper.list_namespaced_pod("default", label_selector=f"app={app_name}")
         assert len(pods.items) == 1, f"No pods found for app {app_name}"
 
         assert (
@@ -245,7 +213,7 @@ class TestConfigMapAutoInject:
 
         deployment_name = f"test-{test_k8s_instance.library}-deployment"
         rc_id = "11777398274940883092"
-        deployment = self.read_namespaced_deployment(test_k8s_instance, deployment_name)
+        deployment = test_k8s_instance.k8s_wrapper.read_namespaced_deployment(deployment_name)
         assert (
             deployment.metadata.annotations["admission.datadoghq.com/rc.id"] == rc_id
         ), f"Deployment annotation 'admission.datadoghq.com/rc.id' not equal [{rc_id}]. Deployment description: {deployment}"
@@ -258,20 +226,19 @@ class TestConfigMapAutoInject:
           It returns when the deployment is available and the rollout is finished. 
         """
         deployment_name = f"test-{test_k8s_instance.library}-deployment"
-        _, api = self.get_k8s_api(test_k8s_instance.k8s_kind_cluster)
-        deploy_data = self.read_namespaced_deployment(test_k8s_instance, deployment_name)
+        deploy_data = test_k8s_instance.k8s_wrapper.read_namespaced_deployment(deployment_name)
         # get envs from deployment's first container
         dep_envs = deploy_data.spec.template.spec.containers[0].env
         dep_envs.append(client.V1EnvVar(name="ENV_FOO", value="ENV_BAR"))
         deploy_data.spec.template.spec.containers[0].env = dep_envs
-        api.patch_namespaced_deployment(deployment_name, "default", deploy_data)
+        test_k8s_instance.k8s_wrapper.patch_namespaced_deployment(deployment_name, "default", deploy_data)
         time.sleep(30)
         test_k8s_instance.test_weblog.wait_for_weblog_after_apply_configmap(f"{test_k8s_instance.library}-app")
 
     def _check_for_no_pod_metadata(self, test_k8s_instance):
         """ Ensures the targeted pod doesn't have admission labels. """
         app_name = f"{test_k8s_instance.library}-app"
-        pods = self.list_namespaced_pod(test_k8s_instance, label_selector=f"app={app_name}")
+        pods = test_k8s_instance.k8s_wrapper.list_namespaced_pod("default", label_selector=f"app={app_name}")
         assert len(pods.items) != 0, f"No pods found for app {app_name}"
 
         assert (
@@ -282,7 +249,7 @@ class TestConfigMapAutoInject:
         """ Ensures the targeted pod doesn't have admission labels. """
 
         app_name = f"{test_k8s_instance.library}-app"
-        pods = self.list_namespaced_pod(test_k8s_instance, label_selector=f"app={app_name}")
+        pods = test_k8s_instance.k8s_wrapper.list_namespaced_pod("default", label_selector=f"app={app_name}")
         assert len(pods.items) != 0, f"No pods found for app {app_name}"
         assert (
             pods.items[0].metadata.labels["admission.datadoghq.com/enabled"] == "false"

--- a/tests/k8s_lib_injection/test_k8s_manual_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_manual_inject.py
@@ -21,7 +21,7 @@ class TestAdmisionController:
             time.sleep(2)
         return []
 
-    def test_inject_admission_controller(self, test_k8s_instance):
+    def _test_inject_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test _test_inject_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )
@@ -32,7 +32,7 @@ class TestAdmisionController:
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_admission_controller finished")
 
-    def test_inject_without_admission_controller(self, test_k8s_instance):
+    def _test_inject_without_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test _test_inject_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )
@@ -42,7 +42,7 @@ class TestAdmisionController:
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_without_admission_controller finished")
 
-    def test_inject_uds_without_admission_controller(self, test_k8s_instance):
+    def _test_inject_uds_without_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test test_inject_uds_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -1,6 +1,9 @@
 import time
-from kubernetes import client, config, watch
-from kubernetes.utils import create_from_yaml
+import os
+import json
+
+from kubernetes import client, watch
+
 from utils.k8s_lib_injection.k8s_command_utils import (
     helm_add_repo,
     helm_install_chart,
@@ -8,9 +11,6 @@ from utils.k8s_lib_injection.k8s_command_utils import (
     path_clusterrole,
 )
 from utils.k8s_lib_injection.k8s_logger import k8s_logger
-
-import os
-import json
 
 
 class K8sDatadogClusterTestAgent:
@@ -20,29 +20,13 @@ class K8sDatadogClusterTestAgent:
         self.output_folder = output_folder
         self.test_name = test_name
         self.logger = None
+        self.k8s_wrapper = None
 
-    def configure(self, k8s_kind_cluster):
+    def configure(self, k8s_kind_cluster, k8s_wrapper):
         self.k8s_kind_cluster = k8s_kind_cluster
+        self.k8s_wrapper = k8s_wrapper
         self.logger = k8s_logger(self.output_folder, self.test_name, "k8s_logger")
         self.logger.info(f"K8sDatadogClusterTestAgent configured with cluster: {self.k8s_kind_cluster.cluster_name}")
-
-    def get_k8s_api(self):
-        """ Get the k8s api. It retries 5 times if it fails. Sometimes there are 
-        collisions when we execute a lot of tests in parallel."""
-        for i in range(5):
-            try:
-                return self._k8s_api()
-            except Exception as e:
-                self.logger.info(f"Error getting k8s api: {e}")
-                time.sleep(2)
-        raise Exception("Error getting k8s api")
-
-    def _k8s_api(self):
-        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
-        apps_api = client.AppsV1Api(
-            api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name)
-        )
-        return v1, apps_api
 
     def desploy_test_agent(self):
         """ Installs the test agent pod."""
@@ -51,7 +35,6 @@ class K8sDatadogClusterTestAgent:
             f"[Test agent] Deploying Datadog test agent on the cluster: {self.k8s_kind_cluster.cluster_name}"
         )
 
-        _, apps_api = self.get_k8s_api()
         container = client.V1Container(
             name="trace-agent",
             image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest",
@@ -111,14 +94,8 @@ class K8sDatadogClusterTestAgent:
         daemonset = client.V1DaemonSet(
             api_version="apps/v1", kind="DaemonSet", metadata=client.V1ObjectMeta(name="datadog"), spec=spec
         )
-        try:
-            apps_api.create_namespaced_daemon_set(namespace="default", body=daemonset)
-        except client.exceptions.ApiException as e:
-            # Ok, let's try again
-            time.sleep(5)
-            _, apps_api = self.get_k8s_api()
-            apps_api.create_namespaced_daemon_set(namespace="default", body=daemonset)
 
+        self.k8s_wrapper.create_namespaced_daemon_set(body=daemonset)
         self.wait_for_test_agent()
         self.logger.info("[Test agent] Daemonset created")
 
@@ -183,18 +160,17 @@ class K8sDatadogClusterTestAgent:
             It returns when the targeted deployment finishes the rollout."""
 
         self.logger.info(f"[Auto Config] Applying config for auto-inject: {config_data}")
-        v1, _ = self.get_k8s_api()
         metadata = client.V1ObjectMeta(name="auto-instru", namespace="default",)
         configmap = client.V1ConfigMap(kind="ConfigMap", data={"auto-instru.json": config_data,}, metadata=metadata)
-        r = v1.replace_namespaced_config_map(name="auto-instru", namespace="default", body=configmap)
+        r = self.k8s_wrapper.replace_namespaced_config_map(name="auto-instru", body=configmap)
         self.logger.info(f"[Auto Config] Configmap replaced!")
         k8s_logger(self.output_folder, self.test_name, "applied_configmaps").info(r)
         self.wait_configmap_auto_inject(timeout=150, rev=rev)
 
     def create_configmap_auto_inject(self):
         """ Minimal configuration needed when we install operator auto """
+
         self.logger.info("[Auto Config] Creating configmap for auto-inject")
-        v1, _ = self.get_k8s_api()
         metadata = client.V1ObjectMeta(name="auto-instru", namespace="default",)
         configmap = client.V1ConfigMap(
             kind="ConfigMap",
@@ -204,111 +180,86 @@ class K8sDatadogClusterTestAgent:
             },
             metadata=metadata,
         )
-        v1.create_namespaced_config_map(namespace="default", body=configmap)
+        self.k8s_wrapper.create_namespaced_config_map(body=configmap)
         time.sleep(5)
 
     def wait_configmap_auto_inject(self, timeout=90, rev=0):
         """ wait for the configmap to be read by the datadog-cluster-agent."""
+
         patch_id = "11777398274940883092"
         self.logger.info("[Auto Config] Waiting for the configmap to be read by the datadog-cluster-agent.")
         # First we need to wait for the configmap to be created
-        v1, _ = self.get_k8s_api()
-        try:
-            w = watch.Watch()
-            for event in w.stream(func=v1.list_namespaced_config_map, namespace="default", timeout_seconds=timeout):
-                k8s_logger(self.output_folder, self.test_name, "events_configmaps").info(event)
-                if event["type"] == "ADDED" and event["object"].metadata.name == "auto-instru":
-                    self.logger.info("[Auto Config] Configmap applied!")
-                    w.stop()
-                    break
-        except Exception as e:
-            self.logger.error(f"[Auto Config] Error waiting for the configmap: {e}")
+        w = watch.Watch()
+        for event in w.stream(
+            func=self.k8s_wrapper.list_namespaced_config_map, namespace="default", timeout_seconds=timeout
+        ):
+            k8s_logger(self.output_folder, self.test_name, "events_configmaps").info(event)
+            if event["type"] == "ADDED" and event["object"].metadata.name == "auto-instru":
+                self.logger.info("[Auto Config] Configmap applied!")
+                w.stop()
+                break
 
         # Second wait for datadog-cluster-agent read the configmap
         expected_log = f'Applying Remote Config ID "{patch_id}" with revision "{rev}" and action'
-        pod_cluster_agent_name = None
+        pods = self.k8s_wrapper.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
+        assert len(pods.items) > 0, "No pods found for app datadog-cluster-agent"
+        pod_cluster_agent_name = pods.items[0].metadata.name
         timeout = time.time() + timeout
         while True:
-            try:
-                if pod_cluster_agent_name is None:
-                    pods = v1.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
-                    assert len(pods.items) > 0, "No pods found for app datadog-cluster-agent"
-                    pod_cluster_agent_name = pods.items[0].metadata.name
-                api_response = v1.read_namespaced_pod_log(name=pod_cluster_agent_name, namespace="default")
-                for log_line in api_response.splitlines():
-                    if log_line.find(expected_log) != -1:
-                        self.logger.info(f"Configmap read by datadog-cluster-agent: {log_line}")
-                        return
-            except Exception as e:
-                self.logger.error(
-                    f"[Auto Config] Error waiting for the datadog-cluster-agent to read the configmap: {e}"
-                )
+            api_response = self.k8s_wrapper.read_namespaced_pod_log(name=pod_cluster_agent_name)
+            for log_line in api_response.splitlines():
+                if log_line.find(expected_log) != -1:
+                    self.logger.info(f"Configmap read by datadog-cluster-agent: {log_line}")
+                    return
             if time.time() > timeout:
                 self.logger.error(f"Timeout waiting for the datadog-cluster-agent to read the configmap")
                 raise TimeoutError("Timeout waiting for the datadog-cluster-agent to read the configmap")
             time.sleep(5)
 
     def wait_for_test_agent(self):
-        v1, apps_api = self.get_k8s_api()
+        """ Waits for the test agent to be ready."""
         daemonset_created = False
         daemonset_status = None
         # Wait for the daemonset to be created
         for i in range(20):
-            try:
-                daemonset_status = apps_api.read_namespaced_daemon_set_status(name="datadog", namespace="default")
-                if daemonset_status.status.number_ready > 0:
-                    self.logger.info(f"[Test agent] daemonset status datadog running!")
-                    daemonset_created = True
-                    break
-                time.sleep(5)
-            except Exception as e:
-                self.logger.info(f"[Test agent] daemonset status error: {e}")
-                time.sleep(5)
+            daemonset_status = self.k8s_wrapper.read_namespaced_daemon_set_status(name="datadog")
+            if daemonset_status.status.number_ready > 0:
+                self.logger.info(f"[Test agent] daemonset status datadog running!")
+                daemonset_created = True
+                break
+            time.sleep(5)
 
         if not daemonset_created:
             self.logger.info("[Test agent] Daemonset not created. Last status: %s" % daemonset_status)
             raise Exception("Daemonset not created")
-        try:
-            w = watch.Watch()
-            for event in w.stream(
-                func=v1.list_namespaced_pod, namespace="default", label_selector="app=datadog", timeout_seconds=60
-            ):
-                if event["object"].status.phase == "Running":
-                    w.stop()
-                    self.logger.info("Datadog test agent started!")
-                    break
-        except Exception as e:
-            self.logger.error(f"Error waiting for the test agent: {e}")
-            # Wait 10 second and continue. Sometimes we have conflict when we run a lot of tests in parallel
-            time.sleep(10)
+
+        w = watch.Watch()
+        for event in w.stream(
+            func=self.k8s_wrapper.list_namespaced_pod, label_selector="app=datadog", timeout_seconds=60
+        ):
+            if event["object"].status.phase == "Running":
+                w.stop()
+                self.logger.info("Datadog test agent started!")
+                break
 
     def _wait_for_operator_ready(self):
-        datadog_cluster_name = None
-        v1, _ = self.get_k8s_api()
         operator_ready = False
         operator_status = None
 
+        pods = self.k8s_wrapper.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
+        datadog_cluster_name = pods.items[0].metadata.name
+
         for i in range(20):
-            try:
-                if datadog_cluster_name is None:
-                    pods = v1.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
-                    datadog_cluster_name = pods.items[0].metadata.name
-                operator_status = v1.read_namespaced_pod_status(name=datadog_cluster_name, namespace="default")
-                if (
-                    operator_status.status.phase == "Running"
-                    and operator_status.status.container_statuses[0].ready == True
-                ):
-                    self.logger.info(f"[Deploy operator] Operator datadog running!")
-                    operator_ready = True
-                    break
-                time.sleep(5)
-            except Exception as e:
-                self.logger.info(f"Pod status error: {e}")
-                time.sleep(5)
+            operator_status = self.k8s_wrapper.read_namespaced_pod_status(name=datadog_cluster_name)
+            if operator_status.status.phase == "Running" and operator_status.status.container_statuses[0].ready == True:
+                self.logger.info(f"[Deploy operator] Operator datadog running!")
+                operator_ready = True
+                break
+            time.sleep(5)
 
         if not operator_ready:
             self.logger.error("Operator not created. Last status: %s" % operator_status)
-            operator_logs = v1.read_namespaced_pod_log(name=datadog_cluster_name, namespace="default")
+            operator_logs = self.k8s_wrapper.read_namespaced_pod_log(name=datadog_cluster_name)
             self.logger.error(f"Operator logs: {operator_logs}")
             raise Exception("Operator not created")
         # At this point the operator should be ready, we are going to wait a little bit more
@@ -318,61 +269,45 @@ class K8sDatadogClusterTestAgent:
     def export_debug_info(self):
         """ Exports debug information for the test agent and the operator.
         We shouldn't raise any exception here, we just log the errors."""
-        v1, api = self.get_k8s_api()
 
-        try:
-            # Get all pods
-            ret = v1.list_namespaced_pod(namespace="default", watch=False)
-            for i in ret.items:
-                k8s_logger(self.output_folder, self.test_name, "get.pods").info(
-                    "%s\t%s\t%s" % (i.status.pod_ip, i.metadata.namespace, i.metadata.name)
-                )
-                execute_command_sync(
-                    f"kubectl get event --field-selector involvedObject.name={i.metadata.name}",
-                    self.k8s_kind_cluster,
-                    logfile=f"{self.output_folder}/{i.metadata.name}_events.log",
-                )
-        except Exception as e:
+        # Get all pods
+        ret = self.k8s_wrapper.list_namespaced_pod(namespace="default", watch=False)
+        for i in ret.items:
             k8s_logger(self.output_folder, self.test_name, "get.pods").info(
-                "Exception when calling CoreV1Api->list_namespaced_pod: %s\n" % e
+                "%s\t%s\t%s" % (i.status.pod_ip, i.metadata.namespace, i.metadata.name)
+            )
+            execute_command_sync(
+                f"kubectl get event --field-selector involvedObject.name={i.metadata.name}",
+                self.k8s_kind_cluster,
+                logfile=f"{self.output_folder}/{i.metadata.name}_events.log",
             )
 
         # Get all deployments
-        deployments = api.list_deployment_for_all_namespaces()
+        deployments = self.k8s_wrapper.list_deployment_for_all_namespaces()
         for deployment in deployments.items:
             k8s_logger(self.output_folder, self.test_name, "get.deployments").info(deployment)
 
         # Daemonset describe
-        try:
-            api_response = api.read_namespaced_daemon_set(name="datadog", namespace="default")
-            k8s_logger(self.output_folder, self.test_name, "daemon.set.describe").info(api_response)
-        except Exception as e:
-            k8s_logger(self.output_folder, self.test_name, "daemon.set.describe").info(
-                "Exception when calling CoreV1Api->read_namespaced_daemon_set: %s\n" % e
-            )
+        api_response = self.k8s_wrapper.read_namespaced_daemon_set(name="datadog")
+        k8s_logger(self.output_folder, self.test_name, "daemon.set.describe").info(api_response)
 
         # Cluster logs, admission controller
-        try:
-            pods = v1.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
-            assert len(pods.items) > 0, "No pods found for app datadog-cluster-agent"
-            api_response = v1.read_namespaced_pod_log(name=pods.items[0].metadata.name, namespace="default")
-            k8s_logger(self.output_folder, self.test_name, "datadog-cluster-agent").info(api_response)
+        pods = self.k8s_wrapper.list_namespaced_pod(label_selector="app=datadog-cluster-agent")
+        assert len(pods.items) > 0, "No pods found for app datadog-cluster-agent"
+        api_response = self.k8s_wrapper.read_namespaced_pod_log(name=pods.items[0].metadata.name, namespace="default")
+        k8s_logger(self.output_folder, self.test_name, "datadog-cluster-agent").info(api_response)
 
-            # Export: Telemetry datadog-cluster-agent
-            execute_command_sync(
-                f"kubectl exec -it {pods.items[0].metadata.name} -- agent telemetry ",
-                self.k8s_kind_cluster,
-                logfile=f"{self.output_folder}/{pods.items[0].metadata.name}_telemetry.log",
-            )
+        # Export: Telemetry datadog-cluster-agent
+        execute_command_sync(
+            f"kubectl exec -it {pods.items[0].metadata.name} -- agent telemetry ",
+            self.k8s_kind_cluster,
+            logfile=f"{self.output_folder}/{pods.items[0].metadata.name}_telemetry.log",
+        )
 
-            # Export: Status datadog-cluster-agent
-            # Sometimes this command fails. Ignore this error
-            execute_command_sync(
-                f"kubectl exec -it {pods.items[0].metadata.name} -- agent status || true ",
-                self.k8s_kind_cluster,
-                logfile=f"{self.output_folder}/{pods.items[0].metadata.name}_status.log",
-            )
-        except Exception as e:
-            k8s_logger(self.output_folder, self.test_name, "daemon.set.describe").info(
-                "Exception when calling CoreV1Api->datadog-cluster-agent logs: %s\n" % e
-            )
+        # Export: Status datadog-cluster-agent
+        # Sometimes this command fails. Ignore this error
+        execute_command_sync(
+            f"kubectl exec -it {pods.items[0].metadata.name} -- agent status || true ",
+            self.k8s_kind_cluster,
+            logfile=f"{self.output_folder}/{pods.items[0].metadata.name}_status.log",
+        )

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -227,7 +227,7 @@ class K8sDatadogClusterTestAgent:
         # Wait for the daemonset to be created
         for i in range(20):
             daemonset_status = self.k8s_wrapper.read_namespaced_daemon_set_status(name="datadog")
-            if daemonset_status.status.number_ready > 0:
+            if daemonset_status is not None and daemonset_status.status.number_ready > 0:
                 self.logger.info(f"[Test agent] daemonset status datadog running!")
                 daemonset_created = True
                 break
@@ -244,7 +244,7 @@ class K8sDatadogClusterTestAgent:
             label_selector="app=datadog",
             timeout_seconds=60,
         ):
-            if hasattr(event["object"], "status") and event["object"].status.phase == "Running":
+            if "status" in event["object"] and event["object"]["status"]["phase"] == "Running":
                 w.stop()
                 self.logger.info("Datadog test agent started!")
                 break

--- a/utils/k8s_lib_injection/k8s_weblog.py
+++ b/utils/k8s_lib_injection/k8s_weblog.py
@@ -43,7 +43,8 @@ class K8sWeblog:
             except Exception as e:
                 self.logger.info(f"Error getting k8s api: {e}")
                 time.sleep(2)
-        raise Exception("Error getting k8s api")
+        self.logger.error(f"RMM Error getting k8s api")
+        raise Exception("RMM Error getting k8s api")
 
     def _k8s_api(self):
         v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))

--- a/utils/k8s_lib_injection/k8s_weblog.py
+++ b/utils/k8s_lib_injection/k8s_weblog.py
@@ -281,7 +281,7 @@ class K8sWeblog:
         start = datetime.datetime.now()
         while True:
             pod = self.k8s_wrapper.read_namespaced_pod(pod_name)
-            if pod.status.phase == "Running" and pod.status.container_statuses[0].ready:
+            if pod is not None and pod.status.phase == "Running" and pod.status.container_statuses[0].ready:
                 self.logger.info("[Deploy weblog] Weblog pod started!")
                 return
             time.sleep(1)

--- a/utils/k8s_lib_injection/k8s_weblog.py
+++ b/utils/k8s_lib_injection/k8s_weblog.py
@@ -12,6 +12,7 @@ class K8sWeblog:
         self.output_folder = output_folder
         self.test_name = test_name
         self.logger = None
+        self.k8s_wrapper = None
 
         self.manual_injection_props = {
             "python": [
@@ -30,28 +31,10 @@ class K8sWeblog:
             "ruby": [{"name": "RUBYOPT", "value": " -r/datadog-lib/auto_inject"}],
         }
 
-    def configure(self, k8s_kind_cluster):
+    def configure(self, k8s_kind_cluster, k8s_wrapper):
         self.k8s_kind_cluster = k8s_kind_cluster
+        self.k8s_wrapper = k8s_wrapper
         self.logger = k8s_logger(self.output_folder, self.test_name, "k8s_logger")
-
-    def get_k8s_api(self):
-        """ Get the k8s api. It retries 5 times if it fails. Sometimes there are 
-        collisions when we execute a lot of tests in parallel."""
-        for i in range(5):
-            try:
-                return self._k8s_api()
-            except Exception as e:
-                self.logger.info(f"Error getting k8s api: {e}")
-                time.sleep(2)
-        self.logger.error(f"RMM Error getting k8s api")
-        raise Exception("RMM Error getting k8s api")
-
-    def _k8s_api(self):
-        v1 = client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
-        apps_api = client.AppsV1Api(
-            api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name)
-        )
-        return v1, apps_api
 
     def _get_base_weblog_pod(self):
         """ Installs a target app for manual library injection testing.
@@ -125,15 +108,13 @@ class K8sWeblog:
         return pod_body
 
     def install_weblog_pod_with_admission_controller(self):
-        v1, _ = self.get_k8s_api()
         self.logger.info("[Deploy weblog] Installing weblog pod using admission controller")
         pod_body = self._get_base_weblog_pod()
-        v1.create_namespaced_pod(namespace="default", body=pod_body)
+        self.k8s_wrapper.create_namespaced_pod(body=pod_body)
         self.logger.info("[Deploy weblog] Weblog pod using admission controller created. Waiting for it to be ready!")
         self.wait_for_weblog_ready_by_label_app("my-app", timeout=200)
 
     def install_weblog_pod_without_admission_controller(self, use_uds):
-        v1, _ = self.get_k8s_api()
         pod_body = self._get_base_weblog_pod()
         pod_body.spec.init_containers = []
         init_container1 = client.V1Container(
@@ -185,13 +166,12 @@ class K8sWeblog:
             )
         pod_body.spec.volumes = volumes
 
-        v1.create_namespaced_pod(namespace="default", body=pod_body)
+        self.k8s_wrapper.create_namespaced_pod(body=pod_body)
         self.wait_for_weblog_ready_by_label_app("my-app", timeout=200)
 
     def deploy_app_auto(self):
         """ Installs a target app for auto library injection testing.
             It returns when the deployment is available and the rollout is finished."""
-        _, api = self.get_k8s_api()
         deployment_name = f"test-{self.library}-deployment"
 
         deployment_metadata = client.V1ObjectMeta(
@@ -230,18 +210,14 @@ class K8sWeblog:
             api_version="apps/v1", kind="Deployment", metadata=deployment_metadata, spec=spec,
         )
         # Create deployment. retry if it fails
-        try:
-            api.create_namespaced_deployment(body=deployment, namespace="default")
-        except Exception as e:
-            api.create_namespaced_deployment(body=deployment, namespace="default")
+        self.k8s_wrapper.create_namespaced_deployment(body=deployment)
 
         self._wait_for_deployment_complete(deployment_name, timeout=180)
 
     def wait_for_weblog_after_apply_configmap(self, app_name, timeout=200):
         """ Waits for the weblog to be ready after applying a configmap. We added a lot of debug traces 
         because we have seen some flakiness in the past."""
-        v1, _ = self.get_k8s_api()
-        pods = v1.list_namespaced_pod(namespace="default", label_selector=f"app={app_name}")
+        pods = self.k8s_wrapper.list_namespaced_pod(namespace="default", label_selector=f"app={app_name}")
         self.logger.info(f"[Weblog] Currently running pods [{app_name}]:[{len(pods.items)}]")
         if len(pods.items) == 2:
             for pod in pods.items:
@@ -272,34 +248,39 @@ class K8sWeblog:
         self.logger.info(
             f"[Deploy weblog] Waiting for weblog to be ready(by label) .App {app_name}. Timeout {timeout} seconds."
         )
-        v1, _ = self.get_k8s_api()
         pod_ready = False
         w = watch.Watch()
         for event in w.stream(
-            func=v1.list_namespaced_pod, namespace="default", label_selector=f"app={app_name}", timeout_seconds=timeout
+            func=self.k8s_wrapper.list_namespaced_pod,
+            namespace="default",
+            label_selector=f"app={app_name}",
+            timeout_seconds=timeout,
         ):
-            if event["object"].status.phase == "Running" and event["object"].status.container_statuses[0].ready:
+            if (
+                "status" in event["object"]
+                and event["object"]["status"]["phase"] == "Running"
+                and event["object"]["status"]["containerStatuses"][0]["ready"]
+            ):
                 w.stop()
                 self.logger.info("[Deploy weblog] Weblog started!")
                 pod_ready = True
                 break
 
         if not pod_ready:
-            pod_status = v1.read_namespaced_pod_status(name="my-app", namespace="default")
+            pod_status = self.k8s_wrapper.read_namespaced_pod_status(name="my-app", namespace="default")
             self.logger.error("[Deploy weblog] weblog not created. Last status: %s" % pod_status)
-            pod_logs = v1.read_namespaced_pod_log(name="my-app", namespace="default")
+            pod_logs = self.k8s_wrapper.read_namespaced_pod_log(name="my-app", namespace="default")
             self.logger.error(f"[Deploy weblog] weblog logs: {pod_logs}")
             raise Exception("[Deploy weblog] Weblog not created")
 
     def wait_for_weblog_ready_by_pod_name(self, pod_name, timeout=60):
-        v1, _ = self.get_k8s_api()
         self.logger.info(
             f"[Deploy weblog] Waiting for weblog to be ready(by pod name) .App {pod_name}. Timeout {timeout} seconds."
         )
 
         start = datetime.datetime.now()
         while True:
-            pod = v1.read_namespaced_pod(pod_name, "default")
+            pod = self.k8s_wrapper.read_namespaced_pod(pod_name)
             if pod.status.phase == "Running" and pod.status.container_statuses[0].ready:
                 self.logger.info("[Deploy weblog] Weblog pod started!")
                 return
@@ -310,13 +291,12 @@ class K8sWeblog:
                 raise Exception(f"Pod {pod_name} did not start in {timeout} seconds")
 
     def _wait_for_deployment_complete(self, deployment_name, timeout=60):
-        _, api = self.get_k8s_api()
         self.logger.info("[Deploy weblog] Waiting for weblog deployment complete!")
         start = time.time()
         while time.time() - start < timeout:
             time.sleep(2)
             try:
-                response = api.read_namespaced_deployment_status(deployment_name, "default")
+                response = self.k8s_wrapper.read_namespaced_deployment_status(deployment_name, "default")
                 s = response.status
                 if (
                     s.updated_replicas == response.spec.replicas
@@ -338,11 +318,10 @@ class K8sWeblog:
 
     def export_debug_info(self):
         """ Extracts debug info from the k8s weblog app and logs it to the specified folder."""
-        v1, api = self.get_k8s_api()
 
         # check weblog describe pod
         try:
-            api_response = v1.read_namespaced_pod("my-app", "default", pretty="true")
+            api_response = self.k8s_wrapper.read_namespaced_pod("my-app", "default", pretty="true")
             k8s_logger(self.output_folder, self.test_name, "myapp.describe").info(api_response)
         except Exception as e:
             k8s_logger(self.output_folder, self.test_name, "myapp.describe").info(
@@ -351,7 +330,7 @@ class K8sWeblog:
 
         # check weblog logs for pod
         try:
-            api_response = v1.read_namespaced_pod_log(name="my-app", namespace="default")
+            api_response = self.k8s_wrapper.read_namespaced_pod_log(name="my-app", namespace="default")
             k8s_logger(self.output_folder, self.test_name, "myapp.logs").info(api_response)
         except Exception as e:
             k8s_logger(self.output_folder, self.test_name, "myapp.logs").info(
@@ -362,7 +341,7 @@ class K8sWeblog:
         deployment_name = f"test-{self.library}-deployment"
         app_name = f"{self.library}-app"
         try:
-            response = api.read_namespaced_deployment(deployment_name, "default")
+            response = self.k8s_wrapper.read_namespaced_deployment(deployment_name, "default")
             k8s_logger(self.output_folder, self.test_name, "deployment.desribe").info(response)
         except Exception as e:
             k8s_logger(self.output_folder, self.test_name, "deployment.describe").info(
@@ -373,11 +352,15 @@ class K8sWeblog:
         deployment_name = f"test-{self.library}-deployment"
         app_name = f"{self.library}-app"
         try:
-            pods = v1.list_namespaced_pod(namespace="default", label_selector=f"app={app_name}")
+            pods = self.k8s_wrapper.list_namespaced_pod(namespace="default", label_selector=f"app={app_name}")
             if len(pods.items) > 0:
-                api_response = v1.read_namespaced_pod(pods.items[0].metadata.name, "default", pretty="true")
+                api_response = self.k8s_wrapper.read_namespaced_pod(
+                    pods.items[0].metadata.name, "default", pretty="true"
+                )
                 k8s_logger(self.output_folder, self.test_name, "deployment.logs").info(api_response)
-                api_response = v1.read_namespaced_pod_log(name=pods.items[0].metadata.name, namespace="default")
+                api_response = self.k8s_wrapper.read_namespaced_pod_log(
+                    name=pods.items[0].metadata.name, namespace="default"
+                )
                 k8s_logger(self.output_folder, self.test_name, "deployment.logs").info(api_response)
         except Exception as e:
             k8s_logger(self.output_folder, self.test_name, "deployment.logs").info(

--- a/utils/k8s_lib_injection/k8s_wrapper.py
+++ b/utils/k8s_lib_injection/k8s_wrapper.py
@@ -59,12 +59,12 @@ class K8sWrapper:
         return self.core_v1_api().create_namespaced_config_map(namespace=namespace, body=body)
 
     @retry(max_retries=5, wait_time=1)
-    def list_namespaced_config_map(self, namespace="default", timeout_seconds=None):
-        return self.core_v1_api().list_namespaced_config_map(namespace=namespace, timeout_seconds=timeout_seconds)
+    def list_namespaced_config_map(self, namespace, **kwargs):
+        return self.core_v1_api().list_namespaced_config_map(namespace, **kwargs)
 
     @retry(max_retries=5, wait_time=1)
-    def list_namespaced_pod(self, namespace="default", label_selector="app=datadog-cluster-agent"):
-        return self.core_v1_api().list_namespaced_pod(namespace=namespace, label_selector=label_selector)
+    def list_namespaced_pod(self, namespace, **kwargs):
+        return self.core_v1_api().list_namespaced_pod(namespace, **kwargs)
 
     @retry(max_retries=5, wait_time=1)
     def read_namespaced_pod_log(self, name=None, namespace="default"):

--- a/utils/k8s_lib_injection/k8s_wrapper.py
+++ b/utils/k8s_lib_injection/k8s_wrapper.py
@@ -1,5 +1,6 @@
 import time
 from kubernetes import client, config, watch
+from utils.tools import logger
 
 
 def retry(max_retries, wait_time):
@@ -17,6 +18,7 @@ def retry(max_retries, wait_time):
                     retries += 1
                     time.sleep(wait_time)
             else:
+                logger.error(f"Max retries of function {func} exceeded")
                 raise Exception(f"Max retries of function {func} exceeded")
 
         return wrapper

--- a/utils/k8s_lib_injection/k8s_wrapper.py
+++ b/utils/k8s_lib_injection/k8s_wrapper.py
@@ -1,0 +1,79 @@
+import time
+from kubernetes import client, config, watch
+
+
+def retry(max_retries, wait_time):
+    """ Decorator to retry a function if it fails."""
+
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            retries = 0
+            if retries < max_retries:
+                try:
+                    result = func(*args, **kwargs)
+                    return result
+                except Exception as e:
+                    retries += 1
+                    time.sleep(wait_time)
+            else:
+                raise Exception(f"Max retries of function {func} exceeded")
+
+        return wrapper
+
+    return decorator
+
+
+class K8sWrapper:
+    """ Wrap methods from CoreV1Api and AppsV1Api to make it fail-safe.
+    In a simple execution, the methods used here are usually smooth.
+    Problems arise when we run tests with a lot of parallelism.
+    We apply a retry policy """
+
+    def __init__(self, k8s_kind_cluster):
+        self.k8s_kind_cluster = k8s_kind_cluster
+
+    def core_v1_api(self):
+        return client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
+
+    def apps_api(self):
+        return client.AppsV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
+
+    @retry(max_retries=5, wait_time=1)
+    def create_namespaced_daemon_set(self, namespace="default", body=None):
+        self.apps_api().create_namespaced_daemon_set(namespace="default", body=body)
+
+    @retry(max_retries=5, wait_time=1)
+    def read_namespaced_daemon_set_status(self, name=None, namespace="default"):
+        return self.apps_api().read_namespaced_daemon_set_status(name=name, namespace=namespace)
+
+    @retry(max_retries=5, wait_time=1)
+    def read_namespaced_daemon_set(self, name=None, namespace="default"):
+        return self.apps_api().read_namespaced_daemon_set(name=name, namespace=namespace)
+
+    @retry(max_retries=5, wait_time=1)
+    def replace_namespaced_config_map(self, name=None, namespace="default", body=None):
+        return self.core_v1_api().replace_namespaced_config_map(name=name, namespace=namespace, body=body)
+
+    @retry(max_retries=5, wait_time=1)
+    def create_namespaced_config_map(self, namespace="default", body=None):
+        return self.core_v1_api().create_namespaced_config_map(namespace=namespace, body=body)
+
+    @retry(max_retries=5, wait_time=1)
+    def list_namespaced_config_map(self, namespace="default", timeout_seconds=None):
+        return self.core_v1_api().list_namespaced_config_map(namespace=namespace, timeout_seconds=timeout_seconds)
+
+    @retry(max_retries=5, wait_time=1)
+    def list_namespaced_pod(self, namespace="default", label_selector="app=datadog-cluster-agent"):
+        return self.core_v1_api().list_namespaced_pod(namespace=namespace, label_selector=label_selector)
+
+    @retry(max_retries=5, wait_time=1)
+    def read_namespaced_pod_log(self, name=None, namespace="default"):
+        return self.core_v1_api().read_namespaced_pod_log(name=name, namespace=namespace)
+
+    @retry(max_retries=5, wait_time=1)
+    def read_namespaced_pod_status(self, name=None, namespace="default"):
+        return self.core_v1_api().read_namespaced_pod_status(name=name, namespace=namespace)
+
+    @retry(max_retries=5, wait_time=1)
+    def list_deployment_for_all_namespaces(self):
+        return self.apps_api().list_deployment_for_all_namespaces()

--- a/utils/k8s_lib_injection/k8s_wrapper.py
+++ b/utils/k8s_lib_injection/k8s_wrapper.py
@@ -67,6 +67,10 @@ class K8sWrapper:
         return self.core_v1_api().list_namespaced_pod(namespace, **kwargs)
 
     @retry(max_retries=5, wait_time=1)
+    def read_namespaced_pod(self, pod_name, namespace="default"):
+        return self.core_v1_api().read_namespaced_pod(pod_name, namespace=namespace)
+
+    @retry(max_retries=5, wait_time=1)
     def read_namespaced_pod_log(self, name=None, namespace="default"):
         return self.core_v1_api().read_namespaced_pod_log(name=name, namespace=namespace)
 
@@ -77,3 +81,19 @@ class K8sWrapper:
     @retry(max_retries=5, wait_time=1)
     def list_deployment_for_all_namespaces(self):
         return self.apps_api().list_deployment_for_all_namespaces()
+
+    @retry(max_retries=5, wait_time=1)
+    def create_namespaced_pod(self, namespace="default", body=None):
+        return self.core_v1_api().create_namespaced_pod(namespace=namespace, body=body)
+
+    @retry(max_retries=5, wait_time=1)
+    def create_namespaced_deployment(self, body=None, namespace="default"):
+        return self.apps_api().create_namespaced_deployment(namespace=namespace, body=body)
+
+    @retry(max_retries=5, wait_time=1)
+    def read_namespaced_deployment_status(self, deployment_name, namespace="default"):
+        return self.apps_api().read_namespaced_deployment_status(deployment_name, namespace=namespace)
+
+    @retry(max_retries=5, wait_time=1)
+    def read_namespaced_deployment(self, deployment_name, namespace="default"):
+        return self.apps_api().read_namespaced_deployment(deployment_name, namespace=namespace)

--- a/utils/k8s_lib_injection/k8s_wrapper.py
+++ b/utils/k8s_lib_injection/k8s_wrapper.py
@@ -96,7 +96,7 @@ class K8sWrapper:
     def read_namespaced_deployment_status(self, deployment_name, namespace="default"):
         return self.apps_api().read_namespaced_deployment_status(deployment_name, namespace=namespace)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(max_retries=10, wait_time=1)
     def read_namespaced_deployment(self, deployment_name, namespace="default"):
         return self.apps_api().read_namespaced_deployment(deployment_name, namespace=namespace)
 

--- a/utils/k8s_lib_injection/k8s_wrapper.py
+++ b/utils/k8s_lib_injection/k8s_wrapper.py
@@ -11,7 +11,8 @@ def retry(max_retries, wait_time):
             if retries < max_retries:
                 try:
                     result = func(*args, **kwargs)
-                    return result
+                    if result is not None:
+                        return result
                 except Exception as e:
                     retries += 1
                     time.sleep(wait_time)

--- a/utils/k8s_lib_injection/k8s_wrapper.py
+++ b/utils/k8s_lib_injection/k8s_wrapper.py
@@ -32,9 +32,11 @@ class K8sWrapper:
     def __init__(self, k8s_kind_cluster):
         self.k8s_kind_cluster = k8s_kind_cluster
 
+    @retry(max_retries=5, wait_time=1)
     def core_v1_api(self):
         return client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
 
+    @retry(max_retries=5, wait_time=1)
     def apps_api(self):
         return client.AppsV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
 
@@ -97,3 +99,11 @@ class K8sWrapper:
     @retry(max_retries=5, wait_time=1)
     def read_namespaced_deployment(self, deployment_name, namespace="default"):
         return self.apps_api().read_namespaced_deployment(deployment_name, namespace=namespace)
+
+    @retry(max_retries=5, wait_time=1)
+    def patch_namespaced_deployment(self, deployment_name, namespace, deploy_data):
+        return self.apps_api().patch_namespaced_deployment(deployment_name, namespace, deploy_data)
+
+    @retry(max_retries=5, wait_time=1)
+    def delete_namespaced_pod(self, pod_name_running, namespace):
+        return self.core_v1_api().delete_namespaced_pod(pod_name_running, namespace=namespace)


### PR DESCRIPTION
## Motivation

Wrap the kubernetes python client in order to apply a retry policy

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
