### PR TITLE
DD_APPSEC_SCA_ENABLED env var test

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -124,6 +124,7 @@ tests/:
     test_span_links.py: missing_feature
     test_telemetry.py:
       Test_TelemetryInstallSignature: missing_feature
+      Test_TelemetrySCAEnvVar: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Globs_Feb2024_Revision: bug (implementation is case-sensitive)
     test_tracer.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -258,6 +258,7 @@ tests/:
       Test_Defaults: missing_feature
       Test_Environment: missing_feature
       Test_TelemetryInstallSignature: v2.45.0
+      Test_TelemetrySCAEnvVar: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: missing_feature
       Test_Trace_Sampling_Globs: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -410,6 +410,7 @@ tests/:
       Test_Defaults: missing_feature
       Test_Environment: missing_feature
       Test_TelemetryInstallSignature: missing_feature
+      Test_TelemetrySCAEnvVar: v1.63.0
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.37.0 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: v1.60.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -410,7 +410,7 @@ tests/:
       Test_Defaults: missing_feature
       Test_Environment: missing_feature
       Test_TelemetryInstallSignature: missing_feature
-      Test_TelemetrySCAEnvVar: v1.63.0
+      Test_TelemetrySCAEnvVar: v1.63.0-rc.1
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.37.0 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: v1.60.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -929,6 +929,7 @@ tests/:
       Test_Defaults: missing_feature
       Test_Environment: missing_feature
       Test_TelemetryInstallSignature: v1.27.0
+      Test_TelemetrySCAEnvVar: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.111.0
       Test_Trace_Sampling_Globs: v1.25.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -397,6 +397,7 @@ tests/:
       Test_Defaults: v5.6.0
       Test_Environment: v5.6.0
       Test_TelemetryInstallSignature: v4.23.0
+      Test_TelemetrySCAEnvVar: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: missing_feature
       Test_Trace_Sampling_Globs: missing_feature

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -247,6 +247,7 @@ tests/:
       Test_Defaults: missing_feature
       Test_Environment: missing_feature
       Test_TelemetryInstallSignature: missing_feature
+      Test_TelemetrySCAEnvVar: v0.99.0
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.68.3 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: v0.96.0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -247,7 +247,7 @@ tests/:
       Test_Defaults: missing_feature
       Test_Environment: missing_feature
       Test_TelemetryInstallSignature: missing_feature
-      Test_TelemetrySCAEnvVar: v0.99.0
+      Test_TelemetrySCAEnvVar: missing_feature  # should be: v0.99.0
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v0.68.3 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: v0.96.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -535,6 +535,7 @@ tests/:
       Test_Defaults: missing_feature
       Test_Environment: missing_feature
       Test_TelemetryInstallSignature: v2.5.0
+      Test_TelemetrySCAEnvVar: v2.9.0.dev
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.9.0 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: v2.8.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -315,6 +315,7 @@ tests/:
       Test_Defaults: missing_feature
       Test_Environment: missing_feature
       Test_TelemetryInstallSignature: missing_feature
+      Test_TelemetrySCAEnvVar: missing_feature
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.0.0 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: missing_feature

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -304,6 +304,10 @@ class Test_TelemetrySCAEnvVar:
             assert cfg_appsec_enabled is not None, "Missing telemetry config item for '{}'".format(
                 DD_APPSEC_SCA_ENABLED
             )
+
+            if context.library in ("golang", "jvm", "dotnet"):
+                outcome_value = True if outcome_value == "true" else False
+
             assert cfg_appsec_enabled.get("value") == outcome_value
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -293,7 +293,7 @@ class Test_TelemetrySCAEnvVar:
         DD_APPSEC_SCA_ENABLED = "DD_APPSEC_SCA_ENABLED"
         if library in ("java", "nodejs"):
             DD_APPSEC_SCA_ENABLED = "appsec.sca.enabled"
-        elif library == "php":
+        elif library in ("php", "ruby"):
             DD_APPSEC_SCA_ENABLED = "appsec.sca_enabled"
         return DD_APPSEC_SCA_ENABLED
 
@@ -316,7 +316,7 @@ class Test_TelemetrySCAEnvVar:
         cfg_appsec_enabled = configuration_by_name.get(DD_APPSEC_SCA_ENABLED)
         assert cfg_appsec_enabled is not None, "Missing telemetry config item for '{}'".format(DD_APPSEC_SCA_ENABLED)
 
-        if context.library in ("golang", "java", "dotnet", "nodejs"):
+        if context.library in ("golang", "java", "dotnet", "nodejs", "ruby"):
             outcome_value = True if outcome_value == "true" else False
 
         assert cfg_appsec_enabled.get("value") == outcome_value

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -291,7 +291,7 @@ class Test_TelemetrySCAEnvVar:
     @staticmethod
     def get_dd_appsec_sca_enabled_str(library):
         DD_APPSEC_SCA_ENABLED = "DD_APPSEC_SCA_ENABLED"
-        if library in ("dotnet", "java", "nodejs"):
+        if library in ("java", "nodejs"):
             DD_APPSEC_SCA_ENABLED = "appsec.sca.enabled"
         elif library == "php":
             DD_APPSEC_SCA_ENABLED = "appsec.sca_enabled"

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -265,7 +265,7 @@ class Test_TelemetrySCAEnvVar:
     """
 
     @pytest.mark.parametrize(
-        "env_vars, outcome_value",
+        "library_env, outcome_value",
         [
             ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "true",}, "true"),
             ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "True",}, "true"),
@@ -275,7 +275,7 @@ class Test_TelemetrySCAEnvVar:
             ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "0",}, "false"),
         ],
     )
-    def test_telemetry_sca_enabled_propagated(self, env_vars, outcome_value, test_agent, test_library):
+    def test_telemetry_sca_enabled_propagated(self, library_env, outcome_value, test_agent, test_library):
         with test_library.start_span("first_span"):
             pass
 
@@ -292,8 +292,8 @@ class Test_TelemetrySCAEnvVar:
 
             assert body["payload"]["configuration"]["DD_APPSEC_SCA_ENABLED"] == outcome_value
 
-    @pytest.mark.parametrize("env_vars, outcome_value", [{**DEFAULT_ENVVARS}])
-    def test_telemetry_sca_enabled_not_propagated(self, env_vars, test_agent, test_library):
+    @pytest.mark.parametrize("library_env, outcome_value", [{**DEFAULT_ENVVARS}])
+    def test_telemetry_sca_enabled_not_propagated(self, library_env, test_agent, test_library):
         with test_library.start_span("first_span"):
             pass
 

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -265,7 +265,7 @@ class Test_TelemetrySCAEnvVar:
     """
 
     @staticmethod
-    def get_app_started_configuration_by_name(library_env, test_agent, test_library):
+    def get_app_started_configuration_by_name(test_agent, test_library):
         with test_library.start_span("first_span"):
             pass
 
@@ -291,7 +291,9 @@ class Test_TelemetrySCAEnvVar:
     @staticmethod
     def get_dd_appsec_sca_enabled_str(library):
         DD_APPSEC_SCA_ENABLED = "DD_APPSEC_SCA_ENABLED"
-        if library in ("java", "nodejs"):
+        if library == "java":
+            DD_APPSEC_SCA_ENABLED = "appsec_sca_enabled"
+        elif library == "nodejs":
             DD_APPSEC_SCA_ENABLED = "appsec.sca.enabled"
         elif library in ("php", "ruby"):
             DD_APPSEC_SCA_ENABLED = "appsec.sca_enabled"
@@ -301,10 +303,10 @@ class Test_TelemetrySCAEnvVar:
         "library_env, specific_libraries_support, outcome_value",
         [
             ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "true",}, False, "true"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "True",}, False, "true"),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "True",}, ("python", "golang"), "true"),
             ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "1",}, ("python", "golang"), "true"),
             ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "false",}, False, "false"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "False",}, False, "false"),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "False",}, ("python", "golang"), "false"),
             ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "0",}, ("python", "golang"), "false"),
         ],
     )
@@ -314,22 +316,29 @@ class Test_TelemetrySCAEnvVar:
         if specific_libraries_support and context.library not in specific_libraries_support:
             pytest.skip(f"unsupported value for {context.library}")
 
-        configuration_by_name = self.get_app_started_configuration_by_name(library_env, test_agent, test_library)
+        configuration_by_name = self.get_app_started_configuration_by_name(test_agent, test_library)
 
         DD_APPSEC_SCA_ENABLED = self.get_dd_appsec_sca_enabled_str(context.library)
 
         cfg_appsec_enabled = configuration_by_name.get(DD_APPSEC_SCA_ENABLED)
         assert cfg_appsec_enabled is not None, "Missing telemetry config item for '{}'".format(DD_APPSEC_SCA_ENABLED)
 
-        if context.library in ("golang", "java", "dotnet", "nodejs", "ruby"):
+        if context.library in ("golang", "dotnet", "nodejs", "ruby"):
             outcome_value = True if outcome_value == "true" else False
 
         assert cfg_appsec_enabled.get("value") == outcome_value
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
     def test_telemetry_sca_enabled_not_propagated(self, library_env, test_agent, test_library):
-        configuration_by_name = self.get_app_started_configuration_by_name(library_env, test_agent, test_library)
+        configuration_by_name = self.get_app_started_configuration_by_name(test_agent, test_library)
 
         DD_APPSEC_SCA_ENABLED = self.get_dd_appsec_sca_enabled_str(context.library)
 
-        assert DD_APPSEC_SCA_ENABLED not in configuration_by_name.keys()
+        if context.library == "java":
+            cfg_appsec_enabled = configuration_by_name.get(DD_APPSEC_SCA_ENABLED)
+            assert cfg_appsec_enabled is not None, "Missing telemetry config item for '{}'".format(
+                DD_APPSEC_SCA_ENABLED
+            )
+            assert cfg_appsec_enabled.get("value") is None
+        else:
+            assert DD_APPSEC_SCA_ENABLED not in configuration_by_name.keys()

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -301,7 +301,9 @@ class Test_TelemetrySCAEnvVar:
                 DD_APPSEC_SCA_ENABLED = "appsec.sca_enabled"
 
             cfg_appsec_enabled = configuration_by_name.get(DD_APPSEC_SCA_ENABLED)
-            assert cfg_appsec_enabled is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
+            assert cfg_appsec_enabled is not None, "Missing telemetry config item for '{}'".format(
+                DD_APPSEC_SCA_ENABLED
+            )
             assert cfg_appsec_enabled.get("value") == outcome_value
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -290,7 +290,19 @@ class Test_TelemetrySCAEnvVar:
                 "configuration" in body["payload"]
             ), "The configuration should be included in the telemetry event, got {}".format(body)
 
-            assert body["payload"]["configuration"]["DD_APPSEC_SCA_ENABLED"] == outcome_value
+            configuration = body["payload"]["configuration"]
+
+            configuration_by_name = {item["name"]: item for item in configuration}
+
+            DD_APPSEC_SCA_ENABLED = "DD_APPSEC_SCA_ENABLED"
+            if context.library in ("dotnet", "jvm", "nodejs"):
+                DD_APPSEC_SCA_ENABLED = "appsec.sca.enabled"
+            elif context.library == "php":
+                DD_APPSEC_SCA_ENABLED = "appsec.sca_enabled"
+
+            cfg_appsec_enabled = configuration_by_name.get(DD_APPSEC_SCA_ENABLED)
+            assert cfg_appsec_enabled is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
+            assert cfg_appsec_enabled.get("value") == outcome_value
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
     def test_telemetry_sca_enabled_not_propagated(self, library_env, test_agent, test_library):
@@ -308,4 +320,14 @@ class Test_TelemetrySCAEnvVar:
                 "configuration" in body["payload"]
             ), "The configuration should be included in the telemetry event, got {}".format(body)
 
-            assert "DD_APPSEC_SCA_ENABLED" not in body["payload"]["configuration"].keys()
+            configuration = body["payload"]["configuration"]
+
+            configuration_by_name = {item["name"]: item for item in configuration}
+
+            DD_APPSEC_SCA_ENABLED = "DD_APPSEC_SCA_ENABLED"
+            if context.library in ("dotnet", "jvm", "nodejs"):
+                DD_APPSEC_SCA_ENABLED = "appsec.sca.enabled"
+            elif context.library == "php":
+                DD_APPSEC_SCA_ENABLED = "appsec.sca_enabled"
+
+            assert DD_APPSEC_SCA_ENABLED not in configuration_by_name.keys()

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -316,7 +316,7 @@ class Test_TelemetrySCAEnvVar:
         cfg_appsec_enabled = configuration_by_name.get(DD_APPSEC_SCA_ENABLED)
         assert cfg_appsec_enabled is not None, "Missing telemetry config item for '{}'".format(DD_APPSEC_SCA_ENABLED)
 
-        if context.library in ("golang", "java", "dotnet"):
+        if context.library in ("golang", "java", "dotnet", "nodejs"):
             outcome_value = True if outcome_value == "true" else False
 
         assert cfg_appsec_enabled.get("value") == outcome_value

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -292,7 +292,7 @@ class Test_TelemetrySCAEnvVar:
 
             assert body["payload"]["configuration"]["DD_APPSEC_SCA_ENABLED"] == outcome_value
 
-    @pytest.mark.parametrize("library_env, outcome_value", [{**DEFAULT_ENVVARS}])
+    @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
     def test_telemetry_sca_enabled_not_propagated(self, library_env, test_agent, test_library):
         with test_library.start_span("first_span"):
             pass

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -298,17 +298,22 @@ class Test_TelemetrySCAEnvVar:
         return DD_APPSEC_SCA_ENABLED
 
     @pytest.mark.parametrize(
-        "library_env, outcome_value",
+        "library_env, specific_libraries_support, outcome_value",
         [
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "true",}, "true"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "True",}, "true"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "1",}, "true"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "false",}, "false"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "False",}, "false"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "0",}, "false"),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "true",}, False, "true"),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "True",}, False, "true"),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "1",}, ("python", "golang"), "true"),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "false",}, False, "false"),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "False",}, False, "false"),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "0",}, ("python", "golang"), "false"),
         ],
     )
-    def test_telemetry_sca_enabled_propagated(self, library_env, outcome_value, test_agent, test_library):
+    def test_telemetry_sca_enabled_propagated(
+        self, library_env, specific_libraries_support, outcome_value, test_agent, test_library
+    ):
+        if specific_libraries_support and context.library not in specific_libraries_support:
+            pytest.skip(f"unsupported value for {context.library}")
+
         configuration_by_name = self.get_app_started_configuration_by_name(library_env, test_agent, test_library)
 
         DD_APPSEC_SCA_ENABLED = self.get_dd_appsec_sca_enabled_str(context.library)


### PR DESCRIPTION
## Motivation

This PR enables the check for `DD_APPSEC_SCA_ENABLED` env variable. This variable and it's value is sent through telemetry if set, otherwise it's not sent.

See RFC: https://docs.google.com/document/d/1xTLC3UEGNooZS0YOYp3swMlAhtvVn1aa639TGxHHYvg/edit

Jira: APPSEC-52424

## Changes

Two more parametric tests for the app-started event, one with the variable set, other with it unset.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
