### PR TITLE
lower library interface timeout for remote config tests

### DIFF
--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -584,7 +584,7 @@ class scenarios:
         rc_api_enabled=True,
         appsec_enabled=False,
         weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true"},
-        library_interface_timeout=100,
+        library_interface_timeout=15,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -598,7 +598,7 @@ class scenarios:
             "DD_REMOTE_CONFIG_ENABLED": "true",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "1000",
         },
-        library_interface_timeout=100,
+        library_interface_timeout=15,
         doc="",
     )
 
@@ -606,7 +606,7 @@ class scenarios:
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD",
         rc_api_enabled=True,
         weblog_env={"DD_APPSEC_RULES": None},
-        library_interface_timeout=100,
+        library_interface_timeout=15,
         doc="""
             The spec says that if DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
             In this scenario, we use remote config. By the spec, whem remote config is available, rules file
@@ -622,7 +622,7 @@ class scenarios:
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE",
         rc_api_enabled=True,
         weblog_env={"DD_APPSEC_ENABLED": "false", "DD_REMOTE_CONFIGURATION_ENABLED": "true",},
-        library_interface_timeout=100,
+        library_interface_timeout=15,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -635,14 +635,14 @@ class scenarios:
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
         },
-        library_interface_timeout=100,
+        library_interface_timeout=15,
         doc="",
     )
 
     remote_config_mocked_backend_asm_dd_nocache = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE",
         rc_api_enabled=True,
-        library_interface_timeout=100,
+        library_interface_timeout=15,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -689,7 +689,7 @@ class scenarios:
             "DD_INTERNAL_RCM_POLL_INTERVAL": "2000",
             "DD_DEBUGGER_DIAGNOSTICS_INTERVAL": "1",
         },
-        library_interface_timeout=100,
+        library_interface_timeout=15,
         doc="Test scenario for checking if method probe statuses can be successfully 'RECEIVED' and 'INSTALLED'",
         scenario_groups=[ScenarioGroup.DEBUGGER],
     )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -583,7 +583,7 @@ class scenarios:
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES",
         rc_api_enabled=True,
         appsec_enabled=False,
-        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",},
+        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",},
         library_interface_timeout=20,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
@@ -596,7 +596,7 @@ class scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "1000",
         },
         library_interface_timeout=20,
@@ -606,7 +606,7 @@ class scenarios:
     remote_config_mocked_backend_asm_dd = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",},
+        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",},
         library_interface_timeout=20,
         doc="""
             The spec says that if DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
@@ -625,7 +625,7 @@ class scenarios:
         weblog_env={
             "DD_APPSEC_ENABLED": "false",
             "DD_REMOTE_CONFIGURATION_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
         },
         library_interface_timeout=20,
         doc="",
@@ -639,7 +639,7 @@ class scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
         },
         library_interface_timeout=20,
         doc="",
@@ -648,7 +648,7 @@ class scenarios:
     remote_config_mocked_backend_asm_dd_nocache = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE",
         rc_api_enabled=True,
-        weblog_env={"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",},
+        weblog_env={"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",},
         library_interface_timeout=20,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
@@ -695,7 +695,7 @@ class scenarios:
             "DD_REMOTE_CONFIG_ENABLED": "true",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "2000",
             "DD_DEBUGGER_DIAGNOSTICS_INTERVAL": "1",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
         },
         library_interface_timeout=20,
         doc="Test scenario for checking if method probe statuses can be successfully 'RECEIVED' and 'INSTALLED'",

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -578,8 +578,7 @@ class scenarios:
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES",
         rc_api_enabled=True,
         appsec_enabled=False,
-        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",},
-        library_interface_timeout=10,
+        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",},
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -591,18 +590,16 @@ class scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "1000",
         },
-        library_interface_timeout=10,
         doc="",
     )
 
     remote_config_mocked_backend_asm_dd = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",},
-        library_interface_timeout=10,
+        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",},
         doc="""
             The spec says that if DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
             In this scenario, we use remote config. By the spec, whem remote config is available, rules file
@@ -620,9 +617,8 @@ class scenarios:
         weblog_env={
             "DD_APPSEC_ENABLED": "false",
             "DD_REMOTE_CONFIGURATION_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",
         },
-        library_interface_timeout=10,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -634,17 +630,15 @@ class scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",
         },
-        library_interface_timeout=10,
         doc="",
     )
 
     remote_config_mocked_backend_asm_dd_nocache = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE",
         rc_api_enabled=True,
-        weblog_env={"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",},
-        library_interface_timeout=10,
+        weblog_env={"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",},
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -690,9 +684,8 @@ class scenarios:
             "DD_REMOTE_CONFIG_ENABLED": "true",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "2000",
             "DD_DEBUGGER_DIAGNOSTICS_INTERVAL": "1",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",
         },
-        library_interface_timeout=10,
         doc="Test scenario for checking if method probe statuses can be successfully 'RECEIVED' and 'INSTALLED'",
         scenario_groups=[ScenarioGroup.DEBUGGER],
     )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -574,17 +574,12 @@ class scenarios:
         scenario_groups=[ScenarioGroup.APPSEC],
     )
 
-    # Remote config scenarios
-    # library timeout is set to 100 seconds
-    # default polling interval for tracers is very low (5 seconds)
-    # TODO configure the polling interval to a lower value instead of increasing the timeout
-
     remote_config_mocked_backend_asm_features = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES",
         rc_api_enabled=True,
         appsec_enabled=False,
-        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",},
-        library_interface_timeout=20,
+        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",},
+        library_interface_timeout=10,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -596,18 +591,18 @@ class scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "1000",
         },
-        library_interface_timeout=20,
+        library_interface_timeout=10,
         doc="",
     )
 
     remote_config_mocked_backend_asm_dd = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",},
-        library_interface_timeout=20,
+        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",},
+        library_interface_timeout=10,
         doc="""
             The spec says that if DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
             In this scenario, we use remote config. By the spec, whem remote config is available, rules file
@@ -625,9 +620,9 @@ class scenarios:
         weblog_env={
             "DD_APPSEC_ENABLED": "false",
             "DD_REMOTE_CONFIGURATION_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
-        library_interface_timeout=20,
+        library_interface_timeout=10,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -639,17 +634,17 @@ class scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
-        library_interface_timeout=20,
+        library_interface_timeout=10,
         doc="",
     )
 
     remote_config_mocked_backend_asm_dd_nocache = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE",
         rc_api_enabled=True,
-        weblog_env={"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",},
-        library_interface_timeout=20,
+        weblog_env={"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",},
+        library_interface_timeout=10,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -695,9 +690,9 @@ class scenarios:
             "DD_REMOTE_CONFIG_ENABLED": "true",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "2000",
             "DD_DEBUGGER_DIAGNOSTICS_INTERVAL": "1",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
-        library_interface_timeout=20,
+        library_interface_timeout=10,
         doc="Test scenario for checking if method probe statuses can be successfully 'RECEIVED' and 'INSTALLED'",
         scenario_groups=[ScenarioGroup.DEBUGGER],
     )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -583,8 +583,8 @@ class scenarios:
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES",
         rc_api_enabled=True,
         appsec_enabled=False,
-        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true"},
-        library_interface_timeout=15,
+        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",},
+        library_interface_timeout=20,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -596,17 +596,18 @@ class scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "1000",
         },
-        library_interface_timeout=15,
+        library_interface_timeout=20,
         doc="",
     )
 
     remote_config_mocked_backend_asm_dd = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None},
-        library_interface_timeout=15,
+        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",},
+        library_interface_timeout=20,
         doc="""
             The spec says that if DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
             In this scenario, we use remote config. By the spec, whem remote config is available, rules file
@@ -621,8 +622,8 @@ class scenarios:
     remote_config_mocked_backend_asm_features_nocache = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_ENABLED": "false", "DD_REMOTE_CONFIGURATION_ENABLED": "true",},
-        library_interface_timeout=15,
+        weblog_env={"DD_APPSEC_ENABLED": "false", "DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",},
+        library_interface_timeout=20,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -634,15 +635,19 @@ class scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",
         },
-        library_interface_timeout=15,
+        library_interface_timeout=20,
         doc="",
     )
 
     remote_config_mocked_backend_asm_dd_nocache = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE",
         rc_api_enabled=True,
-        library_interface_timeout=15,
+        weblog_env={
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",
+        },
+        library_interface_timeout=20,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -688,8 +693,9 @@ class scenarios:
             "DD_REMOTE_CONFIG_ENABLED": "true",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "2000",
             "DD_DEBUGGER_DIAGNOSTICS_INTERVAL": "1",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",
         },
-        library_interface_timeout=15,
+        library_interface_timeout=20,
         doc="Test scenario for checking if method probe statuses can be successfully 'RECEIVED' and 'INSTALLED'",
         scenario_groups=[ScenarioGroup.DEBUGGER],
     )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -622,7 +622,11 @@ class scenarios:
     remote_config_mocked_backend_asm_features_nocache = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_ENABLED": "false", "DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",},
+        weblog_env={
+            "DD_APPSEC_ENABLED": "false",
+            "DD_REMOTE_CONFIGURATION_ENABLED": "true",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",
+        },
         library_interface_timeout=20,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
@@ -644,9 +648,7 @@ class scenarios:
     remote_config_mocked_backend_asm_dd_nocache = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE",
         rc_api_enabled=True,
-        weblog_env={
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",
-        },
+        weblog_env={"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "2",},
         library_interface_timeout=20,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -578,7 +578,8 @@ class scenarios:
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES",
         rc_api_enabled=True,
         appsec_enabled=False,
-        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",},
+        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",},
+        library_interface_timeout=20,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -590,16 +591,18 @@ class scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "1000",
         },
+        library_interface_timeout=20,
         doc="",
     )
 
     remote_config_mocked_backend_asm_dd = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",},
+        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",},
+        library_interface_timeout=20,
         doc="""
             The spec says that if DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
             In this scenario, we use remote config. By the spec, whem remote config is available, rules file
@@ -617,8 +620,9 @@ class scenarios:
         weblog_env={
             "DD_APPSEC_ENABLED": "false",
             "DD_REMOTE_CONFIGURATION_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
         },
+        library_interface_timeout=20,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -630,15 +634,17 @@ class scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
         },
+        library_interface_timeout=20,
         doc="",
     )
 
     remote_config_mocked_backend_asm_dd_nocache = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD_NOCACHE",
         rc_api_enabled=True,
-        weblog_env={"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",},
+        weblog_env={"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",},
+        library_interface_timeout=20,
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC],
     )
@@ -684,8 +690,9 @@ class scenarios:
             "DD_REMOTE_CONFIG_ENABLED": "true",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "2000",
             "DD_DEBUGGER_DIAGNOSTICS_INTERVAL": "1",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.25",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
         },
+        library_interface_timeout=20,
         doc="Test scenario for checking if method probe statuses can be successfully 'RECEIVED' and 'INSTALLED'",
         scenario_groups=[ScenarioGroup.DEBUGGER],
     )


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Waiting 100 seconds seems like a lot, especially since it should be possible to get the remote config from client libraries in milliseconds.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Lower library interface timeout for remote config tests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
