### PR TITLE
[python] skip flaky tests (APMAPI-724)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,6 @@ allow_no_jira_ticket_for_bugs = [
     "tests/integrations/test_db_integrations_sql.py::Test_MsSql.test_db_name",
     "tests/integrations/test_db_integrations_sql.py::Test_MsSql.test_db_system",
     "tests/integrations/test_db_integrations_sql.py::Test_MsSql.test_db_user",
-    "tests/integrations/test_db_integrations_sql.py::Test_MySql.test_db_name",
-    "tests/integrations/test_db_integrations_sql.py::Test_MySql.test_db_user",
     "tests/integrations/test_db_integrations_sql.py::Test_Postgres.test_db_type",
     "tests/integrations/test_dbm.py::Test_Dbm.test_trace_payload_service",
     "tests/integrations/test_dsm.py::Test_DsmRabbitmq.test_dsm_rabbitmq",

--- a/tests/integrations/test_db_integrations_sql.py
+++ b/tests/integrations/test_db_integrations_sql.py
@@ -244,11 +244,11 @@ class Test_MySql(_BaseDatadogDbIntegrationTestClass):
     db_service = "mysql"
 
     @irrelevant(library="java", reason="Java is using the correct span: db.instance")
-    @bug(library="python", reason="the value of this span should be 'world' instead of  'b'world'' ")
+    @bug(context.library < "python@2.12.2", reason="APMRP-360")
     def test_db_name(self):
         super().test_db_name()
 
-    @bug(library="python", reason="the value of this span should be 'mysqldb' instead of  'b'mysqldb'' ")
+    @bug(context.library < "python@2.12.2", reason="APMRP-360")
     def test_db_user(self, excluded_operations=()):
         super().test_db_user()
 

--- a/tests/integrations/test_dbm.py
+++ b/tests/integrations/test_dbm.py
@@ -186,6 +186,10 @@ class Test_Dbm_Comment_Batch_Python_Psycopg(_Test_Dbm_Comment):
     dddbs = "system_tests_dbname"  # db name
     ddh = "postgres"  # container name
 
+    @flaky(library="python", reason="APMAPI-724")
+    def test_dbm_comment(self):
+        return super().test_dbm_comment()
+
 
 @irrelevant(condition=context.library != "python", reason="These are python only tests.")
 @features.database_monitoring_support
@@ -284,6 +288,10 @@ class Test_Dbm_Comment_Python_Pymysql(_Test_Dbm_Comment):
     dddb = "mysql_dbname"  # db name
     dddbs = "mysql_dbname"  # db name
     ddh = "mysqldb"  # container name
+
+    @flaky(library="python", reason="APMAPI-724")
+    def test_dbm_comment(self):
+        return super().test_dbm_comment()
 
 
 @irrelevant(condition=context.library != "python", reason="These are python only tests.")

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -12,7 +12,7 @@ from tests.integrations.utils import (
     delete_sns_topic,
 )
 
-from utils import weblog, interfaces, scenarios, irrelevant, context, bug, features, missing_feature
+from utils import weblog, interfaces, scenarios, irrelevant, context, bug, features, missing_feature, flaky
 from utils.tools import logger
 
 
@@ -124,6 +124,7 @@ class Test_DsmRabbitmq:
         library="dotnet",
         reason="Dotnet calculates 3168906112866048140 as producer hash by using 'routing_key:True' in edge tags, with 'True' capitalized, resulting in different hash.",
     )
+    @flaky(library="python", reason="APMAPI-724")
     def test_dsm_rabbitmq(self):
         assert self.r.text == "ok"
 


### PR DESCRIPTION
## Motivation

he probable cause is that some dsm endpoints hangs randomly hangs for more than 5s. When the scenario does not fails, those endpoints takes few ms, but I didn’t succed to figure out what’s happening

## Changes

* skip those test
* also, activate two easy wins.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
