### PR TITLE
[go] Bump golang to 1.22

### DIFF
--- a/utils/build/docker/golang/chi.Dockerfile
+++ b/utils/build/docker/golang/chi.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/echo.Dockerfile
+++ b/utils/build/docker/golang/echo.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/gin.Dockerfile
+++ b/utils/build/docker/golang/gin.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/gqlgen.Dockerfile
+++ b/utils/build/docker/golang/gqlgen.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/graph-gophers.Dockerfile
+++ b/utils/build/docker/golang/graph-gophers.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/graphql-go.Dockerfile
+++ b/utils/build/docker/golang/graphql-go.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/net-http.Dockerfile
+++ b/utils/build/docker/golang/net-http.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS build
+FROM golang:1.22 AS build
 
 # print important lib versions
 RUN go version && curl --version
@@ -23,7 +23,7 @@ RUN go build -v -tags appsec -o weblog ./net-http
 
 # ==============================================================================
 
-FROM golang:1.21
+FROM golang:1.22
 
 COPY --from=build /app/weblog /app/weblog
 COPY --from=build /app/SYSTEM_TESTS_LIBDDWAF_VERSION /app/SYSTEM_TESTS_LIBDDWAF_VERSION

--- a/utils/build/docker/golang/uds-echo.Dockerfile
+++ b/utils/build/docker/golang/uds-echo.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 # print important lib versions
 RUN go version && curl --version


### PR DESCRIPTION
## Motivation
I'm working on importing some datadog agent code in dd-trace-go, this upgrade will bring dd-trace-go to using 1.22. According to the published support policy in the README this should be OK as 1.23 has already been released (meaning 1.21 is no longer supported)
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
