### PR TITLE
Use a proper Content-Type header in the login events tests

### DIFF
--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -944,7 +944,7 @@ class Test_V2_Login_Events_Anon:
         "Accept-Language": "en-GB, *;q=0.5",
         "Content-Language": "en-GB",
         "Content-Length": "0",
-        "Content-Type": "text/html; charset=utf-8",
+        "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
         "Content-Encoding": "deflate, gzip",
         "Host": "127.0.0.1:1234",
         "User-Agent": "Benign User Agent 1.0",

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -945,7 +945,8 @@ class Test_V2_Login_Events_Anon:
         "Content-Language": "en-GB",
         "Content-Length": "0",
         "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
-        "Content-Encoding": "deflate, gzip",
+        # removed because the request is not using this encoding to make the request and makes the test fail
+        # "Content-Encoding": "deflate, gzip",
         "Host": "127.0.0.1:1234",
         "User-Agent": "Benign User Agent 1.0",
         "X-Forwarded-For": "42.42.42.42, 43.43.43.43",


### PR DESCRIPTION
## Motivation

Tests related to request headers in login events started to fail for the Java tracer due to a wrong `Content-Type` header.

## Changes

Use a proper form content type header in the login event requests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
