### PR TITLE
[nodejs] Refactor NextJS getBody to properly consume request body

### DIFF
--- a/utils/build/docker/nodejs/nextjs/src/app/tag_value/[tag]/[status]/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/tag_value/[tag]/[status]/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { headers } from 'next/headers'
 
 export const dynamic = 'force-dynamic'
 
@@ -34,16 +35,13 @@ export async function GET (request, { params }) {
 export const OPTIONS = GET
 export const POST = GET
 
-// this function only works when formData() is called before json()
-// because formData doesn't consume the body if it doesn't have form data headers
 async function getBody (request) {
-  try {
-    return Object.fromEntries(await request.formData())
-  } catch (err) {}
-
-  try {
+  const contentType = headers().get('content-type')
+  if (contentType?.toLowerCase() === 'application/json') {
     return await request.json()
-  } catch (err) {}
-
+  }
+  if (['multipart/form-data', 'application/x-www-form-urlencoded'].includes(contentType?.toLowerCase())) {
+    return Object.fromEntries(await request.formData())
+  }
   return null
 }


### PR DESCRIPTION
## Motivation

Some test from NextJS variant were failing due to json body was nos correctly consumed (form data body was correctly consumed).

## Changes

Refactor `getBody` function to check content type header and consume body properly.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

