### PR TITLE
[dotnet] Try fix parameteric tests

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -123,8 +123,8 @@ class Test_Otel_Span_Methods:
     @irrelevant(context.library >= "golang@v1.59.0.dev0", reason="New span naming introduced in v1.59.0")
     @irrelevant(context.library == "ruby", reason="Old array encoding no longer supported")
     @irrelevant(context.library == "php", reason="Old array encoding no longer supported")
+    @missing_feature(context.library <= "dotnet", reason="Old array encoding no longer supported")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
-    @missing_feature(context.library <= "dotnet@2.41.0", reason="Implemented in 2.42.0")
     @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
     def test_otel_set_attributes_different_types_legacy(self, test_agent, test_library):
         """
@@ -205,9 +205,7 @@ class Test_Otel_Span_Methods:
     @missing_feature(
         context.library == "nodejs", reason="New operation name mapping & array encoding not yet implemented"
     )
-    @missing_feature(
-        context.library == "dotnet", reason="New operation name mapping & array encoding not yet implemented"
-    )
+    @missing_feature(context.library <= "dotnet@2.52.0", reason="Implemented in 2.53.0")
     @missing_feature(
         context.library == "python", reason="New operation name mapping & array encoding not yet implemented"
     )

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -123,7 +123,7 @@ class Test_Otel_Span_Methods:
     @irrelevant(context.library >= "golang@v1.59.0.dev0", reason="New span naming introduced in v1.59.0")
     @irrelevant(context.library == "ruby", reason="Old array encoding no longer supported")
     @irrelevant(context.library == "php", reason="Old array encoding no longer supported")
-    @missing_feature(context.library <= "dotnet", reason="Old array encoding no longer supported")
+    @missing_feature(context.library > "dotnet@2.52.0", reason="Old array encoding no longer supported")
     @missing_feature(context.library == "nodejs", reason="New operation name mapping not yet implemented")
     @missing_feature(context.library == "python", reason="New operation name mapping not yet implemented")
     def test_otel_set_attributes_different_types_legacy(self, test_agent, test_library):


### PR DESCRIPTION
## Motivation

.NET array encoding changed in a recent PR, and so now system tests are broken on master

## Changes

Disables the legacy test, and enables the "new encoding" test

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

