### PR TITLE
[dotnet] fix dotnet v3, redux

### DIFF
--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -248,7 +248,6 @@ class TestDynamicConfigTracingEnabled:
         "library_env", [{**DEFAULT_ENVVARS}, {**DEFAULT_ENVVARS, "DD_TRACE_ENABLED": "false"},],
     )
     @irrelevant(library="golang")
-    @bug(library="dotnet", reason="With the v3, DD_TRACE_ENABLED=False seems to be ignored")
     def test_tracing_client_tracing_disable_one_way(self, library_env, test_agent, test_library):
         trace_enabled_env = library_env.get("DD_TRACE_ENABLED", "true") == "true"
 

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -454,7 +454,7 @@ RUN /binaries/install_ddtrace.sh
 
 # dotnet restore
 COPY {dotnet_reldir}/ApmTestApi.csproj {dotnet_reldir}/nuget.config ./
-RUN dotnet restore "./ApmTestApi.csproj"
+RUN dotnet restore -p:Configuration=Release "./ApmTestApi.csproj"
 
 # dotnet publish
 COPY {dotnet_reldir} ./

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -468,8 +468,9 @@ WORKDIR /app
 # Opt-out of .NET SDK CLI telemetry (prevent unexpected http client spans)
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-# Set up automatic instrumentation
-ENV CORECLR_ENABLE_PROFILING=1
+# Set up automatic instrumentation (required for OpenTelemetry tests),
+# but don't enable it globally
+ENV CORECLR_ENABLE_PROFILING=0
 ENV CORECLR_PROFILER='{{846F5F1C-F9AE-4B07-969E-05C26BC060D8}}'
 ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 ENV LD_PRELOAD=/opt/datadog/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so

--- a/utils/build/docker/dotnet/parametric/ApmTestApi.csproj
+++ b/utils/build/docker/dotnet/parametric/ApmTestApi.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-
-    <PackageReference Include="Datadog.Trace" Version="*" />
+    <PackageReference Include="Datadog.Trace" Version="*" Condition="'$(Configuration)' != 'Release'" />
+    <Reference Include="/opt/datadog/netcoreapp3.1/Datadog.Trace.dll" Condition="'$(Configuration)' == 'Release'" />
   </ItemGroup>
 
 </Project>

--- a/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
+++ b/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
@@ -1,4 +1,5 @@
 using Datadog.Trace;
+using Datadog.Trace.Configuration;
 using System.Reflection;
 using System.Threading;
 using Newtonsoft.Json;
@@ -36,6 +37,7 @@ public abstract class ApmTestApi
     private static readonly Type ImmutableTracerSettingsType = Type.GetType("Datadog.Trace.Configuration.ImmutableTracerSettings, Datadog.Trace", throwOnError: true)!;
 
     // Propagator types
+    private static readonly Type SpanContextPropagatorType = Type.GetType("Datadog.Trace.Propagators.SpanContextPropagator, Datadog.Trace", throwOnError: true)!;
     internal static readonly Type W3CTraceContextPropagatorType = Type.GetType("Datadog.Trace.Propagators.W3CTraceContextPropagator, Datadog.Trace", throwOnError: true)!;
 
     // Agent-related types
@@ -45,10 +47,12 @@ public abstract class ApmTestApi
     // Accessors for internal properties/fields accessors
     internal static readonly PropertyInfo GetGlobalSettingsInstance  = GlobalSettingsType.GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic)!;
     internal static readonly PropertyInfo GetTracerManager = TracerType.GetProperty("TracerManager", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly PropertyInfo GetSpanContextPropagator = SpanContextPropagatorType.GetProperty("Instance", BindingFlags.Static | BindingFlags.Public)!;
     internal static readonly MethodInfo GetAgentWriter = TracerManagerType.GetProperty("AgentWriter", BindingFlags.Instance | BindingFlags.Public)!.GetGetMethod()!;
     internal static readonly FieldInfo GetStatsAggregator = AgentWriterType.GetField("_statsAggregator", BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static readonly PropertyInfo SpanContext = SpanType.GetProperty("Context", BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static readonly PropertyInfo Origin = SpanContextType.GetProperty("Origin", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo SetMetric = SpanType.GetMethod("SetMetric", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
     internal static readonly PropertyInfo SamplingPriority = SpanContextType.GetProperty("SamplingPriority", BindingFlags.Instance | BindingFlags.NonPublic)!;
     internal static readonly PropertyInfo RawTraceId = SpanContextType.GetProperty("RawTraceId", BindingFlags.Instance | BindingFlags.NonPublic)!;
@@ -57,11 +61,10 @@ public abstract class ApmTestApi
     internal static readonly PropertyInfo PropagationStyleInject = ImmutableTracerSettingsType.GetProperty("PropagationStyleInject", BindingFlags.Instance | BindingFlags.NonPublic)!;
     internal static readonly PropertyInfo RuntimeMetricsEnabled = ImmutableTracerSettingsType.GetProperty("RuntimeMetricsEnabled", BindingFlags.Instance | BindingFlags.NonPublic)!;
     internal static readonly PropertyInfo IsActivityListenerEnabled = ImmutableTracerSettingsType.GetProperty("IsActivityListenerEnabled", BindingFlags.Instance | BindingFlags.NonPublic)!;
-    internal static readonly PropertyInfo GetTracerInstance = TracerType.GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)!;
-    internal static readonly PropertyInfo GetTracerSettings = TracerType.GetProperty("Settings", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!;
     internal static readonly PropertyInfo GetDebugEnabled = GlobalSettingsType.GetProperty("DebugEnabled", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!;
 
     // Propagator methods
+    private static readonly MethodInfo SpanContextPropagatorInject = GenerateInjectMethod()!;
     internal static readonly MethodInfo W3CTraceContextCreateTraceStateHeader = W3CTraceContextPropagatorType.GetMethod("CreateTraceStateHeader", BindingFlags.Static | BindingFlags.NonPublic)!;
 
     // StatsAggregator flush methods
@@ -72,7 +75,6 @@ public abstract class ApmTestApi
 
     internal static ILogger<ApmTestApi>? _logger;
 
-    internal static readonly SpanContextInjector _spanContextInjector = new();
     internal static readonly SpanContextExtractor _spanContextExtractor = new();
 
     internal static IEnumerable<string> GetHeaderValues(string[][] headersList, string key)
@@ -120,13 +122,12 @@ public abstract class ApmTestApi
             if (creationSettings.Parent is null && longParentId > 0 )
             {
                 var parentSpan = Spans[longParentId];
-                // TODO: I suspect this won't work and we need to do a bunch of reflection faffing
-                creationSettings.Parent = parentSpan.Context;
+                creationSettings.Parent = (ISpanContext)SpanContext.GetValue(parentSpan)!;
             }
         }
 
         parsedDictionary.TryGetValue("name", out var name);
-        using var scope = Tracer.Instance.StartActive(operationName: name!.ToString()!, creationSettings);
+        using var scope = Tracer.Instance.StartActive(operationName: name!.ToString(), creationSettings);
         var span = scope.Span;
 
         if (parsedDictionary.TryGetValue("service", out var service))
@@ -146,11 +147,7 @@ public abstract class ApmTestApi
 
         if (parsedDictionary.TryGetValue("origin", out var origin) && !string.IsNullOrWhiteSpace(origin.ToString()))
         {
-            // This implementation is .NET v3 specific, and assumes that the span returned by StartActive is a DuckType
-            var autoSpan = span.GetType()
-                .GetProperty("Instance", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-                ?.GetValue(span);
-            var spanContext = SpanContext.GetValue(autoSpan)!;
+            var spanContext = SpanContext.GetValue(span)!;
             Origin.SetValue(spanContext, origin);
         }
 
@@ -183,19 +180,19 @@ public abstract class ApmTestApi
         parsedDictionary.TryGetValue("value", out var value);
 
         var span = Spans[Convert.ToUInt64(id)];
-        span.SetTag(key!, value);
+        span.SetTag(key, value);
     }
 
     private static async Task SpanSetMetric(HttpRequest request)
     {
         var headerBodyDictionary = await new StreamReader(request.Body).ReadToEndAsync();
-        var parsedDictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(headerBodyDictionary)!;
+        var parsedDictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(headerBodyDictionary)!;
         parsedDictionary.TryGetValue("span_id", out var id);
         parsedDictionary.TryGetValue("key", out var key);
         parsedDictionary.TryGetValue("value", out var value);
 
         var span = Spans[Convert.ToUInt64(id)];
-        span.SetTag(key!, Convert.ToDouble(value));
+        SetMetric.Invoke(span, new object[] { key!, Convert.ToDouble(value) });
     }
 
     private static async Task SpanSetError(HttpRequest request)
@@ -225,12 +222,26 @@ public abstract class ApmTestApi
 
     private static async Task<string> InjectHeaders(HttpRequest request)
     {
+        if (GetSpanContextPropagator is null)
+        {
+            throw new NullReferenceException("GetSpanContextPropagator is null");
+        }
+
+        if (SpanContextPropagatorInject is null)
+        {
+            throw new NullReferenceException("SpanContextPropagatorInject is null");
+        }
+
         var httpHeaders = new List<string[]>();
 
         var spanId = await FindBodyKeyValueAsync(request, "span_id");
 
         if (!string.IsNullOrEmpty(spanId as string) && Spans.TryGetValue(Convert.ToUInt64(spanId), out var span))
         {
+            SpanContext? contextArg = span.Context as SpanContext;
+
+            var spanContextPropagator = GetSpanContextPropagator.GetValue(null);
+
             // Define a function to set headers in HttpRequestHeaders
             static void Setter(List<string[]> headers, string key, string value) =>
                 headers.Add(new string[] { key, value });
@@ -241,7 +252,9 @@ public abstract class ApmTestApi
             }));
 
             // Invoke SpanContextPropagator.Inject with the HttpRequestHeaders
-            _spanContextInjector.Inject(httpHeaders, Setter, span.Context);
+#pragma warning disable CS8974 // Converting method group to non-delegate type
+            SpanContextPropagatorInject.Invoke(spanContextPropagator, new object[] { contextArg!, httpHeaders, Setter });
+#pragma warning restore CS8974 // Converting method group to non-delegate type
         }
 
         return JsonConvert.SerializeObject(new
@@ -271,16 +284,19 @@ public abstract class ApmTestApi
 
     private static string GetTracerConfig(HttpRequest request)
     {
+        if (GetGlobalSettingsInstance is null)
+        {
+            throw new NullReferenceException("GetGlobalSettingsInstance is null");
+        }
+
         var tracerSettings = Tracer.Instance.Settings;
-        var internalTracer = GetTracerInstance.GetValue(null);
-        var internalTracerSettings = GetTracerSettings.GetValue(internalTracer);
 
         var globalSettings = GetGlobalSettingsInstance.GetValue(null)!;
         var debugEnabled = (bool)GetDebugEnabled.GetValue(globalSettings)!;
 
-        var propagationStyleInject = (string[])PropagationStyleInject.GetValue(internalTracerSettings)!;
-        var runtimeMetricsEnabled = (bool)RuntimeMetricsEnabled.GetValue(internalTracerSettings)!;
-        var isOtelEnabled = (bool)IsActivityListenerEnabled.GetValue(internalTracerSettings)!;
+        var propagationStyleInject = (string[])PropagationStyleInject.GetValue(tracerSettings)!;
+        var runtimeMetricsEnabled = (bool)RuntimeMetricsEnabled.GetValue(tracerSettings)!;
+        var isOtelEnabled = (bool)IsActivityListenerEnabled.GetValue(tracerSettings)!;
 
         Dictionary<string, object?> config = new()
         {
@@ -328,7 +344,7 @@ public abstract class ApmTestApi
             throw new NullReferenceException("Tracer.Instance is null");
         }
 
-        var tracerManager = GetTracerManager.GetValue(GetTracerInstance.GetValue(null));
+        var tracerManager = GetTracerManager.GetValue(Tracer.Instance);
         var agentWriter = GetAgentWriter.Invoke(tracerManager, null);
         var statsAggregator = GetStatsAggregator.GetValue(agentWriter);
 
@@ -345,6 +361,35 @@ public abstract class ApmTestApi
             var flushTask = StatsAggregatorFlush.Invoke(statsAggregator, null) as Task;
             await flushTask!;
         }
+    }
+
+    private static MethodInfo? GenerateInjectMethod()
+    {
+        if (SpanContextPropagatorType is null)
+        {
+            throw new NullReferenceException("SpanContextPropagatorType is null");
+        }
+
+        var methods = SpanContextPropagatorType.GetMethods();
+        foreach (var method in methods.Where(m => m.Name == "Inject"))
+        {
+            var parameters = method.GetParameters();
+            var genericArgs = method.GetGenericArguments();
+
+            // Adjusting for HTTP carrier
+            if (parameters.Length == 3 &&
+                genericArgs.Length == 1 &&
+                parameters[0].ParameterType == typeof(SpanContext) &&
+                parameters[1].ParameterType == genericArgs[0] &&
+                parameters[2].ParameterType.Name == "Action`3")
+            {
+                // Adjusting the carrier type for HTTP
+                var carrierType = typeof(List<string[]>);
+                return method.MakeGenericMethod(carrierType);
+            }
+        }
+
+        return null;
     }
 
     internal static async Task<string> FindBodyKeyValueAsync(HttpRequest httpRequest, string keyToFind)

--- a/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApiOtel.cs
+++ b/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApiOtel.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Globalization;
-using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -50,18 +49,14 @@ public abstract class ApmTestApiOtel : ApmTestApi
         // try extracting parent context from headers (remote parent)
         if (requestBodyObject.TryGetValue("http_headers", out var headersList))
         {
-            var manualExtractedContext = _spanContextExtractor.Extract(
+            var extractedContext = _spanContextExtractor.Extract(
             ((Newtonsoft.Json.Linq.JArray)headersList).ToObject<string[][]>(),
             getter: GetHeaderValues!);
 
-            _logger?.LogInformation("Extracted SpanContext: {ExtractedContext}", manualExtractedContext);
+            _logger?.LogInformation("Extracted SpanContext: {ExtractedContext}", extractedContext);
 
-            if (manualExtractedContext is not null)
+            if (extractedContext is not null)
             {
-                // This implementation is .NET v3 specific, and assumes that the span returned by StartActive is a DuckType
-                var extractedContext = manualExtractedContext.GetType()
-                    .GetProperty("Instance", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-                    ?.GetValue(manualExtractedContext);
                 var parentTraceId = ActivityTraceId.CreateFromString(RawTraceId.GetValue(extractedContext) as string);
                 var parentSpanId = ActivitySpanId.CreateFromString(RawSpanId.GetValue(extractedContext) as string);
                 var flags = (SamplingPriority.GetValue(extractedContext) as int?) > 0 ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None;
@@ -142,14 +137,10 @@ public abstract class ApmTestApiOtel : ApmTestApi
                 {
                     var httpHeadersToken = (JArray)spanLink["http_headers"]!;
 
-                    var manualExtractedContext = _spanContextExtractor.Extract(
+                    var extractedContext = _spanContextExtractor.Extract(
                             httpHeadersToken.ToObject<string[][]>(),
                             getter: GetHeaderValues!);
 
-                    // This implementation is .NET v3 specific, and assumes that the span returned by StartActive is a DuckType
-                    var extractedContext = manualExtractedContext?.GetType()
-                        .GetProperty("Instance", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-                        ?.GetValue(manualExtractedContext);
                     var parentTraceId = ActivityTraceId.CreateFromString(RawTraceId.GetValue(extractedContext) as string);
                     var parentSpanId = ActivitySpanId.CreateFromString(RawSpanId.GetValue(extractedContext) as string);
                     var flags = (SamplingPriority.GetValue(extractedContext) as int?) > 0 ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None;

--- a/utils/build/docker/dotnet/poc.Dockerfile
+++ b/utils/build/docker/dotnet/poc.Dockerfile
@@ -11,7 +11,7 @@ RUN /binaries/install_ddtrace.sh
 COPY utils/build/docker/dotnet/weblog/app.csproj app.csproj
 
 RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") \
-    dotnet restore
+    dotnet restore -p:Configuration=Release
 
 # dotnet publish
 COPY utils/build/docker/dotnet/weblog/* .

--- a/utils/build/docker/dotnet/uds.Dockerfile
+++ b/utils/build/docker/dotnet/uds.Dockerfile
@@ -11,7 +11,7 @@ RUN /binaries/install_ddtrace.sh
 COPY utils/build/docker/dotnet/weblog/app.csproj app.csproj
 
 RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") \
-    dotnet restore
+    dotnet restore -p:Configuration=Release
 
 # dotnet publish
 COPY utils/build/docker/dotnet/weblog/* .

--- a/utils/build/docker/dotnet/weblog/app.csproj
+++ b/utils/build/docker/dotnet/weblog/app.csproj
@@ -48,6 +48,7 @@
         <PackageReference Include="RabbitMQ.Client" Version="6.4.0"/>
         <PackageReference Include="MongoDB.Driver" Version="2.23.1"/>
 
-        <PackageReference Include="Datadog.Trace" Version="*" />
+        <PackageReference Include="Datadog.Trace" Version="*" Condition="'$(Configuration)' != 'Release'" />
+        <Reference Include="/opt/datadog/netcoreapp3.1/Datadog.Trace.dll" Condition="'$(Configuration)' == 'Release'" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Motivation

Follow-up from #2962 to fix tests for .NET 3.x release

## Changes

- revert some changes from #2962
  - restore references to `/opt/datadog/netcoreapp3.1/Datadog.Trace.dll`
  - re-enable `DD_TRACE_ENABLED` test
  - leave auto-instrumentation disabled by default in parametric tests (`CORECLR_ENABLE_PROFILING=0`)
  - remove unnecessary reflection meant for `Datadog.Trace.Manual.dll`
  - leave reflection for `GlobalSettings.DebugEnagled`
- fix: use `Release` configuration in `dotnet restore` commands to avoid using the `Datadog.Trace` nuget package (this has been an issue for a few months, but was only recently discovered when we released tracer v3)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
