### PR TITLE
Better output for PARAMETRIC gRPC timeouts

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -598,7 +598,7 @@ def test_library(test_server: APMLibraryTestServer) -> Generator[APMLibrary, Non
         raise RuntimeError("Internal error, no port has been assigned", 1)
 
     if test_server.protocol == "grpc":
-        client = APMLibraryClientGRPC(f"localhost:{test_server.host_port}", test_server_timeout)
+        client = APMLibraryClientGRPC(f"localhost:{test_server.host_port}", test_server_timeout, test_server.container)
     elif test_server.protocol == "http":
         client = APMLibraryClientHTTP(
             f"http://localhost:{test_server.host_port}", test_server_timeout, test_server.container


### PR DESCRIPTION
## Motivation

libraries that use legacy gRPC interface for parametric tests are very flaky. We don't know why the gRPC server did not respond

## Changes

Add container logs when gRPC interface fails to respond
Also a small revamp of get-impacted-scenario

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
