### PR TITLE
move parametric to manifest for python

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -551,7 +551,7 @@ tests/:
     test_otel_tracer.py:
       Test_Otel_Tracer: v2.8.0
     test_partial_flushing.py:
-      Test_Partial_Flushing: 2.9.0.dev1
+      Test_Partial_Flushing: v2.9.0.dev1
     test_sampling_delegation.py:
       Test_Decisionless_Extraction: v2.8.0
       # >-

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1,3 +1,4 @@
+---
 tests/:
   apm_tracing_e2e/:
     test_otel.py:
@@ -23,7 +24,7 @@ tests/:
           python3.12: v2.6.0dev
           uds-flask: v2.6.0dev
           uwsgi-poc: v2.6.0dev
-        Test_API_Security_RC_ASM_processor_overrides_and_custom_scanner: missing_feature # waf does not support it yet
+        Test_API_Security_RC_ASM_processor_overrides_and_custom_scanner: missing_feature
       test_apisec_sampling.py:
         Test_API_Security_sampling: missing_feature
       test_schemas.py:
@@ -186,6 +187,125 @@ tests/:
           TestPath: missing_feature
         test_uri.py:
           TestURI: missing_feature
+    test_PII.py:
+      Test_Scrubbing: missing_feature
+    test_alpha.py:
+      Test_Basic:
+        '*': v1.1.0rc2.dev
+        fastapi: v2.4.0.dev1
+    test_automated_login_events.py:
+      Test_Login_Events: missing_feature
+      Test_Login_Events_Extended: missing_feature
+    test_blocking_addresses.py:
+      Test_BlockingAddresses:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_BlockingGraphqlResolvers: missing_feature
+      Test_Blocking_request_body:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_request_cookies:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_request_headers:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_request_method:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_request_path_params:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.13
+      Test_Blocking_request_query:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_request_uri:
+        '*': v1.16.1
+        django-poc: v1.15
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.15
+      Test_Blocking_response_headers:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_response_status:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Suspicious_Request_Blocking: missing_feature (v1.20.0, but test is not implemented)
+    test_client_ip.py:
+      Test_StandardTagsClientIp: v1.5.0
+    test_conf.py:
+      Test_ConfigurationVariables:
+        '*': v1.1.2
+        fastapi: v2.4.0.dev1
+      Test_RuleSet_1_3_1:
+        '*': v1.2.1
+        fastapi: v2.4.0.dev1
+      Test_StaticRuleSet: missing_feature
+    test_customconf.py:
+      Test_ConfRuleSet: v1.1.0rc2.dev
+      Test_NoLimitOnWafRules: v1.1.0rc2.dev
+    test_event_tracking.py:
+      Test_CustomEvent: v1.10.0
+      Test_UserLoginFailureEvent: v1.9.0
+      Test_UserLoginSuccessEvent: v1.9.0
+    test_identify.py:
+      Test_Basic: v1.5.0rc1.dev
+    test_ip_blocking_full_denylist.py:
+      Test_AppSecIPBlockingFullDenylist: missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
+    test_logs.py:
+      Test_Standardization: missing_feature
+      Test_StandardizationBlockMode: missing_feature
+    test_reports.py:
+      Test_ExtraTagsFromRule: v1.14.0
+      Test_HttpClientIP: v1.5.0rc1.dev
+      Test_Info: v1.1.0rc2.dev
+      Test_RequestHeaders: v1.1.0rc2.dev
+      Test_StatusCode: v1.1.0rc2.dev
+    test_request_blocking.py:
+      Test_AppSecRequestBlocking:
+        '*': v1.10.0
+        fastapi: v2.4.0.dev1
+    test_runtime_activation.py:
+      Test_RuntimeActivation: missing_feature
+    test_shell_execution.py:
+      Test_ShellExecution: missing_feature
+    test_traces.py:
+      Test_AppSecEventSpanTags: v0.58.5
+      Test_AppSecObfuscator:
+        '*': v1.5.0rc1.dev
+        fastapi: v2.6.0.dev1
+      Test_CollectDefaultRequestHeader: v2.9.0.dev40
+      Test_CollectRespondHeaders:
+        '*': v1.4.0rc1.dev
+        fastapi: v2.4.0.dev1
+      Test_DistributedTraceInfo: missing_feature (test not implemented)
+      Test_ExternalWafRequestsIdentification: missing_feature
+      Test_RetainTraces: v1.1.0rc2.dev
+    test_user_blocking_full_denylist.py:
+      Test_UserBlocking_FullDenylist:
+        '*': missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
+        # django-poc: v1.10
+        # flask-poc: v1.10
+    test_versions.py:
+      Test_Events: v0.58.5
     waf/:
       test_addresses.py:
         Test_BodyJson:
@@ -318,125 +438,6 @@ tests/:
         Test_TelemetryMetrics:
           '*': v1.14.0
           fastapi: v2.4.0.dev1
-    test_PII.py:
-      Test_Scrubbing: missing_feature
-    test_alpha.py:
-      Test_Basic:
-        '*': v1.1.0rc2.dev
-        fastapi: v2.4.0.dev1
-    test_automated_login_events.py:
-      Test_Login_Events: missing_feature
-      Test_Login_Events_Extended: missing_feature
-    test_blocking_addresses.py:
-      Test_BlockingAddresses:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_BlockingGraphqlResolvers: missing_feature
-      Test_Blocking_request_body:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_request_cookies:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_request_headers:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_request_method:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_request_path_params:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.13
-      Test_Blocking_request_query:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_request_uri:
-        '*': v1.16.1
-        django-poc: v1.15
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.15
-      Test_Blocking_response_headers:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_response_status:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Suspicious_Request_Blocking: missing_feature (v1.20.0, but test is not implemented)
-    test_client_ip.py:
-      Test_StandardTagsClientIp: v1.5.0
-    test_conf.py:
-      Test_ConfigurationVariables:
-        '*': v1.1.2
-        fastapi: v2.4.0.dev1
-      Test_RuleSet_1_3_1:
-        '*': v1.2.1
-        fastapi: v2.4.0.dev1
-      Test_StaticRuleSet: missing_feature
-    test_customconf.py:
-      Test_ConfRuleSet: v1.1.0rc2.dev
-      Test_NoLimitOnWafRules: v1.1.0rc2.dev
-    test_event_tracking.py:
-      Test_CustomEvent: v1.10.0
-      Test_UserLoginFailureEvent: v1.9.0
-      Test_UserLoginSuccessEvent: v1.9.0
-    test_identify.py:
-      Test_Basic: v1.5.0rc1.dev
-    test_ip_blocking_full_denylist.py:
-      Test_AppSecIPBlockingFullDenylist: missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
-    test_logs.py:
-      Test_Standardization: missing_feature
-      Test_StandardizationBlockMode: missing_feature
-    test_reports.py:
-      Test_ExtraTagsFromRule: v1.14.0
-      Test_HttpClientIP: v1.5.0rc1.dev
-      Test_Info: v1.1.0rc2.dev
-      Test_RequestHeaders: v1.1.0rc2.dev
-      Test_StatusCode: v1.1.0rc2.dev
-    test_request_blocking.py:
-      Test_AppSecRequestBlocking:
-        '*': v1.10.0
-        fastapi: v2.4.0.dev1
-    test_runtime_activation.py:
-      Test_RuntimeActivation: missing_feature
-    test_shell_execution.py:
-      Test_ShellExecution: missing_feature
-    test_traces.py:
-      Test_AppSecEventSpanTags: v0.58.5
-      Test_AppSecObfuscator:
-        '*': v1.5.0rc1.dev
-        fastapi: v2.6.0.dev1
-      Test_CollectDefaultRequestHeader: v2.9.0.dev40
-      Test_CollectRespondHeaders:
-        '*': v1.4.0rc1.dev
-        fastapi: v2.4.0.dev1
-      Test_DistributedTraceInfo: missing_feature (test not implemented)
-      Test_ExternalWafRequestsIdentification: missing_feature
-      Test_RetainTraces: v1.1.0rc2.dev
-    test_user_blocking_full_denylist.py:
-      Test_UserBlocking_FullDenylist:
-        '*': missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
-        # django-poc: v1.10
-        # flask-poc: v1.10
-    test_versions.py:
-      Test_Events: v0.58.5
   debugger/:
     test_debugger.py:
       Test_Debugger_Line_Probe_Snaphots: missing_feature
@@ -453,20 +454,20 @@ tests/:
           flask-poc: v2.5.0
       test_kinesis.py:
         Test_Kinesis_PROPAGATION_VIA_MESSAGE_ATTRIBUTES:
-          "*": irrelevant
+          '*': irrelevant
           flask-poc: v2.6.0
       test_rabbitmq.py:
         Test_RabbitMQ_Trace_Context_Propagation:
           '*': irrelevant
-          flask-poc: v0.1 # real version not known
+          flask-poc: v0.1
       test_sns_to_sqs.py:
         Test_SNS_Propagation:
-          "*": irrelevant
+          '*': irrelevant
           flask-poc: v2.6.0
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           '*': irrelevant
-          flask-poc: v0.1 # real version not known
+          flask-poc: v0.1
         Test_SQS_PROPAGATION_VIA_MESSAGE_ATTRIBUTES:
           '*': irrelevant
           flask-poc: v2.6.0
@@ -483,13 +484,13 @@ tests/:
     test_dbm.py:
       Test_Dbm:
         '*': missing_feature (Missing on weblog)
-        flask-poc: v0.1 # real version not known
+        flask-poc: v0.1
     test_dsm.py:
-      Test_DsmContext_Extraction_Base64: 
-        "*": irrelevant
+      Test_DsmContext_Extraction_Base64:
+        '*': irrelevant
         flask-poc: v2.8.0.dev
-      Test_DsmContext_Injection_Base64: 
-        "*": irrelevant
+      Test_DsmContext_Injection_Base64:
+        '*': irrelevant
         flask-poc: v2.8.0.dev
       Test_DsmHttp: missing_feature
       Test_DsmKafka:
@@ -514,29 +515,62 @@ tests/:
         '*': irrelevant
         flask-poc: v1.16.0
   parametric/:
+    test_128_bit_traceids.py:
+      Test_128_Bit_Traceids: v2.6.0
     test_dynamic_configuration.py:
-      TestDynamicConfigHeaderTags: v2.6.0
+      TestDynamicConfigHeaderTags: missing_feature (failure 2.8.0)
       TestDynamicConfigSamplingRules: missing_feature
-      TestDynamicConfigTracingEnabled: v2.6.0
-      TestDynamicConfigV1: missing_feature
-      TestDynamicConfigV1_ServiceTargets: missing_feature
-      TestDynamicConfigV2: v2.8.0.dev
-    test_otel_api_interoperability.py: missing_feature
-    test_otel_sdk_interoperability.py: missing_feature
+      TestDynamicConfigTracingEnabled: missing_feature (failure 2.8.0)
+      TestDynamicConfigV1: missing_feature (failure 2.8.0)
+      TestDynamicConfigV1_ServiceTargets: missing_feature (failure 2.8.0)
+      TestDynamicConfigV2: missing_feature (failure 2.8.0)
+    test_headers_b3.py:
+      Test_Headers_B3: v2.8.0
+    test_headers_b3multi.py:
+      Test_Headers_B3multi: v2.8.0
+    test_headers_datadog.py:
+      Test_Headers_Datadog: v2.8.0
+    test_headers_none.py:
+      Test_Headers_None: v2.8.0
+    test_headers_precedence.py:
+      Test_Headers_Precedence: v2.8.0
+    test_headers_tracecontext.py:
+      Test_Headers_Tracecontext: v2.8.0
+    test_headers_tracestate_dd.py:
+      Test_Headers_Tracestate_DD: v2.8.0
+    test_library_tracestats.py:
+      Test_Library_Tracestats: missing_feature (failure 2.8.0)
+    test_otel_api_interoperability.py:
+      Test_Otel_API_Interoperability: missing_feature
+    test_otel_sdk_interoperability.py:
+      Test_Otel_SDK_Interoperability: missing_feature
+    test_otel_span_methods.py:
+      Test_Otel_Span_Methods: v2.8.0
+    test_otel_span_with_w3c.py:
+      Test_Otel_Span_With_W3c: v2.8.0
+    test_otel_tracer.py:
+      Test_Otel_Tracer: v2.8.0
+    test_partial_flushing.py:
+      Test_Partial_Flushing: 2.9.0.dev1
     test_sampling_delegation.py:
-      Test_Decisionless_Extraction: >-
-        missing_feature
-        (The "_sampling_priority_v1" numeric tag is missing from the local
-        root span when the trace was extracted without a sampling decision.
-        See <https://github.com/DataDog/system-tests/actions/runs/7629296312/job/20782691947?pr=2005>.)
+      Test_Decisionless_Extraction: v2.8.0
+      # >-
+      #  missing_feature
+      #  (The "_sampling_priority_v1" numeric tag is missing from the local
+      #  root span when the trace was extracted without a sampling decision. See <https://github.com/DataDog/system-tests/actions/runs/7629296312/job/20782691947?pr=2005>.)
+    test_sampling_span_tags.py:
+      AnyRatio: missing_feature
+      Test_Sampling_Span_Tags: v2.8.0
     test_span_links.py:
       Test_Span_Links: v2.3.0
+    test_span_sampling.py:
+      Test_Span_Sampling: v2.8.0
     test_telemetry.py:
-      Test_Defaults: missing_feature
-      Test_Environment: missing_feature
-      Test_TelemetryInstallSignature: v2.5.0
+      Test_Defaults: missing_feature (failure 2.8.0)
+      Test_Environment: missing_feature (failure 2.8.0)
+      Test_TelemetryInstallSignature: missing_feature (failure 2.8.0)
     test_trace_sampling.py:
-      Test_Trace_Sampling_Basic: v1.9.0 # TODO what is the earliest version?
+      Test_Trace_Sampling_Basic: v1.9.0
       Test_Trace_Sampling_Globs: v2.8.0
       Test_Trace_Sampling_Globs_Feb2024_Revision: v2.8.0
       Test_Trace_Sampling_Resource: v2.8.0
@@ -544,10 +578,11 @@ tests/:
       Test_Trace_Sampling_Tags_Feb2024_Revision: bug (v2.8.0 fails. Python PR-8946 is needed to fix it)
       Test_Trace_Sampling_With_W3C: v2.8.0
     test_tracer.py:
+      Test_Tracer: v2.8.0
       Test_TracerSCITagging: v1.12.0
       Test_TracerUniversalServiceTagging: v0.36.0
     test_tracer_flare.py:
-      TestTracerFlareV1: missing_feature
+      TestTracerFlareV1: missing_feature (failure 2.8.0)
   remote_config/:
     test_remote_configuration.py:
       Test_RemoteConfigurationExtraServices: v2.1.0.dev
@@ -562,14 +597,14 @@ tests/:
   test_distributed.py:
     Test_DistributedHttp:
       '*': missing_feature (Missing on weblog)
-      flask-poc: v1.5.0rc2.dev # TODO : is it the good version number ?
+      flask-poc: v1.5.0rc2.dev
   test_identify.py:
     Test_Basic: v1.5.0rc1.dev
     Test_Propagate: v1.9.0
     Test_Propagate_Legacy: v1.5.0rc1.dev
   test_library_conf.py:
     Test_HeaderTags: v0.53
-    Test_HeaderTags_Colon_Leading: v1.2.1 # was marked as ? when we used decorators
+    Test_HeaderTags_Colon_Leading: v1.2.1
     Test_HeaderTags_Colon_Trailing: v2.8.0.dev
     Test_HeaderTags_Long: v1.2.1
     Test_HeaderTags_Short: missing_feature
@@ -579,8 +614,8 @@ tests/:
     Test_HeaderTags_Whitespace_Val_Short: missing_feature
   test_profiling.py:
     Test_Profile:
-      '*': v0.1 # real version unknown
-      python3.12: v2.1.0.dev # 2.0.0 does not support it (seg fault)
+      '*': v0.1
+      python3.12: v2.1.0.dev
   test_scrubbing.py:
     Test_UrlField:
       '*': v1.7.1

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -187,125 +187,6 @@ tests/:
           TestPath: missing_feature
         test_uri.py:
           TestURI: missing_feature
-    test_PII.py:
-      Test_Scrubbing: missing_feature
-    test_alpha.py:
-      Test_Basic:
-        '*': v1.1.0rc2.dev
-        fastapi: v2.4.0.dev1
-    test_automated_login_events.py:
-      Test_Login_Events: missing_feature
-      Test_Login_Events_Extended: missing_feature
-    test_blocking_addresses.py:
-      Test_BlockingAddresses:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_BlockingGraphqlResolvers: missing_feature
-      Test_Blocking_request_body:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_request_cookies:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_request_headers:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_request_method:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_request_path_params:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.13
-      Test_Blocking_request_query:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_request_uri:
-        '*': v1.16.1
-        django-poc: v1.15
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.15
-      Test_Blocking_response_headers:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Blocking_response_status:
-        '*': v1.16.1
-        django-poc: v1.10
-        fastapi: v2.4.0.dev1
-        flask-poc: v1.10
-      Test_Suspicious_Request_Blocking: missing_feature (v1.20.0, but test is not implemented)
-    test_client_ip.py:
-      Test_StandardTagsClientIp: v1.5.0
-    test_conf.py:
-      Test_ConfigurationVariables:
-        '*': v1.1.2
-        fastapi: v2.4.0.dev1
-      Test_RuleSet_1_3_1:
-        '*': v1.2.1
-        fastapi: v2.4.0.dev1
-      Test_StaticRuleSet: missing_feature
-    test_customconf.py:
-      Test_ConfRuleSet: v1.1.0rc2.dev
-      Test_NoLimitOnWafRules: v1.1.0rc2.dev
-    test_event_tracking.py:
-      Test_CustomEvent: v1.10.0
-      Test_UserLoginFailureEvent: v1.9.0
-      Test_UserLoginSuccessEvent: v1.9.0
-    test_identify.py:
-      Test_Basic: v1.5.0rc1.dev
-    test_ip_blocking_full_denylist.py:
-      Test_AppSecIPBlockingFullDenylist: missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
-    test_logs.py:
-      Test_Standardization: missing_feature
-      Test_StandardizationBlockMode: missing_feature
-    test_reports.py:
-      Test_ExtraTagsFromRule: v1.14.0
-      Test_HttpClientIP: v1.5.0rc1.dev
-      Test_Info: v1.1.0rc2.dev
-      Test_RequestHeaders: v1.1.0rc2.dev
-      Test_StatusCode: v1.1.0rc2.dev
-    test_request_blocking.py:
-      Test_AppSecRequestBlocking:
-        '*': v1.10.0
-        fastapi: v2.4.0.dev1
-    test_runtime_activation.py:
-      Test_RuntimeActivation: missing_feature
-    test_shell_execution.py:
-      Test_ShellExecution: missing_feature
-    test_traces.py:
-      Test_AppSecEventSpanTags: v0.58.5
-      Test_AppSecObfuscator:
-        '*': v1.5.0rc1.dev
-        fastapi: v2.6.0.dev1
-      Test_CollectDefaultRequestHeader: v2.9.0.dev40
-      Test_CollectRespondHeaders:
-        '*': v1.4.0rc1.dev
-        fastapi: v2.4.0.dev1
-      Test_DistributedTraceInfo: missing_feature (test not implemented)
-      Test_ExternalWafRequestsIdentification: missing_feature
-      Test_RetainTraces: v1.1.0rc2.dev
-    test_user_blocking_full_denylist.py:
-      Test_UserBlocking_FullDenylist:
-        '*': missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
-        # django-poc: v1.10
-        # flask-poc: v1.10
-    test_versions.py:
-      Test_Events: v0.58.5
     waf/:
       test_addresses.py:
         Test_BodyJson:
@@ -438,6 +319,125 @@ tests/:
         Test_TelemetryMetrics:
           '*': v1.14.0
           fastapi: v2.4.0.dev1
+    test_PII.py:
+      Test_Scrubbing: missing_feature
+    test_alpha.py:
+      Test_Basic:
+        '*': v1.1.0rc2.dev
+        fastapi: v2.4.0.dev1
+    test_automated_login_events.py:
+      Test_Login_Events: missing_feature
+      Test_Login_Events_Extended: missing_feature
+    test_blocking_addresses.py:
+      Test_BlockingAddresses:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_BlockingGraphqlResolvers: missing_feature
+      Test_Blocking_request_body:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_request_cookies:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_request_headers:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_request_method:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_request_path_params:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.13
+      Test_Blocking_request_query:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_request_uri:
+        '*': v1.16.1
+        django-poc: v1.15
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.15
+      Test_Blocking_response_headers:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Blocking_response_status:
+        '*': v1.16.1
+        django-poc: v1.10
+        fastapi: v2.4.0.dev1
+        flask-poc: v1.10
+      Test_Suspicious_Request_Blocking: missing_feature (v1.20.0, but test is not implemented)
+    test_client_ip.py:
+      Test_StandardTagsClientIp: v1.5.0
+    test_conf.py:
+      Test_ConfigurationVariables:
+        '*': v1.1.2
+        fastapi: v2.4.0.dev1
+      Test_RuleSet_1_3_1:
+        '*': v1.2.1
+        fastapi: v2.4.0.dev1
+      Test_StaticRuleSet: missing_feature
+    test_customconf.py:
+      Test_ConfRuleSet: v1.1.0rc2.dev
+      Test_NoLimitOnWafRules: v1.1.0rc2.dev
+    test_event_tracking.py:
+      Test_CustomEvent: v1.10.0
+      Test_UserLoginFailureEvent: v1.9.0
+      Test_UserLoginSuccessEvent: v1.9.0
+    test_identify.py:
+      Test_Basic: v1.5.0rc1.dev
+    test_ip_blocking_full_denylist.py:
+      Test_AppSecIPBlockingFullDenylist: missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
+    test_logs.py:
+      Test_Standardization: missing_feature
+      Test_StandardizationBlockMode: missing_feature
+    test_reports.py:
+      Test_ExtraTagsFromRule: v1.14.0
+      Test_HttpClientIP: v1.5.0rc1.dev
+      Test_Info: v1.1.0rc2.dev
+      Test_RequestHeaders: v1.1.0rc2.dev
+      Test_StatusCode: v1.1.0rc2.dev
+    test_request_blocking.py:
+      Test_AppSecRequestBlocking:
+        '*': v1.10.0
+        fastapi: v2.4.0.dev1
+    test_runtime_activation.py:
+      Test_RuntimeActivation: missing_feature
+    test_shell_execution.py:
+      Test_ShellExecution: missing_feature
+    test_traces.py:
+      Test_AppSecEventSpanTags: v0.58.5
+      Test_AppSecObfuscator:
+        '*': v1.5.0rc1.dev
+        fastapi: v2.6.0.dev1
+      Test_CollectDefaultRequestHeader: v2.9.0.dev40
+      Test_CollectRespondHeaders:
+        '*': v1.4.0rc1.dev
+        fastapi: v2.4.0.dev1
+      Test_DistributedTraceInfo: missing_feature (test not implemented)
+      Test_ExternalWafRequestsIdentification: missing_feature
+      Test_RetainTraces: v1.1.0rc2.dev
+    test_user_blocking_full_denylist.py:
+      Test_UserBlocking_FullDenylist:
+        '*': missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
+        # django-poc: v1.10
+        # flask-poc: v1.10
+    test_versions.py:
+      Test_Events: v0.58.5
   debugger/:
     test_debugger.py:
       Test_Debugger_Line_Probe_Snaphots: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -24,7 +24,7 @@ tests/:
           python3.12: v2.6.0dev
           uds-flask: v2.6.0dev
           uwsgi-poc: v2.6.0dev
-        Test_API_Security_RC_ASM_processor_overrides_and_custom_scanner: missing_feature
+        Test_API_Security_RC_ASM_processor_overrides_and_custom_scanner: missing_feature # waf does not support it yet
       test_apisec_sampling.py:
         Test_API_Security_sampling: missing_feature
       test_schemas.py:
@@ -459,7 +459,7 @@ tests/:
       test_rabbitmq.py:
         Test_RabbitMQ_Trace_Context_Propagation:
           '*': irrelevant
-          flask-poc: v0.1
+          flask-poc: v0.1  # actual version unknown
       test_sns_to_sqs.py:
         Test_SNS_Propagation:
           '*': irrelevant
@@ -467,7 +467,7 @@ tests/:
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
           '*': irrelevant
-          flask-poc: v0.1
+          flask-poc: v0.1 # actual version unknown
         Test_SQS_PROPAGATION_VIA_MESSAGE_ATTRIBUTES:
           '*': irrelevant
           flask-poc: v2.6.0
@@ -484,7 +484,7 @@ tests/:
     test_dbm.py:
       Test_Dbm:
         '*': missing_feature (Missing on weblog)
-        flask-poc: v0.1
+        flask-poc: v0.1 # actual version unknown
     test_dsm.py:
       Test_DsmContext_Extraction_Base64:
         '*': irrelevant
@@ -569,7 +569,7 @@ tests/:
       Test_Environment: missing_feature (failure 2.8.0)
       Test_TelemetryInstallSignature: missing_feature (failure 2.8.0)
     test_trace_sampling.py:
-      Test_Trace_Sampling_Basic: v1.9.0
+      Test_Trace_Sampling_Basic: v1.9.0 # actual version unknown
       Test_Trace_Sampling_Globs: v2.8.0
       Test_Trace_Sampling_Globs_Feb2024_Revision: v2.8.0
       Test_Trace_Sampling_Resource: v2.8.0
@@ -596,14 +596,14 @@ tests/:
   test_distributed.py:
     Test_DistributedHttp:
       '*': missing_feature (Missing on weblog)
-      flask-poc: v1.5.0rc2.dev
+      flask-poc: v1.5.0rc2.dev # actual version unknown
   test_identify.py:
     Test_Basic: v1.5.0rc1.dev
     Test_Propagate: v1.9.0
     Test_Propagate_Legacy: v1.5.0rc1.dev
   test_library_conf.py:
     Test_HeaderTags: v0.53
-    Test_HeaderTags_Colon_Leading: v1.2.1
+    Test_HeaderTags_Colon_Leading: v1.2.1 # actual version unknown
     Test_HeaderTags_Colon_Trailing: v2.8.0.dev
     Test_HeaderTags_Long: v1.2.1
     Test_HeaderTags_Short: missing_feature
@@ -613,8 +613,8 @@ tests/:
     Test_HeaderTags_Whitespace_Val_Short: missing_feature
   test_profiling.py:
     Test_Profile:
-      '*': v0.1
-      python3.12: v2.1.0.dev
+      '*': v0.1 # actual version unknown
+      python3.12: v2.1.0.dev # actual version unknown
   test_scrubbing.py:
     Test_UrlField:
       '*': v1.7.1

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -559,7 +559,6 @@ tests/:
       #  (The "_sampling_priority_v1" numeric tag is missing from the local
       #  root span when the trace was extracted without a sampling decision. See <https://github.com/DataDog/system-tests/actions/runs/7629296312/job/20782691947?pr=2005>.)
     test_sampling_span_tags.py:
-      AnyRatio: missing_feature
       Test_Sampling_Span_Tags: v2.8.0
     test_span_links.py:
       Test_Span_Links: v2.3.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -554,10 +554,6 @@ tests/:
       Test_Partial_Flushing: v2.9.0.dev1
     test_sampling_delegation.py:
       Test_Decisionless_Extraction: v2.8.0
-      # >-
-      #  missing_feature
-      #  (The "_sampling_priority_v1" numeric tag is missing from the local
-      #  root span when the trace was extracted without a sampling decision. See <https://github.com/DataDog/system-tests/actions/runs/7629296312/job/20782691947?pr=2005>.)
     test_sampling_span_tags.py:
       Test_Sampling_Span_Tags: v2.8.0
     test_span_links.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -610,7 +610,7 @@ tests/:
   test_profiling.py:
     Test_Profile:
       '*': v0.1 # actual version unknown
-      python3.12: v2.1.0.dev # actual version unknown
+      python3.12: v2.1.0.dev
   test_scrubbing.py:
     Test_UrlField:
       '*': v1.7.1


### PR DESCRIPTION
## Motivation

decorators in tests are deprecated and manifest is the correct way to declare which test class must run.

Also improve linting of the python manifest

- remove unrequired spaces
- use ' for strings everywhere
- use the same comment everywhere for unknown version

## Changes

add parametric tests to python manifest

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
