### PR TITLE
remove not implemented deprecated tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -227,7 +227,6 @@ tests/:
       Test_AppSecObfuscator: v2.7.0
       Test_CollectDefaultRequestHeader: missing_feature
       Test_CollectRespondHeaders: v2.5.1
-      Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: v2.50.0
       Test_RetainTraces: v1.29.0
     test_user_blocking_full_denylist.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -213,7 +213,6 @@ tests/:
       Test_Main: v2.6.0
     test_reports.py:
       Test_ExtraTagsFromRule: v2.34.0
-      Test_HttpClientIP: v1.30.0
       Test_Info: v2.0.0
       Test_RequestHeaders: v1.30.0
       Test_StatusCode: v1.28.6

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -197,7 +197,6 @@ tests/:
       Test_StandardTagsClientIp: v2.20.0
     test_conf.py:
       Test_RuleSet_1_3_1: v2.7.0
-      Test_StaticRuleSet: v1.29.0
     test_customconf.py:
       Test_NoLimitOnWafRules: v2.4.4
     test_event_tracking.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -305,11 +305,6 @@ tests/:
     test_reports.py:
       Test_ExtraTagsFromRule:
         '*': v1.62.0
-      Test_HttpClientIP:
-        '*': v1.34.0
-        chi: v1.36.0
-        echo: v1.36.0
-        gin: v1.37.0
       Test_Info:
         '*': v1.34.0
         chi: v1.36.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -335,7 +335,6 @@ tests/:
       Test_CollectRespondHeaders:
         '*': v1.36.2
         gin: v1.37.0
-      Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: v1.63.0-dev
       Test_RetainTraces:
         '*': v1.36.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -807,11 +807,6 @@ tests/:
       Test_ExtraTagsFromRule:
         '*': v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      Test_HttpClientIP:
-        '*': v0.98.1
-        akka-http: v1.22.0
-        play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_Info:
         '*': v0.87.0
         akka-http: v1.22.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -867,7 +867,6 @@ tests/:
         akka-http: v1.22.0
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: missing_feature
       Test_RetainTraces:
         '*': v0.92.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -744,10 +744,6 @@ tests/:
         '*': v0.99.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      Test_StaticRuleSet:
-        '*': v0.87.0
-        akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     test_customconf.py:
       Test_ConfRuleSet:
         '*': v0.93.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -343,7 +343,6 @@ tests/:
       Test_Main: v2.0.0
     test_reports.py:
       Test_ExtraTagsFromRule: *ref_4_1_0
-      Test_HttpClientIP: v2.0.0
       Test_Info: v2.0.0
       Test_RequestHeaders: v2.0.0
       Test_StatusCode: v2.0.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -318,7 +318,6 @@ tests/:
     test_conf.py:
       Test_ConfigurationVariables: v2.7.0
       Test_RuleSet_1_3_1: v2.5.0
-      Test_StaticRuleSet: v2.0.0
     test_customconf.py:
       Test_ConfRuleSet: v2.0.0
       Test_MissingRules: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -359,7 +359,6 @@ tests/:
       Test_AppSecObfuscator: v2.6.0
       Test_CollectDefaultRequestHeader: *ref_5_18_0
       Test_CollectRespondHeaders: v2.0.0
-      Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: *ref_5_7_0
       Test_RetainTraces: v2.0.0
     test_user_blocking_full_denylist.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -188,7 +188,6 @@ tests/:
       Test_ShellExecution: v0.95.0
     test_traces.py:
       Test_CollectDefaultRequestHeader: missing_feature
-      Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: missing_feature
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist: v0.86.3

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -425,7 +425,6 @@ tests/:
       Test_RuleSet_1_3_1:
         '*': v1.2.1
         fastapi: v2.4.0.dev1
-      Test_StaticRuleSet: missing_feature
     test_customconf.py:
       Test_ConfRuleSet: v1.1.0rc2.dev
       Test_NoLimitOnWafRules: v1.1.0rc2.dev

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -443,7 +443,6 @@ tests/:
       Test_StandardizationBlockMode: missing_feature
     test_reports.py:
       Test_ExtraTagsFromRule: v1.14.0
-      Test_HttpClientIP: v1.5.0rc1.dev
       Test_Info: v1.1.0rc2.dev
       Test_RequestHeaders: v1.1.0rc2.dev
       Test_StatusCode: v1.1.0rc2.dev

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -463,7 +463,6 @@ tests/:
       Test_CollectRespondHeaders:
         '*': v1.4.0rc1.dev
         fastapi: v2.4.0.dev1
-      Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: v2.9.0.dev1
       Test_RetainTraces: v1.1.0rc2.dev
     test_user_blocking_full_denylist.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -203,7 +203,6 @@ tests/:
       Test_StandardTagsClientIp: v1.8.0
     test_conf.py:
       Test_RuleSet_1_3_1: v1.0.0
-      Test_StaticRuleSet: v1.8.0
     test_customconf.py:
       Test_ConfRuleSet: v1.0.0.beta2
       Test_CorruptedRules: v1.0.0.beta2

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -232,7 +232,6 @@ tests/:
       Test_AppSecObfuscator: v1.0.0
       Test_CollectDefaultRequestHeader: missing_feature
       Test_CollectRespondHeaders: v1.0.0.beta1
-      Test_DistributedTraceInfo: missing_feature (test not implemented)
       Test_ExternalWafRequestsIdentification: v1.22.0
       Test_RetainTraces: v0.54.2
     test_user_blocking_full_denylist.py:

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -11,20 +11,6 @@ TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
 
 
 @features.threats_configuration
-class Test_StaticRuleSet:
-    """Appsec loads rules from a static rules file"""
-
-    @missing_feature(library="golang", reason="standard logs not implemented")
-    @missing_feature(library="ruby", reason="standard logs not implemented")
-    @missing_feature(library="php", reason="Rules file is not parsed")
-    @missing_feature(library="nodejs", reason="Rules file is not parsed")
-    def test_basic_hardcoded_ruleset(self):
-        """ Library has loaded a hardcoded AppSec ruleset"""
-        stdout = interfaces.library_stdout if context.library != "dotnet" else interfaces.library_dotnet_managed
-        stdout.assert_presence(r"AppSec loaded \d+ rules from file <?.*>?$", level="INFO")
-
-
-@features.threats_configuration
 class Test_RuleSet_1_2_4:
     """ AppSec uses rule set 1.2.4 or higher """
 

--- a/tests/appsec/test_reports.py
+++ b/tests/appsec/test_reports.py
@@ -40,41 +40,6 @@ class Test_StatusCode:
         interfaces.library.validate_appsec(self.r, validator=check_http_code, legacy_validator=check_http_code_legacy)
 
 
-@missing_feature(
-    True, reason="Bug on system test: with the runner on the host, we do not have the real IP from weblog POV"
-)
-@features.security_events_metadata
-class Test_HttpClientIP:
-    """AppSec reports good http client IP"""
-
-    def setup_http_remote_ip(self):
-        headers = {"User-Agent": "Arachni/v1"}
-        self.r = weblog.get("/waf/", headers=headers, stream=True)
-        try:
-            s = socket.fromfd(self.r.raw.fileno(), socket.AF_INET, socket.SOCK_STREAM)
-            self.actual_remote_ip = s.getsockname()[0]
-            self.r.close()
-        except:
-            self.actual_remote_ip = None
-
-    def test_http_remote_ip(self):
-        """AppSec reports the HTTP request peer IP."""
-
-        def legacy_validator(event):
-            remote_ip = event["context"]["http"]["request"]["remote_ip"]
-            assert remote_ip == self.actual_remote_ip, f"request remote ip should be {self.actual_remote_ip}"
-
-            return True
-
-        def validator(span, appsec_data):
-            ip = span["meta"]["network.client.ip"]
-            assert ip == self.actual_remote_ip, f"network.client.ip should be {self.actual_remote_ip}"
-
-            return True
-
-        interfaces.library.validate_appsec(self.r, validator=validator, legacy_validator=legacy_validator)
-
-
 @bug(context.library == "python@1.1.0", reason="a PR was not included in the release")
 @features.security_events_metadata
 class Test_Info:

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -324,15 +324,6 @@ class Test_CollectDefaultRequestHeader:
         interfaces.library.validate_spans(self.r, validate_request_headers)
 
 
-@features.security_events_metadata
-class Test_DistributedTraceInfo:
-    """Distributed traces info (Services, URL, trace id)"""
-
-    @irrelevant(True, reason="test non implemented")
-    def test_main(self):
-        assert False, "Test not implemented"
-
-
 @rfc("https://docs.google.com/document/d/1xf-s6PtSr6heZxmO_QLUtcFzY_X_rT94lRXNq6-Ghws/edit?pli=1")
 @features.security_events_metadata
 class Test_ExternalWafRequestsIdentification:

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -328,6 +328,7 @@ class Test_CollectDefaultRequestHeader:
 class Test_DistributedTraceInfo:
     """Distributed traces info (Services, URL, trace id)"""
 
+    @irrelevant(True, reason="test non implemented")
     def test_main(self):
         assert False, "Test not implemented"
 

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -1,4 +1,4 @@
-from utils import interfaces, rfc, weblog, scenarios, context, bug, missing_feature, flaky, features
+from utils import bug, context, interfaces, irrelevant, features, flaky, missing_feature, rfc, scenarios, weblog
 from utils.tools import logger
 
 TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
@@ -77,7 +77,7 @@ class Test_TelemetryMetrics:
 
     setup_metric_waf_updates = _setup
 
-    @missing_feature(reason="Test not implemented")
+    @irrelevant(reason="Test not implemented")
     @bug(context.library < "java@1.13.0", reason="Missing tags")
     def test_metric_waf_updates(self):
         """Test waf.updates metric."""

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -75,40 +75,6 @@ class Test_TelemetryMetrics:
         p = s["points"][0]
         assert p[1] == 1
 
-    setup_metric_waf_updates = _setup
-
-    @irrelevant(reason="Test not implemented")
-    @bug(context.library < "java@1.13.0", reason="Missing tags")
-    def test_metric_waf_updates(self):
-        """Test waf.updates metric."""
-        expected_metric_name = "waf.updates"
-        mandatory_tag_prefixes = {
-            "waf_version",
-            "event_rules_version",
-        }
-        valid_tag_prefixes = {
-            "waf_version",
-            "event_rules_version",
-            "version",
-            "lib_language",
-        }
-        series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
-        assert len(series) == 1
-        s = series[0]
-        assert s["_computed_namespace"] == "appsec"
-        assert s["metric"] == expected_metric_name
-        assert s["common"] is True
-        assert s["type"] == "count"
-
-        full_tags = set(s["tags"])
-        self._assert_valid_tags(
-            full_tags=full_tags, valid_prefixes=valid_tag_prefixes, mandatory_prefixes=mandatory_tag_prefixes
-        )
-
-        assert len(s["points"]) == 1
-        p = s["points"][0]
-        assert p[1] == 1
-
     setup_metric_waf_requests = _setup
 
     @bug(context.library < "java@1.13.0", reason="Missing tags")


### PR DESCRIPTION
## Motivation

deprecated test should be removed

## Changes

Remove deprecated test
- Test_HttpClientIP
- Test_DistributedTraceInfo
- Test_TelemetryMetrics::test_metric_waf_updates

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

