### PR TITLE
[dotnet][IAST] Fix tests with incorrect status code

### DIFF
--- a/tests/appsec/iast/sink/test_path_traversal.py
+++ b/tests/appsec/iast/sink/test_path_traversal.py
@@ -30,7 +30,6 @@ class TestPathTraversal(BaseSinkTest):
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
 
-    @missing_feature(library="dotnet", reason="Endpoint responds 500")
     @missing_feature(library="java", reason="Endpoint not implemented")
     @missing_feature(library="nodejs", reason="Endpoint not implemented")
     def test_secure(self):

--- a/tests/appsec/iast/sink/test_reflection_injection.py
+++ b/tests/appsec/iast/sink/test_reflection_injection.py
@@ -26,6 +26,5 @@ class TestReflectionInjection(BaseSinkTest):
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
 
-    @missing_feature(library="dotnet", reason="Endpoint responds 500")
     def test_secure(self):
         super().test_secure()

--- a/tests/appsec/iast/sink/test_sql_injection.py
+++ b/tests/appsec/iast/sink/test_sql_injection.py
@@ -39,7 +39,6 @@ class TestSqlInjection(BaseSinkTest):
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
 
-    @missing_feature(library="dotnet", reason="Endpoint responds 500")
     @missing_feature(library="python", reason="Endpoint responds 500")
     @missing_feature(context.weblog_variant == "jersey-grizzly2", reason="Endpoint responds 500")
     def test_secure(self):

--- a/tests/appsec/iast/sink/test_ssrf.py
+++ b/tests/appsec/iast/sink/test_ssrf.py
@@ -26,7 +26,6 @@ class TestSSRF(BaseSinkTest):
         super().test_insecure()
 
     @missing_feature(library="nodejs", reason="Endpoint not implemented")
-    @missing_feature(library="dotnet", reason="Endpoint responds 500")
     @missing_feature(library="python", reason="Endpoint responds 403")
     @missing_feature(library="java", reason="Endpoint not implemented")
     def test_secure(self):

--- a/utils/build/docker/dotnet/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/Controllers/IastController.cs
@@ -8,6 +8,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+
 #nullable disable
 
 namespace weblog
@@ -275,8 +277,14 @@ namespace weblog
                 var result = System.IO.File.ReadAllText(data.path);
                 return Content($"File content: " + result);
             }
-            catch
+            catch (UnauthorizedAccessException)
             {
+                // Normal Exception caught: The file in the test "/var/log" is not accessible
+                return StatusCode(200);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
                 return StatusCode(500, "Error reading file.");
             }
         }
@@ -289,8 +297,14 @@ namespace weblog
                 var result = System.IO.File.ReadAllText("file.txt");
                 return Content($"File content: " + result);
             }
-            catch
+            catch (System.IO.FileNotFoundException)
             {
+                // Normal Exception caught: The file "file.txt" hardcoded for the test does not exist
+                return StatusCode(200);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
                 return StatusCode(500, "Error reading file.");
             }
         }
@@ -304,7 +318,7 @@ namespace weblog
         [HttpPost("ssrf/test_secure")]
         public IActionResult TestSecureSSRF([FromForm] RequestData data)
         {
-            return MakeRequest("notAUrl");
+            return MakeRequest("https://www.datadoghq.com");
         }
         
         private IActionResult MakeRequest(string url)
@@ -312,7 +326,7 @@ namespace weblog
             try
             {
                 var result = new System.Net.Http.HttpClient().GetStringAsync(url).Result;
-                return Content($"Reponse: " + result);
+                return Content($"Response: " + result);
             }
             catch
             {
@@ -327,7 +341,7 @@ namespace weblog
             {
                 string ldapPath = "LDAP://" + username + ":" + password + "@ldap.example.com/OU=Users,DC=example,DC=com";
                 _ = new System.DirectoryServices.DirectoryEntry(ldapPath);
-                return Content($"Conection created");
+                return Content($"Connection created");
             }
             catch
             {
@@ -390,8 +404,9 @@ namespace weblog
                     return BadRequest($"No params provided");
                 }
             }
-            catch
+            catch (Exception e)
             {
+                Console.WriteLine(e);
                 return StatusCode(500, "Error executing query.");
             }        
         }
@@ -408,13 +423,13 @@ namespace weblog
                     using var conn = Sql.GetSqliteConnection();
                     conn.Open();
                     using var cmd = conn.CreateCommand();
-                    cmd.CommandText = "SELECT * FROM data WHERE value = $user";
-                    cmd.Parameters.Add("$user");
-                    cmd.Parameters["$user"].Value = username;
+                    cmd.CommandText = "SELECT * FROM users WHERE user = $user";
+                    cmd.Parameters.Add(new SqliteParameter("$user", username));
+
                     using var reader = cmd.ExecuteReader();
                     while (reader.Read())
                     {
-                        sb.AppendLine(reader["value"]?.ToString());
+                        sb.AppendLine(reader["user"]?.ToString() + ", " + reader["pwd"]?.ToString());
                     }
 
                     return Content(sb.ToString());
@@ -424,8 +439,9 @@ namespace weblog
                     return BadRequest($"No params provided");
                 }
             }
-            catch
+            catch (Exception e)
             {
+                Console.WriteLine(e);
                 return StatusCode(500, "Error executing query.");
             }
         }
@@ -580,17 +596,20 @@ namespace weblog
             }
         }
         
+        private class ReflectionInjection { } // Class name passed as parameter in the reflection injection test
+        
         [HttpPost("reflection_injection/test_insecure")]
         public IActionResult test_insecure_reflection_injection([FromForm]string param)
         {
+            
             try
             {
                 var type = Type.GetType(param);
-                Activator.CreateInstance(type);
+                Activator.CreateInstance(type!);
             }
-            catch (Exception)
+            catch
             {
-                // ignored
+                return StatusCode(500, "Error executing reflection.");
             }
 
             return Content("Executed reflection injection");
@@ -601,12 +620,13 @@ namespace weblog
         {
             try
             {
-                var type = Type.GetType("System.String")!;
+                var type = Type.GetType("System.Text.StringBuilder")!;
                 Activator.CreateInstance(type);
                 return Content("Executed secure injection");
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                Console.WriteLine(e);
                 return StatusCode(500, "Error executing safe reflection.");
             }
         }


### PR DESCRIPTION
## Motivation

Fix IAST tests that was reporting bad response code.
These tests were disabled after [this PR](https://github.com/DataDog/system-tests/pull/2262).

## Changes

- Fixing some try/catch clause to not send 500. Only report 200 when the test successfully passed.
- Fixing some tests that weren't properly running

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
