### PR TITLE
Fix run.sh for bash 3 (macOS)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -354,15 +354,18 @@ function main() {
 
     # expand scenario groups
     # bash 3.x does not support mapfile, dance around with tr and IFS
-    for i in "${scenario_args[@]}"; do
-        if [[ "${i}" =~ [A-Z0-9_]+_SCENARIOS$ ]]; then
-                # bash 3.x does not support mapfile, dance around with tr and IFS
-                IFS=',' read -r -a group <<< "$(lookup_scenario_group "${i}" "${run_mode}" | tr '\n' ',')"
-                scenarios+=("${group[@]}")
-        else
-                scenarios+=("${i}")
-        fi
-    done
+    # bash 3.x considers ${arr[@}} undefined if empty
+    if [[ ${#scenario_args[@]} -gt 0 ]]; then
+        for i in "${scenario_args[@]}"; do
+            if [[ "${i}" =~ [A-Z0-9_]+_SCENARIOS$ ]]; then
+                    # bash 3.x does not support mapfile, dance around with tr and IFS
+                    IFS=',' read -r -a group <<< "$(lookup_scenario_group "${i}" "${run_mode}" | tr '\n' ',')"
+                    scenarios+=("${group[@]}")
+            else
+                    scenarios+=("${i}")
+            fi
+        done
+    fi
 
     # when no scenario is provided, use a nice default
     if [[ "${#scenarios[@]}" -lt 1 ]]; then


### PR DESCRIPTION
## Motivation

`run.sh` fails in bash 3 with the following error:

```
/run.sh: line 236: scenario_args[@]: unbound variable
```

bash 3 considers `${arr[@]}` as unbound rather than empty. 

This happens in macOS, which ships old bash. Users can get a newer bash with `brew install bash` (and I would recommend this), but we can fix the script by checking array length first.

## Changes

Checks array length to avoid unbound variable error in bash 3.

## Reviewer checklist

* ~[ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change~
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement) _(failures in parametric tests are in master)_
* ~[ ] A docker base image is modified?~
    * ~[ ] the relevant `build-XXX-image` label is present~
* ~[ ] A scenario is added (or removed)?~
    * ~[ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)~
