### PR TITLE
Add config consistency tests for DD_ENV (Parametric)

### DIFF
--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -73,6 +73,7 @@ def set_service_version_tags():
 class Test_Config_UnifiedServiceTagging:
     @parametrize("library_env", [{}])
     def test_default_version(self, library_env, test_agent, test_library):
+        assert library_env.get("DD_ENV") == None
         with test_library:
             with test_library.start_span(name="s1") as s1:
                 pass
@@ -83,10 +84,12 @@ class Test_Config_UnifiedServiceTagging:
         span = find_span_in_traces(traces, s1.trace_id, s1.span_id)
         assert span["service"] != "version_test"
         assert "version" not in span["meta"]
+        assert "env" not in span["meta"]
 
     # Assert that iff a span has service name set by DD_SERVICE, it also gets the version specified in DD_VERSION
     @parametrize("library_env", [{"DD_SERVICE": "version_test", "DD_VERSION": "5.2.0"}])
     def test_specific_version(self, library_env, test_agent, test_library):
+        assert library_env.get("DD_ENV") == "dev"
         with test_library:
             with test_library.start_span(name="s1") as s1:
                 pass
@@ -99,7 +102,9 @@ class Test_Config_UnifiedServiceTagging:
         span1 = find_span_in_traces(traces, s1.trace_id, s1.span_id)
         assert span1["service"] == "version_test"
         assert span1["meta"]["version"] == "5.2.0"
+        assert span1["meta"]["env"] == "dev"
 
         span2 = find_span_in_traces(traces, s2.trace_id, s2.span_id)
         assert span2["service"] == "no dd_service"
         assert "version" not in span2["meta"]
+        assert span2["meta"]["env"] == "dev"

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -74,7 +74,6 @@ def set_service_version_tags():
 class Test_Config_UnifiedServiceTagging:
     @parametrize("library_env", [{}])
     def test_default_config(self, library_env, test_agent, test_library):
-        assert library_env.get("DD_ENV") == None
         with test_library:
             with test_library.start_span(name="s1") as s1:
                 pass


### PR DESCRIPTION
## Motivation

Adding tests for tracing configs to make sure implementation across all languages are consistent, based upon the following [RFC](https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit#heading=h.m7pxr7de8n4j).

## Changes

- Add test cases for when `DD_ENV` is specified and not specified.
- Included in existing `tracing_configuration_consistency` feature.
- All tests are currently marked as `missing_feature` in the manifest files
- Ticket Link: [APMAPI-659](https://datadoghq.atlassian.net/browse/APMAPI-658)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-659]: https://datadoghq.atlassian.net/browse/APMAPI-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ