### PR TITLE
allow pulling extra images

### DIFF
--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "JSON array of scenarios that will be executed"
     default: "[]"
     required: true
+  extra-images:
+    description: "Comma-separated list of extra images to pull"
+    default: ""
+    required: false
 
 runs:
   using: composite
@@ -32,6 +36,7 @@ runs:
         python utils/scripts/get-image-list.py '${{ inputs.scenarios }}' > compose.yaml
       env:
         PYTHONPATH: "."
+        EXTRA_IMAGES: "${{ matrix.extra-images }}"
 
     - name: Pull
       shell: bash

--- a/utils/scripts/get-image-list.py
+++ b/utils/scripts/get-image-list.py
@@ -14,8 +14,8 @@ if __name__ == "__main__":
         if f'"{scenario.name}"' in executed_scenarios and isinstance(scenario, _DockerScenario):
             images.update(scenario.image_list)
 
-    if os.environ.get('EXTRA_IMAGES'):
-        images.update(os.environ['EXTRA_IMAGES'].split(','))
+    if os.environ.get("EXTRA_IMAGES"):
+        images.update(os.environ["EXTRA_IMAGES"].split(","))
 
     # remove images that will be built locally
     images = [image for image in images if not image.startswith("system_tests/")]

--- a/utils/scripts/get-image-list.py
+++ b/utils/scripts/get-image-list.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 import yaml
@@ -12,6 +13,9 @@ if __name__ == "__main__":
     for scenario in get_all_scenarios():
         if f'"{scenario.name}"' in executed_scenarios and isinstance(scenario, _DockerScenario):
             images.update(scenario.image_list)
+
+    if os.environ.get('EXTRA_IMAGES'):
+        images.update(os.environ['EXTRA_IMAGES'].split(','))
 
     # remove images that will be built locally
     images = [image for image in images if not image.startswith("system_tests/")]


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Makes it easier to pull additional images such as the prebuilt agent image without needing another step.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Allow pulling extra images in `pull_images` script.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

