### PR TITLE
Remove IAST and ASM standalone billing java xpassed tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -579,9 +579,6 @@ tests/:
     test_asm_standalone.py:
       Test_AppSecStandalone_UpstreamPropagation:
         '*': v1.36.0
-        akka-http:  bug (KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags)
-        jersey-grizzly2: bug (KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags)
-        play: bug (KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags)
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     test_automated_login_events.py:
       Test_Login_Events: missing_feature

--- a/tests/appsec/iast/sink/test_weak_hash.py
+++ b/tests/appsec/iast/sink/test_weak_hash.py
@@ -49,7 +49,6 @@ class TestWeakHash(BaseSinkTest):
     def setup_insecure_hash_remove_duplicates(self):
         self.r_insecure_hash_remove_duplicates = weblog.get("/iast/insecure_hashing/deduplicate")
 
-    @missing_feature(weblog_variant="spring-boot-openliberty")
     def test_insecure_hash_remove_duplicates(self):
         """If one line is vulnerable and it is executed multiple times (for instance in a loop) in a request,
         we will report only one vulnerability"""
@@ -64,7 +63,6 @@ class TestWeakHash(BaseSinkTest):
     def setup_insecure_hash_multiple(self):
         self.r_insecure_hash_multiple = weblog.get("/iast/insecure_hashing/multiple_hash")
 
-    @bug(weblog_variant="spring-boot-openliberty")
     def test_insecure_hash_multiple(self):
         """If a endpoint has multiple vulnerabilities (in diferent lines) we will report all of them"""
         assert_iast_vulnerability(

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -1,7 +1,7 @@
 import json
 import re
 
-from utils import weblog, interfaces, scenarios, features, rfc
+from utils import weblog, interfaces, scenarios, features, rfc, bug
 from utils._context.header_tag_vars import *
 from requests.structures import CaseInsensitiveDict
 
@@ -35,6 +35,11 @@ class Test_AppSecStandalone_UpstreamPropagation:
             },
         )
 
+    @bug(
+        library="java",
+        weblog_variant="play",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
     def test_no_appsec_upstream__no_attack__is_kept_with_priority_1__from_minus_1(self):
         spans_checked = 0
         for data, trace, span in interfaces.library.get_spans(request=self.r):
@@ -200,6 +205,21 @@ class Test_AppSecStandalone_UpstreamPropagation:
             },
         )
 
+    @bug(
+        library="java",
+        weblog_variant="akka-http",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
+    @bug(
+        library="java",
+        weblog_variant="jersey-grizzly2",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
+    @bug(
+        library="java",
+        weblog_variant="play",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
     def test_no_upstream_appsec_propagation__with_attack__is_kept_with_priority_2__from_minus_1(self):
         spans_checked = 0
         for data, trace, span in interfaces.library.get_spans(request=self.r):
@@ -241,6 +261,21 @@ class Test_AppSecStandalone_UpstreamPropagation:
             },
         )
 
+    @bug(
+        library="java",
+        weblog_variant="akka-http",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
+    @bug(
+        library="java",
+        weblog_variant="jersey-grizzly2",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
+    @bug(
+        library="java",
+        weblog_variant="play",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
     def test_no_upstream_appsec_propagation__with_attack__is_kept_with_priority_2__from_0(self):
         spans_checked = 0
         for data, trace, span in interfaces.library.get_spans(request=self.r):
@@ -398,6 +433,21 @@ class Test_AppSecStandalone_UpstreamPropagation:
             },
         )
 
+    @bug(
+        library="java",
+        weblog_variant="akka-http",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
+    @bug(
+        library="java",
+        weblog_variant="jersey-grizzly2",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
+    @bug(
+        library="java",
+        weblog_variant="play",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
     def test_any_upstream_propagation__with_attack__raises_priority_to_2__from_minus_1(self):
         spans_checked = 0
         for data, trace, span in interfaces.library.get_spans(request=self.r):
@@ -437,6 +487,21 @@ class Test_AppSecStandalone_UpstreamPropagation:
             },
         )
 
+    @bug(
+        library="java",
+        weblog_variant="akka-http",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
+    @bug(
+        library="java",
+        weblog_variant="jersey-grizzly2",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
+    @bug(
+        library="java",
+        weblog_variant="play",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
     def test_any_upstream_propagation__with_attack__raises_priority_to_2__from_0(self):
         spans_checked = 0
         for data, trace, span in interfaces.library.get_spans(request=self.r):
@@ -476,6 +541,21 @@ class Test_AppSecStandalone_UpstreamPropagation:
             },
         )
 
+    @bug(
+        library="java",
+        weblog_variant="akka-http",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
+    @bug(
+        library="java",
+        weblog_variant="jersey-grizzly2",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
+    @bug(
+        library="java",
+        weblog_variant="play",
+        reason="KeyError x-datadog-origin - span not available on appsec events drives into no propagation tags",
+    )
     def test_any_upstream_propagation__with_attack__raises_priority_to_2__from_1(self):
         spans_checked = 0
         for data, trace, span in interfaces.library.get_spans(request=self.r):


### PR DESCRIPTION
## Motivation

Remove xpassed IAST and ASM standalone billing tests 

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
