### PR TITLE
add srb test on multiple addresses

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -415,7 +415,7 @@ tests/:
         django-poc: v1.10
         fastapi: v2.4.0.dev1
         flask-poc: v1.10
-      Test_Suspicious_Request_Blocking: missing_feature (v1.20.0, but test is not implemented)
+      Test_Suspicious_Request_Blocking: v2.4.0.dev1
     test_client_ip.py:
       Test_StandardTagsClientIp: v1.5.0
     test_conf.py:

--- a/tests/appsec/blocking_rule.json
+++ b/tests/appsec/blocking_rule.json
@@ -495,6 +495,87 @@
       ]
     },
     {
+      "id": "tst-037-012",
+      "name": "Test block on multiple request addresses",
+      "tags": {
+        "type": "lfi",
+        "crs_id": "000012",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.method"
+              }
+            ],
+            "regex": "GET"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.uri.raw"
+              }
+            ],
+            "regex": "ypMrmzrWATkLrPKLblvpRGGltBSgHWrK"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "regex": "SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              }
+            ],
+            "regex": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "block"
+      ]
+    },
+    {
       "id": "monitor-resolvers",
       "name": "Monitor Resolvers",
       "tags": {

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -523,7 +523,11 @@ class Test_Suspicious_Request_Blocking:
     """Test if blocking on multiple addresses with multiple rules is supported"""
 
     def setup_blocking(self):
-        self.rm_req_block = weblog.get(f"/tag_value/cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc_ypMrmzrWATkLrPKLblvpRGGltBSgHWrK/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ", cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"}, headers={"content-type": "text/plain", "client":"kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"})
+        self.rm_req_block = weblog.get(
+            f"/tag_value/cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc_ypMrmzrWATkLrPKLblvpRGGltBSgHWrK/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ",
+            cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"},
+            headers={"content-type": "text/plain", "client": "kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"},
+        )
 
     def test_blocking(self):
         """Test if requests that should be blocked are blocked"""
@@ -531,8 +535,16 @@ class Test_Suspicious_Request_Blocking:
         interfaces.library.assert_waf_attack(self.rm_req_block, rule="tst-037-012")
 
     def setup_blocking_before(self):
-        self.set_req1 = weblog.post("/tag_value/clean_value_3882/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ", data={"good": "value"}, cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"})
-        self.block_req2 = weblog.get(f"/tag_value/cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc_ypMrmzrWATkLrPKLblvpRGGltBSgHWrK/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ", cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"}, headers={"content-type": "text/plain", "client":"kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"})
+        self.set_req1 = weblog.post(
+            "/tag_value/clean_value_3882/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ",
+            data={"good": "value"},
+            cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"},
+        )
+        self.block_req2 = weblog.get(
+            f"/tag_value/cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc_ypMrmzrWATkLrPKLblvpRGGltBSgHWrK/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ",
+            cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"},
+            headers={"content-type": "text/plain", "client": "kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"},
+        )
 
     def test_blocking_before(self):
         """Test that blocked requests are blocked before being processed"""
@@ -552,7 +564,7 @@ class Test_BlockingGraphqlResolvers:
     """Test if blocking is supported on graphql.server.all_resolvers address"""
 
     def setup_request_block_attack(self):
-        """ Currently only monitoring is implemented"""
+        """Currently only monitoring is implemented"""
 
         self.r_attack = weblog.post(
             "/graphql",
@@ -591,7 +603,7 @@ class Test_BlockingGraphqlResolvers:
             assert parameters["value"] == "testblockresolver"
 
     def setup_request_block_attack_directive(self):
-        """ Currently only monitoring is implemented"""
+        """Currently only monitoring is implemented"""
 
         self.r_attack = weblog.post(
             "/graphql",

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -517,22 +517,33 @@ class Test_Blocking_response_headers:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
+@scenarios.appsec_blocking
 @features.appsec_request_blocking
 class Test_Suspicious_Request_Blocking:
     """Test if blocking on multiple addresses with multiple rules is supported"""
 
+    def setup_blocking(self):
+        self.rm_req_block = weblog.get(f"/tag_value/cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc_ypMrmzrWATkLrPKLblvpRGGltBSgHWrK/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ", cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"}, headers={"content-type": "text/plain", "client":"kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"})
+
     def test_blocking(self):
         """Test if requests that should be blocked are blocked"""
-        assert False, "TODO"
+        assert self.rm_req_block.status_code == 403, self.rm_req_block.request.url
+        interfaces.library.assert_waf_attack(self.rm_req_block, rule="tst-037-012")
 
-    def test_non_blocking(self):
-        """Test if requests that should not be blocked are not blocked"""
-        self.test_blocking()
-        assert False, "TODO"
+    def setup_blocking_before(self):
+        self.set_req1 = weblog.post("/tag_value/clean_value_3882/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ", data={"good": "value"}, cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"})
+        self.block_req2 = weblog.get(f"/tag_value/cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc_ypMrmzrWATkLrPKLblvpRGGltBSgHWrK/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ", cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"}, headers={"content-type": "text/plain", "client":"kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"})
 
     def test_blocking_before(self):
         """Test that blocked requests are blocked before being processed"""
-        assert False, "TODO"
+        # first request should not block and must set the tag in span accordingly
+        assert self.set_req1.status_code == 200
+        assert self.set_req1.text == "Value tagged"
+        interfaces.library.validate_spans(self.set_req1, _assert_custom_event_tag_presence("clean_value_3882"))
+        """Test that blocked requests are blocked before being processed"""
+        assert self.block_req2.status_code == 403
+        interfaces.library.assert_waf_attack(self.block_req2, rule="tst-037-012")
+        interfaces.library.validate_spans(self.block_req2, _assert_custom_event_tag_absence())
 
 
 @scenarios.graphql_appsec


### PR DESCRIPTION
## Motivation

Suspicious requests tests each tests one address at a time.

## Changes

`Test_Suspicious_Request_Blocking` class is testing several addresses at once with the new rule `tst-037-012`

- `server.request.method`
- `server.request.uri.raw`
- `server.request.path_params`
- `server.request.query`
- `server.request.headers.no_cookies`
- `server.request.cookies`

They must all match at the same time to trigger the rule.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

