### PR TITLE
start containers in parallel

### DIFF
--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -3,6 +3,7 @@ import json
 
 import pytest
 from utils._context.library_version import LibraryVersion
+from threading import Thread
 
 from utils._context.header_tag_vars import VALID_CONFIGS, INVALID_CONFIGS
 

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -3,7 +3,6 @@ import json
 
 import pytest
 from utils._context.library_version import LibraryVersion
-from threading import Thread
 
 from utils._context.header_tag_vars import VALID_CONFIGS, INVALID_CONFIGS
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Containers that don't depend on each other shouldn't have to wait for each other before starting.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Start containers in parallel. This PR is a replacement for #2670 with less changes and more flexible code to manage interdependencies.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
