### PR TITLE
[cpp] Enable Config Consistency tests

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -139,7 +139,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_RateLimit: missing_feature
       Test_Config_TraceAgentURL: missing_feature
-      Test_Config_TraceEnabled: missing_feature
+      Test_Config_TraceEnabled: v1.1.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: missing_feature
     test_dynamic_configuration.py:

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -137,7 +137,7 @@ tests/:
       Test_Dsm_Manual_Checkpoint_Intra_Process: missing_feature
   parametric/:
     test_config_consistency.py:
-      Test_Config_RateLimit: missing_feature
+      Test_Config_RateLimit: v1.1.0
       Test_Config_TraceAgentURL: v1.1.0
       Test_Config_TraceEnabled: v1.1.0
       Test_Config_TraceLogDirectory: missing_feature

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -141,7 +141,7 @@ tests/:
       Test_Config_TraceAgentURL: v1.1.0
       Test_Config_TraceEnabled: v1.1.0
       Test_Config_TraceLogDirectory: missing_feature
-      Test_Config_UnifiedServiceTagging: missing_feature
+      Test_Config_UnifiedServiceTagging: v1.1.0
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
     test_headers_baggage.py:

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -138,7 +138,7 @@ tests/:
   parametric/:
     test_config_consistency.py:
       Test_Config_RateLimit: missing_feature
-      Test_Config_TraceAgentURL: missing_feature
+      Test_Config_TraceAgentURL: v1.1.0
       Test_Config_TraceEnabled: v1.1.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: missing_feature


### PR DESCRIPTION
## Motivation

Enables running and passing system-tests for dd-trace-cpp to meet the requirements of the config consistency effort (only for existing configurations implemented in the tracer)

## Changes

Unskips config consistency tests for cpp, such that it will run on the next release of dd-trace-cpp. Note: This will only run once dd-trace-cpp has a version increase and/or gets released, but this works locally when tested against the latest DataDog/dd-trace-cpp@89426d570c378fe4eaec7502d53dfb937a80d326 commit, which has the required changes.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
