### PR TITLE
[Python] mark iast parameter value test as irrelevant

### DIFF
--- a/tests/appsec/iast/source/test_parameter_value.py
+++ b/tests/appsec/iast/source/test_parameter_value.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, missing_feature, bug, features, flaky
+from utils import context, missing_feature, irrelevant, features, flaky
 from ..utils import BaseSourceTest
 
 
@@ -29,7 +29,8 @@ class TestParameterValue(BaseSourceTest):
 
     setup_source_post_reported = BaseSourceTest.setup_source_reported
 
-    @bug(library="python", reason="Python frameworks need a header, if not, 415 status code")
+    @irrelevant(library="python", reason="Flask and Django need a header; otherwise, they return a 415 status code."
+                                         "TODO: When FastAPI implements POST body source, verify if it does too.")
     @flaky(context.weblog_variant == "resteasy-netty3", reason="Issue with weak references, needs investigation")
     def test_source_post_reported(self):
         self.validate_request_reported(self.requests["POST"])

--- a/tests/appsec/iast/source/test_parameter_value.py
+++ b/tests/appsec/iast/source/test_parameter_value.py
@@ -29,8 +29,11 @@ class TestParameterValue(BaseSourceTest):
 
     setup_source_post_reported = BaseSourceTest.setup_source_reported
 
-    @irrelevant(library="python", reason="Flask and Django need a header; otherwise, they return a 415 status code."
-                                         "TODO: When FastAPI implements POST body source, verify if it does too.")
+    @irrelevant(
+        library="python",
+        reason="Flask and Django need a header; otherwise, they return a 415 status code."
+        "TODO: When FastAPI implements POST body source, verify if it does too.",
+    )
     @flaky(context.weblog_variant == "resteasy-netty3", reason="Issue with weak references, needs investigation")
     def test_source_post_reported(self):
         self.validate_request_reported(self.requests["POST"])


### PR DESCRIPTION
IAST parameter value test was marked as bug long time ago but it's irrelevant for some python frameworks

Related to: https://github.com/DataDog/dd-trace-py/pull/10331

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
