### PR TITLE
Add ++manifest option to run system-tests from an external manifest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,7 @@ import time
 import pytest
 from pytest_jsonreport.plugin import JSONReport
 
-from manifests.parser.core import load as load_manifests
+from manifests.parser.core import load as load_manifests, load_from_file as load_manifest_from_file
 from utils import context
 from utils._context._scenarios import scenarios
 from utils.tools import logger
@@ -48,6 +48,7 @@ def pytest_addoption(parser):
         "--report-environment", type=str, action="store", default=None, help="The environment the test is run under",
     )
 
+    parser.addoption("--manifest", type=str, action="store", help="Path to custom manifest file")
 
 def pytest_configure(config):
 
@@ -151,7 +152,10 @@ def pytest_pycollect_makemodule(module_path, parent):
 
     library = context.scenario.library.library
 
-    manifests = load_manifests()
+    if context.scenario.manifest:
+        manifests = load_manifest_from_file(context.scenario.manifest, library)
+    else:
+        manifests = load_manifests()
 
     nodeid = str(module_path.relative_to(module_path.cwd()))
 
@@ -177,7 +181,10 @@ def pytest_pycollect_makeitem(collector, name, obj):
 
     if collector.istestclass(obj, name):
 
-        manifest = load_manifests()
+        if context.scenario.manifest:
+            manifest = load_manifest_from_file(context.scenario.manifest, context.scenario.library.library)
+        else:
+            manifest = load_manifests()
 
         nodeid = f"{collector.nodeid}::{name}"
 

--- a/conftest.py
+++ b/conftest.py
@@ -50,6 +50,7 @@ def pytest_addoption(parser):
 
     parser.addoption("--manifest", type=str, action="store", help="Path to custom manifest file")
 
+
 def pytest_configure(config):
 
     # handle options that can be filled by environ

--- a/manifests/parser/core.py
+++ b/manifests/parser/core.py
@@ -70,9 +70,10 @@ def load():
 
     return result
 
+
 @lru_cache
 def load_from_file(file, component):
-    
+
     result = defaultdict(dict)
 
     data = _load_file(file)
@@ -81,6 +82,7 @@ def load_from_file(file, component):
         result[nodeid][component] = value
 
     return result
+
 
 def assert_key_order(obj: dict, path=""):
     last_key = "/"

--- a/manifests/parser/core.py
+++ b/manifests/parser/core.py
@@ -70,6 +70,17 @@ def load():
 
     return result
 
+@lru_cache
+def load_from_file(file, component):
+    
+    result = defaultdict(dict)
+
+    data = _load_file(file)
+
+    for nodeid, value in data.items():
+        result[nodeid][component] = value
+
+    return result
 
 def assert_key_order(obj: dict, path=""):
     last_key = "/"

--- a/run.sh
+++ b/run.sh
@@ -165,6 +165,8 @@ function run_scenario() {
     shift
     local scenario="$1"
     shift
+    local manifest="$1"
+    shift
     local pytest_args=("$@")
 
     local cmd=()
@@ -204,6 +206,11 @@ function run_scenario() {
                 -v "${PWD}"/.env:/app/.env
               )
             fi
+            if [[ "${manifest}" != "" ]]; then
+              cmd+=(
+                -v "${PWD}/${manifest}":"/app/${manifest}"
+              )
+            fi
             cmd+=(
               -v /var/run/docker.sock:/var/run/docker.sock
               -v "${PWD}/${log_dir}":"/app/${log_dir}"
@@ -239,6 +246,7 @@ function main() {
     local scenario_args=()
     local libraries=()
     local pytest_args=()
+    local manifest=''
     local pytest_numprocesses='auto'
 
     ## handle environment variables
@@ -293,6 +301,16 @@ function main() {
                   exit 64
                 fi
                 libraries+=("$2")
+                shift
+                ;;
+            +m|++manifest)
+                if [[ "$#" -eq 1 ]]; then
+                  error "missing argument value for: $1"
+                  hint
+                  exit 64
+                fi
+                manifest="$2"
+                pytest_args+=("--manifest" "${manifest}")
                 shift
                 ;;
             ++)
@@ -427,7 +445,7 @@ function main() {
     fi
 
     for scenario in "${scenarios[@]}"; do
-        run_scenario "${dry}" "${run_mode}" "${scenario}" "${pytest_args[@]}"
+        run_scenario "${dry}" "${run_mode}" "${scenario}" "${manifest}" "${pytest_args[@]}"
     done
 }
 

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -79,6 +79,7 @@ class _Scenario:
 
     def configure(self, config):
         self.replay = config.option.replay
+        self.manifest = config.option.manifest
 
         if not hasattr(config, "workerinput"):
             # https://github.com/pytest-dev/pytest-xdist/issues/271#issuecomment-826396320
@@ -131,6 +132,8 @@ class _Scenario:
     def print_test_context(self):
         logger.terminal.write_sep("=", "test context", bold=True)
         logger.stdout(f"Scenario: {self.name}")
+        if self.manifest:
+            logger.stdout(f"Custom Manifest: {self.manifest}")
         logger.stdout(f"Logs folder: ./{self.host_log_folder}")
 
     def _get_warmups(self):


### PR DESCRIPTION
## Motivation

This was made during the 24q2 k9 innovation week. You can look at the slides at [this link](https://docs.google.com/presentation/d/1Q6UxrBnLsLik_7_-MQoTv8yTy_jYkKAZOfq5yNM5aLA/edit?usp=sharing)

## Changes

This PR adds a ++manifest (or +m) option to run.sh that runs the system-tests using an external manifest

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
