### PR TITLE
Skip python on failing tests on paramatric scenario

### DIFF
--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -6,7 +6,8 @@ from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
 from utils.parametric.spec.trace import span_has_no_parent
 from utils.parametric.headers import make_single_request_and_get_inject_headers
 from utils.parametric.test_agent import get_span
-from utils import missing_feature, context, scenarios, features
+from utils import missing_feature, context, scenarios, features, bug
+from utils.tools import logger
 
 parametrize = pytest.mark.parametrize
 
@@ -76,6 +77,7 @@ class Test_Headers_B3:
 
     @enable_b3()
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @bug(context.library >= "python@2.8.0", reason="Unknown")
     def test_headers_b3_inject_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are injected properly.
         """
@@ -84,6 +86,7 @@ class Test_Headers_B3:
 
         span = get_span(test_agent)
         b3Arr = headers["b3"].split("-")
+        logger.info(f"b3 header is {headers['b3']}")
         b3_trace_id = b3Arr[0]
         b3_span_id = b3Arr[1]
         b3_sampling = b3Arr[2]

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -6,7 +6,7 @@ from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
 from utils.parametric.spec.trace import span_has_no_parent
 from utils.parametric.headers import make_single_request_and_get_inject_headers
 from utils.parametric.test_agent import get_span
-from utils import missing_feature, irrelevant, context, scenarios, features
+from utils import missing_feature, irrelevant, context, scenarios, features, bug
 
 parametrize = pytest.mark.parametrize
 
@@ -87,6 +87,7 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi()
+    @bug(context.library >= "python@2.8.0", reason="Unknown")
     def test_headers_b3multi_inject_valid(self, test_agent, test_library):
         """Ensure that b3multi distributed tracing headers are injected properly.
         """

--- a/tests/parametric/test_headers_datadog.py
+++ b/tests/parametric/test_headers_datadog.py
@@ -2,7 +2,7 @@ from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
 from utils.parametric.spec.trace import span_has_no_parent
 from utils.parametric.headers import make_single_request_and_get_inject_headers
 from utils.parametric.test_agent import get_span
-from utils import features, scenarios
+from utils import features, scenarios, bug, context
 
 
 @features.datadog_headers_propagation
@@ -55,6 +55,7 @@ class Test_Headers_Datadog:
         assert span["meta"].get("_dd.p.dm") != "-4"
         assert span["metrics"].get(SAMPLING_PRIORITY_KEY) != 2
 
+    @bug(context.library >= "python@2.8.0", reason="Unknown")
     def test_distributed_headers_inject_datadog_D003(self, test_agent, test_library):
         """Ensure that Datadog distributed tracing headers are injected properly.
         """
@@ -89,6 +90,7 @@ class Test_Headers_Datadog:
         assert headers["x-datadog-origin"] == "synthetics"
         assert "_dd.p.dm=-4" in headers["x-datadog-tags"]
 
+    @bug(context.library >= "python@2.8.0", reason="Unknown")
     def test_distributed_headers_extractandinject_datadog_invalid_D005(self, test_agent, test_library):
         """Ensure that invalid Datadog distributed tracing headers are not extracted
         and the new span context is injected properly.

--- a/tests/parametric/test_headers_none.py
+++ b/tests/parametric/test_headers_none.py
@@ -5,7 +5,7 @@ import pytest
 from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
 from utils.parametric.headers import make_single_request_and_get_inject_headers
 from utils.parametric.test_agent import get_span
-from utils import missing_feature, context, scenarios, features
+from utils import missing_feature, context, scenarios, features, bug
 
 parametrize = pytest.mark.parametrize
 
@@ -101,6 +101,7 @@ class Test_Headers_None:
         assert "x-datadog-tags" not in headers
 
     @enable_none_invalid()
+    @bug(context.library >= "python@2.8.0", reason="Unknown")
     def test_headers_none_inject_with_other_propagators(self, test_agent, test_library):
         """Ensure that the 'none' propagator is ignored when other propagators are present.
         In this case, ensure that the Datadog distributed tracing headers are injected properly.

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -101,6 +101,7 @@ class Test_Headers_Precedence:
         self.test_headers_precedence_propagationstyle_datadog(test_agent, test_library)
 
     @enable_datadog()
+    @bug(context.library >= "python@2.8.0", reason="Unknown")
     def test_headers_precedence_propagationstyle_datadog(self, test_agent, test_library):
         with test_library:
             # 1) No headers
@@ -227,6 +228,7 @@ class Test_Headers_Precedence:
         self.test_headers_precedence_propagationstyle_tracecontext_datadog(test_agent, test_library)
 
     @enable_tracecontext_datadog()
+    @bug(context.library >= "python@2.8.0", reason="Unknown")
     def test_headers_precedence_propagationstyle_tracecontext_datadog(self, test_agent, test_library):
         with test_library:
             # 1) No headers
@@ -500,6 +502,7 @@ class Test_Headers_Precedence:
         self.test_headers_precedence_propagationstyle_datadog_tracecontext(test_agent, test_library)
 
     @enable_datadog_tracecontext()
+    @bug(context.library >= "python@2.8.0", reason="Unknown")
     def test_headers_precedence_propagationstyle_datadog_tracecontext(self, test_agent, test_library):
         with test_library:
             # 1) No headers


### PR DESCRIPTION
## Motivation

No failing test

## Changes

Per title

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
