### PR TITLE
Improve security of postgres init-db.sh permission fix

### DIFF
--- a/docs/execute/troubleshooting.md
+++ b/docs/execute/troubleshooting.md
@@ -59,8 +59,9 @@ When executing `run.sh`, postgres can fail to start and log:
 ```
 /usr/local/bin/docker-entrypoint.sh: line 177: /docker-entrypoint-initdb.d/init_db.sh: Permission denied
 ```
-Try running:
+This may happen if your `umask` prohibits "other" access to files
+(for example, it is `027` on Datadog Linux laptops). To fix it, try running:
 ```bash
-chmod 777 ./utils/build/docker/postgres-init-db.sh
+chmod 755 ./utils/build/docker/postgres-init-db.sh
 ```
 then rebuild and rerun.


### PR DESCRIPTION
There is no need to permit world-write on the file. It only needs to be world-readable/executable.

Augment the explanation with the reason for the bad permissions as well.

## Motivation

<!-- What inspired you to submit this pull request? -->
World-writable files are a security weakness.

## Changes

Change mode from 0777 to 0755, add an explanation of umask.
<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
