### PR TITLE
Client stats test skeleton

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -152,6 +152,9 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
+  stats/:
+    test_miscs.py:
+      Test_Miscs: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py: irrelevant

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1048,6 +1048,9 @@ tests/:
         '*': v1.4.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
+  stats/:
+    test_miscs.py:
+      Test_Miscs: missing_feature
   test_the_test/:
     test_json_report.py:
       Test_Mock: v0.0.99

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -285,6 +285,9 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
+  stats/:
+    test_miscs.py:
+      Test_Miscs: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -356,6 +356,9 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
+  stats/:
+    test_miscs.py:
+      Test_Miscs: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/tests/stats/test_miscs.py
+++ b/tests/stats/test_miscs.py
@@ -1,0 +1,10 @@
+from utils import interfaces, bug, features
+
+
+@features.client_side_stats_supported
+class Test_Miscs:
+    @bug(library="golang", reason="content-type is not provided")
+    def test_request_headers(self):
+        interfaces.library.assert_request_header(
+            "/v0.6/stats", r"content-type", r"application/msgpack(, application/msgpack)?"
+        )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -458,7 +458,11 @@ class scenarios:
 
     default = EndToEndScenario(
         "DEFAULT",
-        weblog_env={"DD_DBM_PROPAGATION_MODE": "service"},
+        weblog_env={
+            "DD_DBM_PROPAGATION_MODE": "service",
+            # "DD_TRACE_STATS_COMPUTATION_ENABLED": "1",
+            # "DD_TRACE_FEATURES": "discovery",
+        },
         include_postgres_db=True,
         doc="Default scenario, spawn tracer, the Postgres databases and agent, and run most of exisiting tests",
     )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -460,8 +460,8 @@ class scenarios:
         "DEFAULT",
         weblog_env={
             "DD_DBM_PROPAGATION_MODE": "service",
-            # "DD_TRACE_STATS_COMPUTATION_ENABLED": "1",
-            # "DD_TRACE_FEATURES": "discovery",
+            "DD_TRACE_STATS_COMPUTATION_ENABLED": "1",
+            "DD_TRACE_FEATURES": "discovery",
         },
         include_postgres_db=True,
         doc="Default scenario, spawn tracer, the Postgres databases and agent, and run most of exisiting tests",

--- a/utils/interfaces/schemas/miscs/telemetry/v2/objects/configuration.json
+++ b/utils/interfaces/schemas/miscs/telemetry/v2/objects/configuration.json
@@ -14,7 +14,8 @@
           "number",
           "boolean",
           "string",
-          "null"
+          "null",
+          "object"
         ]
       },
       "origin": {

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -104,6 +104,9 @@ def deserialize_http_message(path, message, content: bytes, interface, key):
     content_type = get_header_value("content-type", message["headers"])
     content_type = None if content_type is None else content_type.lower()
 
+    if not content or len(content) == 0:
+        return None
+
     if content_type and any((mime_type in content_type for mime_type in ("application/json", "text/json"))):
         return json_load()
 
@@ -122,7 +125,7 @@ def deserialize_http_message(path, message, content: bytes, interface, key):
             else:
                 return content
 
-    if content_type in ("application/msgpack", "application/msgpack, application/msgpack"):
+    if content_type in ("application/msgpack", "application/msgpack, application/msgpack") or (path == "/v0.6/stats"):
         result = msgpack.unpackb(content, unicode_errors="replace", strict_map_key=False)
 
         if interface == "library":
@@ -134,6 +137,12 @@ def deserialize_http_message(path, message, content: bytes, interface, key):
                 result = _decode_v_0_5_traces(result)
                 _decode_unsigned_int_traces(result)
                 _deserialized_nested_json_from_trace_payloads(result, interface)
+
+            elif path == "/v0.6/stats":
+                # TODO : more strange stuff inside to deserialize
+                # ddsketch protobuf in content.stats[].stats.OkSummary  and ErrorSummary
+                # https://github.com/DataDog/sketches-go/blob/master/ddsketch/pb/ddsketch.proto#L15
+                pass
 
         _convert_bytes_values(result)
 
@@ -190,9 +199,6 @@ def deserialize_http_message(path, message, content: bytes, interface, key):
 
     if content_type == "text/plain":
         return content.decode("ascii")
-
-    if not content or len(content) == 0:
-        return None
 
     return content
 


### PR DESCRIPTION
## Motivation

Test client side stats computation

## Changes

* activate stats computation on default scenario
* add `object` in valid types for configuration value in telemetry request (to be validated)
*  deserialize payload for `/v0.6/stats` requests
* add a basic check on header on the above request (currently failing on go)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
