### PR TITLE
fix(injection): Add old GPG keys

### DIFF
--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject-prepare_repos.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject-prepare_repos.yml
@@ -18,6 +18,8 @@
             sudo chmod a+r /usr/share/keyrings/datadog-archive-keyring.gpg
 
             curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+            curl https://keys.datadoghq.com/DATADOG_APT_KEY_06462314.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+            curl https://keys.datadoghq.com/DATADOG_APT_KEY_C0962C7D.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
             curl https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
             curl https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
 

--- a/utils/build/virtual_machine/provisions/auto-inject/repositories/rpm/datadog-stable.aarch64.repo
+++ b/utils/build/virtual_machine/provisions/auto-inject/repositories/rpm/datadog-stable.aarch64.repo
@@ -3,3 +3,4 @@ baseurl=https://yum.datadoghq.com/stable/7/aarch64/
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_CURRENT.public
+       https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_FD4BF915.public

--- a/utils/build/virtual_machine/provisions/auto-inject/repositories/rpm/datadog-stable.x86_64.repo
+++ b/utils/build/virtual_machine/provisions/auto-inject/repositories/rpm/datadog-stable.x86_64.repo
@@ -3,3 +3,4 @@ baseurl=https://yum.datadoghq.com/stable/7/x86_64/
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_CURRENT.public
+       https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_FD4BF915.public

--- a/utils/build/virtual_machine/provisions/auto-inject/repositories/rpm/datadog-staging.aarch64.repo
+++ b/utils/build/virtual_machine/provisions/auto-inject/repositories/rpm/datadog-staging.aarch64.repo
@@ -3,3 +3,4 @@ baseurl=https://yum.datad0g.com/beta/apm/aarch64/
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_CURRENT.public
+       https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_FD4BF915.public

--- a/utils/build/virtual_machine/provisions/auto-inject/repositories/rpm/datadog-staging.x86_64.repo
+++ b/utils/build/virtual_machine/provisions/auto-inject/repositories/rpm/datadog-staging.x86_64.repo
@@ -3,3 +3,4 @@ baseurl=https://yum.datad0g.com/beta/apm/x86_64/
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_CURRENT.public
+       https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_FD4BF915.public


### PR DESCRIPTION
## Motivation
Tests failing

## Changes
Add previous current (now old) GPG keys to be able to install older deb/rpm packages

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
