### PR TITLE
Adding a new test case of remote sampling rules.

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -119,11 +119,11 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
+      TestDynamicConfigSamplingRules: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: missing_feature
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
-      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: irrelevant (library does not implement OpenTelemetry)
     test_otel_sdk_interoperability.py: irrelevant (library does not implement OpenTelemetry)
     test_otel_span_methods.py: irrelevant (library does not implement OpenTelemetry)

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -123,6 +123,7 @@ tests/:
       TestDynamicConfigV1: missing_feature
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
+      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: irrelevant (library does not implement OpenTelemetry)
     test_otel_sdk_interoperability.py: irrelevant (library does not implement OpenTelemetry)
     test_otel_span_methods.py: irrelevant (library does not implement OpenTelemetry)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -246,11 +246,11 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
+      TestDynamicConfigSamplingRules: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: v2.33.0
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v2.44.0
-      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -250,6 +250,7 @@ tests/:
       TestDynamicConfigV1: v2.33.0
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v2.44.0
+      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -397,8 +397,8 @@ tests/:
         net-http: missing_feature (Endpoint not implemented)
   parametric/:
     test_dynamic_configuration.py:
-      TestDynamicConfigSamplingRules: v1.63.0
       TestDynamicConfigHeaderTags: missing_feature
+      TestDynamicConfigSamplingRules: v1.63.0
       TestDynamicConfigTracingEnabled: v1.61.0
       TestDynamicConfigV1: v1.59.0
       TestDynamicConfigV1_ServiceTargets: v1.59.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -397,6 +397,7 @@ tests/:
         net-http: missing_feature (Endpoint not implemented)
   parametric/:
     test_dynamic_configuration.py:
+      TestDynamicConfigSamplingRules: v1.63.0
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigTracingEnabled: v1.61.0
       TestDynamicConfigV1: v1.59.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -921,6 +921,7 @@ tests/:
       TestDynamicConfigV1: v1.17.0
       TestDynamicConfigV1_ServiceTargets: v1.31.0
       TestDynamicConfigV2: v1.31.0
+      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -917,11 +917,11 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
+      TestDynamicConfigSamplingRules: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: v1.17.0
       TestDynamicConfigV1_ServiceTargets: v1.31.0
       TestDynamicConfigV2: v1.31.0
-      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -389,6 +389,7 @@ tests/:
       TestDynamicConfigV1: v4.11.0
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v4.23.0
+      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -385,11 +385,11 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
+      TestDynamicConfigSamplingRules: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: v4.11.0
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v4.23.0
-      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -221,11 +221,11 @@ tests/:
       Test_128_Bit_Traceids: v0.84.0
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
+      TestDynamicConfigSamplingRules: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: missing_feature
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
-      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py:
       Test_Otel_API_Interoperability: v0.94.0
     test_otel_sdk_interoperability.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -225,6 +225,7 @@ tests/:
       TestDynamicConfigV1: missing_feature
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
+      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py:
       Test_Otel_API_Interoperability: v0.94.0
     test_otel_sdk_interoperability.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -520,6 +520,7 @@ tests/:
       TestDynamicConfigV1: missing_feature
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v2.8.0.dev
+      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_sampling_delegation.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -516,11 +516,11 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: v2.6.0
+      TestDynamicConfigSamplingRules: missing_feature
       TestDynamicConfigTracingEnabled: v2.6.0
       TestDynamicConfigV1: missing_feature
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v2.8.0.dev
-      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_sampling_delegation.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -297,6 +297,7 @@ tests/:
       TestDynamicConfigV1: v1.13.0
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
+      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_otel_span_methods.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -293,11 +293,11 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
+      TestDynamicConfigSamplingRules: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: v1.13.0
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
-      TestDynamicConfigSamplingRules: missing_feature
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_otel_span_methods.py:

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -6,6 +6,8 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+from ddapm_test_agent.trace import root_span
+
 from utils.parametric.spec.remoteconfig import Capabilities
 from utils.parametric.spec.trace import Span, assert_trace_has_tags
 from utils import context, missing_feature, irrelevant, rfc, scenarios, features
@@ -517,3 +519,109 @@ class TestDynamicConfigV2:
         """Ensure the RC request contains the custom tags capability.
         """
         test_agent.wait_for_rc_capabilities([Capabilities.APM_TRACING_CUSTOM_TAGS])
+
+@scenarios.parametric
+@features.dynamic_configuration
+class TestDynamicConfigSamplingRules:
+    @parametrize("library_env", [{**DEFAULT_ENVVARS}])
+    def test_capability_tracing_sample_rules(self, library_env, test_agent, test_library):
+        """Ensure the RC request contains the trace sampling rules capability.
+        """
+        test_agent.wait_for_rc_capabilities([Capabilities.APM_TRACING_SAMPLE_RULES])
+
+    @parametrize(
+        "library_env",
+        [
+            {
+                **DEFAULT_ENVVARS,
+                "DD_TRACE_SAMPLING_RULES": json.dumps([{"sample_rate": ENV_SAMPLING_RULE_RATE, "service": "*"}]),
+            }
+        ],
+    )
+    def test_trace_sampling_rules_override_env(self, library_env, test_agent, test_library):
+        """The RC sampling rules should override the environment variable and decision maker is set appropriately.
+
+        When RC is unset, the environment variable should be used.
+        """
+        RC_SAMPLING_RULE_RATE_CUSTOMER = 0.8
+        RC_SAMPLING_RULE_RATE_DYNAMIC = 0.1
+        assert RC_SAMPLING_RULE_RATE_CUSTOMER != ENV_SAMPLING_RULE_RATE
+        assert RC_SAMPLING_RULE_RATE_DYNAMIC != ENV_SAMPLING_RULE_RATE
+        assert RC_SAMPLING_RULE_RATE_CUSTOMER != DEFAULT_SAMPLE_RATE
+        assert RC_SAMPLING_RULE_RATE_DYNAMIC != DEFAULT_SAMPLE_RATE
+
+        # Create an initial trace to assert that the rule is correctly applied.
+        trace = send_and_wait_trace(test_library, test_agent, name="env_name")
+        assert_sampling_rate(trace, ENV_SAMPLING_RULE_RATE)
+        # Make sure `_dd.p.dm` is set to "-3" (i.e., local RULE_RATE)
+        span = root_span(trace)
+        assert "_dd.p.dm" in span["meta"]
+        # The "-" is a separating hyphen, not a minus sign.
+        assert span["meta"]["_dd.p.dm"] == "-3"
+
+        # Create a remote config entry with two rules at different sample rates.
+        set_and_wait_rc(test_agent, config_overrides={
+            "tracing_sampling_rules": json.dumps([{"sample_rate": RC_SAMPLING_RULE_RATE_CUSTOMER, "service": TEST_SERVICE, "provenance":"customer"},
+                                                  {"sample_rate": RC_SAMPLING_RULE_RATE_DYNAMIC, "service": "*", "provenance":"dynamic"}])})
+
+        trace = send_and_wait_trace(test_library, test_agent, service=TEST_SERVICE)
+        assert_sampling_rate(trace, RC_SAMPLING_RULE_RATE_CUSTOMER)
+        # Make sure `_dd.p.dm` is set to "-10" (i.e., remote user rule)
+        span = root_span(trace)
+        assert "_dd.p.dm" in span["meta"]
+        assert span["meta"]["_dd.p.dm"] == "-10"
+
+        trace = send_and_wait_trace(test_library, test_agent, service="other_service")
+        assert_sampling_rate(trace, RC_SAMPLING_RULE_RATE_DYNAMIC)
+        # Make sure `_dd.p.dm` is set to "-11" (i.e., remote dynamic rule)
+        span = root_span(trace)
+        assert "_dd.p.dm" in span["meta"]
+        assert span["meta"]["_dd.p.dm"] == "-11"
+
+        # Unset the RC sample rate to ensure the previous setting is reapplied.
+        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rules": None})
+        trace = send_and_wait_trace(test_library, test_agent, service=TEST_SERVICE)
+        assert_sampling_rate(trace, ENV_SAMPLING_RULE_RATE)
+        # Make sure `_dd.p.dm` is restored to "-3"
+        span = root_span(trace)
+        assert "_dd.p.dm" in span["meta"]
+        assert span["meta"]["_dd.p.dm"] k== "-3"
+        
+    @parametrize("library_env", [{**DEFAULT_ENVVARS}])
+    def test_trace_sampling_rules_override_rate(self, library_env, test_agent, test_library):
+        """The RC sampling rules should override the RC sampling rate.
+        """
+        RC_SAMPLING_RULE_RATE_CUSTOMER = 0.8
+        RC_SAMPLING_RATE = 0.1
+        assert RC_SAMPLING_RULE_RATE_CUSTOMER != DEFAULT_SAMPLE_RATE
+        assert RC_SAMPLING_RATE != DEFAULT_SAMPLE_RATE
+
+        # Create an initial trace to assert the default sampling settings.
+        trace = send_and_wait_trace(test_library, test_agent, service=TEST_SERVICE)
+        assert_sampling_rate(trace, DEFAULT_SAMPLE_RATE)
+
+        set_and_wait_rc(test_agent, config_overrides={
+            "tracing_sampling_rate":RC_SAMPLING_RATE,
+            "tracing_sampling_rules": json.dumps([{"sample_rate": RC_SAMPLING_RULE_RATE_CUSTOMER, "service": TEST_SERVICE, "provenance":"customer"}])})
+
+        # trace/span matching the rule gets applied the rule's rate
+        trace = send_and_wait_trace(test_library, test_agent, service=TEST_SERVICE)
+        assert_sampling_rate(trace, RC_SAMPLING_RULE_RATE_CUSTOMER)
+        # Make sure `_dd.p.dm` is set to "-10" (i.e., remote user rule)
+        span = root_span(trace)
+        assert "_dd.p.dm" in span["meta"]
+        assert span["meta"]["_dd.p.dm"] == "-10"
+
+        # trace/span not matching the rule gets applied the RC global rate
+        trace = send_and_wait_trace(test_library, test_agent, service="other_service")
+        assert_sampling_rate(trace, RC_SAMPLING_RATE)
+        # `_dd.p.dm` is set to "-3" (rule rate, this is the legacy behavior)
+        span = root_span(trace)
+        assert "_dd.p.dm" in span["meta"]
+        assert span["meta"]["_dd.p.dm"] == "-3"
+
+        # Unset RC to ensure local settings 
+        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rules": None, "tracing_sampling_rules": None})
+        trace = send_and_wait_trace(test_library, test_agent, service="other_service")
+        assert_sampling_rate(trace, DEFAULT_SAMPLE_RATE)
+

--- a/utils/parametric/spec/remoteconfig.py
+++ b/utils/parametric/spec/remoteconfig.py
@@ -30,6 +30,7 @@ class Capabilities(enum.IntEnum):
     APM_TRACING_HTTP_HEADER_TAGS = 14
     APM_TRACING_CUSTOM_TAGS = 15
     APM_TRACING_ENABLED = 19
+    APM_TRACING_SAMPLE_RULES = 29
 
 
 def human_readable_capabilities(caps: int) -> Tuple[str]:


### PR DESCRIPTION
## Motivation

WIP, sharing for co-programming.

System tests of remote sampling rules: its precedence with regard to other sampling mechanism (local rules/global rate etc), as well as the propagation of `_dd.p.dm` for the remote rules (user provided or dynamically configured).

Ran with and passed with this Go PR:
https://github.com/DataDog/dd-trace-go/pull/2643

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
