### PR TITLE
update slack channel to apm-shared-testing

### DIFF
--- a/docs/execute/README.md
+++ b/docs/execute/README.md
@@ -22,7 +22,7 @@ The summary in stdout contains a list of test, then a list of validations. Each 
 * A capital yellow `X`: it was expected to fail, but was a success => **it's time to activate the test**
 * A capital red `F`: Test is failing! a more complete explanation will follow
 * A small yellow `s`: totally skipped. For irrelevant or flaky tests, there is no point to execute them
-* A small red `x`: should not happen, sen a message to `#apm-shared-testing` slack channel
+* A small red `x`: should not happen, send a message to `#apm-shared-testing` slack channel
 
 If system tests fails, you'll need to dig into logs. Most of the time and with some experience, standard ouput will contains enough info to understand the issue. But sometimes, you'll need to have a look [inside logs/ folder](./logs.md).
 

--- a/docs/execute/README.md
+++ b/docs/execute/README.md
@@ -22,7 +22,7 @@ The summary in stdout contains a list of test, then a list of validations. Each 
 * A capital yellow `X`: it was expected to fail, but was a success => **it's time to activate the test**
 * A capital red `F`: Test is failing! a more complete explanation will follow
 * A small yellow `s`: totally skipped. For irrelevant or flaky tests, there is no point to execute them
-* A small red `x`: should not happen, sen a message to `#libraries-system-tests` slack channel
+* A small red `x`: should not happen, sen a message to `#apm-shared-testing` slack channel
 
 If system tests fails, you'll need to dig into logs. Most of the time and with some experience, standard ouput will contains enough info to understand the issue. But sometimes, you'll need to have a look [inside logs/ folder](./logs.md).
 


### PR DESCRIPTION
## Motivation

update the slack channel to `#apm-shared-testing` in docs.

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
