### PR TITLE
Use sidecar sender in system tests

### DIFF
--- a/utils/build/docker/php/common/php.ini
+++ b/utils/build/docker/php/common/php.ini
@@ -33,6 +33,7 @@ ddappsec.helper_extra_args=--log_level debug
 ddappsec.helper_log_file=/tmp/helper.log
 
 datadog.trace.agent_port=8126
+datadog.trace.sidecar_trace_sender=1
 datadog.remote_config_poll_interval=500
 datadog.remote_config_enabled=1
 datadog.experimental_api_security_enabled=1


### PR DESCRIPTION
We want to move to officially use the sidecar sender everywhere, which we want to assert first in system tests.