### PR TITLE
[java] Improve parametric Java client app start

### DIFF
--- a/utils/build/docker/java/parametric/install_ddtrace.sh
+++ b/utils/build/docker/java/parametric/install_ddtrace.sh
@@ -36,3 +36,9 @@ echo "Running Maven build with profiles ${MAVEN_PROFILES}"
 # shellcheck disable=SC2086
 mvn -q $MAVEN_PROFILES package
 
+# Extract application and its dependencies from class lookup performance improvements
+java -Djarmode=tools -jar target/dd-trace-java-client-1.0.0.jar extract --destination application
+# Warm up application and create CDS archive
+APM_TEST_CLIENT_SERVER_PORT=8080 java \
+  -XX:ArchiveClassesAtExit=application.jsa -Dspring.context.exit=onRefresh \
+  -jar application/dd-trace-java-client-1.0.0.jar


### PR DESCRIPTION

## Motivation

Moving away from gRPC server to Spring Boot web server slowed Java parametric tests
<!-- What inspired you to submit this pull request? -->

## Changes

This PR improves parametric Java client app startup by 
* Extracting application to improve class lookup
* Creating CDS archive for faster warmup

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [x] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
