### PR TITLE
Fix crashtracking tests

### DIFF
--- a/tests/parametric/test_crashtracking.py
+++ b/tests/parametric/test_crashtracking.py
@@ -25,7 +25,6 @@ class Test_Crashtracking:
     @missing_feature(context.library == "nodejs", reason="Not implemented")
     @missing_feature(context.library == "php", reason="APMSP-1370")
     @missing_feature(context.library == "cpp", reason="Not implemented")
-    @bug(context.library >= "dotnet@3.4.0", reason="APMAPI-727")
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "false"}])
     def test_disable_crashtracking(self, test_agent, test_library):
         test_library.crash()
@@ -39,10 +38,14 @@ class Test_Crashtracking:
                 assert self.is_crash_report(test_library, event) is False
 
     def is_crash_report(self, test_library, event) -> bool:
-        assert isinstance(event["payload"], list)
-        assert len(event["payload"]) > 0
-        assert isinstance(event["payload"][0], dict)
-        assert "tags" in event["payload"][0]
+        if not isinstance(event.get("payload"), list):
+            return False
+        if not event["payload"]:
+            return False
+        if not isinstance(event["payload"][0], dict):
+            return False
+        if "tags" not in event["payload"][0]:
+            return False
 
         tags = event["payload"][0]["tags"]
         print("tags: ", tags)


### PR DESCRIPTION
## Motivation

`is_crash_report` doesn't behave correctly when it receives telemetry logs that are not a crash report.

## Changes

Assertions were added in https://github.com/DataDog/system-tests/pull/3080. Instead, the `is_crash_report` function should just return false.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
