### PR TITLE
enable spantag rasp tests for python tracer

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -188,8 +188,8 @@ tests/:
         Test_Lfi_BodyXml: v2.10.0.dev
         Test_Lfi_UrlQuery: v2.10.0.dev
       test_span_tags.py:
-        Test_Mandatory_SpanTags: missing_feature
-        Test_Optional_SpanTags: missing_feature
+        Test_Mandatory_SpanTags: v2.10.0.dev
+        Test_Optional_SpanTags: v2.10.0.dev
       test_sqli.py: missing_feature
       test_ssrf.py:
         Test_Ssrf_BodyJson: v2.10.0.dev

--- a/tests/appsec/rasp/test_span_tags.py
+++ b/tests/appsec/rasp/test_span_tags.py
@@ -30,13 +30,13 @@ class Test_Mandatory_SpanTags:
         self.r = weblog.get("/rasp/lfi", params={"file": "../etc/passwd"})
 
     def test_lfi_span_tags(self):
-        validate_span_tags(self.r, expected_metrics=["appsec.rasp.duration"])
+        validate_span_tags(self.r, expected_metrics=["_dd.appsec.rasp.duration"])
 
     def setup_ssrf_span_tags(self):
         self.r = weblog.get("/rasp/ssrf", params={"domain": "169.254.169.254"})
 
     def test_ssrf_span_tags(self):
-        validate_span_tags(self.r, expected_metrics=["appsec.rasp.duration"])
+        validate_span_tags(self.r, expected_metrics=["_dd.appsec.rasp.duration"])
 
     def setup_sqli_span_tags(self):
         self.r = weblog.get("/rasp/sqli", params={"user_id": "' OR 1 = 1 --"})
@@ -44,7 +44,7 @@ class Test_Mandatory_SpanTags:
     @missing_feature(library="python")
     @missing_feature(library="dotnet")
     def test_sqli_span_tags(self):
-        validate_span_tags(self.r, expected_metrics=["appsec.rasp.duration"])
+        validate_span_tags(self.r, expected_metrics=["_dd.appsec.rasp.duration"])
 
 
 @rfc("https://docs.google.com/document/d/1vmMqpl8STDk7rJnd3YBsa6O9hCls_XHHdsodD61zr_4/edit#heading=h.96mezjnqf46y")
@@ -57,16 +57,18 @@ class Test_Optional_SpanTags:
         self.r = weblog.get("/rasp/lfi", params={"file": "../etc/passwd"})
 
     def test_lfi_span_tags(self):
-        validate_span_tags(self.r, expected_metrics=["appsec.rasp.duration_ext", "appsec.rasp.rule.eval"])
+        validate_span_tags(self.r, expected_metrics=["_dd.appsec.rasp.duration_ext", "_dd.appsec.rasp.rule.eval"])
 
     def setup_ssrf_span_tags(self):
         self.r = weblog.get("/rasp/ssrf", params={"domain": "169.254.169.254"})
 
     def test_ssrf_span_tags(self):
-        validate_span_tags(self.r, expected_metrics=["appsec.rasp.duration_ext", "appsec.rasp.rule.eval"])
+        validate_span_tags(self.r, expected_metrics=["_dd.appsec.rasp.duration_ext", "_dd.appsec.rasp.rule.eval"])
 
     def setup_sqli_span_tags(self):
         self.r = weblog.get("/rasp/sqli", params={"user_id": "' OR 1 = 1 --"})
 
+    @missing_feature(library="python")
+    @missing_feature(library="dotnet")
     def test_sqli_span_tags(self):
-        validate_span_tags(self.r, expected_metrics=["appsec.rasp.duration_ext", "appsec.rasp.rule.eval"])
+        validate_span_tags(self.r, expected_metrics=["_dd.appsec.rasp.duration_ext", "_dd.appsec.rasp.rule.eval"])


### PR DESCRIPTION
## Changes

- enable span tag rasp tests for python tracer
- look for the span tags in `_dd` namespace

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

