### PR TITLE
Revert "chore(python): add one more test"

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -428,7 +428,7 @@ tests/:
         '*': v1.4.0rc1.dev
         fastapi: v2.4.0.dev1
       Test_DistributedTraceInfo: missing_feature (test not implemented)
-      Test_ExternalWafRequestsIdentification: v2.9.0.dev1
+      Test_ExternalWafRequestsIdentification: missing_feature
       Test_RetainTraces: v1.1.0rc2.dev
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist:


### PR DESCRIPTION
Reverts DataDog/system-tests#2332

Because 2.8 branch is reporting the same version number, hence the 2.8 backports are failing to pass this test, preventing them from being merged.