### PR TITLE
Fix format script when trailing white spaces 

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -73,7 +73,7 @@ _sed_i() {
 
 if [ "$COMMAND" == "fix" ]; then
   echo "$FILES" | while read file ; do
-    if [ $FILES ]; then
+    if [ "$FILES" ]; then
       echo "Fixing $file"
       _sed_i 's/  *$//g' "$file"
     fi


### PR DESCRIPTION
## Motivation

The format script could not fix the trailing whitespaces.

Example:
```
Checking tailing whitespaces...
./format.sh: line 76: [: ./utils/build/docker/nodejs/express4-typescript/app.ts: unary operator expected
./format.sh: line 76: [: ./utils/build/docker/nodejs/express4-typescript/app.ts: unary operator expected
All good, the system-tests CI will be happy! ✨ 🍰 ✨
```

## Changes

Add quote to the variable.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
