### PR TITLE
chore(python): activate more tests

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -485,6 +485,8 @@ tests/:
       Test_Dbm:
         '*': missing_feature (Missing on weblog)
         flask-poc: v0.1 # actual version unknown
+        uds-flask: v2.9.0.dev # actual version unknown
+        uwsgi-poc: v2.9.0.dev # actual version unknown
     test_dsm.py:
       Test_DsmContext_Extraction_Base64:
         '*': irrelevant

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -242,10 +242,6 @@ class TestDynamicConfigTracingEnabled:
     @parametrize(
         "library_env", [{**DEFAULT_ENVVARS}, {**DEFAULT_ENVVARS, "DD_TRACE_ENABLED": "false"},],
     )
-    @irrelevant(
-        library="python",
-        reason="The Python client library doesn't support the one-way lock functionality of tracing_enabled",
-    )
     @irrelevant(library="golang")
     def test_tracing_client_tracing_disable_one_way(self, library_env, test_agent, test_library):
         trace_enabled_env = library_env.get("DD_TRACE_ENABLED", "true") == "true"

--- a/tests/parametric/test_otel_tracer.py
+++ b/tests/parametric/test_otel_tracer.py
@@ -56,7 +56,6 @@ class Test_Otel_Tracer:
         assert child_span["resource"] == "child"
 
     @irrelevant(context.library == "cpp", reason="library does not implement OpenTelemetry")
-    @missing_feature(context.library == "python", reason="Not implemented")
     @missing_feature(context.library <= "java@1.23.0", reason="OTel resource naming implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "dotnet", reason="Not implemented")

--- a/tests/parametric/test_tracer.py
+++ b/tests/parametric/test_tracer.py
@@ -130,7 +130,6 @@ class Test_TracerSCITagging:
     )
     @missing_feature(context.library == "golang", reason="golang does not strip credentials yet")
     @missing_feature(context.library == "nodejs", reason="nodejs does not strip credentials yet")
-    @missing_feature(context.library == "python", reason="python does not strip credentials yet")
     def test_tracer_repository_url_strip_credentials(
         self, library_env: Dict[str, str], test_agent: _TestAgentAPI, test_library: APMLibrary
     ) -> None:


### PR DESCRIPTION
activate a few more passing tests

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
