### PR TITLE
K8s Lib Injection: Enable appsec

### DIFF
--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -107,12 +107,12 @@ jobs:
       - name: Kubernetes lib-injection tests (using custom weblog image tag)
         if: inputs.build_lib_injection_app_images
         id: k8s-lib-injection-tests-custom-weblog-tag
-        run: DOCKER_IMAGE_WEBLOG_TAG=${{ github.sha }} ./run.sh K8S_LIB_INJECTION_FULL
+        run: DOCKER_IMAGE_WEBLOG_TAG=${{ github.sha }} ./run.sh K8S_LIB_INJECTION_BASIC
 
       - name: Kubernetes lib-injection tests
         if: inputs.build_lib_injection_app_images != true
         id: k8s-lib-injection-tests
-        run: ./run.sh K8S_LIB_INJECTION_FULL
+        run: ./run.sh K8S_LIB_INJECTION_BASIC
 
       - name: Compress logs
         id: compress_logs

--- a/tests/k8s_lib_injection/test_k8s_manual_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_manual_inject.py
@@ -40,7 +40,7 @@ class _TestAdmisionController:
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_without_admission_controller finished")
 
-    def test_inject_uds_without_admission_controller(self, test_k8s_instance):
+    def _test_inject_uds_without_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test test_inject_uds_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
         )

--- a/utils/k8s_lib_injection/k8s_weblog.py
+++ b/utils/k8s_lib_injection/k8s_weblog.py
@@ -128,6 +128,9 @@ class K8sWeblog:
         )
         pod_body.spec.init_containers.append(init_container1)
         pod_body.spec.containers[0].env.append(client.V1EnvVar(name="DD_LOGS_INJECTION", value="true"))
+        pod_body.spec.containers[0].env.append(client.V1EnvVar(name="DD_IAST_ENABLED", value="true"))
+        pod_body.spec.containers[0].env.append(client.V1EnvVar(name="DD_APPSEC_SCA_ENABLED", value="true"))
+        pod_body.spec.containers[0].env.append(client.V1EnvVar(name="DD_APPSEC_ENABLED", value="true"))
         # Env vars for manual injection. Each library has its own env vars
         for lang_env_vars in self.manual_injection_props[self.library]:
             pod_body.spec.containers[0].env.append(

--- a/utils/k8s_lib_injection/resources/operator/operator-helm-values.yaml
+++ b/utils/k8s_lib_injection/resources/operator/operator-helm-values.yaml
@@ -6,6 +6,13 @@ datadog:
   clusterName: $$CLUSTER_NAME$$
   tags: []
   logLevel: DEBUG
+  asm:
+    threats:
+      enabled: true
+    sca:
+      enabled: true
+    iast:
+      enabled: true  
   # datadog.kubelet.tlsVerify should be `false` on kind and minikube
   # to establish communication with the kubelet
   kubelet:


### PR DESCRIPTION
## Motivation
Enable appsec for lib injection: Proof of concept with admission controlling and without admission controller
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
