### PR TITLE
add test to make sure headers are stripped from blocking response

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -122,6 +122,7 @@ tests/:
       test_blocking.py:
         Test_Blocking: v2.27.0
         Test_CustomBlockingResponse: missing_feature
+        Test_Blocking_strip_response_headers: missing_feature
       test_custom_rules.py:
         Test_CustomRules: v2.30.0
       test_exclusions.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -121,8 +121,8 @@ tests/:
         Test_gRPC: missing_feature
       test_blocking.py:
         Test_Blocking: v2.27.0
-        Test_CustomBlockingResponse: missing_feature
         Test_Blocking_strip_response_headers: missing_feature
+        Test_CustomBlockingResponse: missing_feature
       test_custom_rules.py:
         Test_CustomRules: v2.30.0
       test_exclusions.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -158,6 +158,7 @@ tests/:
         Test_CustomBlockingResponse:
           '*': v1.63.0-dev
           uds-echo: bug
+        Test_Blocking_strip_response_headers: missing_feature
       test_custom_rules.py:
         Test_CustomRules: v1.51.0
       test_exclusions.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -155,10 +155,10 @@ tests/:
         Test_gRPC: v1.36.0
       test_blocking.py:
         Test_Blocking: v1.50.0-rc.1
+        Test_Blocking_strip_response_headers: missing_feature
         Test_CustomBlockingResponse:
           '*': v1.63.0-dev
           uds-echo: bug
-        Test_Blocking_strip_response_headers: missing_feature
       test_custom_rules.py:
         Test_CustomRules: v1.51.0
       test_exclusions.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -455,6 +455,7 @@ tests/:
           akka-http: v1.22.0
           play: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_Blocking_strip_response_headers: missing_feature
       test_custom_rules.py:
         Test_CustomRules: missing_feature
       test_exclusions.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -450,12 +450,12 @@ tests/:
           spring-boot-3-native: missing_feature
           spring-boot-openliberty: v1.3.0
           vertx3: v1.7.0
+        Test_Blocking_strip_response_headers: missing_feature
         Test_CustomBlockingResponse:
           '*': v1.11.0
           akka-http: v1.22.0
           play: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_Blocking_strip_response_headers: missing_feature
       test_custom_rules.py:
         Test_CustomRules: missing_feature
       test_exclusions.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -189,8 +189,8 @@ tests/:
         Test_gRPC: missing_feature
       test_blocking.py:
         Test_Blocking: v3.19.0
-        Test_CustomBlockingResponse: missing_feature
         Test_Blocking_strip_response_headers: missing_feature
+        Test_CustomBlockingResponse: missing_feature
       test_custom_rules.py:
         Test_CustomRules: v4.1.0
       test_exclusions.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -190,6 +190,7 @@ tests/:
       test_blocking.py:
         Test_Blocking: v3.19.0
         Test_CustomBlockingResponse: missing_feature
+        Test_Blocking_strip_response_headers: missing_feature
       test_custom_rules.py:
         Test_CustomRules: v4.1.0
       test_exclusions.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -120,8 +120,8 @@ tests/:
         Test_gRPC: missing_feature
       test_blocking.py:
         Test_Blocking: v0.86.0
-        Test_CustomBlockingResponse: v0.86.0
         Test_Blocking_strip_response_headers: missing_feature
+        Test_CustomBlockingResponse: v0.86.0
       test_custom_rules.py:
         Test_CustomRules: v0.87.2
       test_exclusions.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -121,6 +121,7 @@ tests/:
       test_blocking.py:
         Test_Blocking: v0.86.0
         Test_CustomBlockingResponse: v0.86.0
+        Test_Blocking_strip_response_headers: missing_feature
       test_custom_rules.py:
         Test_CustomRules: v0.87.2
       test_exclusions.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -244,10 +244,10 @@ tests/:
           django-poc: v1.10
           fastapi: v2.4.0.dev1
           flask-poc: v1.10
+        Test_Blocking_strip_response_headers: missing_feature
         Test_CustomBlockingResponse:
           '*': v1.20.0.dev
           fastapi: v2.4.0.dev1
-        Test_Blocking_strip_response_headers: missing_feature
       test_custom_rules.py:
         Test_CustomRules:
           '*': v1.16.1

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -247,6 +247,7 @@ tests/:
         Test_CustomBlockingResponse:
           '*': v1.20.0.dev
           fastapi: v2.4.0.dev1
+        Test_Blocking_strip_response_headers: missing_feature
       test_custom_rules.py:
         Test_CustomRules:
           '*': v1.16.1

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -121,8 +121,8 @@ tests/:
         Test_gRPC: missing_feature
       test_blocking.py:
         Test_Blocking: v1.11.0
-        Test_CustomBlockingResponse: missing_feature
         Test_Blocking_strip_response_headers: missing_feature
+        Test_CustomBlockingResponse: missing_feature
       test_custom_rules.py:
         Test_CustomRules: v1.12.0
       test_exclusions.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -122,6 +122,7 @@ tests/:
       test_blocking.py:
         Test_Blocking: v1.11.0
         Test_CustomBlockingResponse: missing_feature
+        Test_Blocking_strip_response_headers: missing_feature
       test_custom_rules.py:
         Test_CustomRules: v1.12.0
       test_exclusions.py:

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -585,6 +585,20 @@ class Test_Blocking_response_headers:
             assert response.status_code == 403, response.request.url
             interfaces.library.assert_waf_attack(response, rule="tst-037-009")
 
+    def setup_blocking_remove_headers(self):
+        self.rm_req_block1 = weblog.get(f"/tag_value/anything/200?content-language=en-us&session-id=123")
+
+    def test_blocking_remove_headers(self):
+        """Test if headers are removed from the blocking response"""
+        assert self.rm_req_block1.status_code == 403, self.rm_req_block1.request.url
+        interfaces.library.assert_waf_attack(self.rm_req_block1, rule="tst-037-009")
+        # these headers are set by the app so they should be not be present in the response
+        assert "content-language" not in self.rm_req_block1.headers
+        assert "session-id" not in self.rm_req_block1.headers
+        # content-length is set by the blocking response so it should be present
+        assert "content-length" in self.rm_req_block1.headers
+
+
     def setup_non_blocking(self):
         self.rm_req_nonblock1 = weblog.get(f"/tag_value/anything/200?content-color=en-us")
         self.rm_req_nonblock2 = weblog.get(f"/tag_value/anything/200?content-language=fr")

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -598,7 +598,6 @@ class Test_Blocking_response_headers:
         # content-length is set by the blocking response so it should be present
         assert "content-length" in self.rm_req_block1.headers
 
-
     def setup_non_blocking(self):
         self.rm_req_nonblock1 = weblog.get(f"/tag_value/anything/200?content-color=en-us")
         self.rm_req_nonblock2 = weblog.get(f"/tag_value/anything/200?content-language=fr")

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -585,19 +585,6 @@ class Test_Blocking_response_headers:
             assert response.status_code == 403, response.request.url
             interfaces.library.assert_waf_attack(response, rule="tst-037-009")
 
-    def setup_blocking_remove_headers(self):
-        self.rm_req_block1 = weblog.get(f"/tag_value/anything/200?content-language=en-us&session-id=123")
-
-    def test_blocking_remove_headers(self):
-        """Test if headers are removed from the blocking response"""
-        assert self.rm_req_block1.status_code == 403, self.rm_req_block1.request.url
-        interfaces.library.assert_waf_attack(self.rm_req_block1, rule="tst-037-009")
-        # these headers are set by the app so they should be not be present in the response
-        assert "content-language" not in self.rm_req_block1.headers
-        assert "session-id" not in self.rm_req_block1.headers
-        # content-length is set by the blocking response so it should be present
-        assert "content-length" in self.rm_req_block1.headers
-
     def setup_non_blocking(self):
         self.rm_req_nonblock1 = weblog.get(f"/tag_value/anything/200?content-color=en-us")
         self.rm_req_nonblock2 = weblog.get(f"/tag_value/anything/200?content-language=fr")

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -196,6 +196,23 @@ class Test_Blocking:
         assert self.r_html_v2.text == BLOCK_TEMPLATE_HTML_MIN_V2
 
 
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2705464728/Blocking#Stripping-response-headers")
+@scenarios.appsec_blocking
+@features.appsec_blocking_action
+class Test_Blocking_strip_response_headers:
+    def setup_strip_response_headers(self):
+        self.r_srh = weblog.get(f"/tag_value/anything/200?content-language=krypton&x-secret-header=123")
+
+    def test_strip_response_headers(self):
+        """Test if headers are stripped from the blocking response"""
+        assert self.r_srh.status_code == 403
+        interfaces.library.assert_waf_attack(self.r_srh, rule="tst-037-009")
+        # x-secret-header is set by the app so is should be not be present in the response
+        assert "x-secret-header" not in self.r_srh.headers
+        # content-length is set by the blocking response so it should be present
+        assert "content-length" in self.r_srh.headers
+
+
 @rfc("https://docs.google.com/document/d/1a_-isT9v_LiiGshzQZtzPzCK_CxMtMIil_2fOq9Z1RE/edit")
 @scenarios.appsec_blocking
 @features.appsec_blocking_action
@@ -238,20 +255,3 @@ class Test_CustomBlockingResponse:
         """Block with an default page because location parameter is missing from redirect request configuration"""
         assert self.r_cr.status_code == 403
         assert self.r_cr.text in BLOCK_TEMPLATE_JSON_ANY
-
-
-@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2705464728/Blocking#Stripping-response-headers")
-@scenarios.appsec_blocking
-@features.appsec_blocking_action
-class Test_Blocking_strip_response_headers:
-    def setup_strip_response_headers(self):
-        self.r_srh = weblog.get(f"/tag_value/anything/200?content-language=krypton&x-secret-header=123")
-
-    def test_strip_response_headers(self):
-        """Test if headers are stripped from the blocking response"""
-        assert self.r_srh.status_code == 403
-        interfaces.library.assert_waf_attack(self.r_srh, rule="tst-037-009")
-        # x-secret-header is set by the app so is should be not be present in the response
-        assert "x-secret-header" not in self.r_srh.headers
-        # content-length is set by the blocking response so it should be present
-        assert "content-length" in self.r_srh.headers

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -239,6 +239,7 @@ class Test_CustomBlockingResponse:
         assert self.r_cr.status_code == 403
         assert self.r_cr.text in BLOCK_TEMPLATE_JSON_ANY
 
+
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2705464728/Blocking#Stripping-response-headers")
 @scenarios.appsec_blocking
 @features.appsec_blocking_action
@@ -248,7 +249,7 @@ class Test_Blocking_strip_response_headers:
 
     def test_strip_response_headers(self):
         """Test if headers are stripped from the blocking response"""
-        assert self.r_srh.status_code == 403, self.r_srh.request.url
+        assert self.r_srh.status_code == 403
         interfaces.library.assert_waf_attack(self.r_srh, rule="tst-037-009")
         # x-secret-header is set by the app so is should be not be present in the response
         assert "x-secret-header" not in self.r_srh.headers

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -201,7 +201,7 @@ class Test_Blocking:
 @features.appsec_blocking_action
 class Test_Blocking_strip_response_headers:
     def setup_strip_response_headers(self):
-        self.r_srh = weblog.get(f"/tag_value/anything/200?content-language=krypton&x-secret-header=123")
+        self.r_srh = weblog.get(f"/tag_value/anything/200?x-secret-header=123&content-language=krypton")
 
     def test_strip_response_headers(self):
         """Test if headers are stripped from the blocking response"""


### PR DESCRIPTION
## Motivation

Standardize a previously undefined behavior in the blocking response.

## Changes

Add a new test that make sure response headers set by the app are not leaked through the blocking response.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
