### PR TITLE
[java] Do not fetch test dependencies

### DIFF
--- a/utils/build/docker/java/akka-http.Dockerfile
+++ b/utils/build/docker/java/akka-http.Dockerfile
@@ -8,7 +8,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/akka-http/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/akka-http/src ./src
 RUN mvn -Dmaven.repo.local=/maven package

--- a/utils/build/docker/java/jersey-grizzly2.Dockerfile
+++ b/utils/build/docker/java/jersey-grizzly2.Dockerfile
@@ -5,7 +5,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/jersey-grizzly2/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/jersey-grizzly2/src ./src
 RUN mvn -Dmaven.repo.local=/maven package

--- a/utils/build/docker/java/play.Dockerfile
+++ b/utils/build/docker/java/play.Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 WORKDIR /app
 
 COPY ./utils/build/docker/java/play/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/play/app ./app
 COPY ./utils/build/docker/java/play/conf ./conf

--- a/utils/build/docker/java/ratpack.Dockerfile
+++ b/utils/build/docker/java/ratpack.Dockerfile
@@ -5,7 +5,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/ratpack/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/ratpack/src ./src
 RUN mvn -Dmaven.repo.local=/maven package

--- a/utils/build/docker/java/resteasy-netty3.Dockerfile
+++ b/utils/build/docker/java/resteasy-netty3.Dockerfile
@@ -5,7 +5,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/resteasy-netty3/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/resteasy-netty3/src ./src
 RUN mvn -Dmaven.repo.local=/maven package

--- a/utils/build/docker/java/spring-boot-3-native.Dockerfile
+++ b/utils/build/docker/java/spring-boot-3-native.Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 
 # Copy application sources and cache dependencies
 COPY ./utils/build/docker/java/spring-boot-3-native/pom.xml .
-RUN /opt/apache-maven-3.8.6/bin/mvn -P native -B dependency:go-offline
+RUN /opt/apache-maven-3.8.6/bin/mvn -P native -B -DincludeScopes=compile dependency:go-offline
 COPY ./utils/build/docker/java/spring-boot-3-native/src ./src
 
 # Copy tracer

--- a/utils/build/docker/java/spring-boot-jetty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-jetty.Dockerfile
@@ -5,7 +5,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Pjetty -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Pjetty -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven -Pjetty package

--- a/utils/build/docker/java/spring-boot-payara.Dockerfile
+++ b/utils/build/docker/java/spring-boot-payara.Dockerfile
@@ -5,7 +5,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Ppayara -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Ppayara -B -DincludeScopes=compile dependency:go-offline
 RUN mvn dependency:get -Dartifact=org.codehaus.woodstox:stax2-api:4.2.1
 
 COPY ./utils/build/docker/java/spring-boot/src ./src

--- a/utils/build/docker/java/spring-boot-undertow.Dockerfile
+++ b/utils/build/docker/java/spring-boot-undertow.Dockerfile
@@ -5,7 +5,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Pundertow -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Pundertow -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven -Pundertow package

--- a/utils/build/docker/java/spring-boot-wildfly.Dockerfile
+++ b/utils/build/docker/java/spring-boot-wildfly.Dockerfile
@@ -5,7 +5,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Pwildfly -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -Pwildfly -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven -Pwildfly package

--- a/utils/build/docker/java/spring-boot.Dockerfile
+++ b/utils/build/docker/java/spring-boot.Dockerfile
@@ -5,7 +5,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven package

--- a/utils/build/docker/java/uds-spring-boot.Dockerfile
+++ b/utils/build/docker/java/uds-spring-boot.Dockerfile
@@ -5,7 +5,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/spring-boot/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven package

--- a/utils/build/docker/java/vertx3.Dockerfile
+++ b/utils/build/docker/java/vertx3.Dockerfile
@@ -5,7 +5,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/vertx3/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/vertx3/src ./src
 RUN mvn -Dmaven.repo.local=/maven package

--- a/utils/build/docker/java/vertx4.Dockerfile
+++ b/utils/build/docker/java/vertx4.Dockerfile
@@ -8,7 +8,7 @@ COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 WORKDIR /app
 
 COPY ./utils/build/docker/java/vertx4/pom.xml .
-RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
+RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B -DincludeScopes=compile dependency:go-offline
 
 COPY ./utils/build/docker/java/vertx4/src ./src
 RUN mvn -Dmaven.repo.local=/maven package


### PR DESCRIPTION
## Motivation

Save build time by not fetching test dependencies for Java weblogs.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
