### PR TITLE
[APMAPM-474] Adding tracerConfig support for `dd_trace_agent_url`

### DIFF
--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
@@ -51,6 +51,7 @@ public class TraceController {
         Method getTracePropagationStylesToInject = configClass.getMethod("getTracePropagationStylesToInject");
         Method isDebugEnabled = configClass.getMethod("isDebugEnabled");
         Method getLogLevel = configClass.getMethod("getLogLevel");
+        Method getAgentUrl = configClass.getMethod("getAgentUrl");
 
         Method isTraceOtelEnabled = instrumenterConfigClass.getMethod("isTraceOtelEnabled");
 
@@ -63,6 +64,7 @@ public class TraceController {
         configMap.put("dd_runtime_metrics_enabled", isRuntimeMetricsEnabled.invoke(configObject).toString());
         configMap.put("dd_trace_debug", isDebugEnabled.invoke(configObject).toString());
         configMap.put("dd_trace_otel_enabled", isTraceOtelEnabled.invoke(instrumenterConfigObject).toString());
+        configMap.put("dd_trace_agent_url", getAgentUrl.invoke(configObject).toString());
         // configMap.put("dd_trace_sample_ignore_parent", Config.get());
 
         Object sampleRate = getTraceSampleRate.invoke(configObject);


### PR DESCRIPTION
## Motivation
The parametric app for Java currently does not support the key `dd_trace_agent_url` as a key in the return value for the endpoint `/trace/config/`. This is a key that is necessary in order to properly test the [`DD_TRACE_AGENT_URL`](https://datadoghq.atlassian.net/browse/APMAPI-474) configuration as part of the configuration consistency effort. 
<!-- What inspired you to submit this pull request? -->
## Changes
Added support for `dd_trace_agent_url` by using the Config::getAgentUrl method and returning it as part of the response to the client-side.
[APMAPI-474](https://datadoghq.atlassian.net/browse/APMAPI-474)
<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-474]: https://datadoghq.atlassian.net/browse/APMAPI-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ