### PR TITLE
[.NET] skip flaky test `test_otel_get_span_context` for now

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -13,7 +13,7 @@ from utils.parametric.spec.trace import find_trace_by_root
 from utils.parametric.spec.trace import retrieve_span_links
 from utils.parametric.spec.tracecontext import TRACECONTEXT_FLAGS_SET
 from utils.parametric.test_agent import get_span
-from utils import bug, features, missing_feature, irrelevant, context, scenarios
+from utils import bug, features, missing_feature, irrelevant, flaky, context, scenarios
 
 # this global mark applies to all tests in this file.
 #   DD_TRACE_OTEL_ENABLED=true is required in some tracers (.NET, Python?)
@@ -397,7 +397,7 @@ class Test_Otel_Span_Methods:
         assert span.get("resource") == "ok_span"
 
     @bug(context.library < "ruby@2.2.0", reason="Older versions do not generate datadog spans with the correct ids")
-    @bug(
+    @flaky(
         context.library == "dotnet",
         reason="Flaky due to span order, tests should never use traces[0] when there are multiple spans",
     )

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -397,6 +397,7 @@ class Test_Otel_Span_Methods:
         assert span.get("resource") == "ok_span"
 
     @bug(context.library < "ruby@2.2.0", reason="Older versions do not generate datadog spans with the correct ids")
+    @bug(context.library == "dotnet", reason="Flaky due to span order, tests should never use traces[0] when there are multiple spans")
     def test_otel_get_span_context(self, test_agent, test_library):
         """
             This test verifies retrieving the span context of a span

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -397,7 +397,10 @@ class Test_Otel_Span_Methods:
         assert span.get("resource") == "ok_span"
 
     @bug(context.library < "ruby@2.2.0", reason="Older versions do not generate datadog spans with the correct ids")
-    @bug(context.library == "dotnet", reason="Flaky due to span order, tests should never use traces[0] when there are multiple spans")
+    @bug(
+        context.library == "dotnet",
+        reason="Flaky due to span order, tests should never use traces[0] when there are multiple spans",
+    )
     def test_otel_get_span_context(self, test_agent, test_library):
         """
             This test verifies retrieving the span context of a span


### PR DESCRIPTION
## Motivation

It's flaky.

Tests should not use `traces[0]` to get the "first" span, since the order of spans is not guaranteed.

## Changes

Skip it by marking with `@flaky`.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

