### PR TITLE
[.NET] enable another parametric test for remote sampling rules

### DIFF
--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -690,7 +690,7 @@ class TestDynamicConfigSamplingRules:
         reason="JSON tag format in RC differs from the JSON tag format used in DD_TRACE_SAMPLING_RULES",
     )
     @bug(context.library == "ruby", reason="RC_SAMPLING_TAGS_RULE_RATE is not respected")
-    @bug(context.library == "dotnet", reason="Not applying correct sampling rate")
+    @bug(context.library <= "dotnet@2.53.2", reason="Applies rate from local sampling rule when no remote rules match.")
     @missing_feature(library="nodejs")
     @missing_feature(library="python")
     def test_trace_sampling_rules_with_tags(self, test_agent, test_library):


### PR DESCRIPTION
## Motivation

Enable another parametric test for remote sampling rules in .NET.

Follow up from #2553, where we enabled `TestDynamicConfigSamplingRules`, but skipped `test_trace_sampling_rules_with_tags` because it was failing for two reasons:
- the .NET test app app did not support adding span tags, fixed in #2553
- the .NET SDK was looking at local sampling rules as a fallback when no remote rules matched, the expected behavior is to ignore all local rules if remote rules are configured (even if none of them match), fixed in DataDog/dd-trace-dotnet/pull/5720

## Changes

Enable this test.
```
test_dynamic_configuration.py
    TestDynamicConfigSamplingRules
        test_trace_sampling_rules_with_tags
```

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

