### PR TITLE
[iast] Hardcoded password vulnerability - variable name as evidence value

### DIFF
--- a/tests/appsec/iast/sink/test_hardcoded_passwords.py
+++ b/tests/appsec/iast/sink/test_hardcoded_passwords.py
@@ -21,6 +21,7 @@ class Test_HardcodedPasswords:
     def setup_hardcoded_passwords_exec(self):
         self.r_hardcoded_passwords_exec = weblog.get("/iast/hardcoded_passwords/test_insecure")
 
+    @missing_feature(reason="Not implemented yet")
     def test_hardcoded_passwords_exec(self):
         assert self.r_hardcoded_passwords_exec.status_code == 200
         hardcoded_passwords = self.get_hardcoded_password_vulnerabilities()

--- a/tests/appsec/iast/sink/test_hardcoded_passwords.py
+++ b/tests/appsec/iast/sink/test_hardcoded_passwords.py
@@ -24,7 +24,7 @@ class Test_HardcodedPasswords:
     def test_hardcoded_passwords_exec(self):
         assert self.r_hardcoded_passwords_exec.status_code == 200
         hardcoded_passwords = self.get_hardcoded_password_vulnerabilities()
-        hardcoded_passwords = [v for v in hardcoded_passwords if v["evidence"]["value"] == "hardcoded-password"]
+        hardcoded_passwords = [v for v in hardcoded_passwords if v["evidence"]["value"] == "hashpwd"]
         assert len(hardcoded_passwords) == 1
         vuln = hardcoded_passwords[0]
         assert vuln["location"]["path"] == self._get_expectation(self.location_map)


### PR DESCRIPTION
## Motivation

Hardcoded password is reporting now the variable name as the evidence value.
marking it as `@missing_feature` until tracer PR merged

## Changes


## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

