### PR TITLE
Run ruby docker mode iif lint and tests are ok

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
       build_proxy_image: ${{ contains(github.event.pull_request.labels.*.name, 'build-proxy-image') }}
       build_lib_injection_app_images: ${{ contains(github.event.pull_request.labels.*.name, 'build-lib-injection-app-images') }}
 
+  system_tests_docker_mode:
+    needs:
+    - lint
+    - test_the_test
+    uses: ./.github/workflows/run-docker-mode.yml
+    secrets: inherit
+
   update-CI-visibility:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/run-docker-mode.yml
+++ b/.github/workflows/run-docker-mode.yml
@@ -1,12 +1,7 @@
 name: System Tests (docker mode)
 
 on:
-  push:
-    branches:
-      - "**"
-  workflow_dispatch: {}
-  schedule:
-    - cron:  '00 03 * * 2-6'
+  workflow_call:
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Motivation

* Help users to see the issue when test the test, or lint job fails
* do not run unecessarelly CIs

## Changes

Run ruby docker mode IIF test the test and lint are ok 

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
