### PR TITLE
[dotnet] Enable supported RASP features

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -115,7 +115,7 @@ tests/:
         Test_Lfi_BodyJson: v2.51.0
         Test_Lfi_BodyUrlEncoded: v2.51.0
         Test_Lfi_BodyXml: v2.51.0
-        Test_Lfi_Capability: missing_feature
+        Test_Lfi_Capability: v3.3.0
         Test_Lfi_Mandatory_SpanTags: v2.52.0
         Test_Lfi_Optional_SpanTags: v2.52.0
         Test_Lfi_RC_CustomAction: bug
@@ -126,17 +126,17 @@ tests/:
         Test_Shi_BodyJson: v3.2.0
         Test_Shi_BodyUrlEncoded: v3.2.0
         Test_Shi_BodyXml: v3.2.0
-        Test_Shi_Capability: missing_feature
+        Test_Shi_Capability: v3.3.0
         Test_Shi_Mandatory_SpanTags: v3.2.0
         Test_Shi_Optional_SpanTags: v3.2.0
         Test_Shi_StackTrace: v3.2.0
-        Test_Shi_Telemetry: missing_feature
+        Test_Shi_Telemetry: v3.3.0
         Test_Shi_UrlQuery: v3.2.0
       test_sqli.py:
         Test_Sqli_BodyJson: v2.54.0
         Test_Sqli_BodyUrlEncoded: v2.54.0
         Test_Sqli_BodyXml: v2.54.0
-        Test_Sqli_Capability: missing_feature
+        Test_Sqli_Capability: v3.3.0
         Test_Sqli_Mandatory_SpanTags: v2.54.0
         Test_Sqli_Optional_SpanTags: v2.54.0
         Test_Sqli_StackTrace: v2.54.0
@@ -146,7 +146,7 @@ tests/:
         Test_Ssrf_BodyJson: v2.51.0
         Test_Ssrf_BodyUrlEncoded: v2.51.0
         Test_Ssrf_BodyXml: v2.51.0
-        Test_Ssrf_Capability: missing_feature
+        Test_Ssrf_Capability: v3.3.0
         Test_Ssrf_Mandatory_SpanTags: v2.51.0
         Test_Ssrf_Optional_SpanTags: v2.51.0
         Test_Ssrf_StackTrace: v2.51.0


### PR DESCRIPTION
## Motivation

Enable the system tests related to RASP with features that we already support.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
