### PR TITLE
OnBoarding:Force update AMIs manually

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,8 @@ variables:
     TEST: 1
     KUBERNETES_CPU_REQUEST: "6"
     KUBERNETES_CPU_LIMIT: "6"
+    AMI_UPDATE:
+      description: "Set to true to force the update the AMIs used in the system-tests"
 
 onboarding_install_extra_vms:
   extends: .base_job_onboarding_system_tests

--- a/utils/virtual_machine/aws_provider.py
+++ b/utils/virtual_machine/aws_provider.py
@@ -164,7 +164,7 @@ class AWSPulumiProvider(VmProvider):
                 ami_name = None
 
             # But if we ser env var, created AMI again mandatory (TODO we should destroy previously existing one)
-            if os.getenv("AMI_UPDATE") is not None:
+            if os.getenv("AMI_UPDATE") is not None and os.getenv("AMI_UPDATE").casefold() == "true":
                 # TODO Pulumi is not prepared to delete resources. Workaround: Import existing ami to pulumi stack, to be deleted when destroying the stack
                 # aws.ec2.Ami( ami_existing.name,
                 #    name=ami_existing.name,


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
We need a way to force the updating of the cached AMIs of system-tests.
The cached AMIs are the AMIs that we create from EC2 instances caching some of the installation steps (configuraton, install docker, install runtime....)



## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
