### PR TITLE
[python] enable test for response headers stripped

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -259,7 +259,7 @@ tests/:
           django-poc: v1.10
           fastapi: v2.4.0.dev1
           flask-poc: v1.10
-        Test_Blocking_strip_response_headers: missing_feature
+        Test_Blocking_strip_response_headers: v2.10.0.dev
         Test_CustomBlockingResponse:
           '*': v1.20.0.dev
           fastapi: v2.4.0.dev1


### PR DESCRIPTION
After the merge of https://github.com/DataDog/system-tests/pull/2350 and https://github.com/DataDog/dd-trace-py/pull/9151 this PR will enable corresponding test for python

APPSEC-52730


## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

