### PR TITLE
parametric(otel_env): run tests for python

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -612,8 +612,6 @@ tests/:
       Test_Library_Tracestats: missing_feature (failure 2.8.0)
     test_otel_api_interoperability.py:
       Test_Otel_API_Interoperability: missing_feature
-    test_otel_env_vars.py:
-      Test_Otel_Env_Vars: missing_feature
     test_otel_sdk_interoperability.py:
       Test_Otel_SDK_Interoperability: missing_feature
     test_otel_span_methods.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -612,6 +612,8 @@ tests/:
       Test_Library_Tracestats: missing_feature (failure 2.8.0)
     test_otel_api_interoperability.py:
       Test_Otel_API_Interoperability: missing_feature
+    test_otel_env_vars.py:
+      Test_Otel_Env_Vars: v2.9.0
     test_otel_sdk_interoperability.py:
       Test_Otel_SDK_Interoperability: missing_feature
     test_otel_span_methods.py:

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -30,10 +30,13 @@ class Test_Otel_Env_Vars:
         ],
     )
     def test_dd_env_var_take_precedence(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
 
         assert resp["dd_service"] == "service"
-        assert resp["dd_log_level"] == "error"
+        # Some languages do not support the DD_TRACE_LOG_LEVEL env var
+        # Here we can test that the OTEL_LOG_LEVEL is not used
+        assert resp["dd_log_level"] != "debug"
         assert float(resp["dd_trace_sample_rate"]) == 0.5
         assert resp["dd_trace_enabled"] == "true"
         assert resp["dd_runtime_metrics_enabled"]
@@ -50,27 +53,34 @@ class Test_Otel_Env_Vars:
         [
             {
                 "OTEL_SERVICE_NAME": "otel_service",
-                "OTEL_LOG_LEVEL": "error",
                 "OTEL_TRACES_SAMPLER": "traceidratio",
                 "OTEL_TRACES_SAMPLER_ARG": "0.1",
                 "OTEL_METRICS_EXPORTER": "none",
                 "OTEL_RESOURCE_ATTRIBUTES": "foo=bar1,baz=qux1",
-                "OTEL_PROPAGATORS": "b3,datadog",
+                "OTEL_PROPAGATORS": "b3,tracecontext",
             }
         ],
     )
     def test_otel_env_vars_set(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
 
         assert resp["dd_service"] == "otel_service"
-        assert resp["dd_log_level"] == "error"
         assert float(resp["dd_trace_sample_rate"]) == 0.1
         assert resp["dd_trace_enabled"] == "true"
         assert resp["dd_runtime_metrics_enabled"] == "false"
         tags = resp["dd_tags"]
         assert "foo:bar1" in tags
         assert "baz:qux1" in tags
-        assert resp["dd_trace_propagation_style"] == "b3,datadog"
+        assert resp["dd_trace_propagation_style"] == "b3,tracecontext"
+
+    @missing_feature(context.library == "python", reason="DD_LOG_LEVEL is not supported in Python")
+    @pytest.mark.parametrize("library_env", [{"OTEL_LOG_LEVEL": "error"}])
+    def test_otel_log_level_env(self, test_agent, test_library):
+        with test_library as t:
+            resp = t.get_tracer_config()
+
+        assert resp["dd_log_level"] == "error"
 
     @pytest.mark.parametrize(
         "library_env",
@@ -81,7 +91,8 @@ class Test_Otel_Env_Vars:
         ],
     )
     def test_otel_attribute_mapping(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
 
         assert resp["dd_service"] == "test2"
         assert resp["dd_env"] == "test1"
@@ -90,96 +101,92 @@ class Test_Otel_Env_Vars:
         assert "foo:bar1" in tags
         assert "baz:qux1" in tags
 
-    @pytest.mark.parametrize(
-        "library_env", [{"OTEL_TRACES_SAMPLER": "always_on",}],
-    )
+    @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "always_on",}])
     def test_otel_traces_always_on(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
-        assert float(resp["dd_trace_sample_rate"]) == 1.0
+        with test_library as t:
+            resp = t.get_tracer_config()
+            assert float(resp["dd_trace_sample_rate"]) == 1.0
 
-    @pytest.mark.parametrize(
-        "library_env", [{"OTEL_TRACES_SAMPLER": "always_off",}],
-    )
+    @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "always_off",}])
     def test_otel_traces_always_off(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
         assert float(resp["dd_trace_sample_rate"]) == 0.0
 
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.1"}],
     )
     def test_otel_traces_traceidratio(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
         assert float(resp["dd_trace_sample_rate"]) == 0.1
 
-    @pytest.mark.parametrize(
-        "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_on",}],
-    )
+    @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_on",}])
     def test_otel_traces_parentbased_on(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
         assert float(resp["dd_trace_sample_rate"]) == 1.0
 
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off",}],
     )
     def test_otel_traces_parentbased_off(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
         assert float(resp["dd_trace_sample_rate"]) == 0.0
 
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.1"}],
     )
     def test_otel_traces_parentbased_ratio(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
         assert float(resp["dd_trace_sample_rate"]) == 0.1
 
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_EXPORTER": "none"}],
     )
     def test_otel_traces_exporter_none(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
         assert resp["dd_trace_enabled"] == "false"
 
-    @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @pytest.mark.parametrize(
-        "library_env", [{"OTEL_LOG_LEVEL": "debug"}],
-    )
+    @pytest.mark.parametrize("library_env", [{"OTEL_LOG_LEVEL": "debug"}])
     def test_otel_log_level_to_debug_mapping(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
-        assert resp["dd_log_level"] == "debug"
+        with test_library as t:
+            resp = t.get_tracer_config()
         assert resp["dd_trace_debug"] == "true"
+        # If dd_log_level is set it must be consistent with dd_trace_debug
+        assert (resp["dd_log_level"] == "debug") or (resp["dd_log_level"] is None)
 
     @missing_feature(context.library == "nodejs", reason="this setting is not exposed in the Node.js config object")
-    @pytest.mark.parametrize(
-        "library_env", [{"DD_TRACE_OTEL_ENABLED": "true", "OTEL_SDK_DISABLED": "true"}],
-    )
+    @pytest.mark.parametrize("library_env", [{"DD_TRACE_OTEL_ENABLED": "true", "OTEL_SDK_DISABLED": "true"}])
     def test_dd_trace_otel_enabled_takes_precedence(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
         assert resp["dd_trace_otel_enabled"] == "true"
 
     @missing_feature(context.library == "nodejs", reason="this setting is not exposed in the Node.js config object")
-    @pytest.mark.parametrize(
-        "library_env", [{"OTEL_SDK_DISABLED": "true"}],
-    )
+    @pytest.mark.parametrize("library_env", [{"OTEL_SDK_DISABLED": "true"}])
     def test_otel_sdk_disabled_set(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
         assert resp["dd_trace_otel_enabled"] == "false"
 
     @missing_feature(
         True, reason="dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language"
     )
-    @pytest.mark.parametrize(
-        "library_env", [{"OTEL_TRACES_SAMPLER": "always_on"}],
-    )
+    @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "always_on"}])
     def test_dd_trace_sample_ignore_parent_true(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
         assert resp["dd_trace_sample_ignore_parent"] == "true"
 
     @missing_feature(
         True, reason="dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language"
     )
-    @pytest.mark.parametrize(
-        "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off"}],
-    )
+    @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off"}])
     def test_dd_trace_sample_ignore_parent_false(self, test_agent, test_library):
-        resp = test_library.get_tracer_config()
+        with test_library as t:
+            resp = t.get_tracer_config()
         assert resp["dd_trace_sample_ignore_parent"] == "false"

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -288,22 +288,21 @@ app.post('/trace/otel/set_attributes', (req, res) => {
 app.get('/trace/config', (req, res) => {
   const dummyTracer = require('dd-trace').init()
   const config = dummyTracer._tracer._config
-  const config_string = JSON.stringify({
-    'dd_service': config?.service !== undefined ? `${config.service}`.toLowerCase() : 'null',
-    'dd_log_level': config?.logLevel !== undefined ? `${config.logLevel}`.toLowerCase() : 'null',
-    'dd_trace_debug': config?.debug !== undefined ? `${config.debug}`.toLowerCase() : 'null',
-    'dd_trace_sample_rate': config?.sampleRate !== undefined ? `${config.sampleRate}` : 'null',
-    'dd_trace_enabled': config ? 'true' : 'false', // in node if dd_trace_enabled is true the tracer won't have a config object
-    'dd_runtime_metrics_enabled': config?.runtimeMetrics !== undefined ? `${config.runtimeMetrics}`.toLowerCase() : 'null',
-    'dd_tags': config?.tags !== undefined ? Object.entries(config.tags).map(([key, val]) => `${key}:${val}`).join(',') : 'null',
-    'dd_trace_propagation_style': config?.tracePropagationStyle?.inject.join(',') ?? 'null',
-    'dd_trace_sample_ignore_parent': 'null', // not implemented in node
-    'dd_trace_otel_enabled': 'null', // not exposed in config object in node
-    'dd_env': config?.tags?.env !== undefined ? `${config.tags.env}` : 'null',
-    'dd_version': config?.tags?.version !== undefined ? `${config.tags.version}` : 'null'
-  })
   res.json( { 
-    config: config_string
+    config: {
+      'dd_service': config?.service !== undefined ? `${config.service}`.toLowerCase() : 'null',
+      'dd_log_level': config?.logLevel !== undefined ? `${config.logLevel}`.toLowerCase() : 'null',
+      'dd_trace_debug': config?.debug !== undefined ? `${config.debug}`.toLowerCase() : 'null',
+      'dd_trace_sample_rate': config?.sampleRate !== undefined ? `${config.sampleRate}` : 'null',
+      'dd_trace_enabled': config ? 'true' : 'false', // in node if dd_trace_enabled is true the tracer won't have a config object
+      'dd_runtime_metrics_enabled': config?.runtimeMetrics !== undefined ? `${config.runtimeMetrics}`.toLowerCase() : 'null',
+      'dd_tags': config?.tags !== undefined ? Object.entries(config.tags).map(([key, val]) => `${key}:${val}`).join(',') : 'null',
+      'dd_trace_propagation_style': config?.tracePropagationStyle?.inject.join(',') ?? 'null',
+      'dd_trace_sample_ignore_parent': 'null', // not implemented in node
+      'dd_trace_otel_enabled': 'null', // not exposed in config object in node
+      'dd_env': config?.tags?.env !== undefined ? `${config.tags.env}` : 'null',
+      'dd_version': config?.tags?.version !== undefined ? `${config.tags.version}` : 'null'
+    }
   });
 });
 

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -107,6 +107,30 @@ class SpanFinishReturn(BaseModel):
     pass
 
 
+class TraceConfigReturn(BaseModel):
+    config: dict[str, Optional[str]]
+
+
+@app.get("/trace/config")
+def trace_config() -> TraceConfigReturn:
+    return TraceConfigReturn(
+        config={
+            "dd_service": config.service,
+            "dd_log_level": None,
+            "dd_trace_sample_rate": str(config._trace_sample_rate),
+            "dd_trace_enabled": str(config._tracing_enabled).lower(),
+            "dd_runtime_metrics_enabled": str(config._runtime_metrics_enabled).lower(),
+            "dd_tags": ",".join(f"{k}:{v}" for k, v in config.tags.items()),
+            "dd_trace_propagation_style": ",".join(config._propagation_style_extract),
+            "dd_trace_debug": str(config._debug_mode).lower(),
+            "dd_trace_otel_enabled": str(config._otel_enabled).lower(),
+            "dd_trace_sample_ignore_parent": None,
+            "dd_env": config.env,
+            "dd_version": config.version,
+        }
+    )
+
+
 @app.post("/trace/span/finish")
 def trace_span_finish(args: SpanFinishArgs) -> SpanFinishReturn:
     span = spans[args.span_id]

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -356,7 +356,7 @@ class APMLibraryClientHTTP(APMLibraryClient):
 
     def get_tracer_config(self) -> Dict[str, Optional[str]]:
         resp = self._session.get(self._url("/trace/config")).json()
-        config_dict = json.loads(resp["config"])
+        config_dict = resp["config"]
         return {
             "dd_service": config_dict.get("dd_service", None),
             "dd_log_level": config_dict.get("dd_log_level", None),


### PR DESCRIPTION
## Motivation

Run tests in `tests/parametric/test_otel_env_vars.py` with the python parametric app

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

