### PR TITLE
fix flaky sca env var test

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -568,9 +568,9 @@ tests/:
     test_span_sampling.py:
       Test_Span_Sampling: v2.8.0
     test_telemetry.py:
-      Test_Defaults: flaky (failure 2.8.0/2.9.0.dev)
-      Test_Environment: v2.9.0.dev # flaky in 2.8.0
-      Test_TelemetryInstallSignature: flaky (failure 2.8.0/2.9.0.dev)
+      Test_Defaults: v2.9.0.dev
+      Test_Environment: v2.8.0
+      Test_TelemetryInstallSignature: v2.5.0
       Test_TelemetrySCAEnvVar: v2.9.0.dev
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.9.0 # actual version unknown

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -571,7 +571,7 @@ tests/:
       Test_Defaults: flaky (failure 2.8.0/2.9.0.dev)
       Test_Environment: v2.9.0.dev # flaky in 2.8.0
       Test_TelemetryInstallSignature: flaky (failure 2.8.0/2.9.0.dev)
-      Test_TelemetrySCAEnvVar: flaky (failure 2.8.0/2.9.0.dev)
+      Test_TelemetrySCAEnvVar: v2.9.0.dev
     test_trace_sampling.py:
       Test_Trace_Sampling_Basic: v1.9.0 # actual version unknown
       Test_Trace_Sampling_Globs: v2.8.0

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -269,7 +269,7 @@ class Test_TelemetrySCAEnvVar:
         with test_library.start_span("first_span"):
             pass
 
-        test_agent.wait_for_telemetry_event("app-started")
+        test_agent.wait_for_telemetry_event("app-started", wait_loops=400)
         requests = test_agent.raw_telemetry(clear=True)
         assert len(requests) > 0, "There should be at least one telemetry event (app-started)"
         for req in requests:

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -49,7 +49,7 @@ class Test_Defaults:
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.start_span("test"):
             pass
-        event = test_agent.wait_for_telemetry_event("app-started")
+        event = test_agent.wait_for_telemetry_event("app-started", wait_loops=400)
         configuration = event["payload"]["configuration"]
 
         configuration_by_name = {item["name"]: item for item in configuration}
@@ -116,7 +116,7 @@ class Test_Environment:
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.start_span("test"):
             pass
-        event = test_agent.wait_for_telemetry_event("app-started")
+        event = test_agent.wait_for_telemetry_event("app-started", wait_loops=400)
         configuration = event["payload"]["configuration"]
 
         configuration_by_name = {item["name"]: item for item in configuration}
@@ -201,7 +201,7 @@ class Test_TelemetryInstallSignature:
         with test_library.start_span("first_span"):
             pass
 
-        test_agent.wait_for_telemetry_event("app-started")
+        test_agent.wait_for_telemetry_event("app-started", wait_loops=400)
         requests = test_agent.raw_telemetry(clear=True)
         assert len(requests) > 0, "There should be at least one telemetry event (app-started)"
         for req in requests:


### PR DESCRIPTION
## Motivation

Fixing a test that shouldn't be flaky

## Changes

Increases wait time for the telemetry event to arrive

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

