### PR TITLE
Pull images after building base images

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -76,12 +76,6 @@ jobs:
       with:
         name: ${{ inputs.binaries_artifact }}
         path: binaries/
-    - name: Pull images
-      uses: ./.github/actions/pull_images
-      with:
-        library: ${{ inputs.library }}
-        weblog: ${{ matrix.weblog }}
-        scenarios: ${{ inputs.scenarios }}
     - name: Build python's weblog base images
       if: inputs.library == 'python' && inputs.build_python_base_images
       run: |
@@ -92,6 +86,12 @@ jobs:
     - name: Build proxy image
       if: inputs.build_proxy_image
       run: ./build.sh -i proxy
+    - name: Pull images
+      uses: ./.github/actions/pull_images
+      with:
+        library: ${{ inputs.library }}
+        weblog: ${{ matrix.weblog }}
+        scenarios: ${{ inputs.scenarios }}
     - name: Log in to the Container registry
       if: ${{ inputs.library == 'ruby' }}
       run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin


### PR DESCRIPTION
## Motivation

Fix egg-chicken-issue

## Changes

When some base images are build (python, proxy, and soon to come, nodejs #2677), their tag does not exists in docker registry, so the pull step fails. By pulling **after** building base images, `docker compose pull` will ignore them, as they exists locally.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

