### PR TITLE
[Node.js] re-enable sampling priority tests

### DIFF
--- a/tests/appsec/test_rate_limiter.py
+++ b/tests/appsec/test_rate_limiter.py
@@ -40,7 +40,10 @@ class Test_Main:
 
         logger.debug(f"Sent 50 requests in {(datetime.datetime.now() - start_time).total_seconds()} s")
 
-    @bug(context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0", reason="_sampling_priority_v1 is missing")
+    @bug(
+        context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0",
+        reason="_sampling_priority_v1 is missing"
+    )
     @flaky("rails" in context.weblog_variant, reason="APPSEC-10303")
     def test_main(self):
         """send requests for 10 seconds, check that only 10-ish traces are sent, as rate limiter is set to 1/s"""

--- a/tests/appsec/test_rate_limiter.py
+++ b/tests/appsec/test_rate_limiter.py
@@ -42,7 +42,7 @@ class Test_Main:
 
     @bug(
         context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0",
-        reason="_sampling_priority_v1 is missing"
+        reason="_sampling_priority_v1 is missing",
     )
     @flaky("rails" in context.weblog_variant, reason="APPSEC-10303")
     def test_main(self):

--- a/tests/appsec/test_rate_limiter.py
+++ b/tests/appsec/test_rate_limiter.py
@@ -40,7 +40,7 @@ class Test_Main:
 
         logger.debug(f"Sent 50 requests in {(datetime.datetime.now() - start_time).total_seconds()} s")
 
-    @bug(context.library > "nodejs@3.14.1", reason="_sampling_priority_v1 is missing")
+    @bug(context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0", reason="_sampling_priority_v1 is missing")
     @flaky("rails" in context.weblog_variant, reason="APPSEC-10303")
     def test_main(self):
         """send requests for 10 seconds, check that only 10-ish traces are sent, as rate limiter is set to 1/s"""

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -64,7 +64,7 @@ class Test_SamplingRates:
     @bug(library="python", reason="When stats are activated, all traces are emitted")
     @bug(
         context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0",
-        reason="_sampling_priority_v1 is missing"
+        reason="_sampling_priority_v1 is missing",
     )
     @flaky(context.weblog_variant == "spring-boot-3-native", reason="Needs investigation")
     @flaky(library="golang", reason="Needs investigation")
@@ -178,7 +178,7 @@ class Test_SamplingDecisions:
     @bug(library="python", reason="Sampling decisions are not taken by the tracer APMRP-259")
     @bug(
         context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0",
-        reason="_sampling_priority_v1 is missing"
+        reason="_sampling_priority_v1 is missing",
     )
     def test_sampling_decision_added(self):
         """Verify that the distributed traces without sampling decisions have a sampling decision added"""

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -62,7 +62,7 @@ class Test_SamplingRates:
             weblog.get(p)
 
     @bug(library="python", reason="When stats are activated, all traces are emitted")
-    @bug(context.library > "nodejs@3.14.1", reason="_sampling_priority_v1 is missing")
+    @bug(context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0", reason="_sampling_priority_v1 is missing")
     @flaky(context.weblog_variant == "spring-boot-3-native", reason="Needs investigation")
     @flaky(library="golang", reason="Needs investigation")
     @flaky(library="ruby", reason="Needs investigation")
@@ -173,7 +173,7 @@ class Test_SamplingDecisions:
             )
 
     @bug(library="python", reason="Sampling decisions are not taken by the tracer APMRP-259")
-    @bug(context.library > "nodejs@3.14.1", reason="_sampling_priority_v1 is missing")
+    @bug(context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0", reason="_sampling_priority_v1 is missing")
     def test_sampling_decision_added(self):
         """Verify that the distributed traces without sampling decisions have a sampling decision added"""
 

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -62,7 +62,10 @@ class Test_SamplingRates:
             weblog.get(p)
 
     @bug(library="python", reason="When stats are activated, all traces are emitted")
-    @bug(context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0", reason="_sampling_priority_v1 is missing")
+    @bug(
+        context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0",
+        reason="_sampling_priority_v1 is missing"
+    )
     @flaky(context.weblog_variant == "spring-boot-3-native", reason="Needs investigation")
     @flaky(library="golang", reason="Needs investigation")
     @flaky(library="ruby", reason="Needs investigation")
@@ -173,7 +176,10 @@ class Test_SamplingDecisions:
             )
 
     @bug(library="python", reason="Sampling decisions are not taken by the tracer APMRP-259")
-    @bug(context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0", reason="_sampling_priority_v1 is missing")
+    @bug(
+        context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0",
+        reason="_sampling_priority_v1 is missing"
+    )
     def test_sampling_decision_added(self):
         """Verify that the distributed traces without sampling decisions have a sampling decision added"""
 

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -66,6 +66,7 @@ class Test_SamplingRates:
         context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0",
         reason="_sampling_priority_v1 is missing",
     )
+    @bug(library="nodejs", reason="Unexpected amount of sampled traces")
     @flaky(context.weblog_variant == "spring-boot-3-native", reason="Needs investigation")
     @flaky(library="golang", reason="Needs investigation")
     @flaky(library="ruby", reason="Needs investigation")


### PR DESCRIPTION
## Motivation

It was x-passing

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
