### PR TITLE
move RC tests to RC feature

### DIFF
--- a/tests/appsec/test_runtime_activation.py
+++ b/tests/appsec/test_runtime_activation.py
@@ -29,7 +29,7 @@ def _send_config(config):
     reason="ASM_FEATURES was not subscribed when a custom rules file was present",
 )
 @bug(context.library == "java@1.6.0", reason="https://github.com/DataDog/dd-trace-java/pull/4614")
-@features.appsec_request_blocking
+@features.changing_rules_using_rc
 class Test_RuntimeActivation:
     """A library should block requests after AppSec is activated via remote config."""
 
@@ -49,7 +49,7 @@ class Test_RuntimeActivation:
 
 
 @scenarios.appsec_runtime_activation
-@features.appsec_request_blocking
+@features.changing_rules_using_rc
 class Test_RuntimeDeactivation:
     """A library should stop blocking after Appsec is deactivated."""
 


### PR DESCRIPTION
## Motivation

Remote Configuration tests should be in the Remote Configuration Rule Changes Feature.

APPSEC-54105

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
