### PR TITLE
Updating Config Consistency Telemetry Test

### DIFF
--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -101,22 +101,21 @@ class Test_Consistent_Configs:
         "library_env",
         [
             {
-                # Decrease the heartbeat/poll intervals to speed up the tests
-                "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1",
-                # Multiple integrations disabled to capture compatibility across tracers
-                "DD_TRACE_GRPC_ENABLED": "false",  # applies to python, java, dotnet, ruby, node
-                "DD_TRACE_PHPREDIS_ENABLED": "false",  # applies to php only
-                "DD_TRACE_RATE_LIMIT": 100,
-                "DD_TRACE_HEADER_TAGS": "header:tag",
-                "DD_TRACE_ENABLED": "true",
-                "DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP": "^[a-zA-Z]$",
+                "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1", # Decrease the heartbeat/poll intervals to speed up the tests
+                "DD_ENV": "dev",
+                "DD_SERVICE": "service_test",
+                "DD_VERSION": "5.2.0",
+                "DD_TRACE_RATE_LIMIT": 10,
+                "DD_TRACE_HEADER_TAGS": "User-Agent:my-user-agent,Content-Type.",
+                "DD_TRACE_ENABLED": "false",
+                "DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP": "\d{3}-\d{2}-\d{4}",
                 "DD_TRACE_LOG_DIRECTORY": "/some/temporary/directory",
-                "DD_VERSION": "123",
-                "DD_HTTP_CLIENT_ERROR_STATUSES": "400",
-                "DD_HTTP_SERVER_ERROR_STATUSES": "500",
-                "DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING": "true",
-                "DD_TRACE_CLIENT_IP_HEADER": "X-Forwarded-For",
+                "DD_TRACE_CLIENT_IP_HEADER": "random-header-name",
+                "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES": "200-250",
+                "DD_TRACE_HTTP_SERVER_ERROR_STATUSES": "250-200",
+                "DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING": "false",
                 # "DD_TRACE_AGENT_URL": "some-host:some-port", # Don't want to configure this, since we need tracer <> agent connection to run these tests!
+                # "DD_TRACE_<INTEGRATION>_ENABLED": "N/A", # Skipping because it is blocked by the telemetry intake & this information is already collected through other (non-config) telemetry.
             }
         ],
     )
@@ -125,54 +124,21 @@ class Test_Consistent_Configs:
             pass
         event = test_agent.wait_for_telemetry_event("app-started", wait_loops=400)
         configuration = event["payload"]["configuration"]
-
         configuration_by_name = {item["name"]: item for item in configuration}
-        for apm_telemetry_name, value in [
-            ("trace_rate_limit", "100"),
-            ("trace_header_tags", "header:tag"),
-            ("trace_enabled", ("true", True)),
-            ("trace_obfuscation_query_string_regexp", "^[a-zA-Z]$"),
-            ("trace_log_directory", "/some/temporary/directory"),
-            ("version", "123"),
-            ("trace_http_client_error_statuses", "400"),
-            ("trace_http_server_error_statuses", "500"),
-            ("trace_http_client_tag_query_string", ("true", True)),
-            (
-                "trace_client_ip_header",
-                "X-Forwarded-For",
-            ),  # Unclear if correct key, see: https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit?disco=AAABVcOUNfU
-        ]:
-            if context.library == "cpp" and apm_telemetry_name in ("trace_header_tags"):
-                continue
-            apm_telemetry_name = _mapped_telemetry_name(context, apm_telemetry_name)
-            cfg_item = configuration_by_name.get(apm_telemetry_name)
-            assert cfg_item is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
-            if isinstance(value, tuple):
-                assert cfg_item.get("value") in value, "Unexpected value for '{}'".format(apm_telemetry_name)
-            else:
-                assert cfg_item.get("value") == value, "Unexpected value for '{}'".format(apm_telemetry_name)
-            assert cfg_item.get("origin") == "env_var", "Unexpected origin for '{}'".format(apm_telemetry_name)
 
-        # Golang and CPP do not support DD_TRACE_<INTEGRATION>_ENABLED, so don't test them for this config.
-        apm_telemetry_name = _mapped_telemetry_name(context, "trace_disabled_integrations")
-        cfg_item = configuration_by_name.get(apm_telemetry_name)
-        if (
-            context.library == "java"
-            or context.library == "dotnet"
-            or context.library == "node"
-            or context.library == "python"
-            or context.library == "ruby"
-        ):
-            assert cfg_item is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
-            assert cfg_item.get("value") is "grpc"
-        if context.library == "php":
-            assert cfg_item is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
-            assert cfg_item.get("value") is "phpredis"
-        # The trace_agent_url is a container address -- don't know the value, but we can assert its not empty (i.e, that it reports)
-        apm_telemetry_name = _mapped_telemetry_name(context, "trace_agent_url")
-        cfg_item = configuration_by_name.get(apm_telemetry_name)
-        assert cfg_item is not None, "Missing telemetry config item for '{}'".format(apm_telemetry_name)
-
+        # Check that the tags name match the expected value
+        assert configuration_by_name.get("DD_ENV").get("value") == "dev"
+        assert configuration_by_name.get("DD_SERVICE").get("value") == "service_test"
+        assert configuration_by_name.get("DD_VERSION").get("value") == "5.2.0"
+        assert configuration_by_name.get("DD_TRACE_RATE_LIMIT").get("value") == 10
+        assert configuration_by_name.get("DD_TRACE_HEADER_TAGS").get("value") == "User-Agent:my-user-agent,Content-Type."
+        assert configuration_by_name.get("DD_TRACE_ENABLED").get("value") == False
+        assert configuration_by_name.get("DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP").get("value") == "\d{3}-\d{2}-\d{4}"
+        assert configuration_by_name.get("DD_TRACE_LOG_DIRECTORY").get("value") == "/some/temporary/directory"
+        assert configuration_by_name.get("DD_TRACE_CLIENT_IP_HEADER").get("value") == "random-header-name"
+        assert configuration_by_name.get("DD_TRACE_HTTP_CLIENT_ERROR_STATUSES").get("value") == "200-250"
+        assert configuration_by_name.get("DD_TRACE_HTTP_SERVER_ERROR_STATUSES").get("value") == "250-200"
+        assert configuration_by_name.get("DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING").get("value") == False # No telemetry received, tested with Python and Java(also tried: DD_HTTP_CLIENT_TAG_QUERY_STRING)
 
 @scenarios.parametric
 @rfc("https://docs.google.com/document/d/1In4TfVBbKEztLzYg4g0si5H56uzAbYB3OfqzRGP2xhg/edit")

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -101,7 +101,7 @@ class Test_Consistent_Configs:
         "library_env",
         [
             {
-                "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1", # Decrease the heartbeat/poll intervals to speed up the tests
+                "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1",  # Decrease the heartbeat/poll intervals to speed up the tests
                 "DD_ENV": "dev",
                 "DD_SERVICE": "service_test",
                 "DD_VERSION": "5.2.0",
@@ -131,14 +131,19 @@ class Test_Consistent_Configs:
         assert configuration_by_name.get("DD_SERVICE").get("value") == "service_test"
         assert configuration_by_name.get("DD_VERSION").get("value") == "5.2.0"
         assert configuration_by_name.get("DD_TRACE_RATE_LIMIT").get("value") == 10
-        assert configuration_by_name.get("DD_TRACE_HEADER_TAGS").get("value") == "User-Agent:my-user-agent,Content-Type."
+        assert (
+            configuration_by_name.get("DD_TRACE_HEADER_TAGS").get("value") == "User-Agent:my-user-agent,Content-Type."
+        )
         assert configuration_by_name.get("DD_TRACE_ENABLED").get("value") == False
         assert configuration_by_name.get("DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP").get("value") == "\d{3}-\d{2}-\d{4}"
         assert configuration_by_name.get("DD_TRACE_LOG_DIRECTORY").get("value") == "/some/temporary/directory"
         assert configuration_by_name.get("DD_TRACE_CLIENT_IP_HEADER").get("value") == "random-header-name"
         assert configuration_by_name.get("DD_TRACE_HTTP_CLIENT_ERROR_STATUSES").get("value") == "200-250"
         assert configuration_by_name.get("DD_TRACE_HTTP_SERVER_ERROR_STATUSES").get("value") == "250-200"
-        assert configuration_by_name.get("DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING").get("value") == False # No telemetry received, tested with Python and Java(also tried: DD_HTTP_CLIENT_TAG_QUERY_STRING)
+        assert (
+            configuration_by_name.get("DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING").get("value") == False
+        )  # No telemetry received, tested with Python and Java(also tried: DD_HTTP_CLIENT_TAG_QUERY_STRING)
+
 
 @scenarios.parametric
 @rfc("https://docs.google.com/document/d/1In4TfVBbKEztLzYg4g0si5H56uzAbYB3OfqzRGP2xhg/edit")


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Noticed something not matching as expected when trying to run the test locally for .NET to test that `DD_SERVICE` was returned as expected.

## Changes

<!-- A brief description of the change being made with this pull request. -->
Instead of using existing data and helper methods, updated the test to look directly for the env var by name as expected in the telemetry based on the new consistency efforts, i.e. `DD_TRACE_HTTP_SERVER_ERROR_STATUSES` instead of `DD_HTTP_SERVER_ERROR_STATUSES` which we should change in both Env Var customers can use and returned `config name` in the respective SDK language config norm file before being able to completely pass the test.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
