### PR TITLE
[python] update manifest for easy wins in iast path parameters

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -189,9 +189,9 @@ tests/:
           TestPathParameter:
             '*': v2.9.0.dev
             fastapi: v2.13.0.dev
-            flask-poc: missing_feature
-            uds-flask: missing_feature
-            uwsgi-poc: missing_feature
+            flask-poc: v2.13.0.dev
+            uds-flask: v2.13.0.dev
+            uwsgi-poc: v2.13.0.dev
         test_uri.py:
           TestURI: missing_feature
     rasp/:


### PR DESCRIPTION
## Motivation

New PRs were merged on ddtrace-py, fixing that feature.

## Changes

enable iast path parameters tests for flask

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
