### PR TITLE
weblog: Use nginx-datadog instead of dd-opentracing-cpp

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -164,4 +164,5 @@ tests/:
   test_telemetry.py:
     Test_Log_Generation: missing_feature
     Test_MessageBatch: missing_feature
+    Test_Metric_Generation_Enabled: missing_feature
     Test_ProductsDisabled: irrelevant

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -159,17 +159,9 @@ tests/:
   test_miscs.py: irrelevant
   test_profiling.py:
     Test_Profile: bug (No Content-Disposition, tests do not parse the content correcly)
-  test_sampling_rates.py:
-    Test_SamplingRates: missing_feature (https://github.com/DataDog/dd-opentracing-cpp/issues/173)
   test_scrubbing.py: irrelevant
-  test_semantic_conventions.py:
-    Test_MetaDatadogTags: bug (Inconsistent implementation across tracers; will need a dedicated testing scenario)
   test_standard_tags.py: irrelevant
   test_telemetry.py:
     Test_Log_Generation: missing_feature
     Test_MessageBatch: missing_feature
-    Test_Metric_Generation_Disabled: missing_feature
-    Test_Metric_Generation_Enabled: missing_feature
     Test_ProductsDisabled: irrelevant
-    Test_Telemetry: missing_feature
-    Test_TelemetryV2: missing_feature

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -22,8 +22,8 @@ class Test_TraceUniqueness:
 class Test_TraceHeaders:
     """All required headers are present in all traces submitted to the agent"""
 
+    @missing_feature(library="cpp")
     @bug(context.library <= "golang@1.37.0")
-    @bug(library="cpp")
     def test_traces_header_present(self):
         """Verify that headers described in RFC are present in traces submitted to the agent"""
 

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -230,7 +230,6 @@ class Test_Meta:
 
         interfaces.library.validate_spans(validator=validator)
 
-    @bug(library="cpp", reason="language tag not implemented")
     @bug(library="php", reason="language tag not implemented")
     # TODO: Versions previous to 1.1.0 might be ok, but were not tested so far.
     @bug(context.library < "java@1.1.0", reason="language tag implemented but not for all spans")
@@ -285,7 +284,6 @@ class Test_Meta:
         # checking that we have at least one root span
         assert len(list(interfaces.library.get_root_spans())) != 0, "Did not recieve any root spans to validate."
 
-    @bug(library="cpp", reason="runtime-id tag not implemented")
     @bug(library="php", reason="runtime-id tag only implemented when profiling is enabled.")
     def test_meta_runtime_id_tag(self):
         """Assert that all spans generated from a weblog_variant have runtime-id metadata tag with some value."""
@@ -323,7 +321,6 @@ class Test_MetaDatadogTags:
 class Test_MetricsStandardTags:
     """metrics object in spans respect all conventions regarding basic tags"""
 
-    @bug(library="cpp", reason="Not implemented")
     @bug(context.library >= "java@1.3.0", reason="process_id set as tag, not metric")
     def test_metrics_process_id(self):
         """Validates that root spans from traces contain a process_id field"""

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -66,7 +66,7 @@ class _Scenario:
         Path(path).mkdir(parents=True, exist_ok=True)
 
     def __call__(self, test_object):
-        """ handles @scenarios.scenario_name """
+        """handles @scenarios.scenario_name"""
 
         # Check that no scenario has been already declared
         for marker in getattr(test_object, "pytestmark", []):
@@ -108,7 +108,7 @@ class _Scenario:
             weblog.init_replay_mode(self.host_log_folder)
 
     def session_start(self):
-        """ called at the very begning of the process """
+        """called at the very begning of the process"""
 
         self.print_test_context()
 
@@ -126,7 +126,7 @@ class _Scenario:
             raise
 
     def pytest_sessionfinish(self, session):
-        """ called at the end of the process  """
+        """called at the end of the process"""
 
     def print_test_context(self):
         logger.terminal.write_sep("=", "test context", bold=True)
@@ -137,10 +137,10 @@ class _Scenario:
         return []
 
     def post_setup(self):
-        """ called after test setup """
+        """called after test setup"""
 
     def close_targets(self):
-        """ called after setup"""
+        """called after setup"""
 
     @property
     def host_log_folder(self):
@@ -232,7 +232,7 @@ class TestTheTestScenario(_Scenario):
 
 
 class _DockerScenario(_Scenario):
-    """ Scenario that tests docker containers """
+    """Scenario that tests docker containers"""
 
     def __init__(
         self,
@@ -302,7 +302,6 @@ class _DockerScenario(_Scenario):
         return None
 
     def _get_warmups(self):
-
         warmups = super()._get_warmups()
 
         warmups.append(create_network)
@@ -321,7 +320,7 @@ class _DockerScenario(_Scenario):
 
 
 class EndToEndScenario(_DockerScenario):
-    """ Scenario that implier an instrumented HTTP application shipping a datadog tracer (weblog) and an datadog agent """
+    """Scenario that implier an instrumented HTTP application shipping a datadog tracer (weblog) and an datadog agent"""
 
     def __init__(
         self,
@@ -550,7 +549,6 @@ class EndToEndScenario(_DockerScenario):
         from utils import interfaces
 
         if self.replay:
-
             logger.terminal.write_sep("-", "Load all data from logs")
             logger.terminal.flush()
 
@@ -676,7 +674,7 @@ class EndToEndScenario(_DockerScenario):
 
 
 class OpenTelemetryScenario(_DockerScenario):
-    """ Scenario for testing opentelemetry"""
+    """Scenario for testing opentelemetry"""
 
     def __init__(
         self,
@@ -859,7 +857,7 @@ class PerformanceScenario(EndToEndScenario):
 
 class ParametricScenario(_Scenario):
     class PersistentParametricTestConf(dict):
-        """ Parametric tests are executed in multiple thread, we need a mechanism to persist each parametrized_tests_metadata on a file"""
+        """Parametric tests are executed in multiple thread, we need a mechanism to persist each parametrized_tests_metadata on a file"""
 
         def __init__(self, outer_inst):
             self.outer_inst = outer_inst
@@ -944,7 +942,7 @@ class ParametricScenario(_Scenario):
 
 
 class _VirtualMachineScenario(_Scenario):
-    """ Scenario that tests virtual machines """
+    """Scenario that tests virtual machines"""
 
     def __init__(
         self,
@@ -1031,7 +1029,7 @@ class _VirtualMachineScenario(_Scenario):
         self.vm_provider.configure(self.required_vms)
 
     def _check_test_environment(self):
-        """ Check if the test environment is correctly set"""
+        """Check if the test environment is correctly set"""
 
         assert self._library is not None, "Library is not set (use --vm-library)"
         assert self._env is not None, "Env is not set (use --vm-env)"
@@ -1114,7 +1112,7 @@ class ContainerAutoInjectionScenario(_VirtualMachineScenario):
 
 
 class _KubernetesScenario(_Scenario):
-    """ Scenario that tests kubernetes lib injection """
+    """Scenario that tests kubernetes lib injection"""
 
     def __init__(self, name, doc) -> None:
         super().__init__(name, doc=doc)
@@ -1298,7 +1296,10 @@ class scenarios:
 
     trace_propagation_style_w3c = EndToEndScenario(
         "TRACE_PROPAGATION_STYLE_W3C",
-        weblog_env={"DD_TRACE_PROPAGATION_STYLE_INJECT": "W3C", "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "W3C",},
+        weblog_env={
+            "DD_TRACE_PROPAGATION_STYLE_INJECT": "tracecontext",
+            "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "tracecontext",
+        },
         doc="Test W3C trace style",
     )
 

--- a/utils/build/docker/cpp/nginx.Dockerfile
+++ b/utils/build/docker/cpp/nginx.Dockerfile
@@ -1,50 +1,23 @@
-FROM nginx:1.17.3
+FROM nginx:1.25.4
 
-RUN apt-get update && \
-  apt-get install -y wget tar jq curl xz-utils \
-    stress-ng
-
-RUN echo '\n\
-env DD_AGENT_HOST;\n\
-env DD_SERVICE;\n\
-env DD_TRACE_SAMPLE_RATE;\n\
-env DD_TRACE_DEBUG;\n\
-load_module modules/ngx_http_opentracing_module.so;\n\
-events {\n\
-    worker_connections  1024;\n\
-}\n\
-http {\n\
-    opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/nginx/dd-config.json;\n\
-    opentracing on;\n\
-    opentracing_tag http_user_agent \$http_user_agent;\n\
-    opentracing_trace_locations off;\n\
-    opentracing_operation_name "\$request_method \$uri";\n\
-    log_format with_trace_id '\''\$remote_addr - \$http_x_forwarded_user [\$time_local] "\$request" '\''\n\
-        '\''\$status \$body_bytes_sent "\$http_referer" '\''\n\
-        '\''"\$http_user_agent" "\$http_x_forwarded_for" '\''\n\
-        '\''"\$opentracing_context_x_datadog_trace_id" "\$opentracing_context_x_datadog_parent_id"'\'';\n\
-    access_log /var/log/nginx/access.log with_trace_id;\n\
-    server {\n\
-        listen       7777;\n\
-        server_name  0.0.0.0;\n\
-        location ~* /sample_rate/([0-9]+) { return 200  '\''OK'\''; }\n\
-        location / { return 200 '\''Hello world\n'\''; }\n\
-    }\n\
-}' > /etc/nginx/nginx.conf
-
-RUN echo '{}' > /etc/nginx/dd-config.json
+ARG NGINX_VERSION="1.25.4"
+ENV NGINX_VERSION=${NGINX_VERSION}
 
 RUN mkdir /builds
 
 # Copy needs a single valid source (ddprof tar can be missing)
-COPY utils/build/docker/cpp/install_ddprof.sh binaries* /builds/
+COPY utils/build/docker/cpp/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY utils/build/docker/cpp/nginx/hello.html /builds/hello.html
 COPY utils/build/docker/cpp/nginx/install_ddtrace.sh /builds/
+COPY utils/build/docker/cpp/install_ddprof.sh binaries* /builds/
+
+RUN apt-get update \
+ && apt-get install -y wget tar jq curl xz-utils stress-ng
+
+# NGINX Plugin setup 
 RUN /builds/install_ddtrace.sh
 
-ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
-
 # Profiling setup
-
 RUN cd /builds && ./install_ddprof.sh /usr/local/bin
 
 COPY utils/build/docker/cpp/nginx/app.sh ./

--- a/utils/build/docker/cpp/nginx/hello.html
+++ b/utils/build/docker/cpp/nginx/hello.html
@@ -1,0 +1,1 @@
+Hello, World!

--- a/utils/build/docker/cpp/nginx/nginx.conf
+++ b/utils/build/docker/cpp/nginx/nginx.conf
@@ -1,0 +1,26 @@
+load_module modules/ngx_http_datadog_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    datadog_trace_locations off;
+
+    server {
+        listen       7777;
+        server_name  0.0.0.0;
+
+        # `return` directives are not traced
+        # See, <https://github.com/DataDog/nginx-datadog/issues/58>
+        location ~* /sample_rate/([0-9]+) {
+          root /builds;
+          try_files /hello.html =404;
+        }
+
+        location / {
+          root /builds;
+          try_files /hello.html =404;
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Given that `dd-opentracing-cpp` is no longer actively developed, transitioning to dd-trace-cpp would be advantageous. As `nginx-datadog` relies on `dd-trace-cpp` internally and now supports several features and bug fixes that were previously marked as missing, this switch would ensure better compatibility and support for the current and future needs.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
