### PR TITLE
solve concurency error that could happen in dotnet rabbit consumer

### DIFF
--- a/utils/build/docker/dotnet/Dependencies/RabbitMQHelper.cs
+++ b/utils/build/docker/dotnet/Dependencies/RabbitMQHelper.cs
@@ -44,7 +44,7 @@ public class RabbitMQHelper : IDisposable
 
     public void CreateQueue(string queue)
     {
-        _channel.QueueDeclare(queue, /*durable=*/true, /*exclusive=*/false, /*autoDelete=*/false, null);
+        _channel.QueueDeclare(queue, durable: true, exclusive: false, autoDelete: false, arguments: null);
         Console.WriteLine($"[rabbitmq] Created queue {queue}");
     }
 

--- a/utils/build/docker/dotnet/Endpoints/MessagingEndpoints.cs
+++ b/utils/build/docker/dotnet/Endpoints/MessagingEndpoints.cs
@@ -114,6 +114,7 @@ public class MessagingEndpoints : ISystemTestEndpoint
     {
         Console.WriteLine("consuming one message from queue " + queue);
         using var helper = new RabbitMQHelper();
+        helper.CreateQueue(queue); // ensure the queue exist in case this starts before the producer
         var completion = new AutoResetEvent(false);
         var received = new List<string>();
         helper.AddListener(queue, msg =>


### PR DESCRIPTION
## Motivation

failure report by @cbeauchesne, showing a 500 error in the consumer
see #2302 as well

## Changes

I think very much that this happens when we subscribe to a non-existing queue. Creating the queue is a noop if it already exists, so we can safely do that in the consumer to ensure it's there.

This is actually what's recommended in the official doc 🫥 https://www.rabbitmq.com/tutorials/tutorial-one-dotnet#receiving

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
