### PR TITLE
build(cpp): Update build args for dd-trace-cpp

### DIFF
--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Load Ruby library binary (skipping release tests, use snapshot instead)
         if: ${{ matrix.version == 'prod' && inputs.library == 'ruby'}}
         run: ./utils/scripts/load-binary.sh ${{ inputs.library }}
+
+      - name: Load C++ library binary (skipping release tests, use snapshot instead)
+        if: ${{ matrix.version == 'prod' && inputs.library == 'cpp'}}
+        run: ./utils/scripts/load-binary.sh ${{ inputs.library }}
+
       - name: Run parametric tests (with timeout)
         if: ${{ inputs.library == 'java' }}
         run: |

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -131,7 +131,13 @@ tests/:
       Test_TelemetryInstallSignature: missing_feature
       Test_TelemetrySCAEnvVar: missing_feature
     test_trace_sampling.py:
+      Test_Trace_Sampling_Basic: bug
+      Test_Trace_Sampling_Globs: bug
       Test_Trace_Sampling_Globs_Feb2024_Revision: bug (implementation is case-sensitive)
+      Test_Trace_Sampling_Resource: bug
+      Test_Trace_Sampling_Tags: bug
+      Test_Trace_Sampling_Tags_Feb2024_Revision: bug
+      Test_Trace_Sampling_With_W3C: bug
     test_tracer.py:
       Test_TracerSCITagging: missing_feature
     test_tracer_flare.py:

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -358,7 +358,7 @@ WORKDIR /usr/app
 COPY {cpp_reldir}/install_ddtrace.sh binaries* /binaries/
 RUN sh /binaries/install_ddtrace.sh
 RUN cd /binaries/dd-trace-cpp \
- && cmake -B .build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=1 . \
+ && cmake -B .build -DCMAKE_BUILD_TYPE=Release -DDD_TRACE_BUILD_TESTING=1 . \
  && cmake --build .build -j $(nproc) \
  && cmake --install .build --prefix /usr/app/
 

--- a/utils/build/docker/cpp/parametric/install_ddtrace.sh
+++ b/utils/build/docker/cpp/parametric/install_ddtrace.sh
@@ -20,8 +20,8 @@ git_clone_latest_release (){
 
 get_version_from_binaries() {
     # shellcheck disable=SC2002
-    version_line=$(cat /binaries/dd-trace-cpp/src/datadog/version.cpp | grep '^#define VERSION *')
-    current_version=$(echo "$version_line" |  awk -F'VERSION' '{ print $2 }')
+    version_line=$(cat /binaries/dd-trace-cpp/src/datadog/version.cpp | grep '^#define DD_TRACE_VERSION *')
+    current_version=$(echo "$version_line" |  awk -F'DD_TRACE_VERSION' '{ print $2 }')
     echo "$current_version" | tr -d '"'> SYSTEM_TESTS_LIBRARY_VERSION
 }
 


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/dd-trace-cpp/pull/119 changes build argument.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

## Note to reviewers
Prod is failing for this exact reason. Since,  `dd-trace-cpp@HEAD` is not as I considered prod. Could you change the system-test to only consider the latest release as of prod?
