### PR TITLE
[PHP] Reenable remote configuration tests

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -99,8 +99,8 @@ jobs:
       run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i agent
     - if: ${{inputs.library == 'php' }}
       run: |
-        wget https://output.circle-artifacts.com/output/job/55f3f4a5-6d33-41da-be3a-bbac53f3ca9e/artifacts/0/datadog-setup.php -P binaries/
-        wget https://output.circle-artifacts.com/output/job/55f3f4a5-6d33-41da-be3a-bbac53f3ca9e/artifacts/0/dd-library-php-1.3.0+af426b6e75479ead00635e05ccb6f89cdc9d94ed-x86_64-linux-gnu.tar.gz -P binaries/
+        wget https://output.circle-artifacts.com/output/job/55f3f4a5-6d33-41da-be3a-bbac53f3ca9e/artifacts/0/datadog-setup.php -O binaries/datadog-setup.php
+        wget https://output.circle-artifacts.com/output/job/55f3f4a5-6d33-41da-be3a-bbac53f3ca9e/artifacts/0/dd-library-php-1.3.0+af426b6e75479ead00635e05ccb6f89cdc9d94ed-x86_64-linux-gnu.tar.gz -O binaries/dd-library-php-x86_64-linux-gnu.tar.gz
     - name: Build weblog
       id: build
       run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i weblog

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -97,10 +97,6 @@ jobs:
       run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
     - name: Build agent
       run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i agent
-    - if: ${{inputs.library == 'php' }}
-      run: |
-        wget https://output.circle-artifacts.com/output/job/55f3f4a5-6d33-41da-be3a-bbac53f3ca9e/artifacts/0/datadog-setup.php -O binaries/datadog-setup.php
-        wget https://output.circle-artifacts.com/output/job/55f3f4a5-6d33-41da-be3a-bbac53f3ca9e/artifacts/0/dd-library-php-1.3.0+af426b6e75479ead00635e05ccb6f89cdc9d94ed-x86_64-linux-gnu.tar.gz -O binaries/dd-library-php-x86_64-linux-gnu.tar.gz
     - name: Build weblog
       id: build
       run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i weblog

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -97,6 +97,10 @@ jobs:
       run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
     - name: Build agent
       run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i agent
+    - if: ${{inputs.library == 'php' }}
+      run: |
+        wget https://output.circle-artifacts.com/output/job/55f3f4a5-6d33-41da-be3a-bbac53f3ca9e/artifacts/0/datadog-setup.php -P binaries/
+        wget https://output.circle-artifacts.com/output/job/55f3f4a5-6d33-41da-be3a-bbac53f3ca9e/artifacts/0/dd-library-php-1.3.0+af426b6e75479ead00635e05ccb6f89cdc9d94ed-x86_64-linux-gnu.tar.gz -P binaries/
     - name: Build weblog
       id: build
       run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i weblog

--- a/tests/appsec/test_ip_blocking_full_denylist.py
+++ b/tests/appsec/test_ip_blocking_full_denylist.py
@@ -28,7 +28,6 @@ class Test_AppSecIPBlockingFullDenylist(BaseFullDenyListTest):
         context.library >= "java@1.22.0" and context.library < "java@1.35.0",
         reason="Failed on large expiration values, which are used in this test",
     )
-    @bug(context.library > "php@1.1.999", reason="APPSEC-54454")
     def test_blocked_ips(self):
         """test blocked ips are enforced"""
 

--- a/tests/appsec/test_remote_config_rule_changes.py
+++ b/tests/appsec/test_remote_config_rule_changes.py
@@ -156,7 +156,6 @@ class Test_UpdateRuleFileWithRemoteConfig:
 
         self.config_state_5 = rc.rc_state.reset().apply()
 
-    @bug(context.library > "php@1.1.999", reason="APPSEC-54454")
     def test_update_rules(self):
         # normal block
         assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -37,7 +37,6 @@ class Test_UserBlocking_FullDenylist(BaseFullDenyListTest):
         reason="Failed on large expiration values, which are used in this test",
     )
     @bug(library="java", reason="Request blocked but appsec.blocked tag not set")
-    @bug(context.library > "php@1.1.999", reason="APPSEC-54454")
     def test_blocking_test(self):
         """Test with a denylisted user"""
 

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -30,7 +30,6 @@ class Test_Agent:
     @missing_feature(library="ruby", reason="ruby tracer does not call /info")
     @irrelevant(library="cpp")
     @scenarios.remote_config_mocked_backend_asm_dd
-    @bug(context.library > "php@1.1.999", reason="APPSEC-54454")
     def test_agent_provide_config_endpoint(self):
         """Check that agent exposes /v0.7/config endpoint"""
         for data in interfaces.library.get_data("/info"):
@@ -195,7 +194,6 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
     )
     @bug(library="golang", reason="missing update file datadog/2/ASM_FEATURES/ASM_FEATURES-third/config")
     @bug(context.library < "java@1.13.0", reason="id reported for config state is not the expected one")
-    @bug(context.library > "php@1.1.999", reason="APPSEC-54454")
     def test_tracer_update_sequence(self):
         """test update sequence, based on a scenario mocked in the proxy"""
 
@@ -343,7 +341,6 @@ class Test_RemoteConfigurationUpdateSequenceASMDD(RemoteConfigurationFieldsBasic
     )
     @bug(context.weblog_variant == "spring-boot-openliberty", reason="APPSEC-6721")
     @bug(context.library <= "java@1.12.1", reason="config state id value was wrong")
-    @bug(context.library > "php@1.1.999", reason="APPSEC-54454")
     def test_tracer_update_sequence(self):
         """test update sequence, based on a scenario mocked in the proxy"""
 


### PR DESCRIPTION
## Motivation

Reenable remote configuration tests on PHP after fixing the bug recently introduced in the main branch.

Related Jira: [APPSEC-54528]

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-54528]: https://datadoghq.atlassian.net/browse/APPSEC-54528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ