### PR TITLE
fix(installer): Close stdout when not closed

### DIFF
--- a/utils/build/virtual_machine/weblogs/dotnet/test-app-dotnet-container/test-app-dotnet_docker_compose_run.sh
+++ b/utils/build/virtual_machine/weblogs/dotnet/test-app-dotnet-container/test-app-dotnet_docker_compose_run.sh
@@ -3,8 +3,6 @@
 
 set -e
 
-[  -z "$DD_DOCKER_LOGIN_PASS" ] && echo "Skipping docker loging. Consider set the variable DOCKER_LOGIN and DOCKER_LOGIN_PASS" || echo "$DD_DOCKER_LOGIN_PASS" | sudo docker login --username "$DD_DOCKER_LOGIN" --password-stdin 
-
 # shellcheck disable=SC2035
 sudo chmod -R 755 *
 


### PR DESCRIPTION
## Motivation
Current hypothesis is that we're hitting https://github.com/paramiko/paramiko/issues/515, so this PR tries to implement the suggested https://github.com/paramiko/paramiko/issues/109#issuecomment-111621658 fix.

## Changes
Implements https://github.com/paramiko/paramiko/issues/109#issuecomment-111621658 for our use case

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

