### PR TITLE
K8s Lib Injeciton: Debug failures

### DIFF
--- a/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
+++ b/utils/k8s_lib_injection/k8s_datadog_cluster_agent.py
@@ -256,26 +256,32 @@ class K8sDatadogClusterTestAgent:
         datadog_cluster_name = None
 
         for i in range(20):
-            if datadog_cluster_name is None:
-                pods = self.k8s_wrapper.list_namespaced_pod("default", label_selector="app=datadog-cluster-agent")
-                datadog_cluster_name = pods.items[0].metadata.name if pods and len(pods.items) > 0 else None
-            operator_status = (
-                self.k8s_wrapper.read_namespaced_pod_status(name=datadog_cluster_name) if datadog_cluster_name else None
-            )
-            if (
-                operator_status
-                and operator_status.status.phase == "Running"
-                and operator_status.status.container_statuses[0].ready == True
-            ):
-                self.logger.info(f"[Deploy operator] Operator datadog running!")
-                operator_ready = True
-                break
+            try:
+                if datadog_cluster_name is None:
+                    pods = self.k8s_wrapper.list_namespaced_pod("default", label_selector="app=datadog-cluster-agent")
+                    datadog_cluster_name = pods.items[0].metadata.name if pods and len(pods.items) > 0 else None
+                operator_status = (
+                    self.k8s_wrapper.read_namespaced_pod_status(name=datadog_cluster_name)
+                    if datadog_cluster_name
+                    else None
+                )
+                if (
+                    operator_status
+                    and operator_status.status.phase == "Running"
+                    and operator_status.status.container_statuses[0].ready == True
+                ):
+                    self.logger.info(f"[Deploy operator] Operator datadog running!")
+                    operator_ready = True
+                    break
+            except Exception as e:
+                self.logger.info(f"Error waiting for operator: {e}")
             time.sleep(5)
 
         if not operator_ready:
             self.logger.error("Operator not created. Last status: %s" % operator_status)
-            operator_logs = self.k8s_wrapper.read_namespaced_pod_log(name=datadog_cluster_name)
-            self.logger.error(f"Operator logs: {operator_logs}")
+            if datadog_cluster_name:
+                operator_logs = self.k8s_wrapper.read_namespaced_pod_log(name=datadog_cluster_name)
+                self.logger.error(f"Operator logs: {operator_logs}")
             raise Exception("Operator not created")
         # At this point the operator should be ready, we are going to wait a little bit more
         # to make sure the operator is ready (some times the operator is ready but the cluster agent is not ready yet)


### PR DESCRIPTION
## Motivation
There are some random failures waiting for the operator to be ready.
This PR catch the exception and retry
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
