### PR TITLE
DotNet: Parametric sampling - revert

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -259,13 +259,13 @@ tests/:
       Test_Environment: missing_feature
       Test_TelemetryInstallSignature: v2.45.0
     test_trace_sampling.py:
-      Test_Trace_Sampling_Basic: v2.46.0
-      Test_Trace_Sampling_Globs: v2.46.0
-      Test_Trace_Sampling_Globs_Feb2024_Revision: v2.48.0
-      Test_Trace_Sampling_Resource: v2.46.0
-      Test_Trace_Sampling_Tags: v2.46.0
-      Test_Trace_Sampling_Tags_Feb2024_Revision: v2.48.0
-      Test_Trace_Sampling_With_W3C: v2.46.0
+      Test_Trace_Sampling_Basic: missing_feature
+      Test_Trace_Sampling_Globs: missing_feature
+      Test_Trace_Sampling_Globs_Feb2024_Revision: missing_feature
+      Test_Trace_Sampling_Resource: missing_feature
+      Test_Trace_Sampling_Tags: missing_feature
+      Test_Trace_Sampling_Tags_Feb2024_Revision: missing_feature
+      Test_Trace_Sampling_With_W3C: missing_feature
     test_tracer.py:
       Test_TracerSCITagging: bug (Both env vars are not independent; injected tags are duplicated in all spans)
     test_tracer_flare.py:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
After parametric sampling test activation for dotnet, there are some test failures.
I revert the change and mark the tests again as missing_feature

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
