### PR TITLE
OnBoarding: Fix autoinject log parser

### DIFF
--- a/utils/onboarding/injection_log_parser.py
+++ b/utils/onboarding/injection_log_parser.py
@@ -24,7 +24,7 @@ def command_injection_skipped(command_line, log_local_path):
 
             # Perhaps the command was instrumented or could be skipped by its arguments. Checking
             elif _get_command_props_values(command_desc, command_args) is True:
-                if last_line_json["msg"] == "error when parsing" and last_line_json["error"].startswith(
+                if last_line_json["msg"] in ["error when parsing", "skipping"] and last_line_json["error"].startswith(
                     "skipping due to ignore rules for language"
                 ):
                     logger.info(f"    Command {command_args} was skipped by ignore arguments")


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

