### PR TITLE
Add support for rasp command injection

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -191,7 +191,11 @@ tests/:
         Test_Lfi_BodyUrlEncoded: v2.10.0.dev
         Test_Lfi_BodyXml: v2.10.0.dev
         Test_Lfi_UrlQuery: v2.10.0.dev
-      test_shi.py: missing_feature
+      test_shi.py:
+        Test_Shi_BodyJson: v2.11.0-rc2
+        Test_Shi_BodyUrlEncoded: v2.11.0-rc2
+        Test_Shi_BodyXml: v2.11.0-rc2
+        Test_Shi_UrlQuery: v2.11.0-rc2
       test_span_tags.py:
         Test_Mandatory_SpanTags: v2.10.0.dev
         Test_Optional_SpanTags: v2.10.0.dev

--- a/tests/appsec/rasp/test_shi.py
+++ b/tests/appsec/rasp/test_shi.py
@@ -44,7 +44,7 @@ class Test_Shi_BodyUrlEncoded:
             "rasp-932-100",
             {
                 "resource": {"address": "server.sys.shell.cmd", "value": "ls $(cat /etc/passwd 1>&2 ; echo .)"},
-                "params": {"address": "server.request.query", "value": "$(cat /etc/passwd 1>&2 ; echo .)"},
+                "params": {"address": "server.request.body", "value": "$(cat /etc/passwd 1>&2 ; echo .)"},
             },
         )
 
@@ -67,7 +67,7 @@ class Test_Shi_BodyXml:
             "rasp-932-100",
             {
                 "resource": {"address": "server.sys.shell.cmd", "value": "ls $(cat /etc/passwd 1>&2 ; echo .)"},
-                "params": {"address": "server.request.query", "value": "$(cat /etc/passwd 1>&2 ; echo .)"},
+                "params": {"address": "server.request.body", "value": "$(cat /etc/passwd 1>&2 ; echo .)"},
             },
         )
 
@@ -80,7 +80,7 @@ class Test_Shi_BodyJson:
 
     def setup_shi_post_json(self):
         """AppSec detects attacks in JSON body values"""
-        self.r = weblog.post("/rasp/shi", json={"list_dir": "$(cat /etc/passwd 1>&amp;2 ; echo .)"})
+        self.r = weblog.post("/rasp/shi", json={"list_dir": "$(cat /etc/passwd 1>&2 ; echo .)"})
 
     def test_shi_post_json(self):
         assert self.r.status_code == 403
@@ -90,6 +90,6 @@ class Test_Shi_BodyJson:
             "rasp-932-100",
             {
                 "resource": {"address": "server.sys.shell.cmd", "value": "ls $(cat /etc/passwd 1>&2 ; echo .)"},
-                "params": {"address": "server.request.query", "value": "$(cat /etc/passwd 1>&2 ; echo .)"},
+                "params": {"address": "server.request.body", "value": "$(cat /etc/passwd 1>&2 ; echo .)"},
             },
         )

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -187,7 +187,7 @@ def rasp_sqli(request, *args, **kwargs):
 def rasp_shi(request, *args, **kwargs):
     list_dir = None
     if request.method == "GET":
-        list_dir = request.GET.get("user_id")
+        list_dir = request.GET.get("list_dir")
     elif request.method == "POST":
         try:
             list_dir = (request.POST or json.loads(request.body)).get("list_dir")

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -183,6 +183,33 @@ def rasp_sqli(request, *args, **kwargs):
         return HttpResponse(f"DB request failure: {e!r}", status=201)
 
 
+@csrf_exempt
+def rasp_shi(request, *args, **kwargs):
+    list_dir = None
+    if request.method == "GET":
+        list_dir = request.GET.get("user_id")
+    elif request.method == "POST":
+        try:
+            list_dir = (request.POST or json.loads(request.body)).get("list_dir")
+        except Exception as e:
+            print(repr(e), file=sys.stderr)
+        try:
+            if list_dir is None:
+                list_dir = xmltodict.parse(request.body).get("list_dir")
+        except Exception as e:
+            print(repr(e), file=sys.stderr)
+            pass
+
+    if list_dir is None:
+        return HttpResponse("missing list_dir parameter", status=400)
+    try:
+        res = os.system(f"ls {list_dir}")
+        return HttpResponse(f"Shell command with result: {res}")
+    except Exception as e:
+        print(f"Shell command failure: {e!r}", file=sys.stderr)
+        return HttpResponse(f"Shell command failure: {e!r}", status=201)
+
+
 ### END EXPLOIT PREVENTION
 
 
@@ -643,8 +670,9 @@ urlpatterns = [
     path("returnheaders", return_headers),
     path("returnheaders/", return_headers),
     path("rasp/lfi", rasp_lfi),
-    path("rasp/ssrf", rasp_ssrf),
+    path("rasp/shi", rasp_shi),
     path("rasp/sqli", rasp_sqli),
+    path("rasp/ssrf", rasp_ssrf),
     path("params/<appscan_fingerprint>", waf),
     path("tag_value/<str:tag_value>/<int:status_code>", waf),
     path("createextraservice", create_extra_service),

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -208,7 +208,7 @@ async def rasp_sqli(request: Request):
 
 @app.get("/rasp/shi")
 @app.post("/rasp/shi")
-async def rasp_sqli(request: Request):
+async def rasp_shi(request: Request):
     list_dir = None
     if request.method == "GET":
         list_dir = request.query_params.get("list_dir")
@@ -228,8 +228,9 @@ async def rasp_sqli(request: Request):
     if list_dir is None:
         return PlainTextResponse("missing list_dir parameter", status_code=400)
     try:
-        res = os.system(f"ls {list_dir}")
-        return PlainTextResponse(f"Shell command with result: {res}")
+        command = f"ls {list_dir}"
+        res = os.system(command)
+        return PlainTextResponse(f"Shell command [{command}] with result: {res}")
     except Exception as e:
         print(f"Shell command failure: {e!r}", file=sys.stderr)
         return PlainTextResponse(f"Shell command failure: {e!r}", status_code=201)

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -206,6 +206,35 @@ async def rasp_sqli(request: Request):
         return PlainTextResponse(f"DB request failure: {e!r}", status_code=201)
 
 
+@app.get("/rasp/shi")
+@app.post("/rasp/shi")
+async def rasp_sqli(request: Request):
+    list_dir = None
+    if request.method == "GET":
+        list_dir = request.query_params.get("list_dir")
+    elif request.method == "POST":
+        body = await request.body()
+        try:
+            list_dir = ((await request.form()) or json.loads(body) or {}).get("list_dir")
+        except Exception as e:
+            print(repr(e), file=sys.stderr)
+        try:
+            if list_dir is None:
+                list_dir = xmltodict.parse(body).get("list_dir")
+        except Exception as e:
+            print(repr(e), file=sys.stderr)
+            pass
+
+    if list_dir is None:
+        return PlainTextResponse("missing list_dir parameter", status_code=400)
+    try:
+        res = os.system(f"ls {list_dir}")
+        return PlainTextResponse(f"Shell command with result: {res}")
+    except Exception as e:
+        print(f"Shell command failure: {e!r}", file=sys.stderr)
+        return PlainTextResponse(f"Shell command failure: {e!r}", status_code=201)
+
+
 ### END EXPLOIT PREVENTION
 
 

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -279,6 +279,33 @@ def rasp_sqli(*args, **kwargs):
         return f"DB request failure: {e!r}", 201
 
 
+@app.route("/rasp/shi", methods=["GET", "POST"])
+def rasp_shi(*args, **kwargs):
+    list_dir = None
+    if request.method == "GET":
+        list_dir = flask_request.args.get("list_dir")
+    elif request.method == "POST":
+        try:
+            list_dir = (request.form or request.json or {}).get("list_dir")
+        except Exception as e:
+            print(repr(e), file=sys.stderr)
+        try:
+            if list_dir is None:
+                list_dir = xmltodict.parse(flask_request.data).get("list_dir")
+        except Exception as e:
+            print(repr(e), file=sys.stderr)
+            pass
+
+    if list_dir is None:
+        return "missing user_id parameter", 400
+    try:
+        print(f">>>> ls {list_dir}")
+        os.system(f"ls {list_dir}")
+    except Exception as e:
+        print(f"DB request failure: {e!r}", file=sys.stderr)
+        return f"DB request failure: {e!r}", 201
+
+
 ### END EXPLOIT PREVENTION
 
 

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -299,11 +299,11 @@ def rasp_shi(*args, **kwargs):
     if list_dir is None:
         return "missing user_id parameter", 400
     try:
-        print(f">>>> ls {list_dir}")
-        os.system(f"ls {list_dir}")
+        res = os.system(f"ls {list_dir}")
+        return f"Shell command with result: {res}", 200
     except Exception as e:
-        print(f"DB request failure: {e!r}", file=sys.stderr)
-        return f"DB request failure: {e!r}", 201
+        print(f"Shell command failure: {e!r}", file=sys.stderr)
+        return f"Shell command failure: {e!r}", 201
 
 
 ### END EXPLOIT PREVENTION

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -299,8 +299,9 @@ def rasp_shi(*args, **kwargs):
     if list_dir is None:
         return "missing user_id parameter", 400
     try:
-        res = os.system(f"ls {list_dir}")
-        return f"Shell command with result: {res}", 200
+        command = f"ls {list_dir}"
+        res = os.system(command)
+        return f"Shell command [{command}] with result: {res}", 200
     except Exception as e:
         print(f"Shell command failure: {e!r}", file=sys.stderr)
         return f"Shell command failure: {e!r}", 201

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -461,10 +461,14 @@ class LibraryInterfaceValidator(ProxyBasedInterfaceValidator):
 
                     obtained_param = obtained_parameters[name]
 
-                    assert obtained_param["address"] == address, f"incorrect address for '{name}', expected '{address}'"
+                    assert (
+                        obtained_param["address"] == address
+                    ), f"incorrect address for '{name}', expected '{address}, found '{obtained_param['address']}'"
 
                     if value is not None:
-                        assert obtained_param["value"] == value, f"incorrect value for '{name}', expected '{value}'"
+                        assert (
+                            obtained_param["value"] == value
+                        ), f"incorrect value for '{name}', expected '{value}', found '{obtained_param['value']}'"
 
                     if key_path is not None:
                         assert (


### PR DESCRIPTION
## Motivation

Following https://github.com/DataDog/dd-trace-py/pull/10073 and https://github.com/DataDog/dd-trace-py/pull/10098, this PR updates weblogs and enables the new RASP tests for python.

## Changes


APPSEC-54439

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
