### PR TITLE
tests(php): Enable Test_TracerSCITagging

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -282,7 +282,7 @@ tests/:
       Test_Trace_Sampling_Tags_Feb2024_Revision: v0.96.0
       Test_Trace_Sampling_With_W3C: missing_feature
     test_tracer.py:
-      Test_TracerSCITagging: missing_feature
+      Test_TracerSCITagging: v1.2.0
     test_tracer_flare.py:
       TestTracerFlareV1: missing_feature
   remote_config/:


### PR DESCRIPTION
## Motivation

SCI Tagging was added in the recent 1.2.0 release of the PHP tracer ([Impl](https://github.com/DataDog/dd-trace-php/pull/2731)).

## Changes

<!-- A brief description of the change being made with this pull request. -->

Enable the tests for the now-implemented SCI feature in the PHP traer.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
