### PR TITLE
config_consistency: test ClientIPHeader

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -169,6 +169,7 @@ tests/:
     test_miscs.py:
       Test_Miscs: missing_feature
   test_config_consistency.py:
+    Test_Config_ClientIPHeader_Configured: v0.2.2
     Test_Config_ClientTagQueryString_Configured: missing_feature
     Test_Config_ClientTagQueryString_Empty: missing_feature (test can not capture span with the expected http.url tag)
     Test_Config_HttpServerErrorStatuses_Default: missing_feature

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -169,7 +169,7 @@ tests/:
     test_miscs.py:
       Test_Miscs: missing_feature
   test_config_consistency.py:
-    Test_Config_ClientIPHeader_Configured: v0.2.2
+    Test_Config_ClientIPHeader_Configured: missing_feature (DD_TRACE_CLIENT_IP_HEADER not implemented)
     Test_Config_ClientTagQueryString_Configured: missing_feature
     Test_Config_ClientTagQueryString_Empty: missing_feature (test can not capture span with the expected http.url tag)
     Test_Config_HttpServerErrorStatuses_Default: missing_feature

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -170,6 +170,7 @@ tests/:
       Test_Miscs: missing_feature
   test_config_consistency.py:
     Test_Config_ClientIPHeader_Configured: missing_feature (DD_TRACE_CLIENT_IP_HEADER not implemented)
+    Test_Config_ClientIPHeader_Precedence: missing_feature (http.client_ip is not supported)
     Test_Config_ClientTagQueryString_Configured: missing_feature
     Test_Config_ClientTagQueryString_Empty: missing_feature (test can not capture span with the expected http.url tag)
     Test_Config_HttpClientErrorStatuses_Default: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -366,6 +366,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
     Test_Config_ClientIPHeader_Configured: v2.48.0
+    Test_Config_ClientIPHeader_Precedence: missing_feature (all headers listed in the RFC are not supported)
     Test_Config_ClientTagQueryString_Configured: missing_feature (configuration DNE)
     Test_Config_ClientTagQueryString_Empty: v2.53.0
     Test_Config_HttpClientErrorStatuses_Default: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -365,6 +365,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: v2.15.0
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
+    Test_Config_ClientIPHeader_Configured: v2.48.0
     Test_Config_ClientTagQueryString_Configured: missing_feature (configuration DNE)
     Test_Config_ClientTagQueryString_Empty: v2.53.0
     Test_Config_HttpServerErrorStatuses_Default: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -485,6 +485,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
+    Test_Config_ClientIPHeader_Configured: v1.60.0
     Test_Config_ClientTagQueryString_Configured: missing_feature (supports DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED)
     Test_Config_ClientTagQueryString_Empty: v1.60.0
     Test_Config_HttpServerErrorStatuses_Default: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -486,6 +486,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
     Test_Config_ClientIPHeader_Configured: v1.60.0
+    Test_Config_ClientIPHeader_Precedence: missing_feature (all headers listed in the RFC are not supported)
     Test_Config_ClientTagQueryString_Configured: missing_feature (supports DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED)
     Test_Config_ClientTagQueryString_Empty: v1.60.0
     Test_Config_HttpClientErrorStatuses_Default: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1236,6 +1236,7 @@ tests/:
       Test_NotReleased: missing_feature
   test_config_consistency.py:
     Test_Config_ClientIPHeader_Configured: v1.38.0
+    Test_Config_ClientIPHeader_Precedence: missing_feature (does not support x-forwarded header)
     Test_Config_ClientTagQueryString_Configured: missing_feature (endpoints return 404, but in theory should work)
     Test_Config_ClientTagQueryString_Empty: missing_feature (incorrect default value)
     Test_Config_HttpClientErrorStatuses_Default: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1235,6 +1235,7 @@ tests/:
       Test_Mock: v0.0.99
       Test_NotReleased: missing_feature
   test_config_consistency.py:
+    Test_Config_ClientIPHeader_Configured: v1.38.0
     Test_Config_ClientTagQueryString_Configured: missing_feature (endpoints return 404, but in theory should work)
     Test_Config_ClientTagQueryString_Empty: missing_feature (incorrect default value)
     Test_Config_HttpServerErrorStatuses_Default: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -561,6 +561,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
     Test_Config_ClientIPHeader_Configured: *ref_5_15_0
+    Test_Config_ClientIPHeader_Precedence: missing_feature (all headers listed in the RFC are not supported)
     Test_Config_ClientTagQueryString_Configured: missing_feature (adding query string to http.url is not supported)
     Test_Config_ClientTagQueryString_Empty: missing_feature (removes query strings by default)
     Test_Config_HttpClientErrorStatuses_Default: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -560,7 +560,6 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: *ref_5_16_0 #actual version unknown
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
-    Test_Config_ClientIPHeader_Configured: *ref_5_15_0
     Test_Config_ClientIPHeader_Precedence: missing_feature (all headers listed in the RFC are not supported)
     Test_Config_ClientTagQueryString_Configured: missing_feature (adding query string to http.url is not supported)
     Test_Config_ClientTagQueryString_Empty: missing_feature (removes query strings by default)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -560,6 +560,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: *ref_5_16_0 #actual version unknown
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
+    Test_Config_ClientIPHeader_Configured: *ref_5_15_0
     Test_Config_ClientTagQueryString_Configured: missing_feature (adding query string to http.url is not supported)
     Test_Config_ClientTagQueryString_Empty: missing_feature (removes query strings by default)
     Test_Config_HttpServerErrorStatuses_Default: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -560,6 +560,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: *ref_5_16_0 #actual version unknown
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: irrelevant (cache is implemented)
   test_config_consistency.py:
+    Test_Config_ClientIPHeader_Configured: v5.22.0
     Test_Config_ClientIPHeader_Precedence: missing_feature (all headers listed in the RFC are not supported)
     Test_Config_ClientTagQueryString_Configured: missing_feature (adding query string to http.url is not supported)
     Test_Config_ClientTagQueryString_Empty: missing_feature (removes query strings by default)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -316,6 +316,7 @@ tests/:
     test_miscs.py:
       Test_Miscs: missing_feature
   test_config_consistency.py:
+    Test_Config_ClientIPHeader_Configured: v1.3,0
     Test_Config_ClientTagQueryString_Configured: missing_feature (supports dd_trace_http_url_query_param_allowed instead)
     Test_Config_ClientTagQueryString_Empty: v1.2.0
     Test_Config_HttpServerErrorStatuses_Default: v1.3.0 # Unknown initial version

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -316,7 +316,8 @@ tests/:
     test_miscs.py:
       Test_Miscs: missing_feature
   test_config_consistency.py:
-    Test_Config_ClientIPHeader_Configured: v1.3,0
+    Test_Config_ClientIPHeader_Configured: v1.3.0
+    Test_Config_ClientIPHeader_Precedence: missing_feature (all headers listed in the RFC are not supported)
     Test_Config_ClientTagQueryString_Configured: missing_feature (supports dd_trace_http_url_query_param_allowed instead)
     Test_Config_ClientTagQueryString_Empty: v1.2.0
     Test_Config_HttpClientErrorStatuses_Default: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -759,6 +759,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
   test_config_consistency.py:
     Test_Config_ClientIPHeader_Configured: v2.12.0
+    Test_Config_ClientIPHeader_Precedence: missing_feature (all headers listed in the RFC are not supported)
     Test_Config_ClientTagQueryString_Configured: missing_feature (supports DD_HTPP_CLIENT_TAGS_QUERY_STRING instead)
     Test_Config_ClientTagQueryString_Empty: v2.12.0
     Test_Config_HttpClientErrorStatuses_Default: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -758,6 +758,7 @@ tests/:
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: v2.8.0.dev
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
   test_config_consistency.py:
+    Test_Config_ClientIPHeader_Configured: v2.12.0
     Test_Config_ClientTagQueryString_Configured: missing_feature (supports DD_HTPP_CLIENT_TAGS_QUERY_STRING instead)
     Test_Config_ClientTagQueryString_Empty: v2.12.0
     Test_Config_HttpServerErrorStatuses_Default: missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -386,6 +386,7 @@ tests/:
     test_miscs.py:
       Test_Miscs: missing_feature
   test_config_consistency.py:
+    Test_Config_ClientIPHeader_Configured: v2.3.0
     Test_Config_ClientTagQueryString_Configured: missing_feature
     Test_Config_ClientTagQueryString_Empty: missing_feature (removes query string by default)
     Test_Config_HttpServerErrorStatuses_Default: missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -387,6 +387,7 @@ tests/:
       Test_Miscs: missing_feature
   test_config_consistency.py:
     Test_Config_ClientIPHeader_Configured: v2.3.0
+    Test_Config_ClientIPHeader_Precedence: missing_feature (all headers listed in the RFC are not supported)
     Test_Config_ClientTagQueryString_Configured: missing_feature
     Test_Config_ClientTagQueryString_Empty: missing_feature (removes query string by default)
     Test_Config_HttpClientErrorStatuses_Default: missing_feature

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -217,7 +217,7 @@ def _get_span_by_tags(spans, tags):
                 break
         else:
             return span
-        return {}
+    return {}
 
 
 @scenarios.tracing_config_nondefault

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -90,9 +90,8 @@ class Test_Config_HttpClientErrorStatuses_Default:
         interfaces.library.assert_trace_exists(self.r)
         spans = [s for _, _, s in interfaces.library.get_spans(request=self.r, full_trace=True)]
 
-        client_span = _get_span_by_tags(spans, tags={"span.kind": "client"})
-
-        assert client_span.get("meta").get("http.status_code") == "400"
+        client_span = _get_span_by_tags(spans, tags={"span.kind": "client", "http.status_code": "400"})
+        assert client_span, spans
         assert client_span.get("error") == 1
 
     def setup_status_code_500(self):
@@ -106,9 +105,8 @@ class Test_Config_HttpClientErrorStatuses_Default:
         interfaces.library.assert_trace_exists(self.r)
         spans = [s for _, _, s in interfaces.library.get_spans(request=self.r, full_trace=True)]
 
-        client_span = _get_span_by_tags(spans, tags={"span.kind": "client"})
-
-        assert client_span.get("meta").get("http.status_code") == "500"
+        client_span = _get_span_by_tags(spans, tags={"span.kind": "client", "http.status_code": "500"})
+        assert client_span, spans
         assert client_span.get("error") == None or client_span.get("error") == 0
 
 
@@ -128,9 +126,8 @@ class Test_Config_HttpClientErrorStatuses_FeatureFlagCustom:
         interfaces.library.assert_trace_exists(self.r)
         spans = [s for _, _, s in interfaces.library.get_spans(request=self.r, full_trace=True)]
 
-        client_span = _get_span_by_tags(spans, tags={"span.kind": "client"})
-
-        assert client_span.get("meta").get("http.status_code") == "200"
+        client_span = _get_span_by_tags(spans, tags={"span.kind": "client", "http.status_code": "200"})
+        assert client_span, spans
         assert client_span.get("error") == 1
 
     def setup_status_code_202(self):
@@ -144,9 +141,8 @@ class Test_Config_HttpClientErrorStatuses_FeatureFlagCustom:
         interfaces.library.assert_trace_exists(self.r)
         spans = [s for _, _, s in interfaces.library.get_spans(request=self.r, full_trace=True)]
 
-        client_span = _get_span_by_tags(spans, tags={"span.kind": "client"})
-
-        assert client_span.get("meta").get("http.status_code") == "202"
+        client_span = _get_span_by_tags(spans, tags={"span.kind": "client", "http.status_code": "202"})
+        assert client_span, spans
         assert client_span.get("error") == 1
 
 

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -108,7 +108,7 @@ class Test_Config_ClientIPHeader_Configured:
     and DD_TRACE_CLIENT_IP_HEADER=custom-ip-header"""
 
     IP_HEADERS = {
-        "custom-ip-header": "0.0.0.1",
+        "custom-ip-header": "5.6.7.8",
         "x-forwarded-for": "98.73.45.0",
         "x-real-ip": "98.73.145.1",
         "true-client-ip": "98.73.45.2",
@@ -118,29 +118,16 @@ class Test_Config_ClientIPHeader_Configured:
         "x-cluster-client-ip": "98.73.45.6",
         "fastly-client-ip": "98.73.45.7",
         "cf-connecting-ip": "98.73.45.8",
-        "cf-connecting-ipv6": "98.73.45.9",
+        "cf-connecting-ipv6": "2001:db8:3333:4444:5555:6666:7777:8888",
     }
 
-    def setup_ip_headers_sent_in_seperate_client_requests(self):
-        for header, ip in self.IP_HEADERS.items():
-            self.r = weblog.get("/make_distant_call", params={"url": "http://weblog:7777"}, headers={header: ip})
-
-    def test_ip_headers_sent_in_seperate_client_requests(self):
-        # Ensures client libraries support each of the headers in Test_Config_ClientIPHeader_Configured.IP_HEADERS
-        spans = [span for _, _, span in interfaces.library.get_spans(self.r, full_trace=True)]
-        ip_headers_found = {span["meta"]["http.client_ip"] for span in spans if "http.client_ip" in span["meta"]}
-        ip_headers = {ip for _, ip in self.IP_HEADERS}
-        assert ip_headers.issubset(
-            ip_headers_found
-        ), f"Expected {ip_headers} but found {ip_headers_found} in spans {spans}"
-
     def setup_ip_headers_sent_in_one_client_requests(self):
-        self.r = weblog.get("/make_distant_call", params={"url": "http://weblog:7777"}, headers=self.IP_HEADERS)
+        self.req2 = weblog.get("/make_distant_call", params={"url": "http://weblog:7777"}, headers=self.IP_HEADERS)
 
-    def test_ip_headers_sent_in_seperate_client_requests(self):
+    def test_ip_headers_sent_in_one_client_requests(self):
         # Ensures the header set in DD_TRACE_CLIENT_IP_HEADER takes precedence over all supported ip headers
-        trace = [span for _, _, span in interfaces.library.get_spans(self.r, full_trace=True)]
-        expected_tags = {"http.client_ip": "0.0.0.1"}
+        trace = [span for _, _, span in interfaces.library.get_spans(self.req2, full_trace=True)]
+        expected_tags = {"http.client_ip": "5.6.7.8"}
         assert _get_span_by_tags(trace, expected_tags), f"Span with tags {expected_tags} not found in {trace}"
 
 

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -444,7 +444,12 @@ class scenarios:
 
     tracing_config_nondefault = EndToEndScenario(
         "TRACING_CONFIG_NONDEFAULT",
-        weblog_env={"DD_TRACE_HTTP_SERVER_ERROR_STATUSES": "200-201,202"},
+        weblog_env={
+            "DD_TRACE_HTTP_SERVER_ERROR_STATUSES": "200-201,202",
+            "DD_TRACE_CLIENT_IP_ENABLED": "true",
+            "DD_TRACE_CLIENT_IP_HEADER": "custom-ip-header",
+            "DD_APPSEC_ENABLED": "false",
+        },
         doc="",
         scenario_groups=[ScenarioGroup.ESSENTIALS],
     )


### PR DESCRIPTION
## Description

- Introduces a test that validates that the `DD_TRACE_CLIENT_IP_HEADER` configuration is supported across client libraries
- Enables this test for the following libraries:  python, ... 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
