### PR TITLE
[ruby] Increment path in ruby "dev" version, and set a prerelease

### DIFF
--- a/tests/test_the_test/test_version.py
+++ b/tests/test_the_test/test_version.py
@@ -37,16 +37,32 @@ def test_version_comparizon():
     assert str(v) == "0.53.0+dev70.g494e6dc0"
 
 
+def test_ruby_version():
+
+    v = LibraryVersion("ruby", "  * ddtrace (0.53.0.appsec.180045)")
+    assert str(v.version) == "0.53.1-appsec+180045"
+
+    v = LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1 de82857)")
+    assert v.version == Version("1.0.1-beta1+de82857")
+
+    v = LibraryVersion("ruby", "  * datadog (2.3.0 7dbcc40)")
+    assert str(v.version) == "2.3.1-z+7dbcc40"
+
+    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1)") == "ruby@1.0.1-z+beta1"
+    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1 de82857)") == "ruby@1.0.1-beta1+de82857"
+
+    # very particular use case, because we hack the path for dev versions
+    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1 de82857)") < "ruby@1.0.1"
+    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.rc1)") < "ruby@1.0.1"
+
+    assert LibraryVersion("ruby", "  * datadog (2.3.0 7dbcc40)") >= "ruby@2.3.1-dev"
+
+
 def test_library_version_comparizon():
 
     assert LibraryVersion("x", "1.31.1") < "x@1.34.1"
     assert "x@1.31.1" < LibraryVersion("x", "v1.34.1")
     assert LibraryVersion("x", "1.31.1") < LibraryVersion("x", "v1.34.1")
-
-    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1)") == LibraryVersion("ruby", "1.0.0.beta1")
-    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1)")
-    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1 de82857)") < LibraryVersion("ruby", "1.0.0")
-    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.rc1)") < LibraryVersion("ruby", "1.0.0")
 
     assert LibraryVersion("python", "1.1.0rc2.dev15+gc41d325d") >= "python@1.1.0rc2.dev"
     assert LibraryVersion("python", "1.1.0") > "python@1.1.0rc2.dev"
@@ -68,16 +84,6 @@ def test_spec():
 def test_version_serialization():
 
     assert LibraryVersion("cpp", "v1.3.1") == "cpp@1.3.1"
-
-    v = LibraryVersion("ruby", "  * ddtrace (0.53.0.appsec.180045)")
-    assert v.version == Version("0.53.0-appsec.180045")
-    assert v.version == "0.53.0-appsec.180045"
-
-    v = LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1)")
-    assert v.version == Version("1.0.0-beta1")
-
-    v = LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1 de82857)")
-    assert v.version == Version("1.0.0-beta1+de82857")
 
     v = LibraryVersion("libddwaf", "* libddwaf (1.0.14.1.0.beta1)")
     assert v.version == Version("1.0.14.1.0.beta1")

--- a/utils/_context/library_version.py
+++ b/utils/_context/library_version.py
@@ -18,16 +18,22 @@ def _build(version):
 
 
 class Version(version_module.Version):
-    def __init__(self, version):
+    def __init__(self, version=None, major=None, minor=None, patch=None, prerelease=None, build=None):
 
-        # remove any leading "v"
-        if version.startswith("v"):
-            version = version[1:]
+        if version is not None:
+            # remove any leading "v"
+            if version.startswith("v"):
+                version = version[1:]
 
-        # and use coerce to allow the wide variaty of version strings
-        x = version_module.Version.coerce(version)
+            # and use coerce to allow the wide variaty of version strings
+            x = version_module.Version.coerce(version)
+            major = x.major
+            minor = x.minor
+            patch = x.patch
+            prerelease = x.prerelease
+            build = x.build
 
-        super().__init__(major=x.major, minor=x.minor, patch=x.patch, prerelease=x.prerelease, build=x.build)
+        super().__init__(major=major, minor=minor, patch=patch, prerelease=prerelease, build=build)
 
     def __eq__(self, other):
         return super().__eq__(_build(other))
@@ -64,25 +70,39 @@ class LibraryVersion:
 
         self.library = library
 
+        ruby_version_from_bundle_info = False
         if version:
             version = version.strip()
 
             if library == "ruby":
+                # small cleanup of the version string
                 if version.startswith("* ddtrace"):
                     version = re.sub(r"\* *ddtrace *\((.*)\)", r"\1", version)
+                    ruby_version_from_bundle_info = True
                 if version.startswith("* datadog"):
                     version = re.sub(r"\* *datadog *\((.*)\)", r"\1", version)
+                    ruby_version_from_bundle_info = True
 
-                # ruby version pattern can be like
+                if ruby_version_from_bundle_info:
+                    # ruby version pattern can be like
 
-                # 2.0.0.rc1 b908262
-                # 2.0.0.rc1
+                    # 2.0.0.rc1 b908262
+                    # 2.0.0 b908262
+                    # 2.0.0.rc1
+                    #   rc1 is a pre-release, so we need to add a - sign
+                    #   b908262 is a build metadata, so we need to add a + sign
 
-                # adding + and - signs in the good places
-                if re.match(r"\d+\.\d+\.\d+\.[\w\d+]+ [\w\d]+", version):
-                    version = re.sub(r"(\d+\.\d+\.\d+)\.([\w\d]+) ([\w\d]+)", r"\1-\2+\3", version)
-                elif re.match(r"\d+\.\d+\.\d+\.[\w\d+]+", version):
-                    version = re.sub(r"(\d+\.\d+\.\d+)\.([\w\d]+)", r"\1-\2", version)
+                    # => adding + and - signs in the good places
+
+                    base = r"\d+\.\d+\.\d+"
+                    prerelease = r"[\w\d+]+"
+                    build = r"[a-f0-9]+"
+                    if re.match(fr"{base}[\. ]{prerelease}[\. ]{build}", version):
+                        version = re.sub(fr"({base})[\. ]({prerelease})[\. ]({build})", r"\1-\2+\3", version)
+                    elif re.match(fr"{base}[\. ]{build}", version):
+                        version = re.sub(rf"({base})[\. ]({build})", r"\1+\2", version)
+                    elif re.match(fr"{base}[\. ]{prerelease}", version):
+                        version = re.sub(rf"({base})[\. ]({prerelease})", r"\1-\2", version)
 
             elif library == "libddwaf":
                 if version.startswith("* libddwaf"):
@@ -99,6 +119,33 @@ class LibraryVersion:
                 version = version.replace("-nightly", "")
 
             self.version = Version(version)
+
+            if library == "ruby" and ruby_version_from_bundle_info:
+                if len(self.version.build) != 0 or len(self.version.prerelease) != 0:
+                    # we are not in a released version, and the version is coing from bundle list
+
+                    # dd-trace-rb main branch expose a version lower than the last release, so hack it:
+                    # * add 1 to minor version
+                    # * and set z as prerelease if not prerelease is set, becasue z will be after any other prerelease
+
+                    # if dd-trace-rb repo fix the underlying issue, we can remove this hack.
+                    self.version = Version(
+                        major=self.version.major,
+                        minor=self.version.minor,
+                        patch=self.version.patch + 1,
+                        prerelease=self.version.prerelease,
+                        build=self.version.build,
+                    )
+
+                    if not self.version.prerelease:
+                        self.version = Version(
+                            major=self.version.major,
+                            minor=self.version.minor,
+                            patch=self.version.patch,
+                            prerelease=("z",),
+                            build=self.version.build,
+                        )
+
             self.add_known_version(self.version)
         else:
             self.version = None
@@ -178,3 +225,8 @@ class LibraryVersion:
             "library": self.library,
             "version": str(self.version),
         }
+
+
+if __name__ == "__main__":
+    v = LibraryVersion("ruby", "  * ddtrace (0.53.0.appsec.180045)")
+    assert str(v.version) == "0.53.1-appsec+180045"


### PR DESCRIPTION
## Motivation

Reminder about semvar syntax : `x.y.z-prerelease+build`.

When the ruby tracer is installed from main branch of dd-trace-rb, we get its version with `bundle info`. Unfortunately, the version provided is equal to the last released version of the tracer, plus some prerelease/build info.

As we are using semver, there is this logic : `x.y.x-pre+build < x.y.z` => the version exposed is considered as anterior to the last released one. So we can't use manifest to activate a test on the main branch of dd-trace-rb, but not on the last released artifact.

## Changes

If the version of ruby lib we are currently parsing is coming from  `bundle info` and the version is a "dev" version (it contains a prerelease or a build info), then we increment its `patch` number. If it does not contains an prerelease info, we arbitrary set it to `z`.

With that change, `x.y.z+build` will be interpreted as `x.y.[z+1]-z+build`. With that change, we can set a version in manifest as `x.y.[z+1]` or even `x.y.[z+1]-dev` (as `dev` < `z`) to activate the test for the main branch of dd-trace-rb.

Hack to be removed when this repo will expose a version of its main branch higher than the last released one.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
