### PR TITLE
Fix version parser for dd-trace-cpp

### DIFF
--- a/utils/build/docker/cpp/parametric/install_ddtrace.sh
+++ b/utils/build/docker/cpp/parametric/install_ddtrace.sh
@@ -20,7 +20,7 @@ git_clone_latest_release (){
 
 get_version_from_binaries() {
     # shellcheck disable=SC2002
-    version_line=$(cat /binaries/dd-trace-cpp/src/datadog/version.cpp | grep '^#define VERSION *')
+    version_line=$(cat /binaries/dd-trace-cpp/src/datadog/version.cpp | grep '^#define .*VERSION *')
     current_version=$(echo "$version_line" |  awk -F'VERSION' '{ print $2 }')
     echo "$current_version" | tr -d '"'> SYSTEM_TESTS_LIBRARY_VERSION
 }


### PR DESCRIPTION
## Motivation

This commit breaks the version parser for dd-trace-cpp

https://github.com/DataDog/dd-trace-cpp/commit/fad4e8d51e2897ae87b86322097a3eef9754d441#diff-e27da700983acadaabf69b80e4d6ef7926e3207a2f4383c3eff0219376505570R6

## Changes

Fix the version parser

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

