### PR TITLE
Improve iast telemetry test easy wins

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -329,7 +329,7 @@ tests/:
           TestParameterValue:
             '*': v1.1.0
             akka-http: v1.12.0
-            jersey-grizzly2: v1.11.0
+            jersey-grizzly2: bug (name field of source not set)
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: v1.11.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -251,7 +251,7 @@ tests/:
           TestCookieValue:
             '*': v1.10.0
             akka-http: v1.12.0
-            jersey-grizzly2: v1.11.0
+            jersey-grizzly2: bug (name field of source not set)
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: v1.11.0
@@ -275,7 +275,7 @@ tests/:
           TestHeaderValue:
             '*': v1.3.0
             akka-http: v1.12.0
-            jersey-grizzly2: v1.11.0
+            jersey-grizzly2: bug (name field of source not set)
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: v1.11.0
@@ -836,7 +836,7 @@ tests/:
         spring-boot: v0.1  # real version not known
         uds-spring-boot: v0.1  # real version not known
     test_debugger_pii.py:
-      Test_Debugger_PII_Redaction:         
+      Test_Debugger_PII_Redaction:
         '*': missing_feature
         spring-boot: v0.1  # real version not known
         uds-spring-boot: v0.1  # real version not known
@@ -880,10 +880,10 @@ tests/:
     test_dbm.py:
       Test_Dbm: missing_feature
     test_dsm.py:
-      Test_DsmContext_Extraction_Base64: 
+      Test_DsmContext_Extraction_Base64:
         "*": irrelevant
         spring-boot: v0.1  # version unknown
-      Test_DsmContext_Injection_Base64: 
+      Test_DsmContext_Injection_Base64:
         "*": irrelevant
         spring-boot: v0.1  # version unknown
       Test_DsmHttp:

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -129,6 +129,12 @@ class BaseSinkTestWithoutTelemetry:
             expected_evidence=self.expected_evidence,
         )
 
+    def check_test_insecure(self):
+        # to avoid false positive, we need to check that iast is implemented
+        # AND that the secure endpoint is not vulnerable
+        interfaces.library.assert_iast_implemented()
+        self.test_insecure()
+
     def setup_secure(self):
 
         # optimize by attaching requests to the class object, to avoid calling it several times. We can't attach them
@@ -149,10 +155,7 @@ class BaseSinkTestWithoutTelemetry:
         self.secure_request = self.__class__.secure_request
 
     def test_secure(self):
-        # to avoid false positive, we need to check that iast is implemented
-        # AND that the secure endpoint is not vulnerable
-        interfaces.library.assert_iast_implemented()
-        self.test_insecure()
+        self.check_test_insecure()
 
         self.assert_no_iast_event(self.secure_request)
 
@@ -169,10 +172,7 @@ class BaseSinkTest(BaseSinkTestWithoutTelemetry):
         self.setup_insecure()
 
     def test_telemetry_metric_instrumented_sink(self):
-        # to avoid false positive, we need to check that iast is implemented
-        # AND that the secure endpoint is not vulnerable
-        interfaces.library.assert_iast_implemented()
-        self.test_insecure()
+        self.check_test_insecure()
 
         _check_telemetry_response_from_agent()
 
@@ -203,10 +203,7 @@ class BaseSinkTest(BaseSinkTestWithoutTelemetry):
         self.setup_insecure()
 
     def test_telemetry_metric_executed_sink(self):
-        # to avoid false positive, we need to check that iast is implemented
-        # AND that the secure endpoint is not vulnerable
-        interfaces.library.assert_iast_implemented()
-        self.test_insecure()
+        self.check_test_insecure()
 
         _check_telemetry_response_from_agent()
 
@@ -261,6 +258,12 @@ class BaseSourceTest:
         for request in self.requests.values():
             self.validate_request_reported(request)
 
+    def check_test_source_reported(self):
+        # to avoid false positive, we need to check that iast is implemented
+        # AND that the secure endpoint is not vulnerable
+        interfaces.library.assert_iast_implemented()
+        self.test_source_reported()
+
     def get_sources(self, request):
         iast = get_iast_event(request=request)
         sources = iast["sources"]
@@ -290,11 +293,7 @@ class BaseSourceTest:
     setup_telemetry_metric_instrumented_source = setup_source_reported
 
     def test_telemetry_metric_instrumented_source(self):
-        # to avoid false positive, we need to check that iast is implemented
-        # AND that the secure endpoint is not vulnerable
-        interfaces.library.assert_iast_implemented()
-
-        test_source_reported(self)
+        self.check_test_source_reported()
 
         _check_telemetry_response_from_agent()
 
@@ -324,11 +323,7 @@ class BaseSourceTest:
     setup_telemetry_metric_executed_source = setup_source_reported
 
     def test_telemetry_metric_executed_source(self):
-        # to avoid false positive, we need to check that iast is implemented
-        # AND that the secure endpoint is not vulnerable
-        interfaces.library.assert_iast_implemented()
-
-        test_source_reported(self)
+        self.check_test_source_reported()
 
         _check_telemetry_response_from_agent()
 

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -259,10 +259,9 @@ class BaseSourceTest:
             self.validate_request_reported(request)
 
     def check_test_source_reported(self):
-        # to avoid false positive, we need to check that iast is implemented
-        # AND that the secure endpoint is not vulnerable
         interfaces.library.assert_iast_implemented()
-        self.test_source_reported()
+        if self.test_source_reported != None:
+            self.test_source_reported()
 
     def get_sources(self, request):
         iast = get_iast_event(request=request)

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -290,6 +290,11 @@ class BaseSourceTest:
     setup_telemetry_metric_instrumented_source = setup_source_reported
 
     def test_telemetry_metric_instrumented_source(self):
+        # to avoid false positive, we need to check that iast is implemented
+        # AND that the secure endpoint is not vulnerable
+        interfaces.library.assert_iast_implemented()
+
+        test_source_reported(self)
 
         _check_telemetry_response_from_agent()
 
@@ -319,6 +324,11 @@ class BaseSourceTest:
     setup_telemetry_metric_executed_source = setup_source_reported
 
     def test_telemetry_metric_executed_source(self):
+        # to avoid false positive, we need to check that iast is implemented
+        # AND that the secure endpoint is not vulnerable
+        interfaces.library.assert_iast_implemented()
+
+        test_source_reported(self)
 
         _check_telemetry_response_from_agent()
 

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -169,6 +169,10 @@ class BaseSinkTest(BaseSinkTestWithoutTelemetry):
         self.setup_insecure()
 
     def test_telemetry_metric_instrumented_sink(self):
+        # to avoid false positive, we need to check that iast is implemented
+        # AND that the secure endpoint is not vulnerable
+        interfaces.library.assert_iast_implemented()
+        self.test_insecure()
 
         _check_telemetry_response_from_agent()
 
@@ -199,6 +203,10 @@ class BaseSinkTest(BaseSinkTestWithoutTelemetry):
         self.setup_insecure()
 
     def test_telemetry_metric_executed_sink(self):
+        # to avoid false positive, we need to check that iast is implemented
+        # AND that the secure endpoint is not vulnerable
+        interfaces.library.assert_iast_implemented()
+        self.test_insecure()
 
         _check_telemetry_response_from_agent()
 

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -131,7 +131,8 @@ class BaseSinkTestWithoutTelemetry:
 
     def check_test_insecure(self):
         # to avoid false positive, we need to check that iast is implemented
-        # AND that the secure endpoint is not vulnerable
+        # AND that the insecure endpoint is vulnerable
+
         interfaces.library.assert_iast_implemented()
         self.test_insecure()
 
@@ -155,6 +156,7 @@ class BaseSinkTestWithoutTelemetry:
         self.secure_request = self.__class__.secure_request
 
     def test_secure(self):
+        # to avoid false positive, we need to check first that the insecure endpoint is vulnerable
         self.check_test_insecure()
 
         self.assert_no_iast_event(self.secure_request)

--- a/tests/appsec/iast/_test_iast_fixtures.py
+++ b/tests/appsec/iast/_test_iast_fixtures.py
@@ -273,7 +273,6 @@ class BaseSourceTest:
                 and method.startswith("test_")
             ):
                 try:
-                    print(method)
                     getattr(self, method)()
                     at_least_one_success = True
                 except Exception as e:

--- a/tests/appsec/iast/source/test_body.py
+++ b/tests/appsec/iast/source/test_body.py
@@ -28,6 +28,7 @@ class TestRequestBody(BaseSourceTest):
     )
     @bug(context.library >= "java@1.13.0" and context.library < "java@1.17.0", reason="Not reported")
     @missing_feature(library="dotnet", reason="Not implemented yet")
+    @missing_feature(library="python", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
@@ -37,5 +38,6 @@ class TestRequestBody(BaseSourceTest):
         reason="Metrics not implemented",
     )
     @missing_feature(library="dotnet", reason="Not implemented yet")
+    @missing_feature(library="python", reason="Not implemented yet")
     def test_telemetry_metric_executed_source(self):
         super().test_telemetry_metric_executed_source()

--- a/tests/appsec/iast/source/test_cookie_value.py
+++ b/tests/appsec/iast/source/test_cookie_value.py
@@ -16,11 +16,6 @@ class TestCookieValue(BaseSourceTest):
     source_names = ["table"]
     source_value = "user"
 
-    @bug(context.weblog_variant == "jersey-grizzly2", reason="name field of source not set")
-    def test_source_reported(self):
-        super().test_source_reported()
-
-    @bug(context.weblog_variant == "jersey-grizzly2", reason="name field of source not set")
     @missing_feature(library="dotnet", reason="Not implemented")
     @missing_feature(context.library < "java@1.17.0", reason="Metrics not implemented")
     @missing_feature(
@@ -30,7 +25,6 @@ class TestCookieValue(BaseSourceTest):
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
-    @bug(context.weblog_variant == "jersey-grizzly2", reason="name field of source not set")
     @missing_feature(context.library < "java@1.17.0", reason="Metrics not implemented")
     @missing_feature(
         context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,

--- a/tests/appsec/iast/source/test_cookie_value.py
+++ b/tests/appsec/iast/source/test_cookie_value.py
@@ -20,6 +20,7 @@ class TestCookieValue(BaseSourceTest):
     def test_source_reported(self):
         super().test_source_reported()
 
+    @bug(context.weblog_variant == "jersey-grizzly2", reason="name field of source not set")
     @missing_feature(library="dotnet", reason="Not implemented")
     @missing_feature(context.library < "java@1.17.0", reason="Metrics not implemented")
     @missing_feature(
@@ -29,6 +30,7 @@ class TestCookieValue(BaseSourceTest):
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
+    @bug(context.weblog_variant == "jersey-grizzly2", reason="name field of source not set")
     @missing_feature(context.library < "java@1.17.0", reason="Metrics not implemented")
     @missing_feature(
         context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,

--- a/tests/appsec/iast/source/test_header_value.py
+++ b/tests/appsec/iast/source/test_header_value.py
@@ -19,11 +19,6 @@ class TestHeaderValue(BaseSourceTest):
     source_type = "http.request.header"
     source_value = "user"
 
-    @bug(context.weblog_variant == "jersey-grizzly2", reason="name field of source not set")
-    def test_source_reported(self):
-        super().test_source_reported()
-
-    @bug(context.weblog_variant == "jersey-grizzly2", reason="name field of source not set")
     @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
     @missing_feature(
         context.library.library == "java" and "spring-boot" not in context.weblog_variant,
@@ -33,7 +28,6 @@ class TestHeaderValue(BaseSourceTest):
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
-    @bug(context.weblog_variant == "jersey-grizzly2", reason="name field of source not set")
     @missing_feature(context.library < "java@1.16.0", reason="Metrics not implemented")
     @missing_feature(
         context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,

--- a/tests/appsec/iast/source/test_header_value.py
+++ b/tests/appsec/iast/source/test_header_value.py
@@ -23,6 +23,7 @@ class TestHeaderValue(BaseSourceTest):
     def test_source_reported(self):
         super().test_source_reported()
 
+    @bug(context.weblog_variant == "jersey-grizzly2", reason="name field of source not set")
     @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")
     @missing_feature(
         context.library.library == "java" and "spring-boot" not in context.weblog_variant,
@@ -32,6 +33,7 @@ class TestHeaderValue(BaseSourceTest):
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
+    @bug(context.weblog_variant == "jersey-grizzly2", reason="name field of source not set")
     @missing_feature(context.library < "java@1.16.0", reason="Metrics not implemented")
     @missing_feature(
         context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,

--- a/tests/appsec/iast/source/test_parameter_value.py
+++ b/tests/appsec/iast/source/test_parameter_value.py
@@ -40,6 +40,7 @@ class TestParameterValue(BaseSourceTest):
     def test_source_get_reported(self):
         self.validate_request_reported(self.requests["GET"], source_type="http.request.parameter")
 
+    @bug(weblog_variant="jersey-grizzly2", reason="name field of source not set")
     @missing_feature(context.library < "java@1.9.0", reason="Not implemented")
     @missing_feature(
         context.library == "java" and not context.weblog_variant.startswith("spring-boot"), reason="Not implemented"
@@ -52,6 +53,7 @@ class TestParameterValue(BaseSourceTest):
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
+    @bug(weblog_variant="jersey-grizzly2", reason="name field of source not set")
     @missing_feature(context.library < "java@1.11.0", reason="Not implemented")
     @missing_feature(
         context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,

--- a/tests/appsec/iast/source/test_parameter_value.py
+++ b/tests/appsec/iast/source/test_parameter_value.py
@@ -29,18 +29,15 @@ class TestParameterValue(BaseSourceTest):
 
     setup_source_post_reported = BaseSourceTest.setup_source_reported
 
-    @bug(weblog_variant="jersey-grizzly2", reason="name field of source not set")
     @bug(library="python", reason="Python frameworks need a header, if not, 415 status code")
     def test_source_post_reported(self):
         self.validate_request_reported(self.requests["POST"])
 
     setup_source_get_reported = BaseSourceTest.setup_source_reported
 
-    @bug(weblog_variant="jersey-grizzly2", reason="name field of source not set")
     def test_source_get_reported(self):
         self.validate_request_reported(self.requests["GET"], source_type="http.request.parameter")
 
-    @bug(weblog_variant="jersey-grizzly2", reason="name field of source not set")
     @missing_feature(context.library < "java@1.9.0", reason="Not implemented")
     @missing_feature(
         context.library == "java" and not context.weblog_variant.startswith("spring-boot"), reason="Not implemented"
@@ -53,7 +50,6 @@ class TestParameterValue(BaseSourceTest):
     def test_telemetry_metric_instrumented_source(self):
         super().test_telemetry_metric_instrumented_source()
 
-    @bug(weblog_variant="jersey-grizzly2", reason="name field of source not set")
     @missing_feature(context.library < "java@1.11.0", reason="Not implemented")
     @missing_feature(
         context.library < "java@1.22.0" and "spring-boot" not in context.weblog_variant,


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Reduce XPASS related with IAST metrics. Improve our false positives in easy wins.

## Changes

<!-- A brief description of the change being made with this pull request. -->
Same approach that was implemented to reduce the easy wins related with secure endpoints in iast test, now for metrics. Metrics tests don't matter if the feature is not implemented.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
