### PR TITLE
[nodejs] try fix iast kafka flaky tests

### DIFF
--- a/utils/build/docker/nodejs/express4-typescript/iast.ts
+++ b/utils/build/docker/nodejs/express4-typescript/iast.ts
@@ -410,7 +410,11 @@ function initSourceRoutes (app: Express): void {
 
     let consumer: any
     const doKafkaOperations = async () => {
-      consumer = kafka.consumer({ groupId: 'testgroup2' })
+      consumer = kafka.consumer({
+        groupId: 'testgroup2',
+        heartbeatInterval: 10000, // should be lower than sessionTimeout
+        sessionTimeout: 60000
+      })
 
       await consumer.connect()
       await consumer.subscribe({ topic, fromBeginning: false })
@@ -476,7 +480,11 @@ function initSourceRoutes (app: Express): void {
 
     let consumer: any
     const doKafkaOperations = async () => {
-      consumer = kafka.consumer({ groupId: 'testgroup2' })
+      consumer = kafka.consumer({
+        groupId: 'testgroup2',
+        heartbeatInterval: 10000, // should be lower than sessionTimeout
+        sessionTimeout: 60000
+      })
 
       await consumer.connect()
       await consumer.subscribe({ topic, fromBeginning: false })
@@ -503,7 +511,9 @@ function initSourceRoutes (app: Express): void {
             // do nothing
           }
 
-          deferred.resolve?.()
+          if (vulnKey === 'hello key!') {
+            deferred.resolve?.()
+          }
         }
       })
 

--- a/utils/build/docker/nodejs/express4/iast/sources.js
+++ b/utils/build/docker/nodejs/express4/iast/sources.js
@@ -122,7 +122,11 @@ function init (app, tracer) {
 
     let consumer
     const doKafkaOperations = async () => {
-      consumer = kafka.consumer({ groupId: 'testgroup2' })
+      consumer = kafka.consumer({
+        groupId: 'testgroup2',
+        heartbeatInterval: 10000, // should be lower than sessionTimeout
+        sessionTimeout: 60000
+      })
 
       await consumer.connect()
       await consumer.subscribe({ topic, fromBeginning: false })
@@ -184,7 +188,11 @@ function init (app, tracer) {
 
     let consumer
     const doKafkaOperations = async () => {
-      consumer = kafka.consumer({ groupId: 'testgroup2' })
+      consumer = kafka.consumer({
+        groupId: 'testgroup2',
+        heartbeatInterval: 10000, // should be lower than sessionTimeout
+        sessionTimeout: 60000
+      })
 
       await consumer.connect()
       await consumer.subscribe({ topic, fromBeginning: false })
@@ -207,7 +215,9 @@ function init (app, tracer) {
             // do nothing
           }
 
-          deferred.resolve()
+          if (vulnKey === 'hello key!') {
+            deferred.resolve()
+          }
         }
       })
 


### PR DESCRIPTION
## Motivation

kafka flaky tests

## Changes

When tests fail, there are errors like 
```json
{"level":"ERROR","timestamp":"2024-07-12T08:42:13.796Z","logger":"kafkajs","message":"[Connection] Response Heartbeat(key: 12, version: 3)","broker":"kafka:9092","clientId":"my-app-iast","error":"The group is rebalancing, so a rejoin is needed","correlationId":9,"size":10}

```

so try configuring a heartbeat for the consumers

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
