### PR TITLE
Avoid false XPASS in test_reports.py

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -733,7 +733,10 @@ tests/:
     test_reports.py:
       Test_AttackTimestamp:
         akka-http: v1.22.0
-      Test_ExtraTagsFromRule: v1.22.0    # Supported since v1.22.0
+        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      Test_ExtraTagsFromRule:
+        '*': v1.22.0
+        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_HttpClientIP:
         '*': v0.98.1
         akka-http: v1.22.0
@@ -752,6 +755,7 @@ tests/:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_TagsFromRule:
         akka-http: v1.22.0
+        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     test_request_blocking.py:
       Test_AppSecRequestBlocking:
         '*': missing_feature

--- a/tests/appsec/test_reports.py
+++ b/tests/appsec/test_reports.py
@@ -185,8 +185,9 @@ class Test_ExtraTagsFromRule:
 def _get_appsec_triggers(request):
     datas = [appsec_data for _, _, _, appsec_data in interfaces.library.get_appsec_events(request=request)]
     assert datas, "No AppSec events found"
-    assert len(datas) == 1, "Only one AppSec event was expected"
-    triggers = [trigger for trigger in datas[0]["triggers"]]
+    triggers = []
+    for data in datas:
+        triggers += data["triggers"]
     assert triggers, "No triggers found"
     for trigger in triggers:
         assert "rule" in trigger
@@ -205,7 +206,6 @@ class Test_AttackTimestamp:
         """attack timestamp is given by start property of span"""
         spans = [span for _, _, span, _ in interfaces.library.get_appsec_events(request=self.r)]
         assert spans, "No AppSec events found"
-        assert len(spans) == 1, "Only one AppSec event was expected"
         for span in spans:
             assert "start" in span, "span should contain start property"
             assert isinstance(span["start"], int), f"start property should an int, not {repr(span['start'])}"


### PR DESCRIPTION
## Motivation

These tests were passing if the library did not implement AppSec at all (no appsec events, no iteration, no assert).

## Changes

* Ensure the tests assert the existence of the expected data.
* Minor refactor to have more descriptive tests (rather than `test_basic`).

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
