### PR TITLE
[Debugger] Temporary disable debugger tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -207,12 +207,12 @@ tests/:
       Test_UserBlocking_FullDenylist: v2.30.0
   debugger/:
     test_debugger.py:
-      Test_Debugger_Line_Probe_Snaphots: v2.33.0
-      Test_Debugger_Method_Probe_Snaphots: v2.33.0
-      Test_Debugger_Mix_Log_Probe: v2.33.0
-      Test_Debugger_Probe_Statuses: v2.33.0
+      Test_Debugger_Line_Probe_Snaphots: bug (statuses are not reported well)
+      Test_Debugger_Method_Probe_Snaphots: bug (statuses are not reported well)
+      Test_Debugger_Mix_Log_Probe: bug (statuses are not reported well)
+      Test_Debugger_Probe_Statuses: bug (statuses are not reported well)
     test_debugger_pii.py:
-      Test_Debugger_PII_Redaction: v2.33.0
+      Test_Debugger_PII_Redaction: bug (statuses are not reported well)
   integrations/:
     crossed_integrations/:
       test_kafka.py:


### PR DESCRIPTION
## Motivation
Debugger tests for dev are currently failing because of the bug.

## Changes
Temporary disable debugger tests