### PR TITLE
fix(installer): Fix docker rate limiting & add local test env var

### DIFF
--- a/utils/build/virtual_machine/provisions/installer-auto-inject/provision.yml
+++ b/utils/build/virtual_machine/provisions/installer-auto-inject/provision.yml
@@ -28,7 +28,6 @@ setup-testing-dependencies:
     - os_type: linux
       os_distro: deb
       remote-command: |
-        sudo docker pull registry:2
         sudo rm -rf /usr/local/go
         sudo curl https://dl.google.com/go/go1.22.1.linux-$(dpkg --print-architecture).tar.gz --output go.tar.gz
         sudo tar -C /usr/local -xzf go.tar.gz
@@ -66,7 +65,7 @@ setup-local-registry:
         export PATH=$PATH:/usr/local/go/bin
         export PATH=$PATH:$(go env GOPATH)/bin
         sudo systemctl start docker
-        sudo docker run -d -p 12345:5000 --restart=always --name registry registry:2
+        sudo docker run -d -p 12345:5000 --restart=always --name registry 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/registry:2
         sleep 10
 
         if [ -n "${DD_INSTALLER_LIBRARY_VERSION}" ]; then

--- a/utils/virtual_machine/aws_provider.py
+++ b/utils/virtual_machine/aws_provider.py
@@ -44,7 +44,8 @@ class AWSPulumiProvider(VmProvider):
             self.stack = auto.create_or_select_stack(
                 stack_name=stack_name, project_name=project_name, program=pulumi_start_program
             )
-            self.stack.set_config("aws:SkipMetadataApiCheck", auto.ConfigValue("false"))
+            if os.getenv("ONBOARDING_LOCAL_TEST") is None:
+                self.stack.set_config("aws:SkipMetadataApiCheck", auto.ConfigValue("false"))
             up_res = self.stack.up(on_output=logger.info)
         except Exception as pulumi_exception:
             logger.error("Exception launching aws provision infraestructure")


### PR DESCRIPTION
## Motivation
Less failures

## Changes
- An env var to check if we're running the tests locally or not - to avoid updating the python at each check
- Properly use the docker mirror in installer tests

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

