### PR TITLE
[java] Fix wrong version schema in header related tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -584,6 +584,8 @@ tests/:
         ratpack: missing_feature (login endpoints not implemented)
         resteasy-netty3: missing_feature (login endpoints not implemented)
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-openliberty: missing_feature (weblog returns error 500)
+        spring-boot-wildfly: bug (manual.keep should be in meta when _sampling_priority_v1 is not MANUAL_KEEP)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)
       Test_Login_Events_Extended:
@@ -594,6 +596,8 @@ tests/:
         ratpack: missing_feature (login endpoints not implemented)
         resteasy-netty3: missing_feature (login endpoints not implemented)
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-openliberty: missing_feature (weblog returns error 500)
+        spring-boot-wildfly: bug (manual.keep should be in meta when _sampling_priority_v1 is not MANUAL_KEEP)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)
       Test_V2_Login_Events: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1066,7 +1066,7 @@ tests/:
     Test_Propagate: missing_feature
     Test_Propagate_Legacy: missing_feature
   test_library_conf.py:
-    Test_HeaderTags: v1.35.0
+    Test_HeaderTags: missing_feature
     Test_HeaderTags_Colon_Leading: v0.102.0
     Test_HeaderTags_Colon_Trailing: v0.102.0
     Test_HeaderTags_Long: v0.102.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -577,7 +577,7 @@ tests/:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     test_automated_login_events.py:
       Test_Login_Events:
-        '*': 1.36.0
+        '*': v1.36.0
         akka-http: missing_feature (login endpoints not implemented)
         jersey-grizzly2: missing_feature (login endpoints not implemented)
         play: missing_feature (login endpoints not implemented)
@@ -587,7 +587,7 @@ tests/:
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)
       Test_Login_Events_Extended:
-        '*': 1.36.0
+        '*': v1.36.0
         akka-http: missing_feature (login endpoints not implemented)
         jersey-grizzly2: missing_feature (login endpoints not implemented)
         play: missing_feature (login endpoints not implemented)
@@ -876,7 +876,7 @@ tests/:
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_CollectDefaultRequestHeader:
-        '*': 1.35.0
+        '*': v1.35.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_CollectRespondHeaders:
         '*': v0.102.0
@@ -884,7 +884,7 @@ tests/:
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_ExternalWafRequestsIdentification:
-        '*': 1.35.0
+        '*': v1.35.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_RetainTraces:
         '*': v0.92.0
@@ -1066,7 +1066,7 @@ tests/:
     Test_Propagate: missing_feature
     Test_Propagate_Legacy: missing_feature
   test_library_conf.py:
-    Test_HeaderTags: 1.35.0
+    Test_HeaderTags: v1.35.0
     Test_HeaderTags_Colon_Leading: v0.102.0
     Test_HeaderTags_Colon_Trailing: v0.102.0
     Test_HeaderTags_Long: v0.102.0

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -340,7 +340,8 @@ class Test_Login_Events_Extended:
                 # theres no login field in ruby
                 assert meta["usr.email"] == "testuser@ddog.com"
                 assert meta["usr.username"] == "test"
-            else:
+            elif context.library != "java":
+                # there are no extra fields in java
                 assert meta["usr.email"] == "testuser@ddog.com"
                 assert meta["usr.username"] == "test"
                 assert meta["usr.login"] == "test"
@@ -358,18 +359,21 @@ class Test_Login_Events_Extended:
             assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "extended"
             assert meta["appsec.events.users.login.success.track"] == "true"
             assert meta["usr.id"] == "social-security-id"
-            assert meta["usr.email"] == "testuser@ddog.com"
 
             if context.library in ("dotnet", "python"):
                 # theres no login field in dotnet
                 # usr.name was in the sdk before so it was kept as is
                 assert meta["usr.name"] == "test"
+                assert meta["usr.email"] == "testuser@ddog.com"
             elif context.library == "ruby":
                 # theres no login field in ruby
                 assert meta["usr.username"] == "test"
-            else:
+                assert meta["usr.email"] == "testuser@ddog.com"
+            elif context.library != "java":
+                # there are no extra fields in java
                 assert meta["usr.username"] == "test"
                 assert meta["usr.login"] == "test"
+                assert meta["usr.email"] == "testuser@ddog.com"
 
             assert_priority(span, meta)
 

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecSdkToken.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecSdkToken.java
@@ -34,11 +34,15 @@ public class AppSecSdkToken extends UsernamePasswordAuthenticationToken {
 
     @Override
     public String getName() {
-        if (getPrincipal() instanceof AppSecUser) {
+        if (sdkEvent != null) {
+            // report the provided username
+            return sdkUser;
+        } else if (getPrincipal() instanceof AppSecUser) {
             // report the id instead of the username
             return ((AppSecUser) getPrincipal()).getId();
+        } else {
+            return super.getName();
         }
-        return super.getName();
     }
 
     public String getSdkEvent() {


### PR DESCRIPTION
## Motivation

The version was badly formatted causing the test to XPASS instead of PASS

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
