### PR TITLE
Add config consistency tests for DD_VERSION

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -139,6 +139,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_TraceEnabled: missing_feature
       Test_Config_TraceLogDirectory: missing_feature
+      Test_Config_UnifiedServiceTagging: missing_feature
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
     test_otel_api_interoperability.py: irrelevant (library does not implement OpenTelemetry)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -315,6 +315,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_TraceEnabled: missing_feature
       Test_Config_TraceLogDirectory: missing_feature
+      Test_Config_UnifiedServiceTagging: missing_feature
     test_crashtracking.py:
       Test_Crashtracking: v3.2.0
     test_dynamic_configuration.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -445,6 +445,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_TraceEnabled: missing_feature
       Test_Config_TraceLogDirectory: missing_feature
+      Test_Config_UnifiedServiceTagging: missing_feature
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigSamplingRules: v1.64.0-dev

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1174,6 +1174,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_TraceEnabled: missing_feature
       Test_Config_TraceLogDirectory: missing_feature
+      Test_Config_UnifiedServiceTagging: missing_feature
     test_crashtracking.py:
       Test_Crashtracking: v1.38.0
     test_dynamic_configuration.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -515,6 +515,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_TraceEnabled: missing_feature
       Test_Config_TraceLogDirectory: missing_feature
+      Test_Config_UnifiedServiceTagging: missing_feature
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigSamplingRules: *ref_5_16_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -258,6 +258,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_TraceEnabled: missing_feature
       Test_Config_TraceLogDirectory: missing_feature
+      Test_Config_UnifiedServiceTagging: missing_feature
     test_crashtracking.py:
       Test_Crashtracking: v1.3.0
     test_dynamic_configuration.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -678,6 +678,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_TraceEnabled: missing_feature
       Test_Config_TraceLogDirectory: missing_feature
+      Test_Config_UnifiedServiceTagging: missing_feature
     test_crashtracking.py:
       Test_Crashtracking: v2.11.2
     test_dynamic_configuration.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -328,6 +328,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_TraceEnabled: missing_feature
       Test_Config_TraceLogDirectory: missing_feature
+      Test_Config_UnifiedServiceTagging: missing_feature
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: bug (To be confirmed, theorical version is v2.0.0)
       TestDynamicConfigSamplingRules: v2.0.0

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -95,7 +95,7 @@ class Test_Config_UnifiedServiceTagging:
 
         span1 = find_span_in_traces(traces, s1.trace_id, s1.span_id)
         assert span1["service"] == "version_test"
-        assert span1['meta']["version"] == "5.2.0"
+        assert span1["meta"]["version"] == "5.2.0"
 
         span2 = find_span_in_traces(traces, s2.trace_id, s2.span_id)
         assert span2["service"] != "version_test"

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -82,7 +82,7 @@ class Test_Config_UnifiedServiceTagging:
         assert span["service"] != "version_test"
         assert "version" not in span["meta"]
 
-    # Assert that if a span has service name set by DD_SERVICE, it also gets the version specified in DD_VERSION
+    # Assert that iff a span has service name set by DD_SERVICE, it also gets the version specified in DD_VERSION
     @parametrize("library_env", [{"DD_SERVICE": "version_test", "DD_VERSION": "5.2.0"}])
     def test_specific_version(self, library_env, test_agent, test_library):
         with test_library:

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -59,3 +59,31 @@ class Test_Config_TraceLogDirectory:
         success, message = test_library.container_exec_run("ls /parametric-tracer-logs")
         assert success, message
         assert len(message.splitlines()) > 0, "No tracer logs detected"
+def set_service_version_tags():
+    env1 = {}
+    env2 = {"DD_SERVICE": "test_service", "DD_VERSION": "5.2.0"}
+    return parametrize("library_env", [env1,env2])
+
+@scenarios.parametric
+@features.tracing_configuration_consistency
+class Test_Config_UnifiedServiceTagging:
+    @set_service_version_tags()
+    def test_version_tag(self, library_env, test_agent, test_library):
+        assert library_env.get("DD_SERVICE", "test_service") == "test_service"
+        assert library_env.get("DD_VERSION", "5.2.0") == "5.2.0"
+        
+        with test_library:
+            with test_library.start_span(name="s1"):
+                pass
+            with test_library.start_span(name="s2", service="no dd_service"):
+                pass
+
+        traces = test_agent.wait_for_num_traces(2)
+        assert len(traces) == 2
+        
+        for trace in traces:
+            for span in trace:
+                if span['service'] == "test_service":
+                    assert span['meta']['version'] == "5.2.0"
+                else:
+                    assert "version" not in span['meta']

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -62,7 +62,8 @@ class Test_Config_TraceLogDirectory:
 def set_service_version_tags():
     env1 = {}
     env2 = {"DD_SERVICE": "test_service", "DD_VERSION": "5.2.0"}
-    return parametrize("library_env", [env1,env2])
+    return parametrize("library_env", [env1, env2])
+
 
 @scenarios.parametric
 @features.tracing_configuration_consistency
@@ -71,7 +72,7 @@ class Test_Config_UnifiedServiceTagging:
     def test_version_tag(self, library_env, test_agent, test_library):
         assert library_env.get("DD_SERVICE", "test_service") == "test_service"
         assert library_env.get("DD_VERSION", "5.2.0") == "5.2.0"
-        
+
         with test_library:
             with test_library.start_span(name="s1"):
                 pass
@@ -80,10 +81,10 @@ class Test_Config_UnifiedServiceTagging:
 
         traces = test_agent.wait_for_num_traces(2)
         assert len(traces) == 2
-        
+
         for trace in traces:
             for span in trace:
-                if span['service'] == "test_service":
-                    assert span['meta']['version'] == "5.2.0"
+                if span["service"] == "test_service":
+                    assert span["meta"]["version"] == "5.2.0"
                 else:
                     assert "version" not in span['meta']

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -60,6 +60,8 @@ class Test_Config_TraceLogDirectory:
         success, message = test_library.container_exec_run("ls /parametric-tracer-logs")
         assert success, message
         assert len(message.splitlines()) > 0, "No tracer logs detected"
+
+
 def set_service_version_tags():
     env1 = {}
     env2 = {"DD_SERVICE": "test_service", "DD_VERSION": "5.2.0"}

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -82,6 +82,7 @@ class Test_Config_UnifiedServiceTagging:
         assert span["service"] != "version_test"
         assert "version" not in span["meta"]
 
+    # Assert that if a span has service name set by DD_SERVICE, it also gets the version specified in DD_VERSION
     @parametrize("library_env", [{"DD_SERVICE": "version_test", "DD_VERSION": "5.2.0"}])
     def test_specific_version(self, library_env, test_agent, test_library):
         with test_library:
@@ -98,5 +99,5 @@ class Test_Config_UnifiedServiceTagging:
         assert span1["meta"]["version"] == "5.2.0"
 
         span2 = find_span_in_traces(traces, s2.trace_id, s2.span_id)
-        assert span2["service"] != "version_test"
+        assert span2["service"] == "no dd_service"
         assert "version" not in span2["meta"]

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -84,6 +84,9 @@ def trace_span_start(args: StartSpanArgs) -> StartSpanReturn:
         parent_id = parent.span_id if parent else None
         parent = Context(trace_id=trace_id, span_id=parent_id, dd_origin=args.origin)
 
+    if args.service == "":
+        args.service = None
+
     if len(args.http_headers) > 0:
         headers = {k: v for k, v in args.http_headers}
         parent = HTTPPropagator.extract(headers)


### PR DESCRIPTION
## Motivation

Adding tests for tracing configs to make sure implementation across all languages are consistent, based upon the following [RFC](https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit#heading=h.o9qoojeu3llz).

## Changes

- Add test cases for when `DD_SERVICE` and `DD_VERSION` are specified, as well as when neither are included.
- Included in existing `tracing_configuration_consistency` feature.
- All tests are currently marked as `missing_feature` in the manifest files
- Small change made to pass in `None` instead of `""` in testing handler call to the python tracer library
- Ticket Link: [APMAPI-347](https://datadoghq.atlassian.net/browse/APMAPI-347)

This PR is stacked on top of #2976 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-347]: https://datadoghq.atlassian.net/browse/APMAPI-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ