### PR TITLE
[.NET][ASM] Enable tests for ASM Standalone Billing for dotnet

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -166,7 +166,7 @@ tests/:
     test_alpha.py:
       Test_Basic: v1.28.6
     test_asm_standalone.py:
-      Test_AppSecStandalone_UpstreamPropagation: missing_feature
+      Test_AppSecStandalone_UpstreamPropagation: v2.55.0
     test_automated_login_events.py:
       Test_Login_Events: v2.32.0
       Test_Login_Events_Extended: v2.33.0

--- a/utils/build/docker/dotnet/weblog/Endpoints/RequestDownStreamEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/RequestDownStreamEndpoint.cs
@@ -1,0 +1,30 @@
+using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace weblog;
+
+public class RequestDownStreamEndpoint : ISystemTestEndpoint
+{
+    public void Register(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder routeBuilder)
+    {
+        const string url = "http://localhost:7777/returnheaders";
+
+        // Get
+        routeBuilder.MapGet("/requestdownstream", async context =>
+            await context.Response.WriteAsync(DoHttpGet(url)));
+
+        // Post
+        routeBuilder.MapPost("/requestdownstream", async context =>
+            await context.Response.WriteAsync(DoHttpGet(url)));
+    }
+
+    private static string DoHttpGet(string url)
+    {
+        using var client = new HttpClient();
+        var response = client.GetAsync(url).Result;
+        response.EnsureSuccessStatusCode();
+
+        return response.Content.ReadAsStringAsync().Result;
+    }
+}

--- a/utils/build/docker/dotnet/weblog/Endpoints/ReturnHeadersEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/ReturnHeadersEndpoint.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace weblog;
+
+public class ReturnHeadersEndpoint : ISystemTestEndpoint
+{
+    public void Register(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder routeBuilder)
+    {
+        routeBuilder.MapGet("/returnheaders", async context =>
+            await context.Response.WriteAsync(HeadersAsJson(context.Request.Headers)));
+    }
+
+    private static string HeadersAsJson(IHeaderDictionary headers)
+    {
+        var headersKeyValued = headers.ToDictionary(h => h.Key, h => h.Value.ToString());
+        return JsonSerializer.Serialize(headersKeyValued);
+    }
+}


### PR DESCRIPTION
## Motivation

Enable ASM Standalone tests for the dotnet tracer.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

