### PR TITLE
fix: suspicious attacker blocking RC payload

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -920,7 +920,7 @@ tests/:
         vertx3: missing_feature (endpoint not implemented)
         vertx4: missing_feature (endpoint not implemented)
     test_suspicious_attacker_blocking.py:
-      Test_Suspicious_Attacker_Blocking: missing_feature
+      Test_Suspicious_Attacker_Blocking: v1.39.0
     test_traces.py:
       Test_AppSecEventSpanTags:
         '*': v0.104.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -920,7 +920,10 @@ tests/:
         vertx3: missing_feature (endpoint not implemented)
         vertx4: missing_feature (endpoint not implemented)
     test_suspicious_attacker_blocking.py:
-      Test_Suspicious_Attacker_Blocking: v1.39.0
+      Test_Suspicious_Attacker_Blocking:
+        '*': v1.39.0
+        play: bug (endpoint returns 404)
+        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     test_traces.py:
       Test_AppSecEventSpanTags:
         '*': v0.104.0

--- a/tests/appsec/test_suspicious_attacker_blocking.py
+++ b/tests/appsec/test_suspicious_attacker_blocking.py
@@ -38,7 +38,7 @@ EXCLUSIONS = (
 )
 
 EXCLUSION_DATA = (
-    "datadog/2/ASM/exclusions_data/config",
+    "datadog/2/ASM_DATA/exclusions_data/config",
     {
         "exclusion_data": [
             {"id": "suspicious_ips_data_id", "type": "ip_with_expiration", "data": [{"value": "34.65.27.85"}],}


### PR DESCRIPTION
## Motivation

According to the [RFC](https://docs.google.com/document/d/123wRO_ha5aZMzIXXJlGHobZrK8F4w5YuzyINncIQVLw/edit#heading=h.88xvn2cvs9dt) we have to use ASM_DATA to update exclusion_data via RC.

## Changes

Update the payloads in the tests to ensure we use ASM_DATA.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
