### PR TITLE
Change RateLimit test to assert value of 1 for sampling priority

### DIFF
--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -194,5 +194,5 @@ class Test_Config_RateLimit:
         traces = test_agent.wait_for_num_traces(2)
         trace_0_sampling_priority = traces[0][0]["metrics"]["_sampling_priority_v1"]
         trace_1_sampling_priority = traces[1][0]["metrics"]["_sampling_priority_v1"]
-        assert trace_0_sampling_priority == 2
-        assert trace_1_sampling_priority == 2
+        assert trace_0_sampling_priority == 1
+        assert trace_1_sampling_priority == 1


### PR DESCRIPTION
## Motivation
The `test_trace_rate_limit_without_trace_sample_rate` tests that rules sampling is not applied when just DD_TRACE_RATE_LIMIT is set without any sampling rules, however, the test was previously looking for a value of `2` on the spans' `_sampling_priority_v1` tag, which was incorrect because `2` represents a form of "user keep."

## Changes
Change assert statements to expect value of `1` on spans' `_sampling_priority_v1` tag.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
