### PR TITLE
Adding functionality for `dd_trace_rate_limit` for get_tracer_config()

### DIFF
--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
@@ -52,6 +52,7 @@ public class TraceController {
         Method isDebugEnabled = configClass.getMethod("isDebugEnabled");
         Method getLogLevel = configClass.getMethod("getLogLevel");
         Method getAgentUrl = configClass.getMethod("getAgentUrl");
+        Method getTraceRateLimit = configClass.getMethod("getTraceRateLimit");
 
         Method isTraceOtelEnabled = instrumenterConfigClass.getMethod("isTraceOtelEnabled");
 
@@ -70,6 +71,11 @@ public class TraceController {
         Object sampleRate = getTraceSampleRate.invoke(configObject);
         if (sampleRate instanceof Double) {
             configMap.put("dd_trace_sample_rate", String.valueOf((Double)sampleRate));
+        }
+
+        Object rateLimit = getTraceRateLimit.invoke(configObject);
+        if (rateLimit instanceof Integer) {
+          configMap.put("dd_trace_rate_limit", Integer.toString((int)rateLimit));
         }
 
         Object globalTags = getGlobalTags.invoke(configObject);


### PR DESCRIPTION
## Motivation

The parametric app for Java currently does not support the key `dd_trace_rate_limit` as a key in the return value for the endpoint /trace/config/. This is a key that is necessary in order to properly test the [DD_TRACE_RATE_LIMIT](https://datadoghq.atlassian.net/browse/APMAPI-468) configuration as part of the configuration consistency effort.

## Changes

Added support for `dd_trace_rate_limit` by using the Config::getAgentUrl method and returning it as part of the response to the client-side.
[APMAPI-468](https://datadoghq.atlassian.net/browse/APMAPI-468)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-468]: https://datadoghq.atlassian.net/browse/APMAPI-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ