### PR TITLE
`build.sh`: fix typo in help text

### DIFF
--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -78,7 +78,7 @@ print_usage() {
     echo -e "  List weblogs for PHP:"
     echo -e "    ${SCRIPT_NAME} --list-weblogs --library php"
     echo -e "  Print default weblog for Python:"
-    echo -e "    ${SCRIPT_NAME} --default-weblogs --library python"
+    echo -e "    ${SCRIPT_NAME} --default-weblog --library python"
     echo
     echo -e "More info at https://github.com/DataDog/system-tests/blob/main/docs/execute/build.md"
     echo


### PR DESCRIPTION
## Motivation

I tried running the example below from `build.sh --help` and it failed.

```
OPTIONS
[...]
  --default-weblog           Prints the name of the default weblog for a given library and exits.

EXAMPLES
[...]
  Print default weblog for Python:
    ./utils/build/build.sh --default-weblogs --library python   <------ HERE
```

## Changes

Changed `--default-weblogs` to `--default-weblog` (no `s`) in the help text.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

