### PR TITLE
[nodejs] Add missing nextjs endpoints to improve execution time

### DIFF
--- a/utils/build/docker/nodejs/nextjs/src/app/iast/[...all]/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/iast/[...all]/route.js
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET () {
+  return NextResponse.json({ message: 'Not implemented' }, { status: 404 })
+}
+
+export async function POST () {
+  return NextResponse.json({ message: 'Not implemented' }, { status: 404 })
+}

--- a/utils/build/docker/nodejs/nextjs/src/app/login/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/login/route.js
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET () {
+  return NextResponse.json({ message: 'Not implemented' }, { status: 404 })
+}
+
+export async function POST () {
+  return NextResponse.json({ message: 'Not implemented' }, { status: 404 })
+}


### PR DESCRIPTION
## Motivation
<!-- What inspired you to submit this pull request? -->
Improve slow nextjs default scenario

## Changes
<!-- A brief description of the change being made with this pull request. -->
Add dummy endpoint returning 404 to force fast response in not implemented nextjs tests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
