### PR TITLE
[Debugger] Fix java exception replay inconsistency

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -958,13 +958,13 @@ tests/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay:
         '*': missing_feature
-        spring-boot: bug (DEBUG-2784, should be v1.38.0)  # real version not known
-        spring-boot-jetty: bug (DEBUG-2784, should be v1.38.0)  # real version not known
-        spring-boot-openliberty: bug (DEBUG-2784, should be v1.38.0)  # real version not known
-        spring-boot-payara: bug (DEBUG-2784, should be v1.38.0)  # real version not known
-        spring-boot-undertow: bug (DEBUG-2784, should be v1.38.0)  # real version not known
-        spring-boot-wildfly: bug (DEBUG-2784, should be v1.38.0)  # real version not known
-        uds-spring-boot: bug (DEBUG-2784, should be v1.38.0)  # real version not known
+        spring-boot: v0.1  # real version not known
+        spring-boot-jetty: v1.38.0  # real version not known
+        spring-boot-openliberty: v1.38.0  # real version not known
+        spring-boot-payara: v1.38.0  # real version not known
+        spring-boot-undertow: v1.38.0  # real version not known
+        spring-boot-wildfly: v1.38.0  # real version not known
+        uds-spring-boot: v0.1  # real version not known
     test_debugger_expression_language.py:
       Test_Debugger_Expression_Language:
         '*': missing_feature

--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -38,14 +38,14 @@ class Test_Debugger_Exception_Replay(base._Base_Debugger_Test):
             if contents:
                 for content in contents:
                     snapshot = content.get("debugger", {}).get("snapshot") or content.get("debugger.snapshot")
-                    if snapshot and snapshot["probe"]["location"]["method"].lower().replace('_', '') == self.method:
+                    if snapshot and snapshot["probe"]["location"]["method"].lower().replace("_", "") == self.method:
                         self.snapshot = snapshot
 
                         logger.debug("Snapshot received")
                         return True
-                        
+
         return False
-        
+
     def setup_exception_replay_simple(self):
         self._setup("/debugger/expression/exception", "expressionexception")
 
@@ -94,5 +94,5 @@ class Test_Debugger_Exception_Replay(base._Base_Debugger_Test):
 
                 expected = __read("expected")
                 assert expected == snapshot
-        
+
         __approve(self.snapshot)

--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -14,7 +14,7 @@ class Test_Debugger_Exception_Replay(base._Base_Debugger_Test):
 
     def _setup(self, request_path):
         self.weblog_responses = [weblog.get(request_path)]
-        time.sleep(1)
+        time.sleep(5)
         self.weblog_responses.append(weblog.get(request_path))
 
     def setup_exception_replay_simple(self):

--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -3,26 +3,55 @@
 # Copyright 2021 Datadog, Inc.
 
 import tests.debugger.utils as base
-import time, json, os
+import json, os
 from utils import scenarios, interfaces, weblog, features
+from utils.tools import logger
 
 
 @features.debugger_exception_replay
 @scenarios.debugger_exception_replay
 class Test_Debugger_Exception_Replay(base._Base_Debugger_Test):
     tracer = None
+    snapshot = None
+    method = None
 
-    def _setup(self, request_path):
-        self.weblog_responses = [weblog.get(request_path)]
-        time.sleep(5)
-        self.weblog_responses.append(weblog.get(request_path))
+    def _setup(self, request_path, method):
+        self.snapshot = None
+        self.weblog_responses = set()
+        self.method = method
 
+        retries = 0
+        max_retries = 60
+
+        while not self.snapshot and retries < max_retries:
+            logger.debug(f"Waiting for snapshot, retry #{retries}")
+
+            self.weblog_responses.add(weblog.get(request_path))
+            interfaces.agent.wait_for(self._wait_for_snapshot_received, timeout=1)
+
+            retries += 1
+
+    def _wait_for_snapshot_received(self, data):
+        if data["path"] == base._LOGS_PATH:
+
+            contents = data["request"].get("content", []) or []
+            if contents:
+                for content in contents:
+                    snapshot = content.get("debugger", {}).get("snapshot") or content.get("debugger.snapshot")
+                    if snapshot and snapshot["probe"]["location"]["method"].lower().replace('_', '') == self.method:
+                        self.snapshot = snapshot
+
+                        logger.debug("Snapshot received")
+                        return True
+                        
+        return False
+        
     def setup_exception_replay_simple(self):
-        self._setup("/debugger/expression/exception")
+        self._setup("/debugger/expression/exception", "expressionexception")
 
     def test_exception_replay_simple(self):
         self.assert_all_weblog_responses_ok(expected_code=500)
-
+        assert self.snapshot, "Snapshot not found"
         self._validate_exception_replay_snapshots(test_name="exception_replay_simple")
 
     def _validate_exception_replay_snapshots(self, test_name: str, override_aprovals: bool = False):
@@ -65,17 +94,5 @@ class Test_Debugger_Exception_Replay(base._Base_Debugger_Test):
 
                 expected = __read("expected")
                 assert expected == snapshot
-
-        agent_logs_endpoint_requests = list(interfaces.agent.get_data(base._LOGS_PATH))
-
-        snapshot_found = False
-        for request in agent_logs_endpoint_requests:
-            content = request["request"]["content"]
-            if content:
-                for item in content:
-                    snapshot = item.get("debugger", {}).get("snapshot") or item.get("debugger.snapshot")
-                    if snapshot:
-                        snapshot_found = True
-                        __approve(snapshot)
-
-        assert snapshot_found, "Snapshot not found"
+        
+        __approve(self.snapshot)


### PR DESCRIPTION
## Motivation
Fix java exception replay inconsistency by adding `wait for snapshot` functionality.