### PR TITLE
[nodejs] Enable incoming identify.py tests

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -431,8 +431,8 @@ tests/:
     Test_DistributedHttp: missing_feature
   test_identify.py:
     Test_Basic: v2.4.0
-    Test_Propagate: missing_feature
-    Test_Propagate_Legacy: missing_feature
+    Test_Propagate: v3.2.0
+    Test_Propagate_Legacy: v3.2.0
   test_library_conf.py:
     Test_HeaderTags: v4.11.0
     Test_HeaderTags_Colon_Leading: v4.11.0

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import weblog, bug, context, interfaces, rfc, features
+from utils import weblog, bug, context, interfaces, rfc, features, missing_feature
 
 
 def assertTagInSpanMeta(span, tag, expected):
@@ -68,6 +68,7 @@ class Test_Propagate_Legacy:
         # Send a request to the identify-propagate endpoint
         self.r_outgoing = weblog.get("/identify-propagate")
 
+    @missing_feature(library="nodejs", reason="only supports incoming tags for now")
     def test_identify_tags_outgoing(self):
         tagTable = {"_dd.p.usr.id": "dXNyLmlk"}
         interfaces.library.validate_spans(self.r_outgoing, validate_identify_tags(tagTable))
@@ -92,6 +93,7 @@ class Test_Propagate:
         # Send a request to the identify-propagate endpoint
         self.r_outgoing = weblog.get("/identify-propagate")
 
+    @missing_feature(library="nodejs", reason="only supports incoming tags for now")
     def test_identify_tags_outgoing(self):
         tagTable = {"usr.id": "usr.id", "_dd.p.usr.id": "dXNyLmlk"}
         interfaces.library.validate_spans(self.r_outgoing, validate_identify_tags(tagTable))


### PR DESCRIPTION
## Motivation

We support these feature but only the incoming part.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

