### PR TITLE
[.NET] enable parametric tests for remote sampling rules

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -276,7 +276,7 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
-      TestDynamicConfigSamplingRules: v2.54.0
+      TestDynamicConfigSamplingRules: v2.53.2
       TestDynamicConfigTracingEnabled: v2.49.0
       TestDynamicConfigV1: v2.33.0
       TestDynamicConfigV1_ServiceTargets: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -276,7 +276,7 @@ tests/:
   parametric/:
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
-      TestDynamicConfigSamplingRules: missing_feature
+      TestDynamicConfigSamplingRules: v2.54.0
       TestDynamicConfigTracingEnabled: v2.49.0
       TestDynamicConfigV1: v2.33.0
       TestDynamicConfigV1_ServiceTargets: missing_feature

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -690,6 +690,7 @@ class TestDynamicConfigSamplingRules:
         reason="JSON tag format in RC differs from the JSON tag format used in DD_TRACE_SAMPLING_RULES",
     )
     @bug(context.library == "ruby", reason="RC_SAMPLING_TAGS_RULE_RATE is not respected")
+    @bug(context.library == "dotnet", reason="Not applying correct sampling rate")
     @missing_feature(library="nodejs")
     @missing_feature(library="python")
     def test_trace_sampling_rules_with_tags(self, test_agent, test_library):

--- a/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
+++ b/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
@@ -148,6 +148,17 @@ public abstract class ApmTestApi
             Origin.SetValue(spanContext, origin);
         }
 
+        if (parsedDictionary.TryGetValue("span_tags", out var tagsToken))
+        {
+            foreach (var tag in (Newtonsoft.Json.Linq.JArray)tagsToken)
+            {
+                var key = (string)tag[0]!;
+                var value = (string?)tag[1];
+
+                span.SetTag(key, value);
+            }
+        }
+
         Spans[span.SpanId] = span;
 
         return JsonConvert.SerializeObject(new

--- a/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
+++ b/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
@@ -1,8 +1,6 @@
 ﻿using Datadog.Trace;
 using Datadog.Trace.Configuration;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Net.Http.Headers;
 using Newtonsoft.Json;
 
 namespace ApmTestApi.Endpoints;

--- a/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
+++ b/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
@@ -261,13 +261,13 @@ public abstract class ApmTestApi
         }
 
         var tracerSettings = Tracer.Instance.Settings;
-        var globalSettings = (GlobalSettings)GetGlobalSettingsInstance.GetValue(null);
+        var globalSettings = (GlobalSettings)GetGlobalSettingsInstance.GetValue(null)!;
 
-        var propagationStyleInject = (string[])PropagationStyleInject.GetValue(tracerSettings);
-        var runtimeMetricsEnabled = (bool)RuntimeMetricsEnabled.GetValue(tracerSettings);
-        var isOtelEnabled = (bool)IsActivityListenerEnabled.GetValue(tracerSettings);
+        var propagationStyleInject = (string[])PropagationStyleInject.GetValue(tracerSettings)!;
+        var runtimeMetricsEnabled = (bool)RuntimeMetricsEnabled.GetValue(tracerSettings)!;
+        var isOtelEnabled = (bool)IsActivityListenerEnabled.GetValue(tracerSettings)!;
 
-        Dictionary<string, object> config = new()
+        Dictionary<string, object?> config = new()
         {
             { "dd_service", tracerSettings.ServiceName },
             { "dd_env", tracerSettings.Environment },

--- a/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
+++ b/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
@@ -25,7 +25,7 @@ public abstract class ApmTestApi
         app.MapPost("/trace/span/finish", FinishSpan);
         app.MapPost("/trace/span/flush", FlushSpans);
     }
-    
+
     // Core types
     private static readonly Type SpanType = Type.GetType("Datadog.Trace.Span, Datadog.Trace", throwOnError: true)!;
     private static readonly Type SpanContextType = Type.GetType("Datadog.Trace.SpanContext, Datadog.Trace", throwOnError: true)!;
@@ -87,7 +87,7 @@ public abstract class ApmTestApi
 
         return values.AsReadOnly();
     }
-    
+
     public static async Task StopTracer()
     {
         await Tracer.Instance.ForceFlushAsync();
@@ -115,7 +115,7 @@ public abstract class ApmTestApi
         if (parsedDictionary!.TryGetValue("parent_id", out var parentId))
         {
             var longParentId = Convert.ToUInt64(parentId);
-            
+
             if (creationSettings.Parent is null && longParentId > 0 )
             {
                 var parentSpan = Spans[longParentId];
@@ -149,14 +149,14 @@ public abstract class ApmTestApi
         }
 
         Spans[span.SpanId] = span;
-        
+
         return JsonConvert.SerializeObject(new
         {
             span_id = span.SpanId.ToString(),
             trace_id = span.TraceId.ToString(),
         });
     }
-    
+
     private static async Task SpanSetMeta(HttpRequest request)
     {
         var headerBodyDictionary = await new StreamReader(request.Body).ReadToEndAsync();
@@ -240,13 +240,13 @@ public abstract class ApmTestApi
             // Invoke SpanContextPropagator.Inject with the HttpRequestHeaders
             SpanContextPropagatorInject.Invoke(spanContextPropagator, new object[] { contextArg!, httpHeaders, Setter });
         }
-        
+
         return JsonConvert.SerializeObject(new
         {
             http_headers = httpHeaders
         });
     }
-        
+
     private static async Task FinishSpan(HttpRequest request)
     {
         var span = Spans[Convert.ToUInt64(await FindBodyKeyValueAsync(request, "span_id"))];
@@ -331,7 +331,7 @@ public abstract class ApmTestApi
             await flushTask!;
         }
     }
-    
+
     private static MethodInfo? GenerateInjectMethod()
     {
         if (SpanContextPropagatorType is null)


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Our .NET SDK added support for remote sampling rules in 2.53.2, so we can enable these tests.

## Changes

<!-- A brief description of the change being made with this pull request. -->
Enable .NET tests for sampling rules over remote configuration (RCM).

Bonus: add support for adding span tags in .NET parametric tests (will be used in another test soon)

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

