### PR TITLE
Add new onboarding tests scenario

### DIFF
--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -147,7 +147,7 @@ class TestSimpleHostAutoInjectManual(_AutoInjectBaseTest):
 
 @features.host_auto_instrumentation
 @scenarios.host_auto_injection_ld_preload
-class TestSimpleHostAutoInjectManual(_AutoInjectBaseTest):
+class TestHostAutoInjectManualLdPreload(_AutoInjectBaseTest):
     def test_install_after_ld_preload(self, virtual_machine):
         """ We added entries to the ld.so.preload. After that, we can install the dd software and the app should be instrumented."""
         logger.info(f"Launching test_install for : [{virtual_machine.name}]...")

--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -145,6 +145,16 @@ class TestSimpleHostAutoInjectManual(_AutoInjectBaseTest):
         logger.info(f"Done test_install for : [{virtual_machine.name}]")
 
 
+@features.host_auto_instrumentation
+@scenarios.host_auto_injection_ld_preload
+class TestSimpleHostAutoInjectManual(_AutoInjectBaseTest):
+    def test_install_after_ld_preload(self, virtual_machine):
+        """ We added entries to the ld.so.preload. After that, we can install the dd software and the app should be instrumented."""
+        logger.info(f"Launching test_install for : [{virtual_machine.name}]...")
+        self._test_install(virtual_machine)
+        logger.info(f"Done test_install for : [{virtual_machine.name}]")
+
+
 @features.container_auto_instrumentation
 @scenarios.container_auto_injection
 class TestContainerAutoInjectManual(_AutoInjectBaseTest):

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1675,6 +1675,12 @@ class scenarios:
         "Onboarding Host Single Step Instrumentation scenario using agent auto install script",
         vm_provision="host-auto-inject-install-script",
     )
+    # TODO Add the provision of this scenario to the default host scenario (when fixes are released)
+    host_auto_injection_ld_preload = HostAutoInjectionScenario(
+        "HOST_AUTO_INJECTION_LD_PRELOAD",
+        "Onboarding Host Single Step Instrumentation scenario. Machines with previous ld.so.preload entries",
+        vm_provision="host-auto-inject-ld-preload",
+    )
 
     container_auto_injection = ContainerAutoInjectionScenario(
         "CONTAINER_AUTO_INJECTION", "Onboarding Container Single Step Instrumentation scenario",

--- a/utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/ld-preload.yml
+++ b/utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/ld-preload.yml
@@ -3,7 +3,6 @@
   os_distro: deb
 
   copy_files:
-
       - name: copy-helloworld-cpp
         local_path: utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/main.c
 
@@ -18,43 +17,12 @@
   os_distro: rpm
 
   copy_files:
-      - name: copy-binaries
-        local_path: binaries/
-
-      - name: copy-tracer-debug-config
-        local_path: utils/build/virtual_machine/provisions/auto-inject/tracer_debug/debug_config.yaml
+      - name: copy-helloworld-cpp
+        local_path: utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/main.c
 
   remote-command: | 
-    architecture=""
-    case $(uname -m) in
-        x86_64) architecture="x86_64" ;;
-        aarch64) architecture="aarch64" ;;
-    esac
-
-    if ls datadog-apm-inject-*.$architecture.rpm 1> /dev/null 2>&1; then
-        echo "Instaling datadog-apm-inject from local folder"
-        sudo yum -q list installed datadog-apm-inject &>/dev/null && sudo yum -y reinstall --disablerepo="*" datadog-apm-inject-*.$architecture.rpm || sudo yum -y install --disablerepo="*" datadog-apm-inject-*.$architecture.rpm
-    else
-        echo "Instaling datadog-apm-inject from remote repository"
-        sudo yum -q list installed datadog-apm-inject &>/dev/null && sudo yum -y reinstall --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject || sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject
-    fi
-
-    if ls datadog-apm-library-$DD_LANG-*.$architecture.rpm 1> /dev/null 2>&1; then
-        echo "Instaling datadog-apm-library-$DD_LANG from local folder"
-        sudo yum -q list installed datadog-apm-library-$DD_LANG &>/dev/null && sudo yum -y reinstall --disablerepo="*" datadog-apm-library-$DD_LANG-*.$architecture.rpm || sudo yum -y install --disablerepo="*" datadog-apm-library-$DD_LANG-*.$architecture.rpm
-    else
-        echo "Instaling datadog-apm-library-$DD_LANG from remote repository"
-        sudo yum -q list installed datadog-apm-library-$DD_LANG &>/dev/null && sudo yum -y reinstall --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-library-$DD_LANG || sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-library-$DD_LANG
-    fi
-
-    dd-host-install
-    sudo cp debug_config.yaml /etc/datadog-agent/inject/debug_config.yaml
-
-    if ls datadog-apm-inject-*.$architecture.rpm 1> /dev/null 2>&1; then
-        echo "Skipping package signature verification for local package"
-    else
-        echo "Verify package signature. Fails if it isn't V4"
-        yumdownloader datadog-apm-inject
-        rpm -v --checksig *.rpm | grep -q "Header V4 RSA/SHA256 Signature"
-        echo "Package signature verified!"
-    fi
+    sudo yum groupinstall "Development Tools"
+    echo "Compiling main.c to main.so"
+    gcc -Wall -fPIC -shared -o main.so main.c -ldl
+    sudo mv main.so /usr/local/lib/
+    sudo bash -c "echo /usr/local/lib/main.so >> /etc/ld.so.preload"

--- a/utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/ld-preload.yml
+++ b/utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/ld-preload.yml
@@ -1,0 +1,60 @@
+#Manual installation for lib-injection packages
+- os_type: linux
+  os_distro: deb
+
+  copy_files:
+
+      - name: copy-helloworld-cpp
+        local_path: utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/main.c
+
+  remote-command: |
+    sudo apt install -y gcc
+    echo "Compiling main.c to main.so"
+    gcc -Wall -fPIC -shared -o main.so main.c -ldl
+    sudo mv main.so /usr/local/lib/
+    sudo bash -c "echo /usr/local/lib/main.so >> /etc/ld.so.preload"
+
+- os_type: linux
+  os_distro: rpm
+
+  copy_files:
+      - name: copy-binaries
+        local_path: binaries/
+
+      - name: copy-tracer-debug-config
+        local_path: utils/build/virtual_machine/provisions/auto-inject/tracer_debug/debug_config.yaml
+
+  remote-command: | 
+    architecture=""
+    case $(uname -m) in
+        x86_64) architecture="x86_64" ;;
+        aarch64) architecture="aarch64" ;;
+    esac
+
+    if ls datadog-apm-inject-*.$architecture.rpm 1> /dev/null 2>&1; then
+        echo "Instaling datadog-apm-inject from local folder"
+        sudo yum -q list installed datadog-apm-inject &>/dev/null && sudo yum -y reinstall --disablerepo="*" datadog-apm-inject-*.$architecture.rpm || sudo yum -y install --disablerepo="*" datadog-apm-inject-*.$architecture.rpm
+    else
+        echo "Instaling datadog-apm-inject from remote repository"
+        sudo yum -q list installed datadog-apm-inject &>/dev/null && sudo yum -y reinstall --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject || sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-inject
+    fi
+
+    if ls datadog-apm-library-$DD_LANG-*.$architecture.rpm 1> /dev/null 2>&1; then
+        echo "Instaling datadog-apm-library-$DD_LANG from local folder"
+        sudo yum -q list installed datadog-apm-library-$DD_LANG &>/dev/null && sudo yum -y reinstall --disablerepo="*" datadog-apm-library-$DD_LANG-*.$architecture.rpm || sudo yum -y install --disablerepo="*" datadog-apm-library-$DD_LANG-*.$architecture.rpm
+    else
+        echo "Instaling datadog-apm-library-$DD_LANG from remote repository"
+        sudo yum -q list installed datadog-apm-library-$DD_LANG &>/dev/null && sudo yum -y reinstall --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-library-$DD_LANG || sudo yum -y install --disablerepo="*" --enablerepo="$DD_rpm_repo_name" datadog-apm-library-$DD_LANG
+    fi
+
+    dd-host-install
+    sudo cp debug_config.yaml /etc/datadog-agent/inject/debug_config.yaml
+
+    if ls datadog-apm-inject-*.$architecture.rpm 1> /dev/null 2>&1; then
+        echo "Skipping package signature verification for local package"
+    else
+        echo "Verify package signature. Fails if it isn't V4"
+        yumdownloader datadog-apm-inject
+        rpm -v --checksig *.rpm | grep -q "Header V4 RSA/SHA256 Signature"
+        echo "Package signature verified!"
+    fi

--- a/utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/main.c
+++ b/utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/main.c
@@ -1,6 +1,5 @@
-#include <stdio.h>
-
-int main(){
-    printf("Welcome to my amazing application!\n");
-    return 0;
+void
+_start()
+{
+        asm("mov $60,%rax; mov $0,%rdi; syscall");
 }

--- a/utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/main.c
+++ b/utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(){
+    printf("Welcome to my amazing application!\n");
+    return 0;
+}

--- a/utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/provision.yml
+++ b/utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/provision.yml
@@ -1,0 +1,34 @@
+#Optional: Load the environment variables
+init-environment: !include utils/build/virtual_machine/provisions/auto-inject/auto-inject-environment.yml
+
+#Mandatory: Scripts to extract the installed/tested components (json {component1:version, component2:version})
+tested_components:
+  install: !include utils/build/virtual_machine/provisions/auto-inject/auto-inject-tested_components.yml
+
+#Mandatory: Steps to install provision 
+provision_steps:
+  - init-config #Very first machine actions, like disable auto updates
+  - prepare-repos #Configure the reporitories for install auto-injection
+  - install-agent #Install the agent (allways latest release)
+  - ld-so-preload #Add custom preload library to the system 
+  - autoinjection_install_manual #Install the auto-injection softaware 'datadog-apm-inject' and 'datadog-apm-library-$DD_LANG'
+
+init-config:
+  cache: true
+  install: !include utils/build/virtual_machine/provisions/auto-inject/auto-inject_init_vm_config.yml
+
+prepare-repos:
+  cache: true
+  install: !include utils/build/virtual_machine/provisions/auto-inject/auto-inject-prepare_repos.yml
+
+install-agent:
+  install:
+    - os_type: linux
+      remote-command: |
+        REPO_URL=$DD_agent_repo_url DD_AGENT_DIST_CHANNEL=$DD_agent_dist_channel DD_AGENT_MAJOR_VERSION=$DD_agent_major_version bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+
+ld-so-preload:
+  install: !include utils/build/virtual_machine/provisions/host-auto-inject-ld-preload/ld-preload.yml
+
+autoinjection_install_manual:
+  install: !include utils/build/virtual_machine/provisions/host-auto-inject/auto-inject_host_manual.yml


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Adding new onboarding scenario in order to test different "ld.so.preload" status before installing the auto injection software

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
