### PR TITLE
k8s regenerate weblog images

### DIFF
--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -207,7 +207,6 @@ jobs:
         #If we execute on system-tests-dashboard, we can't push the images because we don't have the permissions.
         #To asign the permissions, we need to configure the image on ghcr, but due to a issue we can't do it
         #The case is opened with github support
-        if: github.ref == 'refs/heads/main' && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
         env:
           DOCKER_IMAGE_WEBLOG_TAG: latest
           APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ matrix.weblog }}
@@ -220,12 +219,12 @@ jobs:
         uses: ./.github/actions/install_runner       
 
       - name: Kubernetes lib-injection tests (using custom weblog image tag)
-        if: inputs.build_lib_injection_app_images
+        if: 1 == 2
         id: k8s-lib-injection-tests-custom-weblog-tag
         run: DOCKER_IMAGE_WEBLOG_TAG=${{ github.sha }} ./run.sh K8S_LIB_INJECTION_FULL
 
       - name: Kubernetes lib-injection tests
-        if: inputs.build_lib_injection_app_images != true
+        if: 1 == 2
         id: k8s-lib-injection-tests
         run: ./run.sh K8S_LIB_INJECTION_FULL
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

