### PR TITLE
[php] Remove flaky flag from schema extraction tests on php

### DIFF
--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -4,7 +4,6 @@
 
 from utils import (
     context,
-    flaky,
     interfaces,
     missing_feature,
     rfc,
@@ -73,7 +72,6 @@ class Test_Schema_Request_Headers:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@flaky(context.library == "php", reason="APPSEC-53993")
 class Test_Schema_Request_Cookies:
     """Test API Security - Request Cookies Schema"""
 
@@ -97,7 +95,6 @@ class Test_Schema_Request_Cookies:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@flaky(context.library == "php", reason="APPSEC-53993")
 class Test_Schema_Request_Query_Parameters:
     """Test API Security - Request Query Parameters Schema"""
 
@@ -139,7 +136,6 @@ class Test_Schema_Request_Path_Parameters:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@flaky(context.library == "php", reason="APPSEC-53993")
 class Test_Schema_Request_Json_Body:
     """Test API Security - Request Body and list length"""
 
@@ -160,7 +156,6 @@ class Test_Schema_Request_Json_Body:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@flaky(context.library == "php", reason="APPSEC-53993")
 class Test_Schema_Request_FormUrlEncoded_Body:
     """Test API Security - Request Body and list length"""
 
@@ -201,7 +196,6 @@ class Test_Schema_Request_FormUrlEncoded_Body:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@flaky(context.library == "php", reason="APPSEC-53993")
 class Test_Schema_Response_Headers:
     """Test API Security - Response Header Schema"""
 
@@ -221,7 +215,6 @@ class Test_Schema_Response_Headers:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@flaky(context.library == "php", reason="APPSEC-53993")
 class Test_Schema_Response_Body:
     """Test API Security - Response Body Schema with urlencoded body"""
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
