### PR TITLE
AIT-9176 split heartbeat test in two separated tests

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -324,7 +324,7 @@ class Test_Telemetry:
     @flaky(context.library < "java@1.18.0", reason="Telemetry interval drifts")
     @flaky(library="nodejs", reason="AIT-9176")
     @flaky(library="ruby", reason="APMAPI-226")
-    # @bug(context.library > "php@0.90")
+    @flaky(library="php", reason="APMAPI-227")
     @features.telemetry_heart_beat_collected
     def test_app_heartbeat_not_too_fast(self):
         """ Check for telemetry heartbeat are not sent to fast, regarding DD_TELEMETRY_HEARTBEAT_INTERVAL """
@@ -344,7 +344,6 @@ class Test_Telemetry:
     @flaky(context.library < "java@1.18.0", reason="Telemetry interval drifts")
     @flaky(context.library <= "php@0.90", reason="Heartbeats are sometimes sent too slow")
     @flaky(library="ruby", reason="APMAPI-226")
-    # @bug(context.library > "php@0.90")
     @features.telemetry_heart_beat_collected
     def test_app_heartbeat_not_too_slow(self):
         """

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -338,7 +338,7 @@ class Test_Telemetry:
         return delays_by_runtime
 
     @missing_feature(library="cpp", reason="DD_TELEMETRY_HEARTBEAT_INTERVAL not supported")
-    @flaky(context.library < "java@1.18.0", reason="Telemetry interval drifts")
+    @flaky(context.library <= "java@1.38.1", reason="Telemetry second heartbeat was sent too fast")
     @flaky(library="nodejs", reason="AIT-9176")
     @flaky(library="ruby", reason="APMAPI-226")
     @features.telemetry_heart_beat_collected
@@ -358,7 +358,6 @@ class Test_Telemetry:
                 ), f"Heartbeat sent too fast: ({delay}s). It should be sent every {context.telemetry_heartbeat_interval}s"
 
     @missing_feature(library="cpp", reason="DD_TELEMETRY_HEARTBEAT_INTERVAL not supported")
-    @flaky(context.library < "java@1.18.0", reason="Telemetry interval drifts")
     @flaky(context.library <= "php@0.90", reason="Heartbeats are sometimes sent too slow")
     @flaky(library="ruby", reason="APMAPI-226")
     @features.telemetry_heart_beat_collected


### PR DESCRIPTION
## Motivation

Following #2908 , improve heartbeat tests, and reskip it for node.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
