### PR TITLE
OnBoarding: Higher ec2 instance types

### DIFF
--- a/utils/_context/virtual_machines.py
+++ b/utils/_context/virtual_machines.py
@@ -225,7 +225,7 @@ class Ubuntu22amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Ubuntu_22_amd64",
-            aws_config=_AWSConfig(ami_id="ami-007855ac798b5175e", ami_instance_type="t3a.medium", user="ubuntu"),
+            aws_config=_AWSConfig(ami_id="ami-007855ac798b5175e", ami_instance_type="c5ad.large", user="ubuntu"),
             vagrant_config=_VagrantConfig(box_name="bento/ubuntu-22.04"),
             krunvm_config=None,
             os_type="linux",
@@ -255,7 +255,7 @@ class Ubuntu18amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Ubuntu_18_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0263e4deb427da90e", ami_instance_type="t3a.medium", user="ubuntu"),
+            aws_config=_AWSConfig(ami_id="ami-0263e4deb427da90e", ami_instance_type="c5ad.large", user="ubuntu"),
             # vagrant_config=_VagrantConfig(box_name="generic/ubuntu1804"),
             vagrant_config=None,
             krunvm_config=None,
@@ -271,7 +271,7 @@ class AmazonLinux2amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0dfcb1ef8550277af", ami_instance_type="t3a.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0dfcb1ef8550277af", ami_instance_type="c5ad.large", user="ec2-user"),
             vagrant_config=_VagrantConfig(box_name="generic/centos7"),
             krunvm_config=None,
             os_type="linux",
@@ -286,7 +286,7 @@ class AmazonLinux2DotNet6(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2_DotNet6",
-            aws_config=_AWSConfig(ami_id="ami-005b11f8b84489615", ami_instance_type="t3a.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-005b11f8b84489615", ami_instance_type="c5ad.large", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -301,7 +301,7 @@ class AmazonLinux2023amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2023_amd64",
-            aws_config=_AWSConfig(ami_id="ami-064ed2d3fc01d3ec1", ami_instance_type="t3a.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-064ed2d3fc01d3ec1", ami_instance_type="c5ad.large", user="ec2-user"),
             vagrant_config=_VagrantConfig(box_name="generic/centos9s"),
             krunvm_config=None,
             os_type="linux",
@@ -332,7 +332,7 @@ class Centos7amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "CentOS_7_amd64",
-            aws_config=_AWSConfig(ami_id="ami-002070d43b0a4f171", ami_instance_type="t3a.medium", user="centos"),
+            aws_config=_AWSConfig(ami_id="ami-002070d43b0a4f171", ami_instance_type="c5ad.large", user="centos"),
             # vagrant_config=_VagrantConfig(box_name="generic-a64/alma9"),
             vagrant_config=None,
             krunvm_config=None,
@@ -350,7 +350,7 @@ class OracleLinux92amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_9_2_amd64",
-            aws_config=_AWSConfig(ami_id="ami-01453ca80e53609e3", ami_instance_type="t3a.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-01453ca80e53609e3", ami_instance_type="c5ad.large", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -383,7 +383,7 @@ class OracleLinux88amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_8_8_amd64",
-            aws_config=_AWSConfig(ami_id="ami-02a7419f257858fad", ami_instance_type="t3a.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-02a7419f257858fad", ami_instance_type="c5ad.large", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -416,7 +416,7 @@ class OracleLinux79amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_7_9_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0fb08d5eb039a9ebd", ami_instance_type="t3a.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0fb08d5eb039a9ebd", ami_instance_type="c5ad.large", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -434,7 +434,7 @@ class AlmaLinux8amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "AlmaLinux_8_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0825c833650fed842", ami_instance_type="t3a.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0825c833650fed842", ami_instance_type="c5ad.large", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -468,7 +468,7 @@ class AlmaLinux9amd64(_VirtualMachine):
         super().__init__(
             "AlmaLinux_9_amd64",
             aws_config=_AWSConfig(
-                ami_id="ami-0c2163c916f8dd3c8", ami_instance_type="t3a.medium", user="ec2-user"
+                ami_id="ami-0c2163c916f8dd3c8", ami_instance_type="c5ad.large", user="ec2-user"
             ),  # 9.4
             vagrant_config=None,
             krunvm_config=None,

--- a/utils/_context/virtual_machines.py
+++ b/utils/_context/virtual_machines.py
@@ -225,7 +225,7 @@ class Ubuntu22amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Ubuntu_22_amd64",
-            aws_config=_AWSConfig(ami_id="ami-007855ac798b5175e", ami_instance_type="t3.medium", user="ubuntu"),
+            aws_config=_AWSConfig(ami_id="ami-007855ac798b5175e", ami_instance_type="t4g.medium", user="ubuntu"),
             vagrant_config=_VagrantConfig(box_name="bento/ubuntu-22.04"),
             krunvm_config=None,
             os_type="linux",
@@ -255,7 +255,7 @@ class Ubuntu18amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Ubuntu_18_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0263e4deb427da90e", ami_instance_type="t3.medium", user="ubuntu"),
+            aws_config=_AWSConfig(ami_id="ami-0263e4deb427da90e", ami_instance_type="t4g.medium", user="ubuntu"),
             # vagrant_config=_VagrantConfig(box_name="generic/ubuntu1804"),
             vagrant_config=None,
             krunvm_config=None,
@@ -271,7 +271,7 @@ class AmazonLinux2amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0dfcb1ef8550277af", ami_instance_type="t3.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0dfcb1ef8550277af", ami_instance_type="t4g.medium", user="ec2-user"),
             vagrant_config=_VagrantConfig(box_name="generic/centos7"),
             krunvm_config=None,
             os_type="linux",
@@ -286,7 +286,7 @@ class AmazonLinux2DotNet6(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2_DotNet6",
-            aws_config=_AWSConfig(ami_id="ami-005b11f8b84489615", ami_instance_type="t3.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-005b11f8b84489615", ami_instance_type="t4g.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -301,7 +301,7 @@ class AmazonLinux2023amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2023_amd64",
-            aws_config=_AWSConfig(ami_id="ami-064ed2d3fc01d3ec1", ami_instance_type="t3.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-064ed2d3fc01d3ec1", ami_instance_type="t4g.medium", user="ec2-user"),
             vagrant_config=_VagrantConfig(box_name="generic/centos9s"),
             krunvm_config=None,
             os_type="linux",
@@ -332,7 +332,7 @@ class Centos7amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "CentOS_7_amd64",
-            aws_config=_AWSConfig(ami_id="ami-002070d43b0a4f171", ami_instance_type="t3.medium", user="centos"),
+            aws_config=_AWSConfig(ami_id="ami-002070d43b0a4f171", ami_instance_type="t4g.medium", user="centos"),
             # vagrant_config=_VagrantConfig(box_name="generic-a64/alma9"),
             vagrant_config=None,
             krunvm_config=None,
@@ -350,7 +350,7 @@ class OracleLinux92amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_9_2_amd64",
-            aws_config=_AWSConfig(ami_id="ami-01453ca80e53609e3", ami_instance_type="t3.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-01453ca80e53609e3", ami_instance_type="t4g.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -383,7 +383,7 @@ class OracleLinux88amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_8_8_amd64",
-            aws_config=_AWSConfig(ami_id="ami-02a7419f257858fad", ami_instance_type="t3.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-02a7419f257858fad", ami_instance_type="t4g.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -416,7 +416,7 @@ class OracleLinux79amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_7_9_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0fb08d5eb039a9ebd", ami_instance_type="t3.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0fb08d5eb039a9ebd", ami_instance_type="t4g.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -434,7 +434,7 @@ class AlmaLinux8amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "AlmaLinux_8_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0825c833650fed842", ami_instance_type="t3.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0825c833650fed842", ami_instance_type="t4g.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -468,7 +468,7 @@ class AlmaLinux9amd64(_VirtualMachine):
         super().__init__(
             "AlmaLinux_9_amd64",
             aws_config=_AWSConfig(
-                ami_id="ami-0c2163c916f8dd3c8", ami_instance_type="t3.medium", user="ec2-user"
+                ami_id="ami-0c2163c916f8dd3c8", ami_instance_type="t4g.medium", user="ec2-user"
             ),  # 9.4
             vagrant_config=None,
             krunvm_config=None,

--- a/utils/_context/virtual_machines.py
+++ b/utils/_context/virtual_machines.py
@@ -225,7 +225,7 @@ class Ubuntu22amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Ubuntu_22_amd64",
-            aws_config=_AWSConfig(ami_id="ami-007855ac798b5175e", ami_instance_type="t2.medium", user="ubuntu"),
+            aws_config=_AWSConfig(ami_id="ami-007855ac798b5175e", ami_instance_type="t3.medium", user="ubuntu"),
             vagrant_config=_VagrantConfig(box_name="bento/ubuntu-22.04"),
             krunvm_config=None,
             os_type="linux",
@@ -240,7 +240,7 @@ class Ubuntu22arm64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Ubuntu_22_arm64",
-            aws_config=_AWSConfig(ami_id="ami-016485166ec7fa705", ami_instance_type="t4g.small", user="ubuntu"),
+            aws_config=_AWSConfig(ami_id="ami-016485166ec7fa705", ami_instance_type="t4g.medium", user="ubuntu"),
             vagrant_config=_VagrantConfig(box_name="perk/ubuntu-2204-arm64",),
             krunvm_config=_KrunVmConfig(oci_image_name="docker.io/library/ubuntu_datadog:22"),
             os_type="linux",
@@ -255,7 +255,7 @@ class Ubuntu18amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Ubuntu_18_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0263e4deb427da90e", ami_instance_type="t2.medium", user="ubuntu"),
+            aws_config=_AWSConfig(ami_id="ami-0263e4deb427da90e", ami_instance_type="t3.medium", user="ubuntu"),
             # vagrant_config=_VagrantConfig(box_name="generic/ubuntu1804"),
             vagrant_config=None,
             krunvm_config=None,
@@ -271,7 +271,7 @@ class AmazonLinux2amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0dfcb1ef8550277af", ami_instance_type="t2.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0dfcb1ef8550277af", ami_instance_type="t3.medium", user="ec2-user"),
             vagrant_config=_VagrantConfig(box_name="generic/centos7"),
             krunvm_config=None,
             os_type="linux",
@@ -286,7 +286,7 @@ class AmazonLinux2DotNet6(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2_DotNet6",
-            aws_config=_AWSConfig(ami_id="ami-005b11f8b84489615", ami_instance_type="t2.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-005b11f8b84489615", ami_instance_type="t3.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -301,7 +301,7 @@ class AmazonLinux2023amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2023_amd64",
-            aws_config=_AWSConfig(ami_id="ami-064ed2d3fc01d3ec1", ami_instance_type="t2.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-064ed2d3fc01d3ec1", ami_instance_type="t3.medium", user="ec2-user"),
             vagrant_config=_VagrantConfig(box_name="generic/centos9s"),
             krunvm_config=None,
             os_type="linux",
@@ -316,7 +316,7 @@ class AmazonLinux2023arm64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2023_arm64",
-            aws_config=_AWSConfig(ami_id="ami-0a515c154e76934f7", ami_instance_type="t4g.small", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0a515c154e76934f7", ami_instance_type="t4g.medium", user="ec2-user"),
             # vagrant_config=_VagrantConfig(box_name="generic-a64/alma9"),
             vagrant_config=None,
             krunvm_config=_KrunVmConfig(oci_image_name="docker.io/library/amazonlinux_datadog:2023"),
@@ -332,7 +332,7 @@ class Centos7amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "CentOS_7_amd64",
-            aws_config=_AWSConfig(ami_id="ami-002070d43b0a4f171", ami_instance_type="t2.medium", user="centos"),
+            aws_config=_AWSConfig(ami_id="ami-002070d43b0a4f171", ami_instance_type="t3.medium", user="centos"),
             # vagrant_config=_VagrantConfig(box_name="generic-a64/alma9"),
             vagrant_config=None,
             krunvm_config=None,
@@ -350,7 +350,7 @@ class OracleLinux92amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_9_2_amd64",
-            aws_config=_AWSConfig(ami_id="ami-01453ca80e53609e3", ami_instance_type="t2.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-01453ca80e53609e3", ami_instance_type="t3.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -366,7 +366,7 @@ class OracleLinux92arm64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_9_2_arm64",
-            aws_config=_AWSConfig(ami_id="ami-0d1bcd0124ba74024", ami_instance_type="t4g.small", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0d1bcd0124ba74024", ami_instance_type="t4g.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -383,7 +383,7 @@ class OracleLinux88amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_8_8_amd64",
-            aws_config=_AWSConfig(ami_id="ami-02a7419f257858fad", ami_instance_type="t2.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-02a7419f257858fad", ami_instance_type="t3.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -399,7 +399,7 @@ class OracleLinux88arm64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_8_8_arm64",
-            aws_config=_AWSConfig(ami_id="ami-0463a0d7ecd42cc89", ami_instance_type="t4g.small", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0463a0d7ecd42cc89", ami_instance_type="t4g.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -416,7 +416,7 @@ class OracleLinux79amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_7_9_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0fb08d5eb039a9ebd", ami_instance_type="t2.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0fb08d5eb039a9ebd", ami_instance_type="t3.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -434,7 +434,7 @@ class AlmaLinux8amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "AlmaLinux_8_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0825c833650fed842", ami_instance_type="t2.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0825c833650fed842", ami_instance_type="t3.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -450,7 +450,7 @@ class AlmaLinux8arm64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "AlmaLinux_8_arm64",
-            aws_config=_AWSConfig(ami_id="ami-0f1d97cfa7cf5ad5d", ami_instance_type="t4g.small", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0f1d97cfa7cf5ad5d", ami_instance_type="t4g.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -468,7 +468,7 @@ class AlmaLinux9amd64(_VirtualMachine):
         super().__init__(
             "AlmaLinux_9_amd64",
             aws_config=_AWSConfig(
-                ami_id="ami-0c2163c916f8dd3c8", ami_instance_type="t2.medium", user="ec2-user"
+                ami_id="ami-0c2163c916f8dd3c8", ami_instance_type="t3.medium", user="ec2-user"
             ),  # 9.4
             vagrant_config=None,
             krunvm_config=None,
@@ -485,7 +485,7 @@ class AlmaLinux9arm64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "AlmaLinux_9_arm64",
-            aws_config=_AWSConfig(ami_id="ami-0ba8fa4bea636d73f", ami_instance_type="t4g.small", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0ba8fa4bea636d73f", ami_instance_type="t4g.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",

--- a/utils/_context/virtual_machines.py
+++ b/utils/_context/virtual_machines.py
@@ -225,7 +225,7 @@ class Ubuntu22amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Ubuntu_22_amd64",
-            aws_config=_AWSConfig(ami_id="ami-007855ac798b5175e", ami_instance_type="t4g.medium", user="ubuntu"),
+            aws_config=_AWSConfig(ami_id="ami-007855ac798b5175e", ami_instance_type="t3a.medium", user="ubuntu"),
             vagrant_config=_VagrantConfig(box_name="bento/ubuntu-22.04"),
             krunvm_config=None,
             os_type="linux",
@@ -255,7 +255,7 @@ class Ubuntu18amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Ubuntu_18_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0263e4deb427da90e", ami_instance_type="t4g.medium", user="ubuntu"),
+            aws_config=_AWSConfig(ami_id="ami-0263e4deb427da90e", ami_instance_type="t3a.medium", user="ubuntu"),
             # vagrant_config=_VagrantConfig(box_name="generic/ubuntu1804"),
             vagrant_config=None,
             krunvm_config=None,
@@ -271,7 +271,7 @@ class AmazonLinux2amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0dfcb1ef8550277af", ami_instance_type="t4g.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0dfcb1ef8550277af", ami_instance_type="t3a.medium", user="ec2-user"),
             vagrant_config=_VagrantConfig(box_name="generic/centos7"),
             krunvm_config=None,
             os_type="linux",
@@ -286,7 +286,7 @@ class AmazonLinux2DotNet6(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2_DotNet6",
-            aws_config=_AWSConfig(ami_id="ami-005b11f8b84489615", ami_instance_type="t4g.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-005b11f8b84489615", ami_instance_type="t3a.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -301,7 +301,7 @@ class AmazonLinux2023amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "Amazon_Linux_2023_amd64",
-            aws_config=_AWSConfig(ami_id="ami-064ed2d3fc01d3ec1", ami_instance_type="t4g.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-064ed2d3fc01d3ec1", ami_instance_type="t3a.medium", user="ec2-user"),
             vagrant_config=_VagrantConfig(box_name="generic/centos9s"),
             krunvm_config=None,
             os_type="linux",
@@ -332,7 +332,7 @@ class Centos7amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "CentOS_7_amd64",
-            aws_config=_AWSConfig(ami_id="ami-002070d43b0a4f171", ami_instance_type="t4g.medium", user="centos"),
+            aws_config=_AWSConfig(ami_id="ami-002070d43b0a4f171", ami_instance_type="t3a.medium", user="centos"),
             # vagrant_config=_VagrantConfig(box_name="generic-a64/alma9"),
             vagrant_config=None,
             krunvm_config=None,
@@ -350,7 +350,7 @@ class OracleLinux92amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_9_2_amd64",
-            aws_config=_AWSConfig(ami_id="ami-01453ca80e53609e3", ami_instance_type="t4g.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-01453ca80e53609e3", ami_instance_type="t3a.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -383,7 +383,7 @@ class OracleLinux88amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_8_8_amd64",
-            aws_config=_AWSConfig(ami_id="ami-02a7419f257858fad", ami_instance_type="t4g.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-02a7419f257858fad", ami_instance_type="t3a.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -416,7 +416,7 @@ class OracleLinux79amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "OracleLinux_7_9_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0fb08d5eb039a9ebd", ami_instance_type="t4g.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0fb08d5eb039a9ebd", ami_instance_type="t3a.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -434,7 +434,7 @@ class AlmaLinux8amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(
             "AlmaLinux_8_amd64",
-            aws_config=_AWSConfig(ami_id="ami-0825c833650fed842", ami_instance_type="t4g.medium", user="ec2-user"),
+            aws_config=_AWSConfig(ami_id="ami-0825c833650fed842", ami_instance_type="t3a.medium", user="ec2-user"),
             vagrant_config=None,
             krunvm_config=None,
             os_type="linux",
@@ -468,7 +468,7 @@ class AlmaLinux9amd64(_VirtualMachine):
         super().__init__(
             "AlmaLinux_9_amd64",
             aws_config=_AWSConfig(
-                ami_id="ami-0c2163c916f8dd3c8", ami_instance_type="t4g.medium", user="ec2-user"
+                ami_id="ami-0c2163c916f8dd3c8", ami_instance_type="t3a.medium", user="ec2-user"
             ),  # 9.4
             vagrant_config=None,
             krunvm_config=None,

--- a/utils/build/docker/php/php-fpm-8.2.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.2.Dockerfile
@@ -10,6 +10,10 @@ ENV DD_TRACE_GENERATE_ROOT_SPAN=1
 ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
 ENV DD_TRACE_HEADER_TAGS=user-agent
 
+# Fix 'Error: retrieving gpg key timed out'
+RUN apt update && apt install -y gpg
+RUN gpg --keyserver hkp://keyserver.ubuntu.com:80 --refresh-keys
+
 RUN chmod +x /tmp/php/php-fpm/build.sh
 RUN /tmp/php/php-fpm/build.sh $PHP_VERSION
 RUN rm -rf /tmp/php/


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Check if the system-tests onboarding can run faster increasing the ec2 instances capabilities. 
We change the instance types:

- arm:
t2,medium --> t3.medium
- amd 
t4g.small --> t4g.medium
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
