### PR TITLE
Better error message when agent/weblog is not built

### DIFF
--- a/utils/_context/_scenarios/k8s_lib_injection.py
+++ b/utils/_context/_scenarios/k8s_lib_injection.py
@@ -66,7 +66,7 @@ class WeblogInjectionScenario(Scenario):
         )
         self._weblog_injection = WeblogInjectionInitContainer(host_log_folder=self.host_log_folder)
 
-        self._required_containers: list(TestedContainer) = []
+        self._required_containers: list[TestedContainer] = []
         self._required_containers.append(self._mount_injection_volume)
         self._required_containers.append(APMTestAgentContainer(host_log_folder=self.host_log_folder))
         self._required_containers.append(self._weblog_injection)

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -76,6 +76,7 @@ class TestedContainer:
         allow_old_container=False,
         healthcheck=None,
         stdout_interface=None,
+        local_image_only: bool = False,
         **kwargs,
     ) -> None:
         self.name = name
@@ -83,7 +84,7 @@ class TestedContainer:
         self.host_log_folder = host_log_folder
         self.allow_old_container = allow_old_container
 
-        self.image = ImageInfo(image_name)
+        self.image = ImageInfo(image_name, local_image_only=local_image_only)
         self.healthcheck = healthcheck
 
         # healthy values:
@@ -401,14 +402,21 @@ class SqlDbTestedContainer(TestedContainer):
 class ImageInfo:
     """data on docker image. data comes from `docker inspect`"""
 
-    def __init__(self, image_name):
+    def __init__(self, image_name: str, local_image_only: bool):
+        # local_image_only: boolean
+        # True if the image is only available locally and can't be loaded from any hub
+
         self.env = None
         self.name = image_name
+        self.local_image_only = local_image_only
 
     def load(self):
         try:
             self._image = _get_client().images.get(self.name)
         except docker.errors.ImageNotFound:
+            if self.local_image_only:
+                pytest.exit(f"Image {self.name} not found locally, please build it", 1)
+
             logger.stdout(f"Pulling {self.name}")
             self._image = _get_client().images.pull(self.name)
 
@@ -485,6 +493,7 @@ class AgentContainer(TestedContainer):
             },
             ports={self.agent_port: f"{self.agent_port}/tcp"},
             stdout_interface=interfaces.agent_stdout,
+            local_image_only=True,
         )
 
         self.agent_version = None
@@ -594,6 +603,7 @@ class WeblogContainer(TestedContainer):
             },
             ports={"7777/tcp": self.port, "7778/tcp": weblog._grpc_port},
             stdout_interface=interfaces.library_stdout,
+            local_image_only=True,
         )
 
         self.tracer_sampling_rate = tracer_sampling_rate
@@ -1015,7 +1025,7 @@ class MountInjectionVolume(TestedContainer):
         )
 
     def _lib_init_image(self, lib_init_image):
-        self.image = ImageInfo(lib_init_image)
+        self.image = ImageInfo(lib_init_image, local_image_only=False)
         # Dotnet compatible with former folder layer
         if "dd-lib-dotnet-init" in lib_init_image:
             self.kwargs["volumes"] = {


### PR DESCRIPTION
## Motivation

When the agent or weblog image is not built in E2e scenarios, here is the error message : 

```
<huge cryptic stack tace>
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/docker/errors.py", line 39, in create_api_error_from_http_exception
INTERNALERROR>     raise cls(e, response=response, explanation=explanation) from e
INTERNALERROR> docker.errors.ImageNotFound: 404 Client Error for http+docker://localhost/v1.43/images/create?tag=latest&fromImage=system_tests%2Fagent: Not Found ("pull access denied for system_tests/agent, repository does not exist or may require 'docker login': denied: requested access to the resource is denied")
```

It's not a login error, and it's too big => crap

## Changes

Here is the error now : 

```
(venv) ~/repos/system-tests@main $ ./run.sh 
Exit: Image system_tests/agent not found locally, please build it
```

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
