### PR TITLE
[python] move to python 3.11 for python weblogs

### DIFF
--- a/utils/build/docker/python/django-poc.base.Dockerfile
+++ b/utils/build/docker/python/django-poc.base.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 # install bin dependancies
 RUN apt-get update && apt-get install -y curl git gcc g++ make cmake

--- a/utils/build/docker/python/fastapi.base.Dockerfile
+++ b/utils/build/docker/python/fastapi.base.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 # install bin dependancies
 RUN apt-get update && apt-get install -y curl git gcc g++ make cmake

--- a/utils/build/docker/python/flask-poc.base.Dockerfile
+++ b/utils/build/docker/python/flask-poc.base.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 # install bin dependancies
 RUN apt-get update && apt-get install -y curl git gcc g++ make cmake

--- a/utils/build/docker/python/uwsgi-poc.base.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.base.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 # install bin dependancies
 RUN apt-get update && apt-get install -y curl git gcc g++ make cmake


### PR DESCRIPTION
## Motivation

Python 3.9 will reach end of life in 2025. Also Python 3.9 did not get bugfixes since 2021.
This is also an experiment to check if it improves intermittent test failures we may have on nightlies.

## Changes

Change python version for weblogs
- Flask from 3.9 to 3.11
- Django from 3.9 to 3.11
- FastAPI from 3.10 to 3.11


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
