### PR TITLE
Remove Test_TelemetryResponse class

### DIFF
--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -24,19 +24,6 @@ def _setup(self):
     Test_TelemetryMetrics.__common_setup_done = True
 
 
-@features.waf_telemetry
-class Test_TelemetryResponses:
-    """ Test response from backend/agent """
-
-    setup_all_telemetry_requests_are_successful = _setup
-
-    @flaky(True, reason="Backend is far away from being stable enough")
-    def test_all_telemetry_requests_are_successful(self):
-        """Tests that all telemetry requests succeed."""
-        for data in interfaces.library.get_telemetry_data():
-            assert data["response"]["status_code"] == 202
-
-
 @rfc("https://docs.google.com/document/d/1qBDsS_ZKeov226CPx2DneolxaARd66hUJJ5Lh9wjhlE")
 @scenarios.appsec_waf_telemetry
 @features.waf_telemetry


### PR DESCRIPTION
## Motivation

Marked as flaky for everyone, it's useless to keep it

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

