### PR TITLE
Reduce flakyness of parametric tests

### DIFF
--- a/tests/parametric/test_trace_sampling.py
+++ b/tests/parametric/test_trace_sampling.py
@@ -487,13 +487,16 @@ class Test_Trace_Sampling_Tags_Feb2024_Revision:
         self.assert_matching_span(test_agent, name="matching-span", service="test")
 
     @pytest.mark.parametrize("library_env", [tag_sampling_env("*"), tag_sampling_env("**"), tag_sampling_env("***")])
+    @pytest.mark.parametrize("tag_value", [-100, -0.5, 0, 5, 1000])
     @missing_feature(library="cpp", reason="No metric interface")
     @flaky(library="golang", reason="The test itself is probably flaky")
-    def test_metric_existence(self, test_agent, test_library):
+    @bug(library="nodejs", reason="When tag_value==0, SAMPLING_PRIORITY_KEY is -1.0 instead of 0")
+    def test_metric_existence(self, test_agent, test_library, tag_value):
         """Tests that any patterns are equivalent to an existence check for metrics"""
+
         with test_library:
             with test_library.start_span(name="matching-span", service="test") as span:
-                span.set_metric("tag", random.choice([-100, -0.5, 0, 5, 1000]))
+                span.set_metric("tag", tag_value)
 
         self.assert_matching_span(test_agent, name="matching-span", service="test")
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
