### PR TITLE
[php] Fix flaky test Test_Crashtracking::test_report_crash

### DIFF
--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -551,7 +551,11 @@ RUN NO_EXTRACT_VERSION=Y ./install_ddtrace.sh
 RUN php -d error_reporting='' -r 'echo phpversion("ddtrace");' > SYSTEM_TESTS_LIBRARY_VERSION
 ADD {php_reldir}/server.php .
 """,
-        container_cmd=["php", "server.php"],
+        container_cmd=[
+            "bash",
+            "-c",
+            "php server.php || sleep 2s",
+        ],  # In case of crash, give time to the sidecar to upload the crash report
         container_build_dir=php_absolute_appdir,
         container_build_context=_get_base_directory(),
         volumes={os.path.join(php_absolute_appdir, "server.php"): "/client/server.php"},


### PR DESCRIPTION
## Motivation

Enabled in https://github.com/DataDog/system-tests/pull/2961, but is flaky:
- https://github.com/DataDog/system-tests/actions/runs/10686189202/job/29620824384
- https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/17340/workflows/ee976c13-0e1e-4606-a0e3-b8ce4f811486/jobs/5088330/steps

My guess (since I can't reproduce the issue locally), is that when the PHP process (PID 1) is killed by a SIGSEGV signal, the Docker container is almost immediately stopped. This abrupt shutdown likely terminates the 'sidecar' process before it can upload the report. Adding a delay seems to fix the issue

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
