### PR TITLE
Improve output for appsec_api_security

### DIFF
--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -4,6 +4,7 @@
 
 from utils import (
     context,
+    bug,
     interfaces,
     missing_feature,
     rfc,
@@ -224,12 +225,14 @@ class Test_Schema_Response_Body:
             data={"test_int": 1, "test_str": "anything", "test_bool": True, "test_float": 1.5234,},
         )
 
+    @bug(context.library > "php@0.99.1", reason="_dd.appsec.s.res.body is not reported")
     def test_request_method(self):
         """can provide response body schema"""
-        schema = get_schema(self.request, "res.body")
         assert self.request.status_code == 200
-        assert isinstance(schema, list)
-        assert len(schema) == 1
+
+        schema = get_schema(self.request, "res.body")
+        assert isinstance(schema, list), f"_dd.appsec.s.res.body meta tag should be a list, got {schema}"
+        assert len(schema) == 1, f"{schema} is not a list of length 1"
         for key in ("payload",):
             assert key in schema[0]
         payload_schema = schema[0]["payload"][0]


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

Per title.

Also skipping the test for PHP as it's currently failing, wait EOD before merging

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
