### PR TITLE
remove outdated tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -127,13 +127,10 @@ tests/:
         Test_BodyRaw: missing_feature
         Test_BodyUrlEncoded: v2.7.0
         Test_BodyXml: v2.8.0
-        Test_ClientIP: missing_feature
         Test_FullGrpc: missing_feature
         Test_GraphQL: missing_feature
         Test_GrpcServerMethod: missing_feature
         Test_Headers: v1.28.6
-        Test_Lambda: missing_feature
-        Test_Method: missing_feature
         Test_PathParams: v2.5.1
         Test_ResponseStatus: v2.3.0
         Test_UrlQuery: v1.28.6

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -137,7 +137,6 @@ tests/:
         Test_BodyRaw: missing_feature
         Test_BodyUrlEncoded: v1.37.0
         Test_BodyXml: v1.37.0
-        Test_ClientIP: missing_feature
         Test_Cookies:
           '*': v1.34.0
           chi: v1.36.0
@@ -151,8 +150,6 @@ tests/:
           chi: v1.36.0
           echo: v1.36.0
           gin: v1.37.0
-        Test_Lambda: missing_feature
-        Test_Method: missing_feature
         Test_PathParams:
           '*': v1.36.0
           gin: v1.37.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -418,7 +418,6 @@ tests/:
           vertx3: missing_feature
           vertx4: bug (Capability to read body content is incomplete after vert.x
             4.0.0)
-        Test_ClientIP: missing_feature
         Test_Cookies:
           akka-http: v1.22.0
           play: v1.22.0
@@ -430,8 +429,6 @@ tests/:
           '*': v0.87.0
           akka-http: v1.22.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_Lambda: missing_feature
-        Test_Method: missing_feature
         Test_PathParams:
           '*': v0.95.1
           akka-http: missing_feature (unclear how to implement; matching doesn't happen in one go)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -217,7 +217,6 @@ tests/:
         Test_BodyXml:
           '*': v2.2.0
           nextjs: irrelevant # Body xml is not converted to JSON in nextjs
-        Test_ClientIP: missing_feature
         Test_Cookies: v2.0.0
         Test_FullGrpc: missing_feature
         Test_GraphQL:
@@ -225,8 +224,6 @@ tests/:
           nextjs: irrelevant # nextjs is not related with graphql
         Test_GrpcServerMethod: missing_feature
         Test_Headers: v2.0.0
-        Test_Lambda: missing_feature
-        Test_Method: missing_feature
         Test_PathParams:
           '*': v2.0.0
           nextjs: missing_feature

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -115,14 +115,11 @@ tests/:
         Test_BodyRaw: v0.68.3
         Test_BodyUrlEncoded: v0.68.3
         Test_BodyXml: missing_feature
-        Test_ClientIP: missing_feature
         Test_Cookies: v0.68.3
         Test_FullGrpc: missing_feature
         Test_GraphQL: missing_feature
         Test_GrpcServerMethod: missing_feature
         Test_Headers: v0.68.3
-        Test_Lambda: missing_feature
-        Test_Method: missing_feature
         Test_PathParams: v0.71.0
         Test_UrlQuery: v0.68.3
         Test_UrlQueryKey: v0.74.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -218,7 +218,6 @@ tests/:
         Test_BodyXml:
           '*': v1.5.0rc1.dev
           fastapi: v2.4.0.dev1
-        Test_ClientIP: missing_feature (v1.5.0rc1.dev but test is not implemented)
         Test_Cookies:
           django-poc: v1.1.0rc2.dev
           fastapi: v2.4.0.dev1
@@ -231,8 +230,6 @@ tests/:
         Test_GraphQL: missing_feature
         Test_GrpcServerMethod: missing_feature
         Test_Headers: v1.6
-        Test_Lambda: missing_feature
-        Test_Method: missing_feature
         Test_PathParams:
           django-poc: v1.1.0rc2.dev
           fastapi: v2.4.0.dev1

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -116,12 +116,9 @@ tests/:
         Test_BodyRaw: v1.1.0
         Test_BodyUrlEncoded: v1.8.0
         Test_BodyXml: irrelevant (unsupported by framework)
-        Test_ClientIP: missing_feature
         Test_FullGrpc: missing_feature
         Test_GraphQL: missing_feature
         Test_GrpcServerMethod: missing_feature
-        Test_Lambda: missing_feature
-        Test_Method: missing_feature
         Test_PathParams:
           '*': v1.8.0
           rack: irrelevant

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -239,7 +239,7 @@ class Test_BodyRaw:
     def setup_raw_body(self):
         self.r = weblog.post("/waf", data="/.adsensepostnottherenonobook")
 
-    @missing_feature(reason="no rule with body raw yet")
+    @irrelevant(reason="no rule with body raw yet")
     def test_raw_body(self):
         """AppSec detects attacks in raw body"""
         interfaces.library.assert_waf_attack(self.r, address="server.request.body.raw")
@@ -338,22 +338,6 @@ class Test_BodyXml:
     def test_xml_content(self):
         interfaces.library.assert_waf_attack(self.r_content_1, address="server.request.body", value="var_dump ()")
         interfaces.library.assert_waf_attack(self.r_content_2, address="server.request.body", value=self.ATTACK)
-
-
-@features.appsec_request_blocking
-class Test_Method:
-    """Appsec supports server.request.method"""
-
-    def test_main(self):
-        assert False, "Need to write a test"
-
-
-@features.appsec_request_blocking
-class Test_ClientIP:
-    """Appsec supports server.request.client_ip"""
-
-    def test_main(self):
-        assert False, "Need to write a test"
 
 
 @features.appsec_request_blocking
@@ -505,14 +489,6 @@ class Test_GraphQL:
 
     def test_request_monitor_attack_directive(self):
         self.base_test_request_monitor_attack(["userByName", "case", "format"], ["userByName", "0", "case", "format"])
-
-
-@features.appsec_request_blocking
-class Test_Lambda:
-    """Lambda support"""
-
-    def test_main(self):
-        assert False, "Need to write a test"
 
 
 @features.grpc_threats_management


### PR DESCRIPTION
## Motivation

`Test_ClientIP ` and `Test_Method` are already covered by `tests/appsec/test_blocking_addresses.py`

`Test_Lambda` is deprecated

`test_raw_body` is currently irrelevant but it is planned to use it in another not started initiative.

## Changes

Remove deprecated test class

put irrelevant class in irrelevant mode.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
