### PR TITLE
Add config consistency tests for DD_ENV

### DIFF
--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -87,6 +87,15 @@ class Test_Config_UnifiedServiceTagging_CustomService:
         assert len(spans) == 1, "Agent received the incorrect amount of spans"
         assert spans[0]["service"] == "service_test"
 
+    def setup_specified_env_name(self):
+        self.r = weblog.get("/")
+
+    def test_specified_env_name(self):
+        interfaces.library.assert_trace_exists(self.r)
+        spans = interfaces.agent.get_spans_list(self.r)
+        assert len(spans) == 1, "Agent received the incorrect amount of spans"
+        assert spans[0]["meta"]["env"] == "dev"
+
 
 @scenarios.default
 @features.tracing_configuration_consistency

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -472,7 +472,11 @@ class scenarios:
 
     tracing_config_nondefault = EndToEndScenario(
         "TRACING_CONFIG_NONDEFAULT",
-        weblog_env={"DD_TRACE_HTTP_SERVER_ERROR_STATUSES": "200-201,202", "DD_SERVICE": "service_test"},
+        weblog_env={
+            "DD_TRACE_HTTP_SERVER_ERROR_STATUSES": "200-201,202",
+            "DD_SERVICE": "service_test",
+            "DD_ENV": "dev",
+        },
         doc="",
     )
 


### PR DESCRIPTION
## Motivation

Adding tests for tracing configs to make sure implementation across all languages are consistent, based upon the following [RFC](https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit#heading=h.m7pxr7de8n4j).

## Changes

- Add test cases for when `DD_ENV` is specified. Test case for when `DD_ENV` is not specified has not been determined yet, and is a TBD for now.
- Included in existing `tracing_configuration_consistency` feature.
- All tests are currently marked as `missing_feature` in the manifest files
- Ticket Link: [APMAPI-659](https://datadoghq.atlassian.net/browse/APMAPI-658)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-659]: https://datadoghq.atlassian.net/browse/APMAPI-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ