### PR TITLE
fix nodejs otel integration test error

### DIFF
--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1412,6 +1412,7 @@ class scenarios:
             "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
             "OTEL_EXPORTER_OTLP_ENDPOINT": "http://proxy:8126",
             "OTEL_EXPORTER_OTLP_TRACES_HEADERS": "dd-protocol=otlp,dd-otlp-path=agent",
+            "OTEL_INTEGRATIONS_TEST": True,
         },
         include_intake=False,
         include_collector=False,

--- a/utils/build/docker/nodejs/express4/integrations/db/postgres.js
+++ b/utils/build/docker/nodejs/express4/integrations/db/postgres.js
@@ -3,7 +3,17 @@
 const { join } = require('path')
 const { Client } = require('pg')
 const { readFileSync } = require('fs')
-const { createDBMSpy, getDbmQueryString } = require('./utils')
+let createDBMSpy = null
+let getDbmQueryString = null
+
+// load functions requiring dd-trace as long as this isn't an OTEL test
+if (!process.env.OTEL_INTEGRATIONS_TEST) {
+  try {
+    ({ createDBMSpy, getDbmQueryString } = require('./utils'))
+  } catch (error) {
+    // pass
+  }
+}
 
 async function launchQuery (query) {
   return new Promise(function (resolve, reject) {


### PR DESCRIPTION
## Motivation

NodeJS weblog was erroring when trying to run otel tests due to ddtrace require statement.

## Changes

Hide the require behind a try catch with an if statement.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

