### PR TITLE
Skip failing test on agent telemetry payloads

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -45,6 +45,7 @@ class Test_Agent:
             excluded_points=[
                 ("/api/v2/apmtelemetry", "$.payload.configuration[]"),
                 ("/api/v2/apmtelemetry", "$.payload"),  # APPSEC-52845
+                ("/api/v2/apmtelemetry", "$"),  # the main payload sent by the agent may be an array i/o an object
             ]
         )
 
@@ -58,3 +59,7 @@ class Test_Agent:
     @irrelevant(context.scenario is scenarios.crossed_tracing_libraries, reason="APPSEC-52805")
     def test_agent_schema_telemetry_job_object(self):
         interfaces.agent.assert_schema_point("/api/v2/apmtelemetry", "$.payload")
+
+    @bug(context.agent_version > "7.53.0", reason="Jira missing")
+    def test_agent_schema_telemetry_main_payload(self):
+        interfaces.agent.assert_schema_point("/api/v2/apmtelemetry", "$")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -95,6 +95,7 @@ class Test_Telemetry:
         context.agent_version >= "7.36.0" and context.agent_version < "7.37.0",
         reason="Version reporting of trace agent is broken in 7.36.x release",
     )
+    @bug(context.agent_version > "7.53.0", reason="Jira missing")
     def test_telemetry_proxy_enrichment(self):
         """Test telemetry proxy adds necessary information"""
 
@@ -239,6 +240,7 @@ class Test_Telemetry:
     @bug(
         library="java", weblog_variant="spring-boot-wildfly",
     )
+    @bug(context.agent_version > "7.53.0", reason="Jira missing")
     def test_proxy_forwarding(self):
         """Test that all telemetry requests sent by library are forwarded correctly by the agent"""
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

