### PR TITLE
[Java] Enable all test for Payara

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -348,7 +348,6 @@ tests/:
           play: v1.22.0
           ratpack: v0.99.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
           vertx3: v0.99.0
           vertx4: bug (Capability to read body content is incomplete after vert.x
             4.0.0)
@@ -357,14 +356,12 @@ tests/:
           akka-http: v1.22.0
           play: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_BodyUrlEncoded:
           '*': v0.95.1
           akka-http: v1.22.0
           play: v1.22.0
           ratpack: v0.99.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
           spring-boot-undertow: v0.98.0
           vertx3: v0.99.0
         Test_BodyXml:
@@ -373,7 +370,6 @@ tests/:
           play: v1.23.0
           ratpack: v0.99.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
           vertx3: missing_feature
           vertx4: bug (Capability to read body content is incomplete after vert.x
             4.0.0)
@@ -382,14 +378,12 @@ tests/:
           akka-http: v1.22.0
           play: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_FullGrpc: missing_feature
         Test_GraphQL: missing_feature
         Test_Headers:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_Lambda: missing_feature
         Test_Method: missing_feature
         Test_PathParams:
@@ -400,27 +394,22 @@ tests/:
           ratpack: v0.99.0
           resteasy-netty3: missing_feature
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
           vertx3: v0.99.0
         Test_ResponseStatus:
           '*': v0.88.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_UrlQuery:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_UrlQueryKey:
           '*': v0.100.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_UrlRaw:
           '*': v0.87.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_gRPC:
           '*': v0.96.0
           akka-http: irrelevant
@@ -430,7 +419,6 @@ tests/:
           resteasy-netty3: irrelevant
           spring-boot: v0.109.0  # APPSEC-5426
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
           vertx3: irrelevant
           vertx4: irrelevant
       test_blocking.py:
@@ -443,14 +431,12 @@ tests/:
           resteasy-netty3: v1.7.0
           spring-boot-3-native: missing_feature
           spring-boot-openliberty: v1.3.0
-          spring-boot-payara: missing_feature (No AppSec support)
           vertx3: v1.7.0
         Test_CustomBlockingResponse:
           '*': v1.11.0
           akka-http: v1.22.0
           play: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
       test_custom_rules.py:
         Test_CustomRules: missing_feature
       test_exclusions.py:
@@ -464,93 +450,75 @@ tests/:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_CorrectOptionProcessing:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_MultipleAttacks:
           '*': v0.92.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_MultipleHighlight:
           '*': v0.95.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_NoWafTimeout:
           akka-http: v1.22.0
-          spring-boot-payara: missing_feature (No AppSec support)
       test_reports.py:
         Test_Monitoring:
           '*': v0.100.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
       test_rules.py:
         Test_CommandInjection:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_DiscoveryScan:
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
+          spring-boot-payara: bug (APPSEC-52334)
         Test_HttpProtocol:
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_JavaCodeInjection:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_JsInjection:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_LFI:
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_NoSqli:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_PhpCodeInjection:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_RFI:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_SQLI:
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_SSRF:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_Scanners:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
         Test_XSS:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (No AppSec support)
       test_telemetry.py:
         Test_TelemetryMetrics:
           '*': v1.12.0
@@ -563,7 +531,6 @@ tests/:
         '*': v0.87.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
     test_automated_login_events.py:
       Test_Login_Events: missing_feature
       Test_Login_Events_Extended: missing_feature
@@ -577,7 +544,6 @@ tests/:
         resteasy-netty3: v1.7.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         spring-boot-openliberty: v0.115.0
-        spring-boot-payara: missing_feature (Missing support)
         vertx3: v1.7.0
         vertx4: v1.7.0
       Test_BlockingGraphqlResolvers: missing_feature
@@ -586,7 +552,7 @@ tests/:
         akka-http: v1.22.0
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (Missing support)
+        spring-boot-payara: bug (blocking not working)
       Test_Blocking_request_cookies:
         '*': missing_feature
         akka-http: v1.22.0
@@ -598,7 +564,6 @@ tests/:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         spring-boot-jetty: v0.111.0
         spring-boot-openliberty: v0.115.0  # Supported since 0.111.0 but bugged in <0.115.0.
-        spring-boot-payara: missing_feature (Missing support)
         spring-boot-undertow: v0.111.0
         vertx3: v1.7.0
         vertx4: v1.7.0
@@ -613,7 +578,6 @@ tests/:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         spring-boot-jetty: v0.111.0
         spring-boot-openliberty: v0.115.0  # Supported since 0.111.0 but bugged in <0.115.0.
-        spring-boot-payara: missing_feature (Missing support)
         spring-boot-undertow: v0.111.0
         vertx3: v1.7.0
         vertx4: v1.7.0
@@ -636,7 +600,7 @@ tests/:
         akka-http: missing_feature (path parameters not suported)
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (Missing support)
+        spring-boot-payara: bug (APPSEC-52335)
       Test_Blocking_request_query:
         '*': missing_feature
         akka-http: v1.22.0
@@ -648,7 +612,6 @@ tests/:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         spring-boot-jetty: v0.111.0
         spring-boot-openliberty: v0.115.0  # Supported since 0.111.0 but bugged in <0.115.0.
-        spring-boot-payara: missing_feature (Missing support)
         spring-boot-undertow: v0.111.0
         vertx3: v1.7.0
         vertx4: v1.7.0
@@ -671,13 +634,11 @@ tests/:
         akka-http: v1.22.0
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (Missing support)
       Test_Blocking_response_status:
         '*': missing_feature
         akka-http: v1.22.0
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (Missing support)
       Test_Suspicious_Request_Blocking: missing_feature
     test_client_ip.py:
       Test_StandardTagsClientIp: v0.114.0
@@ -686,17 +647,14 @@ tests/:
         '*': v0.100.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_RuleSet_1_3_1:
         '*': v0.99.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_StaticRuleSet:
         '*': v0.87.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
     test_customconf.py:
       Test_ConfRuleSet:
         '*': v0.93.0
@@ -723,17 +681,14 @@ tests/:
         '*': v1.8.0
         play: v1.22.0
         spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_UserLoginFailureEvent:
         '*': v1.8.0
         play: v1.22.0
         spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_UserLoginSuccessEvent:
         '*': v1.8.0
         play: v1.22.0
         spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
     test_identify.py:
       Test_Basic: missing_feature
     test_ip_blocking_full_denylist.py:
@@ -751,7 +706,6 @@ tests/:
       Test_Standardization:
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_StandardizationBlockMode: missing_feature
     test_rate_limiter.py:
       Test_Main:
@@ -761,31 +715,25 @@ tests/:
     test_reports.py:
       Test_AttackTimestamp:
         akka-http: v1.22.0
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_ExtraTagsFromRule: v1.22.0    # Supported since v1.22.0
       Test_HttpClientIP:
         '*': v0.98.1
         akka-http: v1.22.0
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_Info:
         '*': v0.87.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_RequestHeaders:
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_StatusCode:
         '*': v0.92.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_TagsFromRule:
         akka-http: v1.22.0
-        spring-boot-payara: missing_feature (No AppSec support)
     test_request_blocking.py:
       Test_AppSecRequestBlocking:
         '*': missing_feature
@@ -822,25 +770,21 @@ tests/:
         akka-http: v1.22.0
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_AppSecObfuscator:
         '*': v0.113.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_CollectRespondHeaders:
         '*': v0.102.0
         akka-http: v1.22.0
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
       Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: missing_feature
       Test_RetainTraces:
         '*': v0.92.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (No AppSec support)
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist: bug (RC payload limit)
         # '*': missing_feature

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -69,6 +69,7 @@ class Test_BlockingAddresses:
     @missing_feature(
         context.library == "java" and context.weblog_variant == "akka-http", reason="path parameters not supported"
     )
+    @bug(weblog_variant="spring-boot-payara", reason="APPSEC-52335")
     @irrelevant(context.library == "ruby" and context.weblog_variant == "rack")
     @irrelevant(context.library == "golang" and context.weblog_variant == "net-http")
     def test_path_params(self):
@@ -103,6 +104,7 @@ class Test_BlockingAddresses:
 
     @missing_feature(context.library < "java@1.15.0", reason="Happens on a subsequent WAF run")
     @missing_feature(weblog_variant="nextjs", reason="Not supported yet")
+    @bug(weblog_variant="spring-boot-payara", reason="Not blocking")
     @irrelevant(context.library == "golang", reason="Body blocking happens through SDK")
     def test_request_body_urlencoded(self):
         """can block on server.request.body (urlencoded variant)"""
@@ -123,6 +125,7 @@ class Test_BlockingAddresses:
             "spring-boot-jetty",
             "spring-boot-undertow",
             "spring-boot-openliberty",
+            "spring-boot-payara",
             "jersey-grizzly2",
             "resteasy-netty3",
             "ratpack",

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -320,7 +320,7 @@ class Test_BodyXml:
         self.r_attr_1 = self.weblog_post("/waf", data='<string attack="var_dump ()" />')
         self.r_attr_2 = self.weblog_post("/waf", data=f'<string attack="{self.ENCODED_ATTACK}" />')
 
-    @bug(context.weblog_variant == "spring-boot-wildfly")
+    @bug(context.weblog_variant in ("spring-boot-payara", "spring-boot-wildfly"))
     def test_xml_attr_value(self):
         interfaces.library.assert_waf_attack(self.r_attr_1, address="server.request.body", value="var_dump ()")
         interfaces.library.assert_waf_attack(self.r_attr_2, address="server.request.body", value=self.ATTACK)
@@ -329,7 +329,7 @@ class Test_BodyXml:
         self.r_content_1 = self.weblog_post("/waf", data="<string>var_dump ()</string>")
         self.r_content_2 = self.weblog_post("/waf", data=f"<string>{self.ENCODED_ATTACK}</string>")
 
-    @bug(context.weblog_variant == "spring-boot-wildfly")
+    @bug(context.weblog_variant in ("spring-boot-payara", "spring-boot-wildfly"))
     def test_xml_content(self):
         interfaces.library.assert_waf_attack(self.r_content_1, address="server.request.body", value="var_dump ()")
         interfaces.library.assert_waf_attack(self.r_content_2, address="server.request.body", value=self.ATTACK)


### PR DESCRIPTION
## Motivation

* Enable most tests for Payara. Skip some for 2 bugs (JIRA tickets in the skip reason).

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
