### PR TITLE
K8s Helm debug and CI largue runners

### DIFF
--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -13,7 +13,8 @@ env:
 
 jobs:
   k8s-lib-injection-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: "APM Larger Runners"
     permissions:
       contents: read
       packages: write

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -95,15 +95,15 @@ def helm_install_chart(
             for key, value in set_dict.items():
                 set_str += f" --set {key}={value}"
 
-        command = f"helm install {name} --wait {set_str} {chart}"
+        command = f"helm install {name} --verbose --wait {set_str} {chart}"
         if upgrade:
-            command = f"helm upgrade {name} --install --wait {set_str} {chart}"
+            command = f"helm upgrade {name} --verbose --install --wait {set_str} {chart}"
         if custom_value_file:
             # command = f"helm install {name} --wait {set_str} -f {value_file} {chart}"
-            command = f"helm install {name} {set_str} -f {custom_value_file} {chart}"
+            command = f"helm install {name} {set_str} --verbose -f {custom_value_file} {chart}"
             if upgrade:
-                command = f"helm upgrade {name} {set_str}  --install -f {custom_value_file} {chart}"
-
+                command = f"helm upgrade {name} {set_str} --verbose --install -f {custom_value_file} {chart}"
+        execute_command("kubectl config current-context")
         execute_command(command, timeout=90)
 
 

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -95,14 +95,14 @@ def helm_install_chart(
             for key, value in set_dict.items():
                 set_str += f" --set {key}={value}"
 
-        command = f"helm install {name} --verbose --wait {set_str} {chart}"
+        command = f"helm install {name} --debug --wait {set_str} {chart}"
         if upgrade:
-            command = f"helm upgrade {name} --verbose --install --wait {set_str} {chart}"
+            command = f"helm upgrade {name} --debug --install --wait {set_str} {chart}"
         if custom_value_file:
             # command = f"helm install {name} --wait {set_str} -f {value_file} {chart}"
-            command = f"helm install {name} {set_str} --verbose -f {custom_value_file} {chart}"
+            command = f"helm install {name} {set_str} --debug -f {custom_value_file} {chart}"
             if upgrade:
-                command = f"helm upgrade {name} {set_str} --verbose --install -f {custom_value_file} {chart}"
+                command = f"helm upgrade {name} {set_str} --debug --install -f {custom_value_file} {chart}"
         execute_command("kubectl config current-context")
         execute_command(command, timeout=90)
 

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -99,7 +99,7 @@ def helm_install_chart(
         if upgrade:
             command = f"helm upgrade {name} --debug --install --wait {set_str} {chart}"
         if custom_value_file:
-            # command = f"helm install {name} --wait {set_str} -f {value_file} {chart}"
+            # command = f"helm install {name} --wait {set_str} -f {value_file} {chart}"#
             command = f"helm install {name} {set_str} --debug -f {custom_value_file} {chart}"
             if upgrade:
                 command = f"helm upgrade {name} {set_str} --debug --install -f {custom_value_file} {chart}"


### PR DESCRIPTION
## Motivation

Run lib injection tests on largue runners.
Add debug options to helm chart

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
