### PR TITLE
fix(tests): Add retry when waiting for weblog to be available

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,8 +126,7 @@ onboarding_dotnet:
   stage: dotnet_tracer
   allow_failure: true
   dependencies: []
-  only:
-    - schedules
+  when: always
   variables:
     TEST_LIBRARY: "dotnet"
   parallel:
@@ -135,15 +134,6 @@ onboarding_dotnet:
         - ONBOARDING_FILTER_ENV: [dev, prod]
           ONBOARDING_FILTER_WEBLOG: [test-app-dotnet]
           SCENARIO: [HOST_AUTO_INJECTION, HOST_AUTO_INJECTION_INSTALL_SCRIPT]
-        - ONBOARDING_FILTER_ENV: [dev, prod]
-          ONBOARDING_FILTER_WEBLOG: [test-shell-script]
-          SCENARIO: [HOST_AUTO_INJECTION_BLOCK_LIST]
-        - ONBOARDING_FILTER_ENV: [dev, prod]
-          ONBOARDING_FILTER_WEBLOG: [test-app-dotnet,test-app-dotnet-container]
-          SCENARIO: [INSTALLER_AUTO_INJECTION]
-        - ONBOARDING_FILTER_ENV: [dev, prod]
-          ONBOARDING_FILTER_WEBLOG: [test-app-dotnet-container]
-          SCENARIO: [CONTAINER_AUTO_INJECTION, CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT]
   script:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env ${ONBOARDING_FILTER_ENV} --vm-library ${TEST_LIBRARY} --vm-provider aws

--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -29,7 +29,7 @@ class _AutoInjectBaseTest:
             request_uuid = make_internal_get_request(virtual_machine.krunvm_config.stdin, vm_port)
         else:
             logger.info(f"Waiting for weblog available [{vm_ip}:{vm_port}]")
-            wait_for_port(vm_port, vm_ip, 80.0)
+            wait_for_port(vm_port, vm_ip, 80.0, 5)
             logger.info(f"[{vm_ip}]: Weblog app is ready!")
             warmup_weblog(f"http://{vm_ip}:{vm_port}/")
             logger.info(f"Making a request to weblog [{vm_ip}:{vm_port}]")

--- a/utils/onboarding/wait_for_tcp_port.py
+++ b/utils/onboarding/wait_for_tcp_port.py
@@ -20,21 +20,26 @@ SOFTWARE.
 
 import socket
 import time
+from utils.tools import logger
 
 
-def wait_for_port(port: int, host: str = "localhost", timeout: float = 5.0):
+def wait_for_port(port: int, host: str = "localhost", timeout: float = 5.0, min_retries: int = 1):
     """Wait until a port starts accepting TCP connections.
     Args:
         port: Port number.
         host: Host address on which the port should exist.
         timeout: In seconds. How long to wait before raising errors.
+        min_retries: Minimum number of retries. Used to define the per-try timeout.
     Raises:
         TimeoutError: The port isn't accepting connection after time specified in `timeout`.
     """
     start_time = time.perf_counter()
+    try_count = 0
     while True:
+        try_count+=1
+        logger.info(f"Waiting for [{host}:{port}] to accept connections. Try #{try_count}, {timeout - (time.perf_counter() - start_time):.2f}s left.")
         try:
-            with socket.create_connection((host, port), timeout=timeout):
+            with socket.create_connection((host, port), timeout=timeout / min_retries):
                 break
         except OSError as ex:
             time.sleep(0.01)


### PR DESCRIPTION
## Motivation
https://gitlab.ddbuild.io/DataDog/system-tests/-/jobs/555954680 failing semi-consistently

## Changes
We didn't retry when checking if the port is available before a test. The socket connection could get stuck and timeout while the app is ready. This PR adds retries to avoid that.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

