### PR TITLE
K8s Lib Injection: New test added

### DIFF
--- a/tests/k8s_lib_injection/test_k8s_manual_inject.py
+++ b/tests/k8s_lib_injection/test_k8s_manual_inject.py
@@ -30,6 +30,17 @@ class _TestAdmisionController:
         assert len(traces_json) > 0, "No traces found"
         logger.info(f"Test _test_inject_admission_controller finished")
 
+    def test_inject_uds_admission_controller(self, test_k8s_instance):
+        logger.info(
+            f"Launching test test_inject_uds_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"
+        )
+        test_agent = test_k8s_instance.deploy_test_agent()
+        test_agent.deploy_operator_manual(use_uds=True)
+        test_k8s_instance.deploy_weblog_as_pod()
+        traces_json = self._get_dev_agent_traces(test_k8s_instance.k8s_kind_cluster.agent_port)
+        assert len(traces_json) > 0, "No traces found"
+        logger.info(f"Test test_inject_uds_admission_controller finished")
+
     def test_inject_without_admission_controller(self, test_k8s_instance):
         logger.info(
             f"Launching test _test_inject_without_admission_controller: Weblog: [{test_k8s_instance.k8s_kind_cluster.weblog_port}] Agent: [{test_k8s_instance.k8s_kind_cluster.agent_port}]"

--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -211,10 +211,11 @@ class K8sDatadogClusterTestAgent:
         timeout = time.time() + timeout
         while True:
             api_response = self.k8s_wrapper.read_namespaced_pod_log(name=pod_cluster_agent_name)
-            for log_line in api_response.splitlines():
-                if log_line.find(expected_log) != -1:
-                    self.logger.info(f"Configmap read by datadog-cluster-agent: {log_line}")
-                    return
+            if api_response is not None:
+                for log_line in api_response.splitlines():
+                    if log_line.find(expected_log) != -1:
+                        self.logger.info(f"Configmap read by datadog-cluster-agent: {log_line}")
+                        return
             if time.time() > timeout:
                 self.logger.error(f"Timeout waiting for the datadog-cluster-agent to read the configmap")
                 raise TimeoutError("Timeout waiting for the datadog-cluster-agent to read the configmap")


### PR DESCRIPTION
## Motivation

Add a new test on k8s lib injection test
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
