### PR TITLE
[python] more easy wins

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -351,6 +351,8 @@ tests/:
       Test_Login_Events_Extended: 
         '*': missing_feature (weblog endpoint missing)
         flask-poc: v2.10.0.dev
+        uds-flask: v2.10.0.dev
+        uwsgi-poc: v2.10.0.dev
     test_blocking_addresses.py:
       Test_BlockingAddresses:
         '*': v1.16.1

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -107,7 +107,7 @@ tests/:
             python3.12: v1.18.0
         test_ssrf.py:
           TestSSRF:
-            '*': v2.2.0
+            '*': v2.10.0dev
             fastapi: missing_feature
         test_trust_boundary_violation.py:
           Test_TrustBoundaryViolation: missing_feature

--- a/tests/appsec/iast/sink/test_ssrf.py
+++ b/tests/appsec/iast/sink/test_ssrf.py
@@ -31,7 +31,6 @@ class TestSSRF(BaseSinkTest):
     def test_secure(self):
         super().test_secure()
 
-    @missing_feature(library="python", reason="Endpoint not implemented")
     @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()


### PR DESCRIPTION
Enable login user event tests for flask variants and one iast SSRF test.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

