### PR TITLE
[nodejs] Test_Config_ClientIPHeader_Configured : specify minimum supported version

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -10,6 +10,7 @@ refs:
   - &ref_3_15_0 '>=3.15.0 || ^2.28.0'
   - &ref_3_19_0 '>=3.19.0 || ^2.32.0'
   - &ref_3_21_0 '>=3.21.0 || ^2.34.0'
+  - &ref_4_0_0 '>=4.0.0 || ^3.22.0 || ^2.35.0'
   - &ref_4_1_0 '>=4.1.0 || ^3.22.0 || ^2.35.0'
   - &ref_4_3_0 '>=4.3.0 || ^3.24.0 || ^2.37.0'
   - &ref_4_4_0 '>=4.4.0 || ^3.25.0 || ^2.38.0'
@@ -566,7 +567,7 @@ tests/:
     test_stats.py:
       Test_Client_Stats: missing_feature
   test_config_consistency.py:
-    Test_Config_ClientIPHeader_Configured: v5.22.0
+    Test_Config_ClientIPHeader_Configured: *ref_4_0_0
     Test_Config_ClientIPHeader_Precedence: missing_feature (all headers listed in the RFC are not supported)
     Test_Config_ClientTagQueryString_Configured: missing_feature (adding query string to http.url is not supported)
     Test_Config_ClientTagQueryString_Empty: missing_feature (removes query strings by default)


### PR DESCRIPTION
## Motivation

- Updates the nodejs manifest file to specify minimum support version for the `http.client_ip` tag: https://github.com/DataDog/dd-trace-js/commit/989b0d3498feb652ab15e5af32be73403a4c4ccc

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
