### PR TITLE
[java] Enable header collection related tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -861,13 +861,17 @@ tests/:
         '*': v0.113.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      Test_CollectDefaultRequestHeader: missing_feature
+      Test_CollectDefaultRequestHeader:
+        '*': 1.35.0
+        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_CollectRespondHeaders:
         '*': v0.102.0
         akka-http: v1.22.0
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      Test_ExternalWafRequestsIdentification: missing_feature
+      Test_ExternalWafRequestsIdentification:
+        '*': 1.35.0
+        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_RetainTraces:
         '*': v0.92.0
         akka-http: v1.22.0
@@ -1045,7 +1049,7 @@ tests/:
     Test_Propagate: missing_feature
     Test_Propagate_Legacy: missing_feature
   test_library_conf.py:
-    Test_HeaderTags: missing_feature
+    Test_HeaderTags: 1.35.0
     Test_HeaderTags_Colon_Leading: v0.102.0
     Test_HeaderTags_Colon_Trailing: v0.102.0
     Test_HeaderTags_Long: v0.102.0


### PR DESCRIPTION
## Motivation

Header collection was enabled in the java tracer from version 1.35.0

## Changes

Enable tests for header collection in the java tracer.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

