### PR TITLE
Update the expected telemetry tags for OTel env-var mapping

### DIFF
--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -219,17 +219,17 @@ class Test_Environment:
         assert len(otelInvalid) == 0
 
         expected_tags = [
-            ["config.datadog:DD_TRACE_LOG_LEVEL", "config.opentelemetry:OTEL_LOG_LEVEL"]
+            ["config_datadog:dd_trace_log_level", "config_opentelemetry:otel_log_level"]
             if context.library == "nodejs"
-            else ["DD_LOG_LEVEL", "config.opentelemetry:OTEL_LOG_LEVEL"],
-            ["config.datadog:DD_TRACE_PROPAGATION_STYLE", "config.opentelemetry:OTEL_PROPAGATORS"],
-            ["config.datadog:DD_SERVICE", "config.opentelemetry:OTEL_SERVICE_NAME"],
-            ["config.datadog:DD_TRACE_SAMPLE_RATE", "config.opentelemetry:OTEL_TRACES_SAMPLER"],
-            ["config.datadog:DD_TRACE_SAMPLE_RATE", "config.opentelemetry:OTEL_TRACES_SAMPLER_ARG"],
-            ["config.datadog:DD_TRACE_ENABLED", "config.opentelemetry:OTEL_TRACES_EXPORTER"],
-            ["config.datadog:DD_RUNTIME_METRICS_ENABLED", "config.opentelemetry:OTEL_METRICS_EXPORTER"],
-            ["config.datadog:DD_TAGS", "config.opentelemetry:OTEL_RESOURCE_ATTRIBUTES"],
-            ["config.datadog:DD_TRACE_OTEL_ENABLED", "config.opentelemetry:OTEL_SDK_DISABLED"],
+            else ["config_datadog:dd_log_level", "config_opentelemetry:otel_log_level"],
+            ["config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_propagators"],
+            ["config_datadog:dd_service", "config_opentelemetry:otel_service_name"],
+            ["config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler"],
+            ["config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler_arg"],
+            ["config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_exporter"],
+            ["config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_metrics_exporter"],
+            ["config_datadog:dd_tags", "config_opentelemetry:otel_resource_attributes"],
+            ["config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_sdk_disabled"],
         ]
 
         for expected in expected_tags:
@@ -284,16 +284,16 @@ class Test_Environment:
         assert len(otelInvalid) == 8
 
         expected_invalid_tags = [
-            ["config.datadog:DD_TRACE_LOG_LEVEL", "config.opentelemetry:OTEL_LOG_LEVEL"]
+            ["config_datadog:dd_trace_log_level", "config_opentelemetry:otel_log_level"]
             if context.library == "nodejs"
-            else ["config.datadog:DD_LOG_LEVEL", "config.opentelemetry:OTEL_LOG_LEVEL"],
-            ["config.datadog:DD_TRACE_PROPAGATION_STYLE", "config.opentelemetry:OTEL_PROPAGATORS"],
-            ["config.datadog:DD_TRACE_SAMPLE_RATE", "config.opentelemetry:OTEL_TRACES_SAMPLER"],
-            ["config.datadog:DD_TRACE_SAMPLE_RATE", "config.opentelemetry:OTEL_TRACES_SAMPLER_ARG"],
-            ["config.datadog:DD_TRACE_ENABLED", "config.opentelemetry:OTEL_TRACES_EXPORTER"],
-            ["config.datadog:DD_RUNTIME_METRICS_ENABLED", "config.opentelemetry:OTEL_METRICS_EXPORTER"],
-            ["config.datadog:DD_TRACE_OTEL_ENABLED", "config.opentelemetry:OTEL_SDK_DISABLED"],
-            ["config.opentelemetry:OTEL_LOGS_EXPORTER"],
+            else ["config_datadog:dd_log_level", "config_opentelemetry:otel_log_level"],
+            ["config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_propagators"],
+            ["config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler"],
+            ["config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler_arg"],
+            ["config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_exporter"],
+            ["config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_metrics_exporter"],
+            ["config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_sdk_disabled"],
+            ["config_opentelemetry:otel_logs_exporter"],
         ]
 
         for expected in expected_invalid_tags:


### PR DESCRIPTION
## Motivation

The [RFC](https://docs.google.com/document/d/1gtdjhsMSIvuTnM9E4EreI7oZ-bAUoAxkhXX0-fBvdDY/edit?usp=sharing) has been revised since these tests were written

Note: these tests are currently marked with `@missing_feature` for all languages.

## Changes

Updates the expected telemetry tags when reporting OTel env-var mapping issues:
```
 config.datadog       -> config_datadog
 config.opentelemetry -> config_opentelemetry
```
The expected tag values should also be lower-case.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
