### PR TITLE
[python] Fix broken dd-trace-py actions CI

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -340,6 +340,14 @@ function main() {
     else
       echo "Activate venv"
       ls -la venv/bin/
+      rm -f venv/bin/python
+      rm -f venv/bin/python3
+      rm -f venv/bin/python3.12
+
+      ln -s ${pwd}/venv/bin/python3.12 /opt/hostedtoolcache/Python/3.12.4/x64/bin/python3.12
+      ln -s ${pwd}/venv/bin/python3 ${pwd}/venv/bin/python3.12
+      ln -s ${pwd}/venv/bin/python ${pwd}/venv/bin/python3.12
+
       activate_venv
       which -a python
       which -a pytest

--- a/run.sh
+++ b/run.sh
@@ -344,8 +344,11 @@ function main() {
       activate_venv
       which -a python
       which -a pytest
-      python --version
-      python -V
+      echo $(python --version)
+      echo $(python -V)
+      echo $(/opt/hostedtoolcache/Python/3.12.4/x64/bin/python --version)
+      echo $(/opt/hostedtoolcache/Python/3.12.4/x64/python --version)
+      echo $(/usr/bin/python --version)
     fi
 
     python_version=$(python -V 2>&1 | sed -E 's/Python ([0-9]+)\.([0-9]+).*/\1\2/')

--- a/run.sh
+++ b/run.sh
@@ -344,9 +344,9 @@ function main() {
       rm -f venv/bin/python3
       rm -f venv/bin/python3.12
 
-      ln -s ${pwd}/venv/bin/python3.12 /opt/hostedtoolcache/Python/3.12.4/x64/bin/python3.12
-      ln -s ${pwd}/venv/bin/python3 ${pwd}/venv/bin/python3.12
-      ln -s ${pwd}/venv/bin/python ${pwd}/venv/bin/python3.12
+      ln -s $(pwd)/venv/bin/python3.12 /opt/hostedtoolcache/Python/3.12.4/x64/bin/python3.12
+      ln -s $(pwd)/venv/bin/python3 $(pwd)/venv/bin/python3.12
+      ln -s $(pwd)/venv/bin/python $(pwd)/venv/bin/python3.12
 
       activate_venv
       which -a python

--- a/run.sh
+++ b/run.sh
@@ -340,13 +340,13 @@ function main() {
     else
       echo "Activate venv"
       ls -la venv/bin/
-      rm -f venv/bin/python
-      rm -f venv/bin/python3
-      rm -f venv/bin/python3.12
+      # rm -f venv/bin/python
+      # rm -f venv/bin/python3
+      # rm -f venv/bin/python3.12
 
-      ln -s /opt/hostedtoolcache/Python/3.12.4/x64/bin/python3.12 $(pwd)/venv/bin/python3.12
-      ln -s $(pwd)/venv/bin/python3.12 $(pwd)/venv/bin/python3
-      ln -s $(pwd)/venv/bin/python3.12 $(pwd)/venv/bin/python
+      # ln -s /opt/hostedtoolcache/Python/3.12.4/x64/bin/python3.12 $(pwd)/venv/bin/python3.12
+      # ln -s $(pwd)/venv/bin/python3.12 $(pwd)/venv/bin/python3
+      # ln -s $(pwd)/venv/bin/python3.12 $(pwd)/venv/bin/python
 
       activate_venv
       which -a python

--- a/run.sh
+++ b/run.sh
@@ -334,10 +334,22 @@ function main() {
     fi
 
     # ensure environment
-    if [[ "${run_mode}" == "docker" ]] || is_using_nix; then
-        : # no venv needed
+    if command -v python &> /dev/null && commmand -v pytest &> /dev/null
+    then
+      echo "Python and pytest are available"
     else
-        activate_venv
+      echo "Activate venv"
+      activate_venv
+    fi
+
+    python_version=$(python -V 2>&1 | sed -E 's/Python ([0-9]+)\.([0-9]+).*/\1\2/')
+		echo $python_version
+    if [ "$python_version" -lt "312" ]; then
+        echo "⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️"
+        echo "DEPRECRATION WARNING: your using python3.9 to run system-tests."
+        echo "This won't be supported soon. Please install python3.12, then run:"
+        echo "> rm -rf venv && ./build.sh -i runner"
+        echo "⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️"
     fi
 
     # process scenario list

--- a/run.sh
+++ b/run.sh
@@ -340,15 +340,6 @@ function main() {
         activate_venv
     fi
 
-    python_version=$(python -V 2>&1 | sed -E 's/Python ([0-9]+)\.([0-9]+).*/\1\2/')
-    if [ "$python_version" -lt "312" ]; then
-        echo "⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️"
-        echo "DEPRECRATION WARNING: your using python3.9 to run system-tests."
-        echo "This won't be supported soon. Please install python3.12, then run:"
-        echo "> rm -rf venv && ./build.sh -i runner"
-        echo "⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️"
-    fi
-
     # process scenario list
     local scenarios=()
 

--- a/run.sh
+++ b/run.sh
@@ -334,32 +334,13 @@ function main() {
     fi
 
     # ensure environment
-    if command -v python &> /dev/null && commmand -v pytest &> /dev/null
-    then
-      echo "Python and pytest are available"
+    if [[ "${run_mode}" == "docker" ]] || is_using_nix; then
+        : # no venv needed
     else
-      echo "Activate venv"
-      ls -la venv/bin/
-      # rm -f venv/bin/python
-      # rm -f venv/bin/python3
-      # rm -f venv/bin/python3.12
-
-      # ln -s /opt/hostedtoolcache/Python/3.12.4/x64/bin/python3.12 $(pwd)/venv/bin/python3.12
-      # ln -s $(pwd)/venv/bin/python3.12 $(pwd)/venv/bin/python3
-      # ln -s $(pwd)/venv/bin/python3.12 $(pwd)/venv/bin/python
-
-      activate_venv
-      which -a python
-      which -a pytest
-      echo $(python --version)
-      echo $(python -V)
-      echo $(/opt/hostedtoolcache/Python/3.12.4/x64/bin/python --version)
-      echo $(/opt/hostedtoolcache/Python/3.12.4/x64/python --version)
-      echo $(/usr/bin/python --version)
+        activate_venv
     fi
 
     python_version=$(python -V 2>&1 | sed -E 's/Python ([0-9]+)\.([0-9]+).*/\1\2/')
-		echo $python_version
     if [ "$python_version" -lt "312" ]; then
         echo "⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️"
         echo "DEPRECRATION WARNING: your using python3.9 to run system-tests."

--- a/run.sh
+++ b/run.sh
@@ -344,9 +344,9 @@ function main() {
       rm -f venv/bin/python3
       rm -f venv/bin/python3.12
 
-      ln -s $(pwd)/venv/bin/python3.12 /opt/hostedtoolcache/Python/3.12.4/x64/bin/python3.12
-      ln -s $(pwd)/venv/bin/python3 $(pwd)/venv/bin/python3.12
-      ln -s $(pwd)/venv/bin/python $(pwd)/venv/bin/python3.12
+      ln -s /opt/hostedtoolcache/Python/3.12.4/x64/bin/python3.12 $(pwd)/venv/bin/python3.12
+      ln -s $(pwd)/venv/bin/python3.12 $(pwd)/venv/bin/python3
+      ln -s $(pwd)/venv/bin/python3.12 $(pwd)/venv/bin/python
 
       activate_venv
       which -a python

--- a/run.sh
+++ b/run.sh
@@ -339,8 +339,7 @@ function main() {
       echo "Python and pytest are available"
     else
       echo "Activate venv"
-      ls venv
-      ls venv/bin/
+      ls -la venv/bin/
       activate_venv
       which -a python
       which -a pytest

--- a/run.sh
+++ b/run.sh
@@ -339,7 +339,13 @@ function main() {
       echo "Python and pytest are available"
     else
       echo "Activate venv"
+      ls venv
+      ls venv/bin/
       activate_venv
+      which -a python
+      which -a pytest
+      python --version
+      python -V
     fi
 
     python_version=$(python -V 2>&1 | sed -E 's/Python ([0-9]+)\.([0-9]+).*/\1\2/')

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -139,7 +139,7 @@ build() {
                     echo "Build virtual env"
                     if command -v python3.12 &> /dev/null
                     then
-                        python3.12 -m venv venv
+                        python3.12 -m venv venv --copies
                     elif command -v python3.9 &> /dev/null
                     then
                         echo "⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️️️️⚠️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️⚠️⚠️️️️⚠️"


### PR DESCRIPTION
## Motivation

Fix broken dd-trace-py ci and unblock us from merging PRs. 

## Changes

system-tests steps were failing as `venv/bin` folder contained symlinks to python binary. Passing `--copies` to `venv` will copy instead of symlink. 

Tested on https://github.com/DataDog/dd-trace-py/pull/10062

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
