### PR TITLE
[dotnet] Enable suspicious attacker blocking system tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -203,7 +203,7 @@ tests/:
       Test_Blocking_response_headers: v2.32.0
       Test_Blocking_response_status: v2.32.0
       Test_Blocking_user_id: v2.27.0
-      Test_Suspicious_Request_Blocking: missing_feature (v2.29.0, but test is not implemented)
+      Test_Suspicious_Request_Blocking: v3.2.0
     test_client_ip.py:
       Test_StandardTagsClientIp: v2.20.0
     test_customconf.py:


### PR DESCRIPTION
## Motivation

Since this feature is supported from version 3.2, we have enabled the system tests.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
