### PR TITLE
Use digest auth instead of basic in the insecure auth protocol test

### DIFF
--- a/tests/appsec/iast/sink/test_insecure_auth_protocol.py
+++ b/tests/appsec/iast/sink/test_insecure_auth_protocol.py
@@ -15,7 +15,9 @@ class Test_InsecureAuthProtocol(BaseSinkTest):
     insecure_endpoint = "/iast/insecure-auth-protocol/test"
     secure_endpoint = "/iast/insecure-auth-protocol/test"
     data = {}
-    insecure_headers = {"Authorization": "Basic dGVzd"}
+    insecure_headers = {
+        "Authorization": 'Digest username="WATERFORD", realm="Users", nonce="c5rcvu346qavqf3hnmsrnqj5up", uri="/api/partner/validate", response="57c8d9f11ec7a2f1ab13c5e166b2c505"'
+    }
 
     @missing_feature(library="java", reason="Not implemented yet")
     @missing_feature(library="dotnet", reason="Not implemented yet")


### PR DESCRIPTION
## Motivation

User event tracking test use basic authentication that might cause the vulnerability to not be triggered depending on the order of execution of the tests. 

## Changes

Use digest instead of basic for the insecure auth protocol test.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

