### PR TITLE
Use python3 rather than specific minor version (python3.9)

### DIFF
--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -137,7 +137,7 @@ build() {
               if [ ! -d "venv/" ]
               then
                   echo "Build virtual env"
-                  python3.9 -m venv venv
+                  python3 -m venv venv
               fi
 
               source venv/bin/activate


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

On current datadog ubuntu machines the python version is 3.10, not 3.9. Thus python3.9 binary is missing.

## Changes

This PR changes python3.9 reference to just python3.

If a minimum version of 3.9 is required I can add a check for this.

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
