### PR TITLE
Ruby:Update manifest for RC tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -323,9 +323,9 @@ tests/:
       TestDynamicConfigHeaderTags: bug (To be confirmed, theorical version is v2.0.0)
       TestDynamicConfigSamplingRules: v2.0.0
       TestDynamicConfigTracingEnabled: missing_feature
-      TestDynamicConfigV1: bug (to be investigated, theorical version is v1.13.0)
-      TestDynamicConfigV1_ServiceTargets: missing_feature
-      TestDynamicConfigV2: missing_feature
+      TestDynamicConfigV1: v2.3.0
+      TestDynamicConfigV1_ServiceTargets: v2.3.0
+      TestDynamicConfigV2: v2.3.0
     test_otel_api_interoperability.py: missing_feature
     test_otel_env_vars.py:
       Test_Otel_Env_Vars: v2.1.0

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -298,6 +298,7 @@ class TestDynamicConfigV1:
         assert len(events) > 0
 
     @parametrize("library_env", [{**DEFAULT_ENVVARS}])
+    @bug(library="ruby", reason="Telemetry event 'app-client-configuration-change' not found")
     def test_apply_state(self, library_env, test_agent, test_library):
         """Create a default RC record and ensure the apply_state is correctly set.
 
@@ -311,6 +312,7 @@ class TestDynamicConfigV1:
 
     @parametrize("library_env", [{**DEFAULT_ENVVARS}])
     @flaky(context.library >= "dotnet@2.56.0", reason="APMAPI-179")
+    @bug(library="ruby", reason="gRPC error: failed to connect to all addresses; recvmsg:Connection reset by peer")
     def test_trace_sampling_rate_override_default(self, test_agent, test_library):
         """The RC sampling rate should override the default sampling rate.
 
@@ -340,6 +342,7 @@ class TestDynamicConfigV1:
     )
     @bug(library="cpp", reason="Trace sampling RC creates another sampler which makes the computation wrong")
     @flaky(context.library >= "dotnet@2.56.0", reason="APMAPI-179")
+    @bug(library="ruby", reason="Telemetry event 'app-client-configuration-change' not found")
     def test_trace_sampling_rate_override_env(self, library_env, test_agent, test_library):
         """The RC sampling rate should override the environment variable.
 
@@ -382,6 +385,7 @@ class TestDynamicConfigV1:
         ],
     )
     @bug(library="cpp", reason="empty service default to '*'")
+    @bug(library="ruby", reason="Telemetry event 'app-client-configuration-change' not found")
     def test_trace_sampling_rate_with_sampling_rules(self, library_env, test_agent, test_library):
         """Ensure that sampling rules still apply when the sample rate is set via remote config."""
         RC_SAMPLING_RULE_RATE = 0.56
@@ -416,6 +420,7 @@ class TestDynamicConfigV1:
             {**DEFAULT_ENVVARS,},
         ],
     )
+    @bug(library="ruby", reason="Telemetry event 'app-client-configuration-change' not found")
     def test_log_injection_enabled(self, library_env, test_agent, test_library):
         """Ensure that the log injection setting can be set.
 
@@ -452,6 +457,7 @@ class TestDynamicConfigV1_ServiceTargets:
         ],
     )
     @bug(library="nodejs")
+    @bug(library="ruby")
     def test_not_match_service_target(self, library_env, test_agent, test_library):
         """Test that the library reports an erroneous apply_state when the service targeting is not correct.
 
@@ -512,6 +518,7 @@ class TestDynamicConfigV2:
     @parametrize(
         "library_env", [{**DEFAULT_ENVVARS}, {**DEFAULT_ENVVARS, "DD_TAGS": "key1:val1,key2:val2"},],
     )
+    @bug(context.library == "ruby", reason="DD_TAGS rc is not supported")
     def test_tracing_client_tracing_tags(self, library_env, test_agent, test_library):
         expected_local_tags = {}
         if "DD_TAGS" in library_env:
@@ -561,6 +568,7 @@ class TestDynamicConfigV2:
         test_agent.wait_for_rc_capabilities([Capabilities.APM_TRACING_HTTP_HEADER_TAGS])
 
     @parametrize("library_env", [{**DEFAULT_ENVVARS}])
+    @bug(context.library == "ruby", reason="APM_TRACING_CUSTOM_TAGS rc is not supported")
     def test_capability_tracing_custom_tags(self, library_env, test_agent, test_library):
         """Ensure the RC request contains the custom tags capability."""
         test_agent.wait_for_rc_capabilities([Capabilities.APM_TRACING_CUSTOM_TAGS])


### PR DESCRIPTION
This PR enables enables previously skipped dynamic configuration, which are going to be fixed in the Ruby tracer 2.3.0, due to missing capabilities being reported (fixed in https://github.com/DataDog/dd-trace-rb/pull/3888).

Also, this PR enables few `XPASS` tests for dynamic configuration.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
