### PR TITLE
[php] full skip for APPSEC-53993

### DIFF
--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -73,7 +73,7 @@ class Test_Schema_Request_Headers:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@flaky(context.library > "php@1.1.0", reason="APPSEC-53993")
+@flaky(context.library == "php", reason="APPSEC-53993")
 class Test_Schema_Request_Cookies:
     """Test API Security - Request Cookies Schema"""
 
@@ -138,7 +138,7 @@ class Test_Schema_Request_Path_Parameters:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@flaky(context.library > "php@1.1.0", reason="APPSEC-53993")
+@flaky(context.library == "php", reason="APPSEC-53993")
 class Test_Schema_Request_Json_Body:
     """Test API Security - Request Body and list length"""
 
@@ -159,7 +159,7 @@ class Test_Schema_Request_Json_Body:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@flaky(context.library > "php@1.1.0", reason="APPSEC-53993")
+@flaky(context.library == "php", reason="APPSEC-53993")
 class Test_Schema_Request_FormUrlEncoded_Body:
     """Test API Security - Request Body and list length"""
 
@@ -219,7 +219,7 @@ class Test_Schema_Response_Headers:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@flaky(context.library > "php@1.1.0", reason="APPSEC-53993")
+@flaky(context.library == "php", reason="APPSEC-53993")
 class Test_Schema_Response_Body:
     """Test API Security - Response Body Schema with urlencoded body"""
 


### PR DESCRIPTION
## Motivation

The dev version artifact of the PHP lib got a invalid version, so skipping this test for all version

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
