### PR TITLE
Unskip manual ld preload test

### DIFF
--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -39,9 +39,6 @@ class TestHostAutoInjectInstallScriptProfiling(base.AutoInjectBaseTest):
 @features.installer_auto_instrumentation
 @scenarios.installer_auto_injection_ld_preload
 class TestHostAutoInjectManualLdPreload(base.AutoInjectBaseTest):
-    @bug(library="ruby", reason="Test failures for Amazon Linux 2023")
-    @bug(library="python", reason="Test failures in all machines")
-    @bug(library="dotnet", reason="Test failures in all machines")
     def test_install_after_ld_preload(self, virtual_machine):
         """ We added entries to the ld.so.preload. After that, we can install the dd software and the app should be instrumented."""
         logger.info(f"Launching test_install for : [{virtual_machine.name}]...")

--- a/utils/build/virtual_machine/provisions/auto-inject-ld-preload/main.c
+++ b/utils/build/virtual_machine/provisions/auto-inject-ld-preload/main.c
@@ -1,7 +1,12 @@
 #include <stdio.h>
+#include <dlfcn.h>
+
+typedef int (*original_puts_t)(const char *str);
+
 // C program used to add as library in the ld-preload
-int puts(const char *__s)
+int puts(const char *str)
 {
-    return printf("New puts\n");
-    
+    original_puts_t original_puts;
+    original_puts = (original_puts_t) dlsym(RTLD_NEXT,"puts");
+    return original_puts(str);
 }


### PR DESCRIPTION
## Motivation

The previous test was replacing "puts" with a fake function that always outputted the same result. Obviously this broke things.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
