### PR TITLE
parametric(node): flush spans on tracer flush

### DIFF
--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -94,7 +94,6 @@ app.post('/trace/span/finish', (req, res) => {
   const id = req.body.span_id
   const span = spans[id]
   span.finish()
-  delete spans[id]
   res.json({});
 });
 
@@ -103,6 +102,7 @@ app.post('/trace/span/flush', (req, res) => {
   _writer.flush(() => {
     res.json({});
   })
+  spans = {}
 });
 
 app.post('/trace/span/set_meta', (req, res) => {

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -33,8 +33,8 @@ const otelStatusCodes = {
   'ERROR': 2
 }
 
-const spans = {}
-const otelSpans = {}
+const spans = new Map()
+const otelSpans = new Map()
 
 // Endpoint /trace/span/inject_headers
 app.post('/trace/span/inject_headers', (req, res) => {
@@ -102,7 +102,7 @@ app.post('/trace/span/flush', (req, res) => {
   _writer.flush(() => {
     res.json({});
   })
-  spans = {}
+  spans.clear();
 });
 
 app.post('/trace/span/set_meta', (req, res) => {
@@ -193,8 +193,8 @@ app.post('/trace/otel/end_span', (req, res) => {
 
 app.post('/trace/otel/flush', async (req, res) => {
   await tracerProvider.forceFlush()
-  spans = {};
-  otelSpans = {};
+  spans.clear();
+  otelSpans.clear();
   res.json({ success: true });
 });
 


### PR DESCRIPTION
## Motivation

Spans in a parametric application should not be deleted when a span is finished. This makes it difficult to test the state of the a finished span. Spans should be removed from parametric apps when the tracer is flushed. 


This change brings the node parametric app in-line with parametric apps written for other libraries (ex: otel, ruby, python, go, php).

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

