### PR TITLE
Check average heartbeat delay for telemetry (APMAPI-224 and AIT-9176)

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -297,7 +297,6 @@ class Test_Telemetry:
     @flaky(context.library < "java@1.18.0", reason="Telemetry interval drifts")
     @flaky(context.library <= "php@0.90", reason="Heartbeats are sometimes sent too slow")
     @flaky(library="ruby")
-    @bug(context.library >= "nodejs@4.21.0", reason="AIT-9176")
     @bug(context.library > "php@0.90")
     @features.telemetry_heart_beat_collected
     def test_app_heartbeat(self):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -326,7 +326,10 @@ class Test_Telemetry:
         # In theory, it's sorted. Let be safe
         timestamps.sort()
 
+        # Get the delay between the first heartbeat and the last heartbeat
         delta = (timestamps[-1] - timestamps[0]).total_seconds()
+
+        # There is N -1 delay between N heartbeats, so get the average delay with:
         average_delay = delta / (len(heartbeats) - 1)
 
         assert (

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -315,7 +315,7 @@ class Test_Telemetry:
         assert len(telemetry_data) > 0, "No telemetry messages"
 
         heartbeats = [d for d in telemetry_data if d["request"]["content"].get("request_type") == "app-heartbeat"]
-        assert len(heartbeats) >= 2, "Did not receive, at least, 2 heartbeats"
+        assert len(heartbeats) >= 3, "Did not receive, at least, 2 heartbeats"
 
         # depending on the tracer, the very first heartbeat may be sent in a request that pays the
         # connection initialization time. This time is very unpredictible, so we remove the very


### PR DESCRIPTION
## Motivation

This test was checking each delay between all heartbeat. There are lot of reason in an uncontrolled environment for having one delay not respecting the spec. 

## Changes

Check the average delay, rather each individual delay, to reduce flakiness 


* [x] ✅  run 1 : https://github.com/DataDog/system-tests/actions/runs/10522589717/attempts/1?pr=2908
* [x] run 2 : https://github.com/DataDog/system-tests/actions/runs/10522589717/attempts/2?pr=2908
* [x] run 3 : https://github.com/DataDog/system-tests/actions/runs/10522589717/attempts/3?pr=2908


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
