### PR TITLE
[python] remove old Test_Login tests for python

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -348,12 +348,8 @@ tests/:
         '*': v2.10.0-rc1
         uwsgi-poc: bug
     test_automated_login_events.py:
-      Test_Login_Events: 
-        '*': v2.10.0.dev
-        fastapi: missing_feature
-      Test_Login_Events_Extended: 
-        '*': v2.10.0.dev
-        fastapi: missing_feature
+      Test_Login_Events: irrelevant(was v2.10.0.dev but will be replaced by V2)
+      Test_Login_Events_Extended: irrelevant(was v2.10.0.dev but will be replaced by V2)
       Test_V2_Login_Events: missing_feature
       Test_V2_Login_Events_Anon: missing_feature
     test_blocking_addresses.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -348,8 +348,8 @@ tests/:
         '*': v2.10.0-rc1
         uwsgi-poc: bug
     test_automated_login_events.py:
-      Test_Login_Events: irrelevant(was v2.10.0.dev but will be replaced by V2)
-      Test_Login_Events_Extended: irrelevant(was v2.10.0.dev but will be replaced by V2)
+      Test_Login_Events: irrelevant (was v2.10.0.dev but will be replaced by V2)
+      Test_Login_Events_Extended: irrelevant (was v2.10.0.dev but will be replaced by V2)
       Test_V2_Login_Events: missing_feature
       Test_V2_Login_Events_Anon: missing_feature
     test_blocking_addresses.py:


### PR DESCRIPTION
## Motivation

We are changing implementation of the user event feature. We need to deactivate the tests for the old feature to be able to add the new feature. The new feature will be tested later with the V2 version of the tests.

APPSEC-53571

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

