### PR TITLE
add system tests for otel env var mapping

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -127,7 +127,8 @@ tests/:
     test_dynamic_configuration.py: 
       TestDynamicConfigHeaderTags: missing_feature
     test_otel_api_interoperability.py: irrelevant (library does not implement OpenTelemetry)
-    test_otel_env_vars.py: missing_feature
+    test_otel_env_vars.py:
+      Test_Otel_Env_Vars: missing_feature
     test_otel_sdk_interoperability.py: irrelevant (library does not implement OpenTelemetry)
     test_otel_span_methods.py: irrelevant (library does not implement OpenTelemetry)
     test_span_links.py: missing_feature

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -127,6 +127,7 @@ tests/:
     test_dynamic_configuration.py: 
       TestDynamicConfigHeaderTags: missing_feature
     test_otel_api_interoperability.py: irrelevant (library does not implement OpenTelemetry)
+    test_otel_env_vars.py: missing_feature
     test_otel_sdk_interoperability.py: irrelevant (library does not implement OpenTelemetry)
     test_otel_span_methods.py: irrelevant (library does not implement OpenTelemetry)
     test_span_links.py: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -276,7 +276,8 @@ tests/:
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v2.44.0
     test_otel_api_interoperability.py: missing_feature
-    test_otel_env_vars.py: missing_feature
+    test_otel_env_vars.py:
+      Test_Otel_Env_Vars: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_otel_span_with_w3c.py:
       Test_Otel_Span_With_W3c: v2.42.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -276,6 +276,7 @@ tests/:
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v2.44.0
     test_otel_api_interoperability.py: missing_feature
+    test_otel_env_vars.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_otel_span_with_w3c.py:
       Test_Otel_Span_With_W3c: v2.42.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -413,6 +413,7 @@ tests/:
       TestDynamicConfigV1_ServiceTargets: v1.59.0
       TestDynamicConfigV2: v1.59.0
     test_otel_api_interoperability.py: missing_feature
+    test_otel_env_vars.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature
     test_telemetry.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -413,7 +413,8 @@ tests/:
       TestDynamicConfigV1_ServiceTargets: v1.59.0
       TestDynamicConfigV2: v1.59.0
     test_otel_api_interoperability.py: missing_feature
-    test_otel_env_vars.py: missing_feature
+    test_otel_env_vars.py:
+      Test_Otel_Env_Vars: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature
     test_telemetry.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -954,7 +954,8 @@ tests/:
       TestDynamicConfigV1_ServiceTargets: v1.31.0
       TestDynamicConfigV2: v1.31.0
     test_otel_api_interoperability.py: missing_feature
-    test_otel_env_vars.py: missing_feature
+    test_otel_env_vars.py:
+      Test_Otel_Env_Vars: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature
     test_telemetry.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -954,6 +954,7 @@ tests/:
       TestDynamicConfigV1_ServiceTargets: v1.31.0
       TestDynamicConfigV2: v1.31.0
     test_otel_api_interoperability.py: missing_feature
+    test_otel_env_vars.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature
     test_telemetry.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -445,6 +445,8 @@ tests/:
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: *ref_4_23_0
     test_otel_api_interoperability.py: missing_feature
+    test_otel_env_vars.py:
+      Test_Otel_Env_Var: v5.11.0
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: 
       Test_Span_Links: *ref_5_3_0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -446,7 +446,7 @@ tests/:
       TestDynamicConfigV2: *ref_4_23_0
     test_otel_api_interoperability.py: missing_feature
     test_otel_env_vars.py:
-      Test_Otel_Env_Vars: v5.11.0
+      Test_Otel_Env_Vars: v5.11.0 #implemented in v5.11.0, v4.35.0, &v3.56.0
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: 
       Test_Span_Links: *ref_5_3_0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -446,7 +446,7 @@ tests/:
       TestDynamicConfigV2: *ref_4_23_0
     test_otel_api_interoperability.py: missing_feature
     test_otel_env_vars.py:
-      Test_Otel_Env_Var: v5.11.0
+      Test_Otel_Env_Vars: v5.11.0
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: 
       Test_Span_Links: *ref_5_3_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -239,7 +239,8 @@ tests/:
       TestDynamicConfigV2: missing_feature
     test_otel_api_interoperability.py:
       Test_Otel_API_Interoperability: v0.94.0
-    test_otel_env_vars.py: missing_feature
+    test_otel_env_vars.py:
+      Test_Otel_Env_Vars: missing_feature
     test_otel_sdk_interoperability.py:
       Test_Otel_SDK_Interoperability: v0.94.0
     test_otel_span_methods.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -239,6 +239,7 @@ tests/:
       TestDynamicConfigV2: missing_feature
     test_otel_api_interoperability.py:
       Test_Otel_API_Interoperability: v0.94.0
+    test_otel_env_vars.py: missing_feature
     test_otel_sdk_interoperability.py:
       Test_Otel_SDK_Interoperability: v0.94.0
     test_otel_span_methods.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -612,7 +612,8 @@ tests/:
       Test_Library_Tracestats: missing_feature (failure 2.8.0)
     test_otel_api_interoperability.py:
       Test_Otel_API_Interoperability: missing_feature
-    test_otel_env_vars.py: missing_feature
+    test_otel_env_vars.py:
+      Test_Otel_Env_Vars: missing_feature
     test_otel_sdk_interoperability.py:
       Test_Otel_SDK_Interoperability: missing_feature
     test_otel_span_methods.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -612,6 +612,7 @@ tests/:
       Test_Library_Tracestats: missing_feature (failure 2.8.0)
     test_otel_api_interoperability.py:
       Test_Otel_API_Interoperability: missing_feature
+    test_otel_env_vars.py: missing_feature
     test_otel_sdk_interoperability.py:
       Test_Otel_SDK_Interoperability: missing_feature
     test_otel_span_methods.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -310,7 +310,8 @@ tests/:
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_otel_api_interoperability.py: missing_feature
-    test_otel_env_vars.py: missing_feature
+    test_otel_env_vars.py:
+      Test_Otel_Env_Vars: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_otel_span_methods.py:
       Test_Otel_Span_Methods: v1.17.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -310,6 +310,7 @@ tests/:
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_otel_api_interoperability.py: missing_feature
+    test_otel_env_vars.py: missing_feature
     test_otel_sdk_interoperability.py: missing_feature
     test_otel_span_methods.py:
       Test_Otel_Span_Methods: v1.17.0

--- a/tests/parametric/test_otel_env_var.py
+++ b/tests/parametric/test_otel_env_var.py
@@ -1,0 +1,264 @@
+
+import pytest
+from utils import missing_feature, context, scenarios
+
+otel_env_var_to_internal_name_mapper = {
+    'nodejs': {
+        'OTEL_SERVICE_NAME': 'service',
+        'OTEL_LOG_LEVEL': 'logLevel',
+        'OTEL_TRACES_SAMPLER': 'sampleRate',
+        #'OTEL_TRACES_EXPORTER' not exposed by the tracer
+        'OTEL_METRICS_EXPORTER': 'runtimeMetrics',
+        'OTEL_RESOURCE_ATTRIBUTES': 'tags',
+        # both tracePropagationStyle.inject & tracePropagationStyle.extract set the value of OTEL_PROPAGATORS, so test either
+        'OTEL_PROPAGATORS': 'tracePropagationStyle.inject',
+        'OTEL_VERSION': 'version',
+        'OTEL_ENV': 'env'
+    }
+}
+
+def get_nested_dict_value(data, dot_key):
+    keys = dot_key.split('.')
+    for key in keys:
+        if isinstance(data, dict):
+            data = data.get(key)
+        else:
+            return None
+    return data
+
+def get_config_value(config, language, env_var):
+    return get_nested_dict_value(config, otel_env_var_to_internal_name_mapper[language][env_var])
+
+@scenarios.parametric
+class Test_Otel_Env_Var:
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library == "golang", reason="Not implemented")
+    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
+    @missing_feature(context.library == "ruby", reason="Not implemented")
+    @missing_feature(context.library == "php", reason="Not implemented")
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+                "DD_SERVICE": 'service',
+                "OTEL_SERVICE_NAME":  'otel_service',
+                "DD_TRACE_LOG_LEVEL": 'error',
+                "OTEL_LOG_LEVEL": 'debug',
+                "DD_TRACE_SAMPLE_RATE": '0.5',
+                "OTEL_TRACES_SAMPLER": 'traceidratio',
+                "OTEL_TRACES_SAMPLER_ARG": '0.1',
+                "DD_TRACE_ENABLED": 'true',
+                "OTEL_TRACES_EXPORTER": 'none',
+                "DD_RUNTIME_METRICS_ENABLED": 'true',
+                "OTEL_METRICS_EXPORTER": 'none',
+                "DD_TAGS": 'foo:bar,baz:qux',
+                "OTEL_RESOURCE_ATTRIBUTES": 'foo=bar,baz=qux',
+                "DD_TRACE_PROPAGATION_STYLE_INJECT": 'b3,tracecontext',
+                "DD_TRACE_PROPAGATION_STYLE_EXTRACT": 'b3,tracecontext',
+                "OTEL_PROPAGATORS": 'datadog,tracecontext'
+            }
+        ],
+    )
+    def test_dd_env_var_take_precedence(self, test_agent, test_library):
+        resp = test_library.get_tracer_config()
+        config = resp['config']
+        lang = resp['language']
+
+        assert get_config_value(config, lang, 'OTEL_SERVICE_NAME') == 'service'
+        assert get_config_value(config, lang, 'OTEL_LOG_LEVEL') == 'error'
+        assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.5
+        assert get_config_value(config, lang, 'OTEL_METRICS_EXPORTER') == True
+        attr = get_config_value(config, lang, 'OTEL_RESOURCE_ATTRIBUTES')
+        assert attr.get("foo") == "bar"
+        assert attr.get("baz") == "qux"
+        assert get_config_value(config, lang, 'OTEL_PROPAGATORS') == ['b3', 'tracecontext']
+
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library == "golang", reason="Not implemented")
+    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
+    @missing_feature(context.library == "ruby", reason="Not implemented")
+    @missing_feature(context.library == "php", reason="Not implemented")
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+              'OTEL_SERVICE_NAME': 'otel_service',
+              'OTEL_LOG_LEVEL': 'warn',
+              'OTEL_TRACES_SAMPLER': 'traceidratio',
+              'OTEL_TRACES_SAMPLER_ARG': '0.1',
+              # when set this disables the tracer for Node and thus it cant return a config object
+              # 'OTEL_TRACES_EXPORTER': 'none',
+              'OTEL_METRICS_EXPORTER': 'none',
+              'OTEL_RESOURCE_ATTRIBUTES': 'foo=bar1,baz=qux1',
+              'OTEL_PROPAGATORS': 'b3,datadog'
+            }
+        ],
+    )
+    def test_otel_env_vars_set(self, test_agent, test_library):
+        resp = test_library.get_tracer_config()
+        config = resp['config']
+        lang = resp['language']
+        
+        assert get_config_value(config, lang, 'OTEL_SERVICE_NAME') == 'otel_service'
+        assert get_config_value(config, lang, 'OTEL_LOG_LEVEL') == 'warn'
+        assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.1
+        assert get_config_value(config, lang, 'OTEL_METRICS_EXPORTER') == False
+        attr = get_config_value(config, lang, 'OTEL_RESOURCE_ATTRIBUTES')
+        assert attr.get("foo") == "bar1"
+        assert attr.get("baz") == "qux1"
+        assert get_config_value(config, lang, 'OTEL_PROPAGATORS') == ['b3', 'datadog']
+
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library == "golang", reason="Not implemented")
+    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
+    @missing_feature(context.library == "ruby", reason="Not implemented")
+    @missing_feature(context.library == "php", reason="Not implemented")
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+              'OTEL_RESOURCE_ATTRIBUTES': 
+                'deployment.environment=test1,service.name=test2,service.version=5,foo=bar1,baz=qux1'
+            }
+        ],
+    )
+    def test_otel_attribute_mapping(self, test_agent, test_library):
+        resp = test_library.get_tracer_config()
+        config = resp['config']
+        lang = resp['language']
+
+        assert get_config_value(config, lang, 'OTEL_SERVICE_NAME') == 'test2'
+        assert get_config_value(config, lang, 'OTEL_ENV') == 'test1'
+        assert get_config_value(config, lang, 'OTEL_VERSION') == '5'
+        attr = get_config_value(config, lang, 'OTEL_RESOURCE_ATTRIBUTES')
+        assert attr.get("foo") == "bar1"
+        assert attr.get("baz") == "qux1"
+
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library == "golang", reason="Not implemented")
+    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
+    @missing_feature(context.library == "ruby", reason="Not implemented")
+    @missing_feature(context.library == "php", reason="Not implemented")
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+              'OTEL_TRACES_SAMPLER': 'always_on',
+            }
+        ],
+    )
+    def test_otel_traces_always_on(self, test_agent, test_library):
+        resp = test_library.get_tracer_config()
+        config = resp['config']
+        lang = resp['language']
+        assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 1.0
+
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library == "golang", reason="Not implemented")
+    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
+    @missing_feature(context.library == "ruby", reason="Not implemented")
+    @missing_feature(context.library == "php", reason="Not implemented")
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+              'OTEL_TRACES_SAMPLER': 'always_off',
+            }
+        ],
+    )
+    def test_otel_traces_always_off(self, test_agent, test_library):
+        resp = test_library.get_tracer_config()
+        config = resp['config']
+        lang = resp['language']
+        assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.0
+
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library == "golang", reason="Not implemented")
+    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
+    @missing_feature(context.library == "ruby", reason="Not implemented")
+    @missing_feature(context.library == "php", reason="Not implemented")
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+              'OTEL_TRACES_SAMPLER': 'traceidratio',
+              'OTEL_TRACES_SAMPLER_ARG': '0.1'
+            }
+        ],
+    )
+    def test_otel_traces_traceidratio(self, test_agent, test_library):
+        resp = test_library.get_tracer_config()
+        config = resp['config']
+        lang = resp['language']
+
+        assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.1
+
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library == "golang", reason="Not implemented")
+    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
+    @missing_feature(context.library == "ruby", reason="Not implemented")
+    @missing_feature(context.library == "php", reason="Not implemented")
+    @pytest.mark.parametrize(
+      "library_env",
+      [
+          {
+            'OTEL_TRACES_SAMPLER': 'parentbased_always_on',
+          }
+      ],
+    )
+    def test_otel_traces_parentbased_on(self, test_agent, test_library):
+      resp = test_library.get_tracer_config()
+      config = resp['config']
+      lang = resp['language']
+
+      assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 1.0
+
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library == "golang", reason="Not implemented")
+    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
+    @missing_feature(context.library == "ruby", reason="Not implemented")
+    @missing_feature(context.library == "php", reason="Not implemented")
+    @pytest.mark.parametrize(
+      "library_env",
+      [
+          {
+            'OTEL_TRACES_SAMPLER': 'parentbased_always_off',
+          }
+      ],
+    )
+    def test_otel_traces_parentbased_off(self, test_agent, test_library):
+      resp = test_library.get_tracer_config()
+      config = resp['config']
+      lang = resp['language']
+
+      assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.0
+
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
+    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library == "golang", reason="Not implemented")
+    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
+    @missing_feature(context.library == "ruby", reason="Not implemented")
+    @missing_feature(context.library == "php", reason="Not implemented")
+    @pytest.mark.parametrize(
+      "library_env",
+      [
+          {
+            'OTEL_TRACES_SAMPLER': 'parentbased_traceidratio',
+            'OTEL_TRACES_SAMPLER_ARG': '0.1'
+          }
+      ],
+    )
+    def test_otel_traces_parentbased_ratio(self, test_agent, test_library):
+      resp = test_library.get_tracer_config()
+      config = resp['config']
+      lang = resp['language']
+
+      assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.1

--- a/tests/parametric/test_otel_env_var.py
+++ b/tests/parametric/test_otel_env_var.py
@@ -1,24 +1,24 @@
-
 import pytest
 from utils import missing_feature, context, scenarios
 
 otel_env_var_to_internal_name_mapper = {
-    'nodejs': {
-        'OTEL_SERVICE_NAME': 'service',
-        'OTEL_LOG_LEVEL': 'logLevel',
-        'OTEL_TRACES_SAMPLER': 'sampleRate',
+    "nodejs": {
+        "OTEL_SERVICE_NAME": "service",
+        "OTEL_LOG_LEVEL": "logLevel",
+        "OTEL_TRACES_SAMPLER": "sampleRate",
         #'OTEL_TRACES_EXPORTER' not exposed by the tracer
-        'OTEL_METRICS_EXPORTER': 'runtimeMetrics',
-        'OTEL_RESOURCE_ATTRIBUTES': 'tags',
+        "OTEL_METRICS_EXPORTER": "runtimeMetrics",
+        "OTEL_RESOURCE_ATTRIBUTES": "tags",
         # both tracePropagationStyle.inject & tracePropagationStyle.extract set the value of OTEL_PROPAGATORS, so test either
-        'OTEL_PROPAGATORS': 'tracePropagationStyle.inject',
-        'OTEL_VERSION': 'version',
-        'OTEL_ENV': 'env'
+        "OTEL_PROPAGATORS": "tracePropagationStyle.inject",
+        "OTEL_VERSION": "version",
+        "OTEL_ENV": "env",
     }
 }
 
+
 def get_nested_dict_value(data, dot_key):
-    keys = dot_key.split('.')
+    keys = dot_key.split(".")
     for key in keys:
         if isinstance(data, dict):
             data = data.get(key)
@@ -26,8 +26,10 @@ def get_nested_dict_value(data, dot_key):
             return None
     return data
 
+
 def get_config_value(config, language, env_var):
     return get_nested_dict_value(config, otel_env_var_to_internal_name_mapper[language][env_var])
+
 
 @scenarios.parametric
 class Test_Otel_Env_Var:
@@ -41,38 +43,38 @@ class Test_Otel_Env_Var:
         "library_env",
         [
             {
-                "DD_SERVICE": 'service',
-                "OTEL_SERVICE_NAME":  'otel_service',
-                "DD_TRACE_LOG_LEVEL": 'error',
-                "OTEL_LOG_LEVEL": 'debug',
-                "DD_TRACE_SAMPLE_RATE": '0.5',
-                "OTEL_TRACES_SAMPLER": 'traceidratio',
-                "OTEL_TRACES_SAMPLER_ARG": '0.1',
-                "DD_TRACE_ENABLED": 'true',
-                "OTEL_TRACES_EXPORTER": 'none',
-                "DD_RUNTIME_METRICS_ENABLED": 'true',
-                "OTEL_METRICS_EXPORTER": 'none',
-                "DD_TAGS": 'foo:bar,baz:qux',
-                "OTEL_RESOURCE_ATTRIBUTES": 'foo=bar,baz=qux',
-                "DD_TRACE_PROPAGATION_STYLE_INJECT": 'b3,tracecontext',
-                "DD_TRACE_PROPAGATION_STYLE_EXTRACT": 'b3,tracecontext',
-                "OTEL_PROPAGATORS": 'datadog,tracecontext'
+                "DD_SERVICE": "service",
+                "OTEL_SERVICE_NAME": "otel_service",
+                "DD_TRACE_LOG_LEVEL": "error",
+                "OTEL_LOG_LEVEL": "debug",
+                "DD_TRACE_SAMPLE_RATE": "0.5",
+                "OTEL_TRACES_SAMPLER": "traceidratio",
+                "OTEL_TRACES_SAMPLER_ARG": "0.1",
+                "DD_TRACE_ENABLED": "true",
+                "OTEL_TRACES_EXPORTER": "none",
+                "DD_RUNTIME_METRICS_ENABLED": "true",
+                "OTEL_METRICS_EXPORTER": "none",
+                "DD_TAGS": "foo:bar,baz:qux",
+                "OTEL_RESOURCE_ATTRIBUTES": "foo=bar,baz=qux",
+                "DD_TRACE_PROPAGATION_STYLE_INJECT": "b3,tracecontext",
+                "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "b3,tracecontext",
+                "OTEL_PROPAGATORS": "datadog,tracecontext",
             }
         ],
     )
     def test_dd_env_var_take_precedence(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        config = resp['config']
-        lang = resp['language']
+        config = resp["config"]
+        lang = resp["language"]
 
-        assert get_config_value(config, lang, 'OTEL_SERVICE_NAME') == 'service'
-        assert get_config_value(config, lang, 'OTEL_LOG_LEVEL') == 'error'
-        assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.5
-        assert get_config_value(config, lang, 'OTEL_METRICS_EXPORTER') == True
-        attr = get_config_value(config, lang, 'OTEL_RESOURCE_ATTRIBUTES')
+        assert get_config_value(config, lang, "OTEL_SERVICE_NAME") == "service"
+        assert get_config_value(config, lang, "OTEL_LOG_LEVEL") == "error"
+        assert get_config_value(config, lang, "OTEL_TRACES_SAMPLER") == 0.5
+        assert get_config_value(config, lang, "OTEL_METRICS_EXPORTER") == True
+        attr = get_config_value(config, lang, "OTEL_RESOURCE_ATTRIBUTES")
         assert attr.get("foo") == "bar"
         assert attr.get("baz") == "qux"
-        assert get_config_value(config, lang, 'OTEL_PROPAGATORS') == ['b3', 'tracecontext']
+        assert get_config_value(config, lang, "OTEL_PROPAGATORS") == ["b3", "tracecontext"]
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -84,31 +86,31 @@ class Test_Otel_Env_Var:
         "library_env",
         [
             {
-              'OTEL_SERVICE_NAME': 'otel_service',
-              'OTEL_LOG_LEVEL': 'warn',
-              'OTEL_TRACES_SAMPLER': 'traceidratio',
-              'OTEL_TRACES_SAMPLER_ARG': '0.1',
-              # when set this disables the tracer for Node and thus it cant return a config object
-              # 'OTEL_TRACES_EXPORTER': 'none',
-              'OTEL_METRICS_EXPORTER': 'none',
-              'OTEL_RESOURCE_ATTRIBUTES': 'foo=bar1,baz=qux1',
-              'OTEL_PROPAGATORS': 'b3,datadog'
+                "OTEL_SERVICE_NAME": "otel_service",
+                "OTEL_LOG_LEVEL": "warn",
+                "OTEL_TRACES_SAMPLER": "traceidratio",
+                "OTEL_TRACES_SAMPLER_ARG": "0.1",
+                # when set this disables the tracer for Node and thus it cant return a config object
+                # 'OTEL_TRACES_EXPORTER': 'none',
+                "OTEL_METRICS_EXPORTER": "none",
+                "OTEL_RESOURCE_ATTRIBUTES": "foo=bar1,baz=qux1",
+                "OTEL_PROPAGATORS": "b3,datadog",
             }
         ],
     )
     def test_otel_env_vars_set(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        config = resp['config']
-        lang = resp['language']
-        
-        assert get_config_value(config, lang, 'OTEL_SERVICE_NAME') == 'otel_service'
-        assert get_config_value(config, lang, 'OTEL_LOG_LEVEL') == 'warn'
-        assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.1
-        assert get_config_value(config, lang, 'OTEL_METRICS_EXPORTER') == False
-        attr = get_config_value(config, lang, 'OTEL_RESOURCE_ATTRIBUTES')
+        config = resp["config"]
+        lang = resp["language"]
+
+        assert get_config_value(config, lang, "OTEL_SERVICE_NAME") == "otel_service"
+        assert get_config_value(config, lang, "OTEL_LOG_LEVEL") == "warn"
+        assert get_config_value(config, lang, "OTEL_TRACES_SAMPLER") == 0.1
+        assert get_config_value(config, lang, "OTEL_METRICS_EXPORTER") == False
+        attr = get_config_value(config, lang, "OTEL_RESOURCE_ATTRIBUTES")
         assert attr.get("foo") == "bar1"
         assert attr.get("baz") == "qux1"
-        assert get_config_value(config, lang, 'OTEL_PROPAGATORS') == ['b3', 'datadog']
+        assert get_config_value(config, lang, "OTEL_PROPAGATORS") == ["b3", "datadog"]
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -120,20 +122,19 @@ class Test_Otel_Env_Var:
         "library_env",
         [
             {
-              'OTEL_RESOURCE_ATTRIBUTES': 
-                'deployment.environment=test1,service.name=test2,service.version=5,foo=bar1,baz=qux1'
+                "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=test1,service.name=test2,service.version=5,foo=bar1,baz=qux1"
             }
         ],
     )
     def test_otel_attribute_mapping(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        config = resp['config']
-        lang = resp['language']
+        config = resp["config"]
+        lang = resp["language"]
 
-        assert get_config_value(config, lang, 'OTEL_SERVICE_NAME') == 'test2'
-        assert get_config_value(config, lang, 'OTEL_ENV') == 'test1'
-        assert get_config_value(config, lang, 'OTEL_VERSION') == '5'
-        attr = get_config_value(config, lang, 'OTEL_RESOURCE_ATTRIBUTES')
+        assert get_config_value(config, lang, "OTEL_SERVICE_NAME") == "test2"
+        assert get_config_value(config, lang, "OTEL_ENV") == "test1"
+        assert get_config_value(config, lang, "OTEL_VERSION") == "5"
+        attr = get_config_value(config, lang, "OTEL_RESOURCE_ATTRIBUTES")
         assert attr.get("foo") == "bar1"
         assert attr.get("baz") == "qux1"
 
@@ -144,18 +145,13 @@ class Test_Otel_Env_Var:
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
-        "library_env",
-        [
-            {
-              'OTEL_TRACES_SAMPLER': 'always_on',
-            }
-        ],
+        "library_env", [{"OTEL_TRACES_SAMPLER": "always_on",}],
     )
     def test_otel_traces_always_on(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        config = resp['config']
-        lang = resp['language']
-        assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 1.0
+        config = resp["config"]
+        lang = resp["language"]
+        assert get_config_value(config, lang, "OTEL_TRACES_SAMPLER") == 1.0
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -164,18 +160,13 @@ class Test_Otel_Env_Var:
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
-        "library_env",
-        [
-            {
-              'OTEL_TRACES_SAMPLER': 'always_off',
-            }
-        ],
+        "library_env", [{"OTEL_TRACES_SAMPLER": "always_off",}],
     )
     def test_otel_traces_always_off(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        config = resp['config']
-        lang = resp['language']
-        assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.0
+        config = resp["config"]
+        lang = resp["language"]
+        assert get_config_value(config, lang, "OTEL_TRACES_SAMPLER") == 0.0
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -184,20 +175,14 @@ class Test_Otel_Env_Var:
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
-        "library_env",
-        [
-            {
-              'OTEL_TRACES_SAMPLER': 'traceidratio',
-              'OTEL_TRACES_SAMPLER_ARG': '0.1'
-            }
-        ],
+        "library_env", [{"OTEL_TRACES_SAMPLER": "traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.1"}],
     )
     def test_otel_traces_traceidratio(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        config = resp['config']
-        lang = resp['language']
+        config = resp["config"]
+        lang = resp["language"]
 
-        assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.1
+        assert get_config_value(config, lang, "OTEL_TRACES_SAMPLER") == 0.1
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -206,19 +191,14 @@ class Test_Otel_Env_Var:
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
-      "library_env",
-      [
-          {
-            'OTEL_TRACES_SAMPLER': 'parentbased_always_on',
-          }
-      ],
+        "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_on",}],
     )
     def test_otel_traces_parentbased_on(self, test_agent, test_library):
-      resp = test_library.get_tracer_config()
-      config = resp['config']
-      lang = resp['language']
+        resp = test_library.get_tracer_config()
+        config = resp["config"]
+        lang = resp["language"]
 
-      assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 1.0
+        assert get_config_value(config, lang, "OTEL_TRACES_SAMPLER") == 1.0
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -227,19 +207,14 @@ class Test_Otel_Env_Var:
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
-      "library_env",
-      [
-          {
-            'OTEL_TRACES_SAMPLER': 'parentbased_always_off',
-          }
-      ],
+        "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off",}],
     )
     def test_otel_traces_parentbased_off(self, test_agent, test_library):
-      resp = test_library.get_tracer_config()
-      config = resp['config']
-      lang = resp['language']
+        resp = test_library.get_tracer_config()
+        config = resp["config"]
+        lang = resp["language"]
 
-      assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.0
+        assert get_config_value(config, lang, "OTEL_TRACES_SAMPLER") == 0.0
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -248,17 +223,11 @@ class Test_Otel_Env_Var:
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
-      "library_env",
-      [
-          {
-            'OTEL_TRACES_SAMPLER': 'parentbased_traceidratio',
-            'OTEL_TRACES_SAMPLER_ARG': '0.1'
-          }
-      ],
+        "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.1"}],
     )
     def test_otel_traces_parentbased_ratio(self, test_agent, test_library):
-      resp = test_library.get_tracer_config()
-      config = resp['config']
-      lang = resp['language']
+        resp = test_library.get_tracer_config()
+        config = resp["config"]
+        lang = resp["language"]
 
-      assert get_config_value(config, lang, 'OTEL_TRACES_SAMPLER') == 0.1
+        assert get_config_value(config, lang, "OTEL_TRACES_SAMPLER") == 0.1

--- a/tests/parametric/test_otel_env_var.py
+++ b/tests/parametric/test_otel_env_var.py
@@ -1,6 +1,7 @@
 import pytest
 from utils import missing_feature, context, scenarios
 
+
 @scenarios.parametric
 class Test_Otel_Env_Var:
     @missing_feature(context.library == "dotnet", reason="Not implemented")
@@ -15,9 +16,9 @@ class Test_Otel_Env_Var:
             {
                 "DD_SERVICE": "service",
                 "OTEL_SERVICE_NAME": "otel_service",
-                "DD_TRACE_LOG_LEVEL": "error", # Node uses DD_TRACE_LOG_LEVEL
-                "DD_LOG_LEVEL": 'error',
-                "DD_TRACE_DEBUG": 'false',
+                "DD_TRACE_LOG_LEVEL": "error",  # Node uses DD_TRACE_LOG_LEVEL
+                "DD_LOG_LEVEL": "error",
+                "DD_TRACE_DEBUG": "false",
                 "OTEL_LOG_LEVEL": "debug",
                 "DD_TRACE_SAMPLE_RATE": "0.5",
                 "OTEL_TRACES_SAMPLER": "traceidratio",
@@ -32,7 +33,7 @@ class Test_Otel_Env_Var:
                 "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "b3,tracecontext",
                 "OTEL_PROPAGATORS": "datadog,tracecontext",
                 "DD_TRACE_OTEL_ENABLED": "false",
-                "OTEL_SDK_DISABLED": "false"
+                "OTEL_SDK_DISABLED": "false",
             }
         ],
     )
@@ -50,8 +51,8 @@ class Test_Otel_Env_Var:
         assert resp["dd_trace_propagation_style"] == "b3,tracecontext"
         assert resp["dd_trace_debug"] == False
         if context.library != "nodejs":
-          assert resp["dd_trace_otel_enabled"] == False # node does not expose this variable in the config
-          assert resp["dd_trace_sample_ignore_parent"] == True # node does not implement this env variable
+            assert resp["dd_trace_otel_enabled"] == False  # node does not expose this variable in the config
+            assert resp["dd_trace_sample_ignore_parent"] == True  # node does not implement this env variable
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -70,7 +71,7 @@ class Test_Otel_Env_Var:
                 "OTEL_METRICS_EXPORTER": "none",
                 "OTEL_RESOURCE_ATTRIBUTES": "foo=bar1,baz=qux1",
                 "OTEL_PROPAGATORS": "b3,datadog",
-                "OTEL_SDK_DISABLED": "true"
+                "OTEL_SDK_DISABLED": "true",
             }
         ],
     )
@@ -87,9 +88,9 @@ class Test_Otel_Env_Var:
         assert tags.get("baz") == "qux1"
         assert resp["dd_trace_propagation_style"] == "b3,datadog"
         if context.library != "nodejs":
-          assert resp["dd_trace_debug"] == True
-          assert resp["dd_trace_otel_enabled"] == False
-          assert resp["dd_trace_sample_ignore_parent"] == True
+            assert resp["dd_trace_debug"] == True
+            assert resp["dd_trace_otel_enabled"] == False
+            assert resp["dd_trace_sample_ignore_parent"] == True
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -127,7 +128,7 @@ class Test_Otel_Env_Var:
     def test_otel_traces_always_on(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
         if context.library != "nodejs":
-          assert resp["dd_trace_sample_ignore_parent"] == False
+            assert resp["dd_trace_sample_ignore_parent"] == False
         assert resp["dd_trace_sample_rate"] == 1.0
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
@@ -142,7 +143,7 @@ class Test_Otel_Env_Var:
     def test_otel_traces_always_off(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
         if context.library != "nodejs":
-          assert resp["dd_trace_sample_ignore_parent"] == False
+            assert resp["dd_trace_sample_ignore_parent"] == False
         assert resp["dd_trace_sample_rate"] == 0.0
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
@@ -157,7 +158,7 @@ class Test_Otel_Env_Var:
     def test_otel_traces_traceidratio(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
         if context.library != "nodejs":
-          assert resp["dd_trace_sample_ignore_parent"] == False
+            assert resp["dd_trace_sample_ignore_parent"] == False
         assert resp["dd_trace_sample_rate"] == 0.1
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
@@ -172,7 +173,7 @@ class Test_Otel_Env_Var:
     def test_otel_traces_parentbased_on(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
         if context.library != "nodejs":
-          assert resp["dd_trace_sample_ignore_parent"] == False
+            assert resp["dd_trace_sample_ignore_parent"] == False
         assert resp["dd_trace_sample_rate"] == 1.0
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
@@ -187,7 +188,7 @@ class Test_Otel_Env_Var:
     def test_otel_traces_parentbased_off(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
         if context.library != "nodejs":
-          assert resp["dd_trace_sample_ignore_parent"] == False
+            assert resp["dd_trace_sample_ignore_parent"] == False
         assert resp["dd_trace_sample_rate"] == 0.0
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
@@ -202,9 +203,8 @@ class Test_Otel_Env_Var:
     def test_otel_traces_parentbased_ratio(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
         if context.library != "nodejs":
-          assert resp["dd_trace_sample_ignore_parent"] == False
+            assert resp["dd_trace_sample_ignore_parent"] == False
         assert resp["dd_trace_sample_rate"] == 0.1
-
 
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
@@ -213,7 +213,7 @@ class Test_Otel_Env_Var:
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
-        "library_env", [{'OTEL_TRACES_EXPORTER': 'none'}],
+        "library_env", [{"OTEL_TRACES_EXPORTER": "none"}],
     )
     def test_otel_traces_exporter_none(self, test_agent, test_library):
         resp = test_library.get_tracer_config()

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -148,7 +148,7 @@ class Test_Otel_Env_Vars:
         assert resp["dd_log_level"] == "debug"
         assert resp["dd_trace_debug"] == "true"
 
-    @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @missing_feature(context.library == "nodejs", reason="this setting is not exposed in the Node.js config object")
     @pytest.mark.parametrize(
         "library_env", [{"DD_TRACE_OTEL_ENABLED": "true", "OTEL_SDK_DISABLED": "true"}],
     )
@@ -156,7 +156,7 @@ class Test_Otel_Env_Vars:
         resp = test_library.get_tracer_config()
         assert resp["dd_trace_otel_enabled"] == "true"
 
-    @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @missing_feature(context.library == "nodejs", reason="this setting is not exposed in the Node.js config object")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_SDK_DISABLED": "true"}],
     )
@@ -164,7 +164,7 @@ class Test_Otel_Env_Vars:
         resp = test_library.get_tracer_config()
         assert resp["dd_trace_otel_enabled"] == "false"
 
-    @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @missing_feature(True, reason="dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "always_on"}],
     )
@@ -172,7 +172,7 @@ class Test_Otel_Env_Vars:
         resp = test_library.get_tracer_config()
         assert resp["dd_trace_sample_ignore_parent"] == "true"
 
-    @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @missing_feature(True, reason="dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off"}],
     )

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -28,8 +28,6 @@ class Test_Otel_Env_Vars:
                 "DD_TRACE_PROPAGATION_STYLE_INJECT": "b3,tracecontext",
                 "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "b3,tracecontext",
                 "OTEL_PROPAGATORS": "datadog,tracecontext",
-                "DD_TRACE_OTEL_ENABLED": "false",
-                "OTEL_SDK_DISABLED": "false",
             }
         ],
     )
@@ -38,17 +36,14 @@ class Test_Otel_Env_Vars:
 
         assert resp["dd_service"] == "service"
         assert resp["dd_log_level"] == "error"
-        assert resp["dd_trace_sample_rate"] == 0.5
-        assert resp["dd_trace_enabled"] == True
-        assert resp["dd_runtime_metrics_enabled"] == True
+        assert resp["dd_trace_sample_rate"] == "0.5"
+        assert resp["dd_trace_enabled"] == "true"
+        assert resp["dd_runtime_metrics_enabled"]
         tags = resp["dd_tags"]
-        assert tags.get("foo") == "bar"
-        assert tags.get("baz") == "qux"
+        assert "foo:bar" in tags
+        assert "baz:qux" in tags
         assert resp["dd_trace_propagation_style"] == "b3,tracecontext"
-        assert resp["dd_trace_debug"] == False
-        if context.library != "nodejs":
-            assert resp["dd_trace_otel_enabled"] == False  # node does not expose this variable in the config
-            assert resp["dd_trace_sample_ignore_parent"] == True  # node does not implement this env variable
+        assert resp["dd_trace_debug"] == "false"
 
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
@@ -62,7 +57,6 @@ class Test_Otel_Env_Vars:
                 "OTEL_METRICS_EXPORTER": "none",
                 "OTEL_RESOURCE_ATTRIBUTES": "foo=bar1,baz=qux1",
                 "OTEL_PROPAGATORS": "b3,datadog",
-                "OTEL_SDK_DISABLED": "true",
             }
         ],
     )
@@ -71,16 +65,13 @@ class Test_Otel_Env_Vars:
 
         assert resp["dd_service"] == "otel_service"
         assert resp["dd_log_level"] == "error"
-        assert resp["dd_trace_sample_rate"] == 0.1
-        assert resp["dd_trace_enabled"] == True
-        assert resp["dd_runtime_metrics_enabled"] == False
+        assert resp["dd_trace_sample_rate"] == "0.1"
+        assert resp["dd_trace_enabled"] == "true"
+        assert resp["dd_runtime_metrics_enabled"] == "false"
         tags = resp["dd_tags"]
-        assert tags.get("foo") == "bar1"
-        assert tags.get("baz") == "qux1"
+        assert "foo:bar1" in tags
+        assert "baz:qux1" in tags
         assert resp["dd_trace_propagation_style"] == "b3,datadog"
-        if context.library != "nodejs":
-            assert resp["dd_trace_otel_enabled"] == False
-            assert resp["dd_trace_sample_ignore_parent"] == True
 
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
@@ -98,8 +89,8 @@ class Test_Otel_Env_Vars:
         assert resp["dd_env"] == "test1"
         assert resp["dd_version"] == "5"
         tags = resp["dd_tags"]
-        assert tags.get("foo") == "bar1"
-        assert tags.get("baz") == "qux1"
+        assert "foo:bar1" in tags
+        assert "baz:qux1" in tags
 
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
@@ -107,9 +98,7 @@ class Test_Otel_Env_Vars:
     )
     def test_otel_traces_always_on(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        if context.library != "nodejs":
-            assert resp["dd_trace_sample_ignore_parent"] == True
-        assert resp["dd_trace_sample_rate"] == 1.0
+        assert resp["dd_trace_sample_rate"] == "1.0" or "1"
 
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
@@ -117,9 +106,7 @@ class Test_Otel_Env_Vars:
     )
     def test_otel_traces_always_off(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        if context.library != "nodejs":
-            assert resp["dd_trace_sample_ignore_parent"] == True
-        assert resp["dd_trace_sample_rate"] == 0.0
+        assert resp["dd_trace_sample_rate"] == "0.0" or "0"
 
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
@@ -127,9 +114,7 @@ class Test_Otel_Env_Vars:
     )
     def test_otel_traces_traceidratio(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        if context.library != "nodejs":
-            assert resp["dd_trace_sample_ignore_parent"] == True
-        assert resp["dd_trace_sample_rate"] == 0.1
+        assert resp["dd_trace_sample_rate"] == "0.1"
 
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
@@ -137,9 +122,7 @@ class Test_Otel_Env_Vars:
     )
     def test_otel_traces_parentbased_on(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        if context.library != "nodejs":
-            assert resp["dd_trace_sample_ignore_parent"] == False
-        assert resp["dd_trace_sample_rate"] == 1.0
+        assert resp["dd_trace_sample_rate"] == "1.0" or "1"
 
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
@@ -147,9 +130,7 @@ class Test_Otel_Env_Vars:
     )
     def test_otel_traces_parentbased_off(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        if context.library != "nodejs":
-            assert resp["dd_trace_sample_ignore_parent"] == False
-        assert resp["dd_trace_sample_rate"] == 0.0
+        assert resp["dd_trace_sample_rate"] == "0.0" or "0"
 
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
@@ -157,9 +138,7 @@ class Test_Otel_Env_Vars:
     )
     def test_otel_traces_parentbased_ratio(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        if context.library != "nodejs":
-            assert resp["dd_trace_sample_ignore_parent"] == False
-        assert resp["dd_trace_sample_rate"] == 0.1
+        assert resp["dd_trace_sample_rate"] == "0.1"
 
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
@@ -167,7 +146,7 @@ class Test_Otel_Env_Vars:
     )
     def test_otel_traces_exporter_none(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        assert resp["dd_trace_enabled"] == False
+        assert resp["dd_trace_enabled"] == "false"
 
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @pytest.mark.parametrize(
@@ -176,4 +155,36 @@ class Test_Otel_Env_Vars:
     def test_otel_log_level_to_debug_mapping(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
         assert resp["dd_log_level"] == "debug"
-        assert resp["dd_trace_debug"] == True
+        assert resp["dd_trace_debug"] == "true"
+
+    @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @pytest.mark.parametrize(
+        "library_env", [{"DD_TRACE_OTEL_ENABLED": "true", "OTEL_SDK_DISABLED": "true"}],
+    )
+    def test_dd_trace_otel_enabled_takes_precedence(self, test_agent, test_library):
+        resp = test_library.get_tracer_config()
+        assert resp["dd_trace_otel_enabled"] == "true"
+
+    @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @pytest.mark.parametrize(
+        "library_env", [{"OTEL_SDK_DISABLED": "true"}],
+    )
+    def test_otel_sdk_disabled_set(self, test_agent, test_library):
+        resp = test_library.get_tracer_config()
+        assert resp["dd_trace_otel_enabled"] == "true"
+
+    @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @pytest.mark.parametrize(
+        "library_env", [{"OTEL_TRACES_SAMPLER": "always_on"}],
+    )
+    def test_dd_trace_sample_ignore_parent_true(self, test_agent, test_library):
+        resp = test_library.get_tracer_config()
+        assert resp["dd_trace_sample_ignore_parent"] == "true"
+
+    @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @pytest.mark.parametrize(
+        "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off"}],
+    )
+    def test_dd_trace_sample_ignore_parent_false(self, test_agent, test_library):
+        resp = test_library.get_tracer_config()
+        assert resp["dd_trace_sample_ignore_parent"] == "false"

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -24,8 +24,7 @@ class Test_Otel_Env_Vars:
                 "OTEL_METRICS_EXPORTER": "none",
                 "DD_TAGS": "foo:bar,baz:qux",
                 "OTEL_RESOURCE_ATTRIBUTES": "foo=otel_bar,baz=otel_qux",
-                "DD_TRACE_PROPAGATION_STYLE_INJECT": "b3,tracecontext",
-                "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "b3,tracecontext",
+                "DD_TRACE_PROPAGATION_STYLE": "b3,tracecontext",
                 "OTEL_PROPAGATORS": "datadog,tracecontext",
             }
         ],

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -5,7 +5,6 @@ from utils import missing_feature, context, scenarios, features
 @scenarios.parametric
 @features.open_tracing_api
 class Test_Otel_Env_Vars:
-    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
         "library_env",
         [
@@ -36,16 +35,17 @@ class Test_Otel_Env_Vars:
 
         assert resp["dd_service"] == "service"
         assert resp["dd_log_level"] == "error"
-        assert resp["dd_trace_sample_rate"] == "0.5"
+        assert float(resp["dd_trace_sample_rate"]) == 0.5
         assert resp["dd_trace_enabled"] == "true"
         assert resp["dd_runtime_metrics_enabled"]
         tags = resp["dd_tags"]
         assert "foo:bar" in tags
         assert "baz:qux" in tags
+        assert "foo:otel_bar" not in tags
+        assert "baz:otel_qux" not in tags
         assert resp["dd_trace_propagation_style"] == "b3,tracecontext"
         assert resp["dd_trace_debug"] == "false"
 
-    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
         "library_env",
         [
@@ -65,7 +65,7 @@ class Test_Otel_Env_Vars:
 
         assert resp["dd_service"] == "otel_service"
         assert resp["dd_log_level"] == "error"
-        assert resp["dd_trace_sample_rate"] == "0.1"
+        assert float(resp["dd_trace_sample_rate"]) == 0.1
         assert resp["dd_trace_enabled"] == "true"
         assert resp["dd_runtime_metrics_enabled"] == "false"
         tags = resp["dd_tags"]
@@ -73,7 +73,6 @@ class Test_Otel_Env_Vars:
         assert "baz:qux1" in tags
         assert resp["dd_trace_propagation_style"] == "b3,datadog"
 
-    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
         "library_env",
         [
@@ -92,55 +91,48 @@ class Test_Otel_Env_Vars:
         assert "foo:bar1" in tags
         assert "baz:qux1" in tags
 
-    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "always_on",}],
     )
     def test_otel_traces_always_on(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        assert resp["dd_trace_sample_rate"] == "1.0" or "1"
+        assert float(resp["dd_trace_sample_rate"]) == 1.0
 
-    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "always_off",}],
     )
     def test_otel_traces_always_off(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        assert resp["dd_trace_sample_rate"] == "0.0" or "0"
+        assert float(resp["dd_trace_sample_rate"]) == 0.0
 
-    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.1"}],
     )
     def test_otel_traces_traceidratio(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        assert resp["dd_trace_sample_rate"] == "0.1"
+        assert float(resp["dd_trace_sample_rate"]) == 0.1
 
-    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_on",}],
     )
     def test_otel_traces_parentbased_on(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        assert resp["dd_trace_sample_rate"] == "1.0" or "1"
+        assert float(resp["dd_trace_sample_rate"]) == 1.0
 
-    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off",}],
     )
     def test_otel_traces_parentbased_off(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        assert resp["dd_trace_sample_rate"] == "0.0" or "0"
+        assert float(resp["dd_trace_sample_rate"]) == 0.0
 
-    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.1"}],
     )
     def test_otel_traces_parentbased_ratio(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        assert resp["dd_trace_sample_rate"] == "0.1"
+        assert float(resp["dd_trace_sample_rate"]) == 0.1
 
-    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_EXPORTER": "none"}],
     )
@@ -171,7 +163,7 @@ class Test_Otel_Env_Vars:
     )
     def test_otel_sdk_disabled_set(self, test_agent, test_library):
         resp = test_library.get_tracer_config()
-        assert resp["dd_trace_otel_enabled"] == "true"
+        assert resp["dd_trace_otel_enabled"] == "false"
 
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @pytest.mark.parametrize(

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -5,12 +5,7 @@ from utils import missing_feature, context, scenarios, features
 @scenarios.parametric
 @features.open_tracing_api
 class Test_Otel_Env_Vars:
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
-    @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env",
         [
@@ -55,12 +50,7 @@ class Test_Otel_Env_Vars:
             assert resp["dd_trace_otel_enabled"] == False  # node does not expose this variable in the config
             assert resp["dd_trace_sample_ignore_parent"] == True  # node does not implement this env variable
 
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
-    @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env",
         [
@@ -92,12 +82,7 @@ class Test_Otel_Env_Vars:
             assert resp["dd_trace_otel_enabled"] == False
             assert resp["dd_trace_sample_ignore_parent"] == True
 
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
-    @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env",
         [
@@ -116,12 +101,7 @@ class Test_Otel_Env_Vars:
         assert tags.get("foo") == "bar1"
         assert tags.get("baz") == "qux1"
 
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
-    @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "always_on",}],
     )
@@ -131,12 +111,7 @@ class Test_Otel_Env_Vars:
             assert resp["dd_trace_sample_ignore_parent"] == True
         assert resp["dd_trace_sample_rate"] == 1.0
 
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
-    @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "always_off",}],
     )
@@ -146,12 +121,7 @@ class Test_Otel_Env_Vars:
             assert resp["dd_trace_sample_ignore_parent"] == True
         assert resp["dd_trace_sample_rate"] == 0.0
 
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
-    @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.1"}],
     )
@@ -161,12 +131,7 @@ class Test_Otel_Env_Vars:
             assert resp["dd_trace_sample_ignore_parent"] == True
         assert resp["dd_trace_sample_rate"] == 0.1
 
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
-    @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_on",}],
     )
@@ -176,12 +141,7 @@ class Test_Otel_Env_Vars:
             assert resp["dd_trace_sample_ignore_parent"] == False
         assert resp["dd_trace_sample_rate"] == 1.0
 
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
-    @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off",}],
     )
@@ -191,12 +151,7 @@ class Test_Otel_Env_Vars:
             assert resp["dd_trace_sample_ignore_parent"] == False
         assert resp["dd_trace_sample_rate"] == 0.0
 
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
-    @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.1"}],
     )
@@ -206,12 +161,7 @@ class Test_Otel_Env_Vars:
             assert resp["dd_trace_sample_ignore_parent"] == False
         assert resp["dd_trace_sample_rate"] == 0.1
 
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
-    @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_EXPORTER": "none"}],
     )
@@ -219,12 +169,7 @@ class Test_Otel_Env_Vars:
         resp = test_library.get_tracer_config()
         assert resp["dd_trace_enabled"] == False
 
-    @missing_feature(context.library == "dotnet", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @missing_feature(context.library == "ruby", reason="Not implemented")
-    @missing_feature(context.library == "php", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_LOG_LEVEL": "debug"}],
     )

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -3,7 +3,7 @@ from utils import missing_feature, context, scenarios
 
 
 @scenarios.parametric
-class Test_Otel_Env_Var:
+class Test_Otel_Env_Vars:
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
     @missing_feature(context.library == "golang", reason="Not implemented")

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -164,7 +164,9 @@ class Test_Otel_Env_Vars:
         resp = test_library.get_tracer_config()
         assert resp["dd_trace_otel_enabled"] == "false"
 
-    @missing_feature(True, reason="dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language")
+    @missing_feature(
+        True, reason="dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language"
+    )
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "always_on"}],
     )
@@ -172,7 +174,9 @@ class Test_Otel_Env_Vars:
         resp = test_library.get_tracer_config()
         assert resp["dd_trace_sample_ignore_parent"] == "true"
 
-    @missing_feature(True, reason="dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language")
+    @missing_feature(
+        True, reason="dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language"
+    )
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off"}],
     )

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -213,12 +213,13 @@ class Test_Environment:
         otelHiding = [s for s in metrics if s["metric"] == "otel.env.hiding"]
         otelInvalid = [s for s in metrics if s["metric"] == "otel.env.invalid"]
 
-
         assert len(otelHiding) == 9
         assert len(otelInvalid) == 0
 
         expected_tags = [
-            ["DD_TRACE_LOG_LEVEL", "OTEL_LOG_LEVEL"] if context.library == "nodejs" else ["DD_LOG_LEVEL",  "OTEL_LOG_LEVEL"],
+            ["DD_TRACE_LOG_LEVEL", "OTEL_LOG_LEVEL"]
+            if context.library == "nodejs"
+            else ["DD_LOG_LEVEL", "OTEL_LOG_LEVEL"],
             ["DD_TRACE_PROPAGATION_STYLE", "OTEL_PROPAGATORS"],
             ["DD_SERVICE", "OTEL_SERVICE_NAME"],
             ["DD_TRACE_SAMPLE_RATE", "OTEL_TRACES_SAMPLER"],
@@ -230,7 +231,7 @@ class Test_Environment:
         ]
 
         for expected in expected_tags:
-            assert any(all(tag in metric['tags'] for tag in expected) for metric in otelHiding)
+            assert any(all(tag in metric["tags"] for tag in expected) for metric in otelHiding)
 
         for metric in otelHiding:
             assert metric["points"][0][1] == 1
@@ -248,16 +249,16 @@ class Test_Environment:
                 "DD_TRACE_AGENT_PORT": "agent.port",
                 "DD_TELEMETRY_HEARTBEAT_INTERVAL": 1,
                 "TIMEOUT": 1500,
-                'OTEL_SERVICE_NAME': 'otel_service',
-                'OTEL_LOG_LEVEL': 'foo',
-                'OTEL_TRACES_SAMPLER': 'foo',
-                'OTEL_TRACES_SAMPLER_ARG': 'foo',
-                'OTEL_TRACES_EXPORTER': 'foo',
-                'OTEL_METRICS_EXPORTER': 'foo',
-                'OTEL_RESOURCE_ATTRIBUTES': 'foo',
-                'OTEL_PROPAGATORS': 'foo',
-                'OTEL_LOGS_EXPORTER': 'foo',
-                'OTEL_SDK_DISABLED': 'foo'
+                "OTEL_SERVICE_NAME": "otel_service",
+                "OTEL_LOG_LEVEL": "foo",
+                "OTEL_TRACES_SAMPLER": "foo",
+                "OTEL_TRACES_SAMPLER_ARG": "foo",
+                "OTEL_TRACES_EXPORTER": "foo",
+                "OTEL_METRICS_EXPORTER": "foo",
+                "OTEL_RESOURCE_ATTRIBUTES": "foo",
+                "OTEL_PROPAGATORS": "foo",
+                "OTEL_LOGS_EXPORTER": "foo",
+                "OTEL_SDK_DISABLED": "foo",
             }
         ],
     )
@@ -275,23 +276,24 @@ class Test_Environment:
         otelHiding = [s for s in metrics if s["metric"] == "otel.env.hiding"]
         otelInvalid = [s for s in metrics if s["metric"] == "otel.env.invalid"]
 
-
         assert len(otelHiding) == 0
         assert len(otelInvalid) == 8
 
         expected_invalid_tags = [
-            ["DD_TRACE_LOG_LEVEL", "OTEL_LOG_LEVEL"] if context.library == "nodejs" else ["DD_LOG_LEVEL",  "OTEL_LOG_LEVEL"],
+            ["DD_TRACE_LOG_LEVEL", "OTEL_LOG_LEVEL"]
+            if context.library == "nodejs"
+            else ["DD_LOG_LEVEL", "OTEL_LOG_LEVEL"],
             ["DD_TRACE_PROPAGATION_STYLE", "OTEL_PROPAGATORS"],
             ["DD_TRACE_SAMPLE_RATE", "OTEL_TRACES_SAMPLER"],
             ["DD_TRACE_SAMPLE_RATE", "OTEL_TRACES_SAMPLER_ARG"],
             ["DD_TRACE_ENABLED", "OTEL_TRACES_EXPORTER"],
             ["DD_RUNTIME_METRICS_ENABLED", "OTEL_METRICS_EXPORTER"],
             ["DD_TRACE_OTEL_ENABLED", "OTEL_SDK_DISABLED"],
-            ['OTEL_LOGS_EXPORTER']
+            ["OTEL_LOGS_EXPORTER"],
         ]
 
         for expected in expected_invalid_tags:
-            assert any(all(tag in metric['tags'] for tag in expected) for metric in otelInvalid)
+            assert any(all(tag in metric["tags"] for tag in expected) for metric in otelInvalid)
 
         for metric in otelInvalid:
             assert metric["points"][0][1] == 1

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -174,27 +174,27 @@ class Test_Environment:
         "library_env",
         [
             {
-                'DD_TRACE_AGENT_PORT': 'agent.port',
-                'DD_TRACE_OTEL_ENABLED': 1,
-                'DD_TELEMETRY_HEARTBEAT_INTERVAL': 1,
-                'TIMEOUT': 1500,
-                'DD_SERVICE': 'service',
-                'OTEL_SERVICE_NAME': 'otel_service',
-                'DD_TRACE_LOG_LEVEL': 'error',
-                'OTEL_LOG_LEVEL': 'debug',
-                'DD_TRACE_SAMPLE_RATE': '0.5',
-                'OTEL_TRACES_SAMPLER': 'traceidratio',
-                'OTEL_TRACES_SAMPLER_ARG': '0.1',
-                'DD_TRACE_ENABLED': 'true',
-                'OTEL_TRACES_EXPORTER': 'none',
-                'DD_RUNTIME_METRICS_ENABLED': 'true',
-                'OTEL_METRICS_EXPORTER': 'none',
-                'DD_TAGS': 'foo:bar,baz:qux',
-                'OTEL_RESOURCE_ATTRIBUTES': 'foo=bar1,baz=qux1',
-                'DD_TRACE_PROPAGATION_STYLE': 'datadog',
-                'OTEL_PROPAGATORS': 'datadog,tracecontext',
-                'OTEL_LOGS_EXPORTER': 'none',
-                'OTEL_SDK_DISABLED': 'false'
+                "DD_TRACE_AGENT_PORT": "agent.port",
+                "DD_TRACE_OTEL_ENABLED": 1,
+                "DD_TELEMETRY_HEARTBEAT_INTERVAL": 1,
+                "TIMEOUT": 1500,
+                "DD_SERVICE": "service",
+                "OTEL_SERVICE_NAME": "otel_service",
+                "DD_TRACE_LOG_LEVEL": "error",
+                "OTEL_LOG_LEVEL": "debug",
+                "DD_TRACE_SAMPLE_RATE": "0.5",
+                "OTEL_TRACES_SAMPLER": "traceidratio",
+                "OTEL_TRACES_SAMPLER_ARG": "0.1",
+                "DD_TRACE_ENABLED": "true",
+                "OTEL_TRACES_EXPORTER": "none",
+                "DD_RUNTIME_METRICS_ENABLED": "true",
+                "OTEL_METRICS_EXPORTER": "none",
+                "DD_TAGS": "foo:bar,baz:qux",
+                "OTEL_RESOURCE_ATTRIBUTES": "foo=bar1,baz=qux1",
+                "DD_TRACE_PROPAGATION_STYLE": "datadog",
+                "OTEL_PROPAGATORS": "datadog,tracecontext",
+                "OTEL_LOGS_EXPORTER": "none",
+                "OTEL_SDK_DISABLED": "false",
             }
         ],
     )
@@ -203,40 +203,40 @@ class Test_Environment:
             pass
         event = test_agent.wait_for_telemetry_event("generate-metrics", wait_loops=400)
         payload = event["payload"]
-        assert event['request_type'] == 'generate-metrics'
+        assert event["request_type"] == "generate-metrics"
 
-        metrics = payload['series']
+        metrics = payload["series"]
 
-        assert payload['namespace'] == 'tracers'
+        assert payload["namespace"] == "tracers"
 
-        otelHiding = [s for s in metrics if s['metric'] == 'otel.env.hiding']
-        otelInvalid = [s for s in metrics if s['metric'] == 'otel.env.invalid']
+        otelHiding = [s for s in metrics if s["metric"] == "otel.env.hiding"]
+        otelInvalid = [s for s in metrics if s["metric"] == "otel.env.invalid"]
 
         assert len(otelHiding) == 8
         assert len(otelInvalid) == 1
 
         expected_tags = [
-            ['DD_TRACE_LOG_LEVEL', 'OTEL_LOG_LEVEL'],
-            ['DD_TRACE_PROPAGATION_STYLE', 'OTEL_PROPAGATORS'],
-            ['DD_SERVICE', 'OTEL_SERVICE_NAME'],
-            ['DD_TRACE_SAMPLE_RATE', 'OTEL_TRACES_SAMPLER', 'OTEL_TRACES_SAMPLER_ARG'],
-            ['DD_TRACE_ENABLED', 'OTEL_TRACES_EXPORTER'],
-            ['DD_RUNTIME_METRICS_ENABLED', 'OTEL_METRICS_EXPORTER'],
-            ['DD_TAGS', 'OTEL_RESOURCE_ATTRIBUTES'],
-            ['DD_TRACE_OTEL_ENABLED', 'OTEL_SDK_DISABLED']
+            ["DD_TRACE_LOG_LEVEL", "OTEL_LOG_LEVEL"],
+            ["DD_TRACE_PROPAGATION_STYLE", "OTEL_PROPAGATORS"],
+            ["DD_SERVICE", "OTEL_SERVICE_NAME"],
+            ["DD_TRACE_SAMPLE_RATE", "OTEL_TRACES_SAMPLER", "OTEL_TRACES_SAMPLER_ARG"],
+            ["DD_TRACE_ENABLED", "OTEL_TRACES_EXPORTER"],
+            ["DD_RUNTIME_METRICS_ENABLED", "OTEL_METRICS_EXPORTER"],
+            ["DD_TAGS", "OTEL_RESOURCE_ATTRIBUTES"],
+            ["DD_TRACE_OTEL_ENABLED", "OTEL_SDK_DISABLED"],
         ]
 
         for i, tags in enumerate(expected_tags):
-            assert len(otelHiding[i]['tags']) == 4 if tags[0] == 'DD_TRACE_SAMPLE_RATE' else 3
-            assert all(elem in otelHiding[i]['tags'] for elem in tags)
+            assert len(otelHiding[i]["tags"]) == 4 if tags[0] == "DD_TRACE_SAMPLE_RATE" else 3
+            assert all(elem in otelHiding[i]["tags"] for elem in tags)
 
         for metric in otelHiding:
-            assert metric['points'][0][1] == 1
+            assert metric["points"][0][1] == 1
 
-        assert otelInvalid[0]['points'][0][1] == 1
+        assert otelInvalid[0]["points"][0][1] == 1
 
-        assert len(otelInvalid[0]['tags']) == 2
-        assert 'OTEL_LOGS_EXPORTER' in otelInvalid[0]['tags']
+        assert len(otelInvalid[0]["tags"]) == 2
+        assert "OTEL_LOGS_EXPORTER" in otelInvalid[0]["tags"]
 
 
 DEFAULT_ENVVARS = {

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -167,9 +167,11 @@ class Test_Environment:
     @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library == "java", reason="Not implemented")
     @missing_feature(context.library == "golang", reason="Not implemented")
-    @missing_feature(context.library < "nodejs@5.11.0", reason="Implemented in v5.11.0, v4.35.0, &v3.56.0")
+    @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
+    @missing_feature(context.library == "cpp", reason="Not implemented")
+    @missing_feature(context.library == "python", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env",
         [
@@ -242,6 +244,8 @@ class Test_Environment:
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "ruby", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
+    @missing_feature(context.library == "cpp", reason="Not implemented")
+    @missing_feature(context.library == "python", reason="Not implemented")
     @pytest.mark.parametrize(
         "library_env",
         [

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -219,17 +219,17 @@ class Test_Environment:
         assert len(otelInvalid) == 0
 
         expected_tags = [
-            ["DD_TRACE_LOG_LEVEL", "OTEL_LOG_LEVEL"]
+            ["config.datadog:DD_TRACE_LOG_LEVEL", "config.opentelemetry:OTEL_LOG_LEVEL"]
             if context.library == "nodejs"
-            else ["DD_LOG_LEVEL", "OTEL_LOG_LEVEL"],
-            ["DD_TRACE_PROPAGATION_STYLE", "OTEL_PROPAGATORS"],
-            ["DD_SERVICE", "OTEL_SERVICE_NAME"],
-            ["DD_TRACE_SAMPLE_RATE", "OTEL_TRACES_SAMPLER"],
-            ["DD_TRACE_SAMPLE_RATE", "OTEL_TRACES_SAMPLER_ARG"],
-            ["DD_TRACE_ENABLED", "OTEL_TRACES_EXPORTER"],
-            ["DD_RUNTIME_METRICS_ENABLED", "OTEL_METRICS_EXPORTER"],
-            ["DD_TAGS", "OTEL_RESOURCE_ATTRIBUTES"],
-            ["DD_TRACE_OTEL_ENABLED", "OTEL_SDK_DISABLED"],
+            else ["DD_LOG_LEVEL", "config.opentelemetry:OTEL_LOG_LEVEL"],
+            ["config.datadog:DD_TRACE_PROPAGATION_STYLE", "config.opentelemetry:OTEL_PROPAGATORS"],
+            ["config.datadog:DD_SERVICE", "config.opentelemetry:OTEL_SERVICE_NAME"],
+            ["config.datadog:DD_TRACE_SAMPLE_RATE", "config.opentelemetry:OTEL_TRACES_SAMPLER"],
+            ["config.datadog:DD_TRACE_SAMPLE_RATE", "config.opentelemetry:OTEL_TRACES_SAMPLER_ARG"],
+            ["config.datadog:DD_TRACE_ENABLED", "config.opentelemetry:OTEL_TRACES_EXPORTER"],
+            ["config.datadog:DD_RUNTIME_METRICS_ENABLED", "config.opentelemetry:OTEL_METRICS_EXPORTER"],
+            ["config.datadog:DD_TAGS", "config.opentelemetry:OTEL_RESOURCE_ATTRIBUTES"],
+            ["config.datadog:DD_TRACE_OTEL_ENABLED", "config.opentelemetry:OTEL_SDK_DISABLED"],
         ]
 
         for expected in expected_tags:
@@ -284,16 +284,16 @@ class Test_Environment:
         assert len(otelInvalid) == 8
 
         expected_invalid_tags = [
-            ["DD_TRACE_LOG_LEVEL", "OTEL_LOG_LEVEL"]
+            ["config.datadog:DD_TRACE_LOG_LEVEL", "config.opentelemetry:OTEL_LOG_LEVEL"]
             if context.library == "nodejs"
-            else ["DD_LOG_LEVEL", "OTEL_LOG_LEVEL"],
-            ["DD_TRACE_PROPAGATION_STYLE", "OTEL_PROPAGATORS"],
-            ["DD_TRACE_SAMPLE_RATE", "OTEL_TRACES_SAMPLER"],
-            ["DD_TRACE_SAMPLE_RATE", "OTEL_TRACES_SAMPLER_ARG"],
-            ["DD_TRACE_ENABLED", "OTEL_TRACES_EXPORTER"],
-            ["DD_RUNTIME_METRICS_ENABLED", "OTEL_METRICS_EXPORTER"],
-            ["DD_TRACE_OTEL_ENABLED", "OTEL_SDK_DISABLED"],
-            ["OTEL_LOGS_EXPORTER"],
+            else ["config.datadog:DD_LOG_LEVEL", "config.opentelemetry:OTEL_LOG_LEVEL"],
+            ["config.datadog:DD_TRACE_PROPAGATION_STYLE", "config.opentelemetry:OTEL_PROPAGATORS"],
+            ["config.datadog:DD_TRACE_SAMPLE_RATE", "config.opentelemetry:OTEL_TRACES_SAMPLER"],
+            ["config.datadog:DD_TRACE_SAMPLE_RATE", "config.opentelemetry:OTEL_TRACES_SAMPLER_ARG"],
+            ["config.datadog:DD_TRACE_ENABLED", "config.opentelemetry:OTEL_TRACES_EXPORTER"],
+            ["config.datadog:DD_RUNTIME_METRICS_ENABLED", "config.opentelemetry:OTEL_METRICS_EXPORTER"],
+            ["config.datadog:DD_TRACE_OTEL_ENABLED", "config.opentelemetry:OTEL_SDK_DISABLED"],
+            ["config.opentelemetry:OTEL_LOGS_EXPORTER"],
         ]
 
         for expected in expected_invalid_tags:

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -289,18 +289,18 @@ app.get('/trace/config', (req, res) => {
   const dummyTracer = require('dd-trace').init()
   const config = dummyTracer._tracer._config
   const config_string = JSON.stringify({
-    'dd_service': config?.service ?? null,
-    'dd_log_level': config?.logLevel ?? null,
-    'dd_trace_debug': config?.debug ?? null,
-    'dd_trace_sample_rate': config?.sampleRate !== undefined ? config.sampleRate : null,
-    'dd_trace_enabled': config ? true : false, // in node if dd_trace_enabled is true the tracer won't have a config object
-    'dd_runtime_metrics_enabled': config?.runtimeMetrics ?? null,
-    'dd_tags': config?.tags ?? null,
-    'dd_trace_propagation_style': config?.tracePropagationStyle?.inject.join(",") ?? null,
-    'dd_trace_sample_ignore_parent': null, // not implemented in node
-    'dd_trace_otel_enabled': null, // not exposed in config object in node
-    'dd_env': config?.tags?.env ?? null,
-    'dd_version': config?.tags?.version ?? null
+    'dd_service': config?.service !== undefined ? `${config.service}`.toLowerCase() : 'null',
+    'dd_log_level': config?.logLevel !== undefined ? `${config.logLevel}`.toLowerCase() : 'null',
+    'dd_trace_debug': config?.debug !== undefined ? `${config.debug}`.toLowerCase() : 'null',
+    'dd_trace_sample_rate': config?.sampleRate !== undefined ? `${config.sampleRate}` : 'null',
+    'dd_trace_enabled': config ? 'true' : 'false', // in node if dd_trace_enabled is true the tracer won't have a config object
+    'dd_runtime_metrics_enabled': config?.runtimeMetrics !== undefined ? `${config.runtimeMetrics}`.toLowerCase() : 'null',
+    'dd_tags': config?.tags !== undefined ? Object.entries(config.tags).map(([key, val]) => `${key}:${val}`).join(',') : 'null',
+    'dd_trace_propagation_style': config?.tracePropagationStyle?.inject.join(',') ?? 'null',
+    'dd_trace_sample_ignore_parent': 'null', // not implemented in node
+    'dd_trace_otel_enabled': 'null', // not exposed in config object in node
+    'dd_env': config?.tags?.env !== undefined ? `${config.tags.env}` : 'null',
+    'dd_version': config?.tags?.version !== undefined ? `${config.tags.version}` : 'null'
   })
   res.json( { 
     config: config_string

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -285,6 +285,11 @@ app.post('/trace/otel/set_attributes', (req, res) => {
   res.json({});
 });
 
+app.get('/trace/config', (req, res) => {
+  const dummyTracer = require('dd-trace').init()
+  res.json( { config: dummyTracer._tracer._config, language: 'nodejs' });
+});
+
 // TODO: implement this endpoint correctly, current blockers:
 // 1. Fails on invalid url
 // 2. does not generate span, because http instrumentation turned off

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -289,18 +289,18 @@ app.get('/trace/config', (req, res) => {
   const dummyTracer = require('dd-trace').init()
   const config = dummyTracer._tracer._config
   res.json( { 
-    'dd_service': config ? config.service : null,
-    'dd_log_level': config ? config.logLevel : null,
-    'dd_trace_debug': config ? config.debug : null,
-    'dd_trace_sample_rate': config && config.sampleRate !== undefined ? config.sampleRate : null,
+    'dd_service': config?.service ?? null,
+    'dd_log_level': config?.logLevel ?? null,
+    'dd_trace_debug': config?.debug ?? null,
+    'dd_trace_sample_rate': config?.sampleRate !== undefined ? config.sampleRate : null,
     'dd_trace_enabled': config ? true : false, // in node if dd_trace_enabled is true the tracer won't have a config object
-    'dd_runtime_metrics_enabled': config ? config.runtimeMetrics : null,
-    'dd_tags': config ? config.tags : null,
-    'dd_trace_propagation_style': config ? config.tracePropagationStyle.inject.join(",") : null,
+    'dd_runtime_metrics_enabled': config?.runtimeMetrics ?? null,
+    'dd_tags': config?.tags ?? null,
+    'dd_trace_propagation_style': config?.tracePropagationStyle?.inject.join(",") ?? null,
     'dd_trace_sample_ignore_parent': null, // not implemented in node
     'dd_trace_otel_enabled': null, // not exposed in config object in node
-    'dd_env': config && config.tags.env ? config.tags.env : null,
-    'dd_version': config ? config.tags.version : null,
+    'dd_env': config?.tags?.env ?? null,
+    'dd_version': config?.tags?.version ?? null,
   });
 });
 

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -288,7 +288,7 @@ app.post('/trace/otel/set_attributes', (req, res) => {
 app.get('/trace/config', (req, res) => {
   const dummyTracer = require('dd-trace').init()
   const config = dummyTracer._tracer._config
-  res.json( { 
+  const config_string = JSON.stringify({
     'dd_service': config?.service ?? null,
     'dd_log_level': config?.logLevel ?? null,
     'dd_trace_debug': config?.debug ?? null,
@@ -300,7 +300,10 @@ app.get('/trace/config', (req, res) => {
     'dd_trace_sample_ignore_parent': null, // not implemented in node
     'dd_trace_otel_enabled': null, // not exposed in config object in node
     'dd_env': config?.tags?.env ?? null,
-    'dd_version': config?.tags?.version ?? null,
+    'dd_version': config?.tags?.version ?? null
+  })
+  res.json( { 
+    config: config_string
   });
 });
 

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -287,7 +287,21 @@ app.post('/trace/otel/set_attributes', (req, res) => {
 
 app.get('/trace/config', (req, res) => {
   const dummyTracer = require('dd-trace').init()
-  res.json( { config: dummyTracer._tracer._config, language: 'nodejs' });
+  const config = dummyTracer._tracer._config
+  res.json( { 
+    'dd_service': config ? config.service : null,
+    'dd_log_level': config ? config.logLevel : null,
+    'dd_trace_debug': config ? config.debug : null,
+    'dd_trace_sample_rate': config && config.sampleRate !== undefined ? config.sampleRate : null,
+    'dd_trace_enabled': config ? true : false, // in node if dd_trace_enabled is true the tracer won't have a config object
+    'dd_runtime_metrics_enabled': config ? config.runtimeMetrics : null,
+    'dd_tags': config ? config.tags : null,
+    'dd_trace_propagation_style': config ? config.tracePropagationStyle.inject.join(",") : null,
+    'dd_trace_sample_ignore_parent': null, // not implemented in node
+    'dd_trace_otel_enabled': null, // not exposed in config object in node
+    'dd_env': config && config.tags.env ? config.tags.env : null,
+    'dd_version': config ? config.tags.version : null,
+  });
 });
 
 // TODO: implement this endpoint correctly, current blockers:

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -355,7 +355,20 @@ class APMLibraryClientHTTP(APMLibraryClient):
 
     def get_tracer_config(self) -> dict:
         resp = self._session.get(self._url("/trace/config")).json()
-        return resp
+        return {
+            "dd_service": resp["dd_service"],
+            "dd_log_level": resp["dd_log_level"],
+            "dd_trace_sample_rate": resp["dd_trace_sample_rate"],
+            "dd_trace_enabled": resp["dd_trace_enabled"],
+            "dd_runtime_metrics_enabled": resp["dd_runtime_metrics_enabled"],
+            "dd_tags": resp["dd_tags"],
+            "dd_trace_propagation_style": resp["dd_trace_propagation_style"],
+            "dd_trace_debug": resp["dd_trace_debug"],
+            "dd_trace_otel_enabled": resp["dd_trace_otel_enabled"],
+            "dd_trace_sample_ignore_parent": resp["dd_trace_sample_ignore_parent"],
+            "dd_env": resp["dd_env"],
+            "dd_version": resp["dd_version"]
+        }
 
 
 class _TestSpan:
@@ -634,8 +647,18 @@ class APMLibraryClientGRPC:
     def get_tracer_config(self) -> dict:
         resp = self._client.GetTraceConfig(pb.GetTraceConfigArgs())
         return {
-            "config": resp.config,
-            "language": resp.language,
+            "dd_service": resp.dd_service,
+            "dd_log_level": resp.dd_log_level,
+            "dd_trace_sample_rate": resp.dd_trace_sample_rate,
+            "dd_trace_enabled": resp.dd_trace_enabled,
+            "dd_runtime_metrics_enabled": resp.dd_runtime_metrics_enabled,
+            "dd_tags": resp.dd_tags,
+            "dd_trace_propagation_style": resp.dd_trace_propagation_style,
+            "dd_trace_debug": resp.dd_trace_debug,
+            "dd_trace_otel_enabled": resp.dd_trace_otel_enabled,
+            "dd_trace_sample_ignore_parent": resp.dd_trace_sample_ignore_parent,
+            "dd_env": resp.dd_env,
+            "dd_version": resp.dd_version
         }
 
 

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -356,8 +356,7 @@ class APMLibraryClientHTTP(APMLibraryClient):
 
     def get_tracer_config(self) -> Dict[str, Optional[str]]:
         resp = self._session.get(self._url("/trace/config")).json()
-        config = resp["config"]
-        config_dict = json.loads(config)
+        config_dict = json.loads(resp["config"])
         return {
             "dd_service": config_dict.get("dd_service", None),
             "dd_log_level": config_dict.get("dd_log_level", None),

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -367,7 +367,7 @@ class APMLibraryClientHTTP(APMLibraryClient):
             "dd_trace_otel_enabled": resp["dd_trace_otel_enabled"],
             "dd_trace_sample_ignore_parent": resp["dd_trace_sample_ignore_parent"],
             "dd_env": resp["dd_env"],
-            "dd_version": resp["dd_version"]
+            "dd_version": resp["dd_version"],
         }
 
 
@@ -658,7 +658,7 @@ class APMLibraryClientGRPC:
             "dd_trace_otel_enabled": resp.dd_trace_otel_enabled,
             "dd_trace_sample_ignore_parent": resp.dd_trace_sample_ignore_parent,
             "dd_env": resp.dd_env,
-            "dd_version": resp.dd_version
+            "dd_version": resp.dd_version,
         }
 
 

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -3,7 +3,7 @@ import contextlib
 import time
 import urllib.parse
 import json
-from typing import Generator, List, Optional, Tuple, TypedDict, Union
+from typing import Generator, List, Optional, Tuple, TypedDict, Union, Dict
 
 import grpc
 import requests
@@ -142,7 +142,7 @@ class APMLibraryClient:
     def http_request(self, method: str, url: str, headers: List[Tuple[str, str]]) -> None:
         raise NotImplementedError
 
-    def get_tracer_config(self) -> dict:
+    def get_tracer_config(self) -> Dict[str, Optional[str]]:
         raise NotImplementedError
 
 
@@ -354,23 +354,23 @@ class APMLibraryClientHTTP(APMLibraryClient):
         ).json()
         return resp
 
-    def get_tracer_config(self) -> dict:
+    def get_tracer_config(self) -> Dict[str, Optional[str]]:
         resp = self._session.get(self._url("/trace/config")).json()
         config = resp["config"]
         config_dict = json.loads(config)
         return {
-            "dd_service": config_dict["dd_service"],
-            "dd_log_level": config_dict["dd_log_level"],
-            "dd_trace_sample_rate": config_dict["dd_trace_sample_rate"],
-            "dd_trace_enabled": config_dict["dd_trace_enabled"],
-            "dd_runtime_metrics_enabled": config_dict["dd_runtime_metrics_enabled"],
-            "dd_tags": config_dict["dd_tags"],
-            "dd_trace_propagation_style": config_dict["dd_trace_propagation_style"],
-            "dd_trace_debug": config_dict["dd_trace_debug"],
-            "dd_trace_otel_enabled": config_dict["dd_trace_otel_enabled"],
-            "dd_trace_sample_ignore_parent": config_dict["dd_trace_sample_ignore_parent"],
-            "dd_env": config_dict["dd_env"],
-            "dd_version": config_dict["dd_version"],
+            "dd_service": config_dict.get("dd_service", None),
+            "dd_log_level": config_dict.get("dd_log_level", None),
+            "dd_trace_sample_rate": config_dict.get("dd_trace_sample_rate", None),
+            "dd_trace_enabled": config_dict.get("dd_trace_enabled", None),
+            "dd_runtime_metrics_enabled": config_dict.get("dd_runtime_metrics_enabled", None),
+            "dd_tags": config_dict.get("dd_tags", None),
+            "dd_trace_propagation_style": config_dict.get("dd_trace_propagation_style", None),
+            "dd_trace_debug": config_dict.get("dd_trace_debug", None),
+            "dd_trace_otel_enabled": config_dict.get("dd_trace_otel_enabled", None),
+            "dd_trace_sample_ignore_parent": config_dict.get("dd_trace_sample_ignore_parent", None),
+            "dd_env": config_dict.get("dd_env", None),
+            "dd_version": config_dict.get("dd_version", None),
         }
 
 
@@ -647,23 +647,23 @@ class APMLibraryClientGRPC:
     def otel_flush(self, timeout: int) -> bool:
         return self._client.OtelFlushSpans(pb.OtelFlushSpansArgs(seconds=timeout)).success
 
-    def get_tracer_config(self) -> dict:
+    def get_tracer_config(self) -> Dict[str, Optional[str]]:
         resp = self._client.GetTraceConfig(pb.GetTraceConfigArgs())
         config = resp.config
         config_dict = json.loads(config)
         return {
-            "dd_service": config_dict["dd_service"],
-            "dd_log_level": config_dict["dd_log_level"],
-            "dd_trace_sample_rate": config_dict["dd_trace_sample_rate"],
-            "dd_trace_enabled": config_dict["dd_trace_enabled"],
-            "dd_runtime_metrics_enabled": config_dict["dd_runtime_metrics_enabled"],
-            "dd_tags": config_dict["dd_tags"],
-            "dd_trace_propagation_style": config_dict["dd_trace_propagation_style"],
-            "dd_trace_debug": config_dict["dd_trace_debug"],
-            "dd_trace_otel_enabled": config_dict["dd_trace_otel_enabled"],
-            "dd_trace_sample_ignore_parent": config_dict["dd_trace_sample_ignore_parent"],
-            "dd_env": config_dict["dd_env"],
-            "dd_version": config_dict["dd_version"],
+            "dd_service": config_dict.get("dd_service", None),
+            "dd_log_level": config_dict.get("dd_log_level", None),
+            "dd_trace_sample_rate": config_dict.get("dd_trace_sample_rate", None),
+            "dd_trace_enabled": config_dict.get("dd_trace_enabled", None),
+            "dd_runtime_metrics_enabled": config_dict.get("dd_runtime_metrics_enabled", None),
+            "dd_tags": config_dict.get("dd_tags", None),
+            "dd_trace_propagation_style": config_dict.get("dd_trace_propagation_style", None),
+            "dd_trace_debug": config_dict.get("dd_trace_debug", None),
+            "dd_trace_otel_enabled": config_dict.get("dd_trace_otel_enabled", None),
+            "dd_trace_sample_ignore_parent": config_dict.get("dd_trace_sample_ignore_parent", None),
+            "dd_env": config_dict.get("dd_env", None),
+            "dd_version": config_dict.get("dd_version", None),
         }
 
 
@@ -769,5 +769,5 @@ class APMLibrary:
     def finish_span(self, span_id: int) -> None:
         self._client.finish_span(span_id)
 
-    def get_tracer_config(self) -> dict:
+    def get_tracer_config(self) -> Dict[str, Optional[str]]:
         return self._client.get_tracer_config()

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -140,6 +140,7 @@ class APMLibraryClient:
 
     def http_request(self, method: str, url: str, headers: List[Tuple[str, str]]) -> None:
         raise NotImplementedError
+
     def get_tracer_config(self) -> dict:
         raise NotImplementedError
 
@@ -351,7 +352,7 @@ class APMLibraryClientHTTP(APMLibraryClient):
             json={"method": method, "url": url, "headers": headers or [], "body": body.decode()},
         ).json()
         return resp
-    
+
     def get_tracer_config(self) -> dict:
         resp = self._session.get(self._url("/trace/config")).json()
         return resp
@@ -401,7 +402,7 @@ class _TestOtelSpan:
         self.trace_id = trace_id
 
     # API methods
-    
+
     def set_attributes(self, attributes):
         self._client.otel_set_attributes(self.span_id, attributes)
 
@@ -629,7 +630,7 @@ class APMLibraryClientGRPC:
 
     def otel_flush(self, timeout: int) -> bool:
         return self._client.OtelFlushSpans(pb.OtelFlushSpansArgs(seconds=timeout)).success
-    
+
     def get_tracer_config(self) -> dict:
         resp = self._client.GetTraceConfig(pb.GetTraceConfigArgs())
         return {
@@ -739,7 +740,6 @@ class APMLibrary:
 
     def finish_span(self, span_id: int) -> None:
         self._client.finish_span(span_id)
-    
+
     def get_tracer_config(self) -> dict:
         return self._client.get_tracer_config()
-

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -2,6 +2,7 @@
 import contextlib
 import time
 import urllib.parse
+import json
 from typing import Generator, List, Optional, Tuple, TypedDict, Union
 
 import grpc
@@ -355,19 +356,21 @@ class APMLibraryClientHTTP(APMLibraryClient):
 
     def get_tracer_config(self) -> dict:
         resp = self._session.get(self._url("/trace/config")).json()
+        config = resp["config"]
+        config_dict = json.loads(config)
         return {
-            "dd_service": resp["dd_service"],
-            "dd_log_level": resp["dd_log_level"],
-            "dd_trace_sample_rate": resp["dd_trace_sample_rate"],
-            "dd_trace_enabled": resp["dd_trace_enabled"],
-            "dd_runtime_metrics_enabled": resp["dd_runtime_metrics_enabled"],
-            "dd_tags": resp["dd_tags"],
-            "dd_trace_propagation_style": resp["dd_trace_propagation_style"],
-            "dd_trace_debug": resp["dd_trace_debug"],
-            "dd_trace_otel_enabled": resp["dd_trace_otel_enabled"],
-            "dd_trace_sample_ignore_parent": resp["dd_trace_sample_ignore_parent"],
-            "dd_env": resp["dd_env"],
-            "dd_version": resp["dd_version"],
+            "dd_service": config_dict["dd_service"],
+            "dd_log_level": config_dict["dd_log_level"],
+            "dd_trace_sample_rate": config_dict["dd_trace_sample_rate"],
+            "dd_trace_enabled": config_dict["dd_trace_enabled"],
+            "dd_runtime_metrics_enabled": config_dict["dd_runtime_metrics_enabled"],
+            "dd_tags": config_dict["dd_tags"],
+            "dd_trace_propagation_style": config_dict["dd_trace_propagation_style"],
+            "dd_trace_debug": config_dict["dd_trace_debug"],
+            "dd_trace_otel_enabled": config_dict["dd_trace_otel_enabled"],
+            "dd_trace_sample_ignore_parent": config_dict["dd_trace_sample_ignore_parent"],
+            "dd_env": config_dict["dd_env"],
+            "dd_version": config_dict["dd_version"],
         }
 
 
@@ -646,19 +649,21 @@ class APMLibraryClientGRPC:
 
     def get_tracer_config(self) -> dict:
         resp = self._client.GetTraceConfig(pb.GetTraceConfigArgs())
+        config = resp.config
+        config_dict = json.loads(config)
         return {
-            "dd_service": resp.dd_service,
-            "dd_log_level": resp.dd_log_level,
-            "dd_trace_sample_rate": resp.dd_trace_sample_rate,
-            "dd_trace_enabled": resp.dd_trace_enabled,
-            "dd_runtime_metrics_enabled": resp.dd_runtime_metrics_enabled,
-            "dd_tags": resp.dd_tags,
-            "dd_trace_propagation_style": resp.dd_trace_propagation_style,
-            "dd_trace_debug": resp.dd_trace_debug,
-            "dd_trace_otel_enabled": resp.dd_trace_otel_enabled,
-            "dd_trace_sample_ignore_parent": resp.dd_trace_sample_ignore_parent,
-            "dd_env": resp.dd_env,
-            "dd_version": resp.dd_version,
+            "dd_service": config_dict["dd_service"],
+            "dd_log_level": config_dict["dd_log_level"],
+            "dd_trace_sample_rate": config_dict["dd_trace_sample_rate"],
+            "dd_trace_enabled": config_dict["dd_trace_enabled"],
+            "dd_runtime_metrics_enabled": config_dict["dd_runtime_metrics_enabled"],
+            "dd_tags": config_dict["dd_tags"],
+            "dd_trace_propagation_style": config_dict["dd_trace_propagation_style"],
+            "dd_trace_debug": config_dict["dd_trace_debug"],
+            "dd_trace_otel_enabled": config_dict["dd_trace_otel_enabled"],
+            "dd_trace_sample_ignore_parent": config_dict["dd_trace_sample_ignore_parent"],
+            "dd_env": config_dict["dd_env"],
+            "dd_version": config_dict["dd_version"],
         }
 
 

--- a/utils/parametric/protos/apm_test_client.proto
+++ b/utils/parametric/protos/apm_test_client.proto
@@ -41,6 +41,15 @@ service APMClient {
   rpc OtelGetLinks(OtelGetLinksArgs) returns (OtelGetLinksReturn) {}
 
   rpc StopTracer(StopTracerArgs) returns (StopTracerReturn) {}
+
+  rpc GetTraceConfig(GetTraceConfigArgs) returns (GetTraceConfigReturn) {}
+}
+
+message GetTraceConfigArgs {}
+
+message GetTraceConfigReturn {
+  map<string, google.protobuf.Any> config = 1;
+  string language = 2;
 }
 
 message StartSpanArgs {

--- a/utils/parametric/protos/apm_test_client.proto
+++ b/utils/parametric/protos/apm_test_client.proto
@@ -48,18 +48,8 @@ service APMClient {
 message GetTraceConfigArgs {}
 
 message GetTraceConfigReturn {
-  string dd_service = 1;
-  string dd_log_level = 2;
-  float dd_trace_sample_rate = 3;
-  bool dd_trace_enabled = 4;
-  bool dd_runtime_metrics_enabled = 5;
-  map<string, google.protobuf.Any> dd_tags = 6;
-  string dd_trace_propagation_style = 7;
-  bool dd_trace_debug = 8;
-  bool dd_trace_otel_enabled = 9;
-  bool dd_trace_sample_ignore_parent = 10;
-  string dd_env = 11;
-  string dd_version = 12;
+  map<string, string> config = 1;
+
 }
 
 message StartSpanArgs {

--- a/utils/parametric/protos/apm_test_client.proto
+++ b/utils/parametric/protos/apm_test_client.proto
@@ -48,8 +48,18 @@ service APMClient {
 message GetTraceConfigArgs {}
 
 message GetTraceConfigReturn {
-  map<string, google.protobuf.Any> config = 1;
-  string language = 2;
+  string dd_service = 1;
+  string dd_log_level = 2;
+  float dd_trace_sample_rate = 3;
+  bool dd_trace_enabled = 4;
+  bool dd_runtime_metrics_enabled = 5;
+  map<string, google.protobuf.Any> dd_tags = 6;
+  string dd_trace_propagation_style = 7;
+  bool dd_trace_debug = 8;
+  bool dd_trace_otel_enabled = 9;
+  bool dd_trace_sample_ignore_parent = 10;
+  string dd_env = 11;
+  string dd_version = 12;
 }
 
 message StartSpanArgs {


### PR DESCRIPTION
## Motivation

adds system tests for OTEL env var to DD env var mapping 

## Changes

adds a new test telemetry test to test telemetry metrics, a new otel env var test file under parametric/ to test correct mapping, & new http/grpc routes for sending config data from the test app

