### PR TITLE
PROF-9979: Remove the workaround now that installer script has been fixed

### DIFF
--- a/utils/build/virtual_machine/provisions/host-auto-inject-install-script/auto-inject_host_script.yml
+++ b/utils/build/virtual_machine/provisions/host-auto-inject-install-script/auto-inject_host_script.yml
@@ -14,9 +14,6 @@
     cat scenario_agent.env
     export $(cat scenario_agent.env | xargs) 
 
-    #workaround /etc/environment failures on installer script on Amazon Linux
-    printf "BOGUS=foo\n" | sudo tee -a /etc/environment   
-
     printf "DD_APM_RECEIVER_SOCKET=/opt/datadog/apm/inject/run/apm.socket\nDD_DOGSTATSD_SOCKET=/opt/datadog/apm/inject/run/dsd.socket\nDD_USE_DOGSTATSD=true\n" | sudo tee /var/run/datadog-installer/environment
     DD_APM_INSTRUMENTATION_ENABLED=host bash execute_install_script.sh
     sudo mkdir -p /var/run/datadog-installer


### PR DESCRIPTION
## Motivation

The agent linux installer script was released with the fix for failing on empty `/etc/environment`, making the workaround obsolete.

## Changes

Removes the VM setup remote command that ensured `/etc/environment` is not empty.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

