### PR TITLE
Cbeauchesne/stats bugs

### DIFF
--- a/tests/stats/test_miscs.py
+++ b/tests/stats/test_miscs.py
@@ -12,5 +12,5 @@ class Test_Miscs:
     @scenarios.appsec_disabled
     @bug(library="python", reason="Stats seems to be activated by default on python lib. To be confirmed")
     def test_disable(self):
-        requests = interfaces.library.get_data("/v0.6/stats")
+        requests = list(interfaces.library.get_data("/v0.6/stats"))
         assert len(requests) == 0, "Stats should be disabled by default"

--- a/tests/stats/test_miscs.py
+++ b/tests/stats/test_miscs.py
@@ -1,4 +1,4 @@
-from utils import interfaces, bug, features
+from utils import interfaces, bug, features, scenarios
 
 
 @features.client_side_stats_supported
@@ -8,3 +8,9 @@ class Test_Miscs:
         interfaces.library.assert_request_header(
             "/v0.6/stats", r"content-type", r"application/msgpack(, application/msgpack)?"
         )
+
+    @scenarios.appsec_disabled
+    @bug(library="python", reason="Stats seems to be activated by default on python lib. To be confirmed")
+    def test_disable(self):
+        requests = interfaces.library.get_data("/v0.6/stats")
+        assert len(requests) == 0, "Stats should be disabled by default"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -20,6 +20,7 @@ class Test_library:
             excluded_points=[
                 ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]"),
                 ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload"),  # APPSEC-52845
+                ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[].value"),  # APMS-12697
             ]
         )
 
@@ -30,6 +31,12 @@ class Test_library:
     @bug(context.library < "python@v2.9.0.dev", reason="APPSEC-52845")
     def test_library_schema_telemetry_job_object(self):
         interfaces.library.assert_schema_point("/telemetry/proxy/api/v2/apmtelemetry", "$.payload")
+
+    @bug(library="golang", reason="APMS-12697")
+    def test_library_telenetry_configuration_value(self):
+        interfaces.library.assert_schema_point(
+            "/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[].value"
+        )
 
 
 @scenarios.all_endtoend_scenarios
@@ -46,6 +53,7 @@ class Test_Agent:
                 ("/api/v2/apmtelemetry", "$.payload.configuration[]"),
                 ("/api/v2/apmtelemetry", "$.payload"),  # APPSEC-52845
                 ("/api/v2/apmtelemetry", "$"),  # the main payload sent by the agent may be an array i/o an object
+                ("/api/v2/apmtelemetry", "$.payload.configuration[].value"),  # APMS-12697
             ]
         )
 
@@ -63,3 +71,7 @@ class Test_Agent:
     @bug(context.agent_version > "7.53.0", reason="Jira missing")
     def test_agent_schema_telemetry_main_payload(self):
         interfaces.agent.assert_schema_point("/api/v2/apmtelemetry", "$")
+
+    @bug(library="golang", reason="APMS-12697")
+    def test_library_telenetry_configuration_value(self):
+        interfaces.agent.assert_schema_point("/api/v2/apmtelemetry", "$.payload.configuration[].value")

--- a/utils/interfaces/schemas/miscs/telemetry/v2/objects/configuration.json
+++ b/utils/interfaces/schemas/miscs/telemetry/v2/objects/configuration.json
@@ -14,8 +14,7 @@
           "number",
           "boolean",
           "string",
-          "null",
-          "object"
+          "null"
         ]
       },
       "origin": {


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

ADD a test checking that stats is disabled by default
Skip schema for a point on telemetry request on golang ([APMS-12697](https://datadoghq.atlassian.net/browse/APMS-12697))

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMS-12697]: https://datadoghq.atlassian.net/browse/APMS-12697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ