### PR TITLE
Ruby:Update docs for 2.0 gem rename

### DIFF
--- a/docs/execute/binaries.md
+++ b/docs/execute/binaries.md
@@ -54,7 +54,7 @@ But, obviously, testing validated versions of components is not really interesti
 ## Ruby library
 
 * Create an file `ruby-load-from-bundle-add` in `binaries/`, the content will be installed by `bundle add`. Content example:
-  * `gem 'ddtrace', git: "https://github.com/Datadog/dd-trace-rb", branch: "master", require: 'ddtrace/auto_instrument'`
+  * `gem 'datadog', git: "https://github.com/Datadog/dd-trace-rb", branch: "master", require: 'datadog/auto_instrument'`
 2. Clone the dd-trace-rb repo inside `binaries`
 
 ## WAF rule set

--- a/docs/scenarios/parametric.md
+++ b/docs/scenarios/parametric.md
@@ -191,7 +191,7 @@ There is three ways for running the NodeJS tests with a custom tracer:
 There is two ways for running the Ruby tests with a custom tracer:
 
 1. Create an file ruby-load-from-bundle-add in binaries/, the content will be installed by bundle add. Content example:
-gem 'ddtrace', git: "https://github.com/Datadog/dd-trace-rb", branch: "master", require: 'ddtrace/auto_instrument'
+gem 'datadog', git: "https://github.com/Datadog/dd-trace-rb", branch: "master", require: 'datadog/auto_instrument'
 2. Clone the dd-trace-rb repo inside binaries
 
 #### C++


### PR DESCRIPTION
Since the Ruby Tracer gem has been [renamed from `ddtrace` to `datadog`](https://github.com/DataDog/dd-trace-rb/pull/3490), the testing documentation has become stale, recommending uses to point system-tests to an invalid gem name.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
