### PR TITLE
Fixes decision maker tag values for remote user rules and dynamic rules

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -400,7 +400,7 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
-      TestDynamicConfigSamplingRules: v1.63.1-dev
+      TestDynamicConfigSamplingRules: v1.63.1
       TestDynamicConfigTracingEnabled: v1.61.0
       TestDynamicConfigV1: v1.59.0
       TestDynamicConfigV1_ServiceTargets: v1.59.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -400,7 +400,7 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
-      TestDynamicConfigSamplingRules: v1.63.0
+      TestDynamicConfigSamplingRules: v1.63.1-dev
       TestDynamicConfigTracingEnabled: v1.61.0
       TestDynamicConfigV1: v1.59.0
       TestDynamicConfigV1_ServiceTargets: v1.59.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -400,7 +400,7 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
-      TestDynamicConfigSamplingRules: v1.63.1
+      TestDynamicConfigSamplingRules: v1.64.0-dev
       TestDynamicConfigTracingEnabled: v1.61.0
       TestDynamicConfigV1: v1.59.0
       TestDynamicConfigV1_ServiceTargets: v1.59.0

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -617,17 +617,17 @@ class TestDynamicConfigSamplingRules:
 
         trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
         assert_sampling_rate(trace, RC_SAMPLING_RULE_RATE_CUSTOMER)
-        # Make sure `_dd.p.dm` is set to "-10" (i.e., remote user rule)
-        span = root_span(trace)
-        assert "_dd.p.dm" in span["meta"]
-        assert span["meta"]["_dd.p.dm"] == "-10"
-
-        trace = get_sampled_trace(test_library, test_agent, service="other_service", name="op_name")
-        assert_sampling_rate(trace, RC_SAMPLING_RULE_RATE_DYNAMIC)
-        # Make sure `_dd.p.dm` is set to "-11" (i.e., remote dynamic rule)
+        # Make sure `_dd.p.dm` is set to "-11" (i.e., remote user rule)
         span = root_span(trace)
         assert "_dd.p.dm" in span["meta"]
         assert span["meta"]["_dd.p.dm"] == "-11"
+
+        trace = get_sampled_trace(test_library, test_agent, service="other_service", name="op_name")
+        assert_sampling_rate(trace, RC_SAMPLING_RULE_RATE_DYNAMIC)
+        # Make sure `_dd.p.dm` is set to "-12" (i.e., remote dynamic rule)
+        span = root_span(trace)
+        assert "_dd.p.dm" in span["meta"]
+        assert span["meta"]["_dd.p.dm"] == "-12"
 
         # Unset the RC sample rate to ensure the previous setting is reapplied.
         set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rules": None})
@@ -664,10 +664,10 @@ class TestDynamicConfigSamplingRules:
         # trace/span matching the rule gets applied the rule's rate
         trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
         assert_sampling_rate(trace, RC_SAMPLING_RULE_RATE_CUSTOMER)
-        # Make sure `_dd.p.dm` is set to "-10" (i.e., remote user rule)
+        # Make sure `_dd.p.dm` is set to "-11" (i.e., remote user rule)
         span = root_span(trace)
         assert "_dd.p.dm" in span["meta"]
-        assert span["meta"]["_dd.p.dm"] == "-10"
+        assert span["meta"]["_dd.p.dm"] == "-11"
 
         # trace/span not matching the rule gets applied the RC global rate
         trace = get_sampled_trace(test_library, test_agent, service="other_service", name="op_name")


### PR DESCRIPTION
This is to avoid a conflict with the duplicate value `-10` used by data jobs.

The Go tracer change is also being made and will be released in `1.63.1`.
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

