### PR TITLE
[java] Enable addEvent and recordException tests

### DIFF
--- a/docs/scenarios/parametric.md
+++ b/docs/scenarios/parametric.md
@@ -116,20 +116,26 @@ Add a file datadog-dotnet-apm-<VERSION>.tar.gz in binaries/. <VERSION> must be a
 
 ##### Run Parametric tests with a custom Java Tracer version
 
-1. Build Java Tracer artifacts
+1. Clone the repo and checkout to the branch you'd like to test
+Clone the repo: 
 ```bash
 git clone git@github.com:DataDog/dd-trace-java.git
 cd dd-trace-java
+```
+By default you will be on the `master` branch, but if you'd like to run system-tests on the changes you made to your local branch, `gitc checkout` to that branch. 
+
+2. Build Java Tracer artifacts
+```bash
 ./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar
 ```
 
-2. Copy both artifacts into the `system-tests/binaries/` folder:
+3. Copy both artifacts into the `system-tests/binaries/` folder:
   * The Java tracer agent artifact `dd-java-agent-*.jar` from `dd-java-agent/build/libs/`
   * Its public API `dd-trace-api-*.jar` from `dd-trace-api/build/libs/` into
 
 Note, you should have only TWO jar files in `system-tests/binaries`. Do NOT copy sources or javadoc jars.
 
-3. Run Parametric tests from the `system-tests/parametric` folder:
+4. Run Parametric tests from the `system-tests/parametric` folder:
 
 ```bash
 TEST_LIBRARY=java ./run.sh test_span_sampling.py::test_single_rule_match_span_sampling_sss001

--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -868,7 +868,7 @@ class Test_Otel_Span_Methods:
         context.library != "golang@1.66.0-dev" and context.library < "golang@1.67.0", reason="Implemented in v1.67.0"
     )
     @missing_feature(context.library == "php", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library < "java@1.39.0", reason="Not implemented")
     @missing_feature(context.library < "ruby@2.3.0", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.17.0", reason="Implemented in v5.17.0 & v4.41.0")
     @missing_feature(context.library < "python@2.9.0", reason="Not implemented")
@@ -922,7 +922,7 @@ class Test_Otel_Span_Methods:
 
     @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "php@0.95.0", reason="Implemented in 0.96.0")
-    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library < "java@1.39.0", reason="Not implemented")
     @missing_feature(context.library < "ruby@2.3.0", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.17.0", reason="Implemented in v5.17.0 & v4.41.0")
     @missing_feature(context.library < "python@2.9.0", reason="Not implemented")
@@ -943,7 +943,7 @@ class Test_Otel_Span_Methods:
 
     @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library == "php", reason="Not implemented")
-    @missing_feature(context.library == "java", reason="Not implemented")
+    @missing_feature(context.library < "java@1.39.0", reason="Not implemented")
     @missing_feature(context.library < "ruby@2.3.0", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.17.0", reason="Implemented in v5.17.0 & v4.41.0")
     @missing_feature(context.library < "python@2.9.0", reason="Not implemented")

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/opentelemetry/controller/OpenTelemetryController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/opentelemetry/controller/OpenTelemetryController.java
@@ -289,10 +289,8 @@ public class OpenTelemetryController {
     Span span = getSpan(args.spanId());
     if (span != null) {
       if (args.timestamp() == 0L) {
-        System.out.println("MTOFF: adding "+ args.name());
         span.addEvent(args.name(), parseAttributes(args.attributes()));
       } else {
-        System.out.println("MTOFF: adding "+ args.name());
         span.addEvent(args.name(), parseAttributes(args.attributes()), args.timestamp(), MICROSECONDS);
       }
     }

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/opentelemetry/controller/OpenTelemetryController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/opentelemetry/controller/OpenTelemetryController.java
@@ -76,6 +76,9 @@ public class OpenTelemetryController {
   }
 
   private static Attributes parseAttributes(Map<String, Object> attributes) {
+    if(attributes == null) {
+      return null;
+    }
     AttributesBuilder builder = Attributes.builder();
     for (Map.Entry<String, Object> entry : attributes.entrySet()) {
       String key = entry.getKey();
@@ -285,7 +288,13 @@ public class OpenTelemetryController {
     LOGGER.info("Adding OTel span event: {}", args);
     Span span = getSpan(args.spanId());
     if (span != null) {
-      span.addEvent(args.name(), parseAttributes(args.attributes()), args.timestamp(), MICROSECONDS);
+      if (args.timestamp() == 0L) {
+        System.out.println("MTOFF: adding "+ args.name());
+        span.addEvent(args.name(), parseAttributes(args.attributes()));
+      } else {
+        System.out.println("MTOFF: adding "+ args.name());
+        span.addEvent(args.name(), parseAttributes(args.attributes()), args.timestamp(), MICROSECONDS);
+      }
     }
   }
 


### PR DESCRIPTION
## Motivation
https://github.com/DataDog/dd-trace-java/pull/7408

## Changes
Enables addEvent and recordException tests for dd-trace-java 1.39.0+
Also, fixes/clarifies the parametric docs for Java.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
