### PR TITLE
Add APM SDK API team as CODEOWNERS for parametric tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 /utils/build/docker/php*/ @DataDog/apm-php @DataDog/system-tests-core
 /utils/build/docker/python*/ @DataDog/apm-python @DataDog/asm-python @DataDog/system-tests-core
 /utils/build/docker/ruby*/ @DataDog/apm-ruby @DataDog/asm-ruby @DataDog/system-tests-core
-/parametric/ @Kyle-Verhoog @DataDog/system-tests-core
+/parametric/ @Kyle-Verhoog @DataDog/system-tests-core @DataDog/apm-sdk-api
 /tests/parametric/ @Kyle-Verhoog @DataDog/system-tests-core
 /tests/otel_tracing_e2e/ @DataDog/opentelemetry @DataDog/system-tests-core
 /tests/remote_config/ @DataDog/system-tests-core @DataDog/remote-config @DataDog/system-tests-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /utils/build/docker/python*/ @DataDog/apm-python @DataDog/asm-python @DataDog/system-tests-core
 /utils/build/docker/ruby*/ @DataDog/apm-ruby @DataDog/asm-ruby @DataDog/system-tests-core
 /parametric/ @Kyle-Verhoog @DataDog/system-tests-core @DataDog/apm-sdk-api
-/tests/parametric/ @Kyle-Verhoog @DataDog/system-tests-core
+/tests/parametric/ @Kyle-Verhoog @DataDog/system-tests-core @DataDog/apm-sdk-api
 /tests/otel_tracing_e2e/ @DataDog/opentelemetry @DataDog/system-tests-core
 /tests/remote_config/ @DataDog/system-tests-core @DataDog/remote-config @DataDog/system-tests-core
 /tests/appsec/ @DataDog/asm-libraries @DataDog/system-tests-core


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

@DataDog/apm-sdk-api is a frequent maintainer of parametric tests and is responsible for many of the features that parametric tests are meant to exercise

## Changes

<!-- A brief description of the change being made with this pull request. -->

Updates CODEOWNERS to include @DataDog/apm-sdk-api for parametric tests

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
