### PR TITLE
[java] enable RASP SQLi tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -395,32 +395,43 @@ tests/:
     rasp/:
       test_lfi.py: missing_feature
       test_shi.py: missing_feature
+      # SQLi was introduced in v1.38.0 (with RASP disabled by default, but was flaky)
       test_sqli.py:
         Test_Sqli_BodyJson:
-          '*': v1.38.0
+          '*': v1.39.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (Requires payara blockng functionallity)
+          spring-boot-payara: bug (produces 500 errors)
           vertx3: missing_feature (Requires parsed body instrumentation)
           vertx4: missing_feature (Requires parsed body instrumentation)
         Test_Sqli_BodyUrlEncoded:
-          '*': v1.38.0
+          '*': v1.39.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (Requires payara blockng functionallity)
+          spring-boot-payara: bug (produces 500 errors)
         Test_Sqli_BodyXml:
-          '*': v1.38.0
+          '*': v1.39.0
           akka-http: missing_feature (Requires parsed body instrumentation)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (Requires payara blockng functionallity)
+          spring-boot-payara: bug (produces 500 errors)
           vertx3: missing_feature (Requires parsed body instrumentation)
           vertx4: missing_feature (Requires parsed body instrumentation)
-        Test_Sqli_Mandatory_SpanTags: missing_feature
-        Test_Sqli_Optional_SpanTags: missing_feature
-        Test_Sqli_StackTrace: missing_feature
-        Test_Sqli_Telemetry: bug (consistant failure on 1.39.0)
-        Test_Sqli_UrlQuery:
-          '*': v1.38.0
+        Test_Sqli_Mandatory_SpanTags:
+          '*': v1.39.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: missing_feature (Requires payara blockng functionallity)
+        Test_Sqli_Optional_SpanTags:
+          '*': v1.39.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_Sqli_StackTrace:
+          '*': v1.39.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-payara: bug (produces 500 errors)
+        Test_Sqli_Telemetry:
+          '*': v1.39.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-payara: bug (produces 500 errors)
+        Test_Sqli_UrlQuery:
+          '*': v1.39.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-payara: bug (produces 500 errors)
       test_ssrf.py: missing_feature
     waf/:
       test_addresses.py:

--- a/tests/appsec/rasp/test_sqli.py
+++ b/tests/appsec/rasp/test_sqli.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import features, weblog, interfaces, scenarios, rfc, context, flaky
+from utils import features, weblog, interfaces, scenarios, rfc, context
 from tests.appsec.rasp.utils import (
     validate_span_tags,
     validate_stack_traces,
@@ -14,7 +14,6 @@ from tests.appsec.rasp.utils import (
 @rfc("https://docs.google.com/document/d/1vmMqpl8STDk7rJnd3YBsa6O9hCls_XHHdsodD61zr_4/edit#heading=h.gv4kwto3561e")
 @features.rasp_sql_injection
 @scenarios.appsec_rasp
-@flaky(context.library == "java", reason="APPSEC-54578")
 class Test_Sqli_UrlQuery:
     """SQL Injection through query parameters"""
 
@@ -38,7 +37,6 @@ class Test_Sqli_UrlQuery:
 @rfc("https://docs.google.com/document/d/1vmMqpl8STDk7rJnd3YBsa6O9hCls_XHHdsodD61zr_4/edit#heading=h.gv4kwto3561e")
 @features.rasp_sql_injection
 @scenarios.appsec_rasp
-@flaky(context.library == "java", reason="APPSEC-54578")
 class Test_Sqli_BodyUrlEncoded:
     """SQL Injection through a url-encoded body parameter"""
 
@@ -62,7 +60,6 @@ class Test_Sqli_BodyUrlEncoded:
 @rfc("https://docs.google.com/document/d/1vmMqpl8STDk7rJnd3YBsa6O9hCls_XHHdsodD61zr_4/edit#heading=h.gv4kwto3561e")
 @features.rasp_sql_injection
 @scenarios.appsec_rasp
-@flaky(context.library == "java", reason="APPSEC-54578")
 class Test_Sqli_BodyXml:
     """SQL Injection through an xml body parameter"""
 
@@ -87,7 +84,6 @@ class Test_Sqli_BodyXml:
 @rfc("https://docs.google.com/document/d/1vmMqpl8STDk7rJnd3YBsa6O9hCls_XHHdsodD61zr_4/edit#heading=h.gv4kwto3561e")
 @features.rasp_sql_injection
 @scenarios.appsec_rasp
-@flaky(context.library == "java", reason="APPSEC-54578")
 class Test_Sqli_BodyJson:
     """SQL Injection through a json body parameter"""
 


### PR DESCRIPTION
## Motivation

[APPSEC-54578](https://datadoghq.atlassian.net/browse/APPSEC-54578)

## Changes

* Set RASP SQLi tests to v1.39.0. This was released in v1.38.0, disabled by default, but was flaky. Effectively, we'll want to consider v1.39.0 the first release with RASP SQLi support.
* Enable all tests for RASP SQLi in Java.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-54578]: https://datadoghq.atlassian.net/browse/APPSEC-54578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ