### PR TITLE
Add static analysis rules for Java

### DIFF
--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,0 +1,6 @@
+rulesets:
+  - java-best-practices
+  - java-code-style
+  - java-security:
+    ignore:
+      - "utils/build/docker/**"

--- a/utils/scripts/compute_impacted_scenario.py
+++ b/utils/scripts/compute_impacted_scenario.py
@@ -176,6 +176,7 @@ def main():
                     r"pyproject\.toml": None,
                     r"scenario_groups\.yml": None,
                     r"shell\.nix": None,
+                    r"static-analysis\.datadog\.yml": None,
                     ## few files with lot of effect
                     r"requirements\.txt": ScenarioGroup.ALL.value,
                     r"run\.sh": ScenarioGroup.ALL.value,


### PR DESCRIPTION
## Motivation

Ignore security violations in Java test applications. These applications are meant to be vulnerable for our own testing logic, so there's no point in being warned about it.

## Changes

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
