### PR TITLE
update manifest and parametric test to manage easy wins for python

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -520,12 +520,12 @@ tests/:
     test_128_bit_traceids.py:
       Test_128_Bit_Traceids: v2.6.0
     test_dynamic_configuration.py:
-      TestDynamicConfigHeaderTags: missing_feature (failure 2.8.0)
+      TestDynamicConfigHeaderTags: flaky (failure 2.8.0/2.9.0.dev)
       TestDynamicConfigSamplingRules: missing_feature
-      TestDynamicConfigTracingEnabled: missing_feature (failure 2.8.0)
+      TestDynamicConfigTracingEnabled: flaky (failure 2.8.0/2.9.0.dev)
       TestDynamicConfigV1: missing_feature (failure 2.8.0)
       TestDynamicConfigV1_ServiceTargets: missing_feature (failure 2.8.0)
-      TestDynamicConfigV2: missing_feature (failure 2.8.0)
+      TestDynamicConfigV2: flaky (failure 2.8.0/2.9.0.dev)
     test_headers_b3.py:
       Test_Headers_B3: v2.8.0
     test_headers_b3multi.py:
@@ -553,7 +553,7 @@ tests/:
     test_otel_tracer.py:
       Test_Otel_Tracer: v2.8.0
     test_partial_flushing.py:
-      Test_Partial_Flushing: v2.9.0.dev1
+      Test_Partial_Flushing: flaky (failure 2.8.0/2.9.0.dev)
     test_sampling_delegation.py:
       Test_Decisionless_Extraction: v2.8.0
     test_sampling_span_tags.py:
@@ -563,9 +563,9 @@ tests/:
     test_span_sampling.py:
       Test_Span_Sampling: v2.8.0
     test_telemetry.py:
-      Test_Defaults: missing_feature (failure 2.8.0)
-      Test_Environment: missing_feature (failure 2.8.0)
-      Test_TelemetryInstallSignature: missing_feature (failure 2.8.0)
+      Test_Defaults: flaky (failure 2.8.0/2.9.0.dev)
+      Test_Environment: v2.9.0.dev # flaky in 2.8.0
+      Test_TelemetryInstallSignature: flaky (failure 2.8.0/2.9.0.dev)
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.9.0 # actual version unknown
       Test_Trace_Sampling_Globs: v2.8.0

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -158,7 +158,6 @@ class Test_Headers_B3:
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
-    @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     def test_headers_b3_migrated_extract_valid(self, test_agent, test_library):
         self.test_headers_b3_extract_invalid(test_agent, test_library)
 
@@ -169,7 +168,6 @@ class Test_Headers_B3:
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
-    @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     def test_headers_b3_migrated_extract_invalid(self, test_agent, test_library):
         self.test_headers_b3_extract_invalid(test_agent, test_library)
 
@@ -180,7 +178,6 @@ class Test_Headers_B3:
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
-    @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     def test_headers_b3_migrated_inject_valid(self, test_agent, test_library):
         self.test_headers_b3_inject_valid(test_agent, test_library)
 
@@ -191,7 +188,6 @@ class Test_Headers_B3:
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
-    @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     def test_headers_b3_migrated_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3_propagate_valid(test_agent, test_library)
 
@@ -202,7 +198,6 @@ class Test_Headers_B3:
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
-    @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     def test_headers_b3_migrated_propagate_invalid(self, test_agent, test_library):
         self.test_headers_b3_propagate_invalid(test_agent, test_library)
 
@@ -213,7 +208,6 @@ class Test_Headers_B3:
     @missing_feature(context.library == "java", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "nodejs", reason="Need to remove b3=b3multi alias")
     @missing_feature(context.library == "php", reason="Need to remove b3=b3multi alias")
-    @missing_feature(context.library == "python", reason="Need to remove b3=b3multi alias")
     @missing_feature(
         context.library == "ruby", reason="Propagators not configured for DD_TRACE_PROPAGATION_STYLE config",
     )

--- a/tests/parametric/test_partial_flushing.py
+++ b/tests/parametric/test_partial_flushing.py
@@ -32,7 +32,7 @@ class Test_Partial_Flushing:
     @missing_feature(context.library == "php", reason="partial flushing not implemented")
     @missing_feature(context.library == "golang", reason="partial flushing not enabled by default")
     @missing_feature(context.library == "dotnet", reason="partial flushing not enabled by default")
-    @missing_feature(
+    @bug(
         context.library == "python",
         reason="There is a problem with this tests when we execute python on multiple tests workers",
     )


### PR DESCRIPTION
## Changes

- Replace missing features with flaky in manifest for flaky parametric tests
- Remove deprecated missing feature decorator in a parametric test
- Replace one missing feature decorator with the more accurate bug decorator.
- activate Test_Environment for 2.9.0.dev (no flakyness detected anymore)

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
