### PR TITLE
[Telemetry] Telemetry `seq_id` should always increase

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -118,9 +118,6 @@ class Test_Telemetry:
             check_condition=not_onboarding_event,
         )
 
-    @missing_feature(library="python")
-    @flaky(library="ruby", reason="AIT-8418")
-    @flaky(library="java", reason="AIT-9152")
     def test_seq_id(self):
         """Test that messages are sent sequentially"""
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -147,7 +147,7 @@ class Test_Telemetry:
                 seq_ids.append((seq_id, data["log_filename"]))
 
                 if not (200 <= data["response"]["status_code"] < 300):
-                    logger.info(f"Response is {data['response']['status_code']}, tracer should resend the message")
+                    logger.info(f"Response is {data['response']['status_code']}")
 
                 if seq_id > max_seq_id:
                     max_seq_id = seq_id

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -118,6 +118,7 @@ class Test_Telemetry:
             check_condition=not_onboarding_event,
         )
 
+    @flaky(library="ruby", reason="AIT-8418")
     def test_seq_id(self):
         """Test that messages are sent sequentially"""
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -146,9 +146,10 @@ class Test_Telemetry:
                 curr_message_time = datetime.strptime(timestamp_start, FMT)
                 logger.debug(f"Message at {timestamp_start.split('T')[1]} in {data['log_filename']}, seq_id: {seq_id}")
 
-                if 200 <= data["response"]["status_code"] < 300:
-                    seq_ids.append((seq_id, data["log_filename"]))
-                else:
+                # IDs should be sent sequentially, even if there are errors
+                seq_ids.append((seq_id, data["log_filename"]))
+
+                if not (200 <= data["response"]["status_code"] < 300):
                     logger.info(f"Response is {data['response']['status_code']}, tracer should resend the message")
 
                 if seq_id > max_seq_id:


### PR DESCRIPTION
## Motivation

The test requires that you send the same `seq_id` twice when there's an error, but [the documentation explicitly states](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/development.md#telemetry-message-retries) that we shouldn't retry messages. Given that this test relies on the backend (AFAICT), then if there's an error response, the agent passes it on, and we get flake

## Changes

- Assert that the telemetry `seq_id` is always consecutive. 
- Try un-skipping some languages to see if they pass

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
