### PR TITLE
fix(installer): Fix ordering

### DIFF
--- a/utils/build/virtual_machine/provisions/installer-auto-inject/provision.yml
+++ b/utils/build/virtual_machine/provisions/installer-auto-inject/provision.yml
@@ -103,6 +103,6 @@ installer-bootstrap:
   install:
     - os_type: linux
       remote-command: |
+        sudo datadog-installer install "oci://localhost:12345/datadog/apm-inject-package:latest"
         sudo datadog-installer install "oci://localhost:12345/datadog/agent-package:latest"
         sudo datadog-installer install "oci://localhost:12345/datadog/apm-library-${DD_LANG}-package:latest"
-        sudo datadog-installer install "oci://localhost:12345/datadog/apm-inject-package:latest"


### PR DESCRIPTION
## Motivation
Installer tests are broken

## Changes
Following a change in the agent the injector must be installed first - this is enforced in the install script but we don't use it here because we need to override the packages.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

