### PR TITLE
[Ruby] Remove extra condition for ruby for GraphQL blocking test

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -183,7 +183,7 @@ tests/:
       Test_V2_Login_Events_Anon: missing_feature
       Test_V2_Login_Events_RC: missing_feature
     test_blocking_addresses.py:
-      Test_BlockingGraphqlResolvers: v2.3.0
+      Test_BlockingGraphqlResolvers: v2.3.1-dev
       Test_Blocking_client_ip: v1.0.0
       Test_Blocking_request_body: v1.0.0
       Test_Blocking_request_body_multipart: v1.0.0

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -590,12 +590,8 @@ class Test_BlockingGraphqlResolvers:
                 or parameters["address"] == "graphql.server.resolver"
             )
             assert rule_triggered["rule"]["id"] == "block-resolvers"
-            # In Ruby, we can get the resolvers of all the queries before any is executed
-            # So we use the name of the query as the first string in the key_path (or a default name like query1)
             assert parameters["key_path"] == (
-                ["getUserByName", "0", "name"]
-                if context.library == "ruby"
-                else ["userByName", "name"]
+                ["userByName", "name"]
                 if parameters["address"] == "graphql.server.resolver"
                 else ["userByName", "0", "name"]
             )


### PR DESCRIPTION
## Motivation

I am working on a [bugfix for Ruby GraphQL instrumentation](https://github.com/DataDog/dd-trace-rb/pull/3887) and changed our implementation to use resolver names as a key for arguments instead of the query name (since one query might have multiple resolvers). 

The PR that is linked above has to be merged for this test to pass.

## Changes

This PR removes an extra check for Ruby for the test that asserts that GraphQL arguments were extracted correctly.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
