### PR TITLE
feature update

### DIFF
--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -387,7 +387,6 @@ class Test_PathParams:
         )
 
 
-@features.appsec_request_blocking
 @features.grpc_threats_management
 class Test_gRPC:
     """Appsec supports address grpc.server.request.message"""
@@ -408,7 +407,6 @@ class Test_gRPC:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2278064284/gRPC+Protocol+Support")
-@features.appsec_request_blocking
 @features.grpc_threats_management
 class Test_FullGrpc:
     """Full gRPC support"""
@@ -517,7 +515,6 @@ class Test_Lambda:
         assert False, "Need to write a test"
 
 
-@features.appsec_request_blocking
 @features.grpc_threats_management
 @scenarios.appsec_custom_rules
 class Test_GrpcServerMethod:


### PR DESCRIPTION
## Motivation

GRPC threat tests should be in the grpc threat management feature only

## Changes

remove them from the appsec_request_blocking feature (which is http only)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
