### PR TITLE
[python] ensure curl is available for parametric container

### DIFF
--- a/utils/build/docker/python/parametric/ddtracer_version.Dockerfile
+++ b/utils/build/docker/python/parametric/ddtracer_version.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-slim
 
 # install bin dependancies
-RUN apt-get update && apt-get install -y git gcc g++ make cmake
+RUN apt-get update && apt-get install -y git gcc g++ make cmake curl
 
 WORKDIR /app
 


### PR DESCRIPTION
## Motivation

`curl` is needed to install `rustup`. It was available in the other scenario containers, but was missing from the parametric image.

## Changes

Install `curl` in the Python parametric image.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

