### PR TITLE
[php] Support changes in dd-trace-php/master

### DIFF
--- a/utils/build/docker/php/apache-mod/build.sh
+++ b/utils/build/docker/php/apache-mod/build.sh
@@ -29,7 +29,14 @@ printf '#!/bin/sh\n\nexit 101\n' > /usr/sbin/policy-rc.d && \
 
 a2enmod rewrite
 
-curl -Lf -o /tmp/dumb_init.deb https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_amd64.deb && \
+ARCH=$(arch)
+if [[ $ARCH = aarch64 ]]; then
+  ARCH=arm64
+else
+  ARCH=amd64
+fi
+
+curl -Lf -o /tmp/dumb_init.deb https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_${ARCH}.deb && \
 	dpkg -i /tmp/dumb_init.deb && rm /tmp/dumb_init.deb
 
 

--- a/utils/build/docker/php/apache-mod/entrypoint.sh
+++ b/utils/build/docker/php/apache-mod/entrypoint.sh
@@ -9,7 +9,7 @@ fi
 chmod a+rx /root
 
 rm -f /tmp/ddappsec.lock
-LOGS_PHP=(/tmp/appsec.log /tmp/helper.log /tmp/php_error.log)
+LOGS_PHP=(/tmp/appsec.log /tmp/helper.log /tmp/php_error.log /tmp/sidecar.log)
 touch "${LOGS_PHP[@]}"
 chown www-data:www-data "${LOGS_PHP[@]}"
 
@@ -17,6 +17,12 @@ LOGS_APACHE=(/var/log/apache2/{access.log,error.log})
 touch "${LOGS_APACHE[@]}"
 chown root:adm "${LOGS_APACHE[@]}"
 
+#sed -i 's/StartServers.*/StartServers 1/' /etc/apache2/mods-enabled/mpm_prefork.conf
+#sed -i 's/MinSpareServers.*/MinSpareServers 1/' /etc/apache2/mods-enabled/mpm_prefork.conf
+#sed -i 's/MaxSpareServers.*/MaxSpareServers 1/' /etc/apache2/mods-enabled/mpm_prefork.conf
+
+export _DD_DEBUG_SIDECAR_LOG_METHOD=file:///tmp/sidecar.log
+export _DD_SHARED_LIB_DEBUG=1
 export -p | sed 's@declare -x@export@' | tee /dev/stderr >> /etc/apache2/envvars
 
 service apache2 start

--- a/utils/build/docker/php/common/php.ini
+++ b/utils/build/docker/php/common/php.ini
@@ -17,20 +17,14 @@ display_errors=0
 datadog.appsec.log_file=/tmp/appsec.log
 datadog.appsec.log_level=debug
 datadog.appsec.rules_path=/etc/dd-appsec/recommended.json
-datadog.appsec.helper_path=/usr/local/bin/ddappsec-helper
+; will be overridden
+datadog.appsec.helper_path=/usr/local/lib/libddappsec-helper.so
 datadog.appsec.helper_socket_path=/tmp/ddappsec.sock
 datadog.appsec.helper_lock_path=/tmp/ddappsec.lock
+datadog.appsec.helper_log_level=debug
+; legacy
 datadog.appsec.helper_extra_args=--log_level debug
 datadog.appsec.helper_log_file=/tmp/helper.log
-
-ddappsec.log_file=/tmp/appsec.log
-ddappsec.log_level=debug
-ddappsec.rules_path=/etc/dd-appsec/recommended.json
-ddappsec.helper_path=/usr/local/bin/ddappsec-helper
-ddappsec.helper_socket_path=/tmp/ddappsec.sock
-ddappsec.helper_lock_path=/tmp/ddappsec.lock
-ddappsec.helper_extra_args=--log_level debug
-ddappsec.helper_log_file=/tmp/helper.log
 
 datadog.trace.agent_port=8126
 datadog.remote_config_poll_interval=500


### PR DESCRIPTION
dd-trace-php now runs in the helper inside sidecar. This changes a logging setting.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
