### PR TITLE
remove stdout checks for threats configuration

### DIFF
--- a/tests/appsec/test_customconf.py
+++ b/tests/appsec/test_customconf.py
@@ -18,16 +18,8 @@ class Test_CorruptedRules:
         self.r_1 = weblog.get("/", headers={"User-Agent": "Arachni/v1"})
         self.r_2 = weblog.get("/waf", params={"attack": "<script>"})
 
-    @missing_feature(library="golang")
-    @missing_feature(library="nodejs")
-    @missing_feature(library="python")
-    @missing_feature(library="php")
-    @missing_feature(library="ruby", reason="standard logs not implemented")
     @bug(library="dotnet", reason="ERROR io CRITICAL")
     def test_c05(self):
-        """Log C5: Rules file is corrupted"""
-        stdout.assert_presence(r"AppSec could not read the rule file .* as it was invalid: .*", level="CRITICAL")
-
         # Appsec does not catch any attack
         interfaces.library.assert_no_appsec_event(self.r_1)
         interfaces.library.assert_no_appsec_event(self.r_2)
@@ -42,21 +34,8 @@ class Test_MissingRules:
         self.r_1 = weblog.get("/", headers={"User-Agent": "Arachni/v1"})
         self.r_2 = weblog.get("/waf", params={"attack": "<script>"})
 
-    @missing_feature(library="golang")
-    @missing_feature(library="nodejs")
-    @missing_feature(library="python")
-    @missing_feature(library="php")
-    @missing_feature(library="ruby", reason="standard logs not implemented")
     @bug(library="dotnet", reason="ERROR io CRITICAL")  # and the last sentence is missing
     def test_c04(self):
-        """Log C4: Rules file is missing"""
-        stdout.assert_presence(
-            r'AppSec could not find the rules file in path "?/donotexists"?. '
-            r"AppSec will not run any protections in this application. "
-            r"No security activities will be collected.",
-            level="CRITICAL",
-        )
-
         # Appsec does not catch any attack
         interfaces.library.assert_no_appsec_event(self.r_1)
         interfaces.library.assert_no_appsec_event(self.r_2)


### PR DESCRIPTION
## Motivation

We should not do assumption on logs or stdout. Telemetry is now used to report configuration information.

## Changes

Remove stdout checks on missing or corrupted rule file tests

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

