### PR TITLE
Merge some tests with negative searchs to avoid false positive

### DIFF
--- a/tests/appsec/test_customconf.py
+++ b/tests/appsec/test_customconf.py
@@ -14,6 +14,10 @@ stdout = interfaces.library_stdout if context.library != "dotnet" else interface
 class Test_CorruptedRules:
     """AppSec do not report anything if rule file is invalid"""
 
+    def setup_c05(self):
+        self.r_1 = weblog.get("/", headers={"User-Agent": "Arachni/v1"})
+        self.r_2 = weblog.get("/waf", params={"attack": "<script>"})
+
     @missing_feature(library="golang")
     @missing_feature(library="nodejs")
     @missing_feature(library="python")
@@ -24,12 +28,7 @@ class Test_CorruptedRules:
         """Log C5: Rules file is corrupted"""
         stdout.assert_presence(r"AppSec could not read the rule file .* as it was invalid: .*", level="CRITICAL")
 
-    def setup_no_attack_detected(self):
-        self.r_1 = weblog.get("/", headers={"User-Agent": "Arachni/v1"})
-        self.r_2 = weblog.get("/waf", params={"attack": "<script>"})
-
-    def test_no_attack_detected(self):
-        """ Appsec does not catch any attack """
+        # Appsec does not catch any attack
         interfaces.library.assert_no_appsec_event(self.r_1)
         interfaces.library.assert_no_appsec_event(self.r_2)
 
@@ -38,6 +37,10 @@ class Test_CorruptedRules:
 @features.threats_configuration
 class Test_MissingRules:
     """AppSec do not report anything if rule file is missing"""
+
+    def setup_c04(self):
+        self.r_1 = weblog.get("/", headers={"User-Agent": "Arachni/v1"})
+        self.r_2 = weblog.get("/waf", params={"attack": "<script>"})
 
     @missing_feature(library="golang")
     @missing_feature(library="nodejs")
@@ -54,12 +57,7 @@ class Test_MissingRules:
             level="CRITICAL",
         )
 
-    def setup_no_attack_detected(self):
-        self.r_1 = weblog.get("/", headers={"User-Agent": "Arachni/v1"})
-        self.r_2 = weblog.get("/waf", params={"attack": "<script>"})
-
-    def test_no_attack_detected(self):
-        """ Appsec does not catch any attack """
+        # Appsec does not catch any attack
         interfaces.library.assert_no_appsec_event(self.r_1)
         interfaces.library.assert_no_appsec_event(self.r_2)
 


### PR DESCRIPTION
## Motivation

#2278

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
