### PR TITLE
Add tests to long cookie name vulnerabilities

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -175,6 +175,22 @@ must set the appropriate tag in the span to `tainted_value` and return a respons
 
 The goal is to be able to easily test if a request was blocked before reaching the server code or after by looking at the span and also test security rules on reponse status code or response header content.
 
+### GET /iast/insecure-cookie/test_secure
+
+This endpoint should set at least one cookie with all security flags (Secure, HttpOnly, SameSite=Strict) to prevent any vulnerabilities from being detected.
+
+### GET /iast/insecure-cookie/test_insecure
+
+This endpoint should set a cookie with all security flags except Secure, to detect only the INSECURE_COOKIE vulnerability.
+
+### POST /iast/insecure-cookie/custom_cookie
+
+This endpoint should set a cookie with the name and value coming from the request body (using the cookieName and cookieValue properties), with all security flags except Secure, to detect only the INSECURE_COOKIE vulnerability.
+
+### GET /iast/insecure-cookie/test_empty_cookie
+
+This endpoint should set a cookie with empty cookie value without Secure flag, INSECURE_COOKIE vulnerability shouldn't be detected.
+
 ### GET /iast/insecure_hashing/deduplicate
 
 Parameterless endpoint. This endpoint contains a vulnerable souce code line (weak hash) in a loop with at least two iterations.
@@ -196,6 +212,38 @@ The endpoint executes a unique operation of String hashing with unsecure MD5 alg
 ### GET /iast/hardcoded_secrets/test_insecure
 
 Parameterless endpoint. This endpoint contains a hardcoded secret. The declaration of the hardcoded secret should be sufficient to trigger the vulnerability, so returning it in the response is optional.
+
+### GET /iast/no-httponly-cookie/test_secure
+
+This endpoint should set at least one cookie with all security flags (Secure, HttpOnly, SameSite=Strict) to prevent any vulnerabilities from being detected.
+
+### GET /iast/no-httponly-cookie/test_insecure
+
+This endpoint should set a cookie with all security flags except HttpOnly, to detect only the NO_HTTPONLY_COOKIE vulnerability.
+
+### GET /iast/no-httponly-cookie/test_empty_cookie
+
+This endpoint should set a cookie with empty cookie value without HttpOnly flag, NO_HTTPONLY_COOKIE vulnerability shouldn't be detected.
+
+### POST /iast/no-httponly-cookie/custom_cookie
+
+This endpoint should set a cookie with the name and value coming from the request body (using the cookieName and cookieValue properties), with all security flags except HttpOnly, to detect only the NO_HTTPONLY_COOKIE vulnerability.
+
+### GET /iast/no-samesite-cookie/test_secure
+
+This endpoint should set at least one cookie with all security flags (Secure, HttpOnly, SameSite=Strict) to prevent any vulnerabilities from being detected.
+
+### GET /iast/no-samesite-cookie/test_insecure
+
+This endpoint should set a cookie with all security flags except SameSite=Strict, to detect only the NO_SAMESITE_COOKIE vulnerability.
+
+### GET /iast/no-samesite-cookie/test_empty_cookie
+
+This endpoint should set a cookie with empty cookie value without SameSite=Strict flag, NO_SAMESITE_COOKIE vulnerability shouldn't be detected.
+
+### POST /iast/no-samesite-cookie/custom_cookie
+
+This endpoint should set a cookie with the name and value coming from the request body (using the cookieName and cookieValue properties), with all security flags except SameSite=Strict, to detect only the NO_SAMESITE_COOKIE vulnerability.
 
 ### \[GET, POST\] /iast/source/*
 

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -42,12 +42,15 @@ tests/:
           Test_InsecureAuthProtocol: v2.49.0
         test_insecure_cookie.py:
           TestInsecureCookie: v2.39.0
+          TestInsecureCookieNameFilter: missing_feature
         test_ldap_injection.py:
           TestLDAPInjection: v2.36.0
         test_no_httponly_cookie.py:
           TestNoHttponlyCookie: v2.39.0
+          TestNoHttponlyCookieNameFilter: missing_feature
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie: v2.39.0
+          TestNoSamesiteCookieNameFilter: missing_feature
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection: v2.47.0
         test_path_traversal.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -51,12 +51,15 @@ tests/:
           Test_InsecureAuthProtocol: missing_feature
         test_insecure_cookie.py:
           TestInsecureCookie: missing_feature
+          TestInsecureCookieNameFilter: missing_feature
         test_ldap_injection.py:
           TestLDAPInjection: missing_feature
         test_no_httponly_cookie.py:
           TestNoHttponlyCookie: missing_feature
+          TestNoHttponlyCookieNameFilter: missing_feature
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie: missing_feature
+          TestNoSamesiteCookieNameFilter: missing_feature
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection: missing_feature
         test_path_traversal.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -116,6 +116,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             spring-boot-3-native: missing_feature
+          TestInsecureCookieNameFilter: missing_feature
         test_ldap_injection.py:
           TestLDAPInjection:
             '*': v1.3.0
@@ -134,6 +135,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             spring-boot-3-native: missing_feature
+          TestNoHttponlyCookieNameFilter: missing_feature
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie:
             '*': v1.18.0
@@ -141,6 +143,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             spring-boot-3-native: missing_feature
+          TestNoSamesiteCookieNameFilter: missing_feature
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection: missing_feature
         test_path_traversal.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -102,6 +102,7 @@ tests/:
           TestInsecureCookie:
             '*': *ref_4_1_0
             nextjs: missing_feature
+          TestInsecureCookieNameFilter: missing_feature
         test_ldap_injection.py:
           TestLDAPInjection:
             '*': *ref_4_1_0
@@ -110,10 +111,12 @@ tests/:
           TestNoHttponlyCookie:
             '*': *ref_4_3_0
             nextjs: missing_feature
+          TestNoHttponlyCookieNameFilter: missing_feature
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie:
             '*': *ref_4_3_0
             nextjs: missing_feature
+          TestNoSamesiteCookieNameFilter: missing_feature
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection:
             '*': *ref_4_17_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -42,12 +42,15 @@ tests/:
           Test_InsecureAuthProtocol: missing_feature
         test_insecure_cookie.py:
           TestInsecureCookie: missing_feature
+          TestInsecureCookieNameFilter: missing_feature
         test_ldap_injection.py:
           TestLDAPInjection: missing_feature
         test_no_httponly_cookie.py:
           TestNoHttponlyCookie: missing_feature
+          TestNoHttponlyCookieNameFilter: missing_feature
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie: missing_feature
+          TestNoSamesiteCookieNameFilter: missing_feature
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection: missing_feature
         test_path_traversal.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -82,16 +82,19 @@ tests/:
           TestInsecureCookie:
             '*': v1.19.0
             fastapi: missing_feature
+          TestInsecureCookieNameFilter: missing_feature
         test_ldap_injection.py:
           TestLDAPInjection: missing_feature
         test_no_httponly_cookie.py:
           TestNoHttponlyCookie:
             '*': v1.19.0
             fastapi: missing_feature
+          TestNoHttponlyCookieNameFilter: missing_feature
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie:
             '*': v1.19.0
             fastapi: missing_feature
+          TestNoSamesiteCookieNameFilter: missing_feature
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection: missing_feature
         test_path_traversal.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -44,12 +44,15 @@ tests/:
           Test_InsecureAuthProtocol: missing_feature
         test_insecure_cookie.py:
           TestInsecureCookie: missing_feature
+          TestInsecureCookieNameFilter: missing_feature
         test_ldap_injection.py:
           TestLDAPInjection: missing_feature
         test_no_httponly_cookie.py:
           TestNoHttponlyCookie: missing_feature
+          TestNoHttponlyCookieNameFilter: missing_feature
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie: missing_feature
+          TestNoSamesiteCookieNameFilter: missing_feature
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection: missing_feature
         test_path_traversal.py:

--- a/tests/appsec/iast/sink/test_insecure_cookie.py
+++ b/tests/appsec/iast/sink/test_insecure_cookie.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 from utils import context, missing_feature, bug, weblog, features
-from ..utils import BaseSinkTest
+from ..utils import BaseSinkTest, BaseTestCookieNameFilter
 
 
 @features.iast_sink_insecure_cookie
@@ -37,3 +37,11 @@ class TestInsecureCookie(BaseSinkTest):
     @missing_feature(weblog_variant="vertx4", reason="Metrics not implemented")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
+
+
+@features.iast_sink_insecure_cookie
+class TestInsecureCookieNameFilter(BaseTestCookieNameFilter):
+    """Test no SameSite cookie name filter."""
+
+    vulnerability_type = "INSECURE_COOKIE"
+    endpoint = "/iast/insecure-cookie/custom_cookie"

--- a/tests/appsec/iast/sink/test_no_httponly_cookie.py
+++ b/tests/appsec/iast/sink/test_no_httponly_cookie.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 from utils import context, missing_feature, bug, weblog, features
-from ..utils import BaseSinkTest
+from ..utils import BaseSinkTest, BaseSinkTestWithoutTelemetry, BaseTestCookieNameFilter
 
 
 @features.iast_sink_http_only_cookie
@@ -37,3 +37,11 @@ class TestNoHttponlyCookie(BaseSinkTest):
     @missing_feature(weblog_variant="vertx4", reason="Metric not implemented")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
+
+
+@features.iast_sink_http_only_cookie
+class TestNoHttponlyCookieNameFilter(BaseTestCookieNameFilter):
+    """Test no HttpOnly cookie name filter."""
+
+    vulnerability_type = "NO_HTTPONLY_COOKIE"
+    endpoint = "/iast/no-httponly-cookie/custom_cookie"

--- a/tests/appsec/iast/sink/test_no_samesite_cookie.py
+++ b/tests/appsec/iast/sink/test_no_samesite_cookie.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 from utils import context, missing_feature, bug, weblog, features
-from ..utils import BaseSinkTest
+from ..utils import BaseSinkTest, BaseTestCookieNameFilter
 
 
 @features.iast_sink_samesite_cookie
@@ -37,3 +37,11 @@ class TestNoSamesiteCookie(BaseSinkTest):
     @missing_feature(weblog_variant="vertx4", reason="Metrics not implemented")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
+
+
+@features.iast_sink_samesite_cookie
+class TestNoSamesiteCookieNameFilter(BaseTestCookieNameFilter):
+    """Test no SameSite cookie name filter."""
+
+    vulnerability_type = "NO_SAMESITE_COOKIE"
+    endpoint = "/iast/no-samesite-cookie/custom_cookie"

--- a/tests/appsec/iast/utils.py
+++ b/tests/appsec/iast/utils.py
@@ -373,3 +373,24 @@ class BaseSourceTest:
             assert len(s["points"]) == 1
             p = s["points"][0]
             assert p[1] >= 1
+
+
+class BaseTestCookieNameFilter:
+    vulnerability_type = None
+    endpoint = None
+
+    def setup_cookie_name_filter(self):
+        prefix = "0" * 36
+        cookieName1 = prefix + "name1"
+        cookieName2 = "name2"
+        cookieName3 = prefix + "name3"
+        self.req1 = weblog.post(self.endpoint, data={"cookieName": cookieName1, "cookieValue": "value1"})
+        self.req2 = weblog.post(self.endpoint, data={"cookieName": cookieName2, "cookieValue": "value2"})
+        self.req3 = weblog.post(self.endpoint, data={"cookieName": cookieName3, "cookieValue": "value3"})
+
+    def test_cookie_name_filter(self):
+        assert_iast_vulnerability(request=self.req1, vulnerability_count=1, vulnerability_type=self.vulnerability_type)
+        assert_iast_vulnerability(request=self.req2, vulnerability_count=1, vulnerability_type=self.vulnerability_type)
+
+        meta_req3 = _get_span_meta(self.req3)
+        assert "_dd.iast.json" not in meta_req3

--- a/utils/build/docker/nodejs/express4-typescript/iast.ts
+++ b/utils/build/docker/nodejs/express4-typescript/iast.ts
@@ -173,7 +173,7 @@ function initSinkRoutes (app: Express): void {
   })
 
   app.get('/iast/no-samesite-cookie/test_insecure', (req: Request, res: Response): void => {
-    res.cookie('nosamesite', 'cookie', { httpOnly: true, sameSite: true })
+    res.cookie('nosamesite', 'cookie', { secure: true, httpOnly: true })
     res.send('OK')
   })
 

--- a/utils/build/docker/nodejs/express4-typescript/iast.ts
+++ b/utils/build/docker/nodejs/express4-typescript/iast.ts
@@ -137,6 +137,11 @@ function initSinkRoutes (app: Express): void {
     res.send('OK')
   })
 
+  app.post('/iast/insecure-cookie/custom_cookie', (req: Request, res: Response): void => {
+    res.cookie(req.body.cookieName, req.body.cookieValue, { httpOnly: true, sameSite: true })
+    res.send('OK')
+  })
+
   app.get('/iast/insecure-cookie/test_empty_cookie', (req: Request, res: Response): void => {
     res.clearCookie('insecure')
     res.setHeader('set-cookie', 'empty=')
@@ -155,6 +160,11 @@ function initSinkRoutes (app: Express): void {
     res.send('OK')
   })
 
+  app.post('/iast/no-httponly-cookie/custom_cookie', (req: Request, res: Response): void => {
+    res.cookie(req.body.cookieName, req.body.cookieValue, { secure: true, sameSite: true })
+    res.send('OK')
+  })
+
   app.get('/iast/no-httponly-cookie/test_empty_cookie', (req: Request, res: Response): void => {
     res.clearCookie('insecure')
     res.setHeader('set-cookie', 'httponlyempty=')
@@ -170,6 +180,11 @@ function initSinkRoutes (app: Express): void {
   app.get('/iast/no-samesite-cookie/test_secure', (req: Request, res: Response): void => {
     res.setHeader('set-cookie', 'samesite=cookie; Secure; HttpOnly; SameSite=Strict')
     res.cookie('samesite2', 'value', { secure: true, httpOnly: true, sameSite: true })
+    res.send('OK')
+  })
+
+  app.post('/iast/no-samesite-cookie/custom_cookie', (req: Request, res: Response): void => {
+    res.cookie(req.body.cookieName, req.body.cookieValue, { secure: true, httpOnly: true })
     res.send('OK')
   })
 

--- a/utils/build/docker/nodejs/express4-typescript/iast.ts
+++ b/utils/build/docker/nodejs/express4-typescript/iast.ts
@@ -127,7 +127,7 @@ function initSinkRoutes (app: Express): void {
   })
 
   app.get('/iast/insecure-cookie/test_insecure', (req: Request, res: Response): void => {
-    res.cookie('insecure', 'cookie')
+    res.cookie('insecure', 'cookie', { httpOnly: true, sameSite: true })
     res.send('OK')
   })
 
@@ -150,7 +150,7 @@ function initSinkRoutes (app: Express): void {
   })
 
   app.get('/iast/no-httponly-cookie/test_insecure', (req: Request, res: Response): void => {
-    res.cookie('no-httponly', 'cookie')
+    res.cookie('no-httponly', 'cookie', { secure: true, sameSite: true })
     res.send('OK')
   })
 
@@ -173,7 +173,7 @@ function initSinkRoutes (app: Express): void {
   })
 
   app.get('/iast/no-samesite-cookie/test_insecure', (req: Request, res: Response): void => {
-    res.cookie('nosamesite', 'cookie')
+    res.cookie('nosamesite', 'cookie', { httpOnly: true, sameSite: true })
     res.send('OK')
   })
 

--- a/utils/build/docker/nodejs/express4/iast/index.js
+++ b/utils/build/docker/nodejs/express4/iast/index.js
@@ -120,7 +120,7 @@ function initRoutes (app, tracer) {
   })
 
   app.get('/iast/insecure-cookie/test_insecure', (req, res) => {
-    res.cookie('insecure', 'cookie')
+    res.cookie('insecure', 'cookie', { httpOnly: true, sameSite: true })
     res.send('OK')
   })
 
@@ -143,18 +143,18 @@ function initRoutes (app, tracer) {
   })
 
   app.get('/iast/no-httponly-cookie/test_insecure', (req, res) => {
-    res.cookie('no-httponly', 'cookie')
-    res.send('OK')
-  })
-
-  app.post('/iast/no-httponly-cookie/custom_cookie', (req, res) => {
-    res.cookie(req.body.cookieName, req.body.cookieValue, { secure: true, sameSite: true })
+    res.cookie('no-httponly', 'cookie', { secure: true, sameSite: true })
     res.send('OK')
   })
 
   app.get('/iast/no-httponly-cookie/test_secure', (req, res) => {
     res.setHeader('set-cookie', 'httponly=cookie; Secure;HttpOnly;SameSite=Strict;')
     res.cookie('httponly2', 'value', { secure: true, httpOnly: true, sameSite: true })
+    res.send('OK')
+  })
+
+  app.post('/iast/no-httponly-cookie/custom_cookie', (req, res) => {
+    res.cookie(req.body.cookieName, req.body.cookieValue, { secure: true, sameSite: true })
     res.send('OK')
   })
 
@@ -166,7 +166,7 @@ function initRoutes (app, tracer) {
   })
 
   app.get('/iast/no-samesite-cookie/test_insecure', (req, res) => {
-    res.cookie('nosamesite', 'cookie')
+    res.cookie('nosamesite', 'cookie', { secure: true, httpOnly: true })
     res.send('OK')
   })
 

--- a/utils/build/docker/nodejs/express4/iast/index.js
+++ b/utils/build/docker/nodejs/express4/iast/index.js
@@ -130,6 +130,11 @@ function initRoutes (app, tracer) {
     res.send('OK')
   })
 
+  app.post('/iast/insecure-cookie/custom_cookie', (req, res) => {
+    res.cookie(req.body.cookieName, req.body.cookieValue, { httpOnly: true, sameSite: true })
+    res.send('OK')
+  })
+
   app.get('/iast/insecure-cookie/test_empty_cookie', (req, res) => {
     res.clearCookie('insecure')
     res.setHeader('set-cookie', 'empty=')
@@ -139,6 +144,11 @@ function initRoutes (app, tracer) {
 
   app.get('/iast/no-httponly-cookie/test_insecure', (req, res) => {
     res.cookie('no-httponly', 'cookie')
+    res.send('OK')
+  })
+
+  app.post('/iast/no-httponly-cookie/custom_cookie', (req, res) => {
+    res.cookie(req.body.cookieName, req.body.cookieValue, { secure: true, sameSite: true })
     res.send('OK')
   })
 
@@ -163,6 +173,11 @@ function initRoutes (app, tracer) {
   app.get('/iast/no-samesite-cookie/test_secure', (req, res) => {
     res.setHeader('set-cookie', 'samesite=cookie; Secure; HttpOnly; SameSite=Strict')
     res.cookie('samesite2', 'value', { secure: true, httpOnly: true, sameSite: true })
+    res.send('OK')
+  })
+
+  app.post('/iast/no-samesite-cookie/custom_cookie', (req, res) => {
+    res.cookie(req.body.cookieName, req.body.cookieValue, { secure: true, httpOnly: true })
     res.send('OK')
   })
 


### PR DESCRIPTION
## Motivation
We are implementing an improvement to prevent having thousands of vulnerabilities when the cookie name is generated.

## Changes
<!-- A brief description of the change being made with this pull request. -->
- Add system tests to check that cookies with different superlong name are not generating two different vulnerabilities.
- Endpoints for nodejs express4 and express4-typescript. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
