### PR TITLE
[python] enabling builtins.open sink point

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -94,7 +94,7 @@ tests/:
           TestNoSqlMongodbInjection: missing_feature
         test_path_traversal.py:
           TestPathTraversal:
-            '*': bug (v2.9.0dev disables this test due to a bug with mock package)
+            '*': v2.10.0dev
             fastapi: missing_feature
         test_reflection_injection.py:
           TestReflectionInjection: missing_feature
@@ -143,11 +143,11 @@ tests/:
             uwsgi-poc: v1.20.0
         test_cookie_name.py:
           TestCookieName:
-            '*': bug (v2.9.0dev disables Path Traversal vulnerability due to a bug with mock package)
+            '*': v2.10.0dev
             fastapi: missing_feature
         test_cookie_value.py:
           TestCookieValue:
-            '*': bug (v2.9.0dev disables Path Traversal vulnerability due to a bug with mock package)
+            '*': v2.10.0dev
             fastapi: missing_feature
         test_graphql_resolver.py:
           TestGraphqlResolverArgument: missing_feature


### PR DESCRIPTION
## Motivation

After this PR https://github.com/DataDog/dd-trace-py/pull/9307 (fix(asm): enabling builtins.open sink point) we can revert this system-tests PR https://github.com/DataDog/system-tests/pull/2449

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

