### PR TITLE
Change user to table in cookie IAST name tests

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -233,7 +233,7 @@ A GET request using a cookie with name `table` and any value. The value must be 
 
 #### GET /iast/source/cookiename/test
 
-A GET request using a cookie with name `user` and any value. The name must be used in the vulnerability.
+A GET request using a cookie with name `table` and any value. The name must be used in the vulnerability.
 
 #### POST /iast/source/multipart/test
 A multipart request uploading a file (with a file name).

--- a/tests/appsec/iast/source/test_cookie_name.py
+++ b/tests/appsec/iast/source/test_cookie_name.py
@@ -11,9 +11,9 @@ class TestCookieName(BaseSourceTest):
     """Verify that request cookies are tainted"""
 
     endpoint = "/iast/source/cookiename/test"
-    requests_kwargs = [{"method": "GET", "cookies": {"user": "unused"}}]
+    requests_kwargs = [{"method": "GET", "cookies": {"table": "unused"}}]
     source_type = "http.request.cookie.name"
-    source_names = ["user"]
+    source_names = ["table"]
     source_value = "user"
 
     @missing_feature(library="dotnet", reason="Not implemented")

--- a/tests/appsec/iast/source/test_cookie_name.py
+++ b/tests/appsec/iast/source/test_cookie_name.py
@@ -14,7 +14,7 @@ class TestCookieName(BaseSourceTest):
     requests_kwargs = [{"method": "GET", "cookies": {"table": "unused"}}]
     source_type = "http.request.cookie.name"
     source_names = ["table"]
-    source_value = "user"
+    source_value = "table"
 
     @missing_feature(library="dotnet", reason="Not implemented")
     @missing_feature(context.library < "java@1.9.0", reason="Metrics not implemented")

--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/IastRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/IastRoutes.scala
@@ -166,9 +166,9 @@ object IastRoutes {
           } ~
           path("cookiename" / "test") {
             extractRequest { r =>
-              val maybeCookiePair = r.cookies.find(_.name.equals("user"))
+              val maybeCookiePair = r.cookies.find(_.name.equals("table"))
               if (maybeCookiePair.isEmpty) {
-                complete(StatusCodes.BadRequest, "No cookie named 'user'")
+                complete(StatusCodes.BadRequest, "No cookie named 'table'")
               } else {
                 val c = maybeCookiePair.get
                 sql.insecureSql(c.name,

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/IastSourceResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/IastSourceResource.java
@@ -85,7 +85,7 @@ public class IastSourceResource {
     @Path("/cookiename/test")
     public String sourceCookieName(@Context final HttpHeaders headers) {
         Collection<Cookie> cookies = headers.getCookies().values();
-        final String table = find(cookies, c -> c.getName().equalsIgnoreCase("user"), Cookie::getName);
+        final String table = find(cookies, c -> c.getName().equalsIgnoreCase("table"), Cookie::getName);
         sql.insecureSql(table, (statement, sql) -> statement.executeQuery(sql));
         return String.format("Request Cookies => %s", cookies);
     }

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/IastSourceResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/IastSourceResource.java
@@ -85,7 +85,7 @@ public class IastSourceResource {
     @Path("/cookiename/test")
     public String sourceCookieName(@Context final HttpHeaders headers) {
         Collection<Cookie> cookies = headers.getCookies().values();
-        final String table = find(cookies, c -> c.getName().equalsIgnoreCase("user"), Cookie::getName);
+        final String table = find(cookies, c -> c.getName().equalsIgnoreCase("table"), Cookie::getName);
         sql.insecureSql(table, (statement, sql) -> statement.executeQuery(sql));
         return String.format("Request Cookies => %s", cookies);
     }

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIastSource.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/AppSecIastSource.java
@@ -88,7 +88,7 @@ public class AppSecIastSource {
     @GetMapping("/cookiename/test")
     String sourceCookieName(final HttpServletRequest request) {
         List<Cookie> cookies = Arrays.asList(request.getCookies());
-        final String table = find(cookies, c -> c.getName().equalsIgnoreCase("user"), Cookie::getName);
+        final String table = find(cookies, c -> c.getName().equalsIgnoreCase("table"), Cookie::getName);
         sql.insecureSql(table, (statement, sql) -> statement.executeQuery(sql));
         return String.format("Request Cookies => %s", cookies);
     }

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSourceRouteProvider.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/iast/routes/IastSourceRouteProvider.java
@@ -71,7 +71,7 @@ public class IastSourceRouteProvider implements Consumer<Router> {
             ctx.response().end(String.format("Request Headers => %s", table));
         });
         router.get("/iast/source/cookiename/test").handler(ctx -> {
-            Cookie cookie = ctx.getCookie("user");
+            Cookie cookie = ctx.getCookie("table");
             String table = cookie.getName();
             sql.insecureSql(table, (statement, query) -> statement.executeQuery(query));
             ctx.response().end(String.format("Request Cookies => %s", cookie));

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSourceRouteProvider.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/iast/routes/IastSourceRouteProvider.java
@@ -70,7 +70,7 @@ public class IastSourceRouteProvider implements Consumer<Router> {
             ctx.response().end(String.format("Request Headers => %s", table));
         });
         router.get("/iast/source/cookiename/test").handler(ctx -> {
-            Cookie cookie = ctx.request().getCookie("user");
+            Cookie cookie = ctx.request().getCookie("table");
             String table = cookie.getName();
             sql.insecureSql(table, (statement, query) -> statement.executeQuery(query));
             ctx.response().end(String.format("Request Cookies => %s", cookie));

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -455,7 +455,7 @@ def view_iast_source_body(request):
 
 
 def view_iast_source_cookie_name(request):
-    param = [key for key in request.COOKIES.keys() if key == "user"]
+    param = [key for key in request.COOKIES.keys() if key == "table"]
     _sink_point_path_traversal(param[0])
     return HttpResponse("OK")
 

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -356,7 +356,7 @@ async def view_iast_source_body(body: Body_for_iast):
 
 @app.get("/iast/source/cookiename/test", response_class=PlainTextResponse)
 async def view_iast_source_cookie_name(request: Request):
-    param = [key for key in request.cookies if key == "user"]
+    param = [key for key in request.cookies if key == "table"]
     if param:
         _sink_point(id=param[0])
         return "OK"

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -773,7 +773,7 @@ def view_iast_source_body():
 
 @app.route("/iast/source/cookiename/test")
 def view_iast_source_cookie_name():
-    param = [key for key in flask_request.cookies.keys() if key == "user"]
+    param = [key for key in flask_request.cookies.keys() if key == "table"]
     _sink_point_path_traversal(param[0])
     return Response("OK")
 


### PR DESCRIPTION
## Motivation

With the [latest changes](https://github.com/DataDog/experimental/pull/3483), it has been decided to redact IAST keys of the vulnerabilitjies, such as "user" or "username". This would affect the existing system tests that use these keys. In particular the test that checks the tainting of the cookie names had to change the key of the cookie to, table, which is not redacted.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
