### PR TITLE
Add config consistency tests for DD_SERVICE

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -173,6 +173,8 @@ tests/:
     Test_Config_ClientTagQueryString_Empty: missing_feature (test can not capture span with the expected http.url tag)
     Test_Config_HttpServerErrorStatuses_Default: missing_feature
     Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
+    Test_Config_UnifiedServiceTagging_CustomService: missing_feature
+    Test_Config_UnifiedServiceTagging_Default: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py: irrelevant

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -369,6 +369,8 @@ tests/:
     Test_Config_ClientTagQueryString_Empty: v2.53.0
     Test_Config_HttpServerErrorStatuses_Default: missing_feature
     Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
+    Test_Config_UnifiedServiceTagging_CustomService: missing_feature
+    Test_Config_UnifiedServiceTagging_Default: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v2.46.0
   test_distributed.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -489,6 +489,8 @@ tests/:
     Test_Config_ClientTagQueryString_Empty: v1.60.0
     Test_Config_HttpServerErrorStatuses_Default: missing_feature
     Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
+    Test_Config_UnifiedServiceTagging_CustomService: missing_feature
+    Test_Config_UnifiedServiceTagging_Default: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v1.60.0.dev0
   test_distributed.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1239,6 +1239,8 @@ tests/:
     Test_Config_ClientTagQueryString_Empty: missing_feature (incorrect default value)
     Test_Config_HttpServerErrorStatuses_Default: missing_feature
     Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
+    Test_Config_UnifiedServiceTagging_CustomService: missing_feature
+    Test_Config_UnifiedServiceTagging_Default: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v1.29.0
   test_distributed.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -564,6 +564,8 @@ tests/:
     Test_Config_ClientTagQueryString_Empty: missing_feature (removes query strings by default)
     Test_Config_HttpServerErrorStatuses_Default: missing_feature
     Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
+    Test_Config_UnifiedServiceTagging_CustomService: missing_feature
+    Test_Config_UnifiedServiceTagging_Default: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -320,6 +320,8 @@ tests/:
     Test_Config_ClientTagQueryString_Empty: v1.2.0
     Test_Config_HttpServerErrorStatuses_Default: v1.3.0 # Unknown initial version
     Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
+    Test_Config_UnifiedServiceTagging_CustomService: missing_feature
+    Test_Config_UnifiedServiceTagging_Default: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -762,6 +762,8 @@ tests/:
     Test_Config_ClientTagQueryString_Empty: v2.12.0
     Test_Config_HttpServerErrorStatuses_Default: missing_feature
     Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
+    Test_Config_UnifiedServiceTagging_CustomService: missing_feature
+    Test_Config_UnifiedServiceTagging_Default: missing_feature
   test_data_integrity.py:
     Test_LibraryHeaders: v2.7.0
   test_distributed.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -390,6 +390,8 @@ tests/:
     Test_Config_ClientTagQueryString_Empty: missing_feature (removes query string by default)
     Test_Config_HttpServerErrorStatuses_Default: missing_feature
     Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
+    Test_Config_UnifiedServiceTagging_CustomService: missing_feature
+    Test_Config_UnifiedServiceTagging_Default: missing_feature
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -137,4 +137,6 @@ class Test_Config_UnifiedServiceTagging_Default:
         interfaces.library.assert_trace_exists(self.r)
         spans = interfaces.agent.get_spans_list(self.r)
         assert len(spans) == 1, "Agent received the incorrect amount of spans"
-        assert spans[0]["service"] != "service_test" #in default scenario, DD_SERVICE is set to "weblog" in the dockerfile; this is a temp fix to test that it is not the value we manually set in the specific scenario
+        assert (
+            spans[0]["service"] != "service_test"
+        )  # in default scenario, DD_SERVICE is set to "weblog" in the dockerfile; this is a temp fix to test that it is not the value we manually set in the specific scenario

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -110,6 +110,8 @@ def _get_span_by_tags(trace, tags):
                 break
         else:
             return span
+
+
 @scenarios.tracing_config_nondefault
 @features.tracing_configuration_consistency
 class Test_Config_UnifiedServiceTagging_CustomService:

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -137,4 +137,4 @@ class Test_Config_UnifiedServiceTagging_Default:
         interfaces.library.assert_trace_exists(self.r)
         spans = interfaces.agent.get_spans_list(self.r)
         assert len(spans) == 1, "Agent received the incorrect amount of spans"
-        assert not spans[0]["service"] == "service_test"
+        assert spans[0]["service"] != "service_test"

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -110,3 +110,31 @@ def _get_span_by_tags(trace, tags):
                 break
         else:
             return span
+@scenarios.tracing_config_nondefault
+@features.tracing_configuration_consistency
+class Test_Config_UnifiedServiceTagging_CustomService:
+    """ Verify behavior of http clients and distributed traces """
+
+    def setup_specified_service_name(self):
+        self.r = weblog.get("/")
+
+    def test_specified_service_name(self):
+        interfaces.library.assert_trace_exists(self.r)
+        spans = interfaces.agent.get_spans_list(self.r)
+        assert len(spans) == 1, "Agent received the incorrect amount of spans"
+        assert spans[0]["service"] == "service_test"
+
+
+@scenarios.default
+@features.tracing_configuration_consistency
+class Test_Config_UnifiedServiceTagging_Default:
+    """ Verify behavior of http clients and distributed traces """
+
+    def setup_default_service_name(self):
+        self.r = weblog.get("/")
+
+    def test_default_service_name(self):
+        interfaces.library.assert_trace_exists(self.r)
+        spans = interfaces.agent.get_spans_list(self.r)
+        assert len(spans) == 1, "Agent received the incorrect amount of spans"
+        assert not spans[0]["service"] == "service_test"

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -137,4 +137,4 @@ class Test_Config_UnifiedServiceTagging_Default:
         interfaces.library.assert_trace_exists(self.r)
         spans = interfaces.agent.get_spans_list(self.r)
         assert len(spans) == 1, "Agent received the incorrect amount of spans"
-        assert spans[0]["service"] != "service_test"
+        assert spans[0]["service"] != "service_test" #in default scenario, DD_SERVICE is set to "weblog" in the dockerfile; this is a temp fix to test that it is not the value we manually set in the specific scenario

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -444,7 +444,7 @@ class scenarios:
 
     tracing_config_nondefault = EndToEndScenario(
         "TRACING_CONFIG_NONDEFAULT",
-        weblog_env={"DD_TRACE_HTTP_SERVER_ERROR_STATUSES": "200-201,202"},
+        weblog_env={"DD_TRACE_HTTP_SERVER_ERROR_STATUSES": "200-201,202", "DD_SERVICE": "service_test"},
         doc="",
         scenario_groups=[ScenarioGroup.ESSENTIALS],
     )


### PR DESCRIPTION
## Motivation

Adding tests for tracing configs to make sure implementation across all languages are consistent, based upon the following [RFC](https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit#heading=h.u523jef6b4yp).

## Changes

- Add test cases for when `DD_SERVICE` is specified, as well as when it is not included.
- Included in existing `tracing_configuration_consistency` feature.
- All tests are currently marked as `missing_feature` in the manifest files
- Ticket Link: [APMAPI-657](https://datadoghq.atlassian.net/browse/APMAPI-657)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-657]: https://datadoghq.atlassian.net/browse/APMAPI-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ