### PR TITLE
chore(injection): Re-enable disabled weblogs

### DIFF
--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject-environment.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject-environment.yml
@@ -5,7 +5,6 @@
   agent_major_version: "7"
   injection_repo_url: datad0g.com
   injection_dist_channel: beta
-  injection_major_version: apm
   deb_repo_name: beta
   rpm_repo_name: datadog-staging
   oci_registry_template: "669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog/%s-package-dev:latest"
@@ -16,7 +15,6 @@
   agent_major_version: "7"
   injection_repo_url: datadoghq.com
   injection_dist_channel: stable
-  injection_major_version: "7"
   deb_repo_name: stable
   rpm_repo_name: datadog-stable
   oci_registry_template: "669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog/%s-package:latest"

--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject_init_vm_config.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject_init_vm_config.yml
@@ -46,7 +46,21 @@
     echo 'AcceptEnv DD_*' | sudo tee -a /etc/ssh/sshd_config
     sudo systemctl restart sshd.service || true
     echo "DONE"
- 
+- os_type: linux
+  os_distro: rpm
+  os_branch: centos_7_amd64 # CentOS override as the mirrors are not available anymore
+  remote-command: |    
+    sudo sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+    sudo sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+    sudo sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+  
+    #Allow DD env variables from ssh
+    echo 'AcceptEnv DD_*' | sudo tee -a /etc/ssh/sshd_config
+    sudo id -u datadog &>/dev/null || sudo useradd -m datadog
+    sudo yum clean expire-cache
+    #sudo yum -y update
+    sudo systemctl restart sshd.service
+
 - os_type: linux
   os_distro: rpm
   remote-command: |

--- a/utils/build/virtual_machine/provisions/auto-inject/docker/auto-inject_prepare_docker.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/docker/auto-inject_prepare_docker.yml
@@ -22,16 +22,13 @@
     - os_type: linux
       os_distro: rpm
       os_branch: centos_7_amd64 # CentOS override
-      remote-command: |    
-        sudo sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-        sudo sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
-        sudo sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+      remote-command: |
         curl -fsSL https://get.docker.com | sudo sh
         sudo systemctl start docker
         sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/bin/docker-compose && sudo chmod +x /usr/bin/docker-compose && sudo docker-compose --version
     - os_type: linux
       os_distro: rpm
-      remote-command: |    
+      remote-command: |
         sudo yum -y install docker
         sudo systemctl start docker.service
         sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/bin/docker-compose && sudo chmod +x /usr/bin/docker-compose && sudo docker-compose --version

--- a/utils/build/virtual_machine/provisions/auto-inject/repositories/autoinstall/execute_install_script.sh
+++ b/utils/build/virtual_machine/provisions/auto-inject/repositories/autoinstall/execute_install_script.sh
@@ -1,31 +1,19 @@
 #!/bin/bash
 
-#This script is needed only for this reason: https://datadoghq.atlassian.net/browse/AP-2165
+# This script is needed only for this reason: https://datadoghq.atlassian.net/browse/AP-2165
 
 if [ -z "$INSTALLER_URL" ]; then
     INSTALLER_URL="https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh"
 fi
 
-curl -L $INSTALLER_URL --output install_script_agent7.sh
-chmod 755 install_script_agent7.sh
-# shellcheck disable=SC2154
-sed  "s/\"7\"/\"$DD_injection_major_version\"/g" install_script_agent7.sh > install_script_agent7_autoinject_temp.sh
-sed  "s/-eq 7/== \"$DD_injection_major_version\"/g" install_script_agent7_autoinject_temp.sh > install_script_agent7_autoinject.sh
-chmod 755 install_script_agent7_autoinject.sh
-
 if [ "$DD_APM_INSTRUMENTATION_ENABLED" == "docker" ]; then
-    echo "Skipping agent installation in container/docker scenario (Installing only datadog-signing-keys)"
-    # shellcheck disable=SC2154
-    DD_SITE=$DD_injection_repo_url DD_NO_AGENT_INSTALL=true ./install_script_agent7.sh
+    # Skip agent installation in container/docker scenarios
+    export DD_NO_AGENT_INSTALL=true
 fi
+
 # shellcheck disable=SC2154
-DD_SITE=$DD_injection_repo_url  \
-DD_REPO_URL=$DD_injection_repo_url \
-DD_AGENT_DIST_CHANNEL=$DD_injection_dist_channel \
-DD_AGENT_MAJOR_VERSION=$DD_injection_major_version \
+DD_REPO_URL="$DD_injection_repo_url" \
 DD_APM_INSTRUMENTATION_LANGUAGES="$DD_LANG" \
-DD_APM_INSTRUMENTATION_ENABLED="$DD_APM_INSTRUMENTATION_ENABLED" \
-DD_PROFILING_ENABLED="$DD_PROFILING_ENABLED" \
-./install_script_agent7_autoinject.sh
+bash -c "$(curl -L $INSTALLER_URL)"
 
 echo "lib-injection install done"

--- a/utils/build/virtual_machine/provisions/host-auto-inject-install-script/auto-inject_host_script.yml
+++ b/utils/build/virtual_machine/provisions/host-auto-inject-install-script/auto-inject_host_script.yml
@@ -6,17 +6,12 @@
       - name: copy-tracer-debug-config
         local_path: utils/build/virtual_machine/provisions/auto-inject/tracer_debug/debug_config.yaml
   remote-command: |
-    
-    #Env variables set on the scenario definition. Write to file and load  
+    # Env variables set on the scenario definition. Write to file and load  
     SCENARIO_AGENT_ENV="${DD_AGENT_ENV:-''}"
     echo "${SCENARIO_AGENT_ENV}" > scenario_agent.env
     echo "AGENT VARIABLES CONFIGURED FROM THE SCENARIO:"
     cat scenario_agent.env
     export $(cat scenario_agent.env | xargs) 
 
-    printf "DD_APM_RECEIVER_SOCKET=/opt/datadog/apm/inject/run/apm.socket\nDD_DOGSTATSD_SOCKET=/opt/datadog/apm/inject/run/dsd.socket\nDD_USE_DOGSTATSD=true\n" | sudo tee /var/run/datadog-installer/environment
     DD_APM_INSTRUMENTATION_ENABLED=host bash execute_install_script.sh
-    sudo mkdir -p /var/run/datadog-installer
-    sudo mkdir -p /opt/datadog/apm/inject/run
-    sudo chmod 777 /opt/datadog/apm/inject/run
     sudo cp debug_config.yaml /etc/datadog-agent/inject/debug_config.yaml

--- a/utils/build/virtual_machine/provisions/host-auto-inject-install-script/provision.yml
+++ b/utils/build/virtual_machine/provisions/host-auto-inject-install-script/provision.yml
@@ -12,21 +12,12 @@ vm_logs:
 #Mandatory: Steps to install provision 
 provision_steps:
   - init-config #Very first machine actions, like disable auto updates
-  - install-agent #Install the agent (allways latest release)
-  - autoinjection_install_script #Install the auto-injection softaware 'datadog-apm-inject' and 'datadog-apm-library-$DD_LANG' using the agent install script
+  - autoinjection_install_script #Install the injector, the agent, and the tracing library using the install script
 
 init-config:
   cache: true
   populate_env: false
   install: !include utils/build/virtual_machine/provisions/auto-inject/auto-inject_init_vm_config.yml
 
-install-agent:
-  install:
-    - os_type: linux
-      remote-command: |
-        REPO_URL=$DD_agent_repo_url DD_AGENT_DIST_CHANNEL=$DD_agent_dist_channel DD_AGENT_MAJOR_VERSION=$DD_agent_major_version bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
-
 autoinjection_install_script:
   install: !include utils/build/virtual_machine/provisions/host-auto-inject-install-script/auto-inject_host_script.yml
-
-

--- a/utils/build/virtual_machine/weblogs/common/create_and_run_app_container.sh
+++ b/utils/build/virtual_machine/weblogs/common/create_and_run_app_container.sh
@@ -9,6 +9,8 @@ sudo chmod -R 755 *
 rm -rf Dockerfile || true
 cp Dockerfile.template Dockerfile || true
 
+sudo systemctl start docker # Start docker service if it's not started
+
 #The parameter RUNTIME is used only for dotnet
 sudo docker build --no-cache --build-arg RUNTIME="bullseye-slim" -t system-tests/local .
 

--- a/utils/build/virtual_machine/weblogs/dotnet/provision_test-app-dotnet-container.yml
+++ b/utils/build/virtual_machine/weblogs/dotnet/provision_test-app-dotnet-container.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-dotnet-container
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine-jdk15.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine-jdk15.yml
@@ -13,7 +13,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-alpine-jdk15
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64, ubuntu22_arm64, amazon_linux2023_arm64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64, ubuntu22_arm64, amazon_linux2023_arm64]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine-jdk21.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine-jdk21.yml
@@ -7,13 +7,14 @@ lang_variant:
         os_distro: deb
         remote-command: sudo apt-get -y update && sudo apt-get -y install openjdk-11-jdk-headless
 
+      
       - os_type: linux
         os_distro: rpm
         remote-command: sudo amazon-linux-extras install java-openjdk11 || sudo dnf -y install java-11-amazon-corretto-devel || sudo yum -y install java-11-openjdk-devel
 
 weblog:
     name: test-app-java-alpine-jdk21
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine-libgcc.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine-libgcc.yml
@@ -12,7 +12,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-alpine-libgcc
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine.yml
@@ -12,7 +12,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-alpine
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-buildpack.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-buildpack.yml
@@ -12,7 +12,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-buildpack
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64, ubuntu22_arm64, amazon_linux2023_arm64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64, ubuntu22_arm64, amazon_linux2023_arm64]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-container-jdk15.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-container-jdk15.yml
@@ -13,7 +13,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-container-jdk15
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-container.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-container.yml
@@ -12,7 +12,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-container
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java.yml
@@ -12,7 +12,7 @@ lang_variant:
 
 weblog:
     name: test-app-java
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
     install:
       - os_type: linux
 

--- a/utils/build/virtual_machine/weblogs/java/provision_test-shell-script.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-shell-script.yml
@@ -12,7 +12,7 @@ lang_variant:
 
 weblog:
     name: test-shell-script
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
     install:
       - os_type: linux
         remote-command: |

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-alpine-libgcc.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-alpine-libgcc.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-nodejs-alpine-libgcc
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64,amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, centos_7_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-alpine.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-alpine.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-nodejs-alpine
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64,amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, centos_7_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-container.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-container.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-nodejs-container
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, centos_7_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-shell-script.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-shell-script.yml
@@ -19,7 +19,8 @@ lang_variant:
 
 weblog:
     name: test-shell-script
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64, ubuntu18_amd64, amazon_linux2023_amd64, centos_7_amd64]
+    # Requires libc6 >= 2.28, not available in ubuntu18_amd64 / centos_7_amd64 / amazon_linux2_amd64
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, amazon_linux2_amd64, ubuntu18_amd64, centos_7_amd64]
     install:
       - os_type: linux
         remote-command: |

--- a/utils/build/virtual_machine/weblogs/python/provision_test-app-python-alpine-libgcc.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-app-python-alpine-libgcc.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-python-alpine-libgcc
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/python/provision_test-app-python-alpine.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-app-python-alpine.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-python-alpine
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/python/provision_test-app-python-container.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-app-python-container.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-python-container
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/python/provision_test-app-python.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-app-python.yml
@@ -19,7 +19,7 @@ lang_variant:
 
 weblog:
     name: test-app-python
-    excluded_os_branches: [amazon_linux2_dotnet6, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6]
     install:
       - os_type: linux
 

--- a/utils/build/virtual_machine/weblogs/python/provision_test-shell-script.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-shell-script.yml
@@ -20,7 +20,7 @@ lang_variant:
 
 weblog:
     name: test-shell-script
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
     install:
       - os_type: linux
         remote-command: |

--- a/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby-container.yml
+++ b/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby-container.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-ruby-container
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2_amd64]
     install:
       - os_type: linux
 

--- a/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby.yml
+++ b/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby.yml
@@ -24,6 +24,7 @@ lang_variant:
 
 weblog:
     name: test-app-ruby
+    # centos_7_amd64 is excluded because it does not provides the right Ruby versions
     excluded_os_branches: [amazon_linux2_dotnet6, ubuntu18_amd64, amazon_linux2_amd64, centos_7_amd64]
     install:
       - os_type: linux

--- a/utils/build/virtual_machine/weblogs/ruby/provision_test-shell-script.yml
+++ b/utils/build/virtual_machine/weblogs/ruby/provision_test-shell-script.yml
@@ -23,6 +23,7 @@ lang_variant:
 
 weblog:
     name: test-shell-script
+    # centos_7_amd64 is excluded because it does not provides the right Ruby versions
     excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, centos_7_amd64]
     install:
       - os_type: linux


### PR DESCRIPTION
## Motivation
Re-enabling CentOS and AmazonLinux where possible

Example pipeline: https://gitlab.ddbuild.io/DataDog/system-tests/-/pipelines/39523619

## Changes
- Fixed CentOS mirrors issues
- Fixed docker by starting it right before it's needed
- Remove dependency on the "apm" apt / yum repo as it's not needed anymore and prevented the installer from being installed. This was breaking CentOS because of compatibility issues with the latest deb
- Cleanup

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
