### PR TITLE
Enable more telemetry tests in Java and split metrics test cases

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1019,8 +1019,12 @@ tests/:
     Test_MessageBatch:
       '*': v1.23.0
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-    Test_Metric_Generation_Disabled: missing_feature
-    Test_Metric_Generation_Enabled: missing_feature
+    Test_Metric_Generation_Disabled:
+      '*': v1.23.0
+      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+    Test_Metric_Generation_Enabled:
+      '*': v1.23.0
+      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     Test_ProductsDisabled:
       '*': missing_feature
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -705,35 +705,65 @@ class Test_Metric_Generation_Enabled:
         logger.debug("Wait complete")
 
     def test_metric_generation_enabled(self):
-        self.assert_general_metrics()
-        self.assert_tracer_metrics()
-        self.assert_telemetry_metrics()
+        found = False
+        for data in interfaces.library.get_telemetry_data():
+            content = data["request"]["content"]
+            if content.get("request_type") != "generate-metrics":
+                continue
+            if content["payload"]["series"]:
+                found = True
+                break
+        assert found, "No metrics found in telemetry data"
 
-    def assert_general_metrics(self):
-        namespace = "general"
-        self.assert_count_metric(namespace, "logs_created", expect_at_least=1)
+    @missing_feature(library="java", reason="Not implemented")
+    def test_metric_general_logs_created(self):
+        self.assert_count_metric("general", "logs_created", expect_at_least=1)
 
-    def assert_tracer_metrics(self):
-        namespace = "tracers"
-        self.assert_count_metric(namespace, "spans_created", expect_at_least=1)
-        self.assert_count_metric(namespace, "spans_finished", expect_at_least=1)
-        self.assert_count_metric(namespace, "spans_enqueued_for_serialization", expect_at_least=1)
-        self.assert_count_metric(namespace, "trace_segments_created", expect_at_least=1)
-        self.assert_count_metric(namespace, "trace_chunks_enqueued_for_serialization", expect_at_least=1)
-        self.assert_count_metric(namespace, "trace_chunks_sent", expect_at_least=1)
-        self.assert_count_metric(namespace, "trace_segments_closed", expect_at_least=1)
-        self.assert_count_metric(namespace, "trace_api.requests", expect_at_least=1)
-        self.assert_count_metric(namespace, "trace_api.responses", expect_at_least=1)
+    def test_metric_tracers_spans_created(self):
+        self.assert_count_metric("tracers", "spans_created", expect_at_least=1)
 
-    def assert_telemetry_metrics(self):
-        namespace = "telemetry"
-        self.assert_count_metric(namespace, "telemetry_api.requests", expect_at_least=1)
-        self.assert_count_metric(namespace, "telemetry_api.responses", expect_at_least=1)
+    def test_metric_tracers_spans_finished(self):
+        self.assert_count_metric("tracers", "spans_finished", expect_at_least=1)
+
+    @missing_feature(library="java", reason="Not implemented")
+    def test_metric_tracers_spans_enqueued_for_serialization(self):
+        self.assert_count_metric("tracers", "spans_enqueued_for_serialization", expect_at_least=1)
+
+    @missing_feature(library="java", reason="Not implemented")
+    def test_metric_tracers_trace_segments_created(self):
+        self.assert_count_metric("tracers", "trace_segments_created", expect_at_least=1)
+
+    @missing_feature(library="java", reason="Not implemented")
+    def test_metric_tracers_trace_chunks_enqueued_for_serialization(self):
+        self.assert_count_metric("tracers", "trace_chunks_enqueued_for_serialization", expect_at_least=1)
+
+    @missing_feature(library="java", reason="Not implemented")
+    def test_metric_tracers_trace_chunks_sent(self):
+        self.assert_count_metric("tracers", "trace_chunks_sent", expect_at_least=1)
+
+    @missing_feature(library="java", reason="Not implemented")
+    def test_metric_tracers_trace_segments_closed(self):
+        self.assert_count_metric("tracers", "trace_segments_closed", expect_at_least=1)
+
+    @missing_feature(library="java", reason="Not implemented")
+    def test_metric_tracers_trace_api_requests(self):
+        self.assert_count_metric("tracers", "trace_api.requests", expect_at_least=1)
+
+    @missing_feature(library="java", reason="Not implemented")
+    def test_metric_tracers_trace_api_responses(self):
+        self.assert_count_metric("tracers", "trace_api.responses", expect_at_least=1)
+
+    @missing_feature(library="java", reason="Not implemented")
+    def test_metric_telemetry_api_requests(self):
+        self.assert_count_metric("telemetry", "telemetry_api.requests", expect_at_least=1)
+
+    @missing_feature(library="java", reason="Not implemented")
+    def test_metric_telemetry_api_responses(self):
+        self.assert_count_metric("telemetry", "telemetry_api.responses", expect_at_least=1)
 
     def assert_count_metric(self, namespace, metric, expect_at_least):
         series = list(interfaces.library.get_telemetry_metric_series(namespace, metric))
-        if len(series) == 0 and expect_at_least > 0:
-            raise Exception(f"No telemetry data received for metric {namespace}.{metric}")
+        assert len(series) != 0 or expect_at_least == 0, f"No telemetry data received for metric {namespace}.{metric}"
 
         count = 0
         for s in series:


### PR DESCRIPTION
## Motivation

Enabling more telemetry tests in Java.

## Changes

* Split telemetry metrics test case, one per metric.
* Enable these for Java, and skip those for unimplemented metrics.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
