### PR TITLE
[java] Enable some blocking test and simplify asserts

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -741,16 +741,15 @@ tests/:
     test_identify.py:
       Test_Basic: missing_feature
     test_ip_blocking_full_denylist.py:
-      Test_AppSecIPBlockingFullDenylist: bug (RC payload limit)
-        # '*': missing_feature
-        # jersey-grizzly2: v1.7.0
-        # ratpack: v1.7.0
-        # resteasy-netty3: v1.7.0
-        # spring-boot: v0.110.0
-        # spring-boot-openliberty: v0.115.0
-        # spring-boot-undertow: v0.111.0
-        # spring-boot-jetty: v0.111.0
-        # vertx3: v1.7.0
+      Test_AppSecIPBlockingFullDenylist:
+        '*': v0.111.0
+        jersey-grizzly2: v1.7.0
+        ratpack: v1.7.0
+        resteasy-netty3: v1.7.0
+        spring-boot: v0.110.0
+        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-openliberty: v0.115.0
+        vertx3: v1.7.0
     test_logs.py:
       Test_Standardization:
         akka-http: v1.22.0
@@ -840,16 +839,15 @@ tests/:
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     test_user_blocking_full_denylist.py:
-      Test_UserBlocking_FullDenylist: bug (RC payload limit)
-        # '*': missing_feature
-        # jersey-grizzly2: v1.7.0
-        # ratpack: v1.7.0
-        # resteasy-netty3: v1.7.0
-        # spring-boot: v0.110.0
-        # spring-boot-openliberty: v0.115.0
-        # spring-boot-undertow: v0.111.0
-        # spring-boot-jetty: v0.111.0
-        # vertx3: v1.7.0
+      Test_UserBlocking_FullDenylist:
+        '*': v0.111.0
+        jersey-grizzly2: v1.7.0
+        ratpack: v1.7.0
+        resteasy-netty3: v1.7.0
+        spring-boot: v0.110.0
+        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-openliberty: v0.115.0
+        vertx3: v1.7.0
     test_versions.py:
       Test_Events: v0.90.0
   debugger/:

--- a/tests/appsec/test_ip_blocking_full_denylist.py
+++ b/tests/appsec/test_ip_blocking_full_denylist.py
@@ -74,6 +74,10 @@ class Test_AppSecIPBlockingFullDenylist:
         ]
 
     @missing_feature(weblog_variant="spring-boot" and context.library < "java@0.111.0")
+    @bug(
+        context.library >= "java@1.22.0" and context.library < "java@1.35.0",
+        reason="Failed on large expiration values, which are used in this test",
+    )
     @missing_feature(library="python")
     def test_blocked_ips(self):
         """test blocked ips are enforced"""

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -43,6 +43,11 @@ class Test_UserBlocking_FullDenylist:
         ]
 
     @bug(context.library < "ruby@1.12.1", reason="not setting the tags on the service entry span")
+    @bug(
+        context.library >= "java@1.22.0" and context.library < "java@1.35.0",
+        reason="Failed on large expiration values, which are used in this test",
+    )
+    @bug(library="java", reason="Request blocked but appsec.blocked tag not set")
     @missing_feature(library="python")
     def test_blocking_test(self):
         """Test with a denylisted user"""

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
@@ -1,6 +1,7 @@
 package com.datadoghq.jersey;
 
 import com.datadoghq.system_tests.iast.utils.*;
+import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
@@ -134,6 +135,20 @@ public class MyResource {
         h.put("metadata0", "value0");
         h.put("metadata1", "value1");
         return h;
+    }
+
+    @GET
+    @Path("/users")
+    public String users(@QueryParam("user") String user) {
+        final Span span = GlobalTracer.get().activeSpan();
+        if ((span instanceof MutableSpan)) {
+            MutableSpan localRootSpan = ((MutableSpan) span).getLocalRootSpan();
+            localRootSpan.setTag("usr.id", user);
+        }
+        Blocking
+                .forUser(user)
+                .blockIfMatch();
+        return "Hello " + user;
     }
 
     @GET

--- a/utils/build/docker/java/play/conf/routes
+++ b/utils/build/docker/java/play/conf/routes
@@ -8,6 +8,7 @@ GET  /waf/*segments            controllers.AppSecController.params(segments: Seq
 POST /waf                      controllers.AppSecController.wafPost
 GET  /make_distant_call        controllers.AppSecController.distantCall(url: String)
 GET  /status                   controllers.AppSecController.status(code: Int)
+GET  /users                    controllers.AppSecController.users(user: String)
 GET  /user_login_success_event controllers.AppSecController.loginSuccess(event_user_id: Option[String])
 GET  /user_login_failure_event controllers.AppSecController.loginFailure(event_user_id: Option[String], event_user_exists: Option[Boolean])
 GET  /custom_event             controllers.AppSecController.customEvent(event_name: Option[String])

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
@@ -1,5 +1,6 @@
 package com.datadoghq.resteasy;
 
+import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
@@ -131,6 +132,20 @@ public class MyResource {
         h.put("metadata0", "value0");
         h.put("metadata1", "value1");
         return h;
+    }
+
+    @GET
+    @Path("/users")
+    public String users(@QueryParam("user") String user) {
+        final Span span = GlobalTracer.get().activeSpan();
+        if ((span instanceof MutableSpan)) {
+            MutableSpan localRootSpan = ((MutableSpan) span).getLocalRootSpan();
+            localRootSpan.setTag("usr.id", user);
+        }
+        Blocking
+                .forUser(user)
+                .blockIfMatch();
+        return "Hello " + user;
     }
 
     @GET

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
@@ -4,6 +4,7 @@ import com.datadoghq.system_tests.iast.infra.LdapServer;
 import com.datadoghq.system_tests.iast.infra.SqlServer;
 import com.datadoghq.vertx3.iast.routes.IastSinkRouteProvider;
 import com.datadoghq.vertx3.iast.routes.IastSourceRouteProvider;
+import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
@@ -110,6 +111,17 @@ public class Main {
                     String codeString = ctx.request().getParam("code");
                     int code = Integer.parseInt(codeString);
                     ctx.response().setStatusCode(code).end();
+                });
+        router.get("/users")
+                .handler(ctx -> {
+                    final String user = ctx.request().getParam("user");
+                    final Span span = GlobalTracer.get().activeSpan();
+                    if ((span instanceof MutableSpan)) {
+                        MutableSpan localRootSpan = ((MutableSpan) span).getLocalRootSpan();
+                        localRootSpan.setTag("usr.id", user);
+                    }
+                    Blocking.forUser(user).blockIfMatch();
+                    ctx.response().end("Hello " + user);
                 });
         router.get("/user_login_success_event")
                 .handler(ctx -> {


### PR DESCRIPTION
## Changes

* Add `/users` endpoint in Java.
* Enable IP and user blocking tests ([APPSEC-51385](https://datadoghq.atlassian.net/browse/APPSEC-51385)).

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* ~[ ] A docker base image is modified?~
    * ~[ ] the relevant `build-XXX-image` label is present~
* ~[ ] A scenario is added (or removed)?~
    * ~[ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)~



[APPSEC-51385]: https://datadoghq.atlassian.net/browse/APPSEC-51385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ