### PR TITLE
[Debugger] Remove expression language isEmpty test for null

### DIFF
--- a/tests/debugger/test_debugger_expression_language.py
+++ b/tests/debugger/test_debugger_expression_language.py
@@ -223,7 +223,6 @@ class Test_Debugger_Expression_Language(base._Base_Debugger_Test):
                 ##### isempty
                 ["strValue isEmpty", False, Dsl("isEmpty", Dsl("ref", "strValue"))],
                 ["emptyString isEmpty", True, Dsl("isEmpty", Dsl("ref", "emptyString"))],
-                ["nullString isEmpty", True, Dsl("isEmpty", Dsl("ref", "nullString"))],
                 ##### len
                 ["strValue len", 14, Dsl("len", Dsl("ref", "strValue"))],
                 ["emptyString len", 0, Dsl("len", Dsl("ref", "emptyString"))],


### PR DESCRIPTION
## Motivation
It was decided to return error, when isEmpty operator is applied on null entity.
This PR removes redundant test.