### PR TITLE
remove deprecated Test_StaticRuleSet

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -197,7 +197,6 @@ tests/:
       Test_StandardTagsClientIp: v2.20.0
     test_conf.py:
       Test_RuleSet_1_3_1: v2.7.0
-      Test_StaticRuleSet: v1.29.0
     test_customconf.py:
       Test_NoLimitOnWafRules: v2.4.4
     test_event_tracking.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -744,10 +744,6 @@ tests/:
         '*': v0.99.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      Test_StaticRuleSet:
-        '*': v0.87.0
-        akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     test_customconf.py:
       Test_ConfRuleSet:
         '*': v0.93.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -318,7 +318,6 @@ tests/:
     test_conf.py:
       Test_ConfigurationVariables: v2.7.0
       Test_RuleSet_1_3_1: v2.5.0
-      Test_StaticRuleSet: v2.0.0
     test_customconf.py:
       Test_ConfRuleSet: v2.0.0
       Test_MissingRules: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -425,7 +425,6 @@ tests/:
       Test_RuleSet_1_3_1:
         '*': v1.2.1
         fastapi: v2.4.0.dev1
-      Test_StaticRuleSet: missing_feature
     test_customconf.py:
       Test_ConfRuleSet: v1.1.0rc2.dev
       Test_NoLimitOnWafRules: v1.1.0rc2.dev

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -203,7 +203,6 @@ tests/:
       Test_StandardTagsClientIp: v1.8.0
     test_conf.py:
       Test_RuleSet_1_3_1: v1.0.0
-      Test_StaticRuleSet: v1.8.0
     test_customconf.py:
       Test_ConfRuleSet: v1.0.0.beta2
       Test_CorruptedRules: v1.0.0.beta2

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -11,20 +11,6 @@ TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
 
 
 @features.threats_configuration
-class Test_StaticRuleSet:
-    """Appsec loads rules from a static rules file"""
-
-    @missing_feature(library="golang", reason="standard logs not implemented")
-    @missing_feature(library="ruby", reason="standard logs not implemented")
-    @missing_feature(library="php", reason="Rules file is not parsed")
-    @missing_feature(library="nodejs", reason="Rules file is not parsed")
-    def test_basic_hardcoded_ruleset(self):
-        """ Library has loaded a hardcoded AppSec ruleset"""
-        stdout = interfaces.library_stdout if context.library != "dotnet" else interfaces.library_dotnet_managed
-        stdout.assert_presence(r"AppSec loaded \d+ rules from file <?.*>?$", level="INFO")
-
-
-@features.threats_configuration
 class Test_RuleSet_1_2_4:
     """ AppSec uses rule set 1.2.4 or higher """
 


### PR DESCRIPTION
## Motivation

Test_StaticRuleSet is deprecated. Now, we use telemetry to obtain specific information.  And we should not do assumption on logs.

## Changes

Remove test class Test_StaticRuleSet

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

