### PR TITLE
fix command path

### DIFF
--- a/utils/onboarding/injection_log_parser.py
+++ b/utils/onboarding/injection_log_parser.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from utils.tools import logger
 
@@ -59,7 +60,7 @@ def _parse_command(command):
         if "=" in com:
             command_args.remove(com)
             continue
-        return com, command_args
+        return os.path.basename(com), command_args
 
 
 def _get_command_props_values(command_instrumentation_desc, command_args_check):


### PR DESCRIPTION
Other iteration on tests for PR: https://github.com/DataDog/auto_inject/pull/266

detected executable path: executable Path: `/home/datadog/.pyenv/versions/3.8.15/bin/python3.8`
New failure
```
15:12:33.861 DEBUG    - Checking command: ['/home/datadog/.pyenv/shims/python', 'myscript.py', 'arg1', 'arg2', 'arg3']
15:12:33.861 INFO         Command /home/datadog/.pyenv/shims/python was NOT FOUND
```

Changed test to match on base path: https://gitlab.ddbuild.io/DataDog/auto_inject/-/jobs/559879541