### PR TITLE
Avoid Test_Metric_Generation_Disabled XPASS if telemetry is not implemented or broken

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -687,7 +687,7 @@ class Test_Metric_Generation_Disabled:
 
     def test_metric_generation_disabled(self):
         all_data = list(interfaces.library.get_telemetry_data(flatten_message_batches=True))
-        assert all_data, "No telemetry data to validate on"
+        assert len(all_data) != 0, "No telemetry data to validate on"
         generate_metrics_messages = [d for d in all_data if get_request_type(d) == "generate-metrics"]
         assert not generate_metrics_messages, "Metric generation event is sent when metric generation is disabled"
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -689,7 +689,7 @@ class Test_Metric_Generation_Disabled:
         all_data = list(interfaces.library.get_telemetry_data(flatten_message_batches=True))
         assert len(all_data) != 0, "No telemetry data to validate on"
         generate_metrics_messages = [d for d in all_data if get_request_type(d) == "generate-metrics"]
-        assert not generate_metrics_messages, "Metric generation event is sent when metric generation is disabled"
+        assert  len(generate_metrics_messages) == 0, "Metric generation event is sent when metric generation is disabled"
 
 
 @features.telemetry_metrics_collected

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -689,7 +689,7 @@ class Test_Metric_Generation_Disabled:
         all_data = list(interfaces.library.get_telemetry_data(flatten_message_batches=True))
         assert len(all_data) != 0, "No telemetry data to validate on"
         generate_metrics_messages = [d for d in all_data if get_request_type(d) == "generate-metrics"]
-        assert  len(generate_metrics_messages) == 0, "Metric generation event is sent when metric generation is disabled"
+        assert len(generate_metrics_messages) == 0, "Metric generation event is sent when metric generation is disabled"
 
 
 @features.telemetry_metrics_collected

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -686,9 +686,10 @@ class Test_Metric_Generation_Disabled:
     """Assert that metrics are not reported when metric generation is disabled in telemetry"""
 
     def test_metric_generation_disabled(self):
-        for data in interfaces.library.get_telemetry_data(flatten_message_batches=True):
-            if get_request_type(data) == "generate-metrics":
-                raise Exception("Metric generate event is sent when metric generation is disabled")
+        all_data = list(interfaces.library.get_telemetry_data(flatten_message_batches=True))
+        assert all_data, "No telemetry data to validate on"
+        generate_metrics_messages = [d for d in all_data if get_request_type(d) == "generate-metrics"]
+        assert not generate_metrics_messages, "Metric generation event is sent when metric generation is disabled"
 
 
 @features.telemetry_metrics_collected


### PR DESCRIPTION
## Motivation

This scenario passed on GraalVM, where we do not implement telemetry at all.

## Changes

* Assert that we receive telemetry (this scenario should have all telemetry working except metrics).
* Make the assert more informative (it'll print contents if it fails).

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

