### PR TITLE
[python] Fix parametric tests

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -106,9 +106,9 @@ def python_library_factory() -> APMLibraryTestServer:
         container_name="python-test-library",
         container_tag="python-test-library",
         container_img="""
-FROM ghcr.io/datadog/dd-trace-py/testrunner:7ce49bd78b0d510766fc5db12756a8840724febc
+FROM ghcr.io/datadog/dd-trace-py/testrunner:9e3bd1fb9e42a4aa143cae661547517c7fbd8924
 WORKDIR /app
-RUN pyenv global 3.9.11
+RUN pyenv global 3.9.16
 RUN python3.9 -m pip install fastapi==0.89.1 uvicorn==0.20.0
 COPY utils/build/docker/python/install_ddtrace.sh utils/build/docker/python/get_appsec_rules_version.py binaries* /binaries/
 RUN /binaries/install_ddtrace.sh

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -973,6 +973,8 @@ class ParametricScenario(_Scenario):
                 ".",
                 "-t",
                 "ddtracer_version",
+                "--progress",
+                "plain",
                 "-f",
                 f"{tracer_version_dockerfile}",
             ]

--- a/utils/_context/_scenarios.py
+++ b/utils/_context/_scenarios.py
@@ -16,7 +16,6 @@ from utils._context.library_version import LibraryVersion, Version
 from utils._context.header_tag_vars import VALID_CONFIGS, INVALID_CONFIGS
 
 from utils._context.containers import (
-    TestedContainer,
     WeblogContainer,
     AgentContainer,
     ProxyContainer,
@@ -965,34 +964,42 @@ class ParametricScenario(_Scenario):
         parametric_appdir = os.path.join("utils", "build", "docker", os.getenv("TEST_LIBRARY"), "parametric")
         tracer_version_dockerfile = os.path.join(parametric_appdir, "ddtracer_version.Dockerfile")
         if os.path.isfile(tracer_version_dockerfile):
-            try:
-                subprocess.run(
-                    [
-                        "docker",
-                        "build",
-                        ".",
-                        "-t",
-                        "ddtracer_version",
-                        "-f",
-                        f"{tracer_version_dockerfile}",
-                        "--quiet",
-                    ],
-                    stdout=subprocess.DEVNULL,
-                    # stderr=subprocess.DEVNULL,
-                    check=True,
-                )
-                result = subprocess.run(
-                    ["docker", "run", "--rm", "-t", "ddtracer_version"],
-                    cwd=parametric_appdir,
-                    stdout=subprocess.PIPE,
-                    check=False,
-                )
-                self._library = LibraryVersion(os.getenv("TEST_LIBRARY"), result.stdout.decode("utf-8"))
-            except subprocess.CalledProcessError as e:
-                logger.error(f"{e}")
-                raise RuntimeError(e)
+
+            logger.stdout(f"Build container to get {os.getenv('TEST_LIBRARY')} library version...")
+            # TODO : reuse the image build by the test, it'll save 4 mn on python.
+            cmd = [
+                "docker",
+                "build",
+                ".",
+                "-t",
+                "ddtracer_version",
+                "-f",
+                f"{tracer_version_dockerfile}",
+            ]
+            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+
+            if result.returncode != 0:
+                message = f"======== STDOUT ========\n{result.stdout.decode('utf-8')}\n\n"
+                message += f"======== STDERR ========\n{result.stderr.decode('utf-8')}"
+                pytest.exit(f"Can't build the tracer version image:\n{message}", 1)
+
+            result = subprocess.run(
+                ["docker", "run", "--rm", "-t", "ddtracer_version"],
+                cwd=parametric_appdir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            if result.returncode != 0:
+                message = f"======== STDOUT ========\n{result.stdout.decode('utf-8')}\n\n"
+                message += f"======== STDERR ========\n{result.stderr.decode('utf-8')}"
+                pytest.exit(f"Can't get the tracer version image:\n{message}", 1)
+
+            self._library = LibraryVersion(os.getenv("TEST_LIBRARY"), result.stdout.decode("utf-8"))
         else:
             self._library = LibraryVersion(os.getenv("TEST_LIBRARY", "**not-set**"), "99999.99999.99999")
+
         logger.stdout(f"Library: {self.library}")
 
     def _get_warmups(self):

--- a/utils/build/docker/python/parametric/Dockerfile
+++ b/utils/build/docker/python/parametric/Dockerfile
@@ -1,7 +1,7 @@
 
-FROM ghcr.io/datadog/dd-trace-py/testrunner:7ce49bd78b0d510766fc5db12756a8840724febc
+FROM ghcr.io/datadog/dd-trace-py/testrunner:9e3bd1fb9e42a4aa143cae661547517c7fbd8924
 WORKDIR /app
-RUN pyenv global 3.9.11
+RUN pyenv global 3.9.16
 RUN python3.9 -m pip install fastapi==0.89.1 uvicorn==0.20.0
 COPY utils/build/docker/python/install_ddtrace.sh utils/build/docker/python/get_appsec_rules_version.py binaries* /binaries/
 RUN /binaries/install_ddtrace.sh

--- a/utils/build/docker/python/parametric/ddtracer_version.Dockerfile
+++ b/utils/build/docker/python/parametric/ddtracer_version.Dockerfile
@@ -1,7 +1,6 @@
-FROM python:3.9-slim
+FROM ghcr.io/datadog/dd-trace-py/testrunner:9e3bd1fb9e42a4aa143cae661547517c7fbd8924
 
-# install bin dependancies
-RUN apt-get update && apt-get install -y git gcc g++ make cmake curl
+RUN pyenv global 3.9.16
 
 WORKDIR /app
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

* better ouput when version getter fails on parametric test
* use new test runner for python, as it requires rust install

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

