### PR TITLE
PROF-10329: Allow for string values in product enablement

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -623,9 +623,10 @@ class Test_ProductsDisabled:
             ), f"Product information was expected in app-started event, but was missing in {data['log_filename']}"
 
             for product, details in payload["products"].items():
-                assert (
-                    details.get("enabled") is False
-                ), f"Product information expected to indicate {product} is disabled, but found enabled"
+                assert details.get("enabled") in [
+                    False,
+                    "false",
+                ], f"Product information expected to indicate {product} is disabled, but found enabled"
 
         if not data_found:
             raise ValueError("No telemetry data to validate on")


### PR DESCRIPTION
Allow for string values in product enablement

## Motivation

Profiling exposes a string instead of boolean for enablement as its values are "true",  "false", and "auto" since https://github.com/DataDog/dd-trace-js/pull/4592.

## Changes

The relevant test now accepts both a boolean False as well as a string "false".

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
