### PR TITLE
PROF-9791: Allow None as default for profiling_enabled

### DIFF
--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -60,7 +60,7 @@ class Test_Defaults:
             ("trace_header_tags", ""),
             ("trace_tags", ""),
             ("trace_enabled", ("true", True)),
-            ("profiling_enabled", ("false", False)),
+            ("profiling_enabled", ("false", False, None)),
             ("appsec_enabled", ("false", False, "inactive", None)),
             ("data_streams_enabled", ("false", False)),
         ]:


### PR DESCRIPTION
## Motivation

This fixes a test failure with https://github.com/DataDog/dd-trace-js/pull/4322. That PR modifies the default for `profiling_enabled` in our Node.js tracer from `false` to `undefined` as for SSI-enabled profiling we need the ability to distinguish between explicitly specified `DD_PROFILING_ENABLED=false` env var and `DD_PROFILING_ENABLED` not being set; now the `undefined` value represents this latter condition.

## Changes

Adds `None` to the list of acceptable values. Note this is rather analogous to [`05b08aa` (#2172)](https://github.com/DataDog/system-tests/pull/2172/commits/05b08aa4eef210ecf824f112eef7fd3e689600aa).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

