### PR TITLE
[python] Add server.address tag to db span

### DIFF
--- a/tests/integrations/test_db_integrations_sql.py
+++ b/tests/integrations/test_db_integrations_sql.py
@@ -165,6 +165,7 @@ class _BaseDatadogDbIntegrationTestClass(BaseDbIntegrationsTestClass):
                     "db.name",
                     "peer.service",
                     "net.peer.name",
+                    "server.address",
                 ]:  # These fields hostname, user... are the same as password
                     assert span["meta"][key] != db_container.db_password, f"Test is failing for {db_operation}"
 


### PR DESCRIPTION
## Motivation
Failing system test [flask-poc](https://github.com/DataDog/dd-trace-py/actions/runs/10324812052/job/28588236676?pr=10064#step:9:134) is blocking [PR](https://github.com/DataDog/dd-trace-py/pull/10064) to add `server.address` tag to database spans.

This one-line PR adds `server.address` as a valid tag in the span, for sql integration tests.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
