### PR TITLE
fix(onboarding): Make onboarding "dev" tests use staging versions of OCI packages

### DIFF
--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
@@ -7,38 +7,42 @@
       local_path: utils/build/virtual_machine/provisions/auto-inject/docker/docker_config.yaml
 
   remote-command: |
+    if [ "${DD_env}" == "dev" ]; then
+      # To force the installer to pull from dev repositories -- agent config is set manually to datadoghq.com
+      export DD_SITE="datad0g.com"
+      export DD_INSTALLER_REGISTRY_URL='669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog'
+      export DD_INSTALLER_REGISTRY_AUTH='ecr'
+    else 
+      export DD_SITE="datadoghq.com" 
+    fi
+
     # Environment variables for the installer
-    export DD_INSTALLER_REGISTRY_AUTH='ecr'
     export DD_APM_INSTRUMENTATION_ENABLED=all
     export DD_APM_INSTRUMENTATION_LIBRARIES="${DD_LANG}"
     export DD_INSTALLER_DEFAULT_PKG_INSTALL_DATADOG_AGENT=true
 
     if [ -n "${DD_INSTALLER_LIBRARY_VERSION}" ]; then
+      export DD_INSTALLER_REGISTRY_AUTH_APM_LIBRARY_$(echo $DD_LANG | tr a-z A-Z)_PACKAGE='ecr'
       export DD_INSTALLER_REGISTRY_URL_APM_LIBRARY_$(echo $DD_LANG | tr a-z A-Z)_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
       export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_LIBRARY_$(echo $DD_LANG | tr a-z A-Z)="${DD_INSTALLER_LIBRARY_VERSION}"
-    else
-      export DD_INSTALLER_REGISTRY_URL_APM_LIBRARY_$(echo $DD_LANG | tr a-z A-Z)_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog'
     fi
 
     if [ -n "${DD_INSTALLER_INJECTOR_VERSION}" ]; then
+      export DD_INSTALLER_REGISTRY_AUTH_APM_INJECT_PACKAGE='ecr'
       export DD_INSTALLER_REGISTRY_URL_APM_INJECT_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
       export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT="${DD_INSTALLER_INJECTOR_VERSION}"
-    else
-      export DD_INSTALLER_REGISTRY_URL_APM_INJECT_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog'
     fi
 
     if [ -n "${DD_INSTALLER_AGENT_VERSION}" ]; then
+      export DD_INSTALLER_REGISTRY_AUTH_AGENT_PACKAGE='ecr'
       export DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
-      export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT="${DD_INSTALLER_INJECTOR_VERSION}"
-    else
-      export DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog'
+      export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT="${DD_INSTALLER_AGENT_VERSION}"
     fi
 
     if [ -n "${DD_INSTALLER_INSTALLER_VERSION}" ]; then
+      export DD_INSTALLER_REGISTRY_AUTH_INSTALLER_PACKAGE='ecr'
       export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
       export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER="${DD_INSTALLER_INSTALLER_VERSION}"
-    else
-      export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog'
     fi
 
     # Env variables set on the scenario definition. Write to file and load
@@ -47,9 +51,15 @@
     echo "AGENT VARIABLES CONFIGURED FROM THE SCENARIO:"
     cat scenario_agent.env
     export $(cat scenario_agent.env | xargs)
-  
-    sudo -E sh -c "sudo mkdir -p /etc/datadog-agent && echo \"api_key: ${DD_API_KEY}\" > /etc/datadog-agent/datadog.yaml"
-    DD_REPO_URL=${DD_injection_repo_url} DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+
+    sudo -E sh -c "sudo mkdir -p /etc/datadog-agent && printf \"api_key: ${DD_API_KEY}\nsite: datadoghq.com\n\" > /etc/datadog-agent/datadog.yaml"
+    DD_REPO_URL=${DD_injection_repo_url} bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+    
+    echo "installer stdout"
+    sudo cat /tmp/datadog-installer-stderr.log
+
+    echo "installer stderr"
+    sudo cat /tmp/datadog-installer-stderr.log
 
     sudo mkdir -p /etc/datadog-agent/inject
     sudo cp docker_config.yaml /etc/datadog-agent/inject/docker_config.yaml

--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
@@ -22,9 +22,9 @@
     export DD_INSTALLER_DEFAULT_PKG_INSTALL_DATADOG_AGENT=true
 
     if [ -n "${DD_INSTALLER_LIBRARY_VERSION}" ]; then
-      export DD_INSTALLER_REGISTRY_AUTH_APM_LIBRARY_$(echo $DD_LANG | tr a-z A-Z)_PACKAGE='ecr'
-      export DD_INSTALLER_REGISTRY_URL_APM_LIBRARY_$(echo $DD_LANG | tr a-z A-Z)_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
-      export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_LIBRARY_$(echo $DD_LANG | tr a-z A-Z)="${DD_INSTALLER_LIBRARY_VERSION}"
+       export "DD_INSTALLER_REGISTRY_AUTH_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")_PACKAGE"='ecr'
+       export "DD_INSTALLER_REGISTRY_URL_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")_PACKAGE"='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+       export "DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")"="${DD_INSTALLER_LIBRARY_VERSION}"
     fi
 
     if [ -n "${DD_INSTALLER_INJECTOR_VERSION}" ]; then
@@ -55,11 +55,7 @@
     sudo -E sh -c "sudo mkdir -p /etc/datadog-agent && printf \"api_key: ${DD_API_KEY}\nsite: datadoghq.com\n\" > /etc/datadog-agent/datadog.yaml"
     DD_REPO_URL=${DD_injection_repo_url} bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
     
-    echo "installer stdout"
-    sudo cat /tmp/datadog-installer-stderr.log
-
-    echo "installer stderr"
-    sudo cat /tmp/datadog-installer-stderr.log
+    sudo cp /tmp/datadog-installer-*.log /var/log/datadog
 
     sudo mkdir -p /etc/datadog-agent/inject
     sudo cp docker_config.yaml /etc/datadog-agent/inject/docker_config.yaml

--- a/utils/build/virtual_machine/provisions/auto-inject/repositories/autoinstall/execute_install_script.sh
+++ b/utils/build/virtual_machine/provisions/auto-inject/repositories/autoinstall/execute_install_script.sh
@@ -11,9 +11,52 @@ if [ "$DD_APM_INSTRUMENTATION_ENABLED" == "docker" ]; then
     export DD_NO_AGENT_INSTALL=true
 fi
 
+# Installer env vars
+# shellcheck disable=SC2154
+if [ "${DD_env}" == "dev" ]; then
+    # To force the installer to pull from dev repositories -- agent config is set manually to datadoghq.com
+    export DD_SITE="datad0g.com"
+    export DD_INSTALLER_REGISTRY_URL='669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog'
+    export DD_INSTALLER_REGISTRY_AUTH='ecr'
+else 
+    export DD_SITE="datadoghq.com" 
+fi
+
+# Environment variables for the installer
+export DD_APM_INSTRUMENTATION_LIBRARIES="${DD_LANG}"
+export DD_INSTALLER_DEFAULT_PKG_INSTALL_DATADOG_AGENT=true
+
+if [ -n "${DD_INSTALLER_LIBRARY_VERSION}" ]; then
+   export "DD_INSTALLER_REGISTRY_AUTH_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")_PACKAGE"='ecr'
+   export "DD_INSTALLER_REGISTRY_URL_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")_PACKAGE"='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+   export "DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")"="${DD_INSTALLER_LIBRARY_VERSION}" 
+fi
+
+if [ -n "${DD_INSTALLER_INJECTOR_VERSION}" ]; then
+    export DD_INSTALLER_REGISTRY_AUTH_APM_INJECT_PACKAGE='ecr'
+    export DD_INSTALLER_REGISTRY_URL_APM_INJECT_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+    export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT="${DD_INSTALLER_INJECTOR_VERSION}"
+fi
+
+if [ -n "${DD_INSTALLER_AGENT_VERSION}" ]; then
+    export DD_INSTALLER_REGISTRY_AUTH_AGENT_PACKAGE='ecr'
+    export DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+    export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT="${DD_INSTALLER_AGENT_VERSION}"
+fi
+
+if [ -n "${DD_INSTALLER_INSTALLER_VERSION}" ]; then
+    export DD_INSTALLER_REGISTRY_AUTH_INSTALLER_PACKAGE='ecr'
+    export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+    export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER="${DD_INSTALLER_INSTALLER_VERSION}"
+fi
+
+sudo sh -c "sudo mkdir -p /etc/datadog-agent && printf \"api_key: ${DD_API_KEY}\nsite: datadoghq.com\n\" > /etc/datadog-agent/datadog.yaml"
+
 # shellcheck disable=SC2154
 DD_REPO_URL="$DD_injection_repo_url" \
 DD_APM_INSTRUMENTATION_LANGUAGES="$DD_LANG" \
-bash -c "$(curl -L $INSTALLER_URL)"
+bash -c "$(curl -L "$INSTALLER_URL")"
+
+sudo cp /tmp/datadog-installer-*.log /var/log/datadog
 
 echo "lib-injection install done"


### PR DESCRIPTION
## Motivation
[APMON-1459]

## Changes
Uses dev versions of OCI packages when running the onboarding tests with the "dev" vm-env

Pipeline all green: https://gitlab.ddbuild.io/DataDog/system-tests/-/pipelines/44168834
Staging versions: https://gitlab.ddbuild.io/DataDog/system-tests/-/jobs/636991553#L557

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMON-1459]: https://datadoghq.atlassian.net/browse/APMON-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ