### PR TITLE
[python] enable python 3.12 IAST tests

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -63,7 +63,6 @@ tests/:
           TestCommandInjection:
             '*': v2.2.0
             fastapi: missing_feature
-            python3.12: missing_feature
         test_hardcoded_passwords.py:
           Test_HardcodedPasswords: missing_feature
         test_hardcoded_secrets.py:
@@ -73,7 +72,6 @@ tests/:
           TestHeaderInjection:
             '*': v2.10.0dev
             fastapi: missing_feature
-            python3.12: missing_feature
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: missing_feature
         test_insecure_auth_protocol.py:
@@ -82,26 +80,22 @@ tests/:
           TestInsecureCookie:
             '*': v1.19.0
             fastapi: missing_feature
-            python3.12: missing_feature
         test_ldap_injection.py:
           TestLDAPInjection: missing_feature
         test_no_httponly_cookie.py:
           TestNoHttponlyCookie:
             '*': v1.19.0
             fastapi: missing_feature
-            python3.12: missing_feature
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie:
             '*': v1.19.0
             fastapi: missing_feature
-            python3.12: missing_feature
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection: missing_feature
         test_path_traversal.py:
           TestPathTraversal:
             '*': v2.1.0
             fastapi: missing_feature
-            python3.12: missing_feature
         test_reflection_injection.py:
           TestReflectionInjection: missing_feature
         test_sql_injection.py:
@@ -110,12 +104,11 @@ tests/:
             fastapi: missing_feature
             flask-poc: v1.18.0
             pylons: missing_feature
-            python3.12: missing_feature
+            python3.12: v1.18.0
         test_ssrf.py:
           TestSSRF:
             '*': v2.2.0
             fastapi: missing_feature
-            python3.12: missing_feature
         test_trust_boundary_violation.py:
           Test_TrustBoundaryViolation: missing_feature
         test_unvalidated_redirect.py:
@@ -127,15 +120,12 @@ tests/:
           TestWeakCipher:
             '*': v1.18.0
             fastapi: missing_feature
-            python3.12: missing_feature
         test_weak_hash.py:
           TestWeakHash:
             '*': v1.18.0
-            python3.12: missing_feature
         test_weak_randomness.py:
           TestWeakRandomness:
             '*': v2.0.0
-            python3.12: missing_feature
         test_xcontent_sniffing.py:
           Test_XContentSniffing: missing_feature
         test_xpath_injection.py:
@@ -148,31 +138,27 @@ tests/:
             django-poc: v1.20.0
             fastapi: missing_feature
             flask-poc: v1.20.0
-            python3.12: missing_feature
+            python3.12: v1.20.0
             uds-flask: v1.20.0
             uwsgi-poc: v1.20.0
         test_cookie_name.py:
           TestCookieName:
             '*': v1.18.0
             fastapi: missing_feature
-            python3.12: missing_feature
         test_cookie_value.py:
           TestCookieValue:
             '*': v1.18.0
             fastapi: missing_feature
-            python3.12: missing_feature
         test_graphql_resolver.py:
           TestGraphqlResolverArgument: missing_feature
         test_header_name.py:
           TestHeaderName:
             '*': v1.18.0
             fastapi: missing_feature
-            python3.12: missing_feature
         test_header_value.py:
           TestHeaderValue:
             '*': v1.18.0
             fastapi: missing_feature
-            python3.12: missing_feature
         test_kafka_key.py:
           TestKafkaKey: missing_feature
         test_kafka_value.py:
@@ -184,14 +170,13 @@ tests/:
             django-poc: v1.18.0
             fastapi: missing_feature
             flask-poc: missing_feature
-            python3.12: missing_feature
+            python3.12: v1.18.0
             uds-flask: missing_feature
             uwsgi-poc: missing_feature
         test_parameter_value.py:
           TestParameterValue:
             '*': v2.9.0.dev
             fastapi: missing_feature
-            python3.12: bug (should have been v1.18.0)
         test_path.py:
           TestPath: missing_feature
         test_uri.py:

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -512,7 +512,6 @@ class WeblogContainer(TestedContainer):
             self.appsec_rules_file = (self.image.env | self.environment).get("DD_APPSEC_RULES", None)
 
         if self.weblog_variant == "python3.12":
-            self.environment["DD_IAST_ENABLED"] = "false"  # IAST is not working as now on python3.12
             if self.library < "python@2.1.0.dev":  # profiling causes a seg fault on 2.0.0
                 self.environment["DD_PROFILING_ENABLED"] = "false"
 

--- a/utils/build/docker/python/django/app.sh
+++ b/utils/build/docker/python/django/app.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ ${UDS_WEBLOG:-} = "1" ]; then
+if [ "${UDS_WEBLOG:-}" = "1" ]; then
     ./set-uds-transport.sh
 fi
 


### PR DESCRIPTION
## Motivation
Enable python 3.12 IAST tests https://datadoghq.atlassian.net/browse/APPSEC-53107

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

