### PR TITLE
[Java] DSM: Fix kafka test flakiness

### DIFF
--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -23,6 +23,7 @@ DSM_STREAM = "dsm-system-tests-stream"
 DSM_QUEUE = "dsm-system-tests-queue"
 DSM_TOPIC = "dsm-system-tests-topic"
 
+# Queue requests can take a while, so give time for them to complete
 DSM_REQUEST_TIMEOUT = 61
 
 
@@ -78,7 +79,9 @@ class Test_DsmHttp:
     def setup_dsm_http(self):
         # Note that for HTTP, we will still test using Kafka, because the call to Weblog itself is HTTP
         # and will be instrumented as such
-        self.r = weblog.get(f"/dsm?integration=kafka&queue={DSM_QUEUE}&group={DSM_CONSUMER_GROUP}", timeout=DSM_REQUEST_TIMEOUT)
+        self.r = weblog.get(
+            f"/dsm?integration=kafka&queue={DSM_QUEUE}&group={DSM_CONSUMER_GROUP}", timeout=DSM_REQUEST_TIMEOUT
+        )
 
     def test_dsm_http(self):
         assert self.r.text == "ok"
@@ -96,7 +99,7 @@ class Test_DsmRabbitmq:
     def setup_dsm_rabbitmq(self):
         self.r = weblog.get(
             f"/dsm?integration=rabbitmq&queue={DSM_QUEUE}&exchange={DSM_EXCHANGE}&routing_key={DSM_ROUTING_KEY}",
-            timeout=DSM_REQUEST_TIMEOUT
+            timeout=DSM_REQUEST_TIMEOUT,
         )
 
     @bug(
@@ -144,7 +147,7 @@ class Test_DsmRabbitmq:
     def setup_dsm_rabbitmq_dotnet_legacy(self):
         self.r = weblog.get(
             f"/dsm?integration=rabbitmq&queue={DSM_QUEUE}&exchange={DSM_EXCHANGE}&routing_key={DSM_ROUTING_KEY}",
-            timeout=DSM_REQUEST_TIMEOUT
+            timeout=DSM_REQUEST_TIMEOUT,
         )
 
     @irrelevant(context.library != "dotnet" or context.library > "dotnet@2.33.0", reason="legacy dotnet behavior")
@@ -277,7 +280,9 @@ class Test_DsmSNS:
     """ Verify DSM stats points for AWS SNS Service """
 
     def setup_dsm_sns(self):
-        self.r = weblog.get(f"/dsm?integration=sns&timeout=60&queue={DSM_QUEUE}&topic={DSM_TOPIC}", timeout=DSM_REQUEST_TIMEOUT,)
+        self.r = weblog.get(
+            f"/dsm?integration=sns&timeout=60&queue={DSM_QUEUE}&topic={DSM_TOPIC}", timeout=DSM_REQUEST_TIMEOUT,
+        )
 
     @missing_feature(library="java", reason="DSM is not implemented for Java AWS SNS.")
     def test_dsm_sns(self):

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -32,7 +32,6 @@ class Test_DsmKafka:
     def setup_dsm_kafka(self):
         self.r = weblog.get(f"/dsm?integration=kafka&queue={DSM_QUEUE}&group={DSM_CONSUMER_GROUP}")
 
-    @flaky(library="java", reason="AIT-10206")
     def test_dsm_kafka(self):
         assert self.r.text == "ok"
 

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -23,6 +23,8 @@ DSM_STREAM = "dsm-system-tests-stream"
 DSM_QUEUE = "dsm-system-tests-queue"
 DSM_TOPIC = "dsm-system-tests-topic"
 
+DSM_REQUEST_TIMEOUT = 61
+
 
 @features.datastreams_monitoring_support_for_kafka
 @scenarios.integrations
@@ -76,7 +78,7 @@ class Test_DsmHttp:
     def setup_dsm_http(self):
         # Note that for HTTP, we will still test using Kafka, because the call to Weblog itself is HTTP
         # and will be instrumented as such
-        self.r = weblog.get(f"/dsm?integration=kafka&queue={DSM_QUEUE}&group={DSM_CONSUMER_GROUP}")
+        self.r = weblog.get(f"/dsm?integration=kafka&queue={DSM_QUEUE}&group={DSM_CONSUMER_GROUP}", timeout=DSM_REQUEST_TIMEOUT)
 
     def test_dsm_http(self):
         assert self.r.text == "ok"
@@ -93,7 +95,8 @@ class Test_DsmRabbitmq:
 
     def setup_dsm_rabbitmq(self):
         self.r = weblog.get(
-            f"/dsm?integration=rabbitmq&queue={DSM_QUEUE}&exchange={DSM_EXCHANGE}&routing_key={DSM_ROUTING_KEY}"
+            f"/dsm?integration=rabbitmq&queue={DSM_QUEUE}&exchange={DSM_EXCHANGE}&routing_key={DSM_ROUTING_KEY}",
+            timeout=DSM_REQUEST_TIMEOUT
         )
 
     @bug(
@@ -140,7 +143,8 @@ class Test_DsmRabbitmq:
 
     def setup_dsm_rabbitmq_dotnet_legacy(self):
         self.r = weblog.get(
-            f"/dsm?integration=rabbitmq&queue={DSM_QUEUE}&exchange={DSM_EXCHANGE}&routing_key={DSM_ROUTING_KEY}"
+            f"/dsm?integration=rabbitmq&queue={DSM_QUEUE}&exchange={DSM_EXCHANGE}&routing_key={DSM_ROUTING_KEY}",
+            timeout=DSM_REQUEST_TIMEOUT
         )
 
     @irrelevant(context.library != "dotnet" or context.library > "dotnet@2.33.0", reason="legacy dotnet behavior")
@@ -172,7 +176,7 @@ class Test_DsmRabbitmq_TopicExchange:
     """ Verify DSM stats points for RabbitMQ Topic Exchange"""
 
     def setup_dsm_rabbitmq(self):
-        self.r = weblog.get("/dsm?integration=rabbitmq_topic_exchange")
+        self.r = weblog.get("/dsm?integration=rabbitmq_topic_exchange", timeout=DSM_REQUEST_TIMEOUT)
 
     def test_dsm_rabbitmq(self):
         assert self.r.text == "ok"
@@ -208,7 +212,7 @@ class Test_DsmRabbitmq_FanoutExchange:
     """ Verify DSM stats points for RabbitMQ Fanout Exchange"""
 
     def setup_dsm_rabbitmq(self):
-        self.r = weblog.get("/dsm?integration=rabbitmq_fanout_exchange")
+        self.r = weblog.get("/dsm?integration=rabbitmq_fanout_exchange", timeout=DSM_REQUEST_TIMEOUT)
 
     def test_dsm_rabbitmq(self):
         assert self.r.text == "ok"
@@ -244,7 +248,7 @@ class Test_DsmSQS:
     """ Verify DSM stats points for AWS Sqs Service """
 
     def setup_dsm_sqs(self):
-        self.r = weblog.get(f"/dsm?integration=sqs&timeout=60&queue={DSM_QUEUE}", timeout=61)
+        self.r = weblog.get(f"/dsm?integration=sqs&timeout=60&queue={DSM_QUEUE}", timeout=DSM_REQUEST_TIMEOUT)
 
     def test_dsm_sqs(self):
         assert self.r.text == "ok"
@@ -273,7 +277,7 @@ class Test_DsmSNS:
     """ Verify DSM stats points for AWS SNS Service """
 
     def setup_dsm_sns(self):
-        self.r = weblog.get(f"/dsm?integration=sns&timeout=60&queue={DSM_QUEUE}&topic={DSM_TOPIC}", timeout=61,)
+        self.r = weblog.get(f"/dsm?integration=sns&timeout=60&queue={DSM_QUEUE}&topic={DSM_TOPIC}", timeout=DSM_REQUEST_TIMEOUT,)
 
     @missing_feature(library="java", reason="DSM is not implemented for Java AWS SNS.")
     def test_dsm_sns(self):
@@ -303,7 +307,7 @@ class Test_DsmKinesis:
     """ Verify DSM stats points for AWS Kinesis Service """
 
     def setup_dsm_kinesis(self):
-        self.r = weblog.get(f"/dsm?integration=kinesis&timeout=60&stream={DSM_STREAM}", timeout=61,)
+        self.r = weblog.get(f"/dsm?integration=kinesis&timeout=60&stream={DSM_STREAM}", timeout=DSM_REQUEST_TIMEOUT,)
 
     @missing_feature(library="java", reason="DSM is not implemented for Java AWS Kinesis.")
     def test_dsm_kinesis(self):
@@ -350,7 +354,7 @@ class Test_DsmContext_Injection_Base64:
         topic = "dsm-injection-topic"
         integration = "kafka"
 
-        self.r = weblog.get(f"/dsm/inject?topic={topic}&integration={integration}", timeout=61,)
+        self.r = weblog.get(f"/dsm/inject?topic={topic}&integration={integration}", timeout=DSM_REQUEST_TIMEOUT,)
 
     def test_dsmcontext_injection_base64(self):
         assert self.r.status_code == 200
@@ -402,7 +406,7 @@ class Test_DsmContext_Extraction_Base64:
         self.r = weblog.get(
             f"/dsm/extract?topic={topic}&integration={integration}&ctx="
             + json.dumps(ctx),  # GoP2wpyqhGvWhsLZ5mPqhsLZ5mM= for java :(, nMKD2ZEAtFOSrODZ5mOSrODZ5mM= for go,
-            timeout=61,
+            timeout=DSM_REQUEST_TIMEOUT,
         )
 
     def test_dsmcontext_extraction_base64(self):

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -463,7 +463,8 @@ public class App {
         if ("kafka".equals(integration)) {
             KafkaConnector kafka = new KafkaConnector(queue);
             try {
-                kafka.startProducingMessage("hello world!");
+                produce_thread = kafka.startProducingMessage("hello world!");
+                produce_thread.join(5000)
             } catch (Exception e) {
                 System.out.println("[kafka] Failed to start producing message...");
                 e.printStackTrace();

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -467,7 +467,6 @@ public class App {
             try {
                 Thread produceThread = kafka.startProducingMessage("hello world!");
                 produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
-                produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[kafka] Failed to start producing message...");
                 e.printStackTrace();
@@ -475,7 +474,6 @@ public class App {
             }
             try {
                 Thread consumeThread = kafka.startConsumingMessages("");
-                consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
                 consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[kafka] Failed to start consuming message...");
@@ -487,7 +485,6 @@ public class App {
             try {
                 Thread produceThread = rabbitmq.startProducingMessages();
                 produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
-                produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[rabbitmq] Failed to start producing message...");
                 e.printStackTrace();
@@ -495,7 +492,6 @@ public class App {
             }
             try {
                 Thread consumeThread = rabbitmq.startConsumingMessages();
-                consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
                 consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[rabbitmq] Failed to start consuming message...");

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -97,6 +97,7 @@ public class App {
 
     CassandraConnector cassandra;
     MongoClient mongoClient;
+    int PRODUCE_CONSUME_THREAD_TIMEOUT = 5000;
 
     @RequestMapping("/")
     String home(HttpServletResponse response) {
@@ -422,7 +423,8 @@ public class App {
     ResponseEntity<String> rabbitmqProduce(@RequestParam(required = true) String queue, @RequestParam(required = true) String exchange) {
         RabbitmqConnector rabbitmq = new RabbitmqConnector();
         try {
-            rabbitmq.startProducingMessageWithQueue("RabbitMQ Context Propagation Test from Java", queue, exchange);
+            Thread produceThread = rabbitmq.startProducingMessageWithQueue("RabbitMQ Context Propagation Test from Java", queue, exchange);
+            produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
         } catch (Exception e) {
             System.out.println("[RabbitMQ] Failed to start producing message...");
             e.printStackTrace();
@@ -463,15 +465,18 @@ public class App {
         if ("kafka".equals(integration)) {
             KafkaConnector kafka = new KafkaConnector(queue);
             try {
-                produce_thread = kafka.startProducingMessage("hello world!");
-                produce_thread.join(5000)
+                Thread produceThread = kafka.startProducingMessage("hello world!");
+                produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
+                produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[kafka] Failed to start producing message...");
                 e.printStackTrace();
                 return "failed to start producing message";
             }
             try {
-                kafka.startConsumingMessages("");
+                Thread consumeThread = kafka.startConsumingMessages("");
+                consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
+                consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[kafka] Failed to start consuming message...");
                 e.printStackTrace();
@@ -480,14 +485,18 @@ public class App {
         } else if ("rabbitmq".equals(integration)) {
             RabbitmqConnectorForDirectExchange rabbitmq = new RabbitmqConnectorForDirectExchange(queue, exchange, routing_key);
             try {
-                rabbitmq.startProducingMessages();
+                Thread produceThread = rabbitmq.startProducingMessages();
+                produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
+                produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[rabbitmq] Failed to start producing message...");
                 e.printStackTrace();
                 return "failed to start producing message";
             }
             try {
-                rabbitmq.startConsumingMessages();
+                Thread consumeThread = rabbitmq.startConsumingMessages();
+                consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
+                consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[rabbitmq] Failed to start consuming message...");
                 e.printStackTrace();
@@ -496,14 +505,16 @@ public class App {
         } else if ("rabbitmq_topic_exchange".equals(integration)) {
             RabbitmqConnectorForTopicExchange rabbitmq = new RabbitmqConnectorForTopicExchange();
             try {
-                rabbitmq.startProducingMessages();
+                Thread produceThread = rabbitmq.startProducingMessages();
+                produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[rabbitmq_topic] Failed to start producing message...");
                 e.printStackTrace();
                 return "failed to start producing message";
             }
             try {
-                rabbitmq.startConsumingMessages();
+                Thread consumeThread = rabbitmq.startConsumingMessages();
+                consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[rabbitmq_topic] Failed to start consuming message...");
                 e.printStackTrace();
@@ -512,14 +523,16 @@ public class App {
         } else if ("rabbitmq_fanout_exchange".equals(integration)) {
             RabbitmqConnectorForFanoutExchange rabbitmq = new RabbitmqConnectorForFanoutExchange();
             try {
-                rabbitmq.startProducingMessages();
+                Thread produceThread = rabbitmq.startProducingMessages();
+                produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[rabbitmq_fanout] Failed to start producing message...");
                 e.printStackTrace();
                 return "failed to start producing message";
             }
             try {
-                rabbitmq.startConsumingMessages();
+                Thread consumeThread = rabbitmq.startConsumingMessages();
+                consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[rabbitmq_fanout] Failed to start consuming message...");
                 e.printStackTrace();
@@ -528,14 +541,16 @@ public class App {
         } else if ("sqs".equals(integration)) {
             SqsConnector sqs = new SqsConnector(queue);
             try {
-                sqs.startProducingMessage("hello world from SQS Dsm Java!");
+                Thread produceThread = sqs.startProducingMessage("hello world from SQS Dsm Java!");
+                produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[SQS] Failed to start producing message...");
                 e.printStackTrace();
                 return "[SQS] failed to start producing message";
             }
             try {
-                sqs.startConsumingMessages("SQS");
+                Thread consumeThread = sqs.startConsumingMessages("SQS");
+                consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[SQS] Failed to start consuming message...");
                 e.printStackTrace();
@@ -545,14 +560,16 @@ public class App {
             SnsConnector sns = new SnsConnector(topic);
             SqsConnector sqs = new SqsConnector(queue, "http://localstack-main:4566");
             try {
-                sns.startProducingMessage("hello world from SNS->SQS Dsm Java!", sqs);
+                Thread produceThread = sns.startProducingMessage("hello world from SNS->SQS Dsm Java!", sqs);
+                produceThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[SNS->SQS] Failed to start producing message...");
                 e.printStackTrace();
                 return "[SNS->SQS] failed to start producing message";
             }
             try {
-                sqs.startConsumingMessages("SNS->SQS");
+                Thread consumeThread = sqs.startConsumingMessages("SNS->SQS");
+                consumeThread.join(this.PRODUCE_CONSUME_THREAD_TIMEOUT);
             } catch (Exception e) {
                 System.out.println("[SNS->SQS] Failed to start consuming message...");
                 e.printStackTrace();

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/aws/KinesisConnector.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/aws/KinesisConnector.java
@@ -63,7 +63,7 @@ public class KinesisConnector {
         }
     }
 
-    public void startProducingMessage(String message) throws Exception {
+    public Thread startProducingMessage(String message) throws Exception {
         Thread thread = new Thread("KinesisProduce") {
             public void run() {
                 try {
@@ -76,9 +76,10 @@ public class KinesisConnector {
         };
         thread.start();
         System.out.println("[Kinesis] Started Kinesis producer thread");
+        return thread;
     }
 
-    public void startConsumingMessages(int timeout) throws Exception {
+    public Thread startConsumingMessages(int timeout) throws Exception {
         Thread thread = new Thread("KinesisConsume") {
             public void run() {
                 boolean recordFound = false;
@@ -94,6 +95,7 @@ public class KinesisConnector {
         };
         thread.start();
         System.out.println("[Kinesis] Started consumer thread");
+        return thread;
     }
 
     public void produceMessageWithoutNewThread(String message) throws Exception {

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/aws/SnsConnector.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/aws/SnsConnector.java
@@ -68,7 +68,7 @@ public class SnsConnector {
         }
     }
 
-    public void startProducingMessage(String message, SqsConnector sqs) throws Exception {
+    public Thread startProducingMessage(String message, SqsConnector sqs) throws Exception {
         Thread thread = new Thread("SnsProduce") {
             public void run() {
                 try {
@@ -81,6 +81,7 @@ public class SnsConnector {
         };
         thread.start();
         System.out.println("[SNS] Started Sns producer thread");
+        return thread;
     }
 
     // For APM testing, produce message without starting a new thread

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/aws/SqsConnector.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/aws/SqsConnector.java
@@ -58,7 +58,7 @@ public class SqsConnector {
         }
     }
 
-    public void startProducingMessage(String message) throws Exception {
+    public Thread startProducingMessage(String message) throws Exception {
         Thread thread = new Thread("SqsProduce") {
             public void run() {
                 try {
@@ -71,9 +71,10 @@ public class SqsConnector {
         };
         thread.start();
         System.out.println("[SQS] Started Sqs producer thread");
+        return thread;
     }
 
-    public void startConsumingMessages(String service) throws Exception {
+    public Thread startConsumingMessages(String service) throws Exception {
         Thread thread = new Thread(service + "Consume") {
             public void run() {
                 boolean recordFound = false;
@@ -89,6 +90,7 @@ public class SqsConnector {
         };
         thread.start();
         System.out.println("[" + service.toUpperCase() + "] Started consumer thread");
+        return thread;
     }
 
     // For APM testing, produce message without starting a new thread

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/kafka/KafkaConnector.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/kafka/KafkaConnector.java
@@ -61,6 +61,8 @@ public class KafkaConnector {
             }
         };
         thread.start();
+
+        return thread;
     }
 
     // Ideally we should be able to use @Component and @KafkaListener to auto consume messages, but I wasn't able
@@ -78,6 +80,7 @@ public class KafkaConnector {
         };
         thread.start();
         System.out.println("Started Kafka consumer thread");
+        return thread;
     }
 
     public Thread startConsumingMessages(String groupName, long timeoutMs, Consumer<ConsumerRecords<String, String>> callback) throws Exception {

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/kafka/KafkaConnector.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/kafka/KafkaConnector.java
@@ -52,7 +52,7 @@ public class KafkaConnector {
         return new KafkaConsumer<String, String>(props);
     }
 
-    public void startProducingMessage(String message) throws Exception {
+    public Thread startProducingMessage(String message) throws Exception {
         Thread thread = new Thread("KafkaProduce") {
             public void run() {
                 KafkaTemplate<String, String> kafkaTemplate = createKafkaTemplateForProducer();
@@ -67,7 +67,7 @@ public class KafkaConnector {
 
     // Ideally we should be able to use @Component and @KafkaListener to auto consume messages, but I wasn't able
     // to get it to work. Can look into this as a follow up.
-    public void startConsumingMessages(String topicName) throws Exception {
+    public Thread startConsumingMessages(String topicName) throws Exception {
         Thread thread = new Thread("KafkaConsume") {
             public void run() {
                 KafkaConsumer<String, String> consumer = createKafkaConsumer(topicName);

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rabbitmq/RabbitmqConnector.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rabbitmq/RabbitmqConnector.java
@@ -73,7 +73,7 @@ public class RabbitmqConnector {
 		};
 	}
 
-    public void startProducingMessage(String message) throws Exception {
+    public Thread startProducingMessage(String message) throws Exception {
         Thread thread = new Thread("RabbitmqProduce") {
             public void run() {
                 try {
@@ -90,10 +90,11 @@ public class RabbitmqConnector {
             }
         };
         thread.start();
+        return thread;
     }
 
 
-    public void startProducingMessageWithQueue(String message, String queue, String exchange) throws Exception {
+    public Thread startProducingMessageWithQueue(String message, String queue, String exchange) throws Exception {
         Thread thread = new Thread("RabbitmqProduce") {
             public void run() {
                 try {
@@ -110,9 +111,10 @@ public class RabbitmqConnector {
             }
         };
         thread.start();
+        return thread;
     }
 
-    public void startConsumingMessages() throws Exception {
+    public Thread startConsumingMessages() throws Exception {
         System.out.println("[rabbitmq] Start consuming messages");
         Thread thread = new Thread("RabbitmqConsume") {
             public void run() {
@@ -133,6 +135,7 @@ public class RabbitmqConnector {
             }
         };
         thread.start();
+        return thread;
     }
 
     public CompletableFuture<Boolean> startConsumingMessagesWithQueue(String queue, String exchange, Integer timeout) throws Exception {

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rabbitmq/RabbitmqConnectorForDirectExchange.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rabbitmq/RabbitmqConnectorForDirectExchange.java
@@ -43,7 +43,7 @@ public class RabbitmqConnectorForDirectExchange extends RabbitmqConnector {
         channel.queueBind(queue, exchange, routing_key);
 	}
 
-    public void startProducingMessages() throws Exception {
+    public Thread startProducingMessages() throws Exception {
         Thread thread = new Thread("RabbitmqProduce_Direct") {
             public void run() {
                 try {
@@ -59,9 +59,10 @@ public class RabbitmqConnectorForDirectExchange extends RabbitmqConnector {
             }
         };
         thread.start();
+        return thread;
     }
 
-    public void startConsumingMessages() throws Exception {
+    public Thread startConsumingMessages() throws Exception {
         Thread thread = new Thread("RabbitmqConsume_Direct") {
             public void run() {
                 try {
@@ -77,5 +78,6 @@ public class RabbitmqConnectorForDirectExchange extends RabbitmqConnector {
             }
         };
         thread.start();
+        return thread;
     }
 }

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rabbitmq/RabbitmqConnectorForFanoutExchange.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rabbitmq/RabbitmqConnectorForFanoutExchange.java
@@ -43,7 +43,7 @@ public class RabbitmqConnectorForFanoutExchange extends RabbitmqConnector {
         channel.queueBind(FANOUT_EXCHANGE_QUEUE_3, FANOUT_EXCHANGE_NAME, "");
 	}
 
-    public void startProducingMessages() throws Exception {
+    public Thread startProducingMessages() throws Exception {
         Thread thread = new Thread("RabbitmqProduce_Fanout") {
             public void run() {
                 String message = "hello world";
@@ -59,9 +59,10 @@ public class RabbitmqConnectorForFanoutExchange extends RabbitmqConnector {
             }
         };
         thread.start();
+        return thread;
     }
 
-    public void startConsumingMessages() throws Exception {
+    public Thread startConsumingMessages() throws Exception {
         Thread thread = new Thread("RabbitmqConsume_Fanout") {
             public void run() {
                 try {
@@ -79,5 +80,6 @@ public class RabbitmqConnectorForFanoutExchange extends RabbitmqConnector {
             }
         };
         thread.start();
+        return thread;
     }
 }

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rabbitmq/RabbitmqConnectorForTopicExchange.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rabbitmq/RabbitmqConnectorForTopicExchange.java
@@ -43,7 +43,7 @@ public class RabbitmqConnectorForTopicExchange extends RabbitmqConnector {
         channel.queueBind(TOPIC_EXCHANGE_QUEUE_3, TOPIC_EXCHANGE_NAME, "test.topic.chocolate.*");
 	}
 
-    public void startProducingMessages() throws Exception {
+    public Thread startProducingMessages() throws Exception {
         Thread thread = new Thread("RabbitmqProduce_Topic") {
             public void run() {
                 String message = "hello world";
@@ -61,9 +61,10 @@ public class RabbitmqConnectorForTopicExchange extends RabbitmqConnector {
             }
         };
         thread.start();
+        return thread;
     }
 
-    public void startConsumingMessages() throws Exception {
+    public Thread startConsumingMessages() throws Exception {
         Thread thread = new Thread("RabbitmqConsume_Topic") {
             public void run() {
                 try {
@@ -81,5 +82,6 @@ public class RabbitmqConnectorForTopicExchange extends RabbitmqConnector {
             }
         };
         thread.start();
+        return thread;
     }
 }


### PR DESCRIPTION
## Motivation

Fix for flaky DSM tests with the Java app.

## Changes

Adds `thread.join()` calls to all the calls to produce/consume.  Also updates method signatures to allow this to happen.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

