### PR TITLE
Add a test for conflicts in auto-user-instrum

### DIFF
--- a/docs/RC/RC-API.md
+++ b/docs/RC/RC-API.md
@@ -31,8 +31,8 @@ class Test_RemoteConfigSequence:
 
     def test_asm_switch_on_switch_off():
         # first check that both config state are ok, otherwise, next assertions will fail with cryptic messages
-        assert self.config_state_activation["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_state_activation
-        assert self.config_state_deactivation["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_state_deactivation
+        assert self.config_state_activation["asm_features_activation"]["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_state_activation
+        assert self.config_state_deactivation["asm_features_activation"]["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_state_deactivation
 
         interfaces.library.assert_no_appsec_event(self.first_request)
         interfaces.library.assert_waf_attack(self.second_request)

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -1283,16 +1283,20 @@ class Test_V2_Login_Events_RC:
         return "user[password]" if "rails" in context.weblog_variant else "password"
 
     def _send_rc_and_execute_request(self, rc_payload):
-        config_state = rc.send_command(raw_payload=rc_payload)
+        config_states = rc.send_command(raw_payload=rc_payload)
         request = weblog.post(
             "/login?auth=local", data={self.username_key: self.USER, self.password_key: self.PASSWORD}
         )
-        return {"config_state": config_state, "request": request}
+        return {"config_states": config_states, "request": request}
 
     def _assert_response(self, test, validation):
-        config_state, request = test["config_state"], test["request"]
-        assert config_state["apply_state"] == rc.ApplyState.ACKNOWLEDGED, config_state
+        config_states, request = test["config_states"], test["request"]
+
+        for config_state in config_states.values():
+            assert config_state["apply_state"] == rc.ApplyState.ACKNOWLEDGED, config_state
+
         assert request.status_code == 200
+
         spans = [s for _, _, s in interfaces.library.get_spans(request=request)]
         assert spans, "No spans to validate"
         for span in spans:

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -20,6 +20,7 @@ from utils import (
 @features.user_monitoring
 class Test_Login_Events:
     "Test login success/failure use cases"
+
     # User entries in the internal DB:
     # users = [
     #     {
@@ -1235,10 +1236,9 @@ def assert_priority(span, meta):
 @features.user_monitoring
 @scenarios.appsec_auto_events_rc
 class Test_V2_Login_Events_RC:
-
     USER = "test"
     PASSWORD = "1234"
-    # ["disabled", "identification", "anonymization"]
+    # ["disabled", "identification", "anonymization", "anonymization+disabled(conflict)", "anonymization"]
     PAYLOADS = [
         {
             "targets": "eyJzaWduZWQiOnsiX3R5cGUiOiJ0YXJnZXRzIiwiY3VzdG9tIjp7Im9wYXF1ZV9iYWNrZW5kX3N0YXRlIjoiZXlKbWIyOGlPaUFpWW1GeUluMD0ifSwiZXhwaXJlcyI6IjMwMDAtMDEtMDFUMDA6MDA6MDBaIiwic3BlY192ZXJzaW9uIjoiMS4wIiwidGFyZ2V0cyI6eyJkYXRhZG9nLzIvQVNNX0ZFQVRVUkVTL2F1dG8tdXNlci1pbnN0cnVtL2NvbmZpZyI6eyJjdXN0b20iOnsidiI6MX0sImhhc2hlcyI6eyJzaGEyNTYiOiJlZDRiNmZmNWRkMmQ3MWI5NjE0YjcxMzMwMTg4MjU2MmNmNGQ4ODk3YWRlMzIzYTZkMmQ5ZGViZDRhNzNhZDA0In0sImxlbmd0aCI6NTZ9fSwidmVyc2lvbiI6MX0sInNpZ25hdHVyZXMiOlt7ImtleWlkIjoiZWQ3NjcyYzlhMjRhYmRhNzg4NzJlZTMyZWU3MWM3Y2IxZDUyMzVlOGRiNGVjYmYxY2EyOGI5YzUwZWI3NWQ5ZSIsInNpZyI6IjIyZDhlOTE0ZWM1NmE0MmQ4MTE4MmE4Y2RkODQyMTI0OTIyMDhlZDllNjRjZjQ2Mjg1ZTIxY2NjMjdhY2NhZDRlZDc3N2Y5MDkwNGVlYmZiODhiNDQ2ZGUxMGNkMjk1YzNjZDJlNjM1NmY4MjMzNDk5MzM1OTQ4YTRkMDI1ZTBkIn1dfQ==",
@@ -1268,6 +1268,23 @@ class Test_V2_Login_Events_RC:
                     "raw": "ewogICJhdXRvX3VzZXJfaW5zdHJ1bSI6IHsKICAgICJtb2RlIjogImFub255bWl6YXRpb24iCiAgfQp9Cg==",
                 }
             ],
+            "client_configs": ["datadog/2/ASM_FEATURES/auto-user-instrum/config"],
+        },
+        {
+            "targets": "eyJzaWduZWQiOnsiX3R5cGUiOiJ0YXJnZXRzIiwiY3VzdG9tIjp7Im9wYXF1ZV9iYWNrZW5kX3N0YXRlIjoiZXlKbWIyOGlPaUFpWW1GeUluMD0ifSwiZXhwaXJlcyI6IjMwMDAtMDEtMDFUMDA6MDA6MDBaIiwic3BlY192ZXJzaW9uIjoiMS4wIiwidGFyZ2V0cyI6eyJkYXRhZG9nLzIvQVNNX0ZFQVRVUkVTL2F1dG8tdXNlci1pbnN0cnVtLWNvbmZsaWN0L2NvbmZpZyI6eyJjdXN0b20iOnsidiI6Mn0sImhhc2hlcyI6eyJzaGEyNTYiOiJlZDRiNmZmNWRkMmQ3MWI5NjE0YjcxMzMwMTg4MjU2MmNmNGQ4ODk3YWRlMzIzYTZkMmQ5ZGViZDRhNzNhZDA0In0sImxlbmd0aCI6NTZ9LCJkYXRhZG9nLzIvQVNNX0ZFQVRVUkVTL2F1dG8tdXNlci1pbnN0cnVtL2NvbmZpZyI6eyJjdXN0b20iOnsidiI6M30sImhhc2hlcyI6eyJzaGEyNTYiOiIwMjRiOGM4MmQxODBkZjc2NzMzNzVjYzYzZDdiYmRjMzRiNWE4YzE3NWQzNzE3ZGQwYjYyMzg2OTRhY2FiNWI3In0sImxlbmd0aCI6NjF9fSwidmVyc2lvbiI6NH0sInNpZ25hdHVyZXMiOlt7ImtleWlkIjoiZWQ3NjcyYzlhMjRhYmRhNzg4NzJlZTMyZWU3MWM3Y2IxZDUyMzVlOGRiNGVjYmYxY2EyOGI5YzUwZWI3NWQ5ZSIsInNpZyI6IjY4ZDYxM2MxNDlmZDUxM2IzOTFhZWM4ZWJjOTNhZDg2NWViZjA5NDYxMWYzNjRmMmE5YjZjNTJmMjQyMTUyN2U5YjM5ZWZhYTk4N2JmZWViZmUyYTVmZDcxMmI1MTA4Mzk3YWEwODNhNzZkZGExMzUyM2U5M2EyZWJiYjdlZTAyIn1dfQ==",
+            "target_files": [
+                {
+                    "path": "datadog/2/ASM_FEATURES/auto-user-instrum-conflict/config",
+                    "raw": "ewogICJhdXRvX3VzZXJfaW5zdHJ1bSI6IHsKICAgICJtb2RlIjogImRpc2FibGVkIgogIH0KfQo=",
+                }
+            ],
+            "client_configs": [
+                "datadog/2/ASM_FEATURES/auto-user-instrum-conflict/config",
+                "datadog/2/ASM_FEATURES/auto-user-instrum/config",
+            ],
+        },
+        {
+            "targets": "eyJzaWduZWQiOnsiX3R5cGUiOiJ0YXJnZXRzIiwiY3VzdG9tIjp7Im9wYXF1ZV9iYWNrZW5kX3N0YXRlIjoiZXlKbWIyOGlPaUFpWW1GeUluMD0ifSwiZXhwaXJlcyI6IjMwMDAtMDEtMDFUMDA6MDA6MDBaIiwic3BlY192ZXJzaW9uIjoiMS4wIiwidGFyZ2V0cyI6eyJkYXRhZG9nLzIvQVNNX0ZFQVRVUkVTL2F1dG8tdXNlci1pbnN0cnVtL2NvbmZpZyI6eyJjdXN0b20iOnsidiI6M30sImhhc2hlcyI6eyJzaGEyNTYiOiIwMjRiOGM4MmQxODBkZjc2NzMzNzVjYzYzZDdiYmRjMzRiNWE4YzE3NWQzNzE3ZGQwYjYyMzg2OTRhY2FiNWI3In0sImxlbmd0aCI6NjF9fSwidmVyc2lvbiI6NX0sInNpZ25hdHVyZXMiOlt7ImtleWlkIjoiZWQ3NjcyYzlhMjRhYmRhNzg4NzJlZTMyZWU3MWM3Y2IxZDUyMzVlOGRiNGVjYmYxY2EyOGI5YzUwZWI3NWQ5ZSIsInNpZyI6IjkzYmY3N2JmMmVjZTg3NzhhNjlkMWEyOTM3YzM5MTFhYjZiNzIxMDU0ZDNlNmNjMzJkMTA2YWIzOWVlM2I0ZDc5MTllNmZmNWU3NWYyN2U5Y2ViNWY3NTJiZjA2OGYwNjk4MjI3Yjg1MTdiNzBiOTdiMzdlMGI2M2QyMzU5ODAwIn1dfQ==",
             "client_configs": ["datadog/2/ASM_FEATURES/auto-user-instrum/config"],
         },
     ]
@@ -1319,3 +1336,7 @@ class Test_V2_Login_Events_RC:
         self._assert_response(self.tests[0], validate_disabled)
         self._assert_response(self.tests[1], validate_iden)
         self._assert_response(self.tests[2], validate_anon)
+        # after adding conflict (anonymization+disabled), fallback to local tracer value (identification)
+        self._assert_response(self.tests[3], validate_iden)
+        # after removing conflict, use the previous remote config value
+        self._assert_response(self.tests[4], validate_anon)

--- a/tests/appsec/test_runtime_activation.py
+++ b/tests/appsec/test_runtime_activation.py
@@ -39,6 +39,7 @@ class Test_RuntimeActivation:
         self.response_with_activated_waf = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
     def test_asm_features(self):
-        assert self.config_state["apply_state"] == rc.ApplyState.ACKNOWLEDGED, self.config_state
+        activation_state = self.config_state["asm_features_activation"]
+        assert activation_state["apply_state"] == rc.ApplyState.ACKNOWLEDGED, self.config_state
         interfaces.library.assert_no_appsec_event(self.response_with_deactivated_waf)
         interfaces.library.assert_waf_attack(self.response_with_activated_waf)

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -36,41 +36,42 @@ def send_command(raw_payload, *, wait_for_acknowledged_status: bool = True) -> d
 
     client_configs = raw_payload["client_configs"]
 
+    current_states = {}
     if len(client_configs) == 0:
-        config_id, product, version = None, None, None
         if wait_for_acknowledged_status:
             raise ValueError("Empty client config list is not supported with wait_for_acknowledged_status=True")
-    elif len(client_configs) == 1:
+    else:
         targets = json.loads(base64.b64decode(raw_payload["targets"]))
         version = targets["signed"]["version"]
-        _, _, product, config_id, _ = client_configs[0].split("/")
-    else:
-        raise ValueError("Only zero or one client config are supported")
-
-    config_state = {
-        "id": config_id,
-        "product": product,
-        "apply_state": ApplyState.UNKNOWN,
-        "apply_error": "<No known response from the library>",
-    }
+        for client_config in client_configs:
+            _, _, product, config_id, _ = client_config.split("/")
+            current_states[config_id] = {
+                "id": config_id,
+                "product": product,
+                "apply_state": ApplyState.UNKNOWN,
+                "apply_error": "<No known response from the library>",
+            }
 
     def remote_config_applied(data):
         if data["path"] == "/v0.7/config":
             if len(client_configs) == 0:  # is there a way to know if the "no-config" is acknowledged ?
                 return True
 
-            config_states = (
-                data.get("request", {}).get("content", {}).get("client", {}).get("state", {}).get("config_states", [])
-            )
-            for state in config_states:
-                if state["id"] == config_id and state["product"] == product and state["version"] == version:
-                    logger.debug(f"Remote config state: {state}")
-                    config_state.update(state)
-                    if wait_for_acknowledged_status:
-                        if state["apply_state"] == ApplyState.ACKNOWLEDGED:
-                            return True
-                    else:
-                        return True
+            state = data.get("request", {}).get("content", {}).get("client", {}).get("state", {})
+            if state["targets_version"] == version:
+                config_states = state.get("config_states", [])
+                for state in config_states:
+                    config_state = current_states.get(state["id"])
+                    if config_state and state["product"] == product:
+                        logger.debug(f"Remote config state: {state}")
+                        config_state.update(state)
+
+                if wait_for_acknowledged_status:
+                    for state in current_states.values():
+                        if state["apply_state"] == ApplyState.UNKNOWN:
+                            return False
+
+                return True
 
     if "SYSTEM_TESTS_PROXY_HOST" in os.environ:
         domain = os.environ["SYSTEM_TESTS_PROXY_HOST"]
@@ -87,7 +88,7 @@ def send_command(raw_payload, *, wait_for_acknowledged_status: bool = True) -> d
 
     library.wait_for(remote_config_applied, timeout=30)
 
-    return config_state
+    return current_states
 
 
 def build_debugger_command(probes: list, version: int):

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -149,7 +149,7 @@ def build_debugger_command(probes: list, version: int):
                 elif library_name == "java":
                     probe["where"]["typeName"] = "DebuggerController"
                     probe["where"]["methodName"] = (
-                        probe["where"]["methodName"][0].lower() + probe["where"]["methodName"][1:]
+                            probe["where"]["methodName"][0].lower() + probe["where"]["methodName"][1:]
                     )
             elif probe["where"]["sourceFile"] == "ACTUAL_SOURCE_FILE":
                 if library_name == "dotnet":

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -149,7 +149,7 @@ def build_debugger_command(probes: list, version: int):
                 elif library_name == "java":
                     probe["where"]["typeName"] = "DebuggerController"
                     probe["where"]["methodName"] = (
-                            probe["where"]["methodName"][0].lower() + probe["where"]["methodName"][1:]
+                        probe["where"]["methodName"][0].lower() + probe["where"]["methodName"][1:]
                     )
             elif probe["where"]["sourceFile"] == "ACTUAL_SOURCE_FILE":
                 if library_name == "dotnet":


### PR DESCRIPTION
## Motivation

Check the behavior of the tracers when conflicting remote config payloads are received from the agent in regards to auto user instrumentation.

## Changes

Add new config files to the test triggering a conflict in the configuration of auto user instrumentation.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

