### PR TITLE
Fix ruby parametric with GRPC propagation

### DIFF
--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Load library binary
         if: ${{ matrix.version == 'dev' }}
         run: ./utils/scripts/load-binary.sh ${{ inputs.library }}
+      - name: Load Ruby library binary (skipping release tests, use snapshot instead)
+        if: ${{ matrix.version == 'prod' && inputs.library == 'ruby'}}
+        run: ./utils/scripts/load-binary.sh ${{ inputs.library }}
       - name: Run parametric tests (with timeout)
         if: ${{ inputs.library == 'java' }}
         run: |

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -46,6 +46,7 @@ def enable_migrated_b3_single_key() -> Any:
 @scenarios.parametric
 class Test_Headers_B3:
     @enable_b3()
+    @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_extract_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
@@ -63,6 +64,7 @@ class Test_Headers_B3:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3()
+    @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_extract_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted.
@@ -76,6 +78,7 @@ class Test_Headers_B3:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3()
+    @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_inject_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are injected properly.
@@ -97,6 +100,7 @@ class Test_Headers_B3:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3()
+    @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_propagate_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
@@ -120,6 +124,7 @@ class Test_Headers_B3:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3()
+    @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted


### PR DESCRIPTION
## Motivation

Fix ruby parametric with GRPC propagation

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

