### PR TITLE
Remove Test_NoWafTimeout

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -480,8 +480,6 @@ tests/:
           '*': v0.95.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_NoWafTimeout:
-          akka-http: v1.22.0
       test_reports.py:
         Test_Monitoring:
           '*': v0.100.0

--- a/tests/appsec/waf/test_miscs.py
+++ b/tests/appsec/waf/test_miscs.py
@@ -83,12 +83,3 @@ class Test_CorrectOptionProcessing:
     def test_main(self):
         interfaces.library.assert_waf_attack(self.r_match)
         interfaces.library.assert_no_appsec_event(self.r_no_match)
-
-
-@features.threats_configuration
-class Test_NoWafTimeout:
-    """With an high value of DD_APPSEC_WAF_TIMEOUT, there is no WAF timeout"""
-
-    @missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")
-    def test_main(self):
-        interfaces.library_stdout.assert_absence("Ran out of time while running flow")


### PR DESCRIPTION
## Motivation

* This test will never fail, because it checks a log that is not used anymore.
* If we want to bring it back, we'd probably need to check any of `_dd.waf.timeouts`  tags of telemetry metrics on tracers that support them.

## Changes

* Remove `Test_NoWafTimeout`.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * [ ] To R&P team: locally build and push the image to hub.docker.com 
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * [ ] Once merged, add (or remove) it in system-test-dasboard nightly
