### PR TITLE
Fix appsec rate limiter test setup

### DIFF
--- a/tests/appsec/test_rate_limiter.py
+++ b/tests/appsec/test_rate_limiter.py
@@ -44,7 +44,6 @@ class Test_Main:
         context.library > "nodejs@3.14.1" and context.library < "nodejs@4.8.0",
         reason="_sampling_priority_v1 is missing",
     )
-    @flaky("rails" in context.weblog_variant, reason="APPSEC-10303")
     def test_main(self):
         """send requests for 10 seconds, check that only 10-ish traces are sent, as rate limiter is set to 1/s"""
 

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -238,7 +238,7 @@ class scenarios:
     )
     appsec_rate_limiter = EndToEndScenario(
         "APPSEC_RATE_LIMITER",
-        weblog_env={"DD_APPSEC_TRACE_RATE_LIMIT": "1"},
+        weblog_env={"DD_APPSEC_TRACE_RATE_LIMIT": "1", "RAILS_MAX_THREADS": "1"},
         doc="Tests with a low rate trace limit for Appsec",
         scenario_groups=[ScenarioGroup.APPSEC],
     )


### PR DESCRIPTION
Resolves APPSEC-10303

## Motivation

We have sub-optimal test setup for AppSec rate limiter E2E test which passed just by accident. With **5 threads** we can't guarantee that 4/5 requests will be filtered because the rate limiter is **per thread**

## Changes

Puma threads reduced to 1. It allows us to see if the setup broken or it can handle sequential 5 requests within 1 second. With a single thread rate limiter should filter 4/5 requests.

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
