### PR TITLE
Fix SQL Server healthcheck in systems with IPv6

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -764,8 +764,9 @@ class SqlServerContainer(SqlDbTestedContainer):
         if not platform.processor().startswith("arm"):
             # [!NOTE] sqlcmd tool is not available inside the ARM64 version of SQL Edge containers.
             # see https://hub.docker.com/_/microsoft-azure-sql-edge
+            # XXX: Using 127.0.0.1 here instead of localhost to avoid using IPv6 in some systems.
             healthcheck = {
-                "test": '/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "yourStrong(!)Password" -Q "SELECT 1" -b -o /dev/null',
+                "test": '/opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U sa -P "yourStrong(!)Password" -Q "SELECT 1" -b -o /dev/null',
                 "retries": 20,
             }
 


### PR DESCRIPTION
## Motivation

Fix SQL Server healthcheck in systems with IPv6.  In CircleCI we are getting this error:

```
2024/07/11 13:35:18 [launchpadd] WARNING: Failed to connect to SQL because: dial tcp [::1]:1431: getsockopt: connection refused, will reattempt connection.
```

## Changes

Using `127.0.0.1` instead of `localhost` to fix the issue where IPv6 loopback interface exists.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
