### PR TITLE
Better error message when replay mode fails to find setup_properties.json

### DIFF
--- a/utils/properties_serialization.py
+++ b/utils/properties_serialization.py
@@ -87,8 +87,12 @@ class SetupProperties:
             json.dump(self._store, f, indent=2, cls=_PropertiesEncoder)
 
     def load(self, host_log_folder: str):
-        with open(f"{host_log_folder}/setup_properties.json", "r", encoding="utf-8") as f:
-            self._store = json.load(f, cls=_PropertiesDecoder)
+        filename = f"{host_log_folder}/setup_properties.json"
+        try:
+            with open(filename, "r", encoding="utf-8") as f:
+                self._store = json.load(f, cls=_PropertiesDecoder)
+        except FileNotFoundError:
+            pytest.exit(f"{filename} does not exists. Did you run the tests without any INTERNALERROR output?")
 
     def log_requests(self, item: pytest.Item) -> None:
         if properties := self._store.get(item.nodeid):


### PR DESCRIPTION
## Motivation

When `replay` mode fails to find `setup_properties.json` (either because the scenario did not run, or because there is an INTERNALERROR  in the process that generate the log, stdout looks like : 

![image](https://github.com/DataDog/system-tests/assets/11915659/d8d27432-caba-43d3-9c69-efb77147b5d9)

It's totally cryptic.

## Changes

Now, it looks like : 

![image](https://github.com/DataDog/system-tests/assets/11915659/5add5589-061c-4aee-a89b-68228fb7a6de)



## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
