### PR TITLE
Enable more PHP onboarding tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -234,8 +234,23 @@ onboarding_php:
   parallel:
       matrix:
         - ONBOARDING_FILTER_ENV: [dev, prod]
+          ONBOARDING_FILTER_WEBLOG: [test-app-php]
+          SCENARIO: [HOST_AUTO_INJECTION_INSTALL_SCRIPT]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
+          ONBOARDING_FILTER_WEBLOG: [test-shell-script]
+          SCENARIO: [INSTALLER_AUTO_INJECTION_BLOCK_LIST]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
+          ONBOARDING_FILTER_WEBLOG: [test-app-php-container-83]
+          SCENARIO: [ CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
           ONBOARDING_FILTER_WEBLOG: [test-app-php,test-app-php-container-83]
           SCENARIO: [INSTALLER_AUTO_INJECTION]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
+          ONBOARDING_FILTER_WEBLOG: [test-app-php]
+          SCENARIO: [INSTALLER_AUTO_INJECTION_LD_PRELOAD]
+        - ONBOARDING_FILTER_ENV: [dev, prod]
+          ONBOARDING_FILTER_WEBLOG: [test-app-php]
+          SCENARIO: [INSTALLER_HOST_AUTO_INJECTION_CHAOS]
   script:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env ${ONBOARDING_FILTER_ENV} --vm-library ${TEST_LIBRARY} --vm-provider aws

--- a/tests/auto_inject/test_auto_inject_blocklist.py
+++ b/tests/auto_inject/test_auto_inject_blocklist.py
@@ -16,6 +16,7 @@ class _AutoInjectBlockListBaseTest:
         "python": "DD_PYTHON_IGNORED_ARGS",
         "nodejs": "DD_NODE_IGNORED_ARGS",
         "ruby": "DD_RUBY_IGNORED_ARGS",
+        "php": "DD_PHP_IGNORED_ARGS",
     }
 
     yml_config_template = """
@@ -25,7 +26,7 @@ output_paths:
   - file:///tmp/host_injection.log
 env: dev
 config_sources: BASIC
-ignored_processes: 
+ignored_processes:
         - DD_IGNORED_PROCESSES
 ignored_arguments:
     Java:
@@ -38,6 +39,8 @@ ignored_arguments:
         - DD_NODE_IGNORED_ARGS
     Ruby:
         - DD_RUBY_IGNORED_ARGS
+    PHP:
+        - DD_PHP_IGNORED_ARGS
 """
 
     def _execute_remote_command(self, ssh_client, command, config={}, use_injection_config=False):
@@ -206,6 +209,12 @@ class TestAutoInjectBlockListInstallManualHost(_AutoInjectBlockListBaseTest):
             {"ignored_args": "test1,test2", "command": "ruby names.rb --name pepe", "skip": False},
             {"ignored_args": "--name", "command": "ruby names.rb --name pepe", "skip": True},
         ],
+        "php": [
+            {"ignored_args": "", "command": "php index.php -a -b -c", "skip": False},
+            {"ignored_args": "-c", "command": "php index.php -a -b -c", "skip": True},
+            {"ignored_args": "", "command": "php index.php -f --custom Override", "skip": False},
+            {"ignored_args": "--custom", "command": "php index.php -f --custom Override", "skip": True},
+        ],
     }
 
     @irrelevant(
@@ -265,7 +274,7 @@ class TestAutoInjectBlockListInstallManualHost(_AutoInjectBlockListBaseTest):
         reason="Block list not fully implemented ",
     )
     def test_user_ignored_args(self, virtual_machine):
-        """ Check that we are not instrumenting the lang commands (java,ruby,dotnet,python) that match with args set by DD_<LANG>_IGNORED_ARGS env variable"""
+        """ Check that we are not instrumenting the lang commands (java,ruby,dotnet,python,php) that match with args set by DD_<LANG>_IGNORED_ARGS env variable"""
         language = context.scenario.library.library
         if language in self.user_args_commands:
             ssh_client = virtual_machine.ssh_config.get_ssh_connection()

--- a/utils/build/virtual_machine/weblogs/php/provision_test-shell-script.yml
+++ b/utils/build/virtual_machine/weblogs/php/provision_test-shell-script.yml
@@ -1,0 +1,29 @@
+lang_variant:
+    name: PHP
+    cache: true
+    install:
+      - os_type: linux
+        os_distro: deb
+        copy_files:
+          - name: copy-auto-install-script
+            local_path: utils/build/virtual_machine/weblogs/php/test-app-php/php_install.sh
+        remote-command: sudo sh php_install.sh deb
+
+      - os_type: linux
+        os_distro: rpm
+        copy_files:
+          - name: copy-auto-install-script
+            local_path: utils/build/virtual_machine/weblogs/php/test-app-php/php_install.sh
+        remote-command: sudo sh php_install.sh rpm
+
+weblog:
+    name: test-shell-script
+    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
+    install:
+      - os_type: linux
+        remote-command: |
+          sudo mkdir /var/log/datadog_weblog && sudo chmod -R 777 /var/log/datadog_weblog
+          sudo touch /var/log/datadog_weblog/host_injection.log && sudo chmod 777 /var/log/datadog_weblog/host_injection.log
+          sudo sh -c 'echo "DD_APM_INSTRUMENTATION_DEBUG=TRUE" >> /etc/environment'
+          sudo sh -c 'echo "DD_APM_INSTRUMENTATION_OUTPUT_PATHS=/var/log/datadog_weblog/host_injection.log" >> /etc/environment'
+          source /etc/environment


### PR DESCRIPTION
## Motivation

Enable more PHP tests.

They are passing: https://gitlab.ddbuild.io/DataDog/system-tests/-/pipelines/43353183
![image](https://github.com/user-attachments/assets/f2dfcba4-b4d8-4e89-9fa9-3f483452ca23)



## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
