### PR TITLE
k8s lib injection: Don't build weblog images on schedule run

### DIFF
--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -89,7 +89,10 @@ jobs:
           cd ..
 
       - name: Build weblog latest base images
-        if: github.ref == 'refs/heads/main'
+        #If we execute on system-tests-dashboard, we can't push the images because we don't have the permissions.
+        #To asign the permissions, we need to configure the image on ghcr, but due to a issue we can't do it
+        #The case is opened with github support
+        if: github.ref == 'refs/heads/main' && github.event_name != 'schedule'
         env:
           DOCKER_IMAGE_WEBLOG_TAG: latest
           APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ matrix.variant.weblog-variant }}

--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -107,12 +107,12 @@ jobs:
       - name: Kubernetes lib-injection tests (using custom weblog image tag)
         if: inputs.build_lib_injection_app_images
         id: k8s-lib-injection-tests-custom-weblog-tag
-        run: DOCKER_IMAGE_WEBLOG_TAG=${{ github.sha }} ./run.sh K8S_LIB_INJECTION 
+        run: DOCKER_IMAGE_WEBLOG_TAG=${{ github.sha }} ./run.sh K8S_LIB_INJECTION_FULL
 
       - name: Kubernetes lib-injection tests
         if: inputs.build_lib_injection_app_images != true
         id: k8s-lib-injection-tests
-        run: ./run.sh K8S_LIB_INJECTION 
+        run: ./run.sh K8S_LIB_INJECTION_FULL
 
       - name: Compress logs
         id: compress_logs

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,5 @@ kombu==5.3.5
 
 #lib-injection kubernetes
 kubernetes==29.0.0
+
+retry==0.9.2

--- a/run.sh
+++ b/run.sh
@@ -397,7 +397,7 @@ function main() {
 
     # evaluate max pytest number of process for K8s_lib_injection
     for scenario in "${scenarios[@]}"; do
-        if [[ "${scenario}" == "K8S_LIB_INJECTION" ]]; then
+        if [[ "${scenario}" == K8S_LIB_INJECTION_* ]]; then
             pytest_numprocesses=$(nproc)
         fi
     done

--- a/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_configmap_auto_inject.py
@@ -10,7 +10,7 @@ from utils import irrelevant
 
 
 @features.k8s_admission_controller
-@scenarios.k8s_lib_injection
+@scenarios.k8s_lib_injection_full
 class TestConfigMapAutoInject:
     """ Datadog Agent Auto-injection tests using ConfigMap
         Check: https://datadoghq.atlassian.net/wiki/spaces/AO/pages/2983035648/Cluster+Agent+Development

--- a/tests/k8s_lib_injection/test_k8s_manual_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_manual_inject.py
@@ -7,9 +7,7 @@ from utils.tools import logger
 from utils import scenarios, context, features
 
 
-@features.k8s_admission_controller
-@scenarios.k8s_lib_injection
-class TestAdmisionController:
+class _TestAdmisionController:
     def _get_dev_agent_traces(self, agent_port, retry=10):
         for _ in range(retry):
             logger.info(f"[Check traces] Checking traces:")
@@ -21,7 +19,7 @@ class TestAdmisionController:
             time.sleep(2)
         return []
 
-    def _test_inject_admission_controller(self, test_k8s_instance):
+    def test_inject_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test _test_inject_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )
@@ -32,7 +30,7 @@ class TestAdmisionController:
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_admission_controller finished")
 
-    def _test_inject_without_admission_controller(self, test_k8s_instance):
+    def test_inject_without_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test _test_inject_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )
@@ -42,7 +40,7 @@ class TestAdmisionController:
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_without_admission_controller finished")
 
-    def _test_inject_uds_without_admission_controller(self, test_k8s_instance):
+    def test_inject_uds_without_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test test_inject_uds_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )
@@ -51,3 +49,15 @@ class TestAdmisionController:
         traces_json = self._get_dev_agent_traces(test_k8s_instance.k8s_kind_cluster.agent_port)
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test test_inject_uds_without_admission_controller finished")
+
+
+@features.k8s_admission_controller
+@scenarios.k8s_lib_injection_basic
+class TestAdmisionControllerBasic(_TestAdmisionController):
+    pass
+
+
+@features.k8s_admission_controller
+@scenarios.k8s_lib_injection_full
+class TestAdmisionControllerComplete(_TestAdmisionController):
+    pass

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1671,7 +1671,12 @@ class scenarios:
         "Onboarding Container Single Step Instrumentation scenario using agent auto install script",
         vm_provision="container-auto-inject-install-script",
     )
-    k8s_lib_injection = _KubernetesScenario("K8S_LIB_INJECTION", doc=" Kubernetes Instrumentation scenario")
+    k8s_lib_injection_basic = _KubernetesScenario(
+        "K8S_LIB_INJECTION_BASIC", doc=" Kubernetes Instrumentation basic scenario"
+    )
+    k8s_lib_injection_full = _KubernetesScenario(
+        "K8S_LIB_INJECTION_FULL", doc=" Kubernetes Instrumentation complete scenario"
+    )
 
 
 def _main():

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -2,7 +2,7 @@ import subprocess, datetime, os, time, signal
 from utils.tools import logger
 from utils import context
 from utils.k8s_lib_injection.k8s_sync_kubectl import KubectlLock
-from utils.k8s_lib_injection.k8s_wrapper import retry
+from retry import retry
 
 
 def execute_command(command, timeout=None, logfile=None):
@@ -49,7 +49,7 @@ def execute_command(command, timeout=None, logfile=None):
     return output
 
 
-@retry(max_retries=5, wait_time=1)
+@retry(delay=1, tries=5)
 def execute_command_sync(command, k8s_kind_cluster, timeout=None, logfile=None):
     """ Execute a command in the k8s cluster, but we use a lock to change the context of kubectl."""
 
@@ -58,7 +58,7 @@ def execute_command_sync(command, k8s_kind_cluster, timeout=None, logfile=None):
         execute_command(command, timeout=timeout, logfile=logfile)
 
 
-@retry(max_retries=5, wait_time=1)
+@retry(delay=1, tries=5)
 def helm_add_repo(name, url, k8s_kind_cluster, update=False):
 
     with KubectlLock():
@@ -68,7 +68,7 @@ def helm_add_repo(name, url, k8s_kind_cluster, update=False):
             execute_command(f"helm repo update")
 
 
-@retry(max_retries=5, wait_time=1)
+@retry(delay=1, tries=5)
 def helm_install_chart(
     k8s_kind_cluster, name, chart, set_dict={}, value_file=None, prefix_library_init_image=None, upgrade=False
 ):

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -258,7 +258,9 @@ class K8sDatadogClusterTestAgent:
             if datadog_cluster_name is None:
                 pods = self.k8s_wrapper.list_namespaced_pod("default", label_selector="app=datadog-cluster-agent")
                 datadog_cluster_name = pods.items[0].metadata.name if pods and len(pods.items) > 0 else None
-            operator_status = self.k8s_wrapper.read_namespaced_pod_status(name=datadog_cluster_name)
+            operator_status = (
+                self.k8s_wrapper.read_namespaced_pod_status(name=datadog_cluster_name) if datadog_cluster_name else None
+            )
             if (
                 operator_status
                 and operator_status.status.phase == "Running"

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -279,20 +279,22 @@ class K8sDatadogClusterTestAgent:
 
         # Get all pods
         ret = self.k8s_wrapper.list_namespaced_pod(namespace="default", watch=False)
-        for i in ret.items:
-            k8s_logger(self.output_folder, self.test_name, "get.pods").info(
-                "%s\t%s\t%s" % (i.status.pod_ip, i.metadata.namespace, i.metadata.name)
-            )
-            execute_command_sync(
-                f"kubectl get event --field-selector involvedObject.name={i.metadata.name}",
-                self.k8s_kind_cluster,
-                logfile=f"{self.output_folder}/{i.metadata.name}_events.log",
-            )
+        if ret is None:
+            for i in ret.items:
+                k8s_logger(self.output_folder, self.test_name, "get.pods").info(
+                    "%s\t%s\t%s" % (i.status.pod_ip, i.metadata.namespace, i.metadata.name)
+                )
+                execute_command_sync(
+                    f"kubectl get event --field-selector involvedObject.name={i.metadata.name}",
+                    self.k8s_kind_cluster,
+                    logfile=f"{self.output_folder}/{i.metadata.name}_events.log",
+                )
 
         # Get all deployments
         deployments = self.k8s_wrapper.list_deployment_for_all_namespaces()
-        for deployment in deployments.items:
-            k8s_logger(self.output_folder, self.test_name, "get.deployments").info(deployment)
+        if deployments is not None:
+            for deployment in deployments.items:
+                k8s_logger(self.output_folder, self.test_name, "get.deployments").info(deployment)
 
         # Daemonset describe
         api_response = self.k8s_wrapper.read_namespaced_daemon_set(name="datadog")

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -205,7 +205,7 @@ class K8sDatadogClusterTestAgent:
 
         # Second wait for datadog-cluster-agent read the configmap
         expected_log = f'Applying Remote Config ID "{patch_id}" with revision "{rev}" and action'
-        pods = self.k8s_wrapper.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
+        pods = self.k8s_wrapper.list_namespaced_pod("default", label_selector="app=datadog-cluster-agent")
         assert len(pods.items) > 0, "No pods found for app datadog-cluster-agent"
         pod_cluster_agent_name = pods.items[0].metadata.name
         timeout = time.time() + timeout
@@ -283,8 +283,8 @@ class K8sDatadogClusterTestAgent:
         We shouldn't raise any exception here, we just log the errors."""
 
         # Get all pods
-        ret = self.k8s_wrapper.list_namespaced_pod(namespace="default", watch=False)
-        if ret is None:
+        ret = self.k8s_wrapper.list_namespaced_pod("default", watch=False)
+        if ret is not None:
             for i in ret.items:
                 k8s_logger(self.output_folder, self.test_name, "get.pods").info(
                     "%s\t%s\t%s" % (i.status.pod_ip, i.metadata.namespace, i.metadata.name)
@@ -307,7 +307,7 @@ class K8sDatadogClusterTestAgent:
 
         # Cluster logs, admission controller
         try:
-            pods = self.k8s_wrapper.list_namespaced_pod(namespace="default", label_selector="app=datadog-cluster-agent")
+            pods = self.k8s_wrapper.list_namespaced_pod("default", label_selector="app=datadog-cluster-agent")
             assert len(pods.items) > 0, "No pods found for app datadog-cluster-agent"
             api_response = self.k8s_wrapper.read_namespaced_pod_log(
                 name=pods.items[0].metadata.name, namespace="default"

--- a/utils/k8s_lib_injection/k8s_weblog.py
+++ b/utils/k8s_lib_injection/k8s_weblog.py
@@ -217,7 +217,7 @@ class K8sWeblog:
     def wait_for_weblog_after_apply_configmap(self, app_name, timeout=200):
         """ Waits for the weblog to be ready after applying a configmap. We added a lot of debug traces 
         because we have seen some flakiness in the past."""
-        pods = self.k8s_wrapper.list_namespaced_pod(namespace="default", label_selector=f"app={app_name}")
+        pods = self.k8s_wrapper.list_namespaced_pod("default", label_selector=f"app={app_name}")
         self.logger.info(f"[Weblog] Currently running pods [{app_name}]:[{len(pods.items)}]")
         if len(pods.items) == 2:
             for pod in pods.items:
@@ -323,7 +323,7 @@ class K8sWeblog:
 
         # check weblog describe pod
         try:
-            api_response = self.k8s_wrapper.read_namespaced_pod("my-app", "default", pretty="true")
+            api_response = self.k8s_wrapper.read_namespaced_pod("my-app")
             k8s_logger(self.output_folder, self.test_name, "myapp.describe").info(api_response)
         except Exception as e:
             k8s_logger(self.output_folder, self.test_name, "myapp.describe").info(
@@ -332,7 +332,7 @@ class K8sWeblog:
 
         # check weblog logs for pod
         try:
-            api_response = self.k8s_wrapper.read_namespaced_pod_log(name="my-app", namespace="default")
+            api_response = self.k8s_wrapper.read_namespaced_pod_log(name="my-app")
             k8s_logger(self.output_folder, self.test_name, "myapp.logs").info(api_response)
         except Exception as e:
             k8s_logger(self.output_folder, self.test_name, "myapp.logs").info(
@@ -343,7 +343,7 @@ class K8sWeblog:
         deployment_name = f"test-{self.library}-deployment"
         app_name = f"{self.library}-app"
         try:
-            response = self.k8s_wrapper.read_namespaced_deployment(deployment_name, "default")
+            response = self.k8s_wrapper.read_namespaced_deployment(deployment_name)
             k8s_logger(self.output_folder, self.test_name, "deployment.desribe").info(response)
         except Exception as e:
             k8s_logger(self.output_folder, self.test_name, "deployment.describe").info(
@@ -354,15 +354,11 @@ class K8sWeblog:
         deployment_name = f"test-{self.library}-deployment"
         app_name = f"{self.library}-app"
         try:
-            pods = self.k8s_wrapper.list_namespaced_pod(namespace="default", label_selector=f"app={app_name}")
+            pods = self.k8s_wrapper.list_namespaced_pod("default", label_selector=f"app={app_name}")
             if len(pods.items) > 0:
-                api_response = self.k8s_wrapper.read_namespaced_pod(
-                    pods.items[0].metadata.name, "default", pretty="true"
-                )
+                api_response = self.k8s_wrapper.read_namespaced_pod(pods.items[0].metadata.name)
                 k8s_logger(self.output_folder, self.test_name, "deployment.logs").info(api_response)
-                api_response = self.k8s_wrapper.read_namespaced_pod_log(
-                    name=pods.items[0].metadata.name, namespace="default"
-                )
+                api_response = self.k8s_wrapper.read_namespaced_pod_log(name=pods.items[0].metadata.name)
                 k8s_logger(self.output_folder, self.test_name, "deployment.logs").info(api_response)
         except Exception as e:
             k8s_logger(self.output_folder, self.test_name, "deployment.logs").info(

--- a/utils/k8s_lib_injection/k8s_wrapper.py
+++ b/utils/k8s_lib_injection/k8s_wrapper.py
@@ -7,21 +7,22 @@ def retry(max_retries, wait_time):
     """ Decorator to retry a function if it fails."""
 
     def decorator(func):
-        def wrapper(*args, **kwargs):
-            retries = 0
-            if retries < max_retries:
+        def newfn(*args, **kwargs):
+            attempt = 0
+            while attempt < max_retries:
                 try:
-                    result = func(*args, **kwargs)
-                    if result is not None:
-                        return result
-                except Exception as e:
-                    retries += 1
+                    res = func(*args, **kwargs)
+                    if res is not None:
+                        return res
+                except Exception:
+                    logger.info(
+                        "Exception thrown when attempting to run %s, attempt " "%d of %d" % (func, attempt, max_retries)
+                    )
+                    attempt += 1
                     time.sleep(wait_time)
-            else:
-                logger.error(f"Max retries of function {func} exceeded")
-                raise Exception(f"Max retries of function {func} exceeded")
+            return func(*args, **kwargs)
 
-        return wrapper
+        return newfn
 
     return decorator
 

--- a/utils/k8s_lib_injection/k8s_wrapper.py
+++ b/utils/k8s_lib_injection/k8s_wrapper.py
@@ -1,30 +1,7 @@
 import time
 from kubernetes import client, config, watch
 from utils.tools import logger
-
-
-def retry(max_retries, wait_time):
-    """ Decorator to retry a function if it fails."""
-
-    def decorator(func):
-        def newfn(*args, **kwargs):
-            attempt = 0
-            while attempt < max_retries:
-                try:
-                    res = func(*args, **kwargs)
-                    if res is not None:
-                        return res
-                except Exception:
-                    logger.info(
-                        "Exception thrown when attempting to run %s, attempt " "%d of %d" % (func, attempt, max_retries)
-                    )
-                    attempt += 1
-                    time.sleep(wait_time)
-            return func(*args, **kwargs)
-
-        return newfn
-
-    return decorator
+from retry import retry
 
 
 class K8sWrapper:
@@ -36,78 +13,78 @@ class K8sWrapper:
     def __init__(self, k8s_kind_cluster):
         self.k8s_kind_cluster = k8s_kind_cluster
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def core_v1_api(self):
         return client.CoreV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def apps_api(self):
         return client.AppsV1Api(api_client=config.new_client_from_config(context=self.k8s_kind_cluster.context_name))
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def create_namespaced_daemon_set(self, namespace="default", body=None):
         self.apps_api().create_namespaced_daemon_set(namespace="default", body=body)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def read_namespaced_daemon_set_status(self, name=None, namespace="default"):
         return self.apps_api().read_namespaced_daemon_set_status(name=name, namespace=namespace)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def read_namespaced_daemon_set(self, name=None, namespace="default"):
         return self.apps_api().read_namespaced_daemon_set(name=name, namespace=namespace)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def replace_namespaced_config_map(self, name=None, namespace="default", body=None):
         return self.core_v1_api().replace_namespaced_config_map(name=name, namespace=namespace, body=body)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def create_namespaced_config_map(self, namespace="default", body=None):
         return self.core_v1_api().create_namespaced_config_map(namespace=namespace, body=body)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def list_namespaced_config_map(self, namespace, **kwargs):
         return self.core_v1_api().list_namespaced_config_map(namespace, **kwargs)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def list_namespaced_pod(self, namespace, **kwargs):
         return self.core_v1_api().list_namespaced_pod(namespace, **kwargs)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def read_namespaced_pod(self, pod_name, namespace="default"):
         return self.core_v1_api().read_namespaced_pod(pod_name, namespace=namespace)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def read_namespaced_pod_log(self, name=None, namespace="default"):
         return self.core_v1_api().read_namespaced_pod_log(name=name, namespace=namespace)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def read_namespaced_pod_status(self, name=None, namespace="default"):
         return self.core_v1_api().read_namespaced_pod_status(name=name, namespace=namespace)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def list_deployment_for_all_namespaces(self):
         return self.apps_api().list_deployment_for_all_namespaces()
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def create_namespaced_pod(self, namespace="default", body=None):
         return self.core_v1_api().create_namespaced_pod(namespace=namespace, body=body)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def create_namespaced_deployment(self, body=None, namespace="default"):
         return self.apps_api().create_namespaced_deployment(namespace=namespace, body=body)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def read_namespaced_deployment_status(self, deployment_name, namespace="default"):
         return self.apps_api().read_namespaced_deployment_status(deployment_name, namespace=namespace)
 
-    @retry(max_retries=10, wait_time=1)
+    @retry(delay=1, tries=10)
     def read_namespaced_deployment(self, deployment_name, namespace="default"):
         return self.apps_api().read_namespaced_deployment(deployment_name, namespace=namespace)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def patch_namespaced_deployment(self, deployment_name, namespace, deploy_data):
         return self.apps_api().patch_namespaced_deployment(deployment_name, namespace, deploy_data)
 
-    @retry(max_retries=5, wait_time=1)
+    @retry(delay=1, tries=5)
     def delete_namespaced_pod(self, pod_name_running, namespace):
         return self.core_v1_api().delete_namespaced_pod(pod_name_running, namespace=namespace)


### PR DESCRIPTION
## Motivation
   If we execute on system-tests-dashboard, we can't push the images because we don't have the permissions.
   To asign the permissions, we need to configure the image on ghcr, but due to a issue we can't do it
    The case is opened with github support
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
