### PR TITLE
K8s Lib Injection. Ignore errors on destroy

### DIFF
--- a/tests/k8s_lib_injection/conftest.py
+++ b/tests/k8s_lib_injection/conftest.py
@@ -99,7 +99,10 @@ class K8sInstance:
             logger.error(f"Error loading kube config: {e}")
 
     def destroy_instance(self):
-        destroy_cluster(self.k8s_kind_cluster)
+        try:
+            destroy_cluster(self.k8s_kind_cluster)
+        except Exception as e:
+            logger.error(f"Error destroying cluster: {e}. Ignoring failure...")
 
     def deploy_datadog_cluster_agent(self, use_uds=False, features=None):
         """ Deploys datadog cluster agent with admission controller and given features."""


### PR DESCRIPTION
## Motivation

Sometimes when we shutdown the tests, errors arise trying to destroy the k8s cluster. Ignore errors and continue...

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
