### PR TITLE
[nodejs] Add and enable rasp sqli tests in nodejs

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -35,6 +35,7 @@ refs:
   - &ref_5_18_0 '>=5.18.0 || ^4.42.0'
   - &ref_5_20_0 '>=5.20.0 || ^4.44.0'
   - &ref_5_22_0 '>=5.22.0 || ^4.46.0'
+  - &ref_5_23_0 '>=5.23.0 || ^4.47.0'
 
 tests/:
   apm_tracing_e2e/:
@@ -212,7 +213,25 @@ tests/:
     rasp/:
       test_lfi.py: missing_feature
       test_shi.py: missing_feature
-      test_sqli.py: missing_feature
+      test_sqli.py:
+        Test_Sqli_BodyJson:
+          '*': *ref_5_23_0
+          nextjs: missing_feature
+        Test_Sqli_BodyUrlEncoded:
+          '*': *ref_5_23_0
+          nextjs: missing_feature
+        Test_Sqli_BodyXml: missing_feature
+        Test_Sqli_Mandatory_SpanTags: *ref_5_23_0
+        Test_Sqli_Optional_SpanTags: *ref_5_23_0
+        Test_Sqli_StackTrace:
+          '*': *ref_5_23_0
+          nextjs: missing_feature
+        Test_Sqli_Telemetry:
+          '*': *ref_5_23_0
+          nextjs: missing_feature
+        Test_Sqli_UrlQuery:
+          '*': *ref_5_23_0
+          nextjs: missing_feature
       test_ssrf.py:
         Test_Ssrf_BodyJson:
           '*': *ref_5_20_0

--- a/utils/build/docker/nodejs/express4-typescript/rasp.ts
+++ b/utils/build/docker/nodejs/express4-typescript/rasp.ts
@@ -3,7 +3,11 @@
 import type { Express, Request, Response } from 'express';
 
 const http = require('http')
+const pg = require('pg')
+
 function initRaspEndpoints (app: Express) {
+    const pool = new pg.Pool()
+
     app.get('/rasp/ssrf', (req: Request, res: Response) => {
         const clientRequest = http.get(`http://${req.query.domain}`, () => {
             res.end('end')
@@ -26,6 +30,36 @@ function initRaspEndpoints (app: Express) {
             }
             res.writeHead(500).end(e.message)
         })
+    })
+
+    app.get('/rasp/sqli', async (req: Request, res: Response) => {
+        try {
+            await pool.query(`SELECT * FROM users WHERE id='${req.query.user_id}'`)
+        } catch (e: any) {
+            if (e.name === 'DatadogRaspAbortError') {
+                throw e
+            }
+
+            res.writeHead(500).end(e.message)
+            return
+        }
+
+        res.end('end')
+    })
+
+    app.post('/rasp/sqli', async (req: Request, res: Response) => {
+        try {
+            await pool.query(`SELECT * FROM users WHERE id='${req.body.user_id}'`)
+        } catch (e: any) {
+            if (e.name === 'DatadogRaspAbortError') {
+                throw e
+            }
+
+            res.writeHead(500).end(e.message)
+            return
+        }
+
+        res.end('end')
     })
 }
 module.exports = initRaspEndpoints

--- a/utils/build/docker/nodejs/express4/rasp.js
+++ b/utils/build/docker/nodejs/express4/rasp.js
@@ -1,7 +1,11 @@
 'use strict'
 
 const http = require('http')
+const pg = require('pg')
+
 function initRaspEndpoints (app) {
+  const pool = new pg.Pool()
+
   app.get('/rasp/ssrf', (req, res) => {
     const clientRequest = http.get(`http://${req.query.domain}`, () => {
       res.end('end')
@@ -24,6 +28,36 @@ function initRaspEndpoints (app) {
       }
       res.writeHead(500).end(e.message)
     })
+  })
+
+  app.get('/rasp/sqli', async (req, res) => {
+    try {
+      await pool.query(`SELECT * FROM users WHERE id='${req.query.user_id}'`)
+    } catch (e) {
+      if (e.name === 'DatadogRaspAbortError') {
+        throw e
+      }
+
+      res.writeHead(500).end(e.message)
+      return
+    }
+
+    res.end('end')
+  })
+
+  app.post('/rasp/sqli', async (req, res) => {
+    try {
+      await pool.query(`SELECT * FROM users WHERE id='${req.body.user_id}'`)
+    } catch (e) {
+      if (e.name === 'DatadogRaspAbortError') {
+        throw e
+      }
+
+      res.writeHead(500).end(e.message)
+      return
+    }
+
+    res.end('end')
   })
 }
 module.exports = initRaspEndpoints

--- a/utils/build/docker/nodejs/nextjs/package-lock.json
+++ b/utils/build/docker/nodejs/nextjs/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.5.1",
         "next": "latest",
+        "pg": "^8.12.0",
         "react": "latest",
         "react-dom": "latest"
       },
@@ -2781,6 +2782,138 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
+      "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
+      "dependencies": {
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg/node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "optional": true
+    },
+    "node_modules/pg/node_modules/pg-connection-string": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
+    },
+    "node_modules/pg/node_modules/pg-pool": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
+      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg/node_modules/pg-protocol": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
+    },
+    "node_modules/pg/node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/pg-types/node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg/node_modules/pg-types/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/pg-types/node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pg/node_modules/pg-types/node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pg/node_modules/pg-types/node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pg/node_modules/pg-types/node_modules/postgres-interval/node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/pg/node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pg/node_modules/pgpass/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5257,6 +5390,107 @@
     "path-type": {
       "version": "4.0.0",
       "dev": true
+    },
+    "pg": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
+      "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
+      "requires": {
+        "pg-cloudflare": "^1.1.1",
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "dependencies": {
+        "pg-cloudflare": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+          "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+          "optional": true
+        },
+        "pg-connection-string": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+          "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
+        },
+        "pg-pool": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
+          "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
+          "requires": {}
+        },
+        "pg-protocol": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+          "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
+        },
+        "pg-types": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+          "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+          "requires": {
+            "pg-int8": "1.0.1",
+            "postgres-array": "~2.0.0",
+            "postgres-bytea": "~1.0.0",
+            "postgres-date": "~1.0.4",
+            "postgres-interval": "^1.1.0"
+          },
+          "dependencies": {
+            "pg-int8": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+              "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+            },
+            "postgres-array": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+              "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+            },
+            "postgres-bytea": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+              "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+            },
+            "postgres-date": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+              "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+            },
+            "postgres-interval": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+              "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+              "requires": {
+                "xtend": "^4.0.0"
+              },
+              "dependencies": {
+                "xtend": {
+                  "version": "4.0.2",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+                  "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+                }
+              }
+            }
+          }
+        },
+        "pgpass": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+          "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+          "requires": {
+            "split2": "^4.1.0"
+          },
+          "dependencies": {
+            "split2": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+              "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+            }
+          }
+        }
+      }
     },
     "picocolors": {
       "version": "1.0.0",

--- a/utils/build/docker/nodejs/nextjs/package.json
+++ b/utils/build/docker/nodejs/nextjs/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^1.5.1",
     "next": "latest",
+    "pg": "^8.12.0",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/utils/build/docker/nodejs/nextjs/src/app/rasp/sqli/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/rasp/sqli/route.js
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import pg from 'pg'
+
+export const dynamic = 'force-dynamic'
+
+const pool = new pg.Pool()
+
+export async function GET (request) {
+  try {
+    await pool.query(`SELECT * FROM users WHERE id='${request.nextUrl.searchParams.get('user_id')}'`)
+  } catch (e) {
+    if (e.name === 'DatadogRaspAbortError') {
+      throw e
+    }
+  }
+
+  return NextResponse.json({}, {
+    status: 200
+  })
+}


### PR DESCRIPTION
## Motivation
SQLi exploit prevention is merged in dd-trace-js, we should enable the system tests.
<!-- What inspired you to submit this pull request? -->

## Changes
Add endpoints for sqli in weblog variants and enable the tests for the next tracer versions.
<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
    * [ ] Remove `[nodejs]` before merging to check that change in `utils/_context/_scenarios/__init__.py` is not breaking anything.
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
