### PR TITLE
Fix replay_scenarios.sh

### DIFF
--- a/utils/scripts/replay_scenarios.sh
+++ b/utils/scripts/replay_scenarios.sh
@@ -3,8 +3,8 @@
 set -e
 
 
-# scenario getting backedn data are not yet supported
-NOT_SUPPPORTED=("K8S_LIB_INJECTION_BASIC" "K8S_LIB_INJECTION_FULL" "APM_TRACING_E2E_OTEL", "PARAMETRIC")
+# scenario getting backend data are not yet supported
+NOT_SUPPPORTED=("K8S_LIB_INJECTION_BASIC" "K8S_LIB_INJECTION_FULL" "APM_TRACING_E2E_OTEL" "PARAMETRIC")
 
 if [ -d "logs/" ]; then
     echo "[DEFAULT] Running replay mode"


### PR DESCRIPTION
## Motivation

```
Run ./utils/scripts/shellcheck.sh

In utils/scripts/replay_scenarios.sh line 7:
NOT_SUPPPORTED=("K8S_LIB_INJECTION_BASIC" "K8S_LIB_INJECTION_FULL" "APM_TRACING_E2E_OTEL", "PARAMETRIC")
               ^-- SC[205](https://github.com/DataDog/system-tests/actions/runs/9746295616/job/26896265909?pr=2601#step:3:215)4 (warning): Use spaces, not commas, to separate array elements.

For more information:
  https://www.shellcheck.net/wiki/SC2054 -- Use spaces, not commas, to separa...
```

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

