### PR TITLE
Let docker choose an host port 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Test idiomatics scenarios
         run: |
           ./run.sh DEFAULT
-          TEST_LIBRARY=golang ./run.sh PARAMETRIC
+          TEST_LIBRARY=golang ./run.sh PARAMETRIC --splits=8 --group=1
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
 

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on:
       group: "APM Larger Runners"
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         job_instance: ${{ fromJson( inputs._experimental_job_matrix ) }}
     env:

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -64,7 +64,7 @@ jobs:
           RUN_ATTEMPTS=1
           while [ $RUN_ATTEMPTS -le 3 ]; do
             echo "Running parametric test attempt $RUN_ATTEMPTS"
-            timeout 720s ./run.sh PARAMETRIC
+            timeout 720s ./run.sh PARAMETRIC --splits=${{ inputs._experimental_job_count }} --group=${{ matrix.job_instance }}
             status=$?
             #timneout returns 124 if it times out
             #if the return code is not 124, then we exit with the status

--- a/conftest.py
+++ b/conftest.py
@@ -359,11 +359,14 @@ def pytest_sessionfinish(session, exitstatus):
 
         data = session.config._json_report.report  # pylint: disable=protected-access
 
-        junit_modifyreport(
-            data, session.config.option.xmlpath, junit_properties=context.scenario.get_junit_properties(),
-        )
+        try:
+            junit_modifyreport(
+                data, session.config.option.xmlpath, junit_properties=context.scenario.get_junit_properties(),
+            )
 
-        export_feature_parity_dashboard(session, data)
+            export_feature_parity_dashboard(session, data)
+        except Exception:
+            logger.exception("Fail to export export reports", exc_info=True)
 
 
 def export_feature_parity_dashboard(session, data):

--- a/docs/execute/troubleshooting.md
+++ b/docs/execute/troubleshooting.md
@@ -40,3 +40,11 @@ sudo chown -R $(whoami) ~/.docker
 ## NodeJs weblog experimenting segfaults on Mac/Intel
 
 In docker dashbaord, setting, general, untick `Use Virtualization Framework`. See this [Stack overflow thread](https://stackoverflow.com/questions/76735062/segmentation-fault-in-node-js-application-running-in-docker).
+
+## Parametric scenario : `GRPC recvmsg:Connection reset by peer`
+
+The GRPC interface seems to be less stable. No other solution than retry so far.
+
+## Parametric scenario : `Fail to bind port`
+
+Docker seems to sometimes keep a host port open, even after the container being removed. There is wait and rety mechanism, but it may be not enough. No other solution than retry so far.

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -306,10 +306,10 @@ tests/:
         rails70: missing_feature (Endpoint not implemented)
   parametric/:
     test_dynamic_configuration.py:
-      TestDynamicConfigHeaderTags: v2.0.0
+      TestDynamicConfigHeaderTags: bug (To be confirmed, theoricall version is v2.0.0)
       TestDynamicConfigSamplingRules: v2.0.0
       TestDynamicConfigTracingEnabled: missing_feature
-      TestDynamicConfigV1: v1.13.0
+      TestDynamicConfigV1: bug (to be investigated, theoricall version is v1.13.0)
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_otel_api_interoperability.py: missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -306,10 +306,10 @@ tests/:
         rails70: missing_feature (Endpoint not implemented)
   parametric/:
     test_dynamic_configuration.py:
-      TestDynamicConfigHeaderTags: bug (To be confirmed, theoricall version is v2.0.0)
+      TestDynamicConfigHeaderTags: bug (To be confirmed, theorical version is v2.0.0)
       TestDynamicConfigSamplingRules: v2.0.0
       TestDynamicConfigTracingEnabled: missing_feature
-      TestDynamicConfigV1: bug (to be investigated, theoricall version is v1.13.0)
+      TestDynamicConfigV1: bug (to be investigated, theorical version is v1.13.0)
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_otel_api_interoperability.py: missing_feature

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pytest-json-report==1.5.0
 pytest-split==0.9.0
 pytest-xdist==3.2.1
 black==19.10b0  # TODO : move to 22.8.0
+psutil==6.0.0
 pylint==3.0.4
 python-dateutil==2.8.2
 msgpack==1.0.4

--- a/run.sh
+++ b/run.sh
@@ -394,16 +394,12 @@ function main() {
     # In the meantime remove the warning from the output
     pytest_args+=( '-p' 'no:warnings' )
 
-    # parametric xdist are brokken in CI
-    pytest_numprocesses=1
-
     # evaluate max pytest number of process
-    #
-    # for scenario in "${scenarios[@]}"; do
-    #     if [[ "${scenario}" != "PARAMETRIC" ]]; then
-    #         pytest_numprocesses=1
-    #     fi
-    # done
+    for scenario in "${scenarios[@]}"; do
+        if [[ "${scenario}" != "PARAMETRIC" ]]; then
+            pytest_numprocesses=1
+        fi
+    done
 
     if [[ "${#libraries[@]}" -gt 0 ]]; then
       for library in "${libraries[@]}"; do
@@ -428,8 +424,7 @@ function main() {
         0|1)
             ;;
         *)
-            # pytest_args+=( '-n' "${pytest_numprocesses}" ) DO NOT MERGE
-            pytest_args+=( '-n' "16" )
+            pytest_args+=( '-n' "${pytest_numprocesses}" )
             ;;
     esac
 

--- a/run.sh
+++ b/run.sh
@@ -394,12 +394,16 @@ function main() {
     # In the meantime remove the warning from the output
     pytest_args+=( '-p' 'no:warnings' )
 
+    # parametric xdist are brokken in CI
+    pytest_numprocesses=1
+
     # evaluate max pytest number of process
-    for scenario in "${scenarios[@]}"; do
-        if [[ "${scenario}" != "PARAMETRIC" ]]; then
-            pytest_numprocesses=1
-        fi
-    done
+    #
+    # for scenario in "${scenarios[@]}"; do
+    #     if [[ "${scenario}" != "PARAMETRIC" ]]; then
+    #         pytest_numprocesses=1
+    #     fi
+    # done
 
     if [[ "${#libraries[@]}" -gt 0 ]]; then
       for library in "${libraries[@]}"; do
@@ -424,7 +428,8 @@ function main() {
         0|1)
             ;;
         *)
-            pytest_args+=( '-n' "${pytest_numprocesses}" )
+            # pytest_args+=( '-n' "${pytest_numprocesses}" ) DO NOT MERGE
+            pytest_args+=( '-n' "16" )
             ;;
     esac
 

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -30,10 +30,12 @@ default_subprocess_run_timeout = 300
 
 
 @pytest.fixture
-def test_id():
+def test_id(request) -> str:
     import uuid
 
-    yield str(uuid.uuid4())[0:6]
+    result = str(uuid.uuid4())[0:6]
+    logger.info(f"Test {request.node.nodeid} ID: {result}")
+    return result
 
 
 class AgentRequest(TypedDict):
@@ -491,7 +493,7 @@ def test_agent(
         log_file=test_agent_log_file,
         network_name=docker_network,
     ) as host_port:
-        logger.debug(f"Test agent started on host port {host_port}")
+        logger.debug(f"Test agent {test_agent_container_name} started on host port {host_port}")
         test_agent_external_port = host_port
         client = _TestAgentAPI(base_url=f"http://localhost:{test_agent_external_port}", pytest_request=request)
         time.sleep(0.2)  # intial wait time, the trace agent takes 200ms to start

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -570,6 +570,7 @@ class TestDynamicConfigSamplingRules:
             }
         ],
     )
+    @bug(library="ruby", reason="To be investigated")
     def test_trace_sampling_rules_override_env(self, library_env, test_agent, test_library):
         """The RC sampling rules should override the environment variable and decision maker is set appropriately.
 
@@ -635,6 +636,7 @@ class TestDynamicConfigSamplingRules:
         assert span["meta"]["_dd.p.dm"] == "-3"
 
     @parametrize("library_env", [{**DEFAULT_ENVVARS}])
+    @bug(library="ruby", reason="To be investigated")
     def test_trace_sampling_rules_override_rate(self, library_env, test_agent, test_library):
         """The RC sampling rules should override the RC sampling rate."""
         RC_SAMPLING_RULE_RATE_CUSTOMER = 0.8
@@ -808,6 +810,7 @@ class TestDynamicConfigSamplingRules:
         assert span["meta"]["_dd.p.dm"] == "-12"
 
     @bug(library="cpp", reason="unknown")
+    @bug(library="ruby", reason="To be investigated")
     @parametrize("library_env", [{**DEFAULT_ENVVARS}])
     def test_remote_sampling_rules_retention(self, library_env, test_agent, test_library):
         """Only the last set of sampling rules should be applied"""

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -289,7 +289,7 @@ class ParametricScenario(Scenario):
             time.sleep(0.1)
 
         # if this happen, maybe increase the sleep time?
-        raise RuntimeError(f"Docker incorrectly bind ports for {name}")  
+        raise RuntimeError(f"Docker incorrectly bind ports for {name}")
 
 
 def _get_base_directory():

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -164,11 +164,8 @@ class ParametricScenario(Scenario):
 
     def _clean_networks(self):
         """ some network may still exists from previous unfinished sessions """
-
-        for network in _get_client().networks.list():
-            if network.name.startswith(_NETWORK_PREFIX):
-                logger.info(f"Removing {network}")
-                network.remove()
+        logger.info("Removing unused network")
+        _get_client().networks.prune()
 
     @property
     def library(self):

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -70,6 +70,8 @@ class APMLibraryTestServer:
     env: Dict[str, str] = dataclasses.field(default_factory=dict)
     volumes: Dict[str, str] = dataclasses.field(default_factory=dict)
 
+    container: Container = None
+
 
 class ParametricScenario(Scenario):
     TEST_AGENT_IMAGE = "ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.17.0"

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -270,6 +270,10 @@ class ParametricScenario(Scenario):
         for _ in range(10):
             container.reload()
 
+            if container.status == "exited":
+                container.remove()
+                raise RuntimeError(f"Container {name} exited unexpectedly")
+
             if f"{container_port}/tcp" in container.attrs["NetworkSettings"]["Ports"]:
                 if len(container.attrs["NetworkSettings"]["Ports"][f"{container_port}/tcp"]) != 0:
                     logger.debug(f"container {name} started")
@@ -278,7 +282,9 @@ class ParametricScenario(Scenario):
 
             time.sleep(0.1)
 
-        pytest.exit(f"Docker incorrectly bind ports for {name}", 1)  # if this happen, increase the sleep time
+        raise RuntimeError(
+            f"Docker incorrectly bind ports for {name}"
+        )  # if this happen, maybe increase the sleep time?
 
 
 def _get_base_directory():

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -293,6 +293,11 @@ class ParametricScenario(Scenario):
                 return container
             except APIError:
                 logger.exception(f"Failed to run container {name}, retrying...")
+
+                # at this point, even if it failed to start, the container may exists!
+                for container in _get_client().containers.list(filters={"name": name}, all=True):
+                    container.remove(force=True)
+
                 time.sleep(0.5)  # give some to time to docker daemon to free resources
                 attempt -= 1
 

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -4,6 +4,7 @@ import time
 import urllib.parse
 from typing import Generator, List, Optional, Tuple, TypedDict, Union, Dict
 
+from docker.models.containers import Container
 import grpc
 import pytest
 import requests
@@ -147,9 +148,10 @@ class APMLibraryClient:
 
 
 class APMLibraryClientHTTP(APMLibraryClient):
-    def __init__(self, url: str, timeout: int):
+    def __init__(self, url: str, timeout: int, container: Container):
         self._base_url = url
         self._session = requests.Session()
+        self.container = container
 
         # wait for server to start
         self._wait(timeout)
@@ -162,7 +164,10 @@ class APMLibraryClientHTTP(APMLibraryClient):
                 if resp.status_code == 404:
                     break
             except Exception:
-                pass
+                self.container.reload()
+                if self.container.status != "running":
+                    message = f"Container {self.container.name} status is {self.container.status}"
+                    raise RuntimeError(message)
             time.sleep(delay)
         else:
             raise RuntimeError(f"Timeout of {timeout} seconds exceeded waiting for HTTP server to start")

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -5,6 +5,7 @@ import urllib.parse
 from typing import Generator, List, Optional, Tuple, TypedDict, Union, Dict
 
 import grpc
+import pytest
 import requests
 
 from utils.parametric.protos import apm_test_client_pb2 as pb
@@ -195,6 +196,10 @@ class APMLibraryClientHTTP(APMLibraryClient):
                 "span_tags": tags,
             },
         )
+
+        if resp.status_code != 200:
+            raise pytest.fail(f"Failed to start span: {resp.text}", pytrace=False)
+
         resp_json = resp.json()
         return StartSpanResponse(span_id=resp_json["span_id"], trace_id=resp_json["trace_id"],)
 


### PR DESCRIPTION
## Motivation

Fixes #2734

Parametric tests needs two port for each test that being executed. The current solution open a socket, get the port, closes the socket, run the test. Be between the moment we close the socket, and we start the test, the port can be allocated to anything else.

The issue is that, as we use `xdist` to run tests in parallel, and as we use 16-cores machine, the probability of having a port picked by two `xdist` runner is close to 1.

## Changes

Let docker pick an available port.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
