### PR TITLE
Avoid blocking on content-language: en-us

### DIFF
--- a/tests/appsec/blocking_rule.json
+++ b/tests/appsec/blocking_rule.json
@@ -208,7 +208,7 @@
                 ]
               }
             ],
-            "regex": "en-us|krypton"
+            "regex": "fo-fo|krypton"
           },
           "operator": "match_regex",
           "options": {

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -492,7 +492,7 @@ class Test_Blocking_response_headers:
 
     def setup_blocking(self):
         if not hasattr(self, "rm_req_block1") or self.rm_req_block1 is None:
-            self.rm_req_block1 = weblog.get(f"/tag_value/anything/200?content-language=en-us")
+            self.rm_req_block1 = weblog.get(f"/tag_value/anything/200?content-language=fo-fo")
         if not hasattr(self, "rm_req_block2") or self.rm_req_block2 is None:
             self.rm_req_block2 = weblog.get(f"/tag_value/anything/200?content-language=krypton")
 
@@ -504,7 +504,7 @@ class Test_Blocking_response_headers:
 
     def setup_non_blocking(self):
         self.setup_blocking()
-        self.rm_req_nonblock1 = weblog.get(f"/tag_value/anything/200?content-color=en-us")
+        self.rm_req_nonblock1 = weblog.get(f"/tag_value/anything/200?content-color=fo-fo")
         self.rm_req_nonblock2 = weblog.get(f"/tag_value/anything/200?content-language=fr")
 
     def test_non_blocking(self):


### PR DESCRIPTION
## Motivation

OpenLiberty sets `Content-Language: en-US` on responses by default. Using this value in our test rules for blocking makes it trigger for every request. We could workaround this on the weblog side, but using a more uncommon value is simpler.

## Reviewer checklist

* [x] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* ~[ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change~
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* ~[ ] A docker base image is modified?~
    * ~[ ] the relevant `build-XXX-image` label is present~
* ~[ ] A scenario is added (or removed)?~
    * ~[ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)~

