### PR TITLE
Update rasp SQLi queries to conform to documentation

### DIFF
--- a/tests/appsec/rasp/test_sqli.py
+++ b/tests/appsec/rasp/test_sqli.py
@@ -21,7 +21,7 @@ class Test_Sqli_UrlQuery:
             self.r,
             "rasp-942-100",
             {
-                "resource": {"address": "server.db.statement", "value": "SELECT * FROM users WHERE ? OR ? = ? --"},
+                "resource": {"address": "server.db.statement", "value": "SELECT * FROM users WHERE id=? OR ? = ? --'"},
                 "params": {"address": "server.request.query", "value": "' OR 1 = 1 --"},
                 "db_type": {"address": "server.db.system"},
             },
@@ -44,7 +44,7 @@ class Test_Sqli_BodyUrlEncoded:
             self.r,
             "rasp-942-100",
             {
-                "resource": {"address": "server.db.statement", "value": "SELECT * FROM users WHERE ? OR ? = ? --"},
+                "resource": {"address": "server.db.statement", "value": "SELECT * FROM users WHERE id=? OR ? = ? --'"},
                 "params": {"address": "server.request.body", "value": "' OR 1 = 1 --"},
                 "db_type": {"address": "server.db.system"},
             },
@@ -68,7 +68,7 @@ class Test_Sqli_BodyXml:
             self.r,
             "rasp-942-100",
             {
-                "resource": {"address": "server.db.statement", "value": "SELECT * FROM users WHERE ? OR ? = ? --"},
+                "resource": {"address": "server.db.statement", "value": "SELECT * FROM users WHERE id=? OR ? = ? --'"},
                 "params": {"address": "server.request.body", "value": "' OR 1 = 1 --"},
                 "db_type": {"address": "server.db.system"},
             },
@@ -92,7 +92,7 @@ class Test_Sqli_BodyJson:
             self.r,
             "rasp-942-100",
             {
-                "resource": {"address": "server.db.statement", "value": "SELECT * FROM users WHERE ? OR ? = ? --"},
+                "resource": {"address": "server.db.statement", "value": "SELECT * FROM users WHERE id=? OR ? = ? --'"},
                 "params": {"address": "server.request.body", "value": "' OR 1 = 1 --"},
                 "db_type": {"address": "server.db.system"},
             },

--- a/utils/build/docker/golang/app/internal/rasp/rasp.go
+++ b/utils/build/docker/golang/app/internal/rasp/rasp.go
@@ -120,7 +120,7 @@ func SQLi(w http.ResponseWriter, r *http.Request) {
 		log.Fatalln(err.Error())
 	}
 
-	_, err = db.ExecContext(r.Context(), "SELECT * FROM users WHERE '"+sqli)
+	_, err = db.ExecContext(r.Context(), "SELECT * FROM users WHERE id='"+sqli+"'")
 	if events.IsSecurityError(err) {
 		return
 	}

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -174,8 +174,8 @@ def rasp_sqli(request, *args, **kwargs):
         import sqlite3
 
         DB = sqlite3.connect(":memory:")
-        print(f"SELECT * FROM users WHERE {user_id}")
-        cursor = DB.execute(f"SELECT * FROM users WHERE '{user_id}")
+        print(f"SELECT * FROM users WHERE id='{user_id}'")
+        cursor = DB.execute(f"SELECT * FROM users WHERE id='{user_id}'")
         print("DB request with {len(list(cursor))} results")
         return HttpResponse(f"DB request with {len(list(cursor))} results")
     except Exception as e:

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -197,8 +197,8 @@ async def rasp_sqli(request: Request):
         import sqlite3
 
         DB = sqlite3.connect(":memory:")
-        print(f"SELECT * FROM users WHERE {user_id}")
-        cursor = DB.execute(f"SELECT * FROM users WHERE '{user_id}")
+        print(f"SELECT * FROM users WHERE id='{user_id}'")
+        cursor = DB.execute(f"SELECT * FROM users WHERE id='{user_id}'")
         print("DB request with {len(list(cursor))} results")
         return PlainTextResponse(f"DB request with {len(list(cursor))} results")
     except Exception as e:

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -267,8 +267,8 @@ def rasp_sqli(*args, **kwargs):
         import sqlite3
 
         DB = sqlite3.connect(":memory:")
-        print(f"SELECT * FROM users WHERE {user_id}")
-        cursor = DB.execute(f"SELECT * FROM users WHERE '{user_id}")
+        print(f"SELECT * FROM users WHERE id='{user_id}'")
+        cursor = DB.execute(f"SELECT * FROM users WHERE id='{user_id}'")
         print("DB request with {len(list(cursor))} results")
         return f"DB request with {len(list(cursor))} results"
     except Exception as e:


### PR DESCRIPTION
## Motivation

The queries and assertions from the SQLi RASP tests did not conform to the documentation:

The statement used in the query should be similar to the following:

```sql
SELECT * FROM users WHERE id='$user_id';
```

## Changes

Change the queries in order to follow the guidelines included in the RASP endpoint documentation.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

