### PR TITLE
less strict test for Test_Headers

### DIFF
--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -112,7 +112,6 @@ class Test_Headers:
                 self.r_sk_4, pattern="routing.yml", address="server.request.headers.no_cookies", key_path=["x-filename"]
             )
 
-
     def setup_specific_key3(self):
         self.r_sk_5 = weblog.get("/waf/", headers={"referer": "<script >"})
         self.r_sk_6 = weblog.get("/waf/", headers={"RefErEr": "<script >"})

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -97,16 +97,21 @@ class Test_Headers:
     def setup_specific_key2(self):
         self.r_sk_4 = weblog.get("/waf/", headers={"X_Filename": "routing.yml"})
 
-    @missing_feature(library="python")
     @irrelevant(library="ruby", reason="Rack transforms underscores into dashes")
     @irrelevant(library="php", reason="PHP normalizes into dashes; additionally, matching on keys is not supported")
     @missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
     def test_specific_key2(self):
         """attacks on specific header X_Filename, and report it"""
+        try:
+            interfaces.library.assert_waf_attack(
+                self.r_sk_4, pattern="routing.yml", address="server.request.headers.no_cookies", key_path=["x_filename"]
+            )
+        except ValueError:
+            # also accept report on x-filename
+            interfaces.library.assert_waf_attack(
+                self.r_sk_4, pattern="routing.yml", address="server.request.headers.no_cookies", key_path=["x-filename"]
+            )
 
-        interfaces.library.assert_waf_attack(
-            self.r_sk_4, pattern="routing.yml", address="server.request.headers.no_cookies", key_path=["x_filename"]
-        )
 
     def setup_specific_key3(self):
         self.r_sk_5 = weblog.get("/waf/", headers={"referer": "<script >"})


### PR DESCRIPTION
## Motivation

`test_specific_key2` is a very strict test and it should pass for all reasonnable implementation of blocking feature

## Changes

Many frameworks replace underscore with dash to normalize header names. Allow that behaviour in that test too.
Known impacted frameworks:

- Flask (Python)
- Django (Python)
- Rack (Ruby)
- ...

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
