### PR TITLE
[Auto injection tests] Remove telemetry logs from the logs we use to verify the blocklist is implemented

### DIFF
--- a/utils/onboarding/injection_log_parser.py
+++ b/utils/onboarding/injection_log_parser.py
@@ -4,7 +4,8 @@ from utils.tools import logger
 
 
 def exclude_telemetry_logs_filter(line):
-    return "\"command\":\"telemetry\"" not in line
+    return '"command":"telemetry"' not in line
+
 
 def command_injection_skipped(command_line, log_local_path):
     """ From parsed log, search on the list of logged commands 

--- a/utils/onboarding/injection_log_parser.py
+++ b/utils/onboarding/injection_log_parser.py
@@ -98,14 +98,14 @@ def _get_command_props_values(command_instrumentation_desc, command_args_check):
     return False
 
 
-def _get_commands_from_log_file(log_local_path, filter):
+def _get_commands_from_log_file(log_local_path, line_filter):
     """ From instrumentation log file, extract all commands parsed by dd-injection (the log level should be DEBUG)  """
 
     store_as_command = False
     command_lines = []
     with open(log_local_path, encoding="utf-8") as f:
         for line in f:
-            if not filter(line):
+            if not line_filter(line):
                 continue
             if "starting process" in line:
                 store_as_command = True


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

