### PR TITLE
Remove unecessary command call to agent container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ binaries/*
 venv
 venv.
 /vendor/python
+system_tests.egg-info/
 
 .python-version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[project]
+name = 'system_tests'
+version = '0.0.1'
+
+[tool.setuptools]
+packages = ["tests", "utils"]
+
 [tool.black]
 line-length = 120
 exclude = "(venv/|utils/grpc/weblog_pb2_grpc.py|utils/grpc/weblog_pb2.py|parametric/apps|parametric/protos/)"

--- a/tests/test_the_test/test_version.py
+++ b/tests/test_the_test/test_version.py
@@ -71,9 +71,6 @@ def test_version_serialization():
     assert v.version == Version("1.0.14.1.0.beta1")
     assert v.version == "1.0.14+1.0.beta1"
 
-    v = LibraryVersion("agent", "Agent 7.33.0 - Commit: e6cfcb9 - Serialization version: v5.0.4 - Go version: go1.16.7")
-    assert v.version == "7.33.0"
-
     v = LibraryVersion("php", "1.0.0-nightly")
     assert v.version == "1.0.0"
 
@@ -89,19 +86,8 @@ def test_version_serialization():
 
 def test_agent_version():
 
-    v = LibraryVersion(
-        "agent", "Agent 7.37.0 - Commit: 1124d66 - Serialization version: v5.0.22 - Go version: go1.17.11"
-    )
-    assert v == "agent@7.37.0"
-
-    v = LibraryVersion(
-        "agent",
-        "Agent 7.38.0-rc.1 - Meta: git.1.3b34941 - Commit: 3b34941 - Serialization version: v5.0.23 - Go version: go1.17.11",
-    )
-    assert v == "agent@7.38.0-rc.1"
-
-    v = LibraryVersion("agent", "Agent \x1b[36m7.40.0-rc.2\x1b[0m")
-    assert v == "agent@7.40.0-rc.2"
+    v = LibraryVersion("agent", "7.54.0-installer-0.0.7+git.106.b0943ad")
+    assert v == "agent@7.54.0-installer-0.0.7+git.106.b0943ad"
 
 
 def test_in_operator():

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -151,12 +151,7 @@ class _Scenario:
     def session_start(self):
         """called at the very begning of the process"""
 
-        self.print_test_context()
-
-        if self.replay:
-            return
-
-        logger.stdout("Executing warmups...")
+        logger.terminal.write_sep("=", "test context", bold=True)
 
         try:
             for warmup in self._get_warmups():
@@ -169,13 +164,11 @@ class _Scenario:
     def pytest_sessionfinish(self, session):
         """called at the end of the process"""
 
-    def print_test_context(self):
-        logger.terminal.write_sep("=", "test context", bold=True)
-        logger.stdout(f"Scenario: {self.name}")
-        logger.stdout(f"Logs folder: ./{self.host_log_folder}")
-
     def _get_warmups(self):
-        return []
+        return [
+            lambda: logger.stdout(f"Scenario: {self.name}"),
+            lambda: logger.stdout(f"Logs folder: ./{self.host_log_folder}"),
+        ]
 
     def post_setup(self):
         """called after test setup"""
@@ -351,10 +344,14 @@ class _DockerScenario(_Scenario):
     def _get_warmups(self):
         warmups = super()._get_warmups()
 
-        warmups.append(create_network)
+        if not self.replay:
+            warmups.append(create_network)
+
+            for container in self._required_containers:
+                warmups.append(container.start)
 
         for container in self._required_containers:
-            warmups.append(container.start)
+            warmups.append(container.post_start)
 
         return warmups
 
@@ -521,29 +518,8 @@ class EndToEndScenario(_DockerScenario):
                 message = stdout.decode()
         except BaseException as e:
             message = f"Unexpected exception {e}"
+
         logger.stdout(f"Weblog system: {message}")
-
-    def print_test_context(self):
-        from utils import weblog
-
-        super().print_test_context()
-
-        logger.debug(f"Docker host is {weblog.domain}")
-
-        logger.stdout(f"Library: {self.library}")
-        logger.stdout(f"Agent: {self.agent_version}")
-
-        if self.weblog_container.libddwaf_version:
-            logger.stdout(f"libddwaf: {self.weblog_container.libddwaf_version}")
-
-        if self.weblog_container.appsec_rules_file:
-            logger.stdout(f"AppSec rules version: {self.weblog_container.appsec_rules_version}")
-
-        if self.weblog_container.uds_mode:
-            logger.stdout(f"UDS socket: {self.weblog_container.uds_socket}")
-
-        logger.stdout(f"Weblog variant: {self.weblog_container.weblog_variant}")
-        logger.stdout(f"Backend: {self.agent_container.dd_site}")
 
     def _create_interface_folders(self):
         for interface in ("agent", "library", "backend"):
@@ -584,9 +560,10 @@ class EndToEndScenario(_DockerScenario):
     def _get_warmups(self):
         warmups = super()._get_warmups()
 
-        warmups.insert(0, self._create_interface_folders)
-        warmups.insert(1, self._start_interface_watchdog)
-        warmups.append(self._wait_for_app_readiness)
+        if not self.replay:
+            warmups.insert(0, self._create_interface_folders)
+            warmups.insert(1, self._start_interface_watchdog)
+            warmups.append(self._wait_for_app_readiness)
 
         return warmups
 
@@ -846,9 +823,10 @@ class OpenTelemetryScenario(_DockerScenario):
     def _get_warmups(self):
         warmups = super()._get_warmups()
 
-        warmups.insert(0, self._create_interface_folders)
-        warmups.insert(1, self._start_interface_watchdog)
-        warmups.append(self._wait_for_app_readiness)
+        if not self.replay:
+            warmups.insert(0, self._create_interface_folders)
+            warmups.insert(1, self._start_interface_watchdog)
+            warmups.append(self._wait_for_app_readiness)
 
         return warmups
 
@@ -1011,10 +989,11 @@ class ParametricScenario(_Scenario):
             self._library = LibraryVersion(os.getenv("TEST_LIBRARY", "**not-set**"), "99999.99999.99999")
         logger.stdout(f"Library: {self.library}")
 
-    def print_test_context(self):
-        super().print_test_context()
+    def _get_warmups(self):
+        result = super()._get_warmups()
+        result.append(lambda: logger.stdout(f"Library: {self.library}"))
 
-        logger.stdout(f"Library: {self.library}")
+        return result
 
     @property
     def library(self):

--- a/utils/_context/library_version.py
+++ b/utils/_context/library_version.py
@@ -88,12 +88,6 @@ class LibraryVersion:
                 if version.startswith("* libddwaf"):
                     version = re.sub(r"\* *libddwaf *\((.*)\)", r"\1", version)
 
-            elif library == "agent":
-                version = re.sub(r"(.*) - Commit.*", r"\1", version)
-                version = re.sub(r"(.*) - Meta.*", r"\1", version)
-                version = re.sub(r"Agent (.*)", r"\1", version)
-                version = re.sub("\x1b\\[\\d+m", "", version)  # remove color pattern from terminal
-
             elif library == "java":
                 version = version.split("~")[0]
                 version = version.replace("-SNAPSHOT", "")


### PR DESCRIPTION
## Motivation

Faster launch

## Changes

* do not execute a docker command to get agent version, but rather get it from `/info` (as it's already called for healthcheck)
* remove useless cleans on agent version string

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

