### PR TITLE
remove bodyraw test

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -124,7 +124,6 @@ tests/:
     waf/:
       test_addresses.py:
         Test_BodyJson: v2.8.0
-        Test_BodyRaw: missing_feature
         Test_BodyUrlEncoded: v2.7.0
         Test_BodyXml: v2.8.0
         Test_ClientIP: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -134,7 +134,6 @@ tests/:
     waf/:
       test_addresses.py:
         Test_BodyJson: v1.37.0
-        Test_BodyRaw: missing_feature
         Test_BodyUrlEncoded: v1.37.0
         Test_BodyXml: v1.37.0
         Test_ClientIP: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -396,11 +396,6 @@ tests/:
           vertx3: v0.99.0
           vertx4: bug (Capability to read body content is incomplete after vert.x
             4.0.0)
-        Test_BodyRaw:
-          '*': missing_feature
-          akka-http: v1.22.0
-          play: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         Test_BodyUrlEncoded:
           '*': v0.95.1
           akka-http: v1.22.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -210,7 +210,6 @@ tests/:
         Test_BodyJson:
           '*': v2.2.0
           nextjs: *ref_4_17_0
-        Test_BodyRaw: missing_feature
         Test_BodyUrlEncoded:
           '*': v2.2.0
           nextjs: *ref_5_3_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -112,7 +112,6 @@ tests/:
     waf/:
       test_addresses.py:
         Test_BodyJson: v0.98.1 # TODO what is the earliest version?
-        Test_BodyRaw: v0.68.3
         Test_BodyUrlEncoded: v0.68.3
         Test_BodyXml: missing_feature
         Test_ClientIP: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -207,11 +207,6 @@ tests/:
         Test_BodyJson:
           '*': v1.4.0rc1.dev
           fastapi: v2.4.0.dev1
-        Test_BodyRaw:
-          '*': missing_feature
-          django-poc: v1.5.2
-          fastapi: v2.4.0.dev1
-          python3.12: v1.5.2
         Test_BodyUrlEncoded:
           '*': v1.4.0rc1.dev
           fastapi: v2.4.0.dev1

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -113,7 +113,6 @@ tests/:
     waf/:
       test_addresses.py:
         Test_BodyJson: v1.8.0
-        Test_BodyRaw: v1.1.0
         Test_BodyUrlEncoded: v1.8.0
         Test_BodyXml: irrelevant (unsupported by framework)
         Test_ClientIP: missing_feature

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -232,19 +232,6 @@ class Test_Cookies:
         interfaces.library.assert_waf_attack(self.r_cwsc2cc, pattern='o:4:"x":5:{d}', address="server.request.cookies")
 
 
-@features.appsec_request_blocking
-class Test_BodyRaw:
-    """Appsec supports <body>"""
-
-    def setup_raw_body(self):
-        self.r = weblog.post("/waf", data="/.adsensepostnottherenonobook")
-
-    @missing_feature(reason="no rule with body raw yet")
-    def test_raw_body(self):
-        """AppSec detects attacks in raw body"""
-        interfaces.library.assert_waf_attack(self.r, address="server.request.body.raw")
-
-
 @bug(context.library == "nodejs@2.8.0", reason="Capability to read body content is broken")
 @features.appsec_request_blocking
 class Test_BodyUrlEncoded:


### PR DESCRIPTION
## Motivation

This 2 years old test was never implemented, and we will never have a body.raw address at DD.

## Changes

remove the test class.

## Workflow


1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] [Relevant label](https://github.com/DataDog/system-tests/blob/main/docs/CI/labels.md) (`run-parametric-scenario`, `run-profiling-scenario`...) are presents
* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

