### PR TITLE
[java] Add requires endpoints for SQLi protection in RASP

### DIFF
--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/IastRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/IastRoutes.scala
@@ -1,18 +1,14 @@
 package com.datadoghq.akka_http
 
-import akka.http.javadsl.marshallers.jackson.Jackson
-import akka.http.scaladsl.marshalling.Marshaller
-import akka.http.scaladsl.model.{RequestEntity, StatusCodes}
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import com.datadoghq.system_tests.iast.infra.{LdapServer, SqlServer}
+import com.datadoghq.akka_http.Resources.{dataSource, ldapContext}
 import com.datadoghq.system_tests.iast.utils._
 
 import java.sql.Statement
 
 object IastRoutes {
-  private val dataSource = new SqlServer().start
-  private val ldapContext = new LdapServer().start
 
   private val superSecretAccessKey = "insecure"
   private val cmd = new CmdExamples()

--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/Main.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/Main.scala
@@ -2,13 +2,20 @@ package com.datadoghq.akka_http
 
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
+import com.datadoghq.system_tests.iast.infra.{LdapServer, SqlServer}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 
 object Main extends App {
+
   private val bindingFuture: Future[Http.ServerBinding] =
-    Http().newServerAt("0.0.0.0", 7777).bindFlow(AppSecRoutes.route ~ IastRoutes.route)
+    Http().newServerAt("0.0.0.0", 7777).bindFlow(AppSecRoutes.route ~ IastRoutes.route ~ RaspRoutes.route)
 
   LoggerFactory.getLogger(this.getClass).info("Server online at port 7777")
+}
+
+object Resources {
+  final val dataSource = new SqlServer().start
+  final val ldapContext = new LdapServer().start
 }

--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/RaspRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/RaspRoutes.scala
@@ -1,0 +1,66 @@
+package com.datadoghq.akka_http
+
+import akka.http.javadsl.marshallers.jackson.Jackson
+import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
+import com.datadoghq.akka_http.Resources.dataSource
+import com.fasterxml.jackson.annotation.JsonProperty
+
+import scala.util.{Try, Using}
+import scala.xml.{Elem, XML}
+
+object RaspRoutes {
+
+  private final val mapJsonUnmarshaller: Unmarshaller[HttpEntity, UserDTO] = {
+    Jackson.unmarshaller(classOf[UserDTO])
+      .asScala
+      .forContentTypes(MediaTypes.`application/json`)
+  }
+
+  val route: Route = pathPrefix("rasp") {
+    pathPrefix("sqli") {
+      get {
+        parameter("user_id") { userId =>
+          complete(executeSql(userId))
+        }
+      } ~
+        post {
+          formFieldMap { fields: Map[String, String] =>
+            complete(executeSql(fields("user_id")))
+          } ~
+            entity(Unmarshaller.messageUnmarshallerFromEntityUnmarshaller(mapJsonUnmarshaller)) { user =>
+              complete(executeSql(user.userId))
+            } ~ entity(as[UserDTO]) { user =>
+            complete(executeSql(user.userId))
+          }
+        }
+    }
+  }
+
+  case class UserDTO(@JsonProperty("user_id") userId: String) {}
+
+  implicit val userXmlUnmarshaller: FromEntityUnmarshaller[UserDTO] =
+    Unmarshaller.stringUnmarshaller.forContentTypes(MediaTypes.`text/xml`, MediaTypes.`application/xml`).map { string =>
+      val xmlData: Elem = XML.loadString(string)
+      val userId = xmlData.text
+      UserDTO(userId)
+    }
+
+
+  private def executeSql(userId: String): Try[String] = {
+    Using(dataSource.getConnection()) { conn =>
+      val stmt = conn.prepareCall("select * from user where username = '" + userId + "'")
+      val set = stmt.executeQuery();
+      if (set.next()) {
+        "ID: " + set.getLong("ID")
+      } else {
+        "User not found"
+      }
+    }
+  }
+}
+
+
+

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/RaspResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/RaspResource.java
@@ -1,0 +1,76 @@
+package com.datadoghq.jersey;
+
+import static com.datadoghq.jersey.Main.DATA_SOURCE;
+
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlValue;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+
+@Path("/rasp")
+@Produces(MediaType.TEXT_PLAIN)
+public class RaspResource {
+
+    @GET
+    @Path("/sqli")
+    public String sqliGet(@QueryParam("user_id") final String userId) throws Exception {
+        return executeSql(userId);
+    }
+
+    @POST
+    @Path("/sqli")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public String sqliPost(@FormParam("user_id") final String userId) throws Exception {
+        return executeSql(userId);
+    }
+
+    @POST
+    @Path("/sqli")
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON} )
+    public String sqliBody(final UserDTO user) throws Exception {
+        return executeSql(user.getUserId());
+    }
+
+    @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+    private String executeSql(final String userId) throws Exception {
+        try (final Connection conn = DATA_SOURCE.getConnection()) {
+            final CallableStatement stmt = conn.prepareCall("select * from user where username = '" + userId + "'");
+            final ResultSet set = stmt.executeQuery();
+            if (set.next()) {
+                return "ID: " + set.getLong("ID");
+            } else {
+                return "User not found";
+            }
+        }
+    }
+
+    @XmlRootElement(name = "user_id")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class UserDTO {
+        @JsonbProperty("user_id")
+        @XmlValue
+        private String userId;
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public void setUserId(String userId) {
+            this.userId = userId;
+        }
+    }
+}

--- a/utils/build/docker/java/play.Dockerfile
+++ b/utils/build/docker/java/play.Dockerfile
@@ -10,6 +10,7 @@ RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 
 COPY ./utils/build/docker/java/play/app ./app
 COPY ./utils/build/docker/java/play/conf ./conf
+COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 RUN mvn -Dmaven.repo.local=/maven play2:routes-compile package play2:dist-exploded
 
 COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/

--- a/utils/build/docker/java/play/app/Module.scala
+++ b/utils/build/docker/java/play/app/Module.scala
@@ -1,10 +1,8 @@
 import com.google.inject.AbstractModule
-import play.inject.Module.bindClass
-import play.libs.ws.WSClient
+import resources.Resources
 
 class Module extends AbstractModule {
   override def configure() = {
-//    bind(classOf[WSClient]).toInstance()
+    bind(classOf[Resources]).asEagerSingleton()
   }
-
 }

--- a/utils/build/docker/java/play/app/controllers/RaspController.scala
+++ b/utils/build/docker/java/play/app/controllers/RaspController.scala
@@ -1,0 +1,38 @@
+package controllers
+
+import play.api.mvc._
+import resources.Resources
+
+import javax.inject.{Inject, Singleton}
+import scala.util.Using
+
+@Singleton
+class RaspController @Inject()(cc: MessagesControllerComponents, res: Resources) extends AbstractController(cc) {
+
+  def sqli = Action { request =>
+    val userId = request.body match {
+      case AnyContentAsFormUrlEncoded(data) =>
+        data("user_id").head
+      case AnyContentAsJson(data) =>
+        (data \ "user_id").as[String]
+      case AnyContentAsXml(data) =>
+        data.text
+      case _ =>
+        request.queryString("user_id").head
+    }
+    Results.Ok(executeSql(userId))
+  }
+
+  private def executeSql(userId: String): String = {
+    Using(res.dataSource.getConnection()) { conn =>
+      val stmt = conn.prepareCall("select * from user where username = '" + userId + "'")
+      val set = stmt.executeQuery();
+      if (set.next()) {
+        "ID: " + set.getLong("ID")
+      } else {
+        "User not found"
+      }
+    }.get
+  }
+
+}

--- a/utils/build/docker/java/play/app/resources/Resources.scala
+++ b/utils/build/docker/java/play/app/resources/Resources.scala
@@ -1,0 +1,7 @@
+package resources
+
+import com.datadoghq.system_tests.iast.infra.SqlServer
+
+class Resources {
+  final val dataSource = new SqlServer().start
+}

--- a/utils/build/docker/java/play/conf/routes
+++ b/utils/build/docker/java/play/conf/routes
@@ -12,3 +12,5 @@ GET  /users                    controllers.AppSecController.users(user: String)
 GET  /user_login_success_event controllers.AppSecController.loginSuccess(event_user_id: Option[String])
 GET  /user_login_failure_event controllers.AppSecController.loginFailure(event_user_id: Option[String], event_user_exists: Option[Boolean])
 GET  /custom_event             controllers.AppSecController.customEvent(event_name: Option[String])
+GET  /rasp/sqli                controllers.RaspController.sqli
+POST /rasp/sqli                controllers.RaspController.sqli

--- a/utils/build/docker/java/play/pom.xml
+++ b/utils/build/docker/java/play/pom.xml
@@ -66,6 +66,21 @@
             <artifactId>dd-trace-api</artifactId>
             <version>1.14.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.74</version>
+        </dependency>
+        <dependency>
+            <groupId>com.unboundid</groupId>
+            <artifactId>unboundid-ldapsdk</artifactId>
+            <version>6.0.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.7.1</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -135,6 +150,39 @@
                 <executions>
                     <execution>
                         <goals><goal>routes-compile</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>../iast-common/src/main/java/</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-resource</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>../iast-common/src/main/resources/</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
+++ b/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
@@ -1,5 +1,6 @@
 package com.datadoghq.ratpack;
 
+import com.datadoghq.system_tests.iast.infra.SqlServer;
 import com.datadoghq.system_tests.iast.utils.CryptoExamples;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.internal.InternalTracer;
@@ -25,6 +26,8 @@ import java.net.URL;
 import java.util.Map;
 import java.util.List;
 import ratpack.util.MultiValueMap;
+
+import javax.sql.DataSource;
 
 /**
  * Main class.
@@ -62,7 +65,9 @@ public class Main {
     }
 
     public static void main(String[] args) throws Exception {
+
         var iastHandlers = new IastHandlers();
+        var raspHandlers = new RaspHandlers();
         var server = RatpackServer.start(s ->
                 s.serverConfig(action -> action
                         .address(InetAddress.getByName("0.0.0.0"))
@@ -187,8 +192,8 @@ public class Main {
                                 ctx.getResponse().send("ok");
                             });
                         iastHandlers.setup(chain);
-                        }
-                )
+                        raspHandlers.setup(chain);
+                })
         );
         System.out.println("Ratpack server started on port 7777");
         while (!Thread.interrupted()) {
@@ -207,5 +212,7 @@ public class Main {
         public HashMap<String, String> request_headers;
         public HashMap<String, String> response_headers;
     }
+
+    public static final DataSource DATA_SOURCE = new SqlServer().start();
 }
 

--- a/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/RaspHandlers.java
+++ b/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/RaspHandlers.java
@@ -1,0 +1,134 @@
+package com.datadoghq.ratpack;
+
+
+import static com.datadoghq.ratpack.Main.DATA_SOURCE;
+import static ratpack.jackson.Jackson.fromJson;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+import com.google.common.reflect.TypeToken;
+import ratpack.form.Form;
+import ratpack.handling.Chain;
+import ratpack.handling.Context;
+import ratpack.handling.Handler;
+import ratpack.http.HttpMethod;
+import ratpack.http.MediaType;
+import ratpack.http.Status;
+import ratpack.http.TypedData;
+import ratpack.parse.Parse;
+import ratpack.parse.ParserSupport;
+import ratpack.registry.Registry;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+
+public class RaspHandlers {
+
+    public void setup(Chain chain) {
+        chain.path("rasp/sqli", new Handler() {
+            @Override
+            public void handle(final Context ctx) throws Exception {
+                MediaType contentType = ctx.getRequest().getContentType();
+                if (ctx.getRequest().getMethod() == HttpMethod.GET) {
+                    ctx.insert(QueryHandler.INSTANCE);
+                } else if (contentType.isForm()) {
+                    ctx.insert(FormHandler.INSTANCE);
+                } else if (contentType.isJson()) {
+                    ctx.insert(JsonHandler.INSTANCE);
+                } else if (contentType.getType().equals("application/xml") || contentType.getType().equals("text/xml")) {
+                    ctx.insert(Registry.single(XmlParser.INSTANCE), XmlHandler.INSTANCE);
+                } else {
+                    ctx.getResponse().status(Status.BAD_REQUEST);
+                }
+            }
+        });
+    }
+
+    enum FormHandler implements Handler {
+        INSTANCE;
+
+        @Override
+        public void handle(Context ctx) throws Exception {
+            var form = ctx.parse(Form.class);
+            form.then(f -> executeSql(ctx, f.get("user_id")));
+        }
+    }
+
+    enum JsonHandler implements Handler {
+        INSTANCE;
+
+        @Override
+        public void handle(Context ctx) throws Exception {
+            var obj = ctx.parse(fromJson(UserDTO.class));
+            obj.then(user -> executeSql(ctx, user.getUserId()));
+        }
+    }
+
+    static class XmlParser extends ParserSupport<Void> {
+        final static XmlParser INSTANCE = new XmlParser();
+
+        static final XmlMapper XML_MAPPER = new XmlMapper();
+
+        @Override
+        public <T> T parse(Context context, TypedData requestBody, Parse<T, Void> parse) throws Exception {
+            return XML_MAPPER.readValue(requestBody.getInputStream(), toJavaType(parse.getType()));
+        }
+
+        private static <T> JavaType toJavaType(TypeToken<T> type) {
+            return XML_MAPPER.getTypeFactory().constructType(type.getType());
+        }
+    }
+
+    enum XmlHandler implements Handler {
+        INSTANCE;
+
+        @Override
+        public void handle(Context ctx) throws Exception {
+            var xml = ctx.parse(Parse.of(UserDTO.class));
+            xml.then(user -> executeSql(ctx, user.getUserId()));
+        }
+    }
+
+    enum QueryHandler implements Handler {
+        INSTANCE;
+
+        @Override
+        public void handle(Context ctx) throws Exception {
+            var userId = ctx.getRequest().getQueryParams().get("user_id");
+            executeSql(ctx, userId);
+        }
+    }
+
+    @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+    private static void executeSql(final Context ctx, final String userId) throws Exception {
+        try (final Connection conn = DATA_SOURCE.getConnection()) {
+            final CallableStatement stmt = conn.prepareCall("select * from user where username = '" + userId + "'");
+            final ResultSet set = stmt.executeQuery();
+            if (set.next()) {
+                ctx.getResponse().send("text/plain", "ID: " + set.getLong("ID"));
+            } else {
+                ctx.getResponse().send("text/plain", "User not found");
+            }
+        }
+    }
+
+
+    @JacksonXmlRootElement(localName = "user_id")
+    public static class UserDTO {
+        @JsonProperty("user_id")
+        @JacksonXmlText
+        private String userId;
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public void setUserId(String userId) {
+            this.userId = userId;
+        }
+    }
+}

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/Main.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/Main.java
@@ -55,7 +55,8 @@ public class Main {
             private final Set<Object> singletons = Stream.of(
                     new MyResource(),
                     new IastSinkResource(),
-                    new IastSourceResource()
+                    new IastSourceResource(),
+                    new RaspResource()
             ).collect(Collectors.toSet());
 
             @Override

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/RaspResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/RaspResource.java
@@ -1,0 +1,74 @@
+package com.datadoghq.resteasy;
+
+import static com.datadoghq.resteasy.Main.DATA_SOURCE;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+
+@Path("/rasp")
+@Produces(MediaType.TEXT_PLAIN)
+public class RaspResource {
+
+    @GET
+    @Path("/sqli")
+    public String sqliGet(@QueryParam("user_id") final String userId) throws Exception {
+        return executeSql(userId);
+    }
+
+    @POST
+    @Path("/sqli")
+    public String sqliPost(@FormParam("user_id") final String userId) throws Exception {
+        return executeSql(userId);
+    }
+
+    @POST
+    @Path("/sqli")
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON} )
+    public String sqliBody(final UserDTO user) throws Exception {
+        return executeSql(user.getUserId());
+    }
+
+    @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+    private String executeSql(final String userId) throws Exception {
+        try (final Connection conn = DATA_SOURCE.getConnection()) {
+            final CallableStatement stmt = conn.prepareCall("select * from user where username = '" + userId + "'");
+            final ResultSet set = stmt.executeQuery();
+            if (set.next()) {
+                return "ID: " + set.getLong("ID");
+            } else {
+                return "User not found";
+            }
+        }
+    }
+
+    @XmlRootElement(name = "user_id")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class UserDTO {
+        @JsonProperty("user_id")
+        @XmlValue
+        private String userId;
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public void setUserId(String userId) {
+            this.userId = userId;
+        }
+    }
+}

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -670,36 +670,6 @@ public class App {
         return "hi OGNL";
     }
 
-    // E.g. curl "http://localhost:8080/sqli?q=%271%27%20union%20select%20%2A%20from%20display_names"
-    @RequestMapping("/rasp/sqli")
-    String raspSQLi(@RequestParam(required = false, name="q") String param) {
-        final Span span = GlobalTracer.get().activeSpan();
-        if (span != null) {
-            span.setTag("appsec.event", true);
-        }
-
-        // NOTE: see README.md for setting up the docker image to quickly test this
-        String url = "jdbc:postgresql://postgres_db/sportsdb?user=postgres&password=postgres";
-        try (Connection pgConn = DriverManager.getConnection(url)) {
-            String query = "SELECT * FROM display_names WHERE full_name = ";
-            Statement st = pgConn.createStatement();
-            ResultSet rs = st.executeQuery(query + param);
-
-            int i = 0;
-            while (rs.next()) {
-                i++;
-            }
-            System.out.printf("Read %d rows", i);
-            rs.close();
-            st.close();
-        } catch (SQLException e) {
-            e.printStackTrace(System.err);
-            return "pgsql exception :(";
-        }
-
-        return "Done SQL injection with param: " + param;
-    }
-
     @RequestMapping("/rasp/ssrf")
     String raspSSRF(@RequestParam(required = false, name="url") String url) {
         final Span span = GlobalTracer.get().activeSpan();

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rasp/RaspController.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rasp/RaspController.java
@@ -1,0 +1,71 @@
+package com.datadoghq.system_tests.springboot.rasp;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.sql.DataSource;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@Controller
+@RequestMapping("/rasp")
+public class RaspController {
+
+    private final DataSource dataSource;
+
+    public RaspController(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @RequestMapping(value = "/sqli", method = {GET, POST})
+    public ResponseEntity<String> sqli(@RequestParam("user_id") final String userId) throws SQLException {
+        return execSql(userId);
+    }
+
+    @PostMapping(value = "/sqli", consumes = {APPLICATION_XML_VALUE, APPLICATION_JSON_VALUE})
+    public ResponseEntity<String> sqli(@RequestBody final UserDTO body) throws SQLException {
+        return execSql(body.getUserId());
+    }
+
+
+    @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+    private ResponseEntity<String> execSql(final String userId) throws SQLException {
+        try (final Connection conn = dataSource.getConnection()) {
+            final CallableStatement stmt = conn.prepareCall("select * from user where username = '" + userId + "'");
+            final ResultSet set = stmt.executeQuery();
+            if (set.next()) {
+                return ResponseEntity.ok("ID: " + set.getLong("ID"));
+            }
+        }
+        return ResponseEntity.ok("User not found");
+    }
+
+    @JacksonXmlRootElement(localName = "user_id")
+    public static class UserDTO {
+        @JsonProperty("user_id")
+        @JacksonXmlText
+        private String userId;
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public void setUserId(String userId) {
+            this.userId = userId;
+        }
+    }
+}

--- a/utils/build/docker/java/vertx3/pom.xml
+++ b/utils/build/docker/java/vertx3/pom.xml
@@ -50,6 +50,21 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.3.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
@@ -4,6 +4,7 @@ import com.datadoghq.system_tests.iast.infra.LdapServer;
 import com.datadoghq.system_tests.iast.infra.SqlServer;
 import com.datadoghq.vertx3.iast.routes.IastSinkRouteProvider;
 import com.datadoghq.vertx3.iast.routes.IastSourceRouteProvider;
+import com.datadoghq.vertx3.rasp.RaspRouteProvider;
 import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
@@ -161,12 +162,16 @@ public class Main {
                 });
 
         iastRouteProviders().forEach(provider -> provider.accept(router));
-
+        raspRouteProviders().forEach(provider -> provider.accept(router));
         server.requestHandler(router::accept).listen(7777);
     }
 
     private static Stream<Consumer<Router>> iastRouteProviders() {
         return Stream.of(new IastSinkRouteProvider(DATA_SOURCE, LDAP_CONTEXT), new IastSourceRouteProvider(DATA_SOURCE));
+    }
+
+    private static Stream<Consumer<Router>> raspRouteProviders() {
+        return Stream.of(new RaspRouteProvider(DATA_SOURCE));
     }
 
     private static final Map<String, String> METADATA = createMetadata();

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/rasp/RaspRouteProvider.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/rasp/RaspRouteProvider.java
@@ -1,0 +1,83 @@
+package com.datadoghq.vertx3.rasp;
+
+import static io.vertx.core.http.HttpMethod.POST;
+
+import io.netty.buffer.ByteBufInputStream;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+
+import javax.sql.DataSource;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.function.Consumer;
+
+public class RaspRouteProvider implements Consumer<Router> {
+
+    private static final String USER_ID = "user_id";
+
+    private final DataSource dataSource;
+
+    public RaspRouteProvider(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void accept(final Router router) {
+        router.route("/rasp/*").method(POST).handler(BodyHandler.create());
+        router.route().path("/rasp/sqli").consumes("application/xml").blockingHandler(rc -> executeSql(rc, parseXml(rc.getBody()).getUserId()));
+        router.route().path("/rasp/sqli").consumes("application/json").blockingHandler(rc -> executeSql(rc, rc.getBodyAsJson().getString(USER_ID)));
+        router.route().path("/rasp/sqli").blockingHandler(rc -> executeSql(rc, rc.request().getParam(USER_ID)));
+    }
+
+    @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+    private void executeSql(final RoutingContext rc, final String userId) {
+        try (final Connection conn = dataSource.getConnection()) {
+            final CallableStatement stmt = conn.prepareCall("select * from user where username = '" + userId + "'");
+            final ResultSet set = stmt.executeQuery();
+            if (set.next()) {
+                rc.response().end("ID: " + set.getLong("ID"));
+            } else {
+                rc.response().end("User not found");
+            }
+        } catch (final Throwable e) {
+            rc.response().end(e.getMessage());
+        }
+    }
+
+    private UserDTO parseXml(final Buffer buffer) {
+        try {
+            JAXBContext jc = JAXBContext.newInstance(UserDTO.class);
+            Unmarshaller unmarshaller = jc.createUnmarshaller();
+            return (UserDTO) unmarshaller.unmarshal(new ByteBufInputStream(buffer.getByteBuf()));
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @XmlRootElement(name = USER_ID)
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class UserDTO {
+
+        @XmlValue
+        private String userId;
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public void setUserId(String userId) {
+            this.userId = userId;
+        }
+    }
+}

--- a/utils/build/docker/java/vertx4/pom.xml
+++ b/utils/build/docker/java/vertx4/pom.xml
@@ -50,6 +50,21 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.3.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
@@ -4,6 +4,7 @@ import com.datadoghq.system_tests.iast.infra.LdapServer;
 import com.datadoghq.system_tests.iast.infra.SqlServer;
 import com.datadoghq.vertx4.iast.routes.IastSinkRouteProvider;
 import com.datadoghq.vertx4.iast.routes.IastSourceRouteProvider;
+import com.datadoghq.vertx4.rasp.RaspRouteProvider;
 import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
@@ -160,12 +161,16 @@ public class Main {
                 });
 
         iastRouteProviders().forEach(provider -> provider.accept(router));
-
+        raspRouteProviders().forEach(provider -> provider.accept(router));
         server.requestHandler(router).listen(7777);
     }
 
     private static Stream<Consumer<Router>> iastRouteProviders() {
         return Stream.of(new IastSinkRouteProvider(DATA_SOURCE, LDAP_CONTEXT), new IastSourceRouteProvider(DATA_SOURCE));
+    }
+
+    private static Stream<Consumer<Router>> raspRouteProviders() {
+        return Stream.of(new RaspRouteProvider(DATA_SOURCE));
     }
 
     private static final Map<String, String> METADATA = createMetadata();

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/rasp/RaspRouteProvider.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/rasp/RaspRouteProvider.java
@@ -1,0 +1,84 @@
+package com.datadoghq.vertx4.rasp;
+
+import static io.vertx.core.http.HttpMethod.POST;
+
+import io.netty.buffer.ByteBufInputStream;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+
+import javax.sql.DataSource;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.function.Consumer;
+
+public class RaspRouteProvider implements Consumer<Router> {
+
+    private static final String USER_ID = "user_id";
+
+    private final DataSource dataSource;
+
+    public RaspRouteProvider(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void accept(final Router router) {
+        router.route("/rasp/*").method(POST).handler(BodyHandler.create());
+        router.route().path("/rasp/sqli").consumes("application/xml").blockingHandler(rc -> executeSql(rc, parseXml(rc.body().buffer()).getUserId()));
+        router.route().path("/rasp/sqli").consumes("application/json").blockingHandler(rc -> executeSql(rc, rc.body().asJsonObject().getString(USER_ID)));
+        router.route().path("/rasp/sqli").blockingHandler(rc -> executeSql(rc, rc.request().getParam(USER_ID)));
+    }
+
+    @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+    private void executeSql(final RoutingContext rc, final String userId) {
+        try (final Connection conn = dataSource.getConnection()) {
+            final CallableStatement stmt = conn.prepareCall("select * from user where username = '" + userId + "'");
+            final ResultSet set = stmt.executeQuery();
+            if (set.next()) {
+                rc.response().end("ID: " + set.getLong("ID"));
+            } else {
+                rc.response().end("User not found");
+            }
+        } catch (final Throwable e) {
+            rc.response().end(e.getMessage());
+        }
+    }
+
+    private UserDTO parseXml(final Buffer buffer) {
+        try {
+            JAXBContext jc = JAXBContext.newInstance(UserDTO.class);
+            Unmarshaller unmarshaller = jc.createUnmarshaller();
+            return (UserDTO) unmarshaller.unmarshal(new ByteBufInputStream(buffer.getByteBuf()));
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @XmlRootElement(name = USER_ID)
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class UserDTO {
+
+        @XmlValue
+        private String userId;
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public void setUserId(String userId) {
+            this.userId = userId;
+        }
+    }
+}
+


### PR DESCRIPTION
## Motivation

RASP protection requires custom weblog endpoints in order to validate protection capabilities

## Changes

Add required endpoints for RASP SQLi protection to all java weblogs

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

