### PR TITLE
Fix paramiko warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,11 +19,11 @@ jsonschema==4.16.0
 rfc3339-validator==0.1.4
 semantic-version==2.10.0
 
-matplotlib
+matplotlib  # for performance tests
 
 docker==6.0.0
 
-paramiko==3.1.0
+paramiko==3.4.1
 scp==0.14.5
 
 ddapm-test-agent==1.14.0  # for parametric tests


### PR DESCRIPTION
## Motivation

Here is the warning in stdout : 

```
/home/runner/work/system-tests-dashboard/system-tests-dashboard/venv/lib/python3.12/site-packages/paramiko/pkey.py:82: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "cipher": algorithms.TripleDES,
/home/runner/work/system-tests-dashboard/system-tests-dashboard/venv/lib/python3.12/site-packages/paramiko/transport.py:256: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "class": algorithms.TripleDES,
```

## Changes

Update paramiko to `3.4.1`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
