### PR TITLE
[java] Fix Java parametric test flakiness

### DIFF
--- a/utils/build/docker/java/parametric/run.sh
+++ b/utils/build/docker/java/parametric/run.sh
@@ -19,12 +19,15 @@ ENABLE_CRASH_TRACKING=(-XX:OnError="/tmp/datadog/java/dd_crash_uploader.sh %p" \
 # Disable features
 DISABLED_FEATURES=(-Ddd.telemetry.dependency-collection.enabled=false)
 
-# Disable Spring Boot related integration to avoid creating unexpected spans
+# Disable integrations to avoid creating unexpected spans
+# - Spring Boot related integrations
+# - AppSec process monitoring
 DISABLE_INTEGRATIONS=(-Ddd.integration.servlet-request-body.enabled=false \
   -Ddd.integration.spring-beans.enabled=false \
   -Ddd.integration.spring-path-filter.enabled=false \
   -Ddd.integration.spring-web.enabled=false \
-  -Ddd.integration.tomcat.enabled=false)
+  -Ddd.integration.tomcat.enabled=false \
+  -Ddd.integration.java-lang-appsec.enabled=false)
 
 # Limit JIT to tier one as the client application is a short-lived process that frequently killed / restarted
 OPTIMIZATION_OPTIONS=(-XX:TieredStopAtLevel=1)


### PR DESCRIPTION

## Motivation

We got random failures:
```
FAILED tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags[library_env0]
= 1 failed, 306 passed, 16 skipped, 72 xfailed, 12 xpassed in 558.37s (0:09:18) =
```

## Changes

AppSec process monitoring was unexpected creating span when Crash Tracking sets up as it runs a JPS command.
I disabled the AppSec process monitoring integration.

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
