### PR TITLE
[ruby] Add graphql-ruby 2.3 weblog in get_github_parameters

### DIFF
--- a/.github/workflows/run-graphql.yml
+++ b/.github/workflows/run-graphql.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   graphql:
-    if: inputs.library == 'golang' || inputs.library == 'nodejs'
+    if: inputs.library == 'golang' || inputs.library == 'nodejs' || inputs.library == 'ruby'
     runs-on:
       group: "APM Larger Runners"
     strategy:

--- a/utils/scripts/get_github_parameters.py
+++ b/utils/scripts/get_github_parameters.py
@@ -42,7 +42,7 @@ def get_graphql_weblogs(library):
         "nodejs": ["express4", "uds-express4", "express4-typescript"],
         "php": [],
         "python": [],
-        "ruby": [],
+        "ruby": ["graphql23"],
     }
 
     return weblogs[library]


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

The GraphQL tests results are not reported to the feature parity dashboard

## Changes

<!-- A brief description of the change being made with this pull request. -->

Add graphql-ruby 2.3 weblog in get_github_parameters
Add Ruby in the run-graphql workflow

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
