### PR TITLE
Better schema test logic API

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -240,7 +240,7 @@ jobs:
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
     - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES scenario
-      if: always() && steps.build.outcome == 'success' && inputs.run_all
+      if: always() && steps.build.outcome == 'success' && (inputs.run_appsec || inputs.run_all)
       run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
@@ -250,12 +250,12 @@ jobs:
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
     - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD scenario
-      if: always() && steps.build.outcome == 'success' && inputs.run_all
+      if: always() && steps.build.outcome == 'success' && (inputs.run_appsec || inputs.run_all)
       run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
     - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE scenario
-      if: always() && steps.build.outcome == 'success' && inputs.run_all
+      if: always() && steps.build.outcome == 'success' && (inputs.run_appsec || inputs.run_all)
       run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
@@ -265,7 +265,7 @@ jobs:
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
     - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE scenario
-      if: always() && steps.build.outcome == 'success' && inputs.run_all
+      if: always() && steps.build.outcome == 'success' && (inputs.run_appsec || inputs.run_all)
       run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}

--- a/conftest.py
+++ b/conftest.py
@@ -205,7 +205,7 @@ def pytest_collection_modifyitems(session, config, items):
             deselected.append(item)
             continue
 
-        if declared_scenario == context.scenario.name:
+        if context.scenario.is_part_of(declared_scenario):
             logger.info(f"{item.nodeid} is included in {context.scenario}")
             selected.append(item)
 

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -52,44 +52,44 @@ class Test_Agent:
 class RemoteConfigurationFieldsBasicTests:
     """Misc tests on fields and values on remote configuration requests"""
 
-    @bug(context.library < "golang@1.36.0")
-    @bug(context.library < "java@0.93.0")
-    @bug(context.library >= "nodejs@3.14.1")
+    # @bug(context.library < "golang@1.36.0")
+    # @bug(context.library < "java@0.93.0")
+    # @bug(context.library >= "nodejs@3.14.1")
     def test_schemas(self):
         """Test all library schemas"""
-        interfaces.library.assert_schemas()
+        interfaces.library.assert_schema_points()
 
-    def test_non_regression(self):
-        """Non-regression test on shemas"""
+    # def test_non_regression(self):
+    #     """Non-regression test on shemas"""
 
-        # Never skip this test. As a full respect of shemas may be hard, this test ensure that
-        # at least the part that was ok stays ok.
+    #     # Never skip this test. As a full respect of shemas may be hard, this test ensure that
+    #     # at least the part that was ok stays ok.
 
-        allowed_errors = None
-        if context.library == "golang":
-            allowed_errors = (
-                r"'actor' is a required property on instance \['events'\]\[\d+\]\['context'\]",
-                r"'protocol_version' is a required property on instance ",
-            )
-        elif context.library == "java":
-            # pylint: disable=line-too-long
-            allowed_errors = (
-                r"'appsec' was expected on instance \['events'\]\[\d+\]\['event_type'\]",
-                r"'headers' is a required property on instance \['events'\]\[\d+\]\['context'\]\['http'\]\['response'\]",
-                r"'idempotency_key' is a required property on instance ",
-            )
-        elif context.library == "dotnet":
-            allowed_errors = (
-                # value is missing in configuration object in telemetry payloads
-                r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-            )
-        elif context.library == "nodejs":
-            allowed_errors = (
-                # value is missing in configuration object in telemetry payloads
-                r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-            )
+    #     allowed_errors = None
+    #     if context.library == "golang":
+    #         allowed_errors = (
+    #             r"'actor' is a required property on instance \['events'\]\[\d+\]\['context'\]",
+    #             r"'protocol_version' is a required property on instance ",
+    #         )
+    #     elif context.library == "java":
+    #         # pylint: disable=line-too-long
+    #         allowed_errors = (
+    #             r"'appsec' was expected on instance \['events'\]\[\d+\]\['event_type'\]",
+    #             r"'headers' is a required property on instance \['events'\]\[\d+\]\['context'\]\['http'\]\['response'\]",
+    #             r"'idempotency_key' is a required property on instance ",
+    #         )
+    #     elif context.library == "dotnet":
+    #         allowed_errors = (
+    #             # value is missing in configuration object in telemetry payloads
+    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
+    #         )
+    #     elif context.library == "nodejs":
+    #         allowed_errors = (
+    #             # value is missing in configuration object in telemetry payloads
+    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
+    #         )
 
-        interfaces.library.assert_schemas(allowed_errors=allowed_errors)
+    #     interfaces.library.assert_schemas(allowed_errors=allowed_errors)
 
     def test_client_state_errors(self):
         """Ensure that the Client State error is consistent"""

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -18,6 +18,7 @@ from utils import (
     features,
 )
 from utils.tools import logger
+from tests.test_schemas import BaseTestLibrarySchema
 
 with open("tests/remote_config/rc_expected_requests_live_debugging.json", encoding="utf-8") as f:
     LIVE_DEBUGGING_EXPECTED_REQUESTS = json.load(f)
@@ -49,15 +50,15 @@ class Test_Agent:
 
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @features.remote_config_object_supported
-class RemoteConfigurationFieldsBasicTests:
+class RemoteConfigurationFieldsBasicTests(BaseTestLibrarySchema):
     """Misc tests on fields and values on remote configuration requests"""
 
     # @bug(context.library < "golang@1.36.0")
     # @bug(context.library < "java@0.93.0")
     # @bug(context.library >= "nodejs@3.14.1")
-    def test_schemas(self):
-        """Test all library schemas"""
-        interfaces.library.assert_schema_points()
+    # def test_schemas(self):
+    #     """Test all library schemas"""
+    #     interfaces.library.assert_schema_points()
 
     # def test_non_regression(self):
     #     """Non-regression test on shemas"""

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -18,7 +18,6 @@ from utils import (
     features,
 )
 from utils.tools import logger
-from tests.test_schemas import BaseTestLibrarySchema
 
 with open("tests/remote_config/rc_expected_requests_live_debugging.json", encoding="utf-8") as f:
     LIVE_DEBUGGING_EXPECTED_REQUESTS = json.load(f)
@@ -50,47 +49,8 @@ class Test_Agent:
 
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @features.remote_config_object_supported
-class RemoteConfigurationFieldsBasicTests(BaseTestLibrarySchema):
+class RemoteConfigurationFieldsBasicTests:
     """Misc tests on fields and values on remote configuration requests"""
-
-    # @bug(context.library < "golang@1.36.0")
-    # @bug(context.library < "java@0.93.0")
-    # @bug(context.library >= "nodejs@3.14.1")
-    # def test_schemas(self):
-    #     """Test all library schemas"""
-    #     interfaces.library.assert_schema_points()
-
-    # def test_non_regression(self):
-    #     """Non-regression test on shemas"""
-
-    #     # Never skip this test. As a full respect of shemas may be hard, this test ensure that
-    #     # at least the part that was ok stays ok.
-
-    #     allowed_errors = None
-    #     if context.library == "golang":
-    #         allowed_errors = (
-    #             r"'actor' is a required property on instance \['events'\]\[\d+\]\['context'\]",
-    #             r"'protocol_version' is a required property on instance ",
-    #         )
-    #     elif context.library == "java":
-    #         # pylint: disable=line-too-long
-    #         allowed_errors = (
-    #             r"'appsec' was expected on instance \['events'\]\[\d+\]\['event_type'\]",
-    #             r"'headers' is a required property on instance \['events'\]\[\d+\]\['context'\]\['http'\]\['response'\]",
-    #             r"'idempotency_key' is a required property on instance ",
-    #         )
-    #     elif context.library == "dotnet":
-    #         allowed_errors = (
-    #             # value is missing in configuration object in telemetry payloads
-    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-    #         )
-    #     elif context.library == "nodejs":
-    #         allowed_errors = (
-    #             # value is missing in configuration object in telemetry payloads
-    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-    #         )
-
-    #     interfaces.library.assert_schemas(allowed_errors=allowed_errors)
 
     def test_client_state_errors(self):
         """Ensure that the Client State error is consistent"""

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -19,15 +19,22 @@ class Test_library:
         interfaces.library.assert_schema_points(
             excluded_points=[
                 ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]"),
-                ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload"),
+                ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload"),  # APPSEC-52845
             ]
         )
 
     @bug(context.library >= "nodejs@2.27.1")
+    @bug(library="cpp")
+    @bug(library="dotnet")
+    @bug(library="golang")
+    @bug(library="java")
+    @bug(library="php")
+    @bug(library="python")
+    @bug(library="ruby")
     def test_library_schema_telemetry_conf_value(self):
         interfaces.library.assert_schema_point("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]")
 
-    @bug(library="python", reason="XXX-1234")
+    @bug(library="python", reason="APPSEC-52845")
     def test_library_schema_telemetry_job_object(self):
         interfaces.library.assert_schema_point("/telemetry/proxy/api/v2/apmtelemetry", "$.payload")
 
@@ -88,13 +95,24 @@ class Test_Agent:
         interfaces.agent.assert_schema_points(
             excluded_points=[
                 ("/api/v2/apmtelemetry", "$.payload.configuration[]"),
-                ("/api/v2/apmtelemetry", "$.payload"),
+                ("/api/v2/apmtelemetry", "$.payload"),  # APPSEC-52845
             ]
         )
 
     @bug(context.library >= "nodejs@2.27.1")
+    @bug(library="cpp")
+    @bug(library="dotnet")
+    @bug(library="golang")
+    @bug(library="java")
+    @bug(library="php")
+    @bug(library="python")
+    @bug(library="ruby")
     def test_agent_schema_telemetry_conf_value(self):
         interfaces.agent.assert_schema_point("/api/v2/apmtelemetry", "$.payload.configuration[]")
+
+    @bug(library="python", reason="APPSEC-52845")
+    def test_library_schema_telemetry_job_object(self):
+        interfaces.agent.assert_schema_point("/api/v2/apmtelemetry", "$.payload")
 
     # def test_non_regression(self):
     #     """ Non-regression test on shemas """

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -4,11 +4,11 @@
 
 """Test format specifications"""
 
-from utils import weblog, interfaces, bug, context
+from utils import weblog, interfaces, bug, context, scenarios
 
 
-# allow to reuse the same test for other scenarios
-class BaseTestLibrarySchema:
+@scenarios.all_endtoend_scenarios
+class Test_library:
     """Libraries's payload are valid regarding schemas"""
 
     def setup_library_schema_full(self):
@@ -18,19 +18,22 @@ class BaseTestLibrarySchema:
     def test_library_schema_full(self):
         interfaces.library.assert_schema_points(
             excluded_points=[
-                ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property")
+                ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]"),
+                ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload")
             ]
         )
 
     @bug(context.library >= "nodejs@2.27.1")
     def test_library_schema_telemetry_conf_value(self):
         interfaces.library.assert_schema_point(
-            "/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property"
+            "/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]"
         )
 
-
-class Test_library(BaseTestLibrarySchema):
-    ...
+    @bug(library="python", reason="XXX-1234")
+    def test_library_schema_telemetry_job_object(self):
+        interfaces.library.assert_schema_point(
+            "/telemetry/proxy/api/v2/apmtelemetry", "$.payload"
+        )
 
     # @bug(context.library < "golang@1.36.0")
     # @bug(context.library < "java@0.93.0")
@@ -74,6 +77,7 @@ class Test_library(BaseTestLibrarySchema):
     #     interfaces.library.assert_schemas(allowed_errors=allowed_errors)
 
 
+@scenarios.all_endtoend_scenarios
 class Test_Agent:
     """Agents's payload are valid regarding schemas"""
 
@@ -86,14 +90,15 @@ class Test_Agent:
     # @bug(context.library >= "dotnet@2.24.0")
     def test_agent_schema_full(self):
         interfaces.agent.assert_schema_points(
-            excluded_points=[("/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property")]
+            excluded_points=[
+                ("/api/v2/apmtelemetry", "$.payload.configuration[]"),
+                ("/api/v2/apmtelemetry", "$.payload")
+            ]
         )
 
     @bug(context.library >= "nodejs@2.27.1")
     def test_agent_schema_telemetry_conf_value(self):
-        interfaces.agent.assert_schema_point(
-            "/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property"
-        )
+        interfaces.agent.assert_schema_point("/api/v2/apmtelemetry", "$.payload.configuration[]")
 
     # def test_non_regression(self):
     #     """ Non-regression test on shemas """

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -14,52 +14,62 @@ class Test_Library:
         # send some requests to be sure to trigger events
         weblog.get("/waf", params={"key": "\n :"})  # rules.http_protocol_violation.crs_921_160
 
-    @bug(context.library < "golang@1.36.0")
-    @bug(context.library < "java@0.93.0")
-    @bug(context.library >= "dotnet@2.24.0")
-    @bug(context.library >= "nodejs@2.27.1")
-    @bug(
-        context.library >= "python@1.16.0rc2.dev37"
-        and context.agent_version >= "7.47.0rc2"
-        and context.appsec_rules_file is not None,
-        reason="on /v0.7/config, client.products is an empty array",
-    )
+    # def test_some_schema_point(self):
+    #     interfaces.library.assert_schema_point("/v0.4/traces", "$[][]['name']")
+
     def test_full(self):
-        interfaces.library.assert_schemas()
+        interfaces.library.assert_schema_points(
+            excluded_points=[
+                # ("/v0.4/traces", "$[][]['name']")
+            ]
+        )
 
-    def test_non_regression(self):
-        """ Non-regression test on shemas """
+    # @bug(context.library < "golang@1.36.0")
+    # @bug(context.library < "java@0.93.0")
+    # @bug(context.library >= "dotnet@2.24.0")
+    # @bug(context.library >= "nodejs@2.27.1")
+    # @bug(
+    #     context.library >= "python@1.16.0rc2.dev37"
+    #     and context.agent_version >= "7.47.0rc2"
+    #     and context.appsec_rules_file is not None,
+    #     reason="on /v0.7/config, client.products is an empty array",
+    # )
+    # def test_full(self):
+    #     interfaces.library.assert_schemas()
 
-        # Never skip this test. As a full respect of shemas may be hard, this test ensure that
-        # at least the part that was ok stays ok.
+    # def test_non_regression(self):
+    #     """ Non-regression test on shemas """
 
-        allowed_errors = None
-        if context.library == "golang":
-            allowed_errors = (
-                r"'actor' is a required property on instance \['events'\]\[\d+\]\['context'\]",
-                r"'protocol_version' is a required property on instance ",
-            )
-        elif context.library == "java":
-            # pylint: disable=line-too-long
-            allowed_errors = (
-                r"'appsec' was expected on instance \['events'\]\[\d+\]\['event_type'\]",
-                r"'headers' is a required property on instance \['events'\]\[\d+\]\['context'\]\['http'\]\['response'\]",
-                r"'idempotency_key' is a required property on instance ",
-            )
-        elif context.library == "dotnet":
-            allowed_errors = (
-                # value is missing in configuration object in telemetry payloads
-                r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-            )
-        elif context.library == "nodejs":
-            allowed_errors = (
-                # value is missing in configuration object in telemetry payloads
-                r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-            )
-        elif context.library == "python":
-            allowed_errors = (r"\[\] is too short on instance \['client'\]\['products'\]",)
+    #     # Never skip this test. As a full respect of shemas may be hard, this test ensure that
+    #     # at least the part that was ok stays ok.
 
-        interfaces.library.assert_schemas(allowed_errors=allowed_errors)
+    #     allowed_errors = None
+    #     if context.library == "golang":
+    #         allowed_errors = (
+    #             r"'actor' is a required property on instance \['events'\]\[\d+\]\['context'\]",
+    #             r"'protocol_version' is a required property on instance ",
+    #         )
+    #     elif context.library == "java":
+    #         # pylint: disable=line-too-long
+    #         allowed_errors = (
+    #             r"'appsec' was expected on instance \['events'\]\[\d+\]\['event_type'\]",
+    #             r"'headers' is a required property on instance \['events'\]\[\d+\]\['context'\]\['http'\]\['response'\]",
+    #             r"'idempotency_key' is a required property on instance ",
+    #         )
+    #     elif context.library == "dotnet":
+    #         allowed_errors = (
+    #             # value is missing in configuration object in telemetry payloads
+    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
+    #         )
+    #     elif context.library == "nodejs":
+    #         allowed_errors = (
+    #             # value is missing in configuration object in telemetry payloads
+    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
+    #         )
+    #     elif context.library == "python":
+    #         allowed_errors = (r"\[\] is too short on instance \['client'\]\['products'\]",)
+
+    #     interfaces.library.assert_schemas(allowed_errors=allowed_errors)
 
 
 class Test_Agent:
@@ -69,41 +79,41 @@ class Test_Agent:
         # send some requests to be sure to trigger events
         weblog.get("/waf", params={"key": "\n :"})  # rules.http_protocol_violation.crs_921_160
 
-    @bug(context.library < "golang@1.36.0")
-    @bug(context.library < "java@0.93.0")
-    @bug(context.library >= "dotnet@2.24.0")
-    @bug(context.library >= "nodejs@2.27.1")
+    # @bug(context.library < "golang@1.36.0")
+    # @bug(context.library < "java@0.93.0")
+    # @bug(context.library >= "dotnet@2.24.0")
+    # @bug(context.library >= "nodejs@2.27.1")
     def test_full(self):
-        interfaces.agent.assert_schemas()
+        interfaces.agent.assert_schema_points()
 
-    def test_non_regression(self):
-        """ Non-regression test on shemas """
+    # def test_non_regression(self):
+    #     """ Non-regression test on shemas """
 
-        # Never skip this test. As a full respect of shemas may be hard, this test ensure that
-        # at least the part that was ok stays ok.
+    #     # Never skip this test. As a full respect of shemas may be hard, this test ensure that
+    #     # at least the part that was ok stays ok.
 
-        allowed_errors = None
-        if context.library == "golang":
-            allowed_errors = (
-                r"'actor' is a required property on instance \['events'\]\[\d+\]\['context'\]",
-                r"'protocol_version' is a required property on instance ",
-            )
-        elif context.library == "java":
-            # pylint: disable=line-too-long
-            allowed_errors = (
-                r"'appsec' was expected on instance \['events'\]\[\d+\]\['event_type'\]",
-                r"'headers' is a required property on instance \['events'\]\[\d+\]\['context'\]\['http'\]\['response'\]",
-                r"'idempotency_key' is a required property on instance ",
-            )
-        elif context.library == "dotnet":
-            allowed_errors = (
-                # value is missing in configuration object in telemetry payloads
-                r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-            )
-        elif context.library == "nodejs":
-            allowed_errors = (
-                # value is missing in configuration object in telemetry payloads
-                r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-            )
+    #     allowed_errors = None
+    #     if context.library == "golang":
+    #         allowed_errors = (
+    #             r"'actor' is a required property on instance \['events'\]\[\d+\]\['context'\]",
+    #             r"'protocol_version' is a required property on instance ",
+    #         )
+    #     elif context.library == "java":
+    #         # pylint: disable=line-too-long
+    #         allowed_errors = (
+    #             r"'appsec' was expected on instance \['events'\]\[\d+\]\['event_type'\]",
+    #             r"'headers' is a required property on instance \['events'\]\[\d+\]\['context'\]\['http'\]\['response'\]",
+    #             r"'idempotency_key' is a required property on instance ",
+    #         )
+    #     elif context.library == "dotnet":
+    #         allowed_errors = (
+    #             # value is missing in configuration object in telemetry payloads
+    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
+    #         )
+    #     elif context.library == "nodejs":
+    #         allowed_errors = (
+    #             # value is missing in configuration object in telemetry payloads
+    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
+    #         )
 
-        interfaces.agent.assert_schemas(allowed_errors=allowed_errors)
+    #     interfaces.agent.assert_schemas(allowed_errors=allowed_errors)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -49,6 +49,7 @@ class Test_Agent:
         )
 
     @irrelevant(context.scenario is scenarios.crossed_tracing_libraries, reason="APPSEC-52805")
+    @irrelevant(context.scenario is scenarios.graphql_appsec, reason="APPSEC-52805")
     def test_agent_schema_telemetry_conf_value(self):
         interfaces.agent.assert_schema_point("/api/v2/apmtelemetry", "$.payload.configuration[]")
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -4,7 +4,7 @@
 
 """Test format specifications"""
 
-from utils import weblog, interfaces, bug, context, scenarios
+from utils import weblog, interfaces, bug, irrelevant, context, scenarios
 
 
 @scenarios.all_endtoend_scenarios
@@ -13,7 +13,7 @@ class Test_library:
 
     def setup_library_schema_full(self):
         # send some requests to be sure to trigger events
-        weblog.get("/waf", params={"key": "\n :"})  # rules.http_protocol_violation.crs_921_160
+        weblog.get("/waf", params={"key": "\n :"})
 
     def test_library_schema_full(self):
         interfaces.library.assert_schema_points(
@@ -23,61 +23,13 @@ class Test_library:
             ]
         )
 
-    @bug(context.library >= "nodejs@2.27.1")
-    @bug(library="cpp")
-    @bug(library="dotnet")
-    @bug(library="golang")
-    @bug(library="java")
-    @bug(library="php")
-    @bug(library="python")
-    @bug(library="ruby")
+    @bug(context.library >= "nodejs@2.27.1", reason="APPSEC-52805")
     def test_library_schema_telemetry_conf_value(self):
         interfaces.library.assert_schema_point("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]")
 
     @bug(library="python", reason="APPSEC-52845")
     def test_library_schema_telemetry_job_object(self):
         interfaces.library.assert_schema_point("/telemetry/proxy/api/v2/apmtelemetry", "$.payload")
-
-    # @bug(context.library < "golang@1.36.0")
-    # @bug(context.library < "java@0.93.0")
-    # @bug(context.library >= "dotnet@2.24.0")
-    # @bug(
-    #     context.library >= "python@1.16.0rc2.dev37"
-    #     and context.agent_version >= "7.47.0rc2"
-    #     and context.appsec_rules_file is not None,
-    #     reason="on /v0.7/config, client.products is an empty array",
-    # )
-    # def test_full(self):
-    #     interfaces.library.assert_schemas()
-
-    # def test_non_regression(self):
-    #     """ Non-regression test on shemas """
-
-    #     # Never skip this test. As a full respect of shemas may be hard, this test ensure that
-    #     # at least the part that was ok stays ok.
-
-    #     allowed_errors = None
-    #     if context.library == "golang":
-    #         allowed_errors = (
-    #             r"'actor' is a required property on instance \['events'\]\[\d+\]\['context'\]",
-    #             r"'protocol_version' is a required property on instance ",
-    #         )
-    #     elif context.library == "java":
-    #         # pylint: disable=line-too-long
-    #         allowed_errors = (
-    #             r"'appsec' was expected on instance \['events'\]\[\d+\]\['event_type'\]",
-    #             r"'headers' is a required property on instance \['events'\]\[\d+\]\['context'\]\['http'\]\['response'\]",
-    #             r"'idempotency_key' is a required property on instance ",
-    #         )
-    #     elif context.library == "dotnet":
-    #         allowed_errors = (
-    #             # value is missing in configuration object in telemetry payloads
-    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-    #         )
-    #     elif context.library == "python":
-    #         allowed_errors = (r"\[\] is too short on instance \['client'\]\['products'\]",)
-
-    #     interfaces.library.assert_schemas(allowed_errors=allowed_errors)
 
 
 @scenarios.all_endtoend_scenarios
@@ -86,11 +38,8 @@ class Test_Agent:
 
     def setup_agent_schema_full(self):
         # send some requests to be sure to trigger events
-        weblog.get("/waf", params={"key": "\n :"})  # rules.http_protocol_violation.crs_921_160
+        weblog.get("/waf", params={"key": "\n :"})
 
-    # @bug(context.library < "golang@1.36.0")
-    # @bug(context.library < "java@0.93.0")
-    # @bug(context.library >= "dotnet@2.24.0")
     def test_agent_schema_full(self):
         interfaces.agent.assert_schema_points(
             excluded_points=[
@@ -99,44 +48,10 @@ class Test_Agent:
             ]
         )
 
-    @bug(context.library >= "nodejs@2.27.1")
-    @bug(library="cpp")
-    @bug(library="dotnet")
-    @bug(library="golang")
-    @bug(library="java")
-    @bug(library="php")
-    @bug(library="python")
-    @bug(library="ruby")
+    @irrelevant(context.scenario is scenarios.crossed_tracing_libraries, reason="APPSEC-52805")
     def test_agent_schema_telemetry_conf_value(self):
         interfaces.agent.assert_schema_point("/api/v2/apmtelemetry", "$.payload.configuration[]")
 
     @bug(library="python", reason="APPSEC-52845")
     def test_library_schema_telemetry_job_object(self):
         interfaces.agent.assert_schema_point("/api/v2/apmtelemetry", "$.payload")
-
-    # def test_non_regression(self):
-    #     """ Non-regression test on shemas """
-
-    #     # Never skip this test. As a full respect of shemas may be hard, this test ensure that
-    #     # at least the part that was ok stays ok.
-
-    #     allowed_errors = None
-    #     if context.library == "golang":
-    #         allowed_errors = (
-    #             r"'actor' is a required property on instance \['events'\]\[\d+\]\['context'\]",
-    #             r"'protocol_version' is a required property on instance ",
-    #         )
-    #     elif context.library == "java":
-    #         # pylint: disable=line-too-long
-    #         allowed_errors = (
-    #             r"'appsec' was expected on instance \['events'\]\[\d+\]\['event_type'\]",
-    #             r"'headers' is a required property on instance \['events'\]\[\d+\]\['context'\]\['http'\]\['response'\]",
-    #             r"'idempotency_key' is a required property on instance ",
-    #         )
-    #     elif context.library == "dotnet":
-    #         allowed_errors = (
-    #             # value is missing in configuration object in telemetry payloads
-    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-    #         )
-
-    #     interfaces.agent.assert_schemas(allowed_errors=allowed_errors)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -48,6 +48,7 @@ class Test_Agent:
             ]
         )
 
+    @bug(context.library >= "nodejs@2.27.1", reason="APPSEC-52805")
     @irrelevant(context.scenario is scenarios.crossed_tracing_libraries, reason="APPSEC-52805")
     @irrelevant(context.scenario is scenarios.graphql_appsec, reason="APPSEC-52805")
     def test_agent_schema_telemetry_conf_value(self):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -19,21 +19,17 @@ class Test_library:
         interfaces.library.assert_schema_points(
             excluded_points=[
                 ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]"),
-                ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload")
+                ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload"),
             ]
         )
 
     @bug(context.library >= "nodejs@2.27.1")
     def test_library_schema_telemetry_conf_value(self):
-        interfaces.library.assert_schema_point(
-            "/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]"
-        )
+        interfaces.library.assert_schema_point("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]")
 
     @bug(library="python", reason="XXX-1234")
     def test_library_schema_telemetry_job_object(self):
-        interfaces.library.assert_schema_point(
-            "/telemetry/proxy/api/v2/apmtelemetry", "$.payload"
-        )
+        interfaces.library.assert_schema_point("/telemetry/proxy/api/v2/apmtelemetry", "$.payload")
 
     # @bug(context.library < "golang@1.36.0")
     # @bug(context.library < "java@0.93.0")
@@ -92,7 +88,7 @@ class Test_Agent:
         interfaces.agent.assert_schema_points(
             excluded_points=[
                 ("/api/v2/apmtelemetry", "$.payload.configuration[]"),
-                ("/api/v2/apmtelemetry", "$.payload")
+                ("/api/v2/apmtelemetry", "$.payload"),
             ]
         )
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -7,14 +7,15 @@
 from utils import weblog, interfaces, bug, context
 
 
-class Test_Library:
+# allow to reuse the same test for other scenarios
+class BaseTestLibrarySchema:
     """Libraries's payload are valid regarding schemas"""
 
-    def setup_full(self):
+    def setup_library_schema_full(self):
         # send some requests to be sure to trigger events
         weblog.get("/waf", params={"key": "\n :"})  # rules.http_protocol_violation.crs_921_160
 
-    def test_full(self):
+    def test_library_schema_full(self):
         interfaces.library.assert_schema_points(
             excluded_points=[
                 ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property")
@@ -22,10 +23,14 @@ class Test_Library:
         )
 
     @bug(context.library >= "nodejs@2.27.1")
-    def test_telemetry_conf_value(self):
+    def test_library_schema_telemetry_conf_value(self):
         interfaces.library.assert_schema_point(
             "/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property"
         )
+
+
+class Test_library(BaseTestLibrarySchema):
+    ...
 
     # @bug(context.library < "golang@1.36.0")
     # @bug(context.library < "java@0.93.0")
@@ -72,20 +77,20 @@ class Test_Library:
 class Test_Agent:
     """Agents's payload are valid regarding schemas"""
 
-    def setup_full(self):
+    def setup_agent_schema_full(self):
         # send some requests to be sure to trigger events
         weblog.get("/waf", params={"key": "\n :"})  # rules.http_protocol_violation.crs_921_160
 
     # @bug(context.library < "golang@1.36.0")
     # @bug(context.library < "java@0.93.0")
     # @bug(context.library >= "dotnet@2.24.0")
-    def test_full(self):
+    def test_agent_schema_full(self):
         interfaces.agent.assert_schema_points(
             excluded_points=[("/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property")]
         )
 
     @bug(context.library >= "nodejs@2.27.1")
-    def test_telemetry_conf_value(self):
+    def test_agent_schema_telemetry_conf_value(self):
         interfaces.agent.assert_schema_point(
             "/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property"
         )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -14,20 +14,22 @@ class Test_Library:
         # send some requests to be sure to trigger events
         weblog.get("/waf", params={"key": "\n :"})  # rules.http_protocol_violation.crs_921_160
 
-    # def test_some_schema_point(self):
-    #     interfaces.library.assert_schema_point("/v0.4/traces", "$[][]['name']")
-
     def test_full(self):
         interfaces.library.assert_schema_points(
             excluded_points=[
-                # ("/v0.4/traces", "$[][]['name']")
+                ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property")
             ]
+        )
+
+    @bug(context.library >= "nodejs@2.27.1")
+    def test_telemetry_conf_value(self):
+        interfaces.library.assert_schema_point(
+            "/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property"
         )
 
     # @bug(context.library < "golang@1.36.0")
     # @bug(context.library < "java@0.93.0")
     # @bug(context.library >= "dotnet@2.24.0")
-    # @bug(context.library >= "nodejs@2.27.1")
     # @bug(
     #     context.library >= "python@1.16.0rc2.dev37"
     #     and context.agent_version >= "7.47.0rc2"
@@ -61,11 +63,6 @@ class Test_Library:
     #             # value is missing in configuration object in telemetry payloads
     #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
     #         )
-    #     elif context.library == "nodejs":
-    #         allowed_errors = (
-    #             # value is missing in configuration object in telemetry payloads
-    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-    #         )
     #     elif context.library == "python":
     #         allowed_errors = (r"\[\] is too short on instance \['client'\]\['products'\]",)
 
@@ -82,9 +79,16 @@ class Test_Agent:
     # @bug(context.library < "golang@1.36.0")
     # @bug(context.library < "java@0.93.0")
     # @bug(context.library >= "dotnet@2.24.0")
-    # @bug(context.library >= "nodejs@2.27.1")
     def test_full(self):
-        interfaces.agent.assert_schema_points()
+        interfaces.agent.assert_schema_points(
+            excluded_points=[("/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property")]
+        )
+
+    @bug(context.library >= "nodejs@2.27.1")
+    def test_telemetry_conf_value(self):
+        interfaces.agent.assert_schema_point(
+            "/api/v2/apmtelemetry", "$.payload.configuration[]", "'value' is a required property"
+        )
 
     # def test_non_regression(self):
     #     """ Non-regression test on shemas """
@@ -106,11 +110,6 @@ class Test_Agent:
     #             r"'idempotency_key' is a required property on instance ",
     #         )
     #     elif context.library == "dotnet":
-    #         allowed_errors = (
-    #             # value is missing in configuration object in telemetry payloads
-    #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",
-    #         )
-    #     elif context.library == "nodejs":
     #         allowed_errors = (
     #             # value is missing in configuration object in telemetry payloads
     #             r"'value' is a required property on instance \['payload'\]\['configuration'\]\[\d+\]",

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1229,7 +1229,6 @@ class _KubernetesScenario(_Scenario):
 
 
 class scenarios:
-
     @staticmethod
     def all_endtoend_scenarios(test_object):
         """particular use case where a klass applies on all scenarios"""

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -452,6 +452,10 @@ class EndToEndScenario(_DockerScenario):
 
     def session_start(self):
         super().session_start()
+
+        if self.replay:
+            return
+
         try:
             code, (stdout, stderr) = self.weblog_container._container.exec_run("uname -a", demux=True)
             if code:

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -208,6 +208,9 @@ class _Scenario:
     def __str__(self) -> str:
         return f"Scenario '{self.name}'"
 
+    def is_part_of(self, declared_scenario):
+        return self.name == declared_scenario
+
 
 class TestTheTestScenario(_Scenario):
     @property
@@ -419,6 +422,9 @@ class EndToEndScenario(_DockerScenario):
         self.agent_interface_timeout = agent_interface_timeout
         self.backend_interface_timeout = backend_interface_timeout
         self.library_interface_timeout = library_interface_timeout
+
+    def is_part_of(self, declared_scenario):
+        return declared_scenario in (self.name, "EndToEndScenario")
 
     def configure(self, config):
         from utils import interfaces
@@ -1223,6 +1229,20 @@ class _KubernetesScenario(_Scenario):
 
 
 class scenarios:
+
+    @staticmethod
+    def all_endtoend_scenarios(test_object):
+        """particular use case where a klass applies on all scenarios"""
+
+        # Check that no scenario has been already declared
+        for marker in getattr(test_object, "pytestmark", []):
+            if marker.name == "scenario":
+                raise ValueError(f"Error on {test_object}: You can declare only one scenario")
+
+        pytest.mark.scenario("EndToEndScenario")(test_object)
+
+        return test_object
+
     todo = _Scenario("TODO", doc="scenario that skips tests not yet executed")
     test_the_test = TestTheTestScenario("TEST_THE_TEST", doc="Small scenario that check system-tests internals")
     mock_the_test = TestTheTestScenario("MOCK_THE_TEST", doc="Mock scenario that check system-tests internals")

--- a/utils/interfaces/_agent.py
+++ b/utils/interfaces/_agent.py
@@ -11,7 +11,6 @@ import copy
 
 from utils.tools import logger, get_rid_from_span, get_rid_from_request
 from utils.interfaces._core import ProxyBasedInterfaceValidator
-from utils.interfaces._schemas_validators import SchemaValidator
 from utils.interfaces._misc_validators import HeadersPresenceValidator, HeadersMatchValidator
 
 
@@ -59,10 +58,6 @@ class AgentInterfaceValidator(ProxyBasedInterfaceValidator):
 
             if domain != expected_domain:
                 raise ValueError(f"Message #{data['log_filename']} uses host {domain} instead of {expected_domain}")
-
-    def assert_schemas(self, allowed_errors=None):
-        validator = SchemaValidator("agent", allowed_errors)
-        self.validate(validator, success_by_default=True)
 
     def get_profiling_data(self):
         yield from self.get_data(path_filters="/api/v2/profile")

--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -178,11 +178,11 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
 
         return self._schema_errors
 
-    def assert_schema_point(self, endpoint, data_path, assertion):
+    def assert_schema_point(self, endpoint, data_path):
         has_error = False
 
         for error in self.get_schemas_errors():
-            if error.endpoint == endpoint and error.data_path == data_path and error.error.message == assertion:
+            if error.endpoint == endpoint and error.data_path == data_path:
                 has_error = True
                 logger.error(f"* {error.message}")
 
@@ -193,7 +193,7 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
         excluded_points = excluded_points or []
 
         for error in self.get_schemas_errors():
-            if (error.endpoint, error.data_path, error.error.message) in excluded_points:
+            if (error.endpoint, error.data_path) in excluded_points:
                 continue
 
             has_error = True

--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -4,17 +4,19 @@
 
 """ This file contains base class used to validate interfaces """
 
-import threading
+from functools import lru_cache
 import json
 from os import listdir
 from os.path import isfile, join
 import re
+import threading
 import time
 
 import pytest
 
 from utils._context.core import context
 from utils.tools import logger
+from utils.interfaces._schemas_validators import SchemaValidator, SchemaError
 
 
 class InterfaceValidator:
@@ -165,6 +167,38 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
             logger.error(f"Wait for {wait_for_function} finished in error")
 
         self._wait_for_function = None
+
+    @lru_cache
+    def get_schemas_errors(self) -> list[SchemaError]:
+        result = []
+        validator = SchemaValidator(self.name)
+
+        for data in self.get_data():
+            result.extend(validator.get_errors(data))
+
+        return result
+
+    def assert_schema_point(self, endpoint, data_path):
+        has_error = False
+
+        for error in self.get_schemas_errors():
+            if error.endpoint == endpoint and error.data_path == data_path:
+                has_error = True
+                logger.error(f"* {error.message}")
+
+        assert not has_error, f"Schema is invalid for endpoint {endpoint} on data path {data_path}"
+
+    def assert_schema_points(self, excluded_points=None):
+        has_error = False
+
+        for error in self.get_schemas_errors():
+            if (error.endpoint, error.data_path) in excluded_points:
+                continue
+
+            has_error = True
+            logger.error(f"* {error.message}")
+
+        assert not has_error, f"Schema validation failed for {self.name}"
 
 
 class ValidationError(Exception):

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -17,7 +17,6 @@ from utils.interfaces._library.telemetry import (
 )
 
 from utils.interfaces._misc_validators import HeadersPresenceValidator
-from utils.interfaces._schemas_validators import SchemaValidator
 
 
 class LibraryInterfaceValidator(ProxyBasedInterfaceValidator):
@@ -232,10 +231,6 @@ class LibraryInterfaceValidator(ProxyBasedInterfaceValidator):
                 return
 
         raise ValueError("Nothing has been reported. No request root span with has been found")
-
-    def assert_schemas(self, allowed_errors=None):
-        validator = SchemaValidator("library", allowed_errors)
-        self.validate(validator, success_by_default=True)
 
     def assert_all_traces_requests_forwarded(self, paths):
         # TODO : move this in test class

--- a/utils/interfaces/_schemas_validators.py
+++ b/utils/interfaces/_schemas_validators.py
@@ -78,7 +78,10 @@ class SchemaError:
 
     @property
     def message(self):
-        return f"{self.error.message} on instance {self.error.json_path} in " + self.data["log_filename"]
+        return (
+            f"{self.error.message} on instance {self.error.json_path} in {self.endpoint}. Please check "
+            + self.data["log_filename"]
+        )
 
     @property
     def data_path(self):

--- a/utils/interfaces/_schemas_validators.py
+++ b/utils/interfaces/_schemas_validators.py
@@ -109,31 +109,25 @@ class SchemaValidator:
             for error in validator.iter_errors(data["request"]["content"])
         ]
 
-    # def __call__(self, data):
-    #     errors = self.get_errors(data)
 
-    #     if len(errors) == 0:
-    #         logger.debug(f"{data['log_filename']} schema validation ok")
-    #         return
+def _main():
+    for interface in ("agent", "library"):
+        validator = SchemaValidator(interface)
+        folders = [folder for folder in os.listdir(".") if os.path.isdir(folder) and folder.startswith("logs")]
+        for folder in folders:
+            path = f"{folder}/interfaces/{interface}"
 
-    #     for error in errors:
-    #         logger.error(f"* {error.message}")
+            if not os.path.exists(path):
+                continue
+            files = [file for file in os.listdir(path) if os.path.isfile(os.path.join(path, file))]
+            for file in files:
+                with open(os.path.join(path, file), encoding="utf-8") as f:
+                    data = json.load(f)
 
-    #     raise ValueError(f"Schema is invalid in {data['log_filename']}")
-
-
-# def _main():
-#     for interface in ("agent", "library"):
-#         validator = SchemaValidator(interface)
-#         path = f"logs/interfaces/{interface}"
-#         files = [file for file in os.listdir(path) if os.path.isfile(os.path.join(path, file))]
-#         for file in files:
-#             with open(os.path.join(path, file), encoding="utf-8") as f:
-#                 data = json.load(f)
-
-#            if "request" in data and data["request"]["length"] != 0:
-#                validator(data)
+                if "request" in data and data["request"]["length"] != 0:
+                    for error in validator.get_errors(data):
+                        print(error.message)
 
 
-# if __name__ == "__main__":
-#     _main()
+if __name__ == "__main__":
+    _main()

--- a/utils/interfaces/_schemas_validators.py
+++ b/utils/interfaces/_schemas_validators.py
@@ -16,8 +16,6 @@ import functools
 from jsonschema import Draft7Validator, RefResolver, ValidationError
 from jsonschema.validators import extend
 
-from utils.tools import logger
-
 
 def _is_bytes_or_string(_checker, instance):
     return Draft7Validator.TYPE_CHECKER.is_type(instance, "string") or isinstance(instance, bytes)
@@ -121,18 +119,18 @@ class SchemaValidator:
     #     raise ValueError(f"Schema is invalid in {data['log_filename']}")
 
 
-def _main():
-    for interface in ("agent", "library"):
-        validator = SchemaValidator(interface)
-        path = f"logs/interfaces/{interface}"
-        files = [file for file in os.listdir(path) if os.path.isfile(os.path.join(path, file))]
-        for file in files:
-            with open(os.path.join(path, file), encoding="utf-8") as f:
-                data = json.load(f)
+# def _main():
+#     for interface in ("agent", "library"):
+#         validator = SchemaValidator(interface)
+#         path = f"logs/interfaces/{interface}"
+#         files = [file for file in os.listdir(path) if os.path.isfile(os.path.join(path, file))]
+#         for file in files:
+#             with open(os.path.join(path, file), encoding="utf-8") as f:
+#                 data = json.load(f)
 
-            if "request" in data and data["request"]["length"] != 0:
-                validator(data)
+#            if "request" in data and data["request"]["length"] != 0:
+#                validator(data)
 
 
-if __name__ == "__main__":
-    _main()
+# if __name__ == "__main__":
+#     _main()

--- a/utils/interfaces/schemas/agent/api/v2/debugger-request.json
+++ b/utils/interfaces/schemas/agent/api/v2/debugger-request.json
@@ -1,0 +1,3 @@
+{
+  "$id": "/agent/api/v2/debugger-request.json"
+}

--- a/utils/interfaces/schemas/library/debugger/v1/diagnostics-request.json
+++ b/utils/interfaces/schemas/library/debugger/v1/diagnostics-request.json
@@ -1,0 +1,4 @@
+{
+    "$id": "/library/debugger/v1/diagnostics-request.json"
+  }
+  

--- a/utils/interfaces/schemas/library/debugger/v1/input-request.json
+++ b/utils/interfaces/schemas/library/debugger/v1/input-request.json
@@ -1,0 +1,4 @@
+{
+    "$id": "/library/debugger/v1/input-request.json"
+  }
+  


### PR DESCRIPTION
## Motivation

Simpler API for testing schema

## Changes

* The default check verifies all points, excluding failing ones
* Excluded point are checked individually in a dedicated test method (one per point), skipping the lib that are failing
* And schema tests are activated for all end-to-end scenarios

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

