### PR TITLE
ASM: tests for new User Id collection RFC [ATO]

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -176,7 +176,7 @@ tests/:
       Test_Login_Events: v2.32.0
       Test_Login_Events_Extended: v2.33.0
       Test_V2_Login_Events: missing_feature
-      Test_V2_Login_Events_Extended: missing_feature
+      Test_V2_Login_Events_Anon: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses: v2.27.0
       Test_BlockingGraphqlResolvers: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -175,6 +175,8 @@ tests/:
     test_automated_login_events.py:
       Test_Login_Events: v2.32.0
       Test_Login_Events_Extended: v2.33.0
+      Test_V2_Login_Events: missing_feature
+      Test_V2_Login_Events_Extended: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses: v2.27.0
       Test_BlockingGraphqlResolvers: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -246,6 +246,8 @@ tests/:
     test_automated_login_events.py:
       Test_Login_Events: missing_feature
       Test_Login_Events_Extended: missing_feature
+      Test_V2_Login_Events: missing_feature
+      Test_V2_Login_Events_Extended: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses: v1.51.0
       Test_BlockingGraphqlResolvers: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -247,7 +247,7 @@ tests/:
       Test_Login_Events: missing_feature
       Test_Login_Events_Extended: missing_feature
       Test_V2_Login_Events: missing_feature
-      Test_V2_Login_Events_Extended: missing_feature
+      Test_V2_Login_Events_Anon: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses: v1.51.0
       Test_BlockingGraphqlResolvers: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -581,6 +581,8 @@ tests/:
     test_automated_login_events.py:
       Test_Login_Events: missing_feature
       Test_Login_Events_Extended: missing_feature
+      Test_V2_Login_Events: missing_feature
+      Test_V2_Login_Events_Extended: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses:
         '*': v0.111.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -582,7 +582,7 @@ tests/:
       Test_Login_Events: missing_feature
       Test_Login_Events_Extended: missing_feature
       Test_V2_Login_Events: missing_feature
-      Test_V2_Login_Events_Extended: missing_feature
+      Test_V2_Login_Events_Anon: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses:
         '*': v0.111.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -282,6 +282,8 @@ tests/:
       Test_Login_Events_Extended:
         '*': *ref_4_4_0
         nextjs: missing_feature
+      Test_V2_Login_Events: missing_feature
+      Test_V2_Login_Events_Extended: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses: *ref_3_19_0
       Test_BlockingGraphqlResolvers:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -283,7 +283,7 @@ tests/:
         '*': *ref_4_4_0
         nextjs: missing_feature
       Test_V2_Login_Events: missing_feature
-      Test_V2_Login_Events_Extended: missing_feature
+      Test_V2_Login_Events_Anon: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses: *ref_3_19_0
       Test_BlockingGraphqlResolvers:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -165,6 +165,8 @@ tests/:
     test_automated_login_events.py:
       Test_Login_Events: v0.89.0
       Test_Login_Events_Extended: v0.89.0
+      Test_V2_Login_Events: missing_feature
+      Test_V2_Login_Events_Extended: missing_feature
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
       Test_Blocking_request_body: irrelevant (Php does not accept url encoded entries without key)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -166,7 +166,7 @@ tests/:
       Test_Login_Events: v0.89.0
       Test_Login_Events_Extended: v0.89.0
       Test_V2_Login_Events: missing_feature
-      Test_V2_Login_Events_Extended: missing_feature
+      Test_V2_Login_Events_Anon: missing_feature
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
       Test_Blocking_request_body: irrelevant (Php does not accept url encoded entries without key)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -353,7 +353,7 @@ tests/:
         '*': v2.10.0.dev
         fastapi: missing_feature
       Test_V2_Login_Events: missing_feature
-      Test_V2_Login_Events_Extended: missing_feature
+      Test_V2_Login_Events_Anon: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses:
         '*': v1.16.1

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -352,6 +352,8 @@ tests/:
       Test_Login_Events_Extended: 
         '*': v2.10.0.dev
         fastapi: missing_feature
+      Test_V2_Login_Events: missing_feature
+      Test_V2_Login_Events_Extended: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses:
         '*': v1.16.1

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -179,6 +179,8 @@ tests/:
         sinatra32: missing_feature (We do not support authentication framework for sinatra or rack)
         sinatra40: missing_feature (We do not support authentication framework for sinatra or rack)
         uds-sinatra: missing_feature (We do not support authentication framework for sinatra or rack)
+      Test_V2_Login_Events: missing_feature
+      Test_V2_Login_Events_Extended: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses: v1.0.0
       Test_BlockingGraphqlResolvers: missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -180,7 +180,7 @@ tests/:
         sinatra40: missing_feature (We do not support authentication framework for sinatra or rack)
         uds-sinatra: missing_feature (We do not support authentication framework for sinatra or rack)
       Test_V2_Login_Events: missing_feature
-      Test_V2_Login_Events_Extended: missing_feature
+      Test_V2_Login_Events_Anon: missing_feature
     test_blocking_addresses.py:
       Test_BlockingAddresses: v1.0.0
       Test_BlockingGraphqlResolvers: missing_feature

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -858,7 +858,7 @@ class Test_V2_Login_Events:
 @rfc("https://docs.google.com/document/d/19VHLdJLVFwRb_JrE87fmlIM5CL5LdOBv4AmLxgdo9qI/edit")
 @scenarios.appsec_auto_events_extended
 @features.user_monitoring
-class Test_V2_Login_Events_Extended:
+class Test_V2_Login_Events_Anon:
     """Test login success/failure use cases
        As default mode is identification, this scenario will test anonymization. 
     """

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -855,7 +855,7 @@ class Test_V2_Login_Events:
             assert_priority(span, meta)
 
 
-@rfc("https://docs.google.com/document/d/1-trUpphvyZY7k5ldjhW-MgqWl0xOm7AMEQDJEAZ63_Q/edit#heading=h.8d3o7vtyu1y1")
+@rfc("https://docs.google.com/document/d/19VHLdJLVFwRb_JrE87fmlIM5CL5LdOBv4AmLxgdo9qI/edit")
 @scenarios.appsec_auto_events_extended
 @features.user_monitoring
 class Test_V2_Login_Events_Extended:

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -587,6 +587,546 @@ class Test_Login_Events_Extended:
         interfaces.library.validate_spans(self.r_hdr_failure, validate_login_failure_headers)
 
 
+@rfc("https://docs.google.com/document/d/19VHLdJLVFwRb_JrE87fmlIM5CL5LdOBv4AmLxgdo9qI/edit")
+@features.user_monitoring
+class Test_V2_Login_Events:
+    """
+    Test login success/failure use cases
+    By default, mode is identification
+    """
+
+    # User entries in the internal DB:
+    # users = [
+    #     {
+    #         id: 'social-security-id',
+    #         username: 'test',
+    #         password: '1234',
+    #         email: 'testuser@ddog.com'
+    #     },
+    #     {
+    #         id: '591dc126-8431-4d0f-9509-b23318d3dce4',
+    #         username: 'testuuid',
+    #         password: '1234',
+    #         email: 'testuseruuid@ddog.com'
+    #     }
+    # ]
+
+    @property
+    def username_key(self):
+        """ In Rails the parametesr are group by scope. In the case of the test the scope is user. The syntax to group parameters in a POST request is scope[parameter] """
+        return "user[username]" if "rails" in context.weblog_variant else "username"
+
+    @property
+    def password_key(self):
+        """ In Rails the parametesr are group by scope. In the case of the test the scope is user. The syntax to group parameters in a POST request is scope[parameter] """
+        return "user[password]" if "rails" in context.weblog_variant else "password"
+
+    USER = "test"
+    UUID_USER = "testuuid"
+    PASSWORD = "1234"
+    INVALID_USER = "invalidUser"
+
+    BASIC_AUTH_USER_HEADER = "Basic dGVzdDoxMjM0"  # base64(test:1234)
+    BASIC_AUTH_USER_UUID_HEADER = "Basic dGVzdHV1aWQ6MTIzNA=="  # base64(testuuid:1234)
+    BASIC_AUTH_INVALID_USER_HEADER = "Basic aW52YWxpZFVzZXI6MTIzNA=="  # base64(invalidUser:1234)
+    BASIC_AUTH_INVALID_PASSWORD_HEADER = "Basic dGVzdDoxMjM0NQ=="  # base64(test:12345)
+
+    def setup_login_pii_success_local(self):
+        self.r_pii_success = weblog.post(
+            "/login?auth=local", data={self.username_key: self.USER, self.password_key: self.PASSWORD}
+        )
+
+    def test_login_pii_success_local(self):
+        assert self.r_pii_success.status_code == 200
+        for _, _, span in interfaces.library.get_spans(request=self.r_pii_success):
+            meta = span.get("meta", {})
+            assert "usr.id" in meta
+            assert "usr.id" == "social-security-id"
+            # deprecated tags
+            assert "appsec.events.users.login.success.email" not in meta
+            assert "appsec.events.users.login.success.username" not in meta
+            assert "appsec.events.users.login.success.login" not in meta
+            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
+            assert meta["appsec.events.users.login.success.track"] == "true"
+            assert_priority(span, meta)
+
+    def setup_login_pii_success_basic(self):
+        self.r_pii_success = weblog.get("/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_USER_HEADER})
+
+    def test_login_pii_success_basic(self):
+        assert self.r_pii_success.status_code == 200
+        for _, _, span in interfaces.library.get_spans(request=self.r_pii_success):
+            meta = span.get("meta", {})
+            assert "usr.id" in meta
+            assert "usr.id" == "social-security-id"
+            # deprecated tags
+            assert "appsec.events.users.login.success.email" not in meta
+            assert "appsec.events.users.login.success.username" not in meta
+            assert "appsec.events.users.login.success.login" not in meta
+            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
+            assert meta["appsec.events.users.login.success.track"] == "true"
+            assert_priority(span, meta)
+
+    def setup_login_success_local(self):
+        self.r_success = weblog.post(
+            "/login?auth=local", data={self.username_key: self.UUID_USER, self.password_key: self.PASSWORD}
+        )
+
+    def test_login_success_local(self):
+        assert self.r_success.status_code == 200
+        for _, _, span in interfaces.library.get_spans(request=self.r_success):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
+            assert meta["appsec.events.users.login.success.track"] == "true"
+            assert meta["usr.id"] == "591dc126-8431-4d0f-9509-b23318d3dce4"
+            # deprecated tags
+            assert "appsec.events.users.login.success.email" not in meta
+            assert "appsec.events.users.login.success.username" not in meta
+            assert "appsec.events.users.login.success.login" not in meta
+            assert_priority(span, meta)
+
+    def setup_login_success_basic(self):
+        self.r_success = weblog.get("/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_USER_UUID_HEADER})
+
+    def test_login_success_basic(self):
+        assert self.r_success.status_code == 200
+        for _, _, span in interfaces.library.get_spans(request=self.r_success):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
+            assert meta["appsec.events.users.login.success.track"] == "true"
+            assert meta["usr.id"] == "591dc126-8431-4d0f-9509-b23318d3dce4"
+            # deprecated tags
+            assert "appsec.events.users.login.success.email" not in meta
+            assert "appsec.events.users.login.success.username" not in meta
+            assert "appsec.events.users.login.success.login" not in meta
+            assert_priority(span, meta)
+
+    def setup_login_wrong_user_failure_local(self):
+        self.r_wrong_user_failure = weblog.post(
+            "/login?auth=local", data={self.username_key: self.INVALID_USER, self.password_key: self.PASSWORD}
+        )
+
+    def test_login_wrong_user_failure_local(self):
+        assert self.r_wrong_user_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
+            meta = span.get("meta", {})
+            if context.library != "nodejs":
+                # Currently in nodejs there is no way to check if the user exists upon authentication failure so
+                # this assertion is disabled for this library.
+                assert meta["appsec.events.users.login.failure.usr.exists"] == "false"
+
+            assert "appsec.events.users.login.failure.usr.id" not in meta
+            assert "appsec.events.users.login.failure.usr.email" not in meta
+            assert "appsec.events.users.login.failure.usr.login" not in meta
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+            assert_priority(span, meta)
+
+    def setup_login_wrong_user_failure_basic(self):
+        self.r_wrong_user_failure = weblog.get(
+            "/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_INVALID_USER_HEADER}
+        )
+
+    def test_login_wrong_user_failure_basic(self):
+        assert self.r_wrong_user_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
+            meta = span.get("meta", {})
+            if context.library != "nodejs":
+                # Currently in nodejs there is no way to check if the user exists upon authentication failure so
+                # this assertion is disabled for this library.
+                assert meta["appsec.events.users.login.failure.usr.exists"] == "false"
+
+            assert "appsec.events.users.login.failure.usr.id" not in meta
+            assert "appsec.events.users.login.failure.usr.email" not in meta
+            assert "appsec.events.users.login.failure.usr.login" not in meta
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+            assert_priority(span, meta)
+
+    def setup_login_wrong_password_failure_local(self):
+        self.r_wrong_user_failure = weblog.post(
+            "/login?auth=local", data={self.username_key: self.USER, self.password_key: "12345"}
+        )
+
+    def test_login_wrong_password_failure_local(self):
+        assert self.r_wrong_user_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
+            meta = span.get("meta", {})
+            if context.library != "nodejs":
+                # Currently in nodejs there is no way to check if the user exists upon authentication failure so
+                # this assertion is disabled for this library.
+                assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+
+            assert "appsec.events.users.login.failure.usr.id" in meta
+            assert meta["appsec.events.users.login.failure.usr.id"] == "social-security-id"
+            # deprecated
+            assert "appsec.events.users.login.failure.usr.email" not in meta
+            assert "appsec.events.users.login.failure.usr.login" not in meta
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+            assert_priority(span, meta)
+
+    def setup_login_wrong_password_failure_basic(self):
+        self.r_wrong_user_failure = weblog.get(
+            "/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_INVALID_PASSWORD_HEADER}
+        )
+
+    def test_login_wrong_password_failure_basic(self):
+        assert self.r_wrong_user_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
+            meta = span.get("meta", {})
+            if context.library != "nodejs":
+                # Currently in nodejs there is no way to check if the user exists upon authentication failure so
+                # this assertion is disabled for this library.
+                assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+
+            assert "appsec.events.users.login.failure.usr.id" in meta
+            assert meta["appsec.events.users.login.failure.usr.id"] == "social-security-id"
+            assert "appsec.events.users.login.failure.usr.email" not in meta
+            assert "appsec.events.users.login.failure.usr.login" not in meta
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+            assert_priority(span, meta)
+
+    def setup_login_sdk_success_local(self):
+        self.r_sdk_success = weblog.post(
+            "/login?auth=local&sdk_event=success&sdk_user=sdkUser",
+            data={self.username_key: self.USER, self.password_key: self.PASSWORD},
+        )
+
+    def test_login_sdk_success_local(self):
+        assert self.r_sdk_success.status_code == 200
+        for _, _, span in interfaces.library.get_spans(request=self.r_sdk_success):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
+            assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
+            assert meta["appsec.events.users.login.success.track"] == "true"
+            assert meta["usr.id"] == "sdkUser"
+            assert_priority(span, meta)
+
+    def setup_login_sdk_success_basic(self):
+        self.r_sdk_success = weblog.get(
+            "/login?auth=basic&sdk_event=success&sdk_user=sdkUser",
+            headers={"Authorization": self.BASIC_AUTH_USER_HEADER},
+        )
+
+    def test_login_sdk_success_basic(self):
+        assert self.r_sdk_success.status_code == 200
+        for _, _, span in interfaces.library.get_spans(request=self.r_sdk_success):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
+            assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
+            assert meta["appsec.events.users.login.success.track"] == "true"
+            assert meta["usr.id"] == "sdkUser"
+            assert_priority(span, meta)
+
+    def setup_login_sdk_failure_local(self):
+        self.r_sdk_failure = weblog.post(
+            "/login?auth=local&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
+            data={self.username_key: self.INVALID_USER, self.password_key: self.PASSWORD},
+        )
+
+    def test_login_sdk_failure_local(self):
+        assert self.r_sdk_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_sdk_failure):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
+            assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+            assert meta["appsec.events.users.login.failure.usr.id"] == "sdkUser"
+            assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+            assert_priority(span, meta)
+
+    def setup_login_sdk_failure_basic(self):
+        self.r_sdk_failure = weblog.get(
+            "/login?auth=basic&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
+            headers={"Authorization": self.BASIC_AUTH_INVALID_USER_HEADER},
+        )
+
+    def test_login_sdk_failure_basic(self):
+        assert self.r_sdk_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_sdk_failure):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
+            assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+            assert meta["appsec.events.users.login.failure.usr.id"] == "sdkUser"
+            assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+            assert_priority(span, meta)
+
+
+@rfc("https://docs.google.com/document/d/1-trUpphvyZY7k5ldjhW-MgqWl0xOm7AMEQDJEAZ63_Q/edit#heading=h.8d3o7vtyu1y1")
+@scenarios.appsec_auto_events_extended
+@features.user_monitoring
+class Test_V2_Login_Events_Extended:
+    """Test login success/failure use cases
+       As default mode is identification, this scenario will test anonymization. 
+    """
+
+    @property
+    def username_key(self):
+        """ In Rails the parametesr are group by scope. In the case of the test the scope is user. The syntax to group parameters in a POST request is scope[parameter] """
+        return "user[username]" if "rails" in context.weblog_variant else "username"
+
+    @property
+    def password_key(self):
+        """ In Rails the parametesr are group by scope. In the case of the test the scope is user. The syntax to group parameters in a POST request is scope[parameter] """
+        return "user[password]" if "rails" in context.weblog_variant else "password"
+
+    USER = "test"
+    USER_HASH = "anon_5f31ffaf95946d2dc703ddc96a100de5"
+    UUID_USER = "testuuid"
+    PASSWORD = "1234"
+
+    BASIC_AUTH_USER_HEADER = "Basic dGVzdDoxMjM0"  # base64(test:1234)
+    BASIC_AUTH_USER_UUID_HEADER = "Basic dGVzdHV1aWQ6MTIzNA=="  # base64(testuuid:1234)
+
+    HEADERS = {
+        "Accept": "text/html",
+        "Accept-Encoding": "br;q=1.0, gzip;q=0.8, *;q=0.1",
+        "Accept-Language": "en-GB, *;q=0.5",
+        "Content-Language": "en-GB",
+        "Content-Length": "0",
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Encoding": "deflate, gzip",
+        "Host": "127.0.0.1:1234",
+        "User-Agent": "Benign User Agent 1.0",
+        "X-Forwarded-For": "42.42.42.42, 43.43.43.43",
+        "X-Client-IP": "42.42.42.42, 43.43.43.43",
+        "X-Real-IP": "42.42.42.42, 43.43.43.43",
+        "X-Forwarded": "42.42.42.42, 43.43.43.43",
+        "X-Cluster-Client-IP": "42.42.42.42, 43.43.43.43",
+        "Forwarded-For": "42.42.42.42, 43.43.43.43",
+        "Forwarded": "42.42.42.42, 43.43.43.43",
+        "Via": "42.42.42.42, 43.43.43.43",
+        "True-Client-IP": "42.42.42.42, 43.43.43.43",
+    }
+
+    def setup_login_success_local(self):
+        self.r_success = weblog.post(
+            "/login?auth=local", data={self.username_key: self.USER, self.password_key: self.PASSWORD}
+        )
+
+    def test_login_success_local(self):
+        assert self.r_success.status_code == 200
+        for _, _, span in interfaces.library.get_spans(request=self.r_success):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
+            assert meta["appsec.events.users.login.success.track"] == "true"
+            assert meta["usr.id"] == self.USER_HASH
+
+            # deprecated
+            "appsec.events.users.login.success.username" not in meta
+            "appsec.events.users.login.success.email" not in meta
+            "usr.email" not in meta
+            "usr.username" not in meta
+            "usr.login" not in meta
+
+            assert_priority(span, meta)
+
+    def setup_login_success_basic(self):
+        self.r_success = weblog.get("/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_USER_HEADER})
+
+    def test_login_success_basic(self):
+        assert self.r_success.status_code == 200
+        for _, _, span in interfaces.library.get_spans(request=self.r_success):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
+            assert meta["appsec.events.users.login.success.track"] == "true"
+            assert meta["usr.id"] == self.USER_HASH
+
+            # deprecated
+            "appsec.events.users.login.success.username" not in meta
+            "appsec.events.users.login.success.email" not in meta
+            "usr.email" not in meta
+            "usr.username" not in meta
+            "usr.login" not in meta
+
+            assert_priority(span, meta)
+
+    def setup_login_wrong_user_failure_local(self):
+        self.r_wrong_user_failure = weblog.post(
+            "/login?auth=local", data={self.username_key: "invalidUser", self.password_key: self.PASSWORD}
+        )
+
+    def test_login_wrong_user_failure_local(self):
+        assert self.r_wrong_user_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
+            meta = span.get("meta", {})
+            assert meta["appsec.events.users.login.failure.usr.exists"] == "false"
+
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+
+            assert "appsec.events.users.login.failure.usr.id" not in meta
+            assert "appsec.events.users.login.failure.email" not in meta
+            assert "appsec.events.users.login.failure.username" not in meta
+
+            assert_priority(span, meta)
+
+    def setup_login_wrong_user_failure_basic(self):
+        self.r_wrong_user_failure = weblog.get(
+            "/login?auth=basic", headers={"Authorization": "Basic aW52YWxpZFVzZXI6MTIzNA=="}
+        )
+
+    def test_login_wrong_user_failure_basic(self):
+        assert self.r_wrong_user_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
+            meta = span.get("meta", {})
+            assert meta["appsec.events.users.login.failure.usr.exists"] == "false"
+
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+
+            assert "appsec.events.users.login.failure.usr.id" not in meta
+            assert "appsec.events.users.login.failure.email" not in meta
+            assert "appsec.events.users.login.failure.username" not in meta
+
+            assert_priority(span, meta)
+
+    def setup_login_wrong_password_failure_local(self):
+        self.r_wrong_user_failure = weblog.post(
+            "/login?auth=local", data={self.username_key: self.USER, self.password_key: "12345"}
+        )
+
+    def test_login_wrong_password_failure_local(self):
+        assert self.r_wrong_user_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
+            meta = span.get("meta", {})
+            assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+
+            assert meta["appsec.events.users.login.failure.usr.id"] == self.USER_HASH
+            assert "appsec.events.users.login.failure.email" not in meta
+            assert "appsec.events.users.login.failure.username" not in meta
+
+            assert_priority(span, meta)
+
+    def setup_login_wrong_password_failure_basic(self):
+        self.r_wrong_user_failure = weblog.get("/login?auth=basic", headers={"Authorization": "Basic dGVzdDoxMjM0NQ=="})
+
+    def test_login_wrong_password_failure_basic(self):
+        assert self.r_wrong_user_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
+            meta = span.get("meta", {})
+            assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+
+            assert meta["appsec.events.users.login.failure.usr.id"] == self.USER_HASH
+            assert "appsec.events.users.login.failure.email" not in meta
+            assert "appsec.events.users.login.failure.username" not in meta
+
+            assert_priority(span, meta)
+
+    def setup_login_sdk_success_local(self):
+        self.r_sdk_success = weblog.post(
+            "/login?auth=local&sdk_event=success&sdk_user=sdkUser",
+            data={self.username_key: self.USER, self.password_key: self.PASSWORD},
+        )
+
+    def test_login_sdk_success_local(self):
+        assert self.r_sdk_success.status_code == 200
+        for _, _, span in interfaces.library.get_spans(request=self.r_sdk_success):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
+            assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
+            assert meta["appsec.events.users.login.success.track"] == "true"
+            assert meta["usr.id"] == "sdkUser"
+            assert_priority(span, meta)
+
+    def setup_login_sdk_success_basic(self):
+        self.r_sdk_success = weblog.get(
+            "/login?auth=basic&sdk_event=success&sdk_user=sdkUser",
+            headers={"Authorization": self.BASIC_AUTH_USER_HEADER},
+        )
+
+    def test_login_sdk_success_basic(self):
+        assert self.r_sdk_success.status_code == 200
+        for _, _, span in interfaces.library.get_spans(request=self.r_sdk_success):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
+            assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
+            assert meta["appsec.events.users.login.success.track"] == "true"
+            assert meta["usr.id"] == "sdkUser"
+            assert_priority(span, meta)
+
+    def setup_login_sdk_failure_basic(self):
+        self.r_sdk_failure = weblog.get(
+            "/login?auth=basic&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
+            headers={"Authorization": "Basic aW52YWxpZFVzZXI6MTIzNA=="},
+        )
+
+    def test_login_sdk_failure_basic(self):
+        assert self.r_sdk_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_sdk_failure):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
+            assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+            assert meta["appsec.events.users.login.failure.usr.id"] == "sdkUser"
+            assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+            assert_priority(span, meta)
+
+    def setup_login_sdk_failure_local(self):
+        self.r_sdk_failure = weblog.post(
+            "/login?auth=local&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
+            data={self.username_key: "invalidUser", self.password_key: self.PASSWORD},
+        )
+
+    def test_login_sdk_failure_local(self):
+        assert self.r_sdk_failure.status_code == 401
+        for _, _, span in interfaces.library.get_spans(request=self.r_sdk_failure):
+            meta = span.get("meta", {})
+            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
+            assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
+            assert meta["appsec.events.users.login.failure.track"] == "true"
+            assert meta["appsec.events.users.login.failure.usr.id"] == "sdkUser"
+            assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+            assert_priority(span, meta)
+
+    def setup_login_success_headers(self):
+        self.r_hdr_success = weblog.post(
+            "/login?auth=local",
+            data={self.username_key: self.USER, self.password_key: self.PASSWORD},
+            headers=self.HEADERS,
+        )
+
+    def test_login_success_headers(self):
+        # Validate that all relevant headers are included on user login success on extended mode
+
+        def validate_login_success_headers(span):
+            if span.get("parent_id") not in (0, None):
+                return
+
+            for header in self.HEADERS:
+                assert f"http.request.headers.{header.lower()}" in span["meta"], f"Can't find {header} in span's meta"
+            return True
+
+        interfaces.library.validate_spans(self.r_hdr_success, validate_login_success_headers)
+
+    def setup_login_failure_headers(self):
+        self.r_hdr_failure = weblog.post(
+            "/login?auth=local",
+            data={self.username_key: "invalidUser", self.password_key: self.PASSWORD},
+            headers=self.HEADERS,
+        )
+
+    def test_login_failure_headers(self):
+        # Validate that all relevant headers are included on user login failure on extended mode
+
+        def validate_login_failure_headers(span):
+            if span.get("parent_id") not in (0, None):
+                return
+
+            for header in self.HEADERS:
+                assert f"http.request.headers.{header.lower()}" in span["meta"], f"Can't find {header} in span's meta"
+            return True
+
+        interfaces.library.validate_spans(self.r_hdr_failure, validate_login_failure_headers)
+
+
 def assert_priority(span, meta):
     MANUAL_KEEP_SAMPLING_PRIORITY = 2
     if span["metrics"].get("_sampling_priority_v1") != MANUAL_KEEP_SAMPLING_PRIORITY:

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1716,7 +1716,11 @@ class scenarios:
 
     appsec_auto_events_extended = EndToEndScenario(
         "APPSEC_AUTO_EVENTS_EXTENDED",
-        weblog_env={"DD_APPSEC_ENABLED": "true", "DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING": "extended", "DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE": "anonymization"},
+        weblog_env={
+            "DD_APPSEC_ENABLED": "true",
+            "DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING": "extended",
+            "DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE": "anonymization",
+        },
         appsec_enabled=True,
         doc="Scenario for checking extended mode in automatic user events",
         scenario_groups=[ScenarioGroup.APPSEC],

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -1716,7 +1716,7 @@ class scenarios:
 
     appsec_auto_events_extended = EndToEndScenario(
         "APPSEC_AUTO_EVENTS_EXTENDED",
-        weblog_env={"DD_APPSEC_ENABLED": "true", "DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING": "extended"},
+        weblog_env={"DD_APPSEC_ENABLED": "true", "DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING": "extended", "DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE": "anonymization"},
         appsec_enabled=True,
         doc="Scenario for checking extended mode in automatic user events",
         scenario_groups=[ScenarioGroup.APPSEC],


### PR DESCRIPTION
Add two tests classes 'V2'. The plan is that each tracer will stop conforming to V1 tests and use V2 to implement the new RFC.

- The first class `Test_V2_Login_Events` will use the DEFAULT scenario and check the default mode "identification"
- The second class `Test_V2_Login_Events_Anon` will use the APPSEC_AUTO_EVENTS_EXTENDED scenario and check the new mode "anonymization"

APPSEC-53571
## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

