### PR TITLE
(asm) Add system test for collecting header by default in ASM

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -198,6 +198,7 @@ tests/:
     test_traces.py:
       Test_AppSecEventSpanTags: v1.29.0
       Test_AppSecObfuscator: v2.7.0
+      Test_CollectDefaultRequestHeader: missing_feature
       Test_CollectRespondHeaders: v2.5.1
       Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -310,6 +310,9 @@ tests/:
         '*': v1.36.0
         gin: v1.37.0
       Test_AppSecObfuscator: v1.38.0
+      Test_CollectDefaultRequestHeader:
+        '*': v1.36.2
+        gin: v1.37.0
       Test_CollectRespondHeaders:
         '*': v1.36.2
         gin: v1.37.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -792,6 +792,7 @@ tests/:
         '*': v0.113.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      Test_CollectDefaultRequestHeader: missing_feature
       Test_CollectRespondHeaders:
         '*': v0.102.0
         akka-http: v1.22.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -297,6 +297,7 @@ tests/:
     test_traces.py:
       Test_AppSecEventSpanTags: v2.0.0
       Test_AppSecObfuscator: v2.6.0
+      Test_CollectDefaultRequestHeader: missing_feature
       Test_CollectRespondHeaders: v2.0.0
       Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: v5.7.0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -170,6 +170,7 @@ tests/:
     test_shell_execution.py:
       Test_ShellExecution: v0.95.0
     test_traces.py:
+      Test_CollectDefaultRequestHeader: missing_feature
       Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: missing_feature
     test_user_blocking_full_denylist.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -423,6 +423,7 @@ tests/:
       Test_AppSecObfuscator:
         '*': v1.5.0rc1.dev
         fastapi: v2.6.0.dev1
+      Test_CollectDefaultRequestHeader: missing_feature
       Test_CollectRespondHeaders:
         '*': v1.4.0rc1.dev
         fastapi: v2.4.0.dev1

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -213,6 +213,7 @@ tests/:
     test_traces.py:
       Test_AppSecEventSpanTags: v0.54.2
       Test_AppSecObfuscator: v1.0.0
+      Test_CollectDefaultRequestHeader: missing_feature
       Test_CollectRespondHeaders: v1.0.0.beta1
       Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: missing_feature

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -323,6 +323,7 @@ class Test_CollectRespondHeaders:
 
         interfaces.library.validate_spans(self.r, validate_response_headers)
 
+
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2186870984/HTTP+header+collection")
 @features.security_events_metadata
 class Test_CollectDefaultRequestHeader:
@@ -330,13 +331,7 @@ class Test_CollectDefaultRequestHeader:
     HEADERS = ["User-Agent", "Accept", "Content-Type"]
 
     def setup_wafs_header_collection(self):
-        self.r = weblog.get(
-            "/headers",
-            headers={
-                header: "myHeaderValue"
-                for header in self.HEADERS
-            },
-        )
+        self.r = weblog.get("/headers", headers={header: "myHeaderValue" for header in self.HEADERS},)
 
     def test_collect_default_request_headers(self):
         """

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -330,7 +330,7 @@ class Test_CollectDefaultRequestHeader:
 
     HEADERS = ["User-Agent", "Accept", "Content-Type"]
 
-    def setup_wafs_header_collection(self):
+    def setup_collect_default_request_headers(self):
         self.r = weblog.get("/headers", headers={header: "myHeaderValue" for header in self.HEADERS},)
 
     def test_collect_default_request_headers(self):


### PR DESCRIPTION
## Motivation

Update in header spec to enforce collecting se headers: https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2186870984/HTTP+header+collection
<!-- What inspired you to submit this pull request? -->

## Changes

Add a test that check that Accept User agent and content-type header are sent in all spans
<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly