### PR TITLE
enable otel span link system tests for golang

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -413,7 +413,7 @@ tests/:
       TestDynamicConfigV2: v1.59.0
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
-    test_span_links.py: missing_feature
+    test_span_links.py: v1.61.0
     test_telemetry.py:
       Test_Defaults: missing_feature
       Test_Environment: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -413,7 +413,7 @@ tests/:
       TestDynamicConfigV2: v1.59.0
     test_otel_api_interoperability.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
-    test_span_links.py: v1.61.0
+    test_span_links.py: missing_feature
     test_telemetry.py:
       Test_Defaults: missing_feature
       Test_Environment: missing_feature

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -560,8 +560,7 @@ class Test_Otel_Span_Methods:
                             ["x-datadog-origin", "synthetics"],
                             ["x-datadog-tags", "_dd.p.dm=-4,_dd.p.tid=0000000000000010"],
                         ],
-                        attributes={"foo": "bar", "array": ["a", "b", "c"],
-                                    "bools": [True, False], "nested": [1, 2]},
+                        attributes={"foo": "bar", "array": ["a", "b", "c"], "bools": [True, False], "nested": [1, 2]},
                     )
                 ],
             ) as span:

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -404,8 +404,8 @@ class Test_Otel_Span_Methods:
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library < "java@1.26.0", reason="Implemented in 1.26.0")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.3.0", reason="Implemented in 3.48.0, 4.27.0, and 5.3.0")
+    @missing_feature(context.library < "golang@1.61.0", reason="Implemented in 1.61.0")
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
     def test_otel_span_started_with_link_from_another_span(self, test_agent, test_library):
@@ -440,15 +440,11 @@ class Test_Otel_Span_Methods:
         assert link.get("trace_id") == root.get("trace_id")
         root_tid = root["meta"].get("_dd.p.tid") or "0" if "meta" in root else "0"
         assert (link.get("trace_id_high") or 0) == int(root_tid, 16)
-        assert link["attributes"].get("foo") == "bar"
-        assert link["attributes"].get("array.0") == "a"
-        assert link["attributes"].get("array.1") == "b"
-        assert link["attributes"].get("array.2") == "c"
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library < "java@1.26.0", reason="Implemented in 1.26.0")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.3.0", reason="Implemented in 3.48.0, 4.27.0, and 5.3.0")
+    @missing_feature(context.library < "golang@1.61.0", reason="Implemented in 1.61.0")
     @missing_feature(context.library < "ruby@2.0.0", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
     def test_otel_span_started_with_link_from_datadog_headers(self, test_agent, test_library):
@@ -494,12 +490,11 @@ class Test_Otel_Span_Methods:
             assert link.get("flags") == 1 | TRACECONTEXT_FLAGS_SET
 
         assert len(link.get("attributes")) == 1
-        assert link["attributes"].get("foo") == "bar"
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library < "java@1.28.0", reason="Implemented in 1.28.0")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.3.0", reason="Implemented in 3.48.0, 4.27.0, and 5.3.0")
+    @missing_feature(context.library < "golang@1.61.0", reason="Implemented in 1.61.0")
     @missing_feature(context.library < "ruby@2.0.0", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
     def test_otel_span_started_with_link_from_w3c_headers(self, test_agent, test_library):
@@ -541,13 +536,58 @@ class Test_Otel_Span_Methods:
         assert "s:2" in tracestateDD
         assert "t.dm:-4" in tracestateDD
 
-        assert link.get("flags") == 1 | TRACECONTEXT_FLAGS_SET
-        assert link.get("attributes") is None
+        assert link.get("flags") == 1 | TRACECONTEXT_FLAGS_SET or TRACECONTEXT_FLAGS_SET
+        assert link.get("attributes") is None or len(link.get("attributes")) == 0
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library < "java@1.26.0", reason="Implemented in 1.26.0")
     @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.3.0", reason="Implemented in 3.48.0, 4.27.0, and 5.3.0")
+    @missing_feature(context.library < "ruby@2.0.0", reason="Not implemented")
+    @missing_feature(context.library == "php", reason="Not implemented")
+    def test_otel_span_link_attribute_handling(self, test_agent, test_library):
+        """Test that span links implementations correctly handle attributes according to spec.
+        """
+        with test_library:
+            with test_library.otel_start_span(
+                "root",
+                links=[
+                    Link(
+                        http_headers=[
+                            ["x-datadog-trace-id", "1234567890"],
+                            ["x-datadog-parent-id", "9876543210"],
+                            ["x-datadog-sampling-priority", "2"],
+                            ["x-datadog-origin", "synthetics"],
+                            ["x-datadog-tags", "_dd.p.dm=-4,_dd.p.tid=0000000000000010"],
+                        ],
+                        attributes={"foo": "bar", "array": ["a", "b", "c"],
+                                    "bools": [True, False], "nested": [1, 2]},
+                    )
+                ],
+            ) as span:
+                span.end_span()
+
+        span = get_span(test_agent)
+        span_links = retrieve_span_links(span)
+        assert span_links is not None
+        assert len(span_links) == 1
+
+        link = span_links[0]
+
+        assert len(link.get("attributes")) == 8
+        assert link["attributes"].get("foo") == "bar"
+        assert link["attributes"].get("bools.0") == "true"
+        assert link["attributes"].get("bools.1") == "false"
+        assert link["attributes"].get("nested.0") == "1"
+        assert link["attributes"].get("nested.1") == "2"
+        assert link["attributes"].get("array.0") == "a"
+        assert link["attributes"].get("array.1") == "b"
+        assert link["attributes"].get("array.2") == "c"
+
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library < "java@1.26.0", reason="Implemented in 1.26.0")
+    @missing_feature(context.library < "golang@1.61.0", reason="Implemented in 1.61.0")
+    @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library < "ruby@2.0.0", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
     def test_otel_span_started_with_link_from_other_spans(self, test_agent, test_library):
@@ -587,7 +627,7 @@ class Test_Otel_Span_Methods:
         assert link.get("span_id") == root.get("span_id")
         assert link.get("trace_id") == root.get("trace_id")
         assert link.get("trace_id_high") == int(root_tid, 16)
-        assert link.get("attributes") is None
+        assert link.get("attributes") is None or len(link.get("attributes")) == 0
         # Tracestate is not required, but if it is present, it must contain the linked span's tracestate
         assert link.get("tracestate") is None or "dd=" in link.get("tracestate")
 
@@ -595,11 +635,6 @@ class Test_Otel_Span_Methods:
         assert link.get("span_id") == first.get("span_id")
         assert link.get("trace_id") == first.get("trace_id")
         assert link.get("trace_id_high") == int(root_tid, 16)
-        assert len(link.get("attributes")) == 4
-        assert link["attributes"].get("bools.0") == "true"
-        assert link["attributes"].get("bools.1") == "false"
-        assert link["attributes"].get("nested.0") == "1"
-        assert link["attributes"].get("nested.1") == "2"
         assert link.get("tracestate") is None or "dd=" in link.get("tracestate")
 
     @missing_feature(context.library < "java@1.24.1", reason="Implemented in 1.24.1")

--- a/utils/build/docker/golang/parametric/otel.go
+++ b/utils/build/docker/golang/parametric/otel.go
@@ -2,17 +2,58 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/labstack/gommon/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	otel_trace "go.opentelemetry.io/otel/trace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	ddotel "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentelemetry"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
+
+func ConvertKeyValsToAttributes(keyVals map[string]*ListVal) []attribute.KeyValue {
+	attributes := make([]attribute.KeyValue, 0, len(keyVals))
+	for k, lv := range keyVals {
+		n := len(lv.GetVal())
+		if n == 0 {
+			continue
+		}
+		first := lv.GetVal()[0]
+		switch first.Val.(type) {
+		case *AttrVal_StringVal:
+			inp := make([]string, n)
+			for i, v := range lv.GetVal() {
+				inp[i] = v.GetStringVal()
+			}
+			attributes = append(attributes, attribute.String(k, "["+strings.Join(inp, ", ")+"]"))
+		case *AttrVal_BoolVal:
+			inp := make([]string, n)
+			for i, v := range lv.GetVal() {
+				inp[i] = strconv.FormatBool(v.GetBoolVal())
+			}
+			attributes = append(attributes, attribute.String(k, "["+strings.Join(inp, ", ")+"]"))
+		case *AttrVal_DoubleVal:
+			inp := make([]string, n)
+			for i, v := range lv.GetVal() {
+				inp[i] = strconv.FormatFloat(v.GetDoubleVal(), 'f', -1, 64)
+			}
+			attributes = append(attributes, attribute.String(k, "["+strings.Join(inp, ", ")+"]"))
+		case *AttrVal_IntegerVal:
+			inp := make([]string, n)
+			for i, v := range lv.GetVal() {
+				inp[i] = strconv.FormatInt(v.GetIntegerVal(), 10)
+			}
+			attributes = append(attributes, attribute.String(k, "["+strings.Join(inp, ", ")+"]"))
+		}
+	}
+	return attributes
+}
 
 func (s *apmClientServer) OtelStartSpan(ctx context.Context, args *OtelStartSpanArgs) (*OtelStartSpanReturn, error) {
 	if s.tracer == nil {
@@ -102,16 +143,65 @@ func (s *apmClientServer) OtelStartSpan(ctx context.Context, args *OtelStartSpan
 			ddOpts = append(ddOpts, tracer.ChildOf(sctx))
 		}
 	}
+
+	if links := args.GetSpanLinks(); links != nil {
+		for _, link := range links {
+			switch from := link.From.(type) {
+			case *SpanLink_ParentId:
+				if _, ok := s.otelSpans[from.ParentId]; ok {
+					otelOpts = append(otelOpts, otel_trace.WithLinks(otel_trace.Link{SpanContext: s.otelSpans[from.ParentId].span.SpanContext(), Attributes: ConvertKeyValsToAttributes(link.GetAttributes().KeyVals)}))
+				}
+			case *SpanLink_HttpHeaders:
+				headers := map[string]string{}
+				for _, headerTuple := range from.HttpHeaders.HttpHeaders {
+					k := headerTuple.GetKey()
+					v := headerTuple.GetValue()
+					if k != "" && v != "" {
+						headers[k] = v
+					}
+				}
+				extractedContext, _ := tracer.NewPropagator(nil).Extract(tracer.TextMapCarrier(headers))
+				state, _ := otel_trace.ParseTraceState(headers["tracestate"])
+
+				var traceID otel_trace.TraceID
+				var spanID otel_trace.SpanID
+				if w3cCtx, ok := extractedContext.(ddtrace.SpanContextW3C); ok {
+					traceID = w3cCtx.TraceID128Bytes()
+				} else {
+					log.Debug("Non-W3C context found in span, unable to get full 128 bit trace id")
+					uint64ToByte(extractedContext.TraceID(), traceID[:])
+				}
+				uint64ToByte(extractedContext.SpanID(), spanID[:])
+				config := otel_trace.SpanContextConfig{
+					TraceID:    traceID,
+					SpanID:     spanID,
+					TraceState: state,
+				}
+				var newCtx = otel_trace.NewSpanContext(config)
+				otelOpts = append(otelOpts, otel_trace.WithLinks(otel_trace.Link{
+					SpanContext: newCtx,
+					Attributes:  ConvertKeyValsToAttributes(link.GetAttributes().KeyVals),
+				}))
+			}
+
+		}
+	}
+
 	ctx, span := s.tracer.Start(ddotel.ContextWithStartOptions(pCtx, ddOpts...), args.Name, otelOpts...)
 	hexSpanId := hex2int(span.SpanContext().SpanID().String())
 	s.otelSpans[hexSpanId] = spanContext{
 		span: span,
 		ctx:  ctx,
 	}
+
 	return &OtelStartSpanReturn{
 		SpanId:  hexSpanId,
 		TraceId: hex2int(span.SpanContext().TraceID().String()),
 	}, nil
+}
+
+func uint64ToByte(n uint64, b []byte) {
+	binary.BigEndian.PutUint64(b, n)
 }
 
 func (s *apmClientServer) OtelEndSpan(ctx context.Context, args *OtelEndSpanArgs) (*OtelEndSpanReturn, error) {

--- a/utils/build/docker/golang/parametric/otel.go
+++ b/utils/build/docker/golang/parametric/otel.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/labstack/gommon/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	otel_trace "go.opentelemetry.io/otel/trace"
@@ -168,7 +167,7 @@ func (s *apmClientServer) OtelStartSpan(ctx context.Context, args *OtelStartSpan
 				if w3cCtx, ok := extractedContext.(ddtrace.SpanContextW3C); ok {
 					traceID = w3cCtx.TraceID128Bytes()
 				} else {
-					log.Debug("Non-W3C context found in span, unable to get full 128 bit trace id")
+					fmt.Printf("Non-W3C context found in span, unable to get full 128 bit trace id")
 					uint64ToByte(extractedContext.TraceID(), traceID[:])
 				}
 				uint64ToByte(extractedContext.SpanID(), spanID[:])


### PR DESCRIPTION
enable otel span link system tests for golang & separate span link attribute validation into its own test

## Motivation

enable otel span link tests for golang

## Changes

update golang parametric server to create span links & isolate attribute validations from existing span link system tests into a separate system test