### PR TITLE
[python] enable iast source parameter value

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -186,9 +186,9 @@ tests/:
             uwsgi-poc: missing_feature
         test_parameter_value.py:
           TestParameterValue:
-          '*': v2.9.0.dev
-          python3.12: bug (should have been v1.18.0)
-          fastapi: missing_feature
+            '*': v2.9.0.dev
+            python3.12: bug (should have been v1.18.0)
+            fastapi: missing_feature
         test_path.py:
           TestPath: missing_feature
         test_uri.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -185,7 +185,7 @@ tests/:
             uds-flask: missing_feature
             uwsgi-poc: missing_feature
         test_parameter_value.py:
-          TestParameterValue: bug (should have been v1.18.0)
+          TestParameterValue: v2.9.0.dev
         test_path.py:
           TestPath: missing_feature
         test_uri.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -187,8 +187,8 @@ tests/:
         test_parameter_value.py:
           TestParameterValue:
             '*': v2.9.0.dev
-            python3.12: bug (should have been v1.18.0)
             fastapi: missing_feature
+            python3.12: bug (should have been v1.18.0)
         test_path.py:
           TestPath: missing_feature
         test_uri.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -185,7 +185,10 @@ tests/:
             uds-flask: missing_feature
             uwsgi-poc: missing_feature
         test_parameter_value.py:
-          TestParameterValue: v2.9.0.dev
+          TestParameterValue:
+          '*': v2.9.0.dev
+          python3.12: bug (should have been v1.18.0)
+          fastapi: missing_feature
         test_path.py:
           TestPath: missing_feature
         test_uri.py:

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -662,7 +662,10 @@ def _sink_point(table="user", id="1"):
     sql = "SELECT * FROM " + table + " WHERE id = '" + id + "'"
     postgres_db = psycopg2.connect(**POSTGRES_CONFIG)
     cursor = postgres_db.cursor()
-    cursor.execute(sql)
+    try:
+        cursor.execute(sql)
+    except Exception:
+        pass
 
 
 @app.route("/iast/source/body/test", methods=["POST"])


### PR DESCRIPTION
Enable Code Security (IAST) source parameter value

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

