### PR TITLE
Ability to change the support state of meta struct of the agent

### DIFF
--- a/utils/_context/_scenarios/core.py
+++ b/utils/_context/_scenarios/core.py
@@ -232,6 +232,7 @@ class DockerScenario(Scenario):
         scenario_groups=None,
         use_proxy=True,
         rc_api_enabled=False,
+        meta_structs_disabled=False,
         include_postgres_db=False,
         include_cassandra_db=False,
         include_mongo_db=False,
@@ -246,6 +247,7 @@ class DockerScenario(Scenario):
 
         self.use_proxy = use_proxy
         self.rc_api_enabled = rc_api_enabled
+        self.meta_structs_disabled = False
 
         if not self.use_proxy and self.rc_api_enabled:
             raise ValueError("rc_api_enabled requires use_proxy")
@@ -254,7 +256,7 @@ class DockerScenario(Scenario):
 
         if self.use_proxy:
             self._required_containers.append(
-                ProxyContainer(host_log_folder=self.host_log_folder, rc_api_enabled=rc_api_enabled)
+                ProxyContainer(host_log_folder=self.host_log_folder, rc_api_enabled=rc_api_enabled, meta_structs_disabled=meta_structs_disabled)
             )  # we want the proxy being the first container to start
 
         if include_postgres_db:
@@ -345,6 +347,7 @@ class EndToEndScenario(DockerScenario):
         agent_interface_timeout=5,
         use_proxy=True,
         rc_api_enabled=False,
+        meta_structs_disabled=False,
         backend_interface_timeout=0,
         include_postgres_db=False,
         include_cassandra_db=False,
@@ -367,6 +370,7 @@ class EndToEndScenario(DockerScenario):
             scenario_groups=scenario_groups,
             use_proxy=use_proxy,
             rc_api_enabled=rc_api_enabled,
+            meta_structs_disabled=meta_structs_disabled,
             include_postgres_db=include_postgres_db,
             include_cassandra_db=include_cassandra_db,
             include_mongo_db=include_mongo_db,

--- a/utils/_context/_scenarios/core.py
+++ b/utils/_context/_scenarios/core.py
@@ -256,7 +256,11 @@ class DockerScenario(Scenario):
 
         if self.use_proxy:
             self._required_containers.append(
-                ProxyContainer(host_log_folder=self.host_log_folder, rc_api_enabled=rc_api_enabled, meta_structs_disabled=meta_structs_disabled)
+                ProxyContainer(
+                    host_log_folder=self.host_log_folder,
+                    rc_api_enabled=rc_api_enabled,
+                    meta_structs_disabled=meta_structs_disabled,
+                )
             )  # we want the proxy being the first container to start
 
         if include_postgres_db:

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -351,7 +351,7 @@ class ImageInfo:
 
 
 class ProxyContainer(TestedContainer):
-    def __init__(self, host_log_folder, rc_api_enabled: bool) -> None:
+    def __init__(self, host_log_folder, rc_api_enabled: bool, meta_structs_disabled: bool) -> None:
 
         super().__init__(
             image_name="datadog/system-tests:proxy-v1",
@@ -363,6 +363,7 @@ class ProxyContainer(TestedContainer):
                 "DD_APP_KEY": os.environ.get("DD_APP_KEY"),
                 "SYSTEM_TESTS_HOST_LOG_FOLDER": host_log_folder,
                 "SYSTEM_TESTS_RC_API_ENABLED": str(rc_api_enabled),
+                "SYSTEM_TESTS_AGENT_SPAN_META_STRUCTS_DISABLED": str(meta_structs_disabled),
             },
             working_dir="/app",
             volumes={

--- a/utils/proxy/core.py
+++ b/utils/proxy/core.py
@@ -47,6 +47,7 @@ class _RequestLogger:
         self.original_ports = {}
 
         self.rc_api_enabled = os.environ.get("SYSTEM_TESTS_RC_API_ENABLED") == "True"
+        self.span_meta_structs_disabled = os.environ.get("SYSTEM_TESTS_AGENT_SPAN_META_STRUCTS_DISABLED") == "True"
 
         self.rc_api_command = None
         self.rc_api_runtime_ids_applied = set()
@@ -224,41 +225,53 @@ class _RequestLogger:
             logger.exception("Unexpected error")
 
     def _modify_response(self, flow):
-        if self.rc_api_enabled and self.request_is_from_tracer(flow.request):
-            self._add_rc_capabilities_in_info_request(flow)
+        if self.request_is_from_tracer(flow.request):
+            if self.rc_api_enabled:
+                self._add_rc_capabilities_in_info_request(flow)
 
-            if flow.request.path == "/v0.7/config":
-                if self.rc_api_command is not None:
-                    request_content = json.loads(flow.request.content)
-                    runtime_id = request_content["client"]["client_tracer"]["runtime_id"]
+                if flow.request.path == "/v0.7/config":
+                    if self.rc_api_command is not None:
+                        request_content = json.loads(flow.request.content)
+                        runtime_id = request_content["client"]["client_tracer"]["runtime_id"]
 
-                    if runtime_id in self.rc_api_runtime_ids_applied:
-                        # this runtime id has already been applied
-                        return
+                        if runtime_id in self.rc_api_runtime_ids_applied:
+                            # this runtime id has already been applied
+                            return
 
-                    logger.info(f"    => modifying rc response for runtime ID {runtime_id}")
+                        logger.info(f"    => modifying rc response for runtime ID {runtime_id}")
 
-                    flow.response.status_code = 200
-                    flow.response.content = self.rc_api_command
+                        flow.response.status_code = 200
+                        flow.response.content = self.rc_api_command
 
-                    self.rc_api_runtime_ids_applied.add(runtime_id)
-                elif self.rc_api_sequential_commands is not None:
-                    request_content = json.loads(flow.request.content)
-                    runtime_id = request_content["client"]["client_tracer"]["runtime_id"]
-                    logger.info(f"    => modifying rc response for runtime ID {runtime_id}")
-                    logger.info(
-                        f"    => Overwriting /v0.7/config response #{self.rc_api_runtime_ids_request_count[runtime_id] + 1}"
-                    )
+                        self.rc_api_runtime_ids_applied.add(runtime_id)
+                    elif self.rc_api_sequential_commands is not None:
+                        request_content = json.loads(flow.request.content)
+                        runtime_id = request_content["client"]["client_tracer"]["runtime_id"]
+                        logger.info(f"    => modifying rc response for runtime ID {runtime_id}")
+                        logger.info(
+                            f"    => Overwriting /v0.7/config response #{self.rc_api_runtime_ids_request_count[runtime_id] + 1}"
+                        )
 
-                    if self.rc_api_runtime_ids_request_count[runtime_id] + 1 > len(self.rc_api_sequential_commands):
-                        response = {}  # default content when there isn't an RC update
-                    else:
-                        response = self.rc_api_sequential_commands[self.rc_api_runtime_ids_request_count[runtime_id]]
+                        if self.rc_api_runtime_ids_request_count[runtime_id] + 1 > len(self.rc_api_sequential_commands):
+                            response = {}  # default content when there isn't an RC update
+                        else:
+                            response = self.rc_api_sequential_commands[self.rc_api_runtime_ids_request_count[runtime_id]]
 
-                    flow.response.status_code = 200
-                    flow.response.content = json.dumps(response).encode()
+                        flow.response.status_code = 200
+                        flow.response.content = json.dumps(response).encode()
 
-                    self.rc_api_runtime_ids_request_count[runtime_id] += 1
+                        self.rc_api_runtime_ids_request_count[runtime_id] += 1
+
+            if self.span_meta_structs_disabled:
+                self._remove_meta_structs_support(flow)
+
+    def _remove_meta_structs_support(self, flow):
+        if flow.request.path == "/info" and str(flow.response.status_code) == "200":
+            c = json.loads(flow.response.content)
+            if "span_meta_structs" in c:
+                logger.info("    => Overwriting /info response to remove span_meta_structs field")
+                c.pop("span_meta_structs")
+                flow.response.content = json.dumps(c).encode()
 
     def _add_rc_capabilities_in_info_request(self, flow):
         if flow.request.path == "/info" and str(flow.response.status_code) == "200":

--- a/utils/proxy/core.py
+++ b/utils/proxy/core.py
@@ -255,7 +255,9 @@ class _RequestLogger:
                         if self.rc_api_runtime_ids_request_count[runtime_id] + 1 > len(self.rc_api_sequential_commands):
                             response = {}  # default content when there isn't an RC update
                         else:
-                            response = self.rc_api_sequential_commands[self.rc_api_runtime_ids_request_count[runtime_id]]
+                            response = self.rc_api_sequential_commands[
+                                self.rc_api_runtime_ids_request_count[runtime_id]
+                            ]
 
                         flow.response.status_code = 200
                         flow.response.content = json.dumps(response).encode()


### PR DESCRIPTION
## Motivation

The agent sent in its configuration a boolean linked to the `span_meta_structs` to advertise its compatibility to meta struct.
In part of the [RFC Security events in meta struct](https://docs.google.com/document/d/1iWQsOfT6Lg_IFyvQeqry9wVmXOE2Yav0X4MgOTk7mks/edit#heading=h.o5gstqo08gu5), we want a way to test when this meta struct compatibility is not available from the agent.

## Changes

Added a new environment variable `SYSTEM_TESTS_AGENT_SPAN_META_STRUCTS_DISABLED` for the system tests internals.

Add this env var to the config of ProxyContainer and bubble it up to the configuration of the scenario (`meta_structs_disabled` argument)

When it's value is set to `true`, the [`/info`](https://datadoghq.atlassian.net/wiki/spaces/SAAL/pages/2420244556/Trace+Agent+Discovery+mechanisms) endpoint will not contains the `span_meta_structs` key anymore, thus marking meta struct as unsupported by the agent.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
