### PR TITLE
[python] ensure rustup is on the PATH

### DIFF
--- a/utils/build/docker/python/install_ddtrace.sh
+++ b/utils/build/docker/python/install_ddtrace.sh
@@ -4,6 +4,7 @@ set -eu
 
 # Install Rust toolchain
 curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
+export PATH="/root/.cargo/bin:$PATH"
 
 cd /binaries
 


### PR DESCRIPTION
## Motivation

The change #2454 did not add /root/.cargo/bin to the path, so even though it is installed, rust is still not available to ddtrace install.

## Changes

Add /root.cargo/bin to the $PATH

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

