### PR TITLE
[python] more easywins for python appsec

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -418,7 +418,7 @@ tests/:
     test_identify.py:
       Test_Basic: v1.5.0rc1.dev
     test_ip_blocking_full_denylist.py:
-      Test_AppSecIPBlockingFullDenylist: missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
+      Test_AppSecIPBlockingFullDenylist: v1.10.0 # partially missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
     test_logs.py:
       Test_Standardization: missing_feature
       Test_StandardizationBlockMode: missing_feature
@@ -449,10 +449,7 @@ tests/:
       Test_ExternalWafRequestsIdentification: v2.9.0.dev1
       Test_RetainTraces: v1.1.0rc2.dev
     test_user_blocking_full_denylist.py:
-      Test_UserBlocking_FullDenylist:
-        '*': missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
-        # django-poc: v1.10
-        # flask-poc: v1.10
+      Test_UserBlocking_FullDenylist: v1.10.0 # partially missing_feature missing_feature (Python supported denylists of 2500 entries but it fails to block this those 15000)
     test_versions.py:
       Test_Events: v0.58.5
   debugger/:

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -8,8 +8,6 @@ from tests.constants import PYTHON_RELEASE_GA_1_1
 from .waf.utils import rules
 
 
-TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
-
 @features.threats_configuration
 class Test_StaticRuleSet:
     """Appsec loads rules from a static rules file"""
@@ -104,7 +102,7 @@ class Test_ConfigurationVariables:
         interfaces.library.assert_waf_attack(self.r_appsec_rules, pattern="dedicated-value-for-testing-purpose")
 
     def setup_waf_timeout(self):
-        long_payload = "?" + "&".join(f"{k}={v}" for k, v in ((f"key_{i}", f"value{i}") for i in range(256)))
+        long_payload = "?" + "&".join(f"{k}={v}" for k, v in ((f"key_{i}", f"value{i}") for i in range(10_000)))
         self.r_waf_timeout = weblog.get(f"/waf/{long_payload}", headers={"User-Agent": "Arachni/v1"})
 
     @missing_feature(context.library < "java@0.113.0")
@@ -113,10 +111,7 @@ class Test_ConfigurationVariables:
     @scenarios.appsec_low_waf_timeout
     def test_waf_timeout(self):
         """ test DD_APPSEC_WAF_TIMEOUT = low value """
-        series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", "waf.timeout")
-        print(series)
-        assert series
-        #interfaces.library.assert_no_appsec_event(self.r_waf_timeout)
+        interfaces.library.assert_no_appsec_event(self.r_waf_timeout)
 
     def setup_obfuscation_parameter_key(self):
         self.r_op_key = weblog.get("/waf", headers={"hide-key": f"acunetix-user-agreement {self.SECRET}"})

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -2,13 +2,11 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import weblog, context, interfaces, missing_feature, irrelevant, rfc, scenarios, features
+from utils import weblog, context, interfaces, missing_feature, irrelevant, rfc, scenarios, features, flaky
 from utils.tools import nested_lookup
 from tests.constants import PYTHON_RELEASE_GA_1_1
 from .waf.utils import rules
 
-
-TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
 
 @features.threats_configuration
 class Test_StaticRuleSet:
@@ -103,39 +101,18 @@ class Test_ConfigurationVariables:
         """ test DD_APPSEC_RULES = custom rules file """
         interfaces.library.assert_waf_attack(self.r_appsec_rules, pattern="dedicated-value-for-testing-purpose")
 
-    def _find_series(self, request_type, namespace, metric):
-        series = []
-        for data in interfaces.library.get_telemetry_data():
-            content = data["request"]["content"]
-            if content.get("request_type") != request_type:
-                continue
-            fallback_namespace = content["payload"].get("namespace")
-            for serie in content["payload"]["series"]:
-                computed_namespace = serie.get("namespace", fallback_namespace)
-                # Inject here the computed namespace considering the fallback. This simplifies later assertions.
-                serie["_computed_namespace"] = computed_namespace
-                if computed_namespace == namespace and serie["metric"] == metric:
-                    series.append(serie)
-        return series
-
     def setup_waf_timeout(self):
-        long_payload = "?" + "&".join(f"{k}={v}" for k, v in ((f"key_{i}", f"value{i}") for i in range(256)))
+        long_payload = "?" + "&".join(f"{k}={v}" for k, v in ((f"key_{i}", f"value{i}") for i in range(10_000)))
         self.r_waf_timeout = weblog.get(f"/waf/{long_payload}", headers={"User-Agent": "Arachni/v1"})
 
     @missing_feature(context.library < "java@0.113.0")
     @missing_feature(context.library == "java" and context.weblog_variant == "spring-boot-openliberty")
     @missing_feature(context.library == "java" and context.weblog_variant == "spring-boot-wildfly")
+    @flaky(context.weblog_variant == "fastapi", reason="APPSEC-53058")
     @scenarios.appsec_low_waf_timeout
     def test_waf_timeout(self):
         """ test DD_APPSEC_WAF_TIMEOUT = low value """
-        series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", "waf.requests")
-        for s in series:
-            print(s)
-        assert len(series) == 1
-        assert "waf_timeout:true" in series[0]["tags"]
-        assert series
-        print(self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", "waf.requests"))
-        #interfaces.library.assert_no_appsec_event(self.r_waf_timeout)
+        interfaces.library.assert_no_appsec_event(self.r_waf_timeout)
 
     def setup_obfuscation_parameter_key(self):
         self.r_op_key = weblog.get("/waf", headers={"hide-key": f"acunetix-user-agreement {self.SECRET}"})

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -2,11 +2,13 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import weblog, context, interfaces, missing_feature, irrelevant, rfc, scenarios, features, flaky
+from utils import weblog, context, interfaces, missing_feature, irrelevant, rfc, scenarios, features
 from utils.tools import nested_lookup
 from tests.constants import PYTHON_RELEASE_GA_1_1
 from .waf.utils import rules
 
+
+TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
 
 @features.threats_configuration
 class Test_StaticRuleSet:
@@ -101,18 +103,39 @@ class Test_ConfigurationVariables:
         """ test DD_APPSEC_RULES = custom rules file """
         interfaces.library.assert_waf_attack(self.r_appsec_rules, pattern="dedicated-value-for-testing-purpose")
 
+    def _find_series(self, request_type, namespace, metric):
+        series = []
+        for data in interfaces.library.get_telemetry_data():
+            content = data["request"]["content"]
+            if content.get("request_type") != request_type:
+                continue
+            fallback_namespace = content["payload"].get("namespace")
+            for serie in content["payload"]["series"]:
+                computed_namespace = serie.get("namespace", fallback_namespace)
+                # Inject here the computed namespace considering the fallback. This simplifies later assertions.
+                serie["_computed_namespace"] = computed_namespace
+                if computed_namespace == namespace and serie["metric"] == metric:
+                    series.append(serie)
+        return series
+
     def setup_waf_timeout(self):
-        long_payload = "?" + "&".join(f"{k}={v}" for k, v in ((f"key_{i}", f"value{i}") for i in range(10_000)))
+        long_payload = "?" + "&".join(f"{k}={v}" for k, v in ((f"key_{i}", f"value{i}") for i in range(256)))
         self.r_waf_timeout = weblog.get(f"/waf/{long_payload}", headers={"User-Agent": "Arachni/v1"})
 
     @missing_feature(context.library < "java@0.113.0")
     @missing_feature(context.library == "java" and context.weblog_variant == "spring-boot-openliberty")
     @missing_feature(context.library == "java" and context.weblog_variant == "spring-boot-wildfly")
-    @flaky(context.weblog_variant == "fastapi", reason="APPSEC-53058")
     @scenarios.appsec_low_waf_timeout
     def test_waf_timeout(self):
         """ test DD_APPSEC_WAF_TIMEOUT = low value """
-        interfaces.library.assert_no_appsec_event(self.r_waf_timeout)
+        series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", "waf.requests")
+        for s in series:
+            print(s)
+        assert len(series) == 1
+        assert "waf_timeout:true" in series[0]["tags"]
+        assert series
+        print(self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", "waf.requests"))
+        #interfaces.library.assert_no_appsec_event(self.r_waf_timeout)
 
     def setup_obfuscation_parameter_key(self):
         self.r_op_key = weblog.get("/waf", headers={"hide-key": f"acunetix-user-agreement {self.SECRET}"})

--- a/tests/appsec/test_event_tracking.py
+++ b/tests/appsec/test_event_tracking.py
@@ -64,7 +64,9 @@ class Test_UserLoginSuccessEvent:
     @missing_feature(library="dotnet")
     @missing_feature(library="java")
     @missing_feature(library="nodejs")
-    @missing_feature(context.library =="python" and context.weblog_variant in ["fastapi", "flask-poc", "uds-flask", "uwsgi-poc"])
+    @missing_feature(
+        context.library == "python" and context.weblog_variant in ["fastapi", "flask-poc", "uds-flask", "uwsgi-poc"]
+    )
     @missing_feature(library="php")
     @missing_feature(library="ruby")
     def test_user_login_success_header_collection(self):
@@ -121,7 +123,9 @@ class Test_UserLoginFailureEvent:
     @missing_feature(library="dotnet")
     @missing_feature(library="java")
     @missing_feature(library="nodejs")
-    @missing_feature(context.library =="python" and context.weblog_variant in ["fastapi", "flask-poc", "uds-flask", "uwsgi-poc"])
+    @missing_feature(
+        context.library == "python" and context.weblog_variant in ["fastapi", "flask-poc", "uds-flask", "uwsgi-poc"]
+    )
     @missing_feature(library="php")
     @missing_feature(library="ruby")
     def test_user_login_failure_header_collection(self):

--- a/tests/appsec/test_event_tracking.py
+++ b/tests/appsec/test_event_tracking.py
@@ -1,7 +1,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
-from utils import weblog, interfaces, features, missing_feature
+from utils import weblog, interfaces, features, missing_feature, context
 
 HEADERS = {
     "Accept": "text/html",
@@ -64,7 +64,7 @@ class Test_UserLoginSuccessEvent:
     @missing_feature(library="dotnet")
     @missing_feature(library="java")
     @missing_feature(library="nodejs")
-    @missing_feature(library="python")
+    @missing_feature(context.library =="python" and context.weblog_variant in ["fastapi", "flask-poc", "uds-flask", "uwsgi-poc"])
     @missing_feature(library="php")
     @missing_feature(library="ruby")
     def test_user_login_success_header_collection(self):
@@ -121,7 +121,7 @@ class Test_UserLoginFailureEvent:
     @missing_feature(library="dotnet")
     @missing_feature(library="java")
     @missing_feature(library="nodejs")
-    @missing_feature(library="python")
+    @missing_feature(context.library =="python" and context.weblog_variant in ["fastapi", "flask-poc", "uds-flask", "uwsgi-poc"])
     @missing_feature(library="php")
     @missing_feature(library="ruby")
     def test_user_login_failure_header_collection(self):

--- a/tests/appsec/test_ip_blocking_full_denylist.py
+++ b/tests/appsec/test_ip_blocking_full_denylist.py
@@ -74,6 +74,7 @@ class Test_AppSecIPBlockingFullDenylist:
         ]
 
     @missing_feature(weblog_variant="spring-boot" and context.library < "java@0.111.0")
+    @missing_feature(library="python")
     def test_blocked_ips(self):
         """test blocked ips are enforced"""
 

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -1,4 +1,4 @@
-from utils import context, interfaces, scenarios, weblog, bug, features
+from utils import context, interfaces, scenarios, weblog, bug, features, missing_feature
 
 
 @features.appsec_user_blocking
@@ -43,6 +43,7 @@ class Test_UserBlocking_FullDenylist:
         ]
 
     @bug(context.library < "ruby@1.12.1", reason="not setting the tags on the service entry span")
+    @missing_feature(library="python")
     def test_blocking_test(self):
         """Test with a denylisted user"""
 


### PR DESCRIPTION
Activate more tests or test parts for python appsec

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

