### PR TITLE
[parametric] Enable OTEL Env parametric tests for Java

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1174,7 +1174,7 @@ tests/:
       TestDynamicConfigV2: v1.31.0
     test_otel_api_interoperability.py: missing_feature
     test_otel_env_vars.py:
-      Test_Otel_Env_Vars: missing_feature
+      Test_Otel_Env_Vars: v1.35.2
     test_otel_sdk_interoperability.py: missing_feature
     test_span_links.py: missing_feature
     test_telemetry.py:

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
@@ -2,9 +2,19 @@ package com.datadoghq.trace.controller;
 
 import static com.datadoghq.ApmTestClient.LOGGER;
 
+import com.datadoghq.trace.trace.dto.GetTraceConfigResult;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import datadog.trace.api.TracePropagationStyle;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -15,6 +25,78 @@ public class TraceController {
    * Crash tracking script path, as defined in run.sh script
    */
   private static final Path CRASH_TRACKING_SCRIPT = Path.of("/tmp/datadog/java/dd_crash_uploader.sh");
+
+  @GetMapping("config")
+  public GetTraceConfigResult config() {
+    LOGGER.info("Getting tracer config");
+    try
+    {
+        // Use reflection to get the static Config instance
+        Class configClass = Class.forName("datadog.trace.api.Config");
+        Method getConfigMethod = configClass.getMethod("get");
+
+        Class instrumenterConfigClass = Class.forName("datadog.trace.api.InstrumenterConfig");
+        Method getInstrumenterConfigMethod = instrumenterConfigClass.getMethod("get");
+
+        Object configObject = getConfigMethod.invoke(null);
+        Object instrumenterConfigObject = getInstrumenterConfigMethod.invoke(null);
+
+        Method getServiceName = configClass.getMethod("getServiceName");
+        Method getEnv = configClass.getMethod("getEnv");
+        Method getVersion = configClass.getMethod("getVersion");
+        Method getTraceSampleRate = configClass.getMethod("getTraceSampleRate");
+        Method isTraceEnabled = configClass.getMethod("isTraceEnabled");
+        Method isRuntimeMetricsEnabled = configClass.getMethod("isRuntimeMetricsEnabled");
+        Method getGlobalTags = configClass.getMethod("getGlobalTags");
+        Method getTracePropagationStylesToInject = configClass.getMethod("getTracePropagationStylesToInject");
+        Method isDebugEnabled = configClass.getMethod("isDebugEnabled");
+        Method getLogLevel = configClass.getMethod("getLogLevel");
+
+        Method isTraceOtelEnabled = instrumenterConfigClass.getMethod("isTraceOtelEnabled");
+
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("dd_service", getServiceName.invoke(configObject).toString());
+        configMap.put("dd_env", getEnv.invoke(configObject).toString());
+        configMap.put("dd_version", getVersion.invoke(configObject).toString());
+        configMap.put("dd_log_level", Optional.ofNullable(getLogLevel.invoke(configObject)).map(Object::toString).orElse(null));
+        configMap.put("dd_trace_enabled", isTraceEnabled.invoke(configObject).toString());
+        configMap.put("dd_runtime_metrics_enabled", isRuntimeMetricsEnabled.invoke(configObject).toString());
+        configMap.put("dd_trace_debug", isDebugEnabled.invoke(configObject).toString());
+        configMap.put("dd_trace_otel_enabled", isTraceOtelEnabled.invoke(instrumenterConfigObject).toString());
+        // configMap.put("dd_trace_sample_ignore_parent", Config.get());
+
+        Object sampleRate = getTraceSampleRate.invoke(configObject);
+        if (sampleRate instanceof Double) {
+            configMap.put("dd_trace_sample_rate", String.valueOf((Double)sampleRate));
+        }
+
+        Object globalTags = getGlobalTags.invoke(configObject);
+        if (globalTags != null) {
+            String result = ((Map<String, String>)globalTags).entrySet()
+                .stream()
+                .map(entry -> entry.getKey() + ":" + entry.getValue())
+                .collect(Collectors.joining(","));
+
+            configMap.put("dd_tags", result);
+        }
+
+        Object propagationStyles = getTracePropagationStylesToInject.invoke(configObject);
+        if (propagationStyles != null) {
+            String result = ((Set<TracePropagationStyle>)propagationStyles)
+                .stream()
+                .map(style -> style.toString())
+                .collect(Collectors.joining(","));
+
+            configMap.put("dd_trace_propagation_style", result);
+        }
+
+        configMap.values().removeIf(Objects::isNull);
+        return new GetTraceConfigResult(configMap);
+    } catch (Throwable t) {
+        LOGGER.error("Uncaught throwable", t);
+        return GetTraceConfigResult.error();
+    }
+  }
 
   @GetMapping("crash")
   public void crash() {

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/dto/GetTraceConfigResult.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/dto/GetTraceConfigResult.java
@@ -1,0 +1,12 @@
+package com.datadoghq.trace.trace.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
+import java.util.Map;
+
+public record GetTraceConfigResult(
+    Map<String, String> config) {
+  public static GetTraceConfigResult error(){
+    return new GetTraceConfigResult(new HashMap<>());
+  }
+}

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/metrics/controller/MetricsController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/metrics/controller/MetricsController.java
@@ -15,7 +15,10 @@ public class MetricsController {
   public void flush() {
     LOGGER.info("Flushing metrics");
     try {
-      ((InternalTracer) GlobalTracer.get()).flushMetrics();
+      // Only flush trace stats when tracing was enabled
+      if (GlobalTracer.get() instanceof InternalTracer) {
+          ((InternalTracer) GlobalTracer.get()).flushMetrics();
+      }
     } catch (Exception e) {
       LOGGER.warn("Failed to flush metrics", e);
     }

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryController.java
@@ -319,7 +319,10 @@ public class OpenTelemetryController {
   public FlushResult flush(@RequestBody FlushArgs args) {
     LOGGER.info("Flushing OTel spans: {}", args);
     try {
-      ((InternalTracer) GlobalTracer.get()).flush();
+      // Only flush spans when tracing was enabled
+      if (GlobalTracer.get() instanceof InternalTracer) {
+          ((InternalTracer) GlobalTracer.get()).flush();
+      }
       this.spans.clear();
       return new FlushResult(true);
     } catch (Exception e) {

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentracing/controller/OpenTracingController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentracing/controller/OpenTracingController.java
@@ -175,7 +175,10 @@ public class OpenTracingController implements Closeable {
   public void flushSpans() {
     LOGGER.info("Flushing OT spans");
     try {
-      ((InternalTracer) datadog.trace.api.GlobalTracer.get()).flush();
+      // Only flush spans when tracing was enabled
+      if (datadog.trace.api.GlobalTracer.get() instanceof InternalTracer) {
+          ((InternalTracer) datadog.trace.api.GlobalTracer.get()).flush();
+      }
       this.spans.clear();
     } catch (Throwable t) {
       LOGGER.error("Uncaught throwable", t);


### PR DESCRIPTION
## Motivation

Ensures that all languages that have implemented the OpenTelemetry environment variable mapping feature are running the corresponding system-tests.

## Changes

Enables test cases in `parametric/test_otel_env_vars.py` for Java. This required adding special mappings for propagation style names and setting DD_TRACE_OTEL_ENABLED=true in all test cases to run the Java code.

Since the tests require a new GetTraceConfig endpoint, this was implemented as part of this commit. Note that there's an obscene amount of reflection to get the required tracer settings from the internal config object. Any and all feedback is welcome to improve the maintainability of this endpoint.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
