### PR TITLE
WIP: telemetry test for remote sampling rules

### DIFF
--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -89,6 +89,22 @@ def set_and_wait_rc(test_agent, config_overrides: Dict[str, Any]) -> Dict:
     return test_agent.wait_for_rc_apply_state("APM_TRACING", state=2, clear=True)
 
 
+def set_and_wait_rc_telemetry(test_agent, config_overrides: Dict[str, Any]) -> Dict:
+    """Helper to create an RC configuration with the given settings and return associated telemetry event
+
+    It is assumed that the configuration is successfully applied.
+    """
+    rc_config = _create_rc_config(config_overrides)
+
+    _set_rc(test_agent, rc_config)
+
+    # skip the first telemetry event for golang
+    if context.library.library == "golang":
+        test_agent.wait_for_telemetry_event("app-client-configuration-change", clear=True, wait_loops=300)
+
+    return test_agent.wait_for_telemetry_event("app-client-configuration-change", clear=True, wait_loops=300)
+
+
 def assert_sampling_rate(trace: List[Dict], rate: float):
     """Asserts that a trace returned from the test agent is consistent with the given sample rate.
 
@@ -801,3 +817,56 @@ class TestDynamicConfigSamplingRules:
         span = trace[0]
         assert "_dd.p.dm" in span["meta"]
         assert span["meta"]["_dd.p.dm"] == "-12"
+
+    @parametrize("library_env", [{**DEFAULT_ENVVARS}])
+    def test_remote_sampling_rules_telemetry(self, library_env, test_agent, test_library):
+        """RC sampling rules should be reported by telemetry"""
+        sampling_rule = [
+            {
+                "service": "svc*",
+                "resource": "*abc",
+                "name": "op-??",
+                "tags": [
+                    {"key": "tag-a", "value_glob": "ta-v*"},
+                    {"key": "tag-b", "value_glob": "tb-v?"},
+                    {"key": "tag-c", "value_glob": "tc-v"},
+                ],
+                "sample_rate": 0.5,
+                "provenance": "dynamic",
+            }
+        ]
+        sampling_rule_without_tags = [
+            {"service": "svc*", "resource": "*abc", "name": "op-??", "sample_rate": 0.5, "provenance": "dynamic",}
+        ]
+        sampling_rule_with_modified_tags = [
+            {
+                "service": "svc*",
+                "resource": "*abc",
+                "name": "op-??",
+                "tags": {"tag-a": "ta-v*", "tag-b": "tb-v?", "tag-c": "tc-v"},
+                "sample_rate": 0.5,
+                "provenance": "dynamic",
+            }
+        ]
+        telemetry_names = set(
+            [
+                "sampling_rules",
+                "trace.sampling_rules",
+                "DD_TRACE_SAMPLING_RULES",
+                "trace_sampling_rules",
+                "trace_sample_rules",
+            ]
+        )
+        event = set_and_wait_rc_telemetry(test_agent, config_overrides={"tracing_sampling_rules": sampling_rule,},)
+        configuration = event["payload"]["configuration"]
+        rules = next(filter(lambda x: x["name"] in telemetry_names, configuration))["value"]
+        if context.library.library == "nodejs":
+            assert json.loads(rules) == sampling_rule_without_tags
+        elif context.library.library == "python":
+            assert json.loads(rules) == sampling_rule_with_modified_tags
+        elif context.library.library == "golang":
+            assert json.loads(rules) == sampling_rule_with_modified_tags
+        elif context.library.library == "ruby":
+            assert rules == sampling_rule_with_modified_tags
+        else:
+            assert json.loads(rules) == sampling_rule


### PR DESCRIPTION
The tracers currently send slightly different telemetry payloads. We'll unify telemetry behaviour across languages before adding this test.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

