### PR TITLE
update test for user events

### DIFF
--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -641,7 +641,7 @@ class Test_V2_Login_Events:
         for _, _, span in interfaces.library.get_spans(request=self.r_pii_success):
             meta = span.get("meta", {})
             assert "usr.id" in meta
-            assert "usr.id" == "social-security-id"
+            assert meta["usr.id"] == "social-security-id"
             # deprecated tags
             assert "appsec.events.users.login.success.email" not in meta
             assert "appsec.events.users.login.success.username" not in meta
@@ -658,7 +658,7 @@ class Test_V2_Login_Events:
         for _, _, span in interfaces.library.get_spans(request=self.r_pii_success):
             meta = span.get("meta", {})
             assert "usr.id" in meta
-            assert "usr.id" == "social-security-id"
+            assert meta["usr.id"] == "social-security-id"
             # deprecated tags
             assert "appsec.events.users.login.success.email" not in meta
             assert "appsec.events.users.login.success.username" not in meta
@@ -715,7 +715,7 @@ class Test_V2_Login_Events:
                 # this assertion is disabled for this library.
                 assert meta["appsec.events.users.login.failure.usr.exists"] == "false"
 
-            assert "appsec.events.users.login.failure.usr.id" not in meta
+            assert meta["appsec.events.users.login.failure.usr.id"] == "invalidUser"
             assert "appsec.events.users.login.failure.usr.email" not in meta
             assert "appsec.events.users.login.failure.usr.login" not in meta
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
@@ -736,7 +736,7 @@ class Test_V2_Login_Events:
                 # this assertion is disabled for this library.
                 assert meta["appsec.events.users.login.failure.usr.exists"] == "false"
 
-            assert "appsec.events.users.login.failure.usr.id" not in meta
+            assert meta["appsec.events.users.login.failure.usr.id"] == "invalidUser"
             assert "appsec.events.users.login.failure.usr.email" not in meta
             assert "appsec.events.users.login.failure.usr.login" not in meta
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
@@ -958,7 +958,7 @@ class Test_V2_Login_Events_Anon:
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
             assert meta["appsec.events.users.login.failure.track"] == "true"
 
-            assert "appsec.events.users.login.failure.usr.id" not in meta
+            assert meta["appsec.events.users.login.failure.usr.id"] == "anon_2141e3bee69f7de45b4f1d8d1f29258a"
             assert "appsec.events.users.login.failure.email" not in meta
             assert "appsec.events.users.login.failure.username" not in meta
 
@@ -978,7 +978,7 @@ class Test_V2_Login_Events_Anon:
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
             assert meta["appsec.events.users.login.failure.track"] == "true"
 
-            assert "appsec.events.users.login.failure.usr.id" not in meta
+            assert meta["appsec.events.users.login.failure.usr.id"] == "anon_2141e3bee69f7de45b4f1d8d1f29258a"
             assert "appsec.events.users.login.failure.email" not in meta
             assert "appsec.events.users.login.failure.username" not in meta
 


### PR DESCRIPTION
- fix a small error (wrong assertions)
- add check for user.id when user does not exist

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

