### PR TITLE
Set @flaky to APPSEC_RASP java vertx

### DIFF
--- a/tests/appsec/rasp/test_sqli.py
+++ b/tests/appsec/rasp/test_sqli.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import features, weblog, interfaces, scenarios, rfc
+from utils import features, weblog, interfaces, scenarios, rfc, context, flaky
 
 
 @rfc("https://docs.google.com/document/d/1vmMqpl8STDk7rJnd3YBsa6O9hCls_XHHdsodD61zr_4/edit#heading=h.gv4kwto3561e")
@@ -14,6 +14,7 @@ class Test_Sqli_UrlQuery:
     def setup_sqli_get(self):
         self.r = weblog.get("/rasp/sqli", params={"user_id": "' OR 1 = 1 --"})
 
+    @flaky(context.weblog_variant in ("vertx3", "vertx4"), reason="APPSEC-54465")
     def test_sqli_get(self):
         assert self.r.status_code == 403
 

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -4,7 +4,7 @@
 import re
 import json
 
-from utils import weblog, context, interfaces, irrelevant, scenarios, features, flaky
+from utils import weblog, context, interfaces, irrelevant, scenarios, features
 
 
 @features.support_in_app_waf_metrics_report
@@ -16,7 +16,6 @@ class Test_Monitoring:
     def setup_waf_monitoring(self):
         self.r = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
-    @flaky(context.weblog_variant in ("vertx3", "vertx4"), reason="APPSEC-54465")
     def test_waf_monitoring(self):
         """WAF monitoring span tags and metrics are expected to be sent on each request"""
 


### PR DESCRIPTION

## Motivation

Annotate as flaky test_sqli.Test_Sqli_UrlQuery in tests/appsec/rasp/test_sqli.py

Remove flaky annotation from tests/appsec/waf/test_reports.py as was introduced by error in 

https://github.com/DataDog/system-tests/pull/2856/files and https://github.com/DataDog/system-tests/pull/2864

## Changes

add flaky to tests/appsec/rasp/test_sqli.py and remove it from tests/appsec/waf/test_reports.py

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
