### PR TITLE
enable node span events system tests

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -874,7 +874,7 @@ class Test_Otel_Span_Methods:
 
         event2 = events[1]
         assert event2.get("name") == "second_event"
-        assert event2.get("time_unix_nano") // 10000 == event2_timestamp_ns // 10000 #reduce the precision tested
+        assert event2.get("time_unix_nano") // 10000 == event2_timestamp_ns // 10000  # reduce the precision tested
         assert event2["attributes"].get("string_val") == "value"
 
         event3 = events[2]
@@ -934,7 +934,9 @@ class Test_Otel_Span_Methods:
         events = json.loads(root_span.get("meta", {}).get("events"))
         assert len(events) == 3
         event1 = events[0]
-        assert event1.get("name").lower() == "exception" or "error" #node uses error objects instead of exception objects
+        assert (
+            event1.get("name").lower() == "exception" or "error"
+        )  # node uses error objects instead of exception objects
         assert event1.get("time_unix_nano") > 0
 
         event2 = events[1]

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -9,6 +9,7 @@ const SpanContext = require('dd-trace/packages/dd-trace/src/opentracing/span_con
 const OtelSpanContext = require('dd-trace/packages/dd-trace/src/opentelemetry/span_context')
 
 const { trace, ROOT_CONTEXT } = require('@opentelemetry/api')
+const { millisToHrTime } = require('@opentelemetry/core')
 
 const { TracerProvider } = tracer
 const tracerProvider = new TracerProvider()
@@ -305,6 +306,21 @@ app.get('/trace/config', (req, res) => {
     }
   });
 });
+
+app.post("/trace/otel/add_event", (req, res) => {
+  const { span_id, name, timestamp, attributes } = req.body;
+  const span = otelSpans[span_id]
+  // convert to TimeInput object using millisToHrTime
+  span.addEvent(name, attributes, millisToHrTime(timestamp / 1000))
+  res.json({})
+})
+
+app.post("/trace/otel/record_exception", (req, res) => {
+  const { span_id, message, attributes } = req.body;
+  const span = otelSpans[span_id]
+  span.recordException(new Error(message))
+  res.json({})
+})
 
 // TODO: implement this endpoint correctly, current blockers:
 // 1. Fails on invalid url


### PR DESCRIPTION
## Motivation
enabling span events and record exception system tests for node.js

## Changes
enables span events and record exception system tests for node.js along with separating record exception serialization test into two since node.js does not support attributes for the record exception api
