### PR TITLE
w3c: remove validation for 0000000000000000 value p key

### DIFF
--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -745,18 +745,9 @@ class Test_Headers_Tracecontext:
             ):
                 pass
 
-            with test_library.start_span(
-                name="p_not_propagated_valid_dd_tracestate",
-                http_headers=[
-                    ["traceparent", "00-12345678901234567890123456789015-1234567890123459-00"],
-                    ["tracestate", "key1=value1,dd=s:2;t.dm:-4"],
-                ],
-            ):
-                pass
+        traces = test_agent.wait_for_num_traces(2)
 
-        traces = test_agent.wait_for_num_traces(3)
-
-        assert len(traces) == 3
+        assert len(traces) == 2
         case1, case2, case3 = traces[0][0], traces[1][0], traces[2][0]
 
         assert case1["name"] == "p_set"
@@ -764,9 +755,6 @@ class Test_Headers_Tracecontext:
 
         assert case2["name"] == "p_invalid"
         assert case2["meta"]["_dd.parent_id"] == "XX!X"
-
-        assert case3["name"] == "p_not_propagated_valid_dd_tracestate"
-        assert case3["meta"]["_dd.parent_id"] == "0000000000000000"
 
     @missing_feature(context.library < "python@2.7.0", reason="Not implemented")
     @missing_feature(context.library < "dotnet@2.51.0", reason="Not implemented")


### PR DESCRIPTION
## Motivation

Tracers currently set `_dd.parent_id` propagation tag to `0000000000000000` when the incoming tracestate does not contain a `p` key. This value currently has no special meaning and it is currently ignored by the backend. The plan is to deprecate/remove this special value in all tracers.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
