### PR TITLE
[python] fix header test for python

### DIFF
--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -97,7 +97,6 @@ class Test_Headers:
     def setup_specific_key2(self):
         self.r_sk_4 = weblog.get("/waf/", headers={"X_Filename": "routing.yml"})
 
-    @bug(context.weblog_variant in ("flask-poc", "django-poc", "uds-flask", "python3.12"), reason="APPSEC-52915")
     @irrelevant(library="ruby", reason="Rack transforms underscores into dashes")
     @irrelevant(library="php", reason="PHP normalizes into dashes; additionally, matching on keys is not supported")
     @missing_feature(weblog_variant="spring-boot-3-native", reason="GraalVM. Tracing support only")

--- a/utils/build/docker/python/django/app.sh
+++ b/utils/build/docker/python/django/app.sh
@@ -4,4 +4,4 @@ if [ ${UDS_WEBLOG:-} = "1" ]; then
     ./set-uds-transport.sh
 fi
 
-ddtrace-run gunicorn -w 1 -b 0.0.0.0:7777 --access-logfile - django_app.wsgi -k gevent
+ddtrace-run gunicorn -w 1 -b 0.0.0.0:7777 --header-map dangerous --access-logfile - django_app.wsgi -k gevent

--- a/utils/build/docker/python/django/app.sh
+++ b/utils/build/docker/python/django/app.sh
@@ -4,4 +4,4 @@ if [ ${UDS_WEBLOG:-} = "1" ]; then
     ./set-uds-transport.sh
 fi
 
-ddtrace-run gunicorn -w 1 -b 0.0.0.0:7777 --header-map dangerous --access-logfile - django_app.wsgi -k gevent
+ddtrace-run gunicorn -w 1 -b 0.0.0.0:7777 --access-logfile - django_app.wsgi -k gevent

--- a/utils/build/docker/python/django/app_3.12.sh
+++ b/utils/build/docker/python/django/app_3.12.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ ${UDS_WEBLOG:-} = "1" ]; then
+if [ "${UDS_WEBLOG:-}" = "1" ]; then
     ./set-uds-transport.sh
 fi
 

--- a/utils/build/docker/python/django/app_3.12.sh
+++ b/utils/build/docker/python/django/app_3.12.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ ${UDS_WEBLOG:-} = "1" ]; then
+    ./set-uds-transport.sh
+fi
+
+ddtrace-run gunicorn -w 1 -b 0.0.0.0:7777 --header-map dangerous --access-logfile - django_app.wsgi -k gevent

--- a/utils/build/docker/python/flask/app.sh
+++ b/utils/build/docker/python/flask/app.sh
@@ -6,4 +6,4 @@ fi
 # CAVEAT: to debug the Python App, use these lines
 # export FLASK_APP=app
 # ddtrace-run flask run --no-reload --host=0.0.0.0 --port=7777
-ddtrace-run gunicorn -w 1 -b 0.0.0.0:7777 --header-map dangerous --access-logfile - app:app -k gevent
+ddtrace-run gunicorn -w 1 -b 0.0.0.0:7777 --access-logfile - app:app -k gevent

--- a/utils/build/docker/python/flask/app.sh
+++ b/utils/build/docker/python/flask/app.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ ${UDS_WEBLOG:-} = "1" ]; then
+if [ "${UDS_WEBLOG:-}" = "1" ]; then
     ./set-uds-transport.sh
 fi
 # CAVEAT: to debug the Python App, use these lines

--- a/utils/build/docker/python/flask/app.sh
+++ b/utils/build/docker/python/flask/app.sh
@@ -6,4 +6,4 @@ fi
 # CAVEAT: to debug the Python App, use these lines
 # export FLASK_APP=app
 # ddtrace-run flask run --no-reload --host=0.0.0.0 --port=7777
-ddtrace-run gunicorn -w 1 -b 0.0.0.0:7777 --access-logfile - app:app -k gevent
+ddtrace-run gunicorn -w 1 -b 0.0.0.0:7777 --header-map dangerous --access-logfile - app:app -k gevent

--- a/utils/build/docker/python/flask/app.sh
+++ b/utils/build/docker/python/flask/app.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${UDS_WEBLOG:-}" = "1" ]; then
+if [ ${UDS_WEBLOG:-} = "1" ]; then
     ./set-uds-transport.sh
 fi
 # CAVEAT: to debug the Python App, use these lines

--- a/utils/build/docker/python/python3.12.Dockerfile
+++ b/utils/build/docker/python/python3.12.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY utils/build/docker/python/install_ddtrace.sh utils/build/docker/python/get_appsec_rules_version.py binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-COPY utils/build/docker/python/django/app_3.12.sh /app/app_3.12.sh
+COPY utils/build/docker/python/django/app_3.12.sh /app/app.sh
 COPY utils/build/docker/python/django/django.app.urls.py /app/app/urls.py
 COPY utils/build/docker/python/iast.py /app/iast.py
 
@@ -14,7 +14,7 @@ ENV DD_REMOTECONFIG_POLL_SECONDS=1
 ENV _DD_APPSEC_DEDUPLICATION_ENABLED=false
 
 # docker startup
-CMD ./app_3.12.sh
+CMD ./app.sh
 
 # docker build -f utils/build/docker/python/django-poc.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test

--- a/utils/build/docker/python/python3.12.Dockerfile
+++ b/utils/build/docker/python/python3.12.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY utils/build/docker/python/install_ddtrace.sh utils/build/docker/python/get_appsec_rules_version.py binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-COPY utils/build/docker/python/django/app.sh /app/app.sh
+COPY utils/build/docker/python/django/app_3.12.sh /app/app_3.12.sh
 COPY utils/build/docker/python/django/django.app.urls.py /app/app/urls.py
 COPY utils/build/docker/python/iast.py /app/iast.py
 
@@ -14,7 +14,7 @@ ENV DD_REMOTECONFIG_POLL_SECONDS=1
 ENV _DD_APPSEC_DEDUPLICATION_ENABLED=false
 
 # docker startup
-CMD ./app.sh
+CMD ./app_3.12.sh
 
 # docker build -f utils/build/docker/python/django-poc.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test


### PR DESCRIPTION
## Changes

- remove bug decorator for waf header tests (this was fixed for Django previously)
- enable gunicorn to manage those headers in Flask by adding the appropriate option (by default, they were entirely dropped by gunicorn)

APPSEC-52926


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

