### PR TITLE
Revert "[python] set 2 worker threads for uwsgi-poc"

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -344,6 +344,7 @@ tests/:
     test_asm_standalone.py:
       Test_AppSecStandalone_UpstreamPropagation:
         '*': v2.10.0rc1
+        uwsgi-poc: bug
     test_automated_login_events.py:
       Test_Login_Events: irrelevant (was v2.10.0.dev but will be replaced by V2)
       Test_Login_Events_Extended: irrelevant (was v2.10.0.dev but will be replaced by V2)

--- a/utils/build/docker/python/uwsgi-poc.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.Dockerfile
@@ -18,7 +18,7 @@ ENV _DD_APPSEC_DEDUPLICATION_ENABLED=false
 # note, only thread mode is supported
 # https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#uwsgi
 RUN echo '#!/bin/bash \n\
-ddtrace-run uwsgi --http :7777 -w app:app --processes=2 --enable-threads\n' > app.sh
+ddtrace-run uwsgi --http :7777 -w app:app --enable-threads\n' > app.sh
 RUN chmod +x app.sh
 CMD ./app.sh
 


### PR DESCRIPTION
Reverts DataDog/system-tests#2838

Due to failures in other uwsgi-poc tests: https://github.com/DataDog/dd-trace-py/actions/runs/10201059538/job/28223498114