### PR TITLE
skip dotnet failures

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
             "module": "pytest",
             "args": ["-p", "no:warnings"],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
         },
         {
             "name": "Replay DEFAULT scenario",
@@ -20,7 +21,8 @@
             "module": "pytest",
             "args": ["-p", "no:warnings", "--replay"],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
         },
         {
             "name": "Run INTEGRATIONS scenario",
@@ -29,7 +31,8 @@
             "module": "pytest",
             "args": ["-S", "INTEGRATIONS", "-p", "no:warnings"],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
         },
         {
             "name": "Run LIBRARY_CONF_CUSTOM_HEADER_TAGS scenario",
@@ -38,7 +41,8 @@
             "module": "pytest",
             "args": ["-S", "LIBRARY_CONF_CUSTOM_HEADER_TAGS", "-p", "no:warnings"],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
         },
         {
             "name": "Run PROFILING scenario",
@@ -47,7 +51,8 @@
             "module": "pytest",
             "args": ["-S", "PROFILING", "-p", "no:warnings"],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
         },
         {
             "name": "Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES scenario",
@@ -56,7 +61,8 @@
             "module": "pytest",
             "args": ["-S", "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES", "-p", "no:warnings"],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
         },
         {
             "name": "Replay REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES scenario",
@@ -65,7 +71,8 @@
             "module": "pytest",
             "args": ["-S", "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES", "-p", "no:warnings", "--replay"],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
         },
         {
             "name": "Replay SAMPLING scenario",
@@ -74,7 +81,8 @@
             "module": "pytest",
             "args": ["-S", "SAMPLING", "-p", "no:warnings", "--replay"],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
         },
         {
             "name": "Run TEST_THE_TEST scenario",
@@ -83,7 +91,8 @@
             "module": "pytest",
             "args": ["-S", "TEST_THE_TEST", "-p", "no:warnings"],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
         },
         {
             "name": "Run GRAPHQL_APPSEC scenario",
@@ -92,7 +101,8 @@
             "module": "pytest",
             "args": ["-S", "GRAPHQL_APPSEC", "-p", "no:warnings"],
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
         },
         {
             "name": "Python: Current File",

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -297,8 +297,8 @@ class Test_Blocking_request_uri:
     def setup_test_blocking_uri_raw(self):
         self.rm_req_uri_raw = weblog.get("/waf/uri_raw_should_not_include_scheme_domain_and_port")
 
-    @bug(library="dotnet", reason="dotnet may include scheme, domain and port in uri.raw")
-    def test_test_blocking_uri_raw(self):
+    @bug(context.library < "dotnet@2.50.0", reason="dotnet may include scheme, domain and port in uri.raw")
+    def test_blocking_uri_raw(self):
         interfaces.library.assert_waf_attack(self.rm_req_uri_raw, rule="tst-037-011")
         assert self.rm_req_uri_raw.status_code == 403
 

--- a/tests/integrations/crossed_integrations/test_rabbitmq.py
+++ b/tests/integrations/crossed_integrations/test_rabbitmq.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 from tests.integrations.crossed_integrations.test_kafka import _java_buddy
-from utils import interfaces, scenarios, weblog, missing_feature, features, flaky, context
+from utils import interfaces, scenarios, weblog, missing_feature, features
 from utils.tools import logger
 
 
@@ -212,7 +212,6 @@ class _Test_RabbitMQ:
 
 @scenarios.crossed_tracing_libraries
 @features.rabbitmq_span_creationcontext_propagation_with_dd_trace
-@flaky(context.library >= "dotnet@2.49.0", reason="Weblog answers 500")
 class Test_RabbitMQ_Trace_Context_Propagation(_Test_RabbitMQ):
     buddy_interface = interfaces.java_buddy
     buddy = _java_buddy

--- a/tests/integrations/crossed_integrations/test_rabbitmq.py
+++ b/tests/integrations/crossed_integrations/test_rabbitmq.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 from tests.integrations.crossed_integrations.test_kafka import _java_buddy
-from utils import interfaces, scenarios, weblog, missing_feature, features
+from utils import interfaces, scenarios, weblog, missing_feature, features, flaky, context
 from utils.tools import logger
 
 
@@ -212,6 +212,7 @@ class _Test_RabbitMQ:
 
 @scenarios.crossed_tracing_libraries
 @features.rabbitmq_span_creationcontext_propagation_with_dd_trace
+@flaky(context.library >= "dotnet@2.49.0", reason="Weblog answers 500")
 class Test_RabbitMQ_Trace_Context_Propagation(_Test_RabbitMQ):
     buddy_interface = interfaces.java_buddy
     buddy = _java_buddy

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -307,12 +307,13 @@ class Test_SamplingDecisions:
                 # Validate the sampling decision
                 trace_id = span["trace_id"]
                 sampling_priority = span["metrics"].get("_sampling_priority_v1")
-                if sampling_priority is None:
-                    raise ValueError(f"Root span of trace_id:{trace_id} has no sampling priority attached")
-                if priority_should_be_kept(sampling_priority) is not sampling_decision:
-                    raise ValueError(
-                        f"Unexpected sampling decision for trace_id:{trace_id}, expected:{sampling_decision}, priority:{sampling_priority}"
-                    )
+                assert (
+                    sampling_priority is not None
+                ), f"Root span of trace_id:{trace_id} has no sampling priority attached"
+                should_be_kept = priority_should_be_kept(sampling_priority)
+                assert (
+                    should_be_kept is sampling_decision
+                ), f"Unexpected sampling decision for trace_id:{trace_id}, expected:{should_be_kept}, priority:{sampling_priority}"
                 break
             else:
                 raise ValueError(f"Did not receive spans for req:{req.request}")

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -301,19 +301,16 @@ class Test_SamplingDecisions:
 
         for req, sampling_decision in self.requests_expected_decision:
             # Ensure the request succeeded, any failure would make the test incorrect.
-            if req.status_code != 200:
-                raise AttributeError(f"Call to /sample_rate_route/:i failed with code: {req.status_code}")
-            for _, _, span in interfaces.library.get_spans(request=req):
+            assert req.status_code == 200, "Call to /sample_rate_route/:i failed"
+
+            for data, _, span in interfaces.library.get_spans(request=req):
                 # Validate the sampling decision
                 trace_id = span["trace_id"]
                 sampling_priority = span["metrics"].get("_sampling_priority_v1")
-                assert (
-                    sampling_priority is not None
-                ), f"Root span of trace_id:{trace_id} has no sampling priority attached"
-                should_be_kept = priority_should_be_kept(sampling_priority)
-                assert (
-                    should_be_kept is sampling_decision
-                ), f"Unexpected sampling decision for trace_id:{trace_id}, expected:{should_be_kept}, priority:{sampling_priority}"
+                logger.info(f"Tring to validate trace_id:{trace_id} from {data['log_filename']}")
+                logger.info(f"Sampling priority: {sampling_priority}")
+                assert sampling_priority is not None, "Root span has no sampling priority attached"
+                assert priority_should_be_kept(sampling_priority) is sampling_decision
                 break
             else:
                 raise ValueError(f"Did not receive spans for req:{req.request}")

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1308,7 +1308,8 @@ class scenarios:
     sampling = EndToEndScenario(
         "SAMPLING",
         tracer_sampling_rate=0.5,
-        doc="Test sampling mechanism. Not included in default scenario because is very slow, and flaky",
+        weblog_env={"DD_TRACE_RATE_LIMIT": "10000000"},
+        doc="Test sampling mechanism. Not included in default scenario because it's a little bit too flaky",
     )
 
     trace_propagation_style_w3c = EndToEndScenario(


### PR DESCRIPTION

## Changes

* ~Mark RabbitMQ test as flaky on dotnet~
* enable xpass blocking_uri_raw on .NET
* Better ouput for test_sample_rate_function
* improve output of test_sample_rate_function
* Fix launch.json

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
