### PR TITLE
[ruby] Fix the (unsupported) docker mode

### DIFF
--- a/utils/build/docker/runner.Dockerfile
+++ b/utils/build/docker/runner.Dockerfile
@@ -9,21 +9,8 @@ COPY build.sh .
 COPY utils/build/build.sh utils/build/build.sh
 RUN mkdir -p /app/utils/build/docker && ./build.sh -i runner
 
-# basically everything except utils/build
-COPY utils/assets /app/utils/assets
-COPY utils/build /app/utils/build
-COPY utils/_context /app/utils/_context
-COPY utils/grpc /app/utils/grpc
-COPY utils/interfaces /app/utils/interfaces
-COPY utils/k8s_lib_injection /app/utils/k8s_lib_injection
-COPY utils/onboarding /app/utils/onboarding
-COPY utils/parametric /app/utils/parametric
-COPY utils/proxy /app/utils/proxy
-COPY utils/scripts /app/utils/scripts
-COPY utils/virtual_machine /app/utils/virtual_machine
-COPY utils/otel_validators /app/utils/otel_validators
-COPY utils/*.py /app/utils/
 
+COPY utils/ /app/utils/
 # tests
 COPY tests /app/tests
 COPY parametric /app/parametric


### PR DESCRIPTION
## Motivation

The comment in the docker file was saying : `basically everything except utils/build`. But, `utils/build` was copied two lines after.

-> Unecessaray docker build steps
-> Unecessaray pain when we add a subfolder

## Changes

Rather than a list of subfolders with everything, copy the entire folder.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
