### PR TITLE
[.NET] enable parametric trace sampling tests, redux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,8 @@
 venv/
 .git/
-.idea/
-.vs/
-.vscode/
+**/.idea/
+**/.vs/
+**/.vscode/
 vendor
 logs*
 shell.nix

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,18 @@
 venv/
 .git/
+.idea/
+.vs/
 .vscode/
 vendor
 logs*
 shell.nix
 __pycache__
 scenario_groups.yml
+
+# dotnet
+**/dotnet/**/bin/
+**/dotnet/**/obj/
+**/dotnet/**/packages/
+**/dotnet/**/out/
+**/dotnet/**/*.user
+**/dotnet/**/*.suo

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -294,13 +294,13 @@ tests/:
       Test_TelemetryInstallSignature: v2.45.0
       Test_TelemetrySCAEnvVar: v2.50.0
     test_trace_sampling.py:
-      Test_Trace_Sampling_Basic: missing_feature
-      Test_Trace_Sampling_Globs: missing_feature
-      Test_Trace_Sampling_Globs_Feb2024_Revision: missing_feature
-      Test_Trace_Sampling_Resource: missing_feature
-      Test_Trace_Sampling_Tags: missing_feature
-      Test_Trace_Sampling_Tags_Feb2024_Revision: missing_feature
-      Test_Trace_Sampling_With_W3C: missing_feature
+      Test_Trace_Sampling_Basic: v2.46.0
+      Test_Trace_Sampling_Globs: v2.46.0
+      Test_Trace_Sampling_Globs_Feb2024_Revision: v2.48.0
+      Test_Trace_Sampling_Resource: v2.46.0
+      Test_Trace_Sampling_Tags: v2.46.0
+      Test_Trace_Sampling_Tags_Feb2024_Revision: v2.48.0
+      Test_Trace_Sampling_With_W3C: v2.46.0
     test_tracer.py:
       # The dotnet parametric app generates trace chunks in a way that differs from the other languages
       # This causes the sci tests to fail. Before enabling these tests we must ensure that the first span in the

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -120,7 +120,7 @@ tests/:
         Test_Ssrf_BodyXml: v2.51.0
         Test_Ssrf_UrlQuery: v2.51.0
       test_stack_traces.py:
-        Test_StackTrace: v2.51.0     
+        Test_StackTrace: v2.51.0
     waf/:
       test_addresses.py:
         Test_BodyJson: v2.8.0

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -236,6 +236,9 @@ ENV DD_TRACE_AspNetCore_ENABLED=false
 ENV DD_TRACE_Process_ENABLED=false
 ENV DD_TRACE_OTEL_ENABLED=false
 
+# "disable" rate limiting by default by setting it to a large value
+ENV DD_TRACE_RATE_LIMIT=10000000
+
 ENTRYPOINT ["dotnet", "ApmTestApi.dll"]
 """,
         container_cmd=["./ApmTestApi"],

--- a/utils/build/docker/dotnet/parametric/.dockerignore
+++ b/utils/build/docker/dotnet/parametric/.dockerignore
@@ -1,9 +1,0 @@
-.idea/
-.vs/
-.vscode/
-bin/
-obj/
-packages/
-out/
-*.user
-*.suo

--- a/utils/build/docker/dotnet/parametric/Dockerfile
+++ b/utils/build/docker/dotnet/parametric/Dockerfile
@@ -36,4 +36,7 @@ ENV DD_TRACE_AspNetCore_ENABLED=false
 ENV DD_TRACE_Process_ENABLED=false
 ENV DD_TRACE_OTEL_ENABLED=false
 
+# "disable" rate limiting by default by setting it to a large value
+ENV DD_TRACE_RATE_LIMIT=10000000
+
 ENTRYPOINT ["dotnet", "ApmTestApi.dll"]


### PR DESCRIPTION
This reverts commit 267542c0a60ca8094bdee522e6badf685cf5e6bf.

## Motivation

<!-- What inspired you to submit this pull request? -->
The original PR #2320 enabled sampling tests for .NET.
The tests were failing, so they were reverted in #2331.
This PR attempts to enable the tests again.

## Changes

<!-- A brief description of the change being made with this pull request. -->
- enable some sampling tests for .NET
- effectively disable the sampling rate limiter by default in parametric tests by setting `DD_TRACE_RATE_LIMIT=10000000`
- bonus: add more entries to `.dockerignore` files to enable easier local .NET builds

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
