### PR TITLE
Enable some xpass tests for dotnet

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -255,6 +255,8 @@ tests/:
     test_otel_sdk_interoperability.py: missing_feature
     test_otel_span_with_w3c.py:
       Test_Otel_Span_With_W3c: v2.42.0
+    test_otel_tracer.py:
+      Test_Otel_Tracer: v2.8.0
     test_span_links.py: missing_feature
     test_telemetry.py:
       Test_Defaults: v2.49.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -255,8 +255,8 @@ tests/:
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature
     test_telemetry.py:
-      Test_Defaults: missing_feature
-      Test_Environment: missing_feature
+      Test_Defaults: v2.49.0
+      Test_Environment: v2.49.0
       Test_TelemetryInstallSignature: v2.45.0
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -253,6 +253,8 @@ tests/:
       TestDynamicConfigV2: v2.44.0
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
+    test_otel_span_with_w3c.py:
+      Test_Otel_Span_With_W3c: v2.42.0
     test_span_links.py: missing_feature
     test_telemetry.py:
       Test_Defaults: v2.49.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -271,7 +271,7 @@ tests/:
       Test_Trace_Sampling_Tags_Feb2024_Revision: missing_feature
       Test_Trace_Sampling_With_W3C: missing_feature
     test_tracer.py:
-      Test_TracerSCITagging: bug (Both env vars are not independent; injected tags are duplicated in all spans)
+      Test_TracerSCITagging: v2.47.0
     test_tracer_flare.py:
       TestTracerFlareV1: missing_feature
   remote_config/:

--- a/tests/parametric/test_otel_span_with_w3c.py
+++ b/tests/parametric/test_otel_span_with_w3c.py
@@ -22,7 +22,6 @@ class Test_Otel_Span_With_W3c:
     @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="OTel resource naming implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
     def test_otel_start_span_with_w3c(self, test_agent, test_library):
         """
         - Start/end a span with start and end options


### PR DESCRIPTION
## Motivation

Since we have some tests with the xpass status, we want to enable them so any regressions are immediately detected.

## Changes

Updates the `manifests/dotnet.yaml` and one in-line `@missing_feature` annotation for dotnet.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
