### PR TITLE
parametric(cpp): enable prod and more parametric tests

### DIFF
--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -41,11 +41,6 @@ jobs:
         with:
           name: ${{ inputs.binaries_artifact }}
           path: binaries/
-
-      - name: Load C++ library binary (skipping release tests, use snapshot instead)
-        if: ${{ inputs.ci_environment == 'prod' && inputs.library == 'cpp'}}
-        run: ./utils/scripts/load-binary.sh ${{ inputs.library }}
-
       - name: Run parametric tests (with timeout)
         if: ${{ inputs.library == 'java' }}
         run: |

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -124,7 +124,8 @@ tests/:
       Test_DsmSNS: missing_feature
       Test_DsmSQS: missing_feature
   parametric/:
-    test_dynamic_configuration.py: missing_feature (float DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS not supported)
+    test_dynamic_configuration.py: 
+      TestDynamicConfigHeaderTags: missing_feature
     test_otel_api_interoperability.py: irrelevant (library does not implement OpenTelemetry)
     test_otel_sdk_interoperability.py: irrelevant (library does not implement OpenTelemetry)
     test_otel_span_methods.py: irrelevant (library does not implement OpenTelemetry)
@@ -132,14 +133,6 @@ tests/:
     test_telemetry.py:
       Test_TelemetryInstallSignature: missing_feature
       Test_TelemetrySCAEnvVar: missing_feature
-    test_trace_sampling.py:
-      Test_Trace_Sampling_Basic: bug
-      Test_Trace_Sampling_Globs: bug
-      Test_Trace_Sampling_Globs_Feb2024_Revision: bug (implementation is case-sensitive)
-      Test_Trace_Sampling_Resource: bug
-      Test_Trace_Sampling_Tags: bug
-      Test_Trace_Sampling_Tags_Feb2024_Revision: bug
-      Test_Trace_Sampling_With_W3C: bug
     test_tracer.py:
       Test_TracerSCITagging: missing_feature
     test_tracer_flare.py:

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -685,7 +685,7 @@ class TestDynamicConfigSamplingRules:
             }
         ],
     )
-    @bug(context.library == "cpp")
+    @bug(context.library == "cpp", reason = "JSON tag format in RC differs from the JSON tag format used in DD_TRACE_SAMPLING_RULES")
     def test_trace_sampling_rules_with_tags(self, test_agent, test_library):
         """RC sampling rules with tags should match/skip spans with/without corresponding tag values.
 

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -368,6 +368,7 @@ class TestDynamicConfigV1:
             }
         ],
     )
+    @bug(library="cpp", reason="empty service default to '*'")
     def test_trace_sampling_rate_with_sampling_rules(self, library_env, test_agent, test_library):
         """Ensure that sampling rules still apply when the sample rate is set via remote config."""
         RC_SAMPLING_RULE_RATE = 0.56
@@ -684,7 +685,8 @@ class TestDynamicConfigSamplingRules:
             }
         ],
     )
-    def test_trace_sampling_rules_with_tags(self, library_env, test_agent, test_library):
+    @bug(context.library == "cpp")
+    def test_trace_sampling_rules_with_tags(self, test_agent, test_library):
         """RC sampling rules with tags should match/skip spans with/without corresponding tag values.
 
         When a sampling rule contains a tag clause/pattern, it should be used to match against a trace/span.

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -685,7 +685,10 @@ class TestDynamicConfigSamplingRules:
             }
         ],
     )
-    @bug(context.library == "cpp", reason = "JSON tag format in RC differs from the JSON tag format used in DD_TRACE_SAMPLING_RULES")
+    @bug(
+        context.library == "cpp",
+        reason="JSON tag format in RC differs from the JSON tag format used in DD_TRACE_SAMPLING_RULES",
+    )
     def test_trace_sampling_rules_with_tags(self, test_agent, test_library):
         """RC sampling rules with tags should match/skip spans with/without corresponding tag values.
 

--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -479,8 +479,8 @@ class Test_Headers_Tracecontext:
         expects the tracestate to be discarded
         """
         with test_library:
-            _, tracestate1 = make_single_request_and_get_tracecontext(test_library, [["tracestate", "foo=1"],])
-            _, tracestate2 = make_single_request_and_get_tracecontext(test_library, [["tracestate", "foo=1,bar=2"],])
+            _, tracestate1 = make_single_request_and_get_tracecontext(test_library, [["tracestate", "foo=1"],],)
+            _, tracestate2 = make_single_request_and_get_tracecontext(test_library, [["tracestate", "foo=1,bar=2"],],)
 
         # Updated the test to check that the number of tracestate list-members is the same,
         # since Datadog will add an entry.
@@ -719,7 +719,6 @@ class Test_Headers_Tracecontext:
     @missing_feature(context.library < "php@0.99.0", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.6.0", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "cpp", reason="Not implemented")
     @missing_feature(context.library < "ruby@2.0.0", reason="Not implemented")
     @missing_feature(context.library < "golang@1.64.0", reason="Not implemented")
     def test_tracestate_w3c_p_extract(self, test_agent, test_library):
@@ -773,7 +772,6 @@ class Test_Headers_Tracecontext:
     @missing_feature(context.library < "php@0.99.0", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.6.0", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "cpp", reason="Not implemented")
     @missing_feature(context.library < "ruby@2.0.0", reason="Not implemented")
     @missing_feature(context.library < "golang@1.64.0", reason="Not implemented")
     def test_tracestate_w3c_p_inject(self, test_agent, test_library):
@@ -805,7 +803,6 @@ class Test_Headers_Tracecontext:
         Ensure the last parent id tag is set according to the W3C phase 3 spec
         """
         with test_library:
-
             # 1) Trace ids and parent ids in datadog and tracecontext headers match
             with test_library.start_span(
                 name="identical_trace_info",

--- a/tests/parametric/test_trace_sampling.py
+++ b/tests/parametric/test_trace_sampling.py
@@ -441,7 +441,6 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
         "library_env",
         [tag_sampling_env("Foo"), tag_sampling_env("Fo*"), tag_sampling_env("F??"), tag_sampling_env("?O*")],
     )
-    @bug(library="cpp", reason="implementation is case-sensitive")
     def test_globs_different_casing(self, test_agent, test_library):
         """Test tag matching with string of matching case"""
         with test_library:


### PR DESCRIPTION
## Motivation
dd-trace-cpp released a new version two days ago. This PR enable prod and enable more parametric tests.

## Changes
- CI
- Parametric tests for cpp
