### PR TITLE
python: activate more easy_wins

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -486,17 +486,17 @@ tests/:
     test_dsm.py:
       Test_DsmContext_Extraction_Base64: 
         "*": irrelevant
-        flask-poc: v2.8.0
+        flask-poc: v2.8.0.dev
       Test_DsmContext_Injection_Base64: 
         "*": irrelevant
-        flask-poc: v2.8.0
+        flask-poc: v2.8.0.dev
       Test_DsmHttp: missing_feature
       Test_DsmKafka:
         '*': irrelevant
         flask-poc: v1.20.3
       Test_DsmKinesis:
         '*': irrelevant
-        flask-poc: v2.8.0
+        flask-poc: v2.8.0.dev
       Test_DsmRabbitmq:
         '*': irrelevant
         flask-poc: v2.6.0
@@ -518,7 +518,7 @@ tests/:
       TestDynamicConfigTracingEnabled: v2.6.0
       TestDynamicConfigV1: missing_feature
       TestDynamicConfigV1_ServiceTargets: missing_feature
-      TestDynamicConfigV2: missing_feature
+      TestDynamicConfigV2: v2.8.0.dev
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_sampling_delegation.py:
@@ -553,7 +553,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: missing_feature
       Test_RemoteConfigurationUpdateSequenceFeatures: v1.7.4
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: irrelevant (cache is implemented)
-      Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
+      Test_RemoteConfigurationUpdateSequenceLiveDebugging: v2.8.0.dev
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
   test_distributed.py:
     Test_DistributedHttp:
@@ -566,7 +566,7 @@ tests/:
   test_library_conf.py:
     Test_HeaderTags: v0.53
     Test_HeaderTags_Colon_Leading: v1.2.1 # was marked as ? when we used decorators
-    Test_HeaderTags_Colon_Trailing: bug (AIT-8601)
+    Test_HeaderTags_Colon_Trailing: v2.8.0.dev
     Test_HeaderTags_Long: v1.2.1
     Test_HeaderTags_Short: missing_feature
     Test_HeaderTags_Whitespace_Header: missing_feature
@@ -594,7 +594,7 @@ tests/:
       '*': v2.4.0.dev
     Test_StandardTagsUserAgent: v1.5.0rc1.dev
   test_telemetry.py:
-    Test_DependencyEnable: missing_feature
+    Test_DependencyEnable: v2.8.0.dev
     Test_Log_Generation: missing_feature
     Test_MessageBatch: missing_feature
     Test_Metric_Generation_Disabled: missing_feature

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -138,7 +138,6 @@ class Test_Meta:
     """meta object in spans respect all conventions"""
 
     @bug(library="cpp", reason="Span.kind said to be implemented but currently not set for nginx")
-    @bug(library="python", reason="Span.kind not implemented yet")
     @bug(library="php", reason="All PHP current weblog variants trace with C++ tracers that do not have Span.Kind")
     def test_meta_span_kind(self):
         """Validates that traces from an http framework carry a span.kind meta tag, with value server or client"""


### PR DESCRIPTION
## Motivation

We want more green

<!-- What inspired you to submit this pull request? -->

## Changes

Activate already passing tests
<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
    * [x] To R&P team: locally build and push the image to hub.docker.com 
* [x] A scenario is added (or removed)?
    * [x] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [x] Once merged, add (or remove) it in system-test-dasboard nightly
