### PR TITLE
[Tracing] Add feature/scenarios for tracing configuration consistency and implement tests for DD_TRACE_HTTP_SERVER_ERROR_STATUSES

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -145,6 +145,11 @@ jobs:
       run: ./run.sh LIBRARY_CONF_CUSTOM_HEADER_TAGS_INVALID
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
+    - name: Run TRACING_CONFIG_NONDEFAULT scenario
+      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"TRACING_CONFIG_NONDEFAULT"')
+      run: ./run.sh TRACING_CONFIG_NONDEFAULT
+      env:
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
     - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES"')
       run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,6 +55,16 @@
             "python": "${workspaceFolder}/venv/bin/python"
         },
         {
+            "name": "Run TRACING_CONFIG_NONDEFAULT scenario",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["-S", "TRACING_CONFIG_NONDEFAULT", "-p", "no:warnings"],
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
+        },
+        {
             "name": "Run PROFILING scenario",
             "type": "python",
             "request": "launch",

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -162,8 +162,8 @@ tests/:
     test_miscs.py:
       Test_Miscs: missing_feature
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: missing_feature
-    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
+    Test_Config_HttpServerErrorStatuses_Default: missing_feature
+    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py: irrelevant

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -161,6 +161,9 @@ tests/:
   stats/:
     test_miscs.py:
       Test_Miscs: missing_feature
+  test_config_consistency.py:
+    Test_ConfigServerErrorStatusesDefault: missing_feature
+    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py: irrelevant

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -350,8 +350,8 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: v2.15.0
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: v3.2.0 # TODO what is the earliest version?
-    Test_ConfigServerErrorStatusesFeatureFlag: v3.2.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesDefault: missing_feature
+    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v2.46.0
   test_distributed.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -350,8 +350,8 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: v2.15.0
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: missing_feature
-    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
+    Test_Config_HttpServerErrorStatuses_Default: missing_feature
+    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v2.46.0
   test_distributed.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -349,6 +349,9 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: v2.15.0
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
+  test_config_consistency.py:
+    Test_ConfigServerErrorStatusesDefault: v3.2.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesFeatureFlag: v3.2.0 # TODO what is the earliest version?
   test_data_integrity.py:
     Test_LibraryHeaders: v2.46.0
   test_distributed.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -472,7 +472,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: v1.67.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesDefault: missing_feature
     Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v1.60.0.dev0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -472,8 +472,8 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: missing_feature
-    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
+    Test_Config_HttpServerErrorStatuses_Default: missing_feature
+    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v1.60.0.dev0
   test_distributed.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -471,6 +471,9 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
+  test_config_consistency.py:
+    Test_ConfigServerErrorStatusesDefault: v1.67.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v1.60.0.dev0
   test_distributed.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1219,8 +1219,8 @@ tests/:
       Test_Mock: v0.0.99
       Test_NotReleased: missing_feature
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: missing_feature
-    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
+    Test_Config_HttpServerErrorStatuses_Default: missing_feature
+    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v1.29.0
   test_distributed.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1218,6 +1218,9 @@ tests/:
     test_json_report.py:
       Test_Mock: v0.0.99
       Test_NotReleased: missing_feature
+  test_config_consistency.py:
+    Test_ConfigServerErrorStatusesDefault: v1.39.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesFeatureFlag: v1.39.0 # TODO what is the earliest version?
   test_data_integrity.py:
     Test_LibraryHeaders: v1.29.0
   test_distributed.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1219,8 +1219,8 @@ tests/:
       Test_Mock: v0.0.99
       Test_NotReleased: missing_feature
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: v1.39.0 # TODO what is the earliest version?
-    Test_ConfigServerErrorStatusesFeatureFlag: v1.39.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesDefault: missing_feature
+    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v1.29.0
   test_distributed.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -523,7 +523,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: *ref_5_16_0 #actual version unknown
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: v5.22.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesDefault: missing_feature
     Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -522,6 +522,9 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: *ref_5_16_0 #actual version unknown
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
+  test_config_consistency.py:
+    Test_ConfigServerErrorStatusesDefault: v5.22.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -523,8 +523,8 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: *ref_5_16_0 #actual version unknown
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: missing_feature
-    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
+    Test_Config_HttpServerErrorStatuses_Default: missing_feature
+    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -308,6 +308,9 @@ tests/:
   stats/:
     test_miscs.py:
       Test_Miscs: missing_feature
+  test_config_consistency.py:
+    Test_ConfigServerErrorStatusesDefault: v1.3.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -309,8 +309,8 @@ tests/:
     test_miscs.py:
       Test_Miscs: missing_feature
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: missing_feature
-    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
+    Test_Config_HttpServerErrorStatuses_Default: missing_feature
+    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -309,7 +309,7 @@ tests/:
     test_miscs.py:
       Test_Miscs: missing_feature
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: v1.3.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesDefault: missing_feature
     Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -728,6 +728,9 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: v2.8.0.dev
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
+  test_config_consistency.py:
+    Test_ConfigServerErrorStatusesDefault: v2.11.3 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v2.7.0
   test_distributed.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -729,7 +729,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: v2.8.0.dev
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: v2.11.3 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesDefault: missing_feature
     Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v2.7.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -729,8 +729,8 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: v2.8.0.dev
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: missing_feature
-    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
+    Test_Config_HttpServerErrorStatuses_Default: missing_feature
+    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v2.7.0
   test_distributed.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -372,7 +372,7 @@ tests/:
     test_miscs.py:
       Test_Miscs: missing_feature
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: v2.3.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesDefault: missing_feature
     Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -372,8 +372,8 @@ tests/:
     test_miscs.py:
       Test_Miscs: missing_feature
   test_config_consistency.py:
-    Test_ConfigServerErrorStatusesDefault: missing_feature
-    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
+    Test_Config_HttpServerErrorStatuses_Default: missing_feature
+    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -371,6 +371,9 @@ tests/:
   stats/:
     test_miscs.py:
       Test_Miscs: missing_feature
+  test_config_consistency.py:
+    Test_ConfigServerErrorStatusesDefault: v2.3.0 # TODO what is the earliest version?
+    Test_ConfigServerErrorStatusesFeatureFlag: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,11 +19,11 @@ jsonschema==4.16.0
 rfc3339-validator==0.1.4
 semantic-version==2.10.0
 
-matplotlib
+matplotlib  # for performance tests
 
 docker==6.0.0
 
-paramiko==3.1.0
+paramiko==3.4.1
 scp==0.14.5
 
 ddapm-test-agent==1.14.0  # for parametric tests

--- a/scenario_groups.yml
+++ b/scenario_groups.yml
@@ -40,7 +40,6 @@ TELEMETRY_SCENARIOS: &telemetry_scenarios
 
 # Scenarios covering tracing configurations
 TRACING_CONFIG_SCENARIOS: &tracing_config_scenarios
-  - TRACING_CONFIG_DEFAULT
   - TRACING_CONFIG_CUSTOM_SERVER_ERROR_STATUSES
 
 # Scenarios to run before a tracer release, basically, all stable scenarios

--- a/scenario_groups.yml
+++ b/scenario_groups.yml
@@ -38,6 +38,11 @@ TELEMETRY_SCENARIOS: &telemetry_scenarios
   - TELEMETRY_METRIC_GENERATION_DISABLED
   - TELEMETRY_METRIC_GENERATION_ENABLED
 
+# Scenarios covering tracing configurations
+TRACING_CONFIG_SCENARIOS: &tracing_config_scenarios
+  - TRACING_CONFIG_DEFAULT
+  - TRACING_CONFIG_CUSTOM_SERVER_ERROR_STATUSES
+
 # Scenarios to run before a tracer release, basically, all stable scenarios
 TRACER_RELEASE_SCENARIOS:
   - DEFAULT
@@ -48,6 +53,7 @@ TRACER_RELEASE_SCENARIOS:
   - *appsec_scenarios
   - *remote_config_scenarios
   - *telemetry_scenarios
+  - *tracing_config_scenarios
 
 # Scenarios to run on tracers PR.
 # Those scenarios are the one that offer the best probability-to-catch-bug/time-to-run ratio
@@ -57,6 +63,7 @@ TRACER_ESSENTIAL_SCENARIOS:
   - APPSEC_API_SECURITY_RC
   - REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES
   - INTEGRATIONS
+  - *tracing_config_scenarios
 
 # Scenarios that rely on backend (and thus, may be a little bit hard to avoid flakyness)
 APM_TRACING_E2E_SCENARIOS:

--- a/scenario_groups.yml
+++ b/scenario_groups.yml
@@ -40,7 +40,7 @@ TELEMETRY_SCENARIOS: &telemetry_scenarios
 
 # Scenarios covering tracing configurations
 TRACING_CONFIG_SCENARIOS: &tracing_config_scenarios
-  - TRACING_CONFIG_CUSTOM_SERVER_ERROR_STATUSES
+  - TRACING_CONFIG_NONDEFAULT
 
 # Scenarios to run before a tracer release, basically, all stable scenarios
 TRACER_RELEASE_SCENARIOS:

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -39,7 +39,7 @@ class Test_ConfigServerErrorStatusesDefault:
         assert spans[0]["error"] == 1
 
 
-@scenarios.tracing_config_custom_server_error_statuses
+@scenarios.tracing_config_nondefault
 @features.tracing_configuration_consistency
 class Test_ConfigServerErrorStatusesFeatureFlag:
     """ Verify behavior of http clients and distributed traces """

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -35,7 +35,6 @@ class Test_ConfigServerErrorStatusesDefault:
         spans = interfaces.agent.get_spans_list(self.r)
         assert len(spans) == 1, "Agent received the incorrect amount of spans"
 
-        assert spans[0]["type"] == "web"
         assert spans[0]["meta"]["http.status_code"] == "500"
         assert spans[0]["error"] == 1
 

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -1,0 +1,74 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2022 Datadog, Inc.
+
+from utils import weblog, interfaces, scenarios, features
+
+
+@scenarios.tracing_config_default
+@features.tracing_configuration_consistency
+class Test_ConfigServerErrorStatusesDefault:
+    """ Verify behavior of http clients and distributed traces """
+
+    def setup_status_code_400(self):
+        self.r = weblog.get("/status?code=400")
+
+    def test_status_code_400(self):
+
+        assert self.r.status_code == 400
+
+        interfaces.library.assert_trace_exists(self.r)
+        spans = interfaces.agent.get_spans_list(self.r)
+        assert len(spans) == 1, "Agent received the incorrect amount of spans"
+
+        assert spans[0]["type"] == "web"
+        assert spans[0]["meta"]["http.status_code"] == "400"
+        assert "error" not in spans[0] or spans[0]["error"] == 0
+
+    def setup_status_code_500(self):
+        self.r = weblog.get("/status?code=500")
+
+    def test_status_code_500(self):
+        assert self.r.status_code == 500
+
+        interfaces.library.assert_trace_exists(self.r)
+        spans = interfaces.agent.get_spans_list(self.r)
+        assert len(spans) == 1, "Agent received the incorrect amount of spans"
+
+        assert spans[0]["type"] == "web"
+        assert spans[0]["meta"]["http.status_code"] == "500"
+        assert spans[0]["error"] == 1
+
+
+@scenarios.tracing_config_custom_server_error_statuses
+@features.tracing_configuration_consistency
+class Test_ConfigServerErrorStatusesFeatureFlag:
+    """ Verify behavior of http clients and distributed traces """
+
+    def setup_status_code_200(self):
+        self.r = weblog.get("/status?code=200")
+
+    def test_status_code_200(self):
+        assert self.r.status_code == 200
+
+        interfaces.library.assert_trace_exists(self.r)
+        spans = interfaces.agent.get_spans_list(self.r)
+        assert len(spans) == 1, "Agent received the incorrect amount of spans"
+
+        assert spans[0]["type"] == "web"
+        assert spans[0]["meta"]["http.status_code"] == "200"
+        assert spans[0]["error"] == 1
+
+    def setup_status_code_202(self):
+        self.r = weblog.get("/status?code=202")
+
+    def test_status_code_202(self):
+        assert self.r.status_code == 202
+
+        interfaces.library.assert_trace_exists(self.r)
+        spans = interfaces.agent.get_spans_list(self.r)
+        assert len(spans) == 1, "Agent received the incorrect amount of spans"
+
+        assert spans[0]["type"] == "web"
+        assert spans[0]["meta"]["http.status_code"] == "202"
+        assert spans[0]["error"] == 1

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -5,7 +5,7 @@
 from utils import weblog, interfaces, scenarios, features
 
 
-@scenarios.tracing_config_default
+@scenarios.default
 @features.tracing_configuration_consistency
 class Test_ConfigServerErrorStatusesDefault:
     """ Verify behavior of http clients and distributed traces """

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -7,7 +7,7 @@ from utils import weblog, interfaces, scenarios, features
 
 @scenarios.default
 @features.tracing_configuration_consistency
-class Test_ConfigServerErrorStatusesDefault:
+class Test_Config_HttpServerErrorStatuses_Default:
     """ Verify behavior of http clients and distributed traces """
 
     def setup_status_code_400(self):
@@ -41,7 +41,7 @@ class Test_ConfigServerErrorStatusesDefault:
 
 @scenarios.tracing_config_nondefault
 @features.tracing_configuration_consistency
-class Test_ConfigServerErrorStatusesFeatureFlag:
+class Test_Config_HttpServerErrorStatuses_FeatureFlagCustom:
     """ Verify behavior of http clients and distributed traces """
 
     def setup_status_code_200(self):

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -471,9 +471,7 @@ class scenarios:
     )
 
     tracing_config_nondefault = EndToEndScenario(
-        "TRACING_CONFIG_NONDEFAULT",
-        weblog_env={"DD_HTTP_SERVER_ERROR_STATUSES": "200-201,202"},
-        doc="",
+        "TRACING_CONFIG_NONDEFAULT", weblog_env={"DD_HTTP_SERVER_ERROR_STATUSES": "200-201,202"}, doc="",
     )
 
     parametric = ParametricScenario("PARAMETRIC", doc="WIP")

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -470,8 +470,8 @@ class scenarios:
         doc="Scenario with custom headers for DD_TRACE_HEADER_TAGS that libraries should reject",
     )
 
-    tracing_config_custom_server_error_statuses = EndToEndScenario(
-        "TRACING_CONFIG_CUSTOM_SERVER_ERROR_STATUSES",
+    tracing_config_nondefault = EndToEndScenario(
+        "TRACING_CONFIG_NONDEFAULT",
         weblog_env={"DD_HTTP_SERVER_ERROR_STATUSES": "200-201,202"},
         doc="",
     )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -471,7 +471,7 @@ class scenarios:
     )
 
     tracing_config_nondefault = EndToEndScenario(
-        "TRACING_CONFIG_NONDEFAULT", weblog_env={"DD_HTTP_SERVER_ERROR_STATUSES": "200-201,202"}, doc="",
+        "TRACING_CONFIG_NONDEFAULT", weblog_env={"DD_TRACE_HTTP_SERVER_ERROR_STATUSES": "200-201,202"}, doc="",
     )
 
     parametric = ParametricScenario("PARAMETRIC", doc="WIP")

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -470,6 +470,13 @@ class scenarios:
         doc="Scenario with custom headers for DD_TRACE_HEADER_TAGS that libraries should reject",
     )
 
+    tracing_config_default = EndToEndScenario("TRACING_CONFIG_DEFAULT", doc="")
+    tracing_config_custom_server_error_statuses = EndToEndScenario(
+        "TRACING_CONFIG_CUSTOM_SERVER_ERROR_STATUSES",
+        weblog_env={"DD_HTTP_SERVER_ERROR_STATUSES": "200-201,202"},
+        doc="",
+    )
+
     parametric = ParametricScenario("PARAMETRIC", doc="WIP")
 
     debugger_probes_status = EndToEndScenario(

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -470,7 +470,6 @@ class scenarios:
         doc="Scenario with custom headers for DD_TRACE_HEADER_TAGS that libraries should reject",
     )
 
-    tracing_config_default = EndToEndScenario("TRACING_CONFIG_DEFAULT", doc="")
     tracing_config_custom_server_error_statuses = EndToEndScenario(
         "TRACING_CONFIG_CUSTOM_SERVER_ERROR_STATUSES",
         weblog_env={"DD_HTTP_SERVER_ERROR_STATUSES": "200-201,202"},

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2356,3 +2356,13 @@ class features:
         """
         pytest.mark.features(feature_id=324)(test_object)
         return test_object
+
+    @staticmethod
+    def tracing_configuration_consistency(test_object):
+        """
+        Enforces standardized behaviors for configurations across the tracing libraries.
+
+        https://feature-parity.us1.prod.dog/#/?feature=325
+        """
+        pytest.mark.features(feature_id=325)(test_object)
+        return test_object


### PR DESCRIPTION
## Motivation

We are systematically adding tests for tracing configurations, ensuring that they are implemented consistently across all languages.

## Changes

- Adds one new scenario `TRACING_CONFIG_NONDEFAULT` in `utils/_context/_scenarios/_init_.py` to cover standardization of tracing feature flags and adds it to the TRACER_RELEASE_SCENARIOS and TRACER_ESSENTIAL_SCENARIOS scenario groups
- Adds a new test file tests/test_config_consistency.py to group all new tracing config consistency test classes/methods
- Adds test cases for when `DD_TRACE_HTTP_SERVER_ERROR_STATUSES` is unset and when it is customized
- Updates the manifest files for the new test cases

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
