### PR TITLE
Allow multiple config files in RC payloads

### DIFF
--- a/docs/RC/RC-API.md
+++ b/docs/RC/RC-API.md
@@ -31,8 +31,8 @@ class Test_RemoteConfigSequence:
 
     def test_asm_switch_on_switch_off():
         # first check that both config state are ok, otherwise, next assertions will fail with cryptic messages
-        assert self.config_state_activation["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_state_activation
-        assert self.config_state_deactivation["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_state_deactivation
+        assert self.config_state_activation["asm_features_activation"]["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_state_activation
+        assert self.config_state_deactivation["asm_features_activation"]["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_state_deactivation
 
         interfaces.library.assert_no_appsec_event(self.first_request)
         interfaces.library.assert_waf_attack(self.second_request)

--- a/docs/RC/RC-API.md
+++ b/docs/RC/RC-API.md
@@ -22,17 +22,17 @@ class Test_RemoteConfigSequence:
         self.first_request = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
         # this function will send a RC payload to the library, and wait for a confirmation from the library
-        self.config_state_activation = remote_config.send_command(raw_payload=ACTIVATE_ASM_PAYLOAD)
+        self.config_states_activation = remote_config.send_command(raw_payload=ACTIVATE_ASM_PAYLOAD)
         self.second_request = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
         # now deactivate the WAF, and check that it does not catch anything
-        self.config_state_deactivation = remote_config.send_command(raw_payload=DEACTIVATE_ASM_PAYLOAD)
+        self.config_states_deactivation = remote_config.send_command(raw_payload=DEACTIVATE_ASM_PAYLOAD)
         self.third_request = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
     def test_asm_switch_on_switch_off():
         # first check that both config state are ok, otherwise, next assertions will fail with cryptic messages
-        assert self.config_state_activation["asm_features_activation"]["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_state_activation
-        assert self.config_state_deactivation["asm_features_activation"]["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_state_deactivation
+        assert self.config_states_activation["asm_features_activation"]["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_states_activation
+        assert self.config_states_deactivation["asm_features_activation"]["apply_state"] == remote_config.ApplyState.ACKNOWLEDGED, self.config_states_deactivation
 
         interfaces.library.assert_no_appsec_event(self.first_request)
         interfaces.library.assert_waf_attack(self.second_request)

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -1283,16 +1283,20 @@ class Test_V2_Login_Events_RC:
         return "user[password]" if "rails" in context.weblog_variant else "password"
 
     def _send_rc_and_execute_request(self, rc_payload):
-        config_state = rc.send_command(raw_payload=rc_payload)
+        config_states = rc.send_command(raw_payload=rc_payload)
         request = weblog.post(
             "/login?auth=local", data={self.username_key: self.USER, self.password_key: self.PASSWORD}
         )
-        return {"config_state": config_state, "request": request}
+        return {"config_states": config_states, "request": request}
 
     def _assert_response(self, test, validation):
-        config_state, request = test["config_state"], test["request"]
-        assert config_state["apply_state"] == rc.ApplyState.ACKNOWLEDGED, config_state
+        config_states, request = test["config_states"], test["request"]
+
+        for config_state in config_states.values():
+            assert config_state["apply_state"] == rc.ApplyState.ACKNOWLEDGED, config_state
+
         assert request.status_code == 200
+
         spans = [s for _, _, s in interfaces.library.get_spans(request=request)]
         assert spans, "No spans to validate"
         for span in spans:

--- a/tests/appsec/test_runtime_activation.py
+++ b/tests/appsec/test_runtime_activation.py
@@ -39,6 +39,7 @@ class Test_RuntimeActivation:
         self.response_with_activated_waf = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
     def test_asm_features(self):
-        assert self.config_state["apply_state"] == rc.ApplyState.ACKNOWLEDGED, self.config_state
+        activation_state = self.config_state["asm_features_activation"]
+        assert activation_state["apply_state"] == rc.ApplyState.ACKNOWLEDGED, self.config_state
         interfaces.library.assert_no_appsec_event(self.response_with_deactivated_waf)
         interfaces.library.assert_waf_attack(self.response_with_activated_waf)

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -17,14 +17,18 @@ from utils.dd_constants import RemoteConfigApplyState as ApplyState
 from utils.tools import logger
 
 
-def send_command(raw_payload, *, wait_for_acknowledged_status: bool = True) -> dict[str, Any]:
+def send_command(raw_payload, *, wait_for_acknowledged_status: bool = True) -> dict[str, dict[str, Any]]:
     """
         Sends a remote config payload to the library and waits for the config to be applied.
-        Then returns the config state returned by the library :
+        Then returns a dictionary with the state of each requested file as returned by the library.
+        
+        The dictionary keys are the IDs from the files that can be extracted from the path,
+        e.g: datadog/2/ASM_FEATURES/asm_features_activation/config => asm_features_activation
+        and the values contain the actual state for each file:
 
-        1. the first config state acknowledging the config
+        1. a config state acknowledging the config
         2. else if not acknowledged, the last config state received
-        3. if not config state received, then an harcoded one with apply_state=UNKNOWN
+        3. if no config state received, then a hardcoded one with apply_state=UNKNOWN
 
         Arguments:
             wait_for_acknowledge_status

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -36,41 +36,42 @@ def send_command(raw_payload, *, wait_for_acknowledged_status: bool = True) -> d
 
     client_configs = raw_payload["client_configs"]
 
+    current_states = {}
     if len(client_configs) == 0:
-        config_id, product, version = None, None, None
         if wait_for_acknowledged_status:
             raise ValueError("Empty client config list is not supported with wait_for_acknowledged_status=True")
-    elif len(client_configs) == 1:
+    else:
         targets = json.loads(base64.b64decode(raw_payload["targets"]))
         version = targets["signed"]["version"]
-        _, _, product, config_id, _ = client_configs[0].split("/")
-    else:
-        raise ValueError("Only zero or one client config are supported")
-
-    config_state = {
-        "id": config_id,
-        "product": product,
-        "apply_state": ApplyState.UNKNOWN,
-        "apply_error": "<No known response from the library>",
-    }
+        for client_config in client_configs:
+            _, _, product, config_id, _ = client_config.split("/")
+            current_states[config_id] = {
+                "id": config_id,
+                "product": product,
+                "apply_state": ApplyState.UNKNOWN,
+                "apply_error": "<No known response from the library>",
+            }
 
     def remote_config_applied(data):
         if data["path"] == "/v0.7/config":
             if len(client_configs) == 0:  # is there a way to know if the "no-config" is acknowledged ?
                 return True
 
-            config_states = (
-                data.get("request", {}).get("content", {}).get("client", {}).get("state", {}).get("config_states", [])
-            )
-            for state in config_states:
-                if state["id"] == config_id and state["product"] == product and state["version"] == version:
-                    logger.debug(f"Remote config state: {state}")
-                    config_state.update(state)
-                    if wait_for_acknowledged_status:
-                        if state["apply_state"] == ApplyState.ACKNOWLEDGED:
-                            return True
-                    else:
-                        return True
+            state = data.get("request", {}).get("content", {}).get("client", {}).get("state", {})
+            if state["targets_version"] == version:
+                config_states = state.get("config_states", [])
+                for state in config_states:
+                    config_state = current_states.get(state["id"])
+                    if config_state and state["product"] == product:
+                        logger.debug(f"Remote config state: {state}")
+                        config_state.update(state)
+
+                if wait_for_acknowledged_status:
+                    for state in current_states.values():
+                        if state["apply_state"] == ApplyState.UNKNOWN:
+                            return False
+
+                return True
 
     if "SYSTEM_TESTS_PROXY_HOST" in os.environ:
         domain = os.environ["SYSTEM_TESTS_PROXY_HOST"]
@@ -87,7 +88,7 @@ def send_command(raw_payload, *, wait_for_acknowledged_status: bool = True) -> d
 
     library.wait_for(remote_config_applied, timeout=30)
 
-    return config_state
+    return current_states
 
 
 def build_debugger_command(probes: list, version: int):


### PR DESCRIPTION
## Motivation

Some RC test scenarios might require using multiple config files at the same time to validate correct behavior.

## Changes

Add support for multiple config files in RC payloads.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

