### PR TITLE
Add tests for external env

### DIFF
--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -165,7 +165,7 @@ class Test_LibraryHeaders:
                 assert all(
                     c in string.hexdigits for c in val[3:]
                 ), f"Datadog-Entity-ID header value {val} doesn't end with hex digits"
-            # The cid prefix is deprecated and should
+            # The cid prefix is deprecated and will be removed in a future version of the agent
             elif val.startswith("cid-"):
                 assert all(
                     c in string.hexdigits for c in val[4:]

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -161,12 +161,34 @@ class Test_LibraryHeaders:
             val = request_headers["datadog-entity-id"]
             if val.startswith("in-"):
                 assert val[3:].isdigit(), f"Datadog-Entity-ID header value {val} doesn't end with digits"
+            elif val.startswith("ci-"):
+                assert all(
+                    c in string.hexdigits for c in val[3:]
+                ), f"Datadog-Entity-ID header value {val} doesn't end with hex digits"
+            # The cid prefix is deprecated and should
             elif val.startswith("cid-"):
                 assert all(
                     c in string.hexdigits for c in val[4:]
                 ), f"Datadog-Entity-ID header value {val} doesn't end with hex digits"
             else:
-                raise ValueError(f"Datadog-Entity-ID header value {val} doesn't start with either 'in-' or 'cid-'")
+                raise ValueError(
+                    f"Datadog-Entity-ID header value {val} doesn't start with either 'in-', 'ci-' or 'cid-'"
+                )
+
+        interfaces.library.validate(validator, success_by_default=True)
+
+    def test_datadog_external_env(self):
+        """Datadog-External-Env header if present is in the {prefix}-{value},... format"""
+
+        def validator(data):
+            for header, value in data["request"]["headers"]:
+                if header.lower() == "datadog-external-env":
+                    assert value, "Datadog-External-Env header is empty"
+                    items = value.split(",")
+                    for item in items:
+                        assert (
+                            item[2] == "-"
+                        ), f"Datadog-External-Env item {item} is not using in the format {{prefix}}-{{value}}"
 
         interfaces.library.validate(validator, success_by_default=True)
 


### PR DESCRIPTION
## Motivation

Update tests to support `datadog-external-env` header and new entity id prefix as defined in the [new RFC](https://datadoghq.atlassian.net/wiki/spaces/CONTP/pages/3731783774/New+Origin+Detection+Spec+for+Traces+and+DogStatsD)

## Changes

- Add `ci` as a valid prefix for `entity-id`
- Add test for `datadog-external-env` format

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

