### PR TITLE
[java] Add support for auto user events in java

### DIFF
--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -73,6 +73,10 @@ class Test_Login_Events:
         context.library == "python" and context.scenario.weblog_variant in ["django-poc", "python3.12"],
         reason="APM reports all user id for now on Django",
     )
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_pii_success_basic(self):
         assert self.r_pii_success.status_code == 200
         for _, _, span in interfaces.library.get_spans(request=self.r_pii_success):
@@ -100,6 +104,10 @@ class Test_Login_Events:
         self.r_success = weblog.get("/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_USER_UUID_HEADER})
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_success_basic(self):
         assert self.r_success.status_code == 200
         for _, _, span in interfaces.library.get_spans(request=self.r_success):
@@ -136,6 +144,10 @@ class Test_Login_Events:
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
     @bug(context.library < "nodejs@4.9.0", reason="Reports empty space in usr.id when id is a PII")
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_wrong_user_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -156,7 +168,6 @@ class Test_Login_Events:
         )
 
     @bug(context.library < "nodejs@4.9.0", reason="Reports empty space in usr.id when id is a PII")
-    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     def test_login_wrong_password_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -177,8 +188,11 @@ class Test_Login_Events:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
-    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     @bug(context.library < "nodejs@4.9.0", reason="Reports empty space in usr.id when id is a PII")
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_wrong_password_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -216,6 +230,10 @@ class Test_Login_Events:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_sdk_success_basic(self):
         assert self.r_sdk_success.status_code == 200
         for _, _, span in interfaces.library.get_spans(request=self.r_sdk_success):
@@ -250,6 +268,10 @@ class Test_Login_Events:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_sdk_failure_basic(self):
         assert self.r_sdk_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_sdk_failure):
@@ -342,6 +364,10 @@ class Test_Login_Events_Extended:
         self.r_success = weblog.get("/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_USER_HEADER})
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_success_basic(self):
         assert self.r_success.status_code == 200
         for _, _, span in interfaces.library.get_spans(request=self.r_success):
@@ -428,7 +454,6 @@ class Test_Login_Events_Extended:
             "/login?auth=local", data={self.username_key: self.USER, self.password_key: "12345"}
         )
 
-    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     def test_login_wrong_password_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -452,7 +477,10 @@ class Test_Login_Events_Extended:
         self.r_wrong_user_failure = weblog.get("/login?auth=basic", headers={"Authorization": "Basic dGVzdDoxMjM0NQ=="})
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
-    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_wrong_password_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -495,6 +523,10 @@ class Test_Login_Events_Extended:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_sdk_success_basic(self):
         assert self.r_sdk_success.status_code == 200
         for _, _, span in interfaces.library.get_spans(request=self.r_sdk_success):
@@ -512,6 +544,10 @@ class Test_Login_Events_Extended:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_sdk_failure_basic(self):
         assert self.r_sdk_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_sdk_failure):
@@ -657,6 +693,10 @@ class Test_V2_Login_Events:
     def setup_login_pii_success_basic(self):
         self.r_pii_success = weblog.get("/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_USER_HEADER})
 
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_pii_success_basic(self):
         assert self.r_pii_success.status_code == 200
         for _, _, span in interfaces.library.get_spans(request=self.r_pii_success):
@@ -692,6 +732,10 @@ class Test_V2_Login_Events:
     def setup_login_success_basic(self):
         self.r_success = weblog.get("/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_USER_UUID_HEADER})
 
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_success_basic(self):
         assert self.r_success.status_code == 200
         for _, _, span in interfaces.library.get_spans(request=self.r_success):
@@ -731,6 +775,10 @@ class Test_V2_Login_Events:
             "/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_INVALID_USER_HEADER}
         )
 
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_wrong_user_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -752,7 +800,6 @@ class Test_V2_Login_Events:
             "/login?auth=local", data={self.username_key: self.USER, self.password_key: "12345"}
         )
 
-    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     def test_login_wrong_password_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -776,7 +823,10 @@ class Test_V2_Login_Events:
             "/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_INVALID_PASSWORD_HEADER}
         )
 
-    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_wrong_password_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -816,6 +866,10 @@ class Test_V2_Login_Events:
             headers={"Authorization": self.BASIC_AUTH_USER_HEADER},
         )
 
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_sdk_success_basic(self):
         assert self.r_sdk_success.status_code == 200
         for _, _, span in interfaces.library.get_spans(request=self.r_sdk_success):
@@ -849,6 +903,10 @@ class Test_V2_Login_Events:
             headers={"Authorization": self.BASIC_AUTH_INVALID_USER_HEADER},
         )
 
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_sdk_failure_basic(self):
         assert self.r_sdk_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_sdk_failure):
@@ -933,6 +991,10 @@ class Test_V2_Login_Events_Anon:
     def setup_login_success_basic(self):
         self.r_success = weblog.get("/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_USER_HEADER})
 
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_success_basic(self):
         assert self.r_success.status_code == 200
         for _, _, span in interfaces.library.get_spans(request=self.r_success):
@@ -975,6 +1037,10 @@ class Test_V2_Login_Events_Anon:
             "/login?auth=basic", headers={"Authorization": "Basic aW52YWxpZFVzZXI6MTIzNA=="}
         )
 
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_wrong_user_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -995,7 +1061,6 @@ class Test_V2_Login_Events_Anon:
             "/login?auth=local", data={self.username_key: self.USER, self.password_key: "12345"}
         )
 
-    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     def test_login_wrong_password_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -1013,7 +1078,10 @@ class Test_V2_Login_Events_Anon:
     def setup_login_wrong_password_failure_basic(self):
         self.r_wrong_user_failure = weblog.get("/login?auth=basic", headers={"Authorization": "Basic dGVzdDoxMjM0NQ=="})
 
-    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_wrong_password_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -1050,6 +1118,10 @@ class Test_V2_Login_Events_Anon:
             headers={"Authorization": self.BASIC_AUTH_USER_HEADER},
         )
 
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_sdk_success_basic(self):
         assert self.r_sdk_success.status_code == 200
         for _, _, span in interfaces.library.get_spans(request=self.r_sdk_success):
@@ -1066,6 +1138,10 @@ class Test_V2_Login_Events_Anon:
             headers={"Authorization": "Basic aW52YWxpZFVzZXI6MTIzNA=="},
         )
 
+    @irrelevant(
+        context.library == "java",
+        reason="Basic auth makes insecure protocol test fail due to dedup, fixed in the next tracer release",
+    )
     def test_login_sdk_failure_basic(self):
         assert self.r_sdk_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_sdk_failure):

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -156,6 +156,7 @@ class Test_Login_Events:
         )
 
     @bug(context.library < "nodejs@4.9.0", reason="Reports empty space in usr.id when id is a PII")
+    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     def test_login_wrong_password_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -176,6 +177,7 @@ class Test_Login_Events:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     @bug(context.library < "nodejs@4.9.0", reason="Reports empty space in usr.id when id is a PII")
     def test_login_wrong_password_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
@@ -426,6 +428,7 @@ class Test_Login_Events_Extended:
             "/login?auth=local", data={self.username_key: self.USER, self.password_key: "12345"}
         )
 
+    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     def test_login_wrong_password_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -449,6 +452,7 @@ class Test_Login_Events_Extended:
         self.r_wrong_user_failure = weblog.get("/login?auth=basic", headers={"Authorization": "Basic dGVzdDoxMjM0NQ=="})
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     def test_login_wrong_password_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -748,6 +752,7 @@ class Test_V2_Login_Events:
             "/login?auth=local", data={self.username_key: self.USER, self.password_key: "12345"}
         )
 
+    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     def test_login_wrong_password_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -771,6 +776,7 @@ class Test_V2_Login_Events:
             "/login?auth=basic", headers={"Authorization": self.BASIC_AUTH_INVALID_PASSWORD_HEADER}
         )
 
+    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     def test_login_wrong_password_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -989,6 +995,7 @@ class Test_V2_Login_Events_Anon:
             "/login?auth=local", data={self.username_key: self.USER, self.password_key: "12345"}
         )
 
+    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     def test_login_wrong_password_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -1006,6 +1013,7 @@ class Test_V2_Login_Events_Anon:
     def setup_login_wrong_password_failure_basic(self):
         self.r_wrong_user_failure = weblog.get("/login?auth=basic", headers={"Authorization": "Basic dGVzdDoxMjM0NQ=="})
 
+    @missing_feature(context.library == "java", reason="Cannot reliably check if the user exists")
     def test_login_wrong_password_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, _, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):

--- a/utils/build/docker/java/spring-boot/pom.xml
+++ b/utils/build/docker/java/spring-boot/pom.xml
@@ -167,6 +167,11 @@
             <artifactId>kinesis</artifactId>
             <version>2.17.51</version>
         </dependency>
+        <dependency>
+            <groupId>com.datadoghq</groupId>
+            <artifactId>dd-trace-api</artifactId>
+            <version>${dd-trace-java.version}</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -434,5 +439,6 @@
         <protobuf.version>3.16.3</protobuf.version>
         <grpc.version>1.31.0</grpc.version>
         <packaging.type>jar</packaging.type>
+        <dd-trace-java.version>1.35.0</dd-trace-java.version>
 	</properties>
 </project>

--- a/utils/build/docker/java/spring-boot/pom.xml
+++ b/utils/build/docker/java/spring-boot/pom.xml
@@ -167,11 +167,6 @@
             <artifactId>kinesis</artifactId>
             <version>2.17.51</version>
         </dependency>
-        <dependency>
-            <groupId>com.datadoghq</groupId>
-            <artifactId>dd-trace-api</artifactId>
-            <version>${dd-trace-java.version}</version>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -439,6 +434,5 @@
         <protobuf.version>3.16.3</protobuf.version>
         <grpc.version>1.31.0</grpc.version>
         <packaging.type>jar</packaging.type>
-        <dd-trace-java.version>1.35.0</dd-trace-java.version>
 	</properties>
 </project>

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/WebSecurityConfig.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/WebSecurityConfig.java
@@ -1,17 +1,44 @@
 package com.datadoghq.system_tests.springboot;
 
+import com.datadoghq.system_tests.springboot.security.AppSecAuthenticationFilter;
+import com.datadoghq.system_tests.springboot.security.AppSecAuthenticationProvider;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 @Configuration
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
+
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return new ProviderManager(new AppSecAuthenticationProvider());
+    }
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+        AuthenticationManager manager = authenticationManager();
         http
-        .authorizeRequests().anyRequest().permitAll()
-        .and()
-        .csrf().disable()
-        .headers().disable();
+            .authenticationManager(manager)
+            .addFilterBefore(new AppSecAuthenticationFilter("/login", manager), UsernamePasswordAuthenticationFilter.class)
+            .authorizeRequests()
+                    .antMatchers("/login").authenticated()
+                    .anyRequest().permitAll()
+            .and()
+            .csrf().disable()
+            .headers().disable();
     }
 }

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecAuthenticationFilter.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.datadoghq.system_tests.springboot.security;
+
+import static java.util.Collections.emptyList;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.Base64Utils;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class AppSecAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    public AppSecAuthenticationFilter(String url, AuthenticationManager authenticationManager) {
+        super(new AntPathRequestMatcher(url), authenticationManager);
+        this.setAuthenticationSuccessHandler((request, response, authentication) -> {
+            response.getWriter().write("Hello " + authentication.getName());
+            response.setStatus(HttpStatus.OK.value());
+        });
+        this.setAuthenticationFailureHandler((request, response, exception) -> {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), exception.getMessage());
+        });
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException, ServletException {
+        final String auth = request.getParameter("auth");
+        String username, password;
+        switch (auth) {
+            case "local":
+                username = request.getParameter("username");
+                password = request.getParameter("password");
+                break;
+            case "basic":
+                String header = request.getHeader("Authorization");
+                String[] parts = header.split("\\s+");
+                assert parts.length == 2;
+                assert parts[0].equals("Basic");
+                String[] usernamePassword = new String(Base64Utils.decodeFromString(parts[1])).split(":");
+                username = usernamePassword[0];
+                password = usernamePassword[1];
+                break;
+            default:
+                return null;
+        }
+        Authentication authentication;
+        String sdkEvent = request.getParameter("sdk_event");
+        if (sdkEvent != null) {
+            String sdkUser = request.getParameter("sdk_user");
+            boolean sdkUserExists = Boolean.parseBoolean(request.getParameter("sdk_user_exists"));
+            authentication = new AppSecSdkToken(username, password, sdkEvent, sdkUser, sdkUserExists);
+        } else {
+            authentication = new AppSecSdkToken(username, password);
+        }
+        return this.getAuthenticationManager().authenticate(authentication);
+    }
+}

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecAuthenticationProvider.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecAuthenticationProvider.java
@@ -1,0 +1,76 @@
+package com.datadoghq.system_tests.springboot.security;
+
+import datadog.trace.api.EventTracker;
+import datadog.trace.api.GlobalTracer;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AppSecAuthenticationProvider implements AuthenticationProvider {
+
+    private static final Map<String, AppSecUser> USERS = new HashMap<>();
+
+    static {
+        Arrays.asList(
+                new AppSecUser("social-security-id", "test", "1234", "testuser@ddog.com"),
+                new AppSecUser("591dc126-8431-4d0f-9509-b23318d3dce4", "testuuid", "1234", "testuseruuid@ddog.com")
+        ).forEach(user -> USERS.put(user.getUsername(), user));
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        AppSecSdkToken token = (AppSecSdkToken) authentication;
+        if (token.getSdkEvent() == null) {
+            return loginUserPassword(token);
+        } else {
+            return loginSdk(token);
+        }
+    }
+
+    private Authentication loginUserPassword(final AppSecSdkToken auth) {
+        String username = auth.getName();
+        if (!USERS.containsKey(username)) {
+            throw new UsernameNotFoundException(username);
+        }
+        final AppSecUser user = USERS.get(username);
+        if (!user.getPassword().equals(auth.getCredentials())) {
+            throw new BadCredentialsException(username);
+        }
+        return new AppSecSdkToken(new AppSecUser(user), auth.getCredentials(), Collections.emptyList());
+    }
+
+    private Authentication loginSdk(final AppSecSdkToken auth) {
+        String username = auth.getSdkUser();
+        Map<String, String> metadata = new HashMap<>();
+        EventTracker tracker = GlobalTracer.getEventTracker();
+        switch (auth.getSdkEvent()) {
+            case "success":
+                tracker.trackLoginSuccessEvent(username, metadata);
+                return new AppSecSdkToken(username, auth.getCredentials(), Collections.emptyList());
+            case "failure":
+                tracker.trackLoginFailureEvent(username, auth.isSdkUserExists(), metadata);
+                if (auth.isSdkUserExists()) {
+                    throw new BadCredentialsException(username);
+                } else {
+                    throw new UsernameNotFoundException(username);
+                }
+            default:
+                throw new IllegalArgumentException("Invalid SDK event: " + auth.getSdkEvent());
+        }
+
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return AppSecSdkToken.class.isAssignableFrom(authentication);
+    }
+
+
+}

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecSdkToken.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecSdkToken.java
@@ -1,0 +1,55 @@
+package com.datadoghq.system_tests.springboot.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+/**
+ * Token used to bypass appsec auto user instrumentation when using the SDK
+ */
+public class AppSecSdkToken extends UsernamePasswordAuthenticationToken {
+
+    private String sdkEvent;
+
+    private String sdkUser;
+
+    private boolean sdkUserExists;
+
+    public AppSecSdkToken(Object principal, Object credentials) {
+        this(principal, credentials, null, null, false);
+    }
+
+    public AppSecSdkToken(Object principal, Object credentials, String sdkEvent, String sdkUser, boolean sdkUserExists) {
+        super(principal, credentials);
+        this.sdkEvent = sdkEvent;
+        this.sdkUser = sdkUser;
+        this.sdkUserExists = sdkUserExists;
+    }
+
+    public AppSecSdkToken(Object principal, Object credentials,
+                          Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+
+    @Override
+    public String getName() {
+        if (getPrincipal() instanceof AppSecUser) {
+            // report the id instead of the username
+            return ((AppSecUser) getPrincipal()).getId();
+        }
+        return super.getName();
+    }
+
+    public String getSdkEvent() {
+        return sdkEvent;
+    }
+
+    public String getSdkUser() {
+        return sdkUser;
+    }
+
+    public boolean isSdkUserExists() {
+        return sdkUserExists;
+    }
+}

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecUser.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecUser.java
@@ -1,0 +1,29 @@
+package com.datadoghq.system_tests.springboot.security;
+
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collections;
+
+public class AppSecUser extends User {
+
+    private final String id;
+    private final String email;
+
+    public AppSecUser(String id, String username, String password, String email) {
+        super(username, password, Collections.emptyList());
+        this.id = id;
+        this.email = email;
+    }
+
+    public AppSecUser(AppSecUser user) {
+        this(user.getId(), user.getUsername(), user.getPassword(), user.getEmail());
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getId() {
+        return id;
+    }
+}


### PR DESCRIPTION
## Motivation

Add support to test auto user login events in java.

## Changes

Updates the spring-boot weblog to include support for the login endpoints

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

