### PR TITLE
Use gem from rubygems.org during 'prod'

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -145,9 +145,6 @@ jobs:
     - name: Load PHP library binary (skipping release tests, use snapshot instead)
       if: ${{ matrix.version == 'prod' && inputs.library == 'php'}}
       run: ./utils/scripts/load-binary.sh ${{ inputs.library }}
-    - name: Load Ruby library binary (skipping release tests, use snapshot instead)
-      if: ${{ matrix.version == 'prod' && inputs.library == 'ruby'}}
-      run: ./utils/scripts/load-binary.sh ${{ inputs.library }}
     - name: Load agent binary
       if: ${{ matrix.version == 'dev' }}
       run: ./utils/scripts/load-binary.sh agent

--- a/utils/build/docker/ruby/install_ddtrace.sh
+++ b/utils/build/docker/ruby/install_ddtrace.sh
@@ -26,7 +26,7 @@ elif [ $(ls /binaries/ruby-load-from-bundle-add | wc -l) = 0 ]; then
     #
     echo "Install prod version"
     # Support multiple versions of the gem
-    echo "gem 'datadog', '~> 2.0.0.beta2'" >> Gemfile
+    echo "gem 'datadog', '>= 2.0.0.beta2'" >> Gemfile
 
     export GEM_NAME=datadog
 else


### PR DESCRIPTION
## Motivation

We have beta2 gem released to rubygems.org. We no longer need to redirect "prod" to "dev"

## Changes

When testing with Ruby `prod`, download the gem from rubygems.org

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

