### PR TITLE
OnBoarding: add ubuntu24

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ onboarding_install_extra_vms:
           TEST_LIBRARY: "php"
   script:
       - ./build.sh -i runner
-      - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env ${ONBOARDING_FILTER_ENV} --vm-library ${TEST_LIBRARY} --vm-provider aws --vm-default-vms False
+      - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env ${ONBOARDING_FILTER_ENV} --vm-library ${TEST_LIBRARY} --vm-provider aws --vm-default-vms False --vm-only-branch ubuntu24
 
 onboarding_nodejs:
   extends: .base_job_onboarding_system_tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ onboarding_install_extra_vms:
           TEST_LIBRARY: "php"
   script:
       - ./build.sh -i runner
-      - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env ${ONBOARDING_FILTER_ENV} --vm-library ${TEST_LIBRARY} --vm-provider aws --vm-default-vms False --vm-only-branch ubuntu24
+      - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env ${ONBOARDING_FILTER_ENV} --vm-library ${TEST_LIBRARY} --vm-provider aws --vm-default-vms False
 
 onboarding_nodejs:
   extends: .base_job_onboarding_system_tests

--- a/utils/_context/_scenarios/auto_injection.py
+++ b/utils/_context/_scenarios/auto_injection.py
@@ -7,6 +7,8 @@ from utils.tools import logger
 from utils._context.virtual_machines import (
     Ubuntu22amd64,
     Ubuntu22arm64,
+    Ubuntu24amd64,
+    Ubuntu24arm64,
     Ubuntu18amd64,
     AmazonLinux2023arm64,
     AmazonLinux2023amd64,
@@ -38,6 +40,8 @@ class _VirtualMachineScenario(Scenario):
         vm_provision=None,
         include_ubuntu_22_amd64=False,
         include_ubuntu_22_arm64=False,
+        include_ubuntu_24_amd64=False,
+        include_ubuntu_24_arm64=False,
         include_ubuntu_18_amd64=False,
         include_amazon_linux_2_amd64=False,
         include_amazon_linux_2_dotnet_6=False,
@@ -73,6 +77,10 @@ class _VirtualMachineScenario(Scenario):
             self.required_vms.append(Ubuntu22amd64())
         if include_ubuntu_22_arm64:
             self.required_vms.append(Ubuntu22arm64())
+        if include_ubuntu_24_amd64:
+            self.required_vms.append(Ubuntu24amd64())
+        if include_ubuntu_24_arm64:
+            self.required_vms.append(Ubuntu24arm64())
         if include_ubuntu_18_amd64:
             self.required_vms.append(Ubuntu18amd64())
         if include_amazon_linux_2_amd64:
@@ -225,6 +233,8 @@ class InstallerAutoInjectionScenario(_VirtualMachineScenario):
             github_workflow=None,
             include_ubuntu_22_amd64=True,
             include_ubuntu_22_arm64=True,
+            include_ubuntu_24_amd64=True,
+            include_ubuntu_24_arm64=True,
             include_ubuntu_18_amd64=True,
             include_amazon_linux_2_amd64=True,
             include_amazon_linux_2_dotnet_6=True,

--- a/utils/_context/virtual_machines.py
+++ b/utils/_context/virtual_machines.py
@@ -495,3 +495,35 @@ class AlmaLinux9arm64(_VirtualMachine):
             default_vm=False,
             **kwargs,
         )
+
+
+class Ubuntu24amd64(_VirtualMachine):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(
+            "Ubuntu_24_amd64",
+            aws_config=_AWSConfig(ami_id="ami-0e86e20dae9224db8", ami_instance_type="t2.medium", user="ubuntu"),
+            vagrant_config=None,
+            krunvm_config=None,
+            os_type="linux",
+            os_distro="deb",
+            os_branch="ubuntu24",
+            os_cpu="amd64",
+            default_vm=False,
+            **kwargs,
+        )
+
+
+class Ubuntu24arm64(_VirtualMachine):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(
+            "Ubuntu_24_arm64",
+            aws_config=_AWSConfig(ami_id="ami-0e879a1b306fffb22", ami_instance_type="t4g.small", user="ubuntu"),
+            vagrant_config=None,
+            krunvm_config=None,
+            os_type="linux",
+            os_distro="deb",
+            os_branch="ubuntu24",
+            os_cpu="arm64",
+            default_vm=False,
+            **kwargs,
+        )

--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject_init_vm_config.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject_init_vm_config.yml
@@ -44,7 +44,7 @@
 
     #Allow DD env variables from ssh
     echo 'AcceptEnv DD_*' | sudo tee -a /etc/ssh/sshd_config
-    sudo systemctl restart sshd.service || true
+    sudo systemctl restart sshd.service || sudo systemctl restart ssh.service || true
     echo "DONE"
 - os_type: linux
   os_distro: rpm

--- a/utils/build/virtual_machine/weblogs/dotnet/provision_test-app-dotnet.yml
+++ b/utils/build/virtual_machine/weblogs/dotnet/provision_test-app-dotnet.yml
@@ -16,7 +16,7 @@ weblog:
     name: test-app-dotnet
     #ubuntu 22 arm excluded due to "dotnet-runtime-6.0 : Depends: liblttng-ust1 (>= 2.13.0) but it is not installable"
     #amazon_linux2_dotnet6 excluded due to https://datadoghq.atlassian.net/browse/AIT-10335
-    excluded_os_branches: [ubuntu22_amd64, ubuntu22_arm64, ubuntu18_amd64, amazon_linux2_amd64, amazon_linux2_dotnet6, centos_7_amd64]
+    excluded_os_branches: [ubuntu22_amd64, ubuntu22_arm64, ubuntu18_amd64, amazon_linux2_amd64, amazon_linux2_dotnet6, centos_7_amd64, ubuntu24]
     excluded_os_names: [OracleLinux_7_9_amd64]
     install: 
       - os_type: linux

--- a/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby.yml
+++ b/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby.yml
@@ -27,7 +27,7 @@ weblog:
     name: test-app-ruby
     # centos_7_amd64 is excluded because it does not provides the right Ruby versions
     # TODO oracle_linux and alma_linux. Failed when we run the app. Related with how we install Ruby
-    excluded_os_branches: [amazon_linux2_dotnet6, ubuntu18_amd64, amazon_linux2_amd64, centos_7_amd64, oracle_linux, alma_linux]
+    excluded_os_branches: [amazon_linux2_dotnet6, ubuntu18_amd64, amazon_linux2_amd64, centos_7_amd64, oracle_linux, alma_linux, ubuntu24]
     install:
       - os_type: linux
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Add ubuntu 24 machines to onboarding tests
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
