### PR TITLE
Small improvments on parametric tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Test idiomatics scenarios
         run: |
           ./run.sh DEFAULT
-          TEST_LIBRARY=golang ./run.sh PARAMETRIC --splits=8 --group=1
+          ./run.sh PARAMETRIC -L golang --splits=8 --group=1
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
 

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -59,8 +59,6 @@ jobs:
         weblog: ${{ fromJson(inputs.weblogs) }}
       fail-fast: false
     env:
-      TEST_LIBRARY: ${{ inputs.library }}
-      WEBLOG_VARIANT: ${{ matrix.weblog }}
       SYSTEM_TESTS_REPORT_ENVIRONMENT: ${{ inputs.ci_environment }}
       SYSTEM_TESTS_REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
@@ -364,6 +362,7 @@ jobs:
       if: always() && steps.compress_logs.outcome == 'success'
       uses: actions/upload-artifact@v4
       with:
+        # log name convention to respect : logs_$SCENARIO-FAMILY_$LIBRARY_$WEBLOG_$CI-ENVIRONMENT
         name: logs_endtoend_${{ inputs.library }}_${{ matrix.weblog }}_${{ inputs.ci_environment }}
         path: artifact.tar.gz
 

--- a/.github/workflows/run-graphql.yml
+++ b/.github/workflows/run-graphql.yml
@@ -41,8 +41,6 @@ jobs:
       fail-fast: false
 
     env:
-      TEST_LIBRARY: ${{ inputs.library }}
-      WEBLOG_VARIANT: ${{ matrix.weblog }}
       SYSTEM_TESTS_REPORT_ENVIRONMENT: ${{ inputs.ci_environment }}
       SYSTEM_TESTS_REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -72,7 +70,7 @@ jobs:
 
       - name: Build weblog
         id: build
-        run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i weblog
+        run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh ${{ inputs.library }} -i weblog -w ${{ matrix.weblog }}
 
       - name: Run GRAPHQL_APPSEC scenario
         run: ./run.sh GRAPHQL_APPSEC

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -41,7 +41,6 @@ jobs:
       matrix:
         job_instance: ${{ fromJson( inputs._experimental_job_matrix ) }}
     env:
-      TEST_LIBRARY: ${{ inputs.library }}
       SYSTEM_TESTS_REPORT_ENVIRONMENT: ${{ inputs.ci_environment }}
       SYSTEM_TESTS_REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
@@ -64,7 +63,7 @@ jobs:
           RUN_ATTEMPTS=1
           while [ $RUN_ATTEMPTS -le 3 ]; do
             echo "Running parametric test attempt $RUN_ATTEMPTS"
-            timeout 720s ./run.sh PARAMETRIC --splits=${{ inputs._experimental_job_count }} --group=${{ matrix.job_instance }}
+            timeout 720s ./run.sh PARAMETRIC -L ${{ inputs.library }} --splits=${{ inputs._experimental_job_count }} --group=${{ matrix.job_instance }}
             status=$?
             #timneout returns 124 if it times out
             #if the return code is not 124, then we exit with the status
@@ -80,7 +79,7 @@ jobs:
           done
       - name: Run parametric (without timeout)
         if: ${{ inputs.library != 'java' }}
-        run: ./run.sh PARAMETRIC --splits=${{ inputs._experimental_job_count }} --group=${{ matrix.job_instance }}
+        run: ./run.sh PARAMETRIC -L ${{ inputs.library }} --splits=${{ inputs._experimental_job_count }} --group=${{ matrix.job_instance }}
       - name: Compress logs
         id: compress_logs
         if: always()

--- a/conftest.py
+++ b/conftest.py
@@ -45,6 +45,17 @@ def pytest_addoption(parser):
     parser.addoption("--vm-only-branch", type=str, action="store", help="Filter to execute only one vm branch")
     parser.addoption("--vm-skip-branches", type=str, action="store", help="Filter exclude vm branches")
 
+    # Parametric scenario options
+    parser.addoption(
+        "--library",
+        "-L",
+        type=str,
+        action="store",
+        default="",
+        help="Library to test (e.g. 'python', 'ruby')",
+        choices=["cpp", "golang", "dotnet", "java", "nodejs", "php", "python", "ruby"],
+    )
+
     # report data to feature parity dashboard
     parser.addoption(
         "--report-run-url", type=str, action="store", default=None, help="URI of the run who produced the report",

--- a/docs/CI/github-actions.md
+++ b/docs/CI/github-actions.md
@@ -23,15 +23,13 @@ jobs:
             weblog-variant: net-http
       fail-fast: false
     env:
-      TEST_LIBRARY: ${{ matrix.library }}
-      WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
-          token: ${{ secrets.GH_TOKEN }}
+          persist_credentials: false
 
       - name: Get component binary
         # you need to copy a valid binary of your component inside binaries/ folder.
@@ -39,7 +37,7 @@ jobs:
         run: <...>
 
       - name: Build
-        run: ./build.sh
+        run: ./build.sh ${{ matrix.library }} -w ${{ matrix.weblog-variant }}
 
       - name: Run
         run: ./run.sh

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -119,8 +119,12 @@ class ParametricScenario(Scenario):
 
     def configure(self, config):
         super().configure(config)
-        assert "TEST_LIBRARY" in os.environ
-        library = os.getenv("TEST_LIBRARY")
+        if config.option.library:
+            library = config.option.library
+        elif "TEST_LIBRARY" in os.environ:
+            library = os.getenv("TEST_LIBRARY")
+        else:
+            raise ValueError("No library specified, please set -L option")
 
         # get tracer version info building and executing the ddtracer-version.docker file
 
@@ -189,6 +193,10 @@ class ParametricScenario(Scenario):
     @property
     def library(self):
         return self._library
+
+    @property
+    def weblog_variant(self):
+        return f"parametric-{self.library.library}"
 
     def _build_apm_test_server_image(self) -> str:
 


### PR DESCRIPTION
## Motivation

DevX, and export to feature parity dashbaord

## Changes

* set a weblog variant name for parametric scenarios
* Add `-L` option as an alternative for env var `TEST_LIBRARY`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
