### PR TITLE
[nodejs] Iast kafka flaky tests again

### DIFF
--- a/tests/appsec/iast/source/test_kafka_key.py
+++ b/tests/appsec/iast/source/test_kafka_key.py
@@ -8,7 +8,6 @@ from ..utils import BaseSourceTest, get_all_iast_events, get_iast_sources
 
 @features.iast_source_kafka_key
 @scenarios.integrations
-@flaky(context.library == "nodejs", reason="APPSEC-54445")
 class TestKafkaKey(BaseSourceTest):
     """Verify that kafka message key is tainted"""
 

--- a/tests/appsec/iast/source/test_kafka_value.py
+++ b/tests/appsec/iast/source/test_kafka_value.py
@@ -8,7 +8,6 @@ from ..utils import BaseSourceTest, get_all_iast_events, get_iast_sources
 
 @features.iast_source_kafka_value
 @scenarios.integrations
-@flaky(context.library == "nodejs", reason="APPSEC-54445")
 class TestKafkaValue(BaseSourceTest):
     """Verify that kafka message value is tainted"""
 

--- a/utils/build/docker/nodejs/express4-typescript/iast.ts
+++ b/utils/build/docker/nodejs/express4-typescript/iast.ts
@@ -440,12 +440,12 @@ function initSourceRoutes (app: Express): void {
         resolve?: Function,
         reject?: Function
       } = {}
-      
+
       const promise = new Promise((resolve: Function, reject: Function): void => {
         deferred.resolve = resolve
         deferred.reject = reject
       })
-      
+
       consumer = await getKafkaConsumer(kafka, topic, 'testgroup-iast-ts-value')
       await consumer.run({
         eachMessage: async ({ message }: { message: any }) => {

--- a/utils/build/docker/nodejs/express4/iast/sources.js
+++ b/utils/build/docker/nodejs/express4/iast/sources.js
@@ -3,17 +3,6 @@
 const { Kafka } = require('kafkajs')
 const { readFileSync } = require('fs')
 
-function getKafka () {
-  return new Kafka({
-    clientId: 'my-app-iast',
-    brokers: ['kafka:9092'],
-    retry: {
-      initialRetryTime: 100, // Time to wait in milliseconds before the first retry
-      retries: 20 // Number of retries before giving up
-    }
-  })
-}
-
 function init (app, tracer) {
   app.post('/iast/source/body/test', (req, res) => {
     try {
@@ -115,6 +104,30 @@ function init (app, tracer) {
     res.send('OK')
   })
 
+  function getKafka () {
+    return new Kafka({
+      clientId: 'my-app-iast',
+      brokers: ['kafka:9092'],
+      retry: {
+        initialRetryTime: 100, // Time to wait in milliseconds before the first retry
+        retries: 20 // Number of retries before giving up
+      }
+    })
+  }
+
+  async function getKafkaConsumer (kafka, topic, groupId) {
+    const consumer = kafka.consumer({
+      groupId,
+      heartbeatInterval: 10000, // should be lower than sessionTimeout
+      sessionTimeout: 60000
+    })
+
+    await consumer.connect()
+    await consumer.subscribe({ topic, fromBeginning: true })
+
+    return consumer
+  }
+
   app.get('/iast/source/kafkavalue/test', (req, res) => {
     const kafka = getKafka()
     const topic = 'dsm-system-tests-queue'
@@ -122,32 +135,25 @@ function init (app, tracer) {
 
     let consumer
     const doKafkaOperations = async () => {
-      consumer = kafka.consumer({
-        groupId: 'testgroup2',
-        heartbeatInterval: 10000, // should be lower than sessionTimeout
-        sessionTimeout: 60000
-      })
-
-      await consumer.connect()
-      await consumer.subscribe({ topic, fromBeginning: false })
-
       const deferred = {}
       const promise = new Promise((resolve, reject) => {
         deferred.resolve = resolve
         deferred.reject = reject
       })
 
+      consumer = await getKafkaConsumer(kafka, topic, 'testgroup-iast-value')
       await consumer.run({
         eachMessage: async ({ topic, partition, message }) => {
-          const vulnValue = message.value.toString()
-          try {
-            readFileSync(vulnValue)
-          } catch {
-            // do nothing
-          }
+          if (!message.value) return
 
-          // in some occasions we consume messages from dsm tests
+          const vulnValue = message.value.toString()
           if (vulnValue === 'hello value!') {
+            try {
+              readFileSync(vulnValue)
+            } catch {
+              // do nothing
+            }
+
             deferred.resolve()
           }
         }
@@ -188,34 +194,25 @@ function init (app, tracer) {
 
     let consumer
     const doKafkaOperations = async () => {
-      consumer = kafka.consumer({
-        groupId: 'testgroup2',
-        heartbeatInterval: 10000, // should be lower than sessionTimeout
-        sessionTimeout: 60000
-      })
-
-      await consumer.connect()
-      await consumer.subscribe({ topic, fromBeginning: false })
-
       const deferred = {}
       const promise = new Promise((resolve, reject) => {
         deferred.resolve = resolve
         deferred.reject = reject
       })
 
+      consumer = await getKafkaConsumer(kafka, topic, 'testgroup-iast-key')
       await consumer.run({
         eachMessage: async ({ topic, partition, message }) => {
-          // in some occasions we consume messages from dsm tests
           if (!message.key) return
 
           const vulnKey = message.key.toString()
-          try {
-            readFileSync(vulnKey)
-          } catch {
-            // do nothing
-          }
-
           if (vulnKey === 'hello key!') {
+            try {
+              readFileSync(vulnKey)
+            } catch {
+            // do nothing
+            }
+
             deferred.resolve()
           }
         }


### PR DESCRIPTION
## Motivation

flaky iast kafka tests are still with us.

Let's see if this is the definitive one 🤞

## Changes

- use different consumer groups
- consume messages from the beginning


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
