### PR TITLE
More resilient logic for _wait_for_snapshot_received

### DIFF
--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -35,14 +35,31 @@ class Test_Debugger_Exception_Replay(base._Base_Debugger_Test):
         if data["path"] == base._LOGS_PATH:
 
             contents = data["request"].get("content", []) or []
-            if contents:
-                for content in contents:
-                    snapshot = content.get("debugger", {}).get("snapshot") or content.get("debugger.snapshot")
-                    if snapshot and snapshot["probe"]["location"]["method"].lower().replace("_", "") == self.method:
-                        self.snapshot = snapshot
+            for content in contents:
+                snapshot = content.get("debugger", {}).get("snapshot") or content.get("debugger.snapshot")
 
-                        logger.debug("Snapshot received")
-                        return True
+                if not snapshot:
+                    continue
+
+                if (
+                    "probe" not in snapshot
+                    or "location" not in snapshot["probe"]
+                    or "method" not in snapshot["probe"]["location"]
+                ):
+                    continue
+
+                method = snapshot["probe"]["location"]["method"]
+
+                if not isinstance(method, str):
+                    continue
+
+                method = method.lower().replace("_", "")
+
+                if method == self.method:
+                    self.snapshot = snapshot
+
+                    logger.debug("Snapshot received")
+                    return True
 
         return False
 


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/system-tests/actions/runs/10581964322/job/29320956211?pr=2933#step:59:98

The current function assumes that `method` always exists in `probe.location`, which is not always true

## Changes

Do no assumes that `method` exists. Even checks its type.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
