### PR TITLE
Optional dependencies in python

### DIFF
--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -366,6 +366,21 @@ class EndToEndScenario(_DockerScenario):
 
         self.agent_container = AgentContainer(host_log_folder=self.host_log_folder, use_proxy=use_proxy)
 
+        weblog_env = dict(weblog_env) if weblog_env else {}
+        weblog_env.update(
+            {
+                "INCLUDE_POSTGRES": str(include_postgres_db).lower(),
+                "INCLUDE_CASSANDRA": str(include_cassandra_db).lower(),
+                "INCLUDE_MONGO": str(include_mongo_db).lower(),
+                "INCLUDE_KAFKA": str(include_kafka).lower(),
+                "INCLUDE_RABBITMQ": str(include_rabbitmq).lower(),
+                "INCLUDE_MYSQL": str(include_mysql_db).lower(),
+                "INCLUDE_SQLSERVER": str(include_sqlserver).lower(),
+                "INCLUDE_ELASTICMQ": str(include_elasticmq).lower(),
+                "INCLUDE_LOCALSTACK": str(include_localstack).lower(),
+            }
+        )
+
         self.weblog_container = WeblogContainer(
             self.host_log_folder,
             environment=weblog_env,

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -5,7 +5,8 @@ import random
 import subprocess
 import threading
 
-import psycopg2
+if os.environ.get("INCLUDE_POSTGRES", "true") == "true":
+    import psycopg2
 import requests
 from flask import Flask, Response, jsonify
 from flask import request
@@ -18,19 +19,26 @@ from iast import (
     weak_hash_multiple,
     weak_hash_secure_algorithm,
 )
-from integrations.db.mssql import executeMssqlOperation
-from integrations.db.mysqldb import executeMysqlOperation
-from integrations.db.postgres import executePostgresOperation
+
+if os.environ.get("INCLUDE_SQLSERVER", "true") == "true":
+    from integrations.db.mssql import executeMssqlOperation
+if os.environ.get("INCLUDE_MYSQL", "true") == "true":
+    from integrations.db.mysqldb import executeMysqlOperation
+if os.environ.get("INCLUDE_POSTGRES", "true") == "true":
+    from integrations.db.postgres import executePostgresOperation
 from integrations.messaging.aws.kinesis import kinesis_consume
 from integrations.messaging.aws.kinesis import kinesis_produce
 from integrations.messaging.aws.sns import sns_consume
 from integrations.messaging.aws.sns import sns_produce
 from integrations.messaging.aws.sqs import sqs_consume
 from integrations.messaging.aws.sqs import sqs_produce
-from integrations.messaging.kafka import kafka_consume
-from integrations.messaging.kafka import kafka_produce
-from integrations.messaging.rabbitmq import rabbitmq_consume
-from integrations.messaging.rabbitmq import rabbitmq_produce
+
+if os.environ.get("INCLUDE_KAFKA", "true") == "true":
+    from integrations.messaging.kafka import kafka_consume
+    from integrations.messaging.kafka import kafka_produce
+if os.environ.get("INCLUDE_RABBITMQ", "true") == "true":
+    from integrations.messaging.rabbitmq import rabbitmq_consume
+    from integrations.messaging.rabbitmq import rabbitmq_produce
 
 import ddtrace
 

--- a/utils/build/docker/python/flask/integrations/db/mssql.py
+++ b/utils/build/docker/python/flask/integrations/db/mssql.py
@@ -1,7 +1,7 @@
 try:
     import pyodbc
 except ModuleNotFoundError:
-    print("pmysql not loaded")
+    print("pyodbc not loaded")
 
 database_mssql_loaded = 0
 SERVER = "mssql"


### PR DESCRIPTION
## Motivation

We use weblog applications for some testing cases outside of system-tests. Being able to run without some of the most complex dependencies, like Sql Server driver or librdkafka is a plus in these cases.

## Changes

* Inject environment variables like `INCLUDE_POSTGRES` to the weblog container, with `true` value if that service will be used in that scenario.
* Modify flask app to make some imports optional to these environment variables.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
