### PR TITLE
OnBoarding: Fix log parser

### DIFF
--- a/utils/onboarding/injection_log_parser.py
+++ b/utils/onboarding/injection_log_parser.py
@@ -18,8 +18,6 @@ def command_injection_skipped(command_line, log_local_path):
         if command in first_line_json["inFilename"]:
             # last line contains the skip message. The command was skipped by build-in deny list or by user deny list
             last_line_json = json.loads(command_desc[-1])
-            logger.info("RMM checking")
-            logger.info(last_line_json)
             # pylint: disable=R1705
             if last_line_json["msg"] == "not injecting; on deny list":
                 logger.debug(f"    Command {command_args} was skipped by build-in deny list")

--- a/utils/onboarding/injection_log_parser.py
+++ b/utils/onboarding/injection_log_parser.py
@@ -18,6 +18,8 @@ def command_injection_skipped(command_line, log_local_path):
         if command in first_line_json["inFilename"]:
             # last line contains the skip message. The command was skipped by build-in deny list or by user deny list
             last_line_json = json.loads(command_desc[-1])
+            logger.info("RMM checking")
+            logger.info(last_line_json)
             # pylint: disable=R1705
             if last_line_json["msg"] == "not injecting; on deny list":
                 logger.debug(f"    Command {command_args} was skipped by build-in deny list")
@@ -28,8 +30,13 @@ def command_injection_skipped(command_line, log_local_path):
 
             # Perhaps the command was instrumented or could be skipped by its arguments. Checking
             elif _get_command_props_values(command_desc, command_args) is True:
-                if last_line_json["msg"] in ["error when parsing", "skipping"] and last_line_json["error"].startswith(
-                    "skipping due to ignore rules for language"
+                if last_line_json["msg"] in ["error injecting", "error when parsing", "skipping"] and (
+                    last_line_json["error"].startswith(
+                        (
+                            "skipping due to ignore rules for language",
+                            "error when parsing: skipping due to ignore rules for language",
+                        )
+                    )
                 ):
                     logger.info(f"    Command {command_args} was skipped by ignore arguments")
                     return True


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The last changes in auto_inject imply changing our log parser, to keep detecting the commands ignored by user rules, by rules related to their arguments

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

