### PR TITLE
upgrade(tests): Add installer-based regular injection tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,9 @@ onboarding_nodejs:
           ONBOARDING_FILTER_WEBLOG: [test-app-nodejs-container,test-app-nodejs-alpine-libgcc]
           SCENARIO: [CONTAINER_AUTO_INJECTION, CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT]
         - ONBOARDING_FILTER_ENV: [dev, prod]
+          ONBOARDING_FILTER_WEBLOG: [test-app-nodejs,test-app-nodejs-container,test-app-nodejs-alpine-libgcc]
+          SCENARIO: [INSTALLER_AUTO_INJECTION]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
           ONBOARDING_FILTER_WEBLOG: [test-app-nodejs-alpine]
           SCENARIO: [CONTAINER_NOT_SUPPORTED_AUTO_INJECTION]
          
@@ -134,7 +137,10 @@ onboarding_dotnet:
           SCENARIO: [HOST_AUTO_INJECTION, HOST_AUTO_INJECTION_INSTALL_SCRIPT]
         - ONBOARDING_FILTER_ENV: [dev, prod]
           ONBOARDING_FILTER_WEBLOG: [test-shell-script]
-          SCENARIO: [HOST_AUTO_INJECTION_BLOCK_LIST]    
+          SCENARIO: [HOST_AUTO_INJECTION_BLOCK_LIST]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
+          ONBOARDING_FILTER_WEBLOG: [test-app-dotnet,test-app-dotnet-container]
+          SCENARIO: [INSTALLER_AUTO_INJECTION] 
         - ONBOARDING_FILTER_ENV: [dev, prod]
           ONBOARDING_FILTER_WEBLOG: [test-app-dotnet-container]
           SCENARIO: [CONTAINER_AUTO_INJECTION, CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT]
@@ -162,6 +168,9 @@ onboarding_ruby:
         - ONBOARDING_FILTER_ENV: [dev, prod]
           ONBOARDING_FILTER_WEBLOG: [test-app-ruby-container]
           SCENARIO: [CONTAINER_AUTO_INJECTION, CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
+          ONBOARDING_FILTER_WEBLOG: [test-app-ruby,test-app-ruby-container]
+          SCENARIO: [INSTALLER_AUTO_INJECTION]
   script:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env ${ONBOARDING_FILTER_ENV} --vm-library ${TEST_LIBRARY} --vm-provider aws 

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-container.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-container.yml
@@ -13,4 +13,7 @@ weblog:
           - name: copy-nodejs-app
             local_path: lib-injection/build/docker/nodejs/sample-app
 
+          - name: copy-nodejs-app-dockerfile
+            local_path: utils/build/virtual_machine/weblogs/nodejs/test-app-nodejs-container/Dockerfile.template
+
         remote-command: sh test-app-nodejs_docker_compose_run.sh

--- a/utils/build/virtual_machine/weblogs/nodejs/test-app-nodejs-container/Dockerfile.template
+++ b/utils/build/virtual_machine/weblogs/nodejs/test-app-nodejs-container/Dockerfile.template
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/docker/library/node:18
+
+# Create app directory
+WORKDIR /usr/src/app
+
+COPY . .
+
+EXPOSE 18080
+CMD [ "node", "index.js" ]

--- a/utils/build/virtual_machine/weblogs/nodejs/test-app-nodejs-container/test-app-nodejs_docker_compose_run.sh
+++ b/utils/build/virtual_machine/weblogs/nodejs/test-app-nodejs-container/test-app-nodejs_docker_compose_run.sh
@@ -3,10 +3,11 @@
 
 set -e
 
-[  -z "$DD_DOCKER_LOGIN_PASS" ] && echo "Skipping docker loging. Consider set the variable DOCKER_LOGIN and DOCKER_LOGIN_PASS" || echo "$DD_DOCKER_LOGIN_PASS" | sudo docker login --username "$DD_DOCKER_LOGIN" --password-stdin 
-
 # shellcheck disable=SC2035
 sudo chmod -R 755 *
+
+rm -rf Dockerfile || true
+cp Dockerfile.template Dockerfile || true
 
 echo "Starting nodejs app deployment"
 sudo docker build --no-cache -t system-tests/local .

--- a/utils/build/virtual_machine/weblogs/python/provision_test-app-python-container.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-app-python-container.yml
@@ -10,5 +10,7 @@ weblog:
             local_path: utils/build/virtual_machine/weblogs/python/test-app-python-container/docker-compose.yml
           - name: copy-python-app
             local_path: lib-injection/build/docker/python/dd-lib-python-init-test-django
+          - name: copy-python-app-dockerfile
+            local_path: utils/build/virtual_machine/weblogs/python/test-app-python-container/Dockerfile.template
 
         remote-command: sh test-app-python_docker_compose_run.sh

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-container/Dockerfile.template
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-container/Dockerfile.template
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/docker/library/python:3
+
+ENV PYTHONUNBUFFERED 1
+ENV DJANGO_SETTINGS_MODULE django_app
+WORKDIR /src
+ADD . /src
+RUN pip install django
+EXPOSE 18080
+CMD python -m django runserver 0.0.0.0:18080

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-container/test-app-python_docker_compose_run.sh
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-container/test-app-python_docker_compose_run.sh
@@ -3,10 +3,11 @@
 
 set -e
 
-[  -z "$DD_DOCKER_LOGIN_PASS" ] && echo "Skipping docker loging. Consider set the variable DOCKER_LOGIN and DOCKER_LOGIN_PASS" || echo "$DD_DOCKER_LOGIN_PASS" | sudo docker login --username "$DD_DOCKER_LOGIN" --password-stdin 
-
 # shellcheck disable=SC2035
 sudo chmod -R 755 *
+
+rm -rf Dockerfile || true
+cp Dockerfile.template Dockerfile || true
 
 sudo docker build --no-cache -t system-tests/local .
 if [ -f docker-compose-agent-prod.yml ]; then

--- a/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby-container.yml
+++ b/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby-container.yml
@@ -14,4 +14,7 @@ weblog:
           - name: copy-ruby-rails-app
             local_path: lib-injection/build/docker/ruby
 
+          - name: copy-ruby-app-dockerfile
+            local_path: utils/build/virtual_machine/weblogs/ruby/test-app-ruby-container/Dockerfile.template
+
         remote-command: sh test-app-ruby_docker_compose_run.sh

--- a/utils/build/virtual_machine/weblogs/ruby/test-app-ruby-container/Dockerfile.template
+++ b/utils/build/virtual_machine/weblogs/ruby/test-app-ruby-container/Dockerfile.template
@@ -1,0 +1,51 @@
+FROM public.ecr.aws/docker/library/ruby:3.1.3
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install prerequisites
+RUN set -ex && \
+  echo "===> Installing dependencies" && \
+  apt-get -y update && \
+  apt-get install -y --force-yes --no-install-recommends \
+      curl wget tar gzip gnupg apt-transport-https ca-certificates tzdata locales && \
+  \
+  echo "===> Installing database libraries" && \
+  apt-get install -y --force-yes --no-install-recommends sqlite3 && \
+  \
+  echo "===> Installing dev tools" && \
+  mkdir -p /usr/share/man/man1 && \
+  apt-get install -y --force-yes --no-install-recommends \
+      sudo git openssh-client rsync vim \
+      net-tools netcat parallel unzip zip bzip2 && \
+  \
+  echo "===> Cleaning up" && \
+  rm -rf /var/lib/apt/lists/*;
+
+# Set timezone to UTC by default
+RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
+# Set language
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+# Upgrade RubyGems and Bundler
+RUN gem update --system 3.4.1
+RUN gem install bundler -v '~> 2.3.26'
+RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
+ENV BUNDLE_SILENCE_ROOT_WARNING 1
+
+# Setup directory
+RUN mkdir /app
+WORKDIR /app
+
+# Add files
+COPY lib_injection_rails_app /app
+
+# Install gems
+RUN bundle install
+
+# Set entrypoint
+ENTRYPOINT ["/bin/bash", "-c"]
+
+CMD ["bin/rails server -b 0.0.0.0 -p 18080"]

--- a/utils/build/virtual_machine/weblogs/ruby/test-app-ruby-container/test-app-ruby_docker_compose_run.sh
+++ b/utils/build/virtual_machine/weblogs/ruby/test-app-ruby-container/test-app-ruby_docker_compose_run.sh
@@ -3,12 +3,12 @@
 
 set -e
 
-[  -z "$DD_DOCKER_LOGIN_PASS" ] && echo "Skipping docker loging. Consider set the variable DOCKER_LOGIN and DOCKER_LOGIN_PASS" || echo "$DD_DOCKER_LOGIN_PASS" | sudo docker login --username "$DD_DOCKER_LOGIN" --password-stdin 
-
 # shellcheck disable=SC2035
 sudo chmod -R 755 *
 
-cp dd-lib-ruby-init-test-rails/* .
+rm -rf Dockerfile || true
+cp Dockerfile.template Dockerfile || true
+
 sudo docker build --no-cache -t system-tests/local .
 if [ -f docker-compose-agent-prod.yml ]; then
     # Agent may be installed in a different way


### PR DESCRIPTION
## Motivation
Having installer-based injection system tests working for all languages

## Changes
- Adds more test scenarios to scheduled injection tests to add all installer-based scenarios
- Override Dockerfiles used in VM scenarios to `public.ecr.aws` to avoid Docker rate limits

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

