### PR TITLE
Fix RASP test : look for AppSec data in meta_struct

### DIFF
--- a/tests/appsec/rasp/test_stack_traces.py
+++ b/tests/appsec/rasp/test_stack_traces.py
@@ -6,16 +6,13 @@ from utils import features, weblog, interfaces, scenarios, rfc, missing_feature
 
 
 def validate_stack_traces(request):
-    spans = [s for _, s in interfaces.library.get_root_spans(request=request)]
-    assert spans, "No spans to validate"
+    events = list(interfaces.library.get_appsec_events(request=request))
+    assert len(events) != 0, "No appsec event has been reported"
 
-    for span in spans:
-        assert "_dd.appsec.json" in span["meta"], "'_dd.appsec.json' not found in 'meta'"
+    for _, _, span, appsec_data in events:
+        assert "triggers" in appsec_data, "'triggers' not found in appsec_data"
 
-        json = span["meta"]["_dd.appsec.json"]
-        assert "triggers" in json, "'triggers' not found in '_dd.appsec.json'"
-
-        triggers = json["triggers"]
+        triggers = appsec_data["triggers"]
 
         # Find all stack IDs
         stack_ids = []


### PR DESCRIPTION
## Motivation

DataDog/dd-trace-dotnet#5779 moved appsec data from json to meta_struct

## Changes

Adapt the RASP test to look for appsec data in both locations.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
