### PR TITLE
Another spelling fix in debugger tests

### DIFF
--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -85,7 +85,7 @@ class Test_Debugger_Probe_Statuses(base._Base_Debugger_Test):
         errors = []
         probe_map = base.get_probes_map(base.read_diagnostic_data())
 
-        assert probe_map, "Probes were not receieved"
+        assert probe_map, "Probes were not received"
 
         for expected_id, expected_status in expected_probes.items():
             error_message = _check_probe_status(expected_id, expected_status, probe_map)


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Desire for proper spelling

## Changes

Spelling fix in one message
<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
