### PR TITLE
Remove unused tests

### DIFF
--- a/tests/appsec/test_alpha.py
+++ b/tests/appsec/test_alpha.py
@@ -27,7 +27,7 @@ class Test_Basic:
         """ Via server.request.headers.no_cookies """
         # Note: we do not check the returned key_path nor rule_id for the alpha version
         address = "server.request.headers.no_cookies"
-        pattern = "/../" if context.appsec_rules_version < "1.2.6" else "../"
+        pattern = "../"
         interfaces.library.assert_waf_attack(self.r_headers_1, pattern=pattern, address=address)
         interfaces.library.assert_waf_attack(self.r_headers_2, pattern="Arachni/v", address=address)
 
@@ -41,6 +41,6 @@ class Test_Basic:
         # on server.request.headers.no_cookies and then retry it with the cookies
         # to validate that cookies are properly excluded from server.request.headers.no_cookies.
         address = "server.request.headers.no_cookies"
-        pattern = "/../" if context.appsec_rules_version < "1.2.6" else "../"
+        pattern = "../"
         interfaces.library.assert_waf_attack(self.r_headers_1, pattern=pattern, address=address)
         interfaces.library.assert_no_appsec_event(self.r_headers_2)

--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -151,32 +151,6 @@ class Test_AppSecObfuscator:
         interfaces.library.assert_waf_attack(self.r_key, address="server.request.query")
         interfaces.library.validate_appsec(self.r_key, validate_appsec_span_tags, success_by_default=True)
 
-    def setup_appsec_obfuscator_cookies(self):
-        cookies = {"Bearer": self.SECRET_VALUE_WITH_SENSITIVE_KEY, "Good": self.SECRET_VALUE_WITH_NON_SENSITIVE_KEY}
-        self.r_cookies = weblog.get("/waf/", cookies=cookies)
-
-    @missing_feature(library="java")
-    @irrelevant(context.appsec_rules_version >= "1.2.7", reason="cookies were disabled for the time being")
-    def test_appsec_obfuscator_cookies(self):
-        """
-        Specific obfuscation test for the cookies which often contain sensitive data and are
-        expected to be properly obfuscated on sensitive cookies only.
-        """
-        # Validate that the AppSec events do not contain the following secret value.
-        # Note that this value must contain an attack pattern in order to be part of the security event data
-        # that is expected to be obfuscated.
-
-        def validate_appsec_span_tags(span, appsec_data):
-            assert not nested_lookup(
-                self.SECRET_VALUE_WITH_SENSITIVE_KEY, appsec_data, look_in_keys=True
-            ), "The security events contain the secret value that should be obfuscated"
-            assert nested_lookup(
-                self.SECRET_VALUE_WITH_NON_SENSITIVE_KEY, appsec_data, exact_match=True
-            ), "Could not find the non-sensitive cookie data"
-
-        interfaces.library.assert_waf_attack(self.r_cookies, address="server.request.cookies")
-        interfaces.library.validate_appsec(self.r_cookies, validate_appsec_span_tags, success_by_default=True)
-
     def setup_appsec_obfuscator_value(self):
         sensitive_raw_payload = r"""{
             "activeTab":"39612314-1890-45f7-8075-c793325c1d70",'

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -141,52 +141,6 @@ class Test_Cookies:
     # Cookies rules has been removed in rules version 1.2.7. Test on cookies are now done on custom rules scenario.
     # Once we have rules with cookie back in the default rules set, we can re-use this class to validated this feature
 
-    def setup_cookies(self):
-        self.r_cookies = weblog.get("/waf/", cookies={"attack": ".htaccess"})
-
-    @irrelevant(context.appsec_rules_version >= "1.2.7", reason="cookies were disabled for the time being")
-    def test_cookies(self):
-        """Appsec WAF detects attackes in cookies"""
-        interfaces.library.assert_waf_attack(self.r_cookies, pattern=".htaccess", address="server.request.cookies")
-
-    def setup_cookies_with_semicolon(self):
-        self.r_cwsc_1 = weblog.get("/waf", cookies={"value": "%3Bshutdown--"})
-        self.r_cwsc_2 = weblog.get("/waf", cookies={"key": ".cookie-%3Bdomain="})
-
-    @irrelevant(
-        library="java",
-        reason="cookies are not urldecoded; see RFC 6265, which only suggests they be base64 "
-        "encoded to represent disallowed octets",
-    )
-    @irrelevant(library="golang", reason="not handled by the Go standard cookie parser")
-    @irrelevant(context.appsec_rules_version >= "1.2.7", reason="cookies were disabled for the time being")
-    def test_cookies_with_semicolon(self):
-        """Cookie with pattern containing a semicolon"""
-        interfaces.library.assert_waf_attack(self.r_cwsc_1, pattern=";shutdown--", address="server.request.cookies")
-        interfaces.library.assert_waf_attack(
-            self.r_cwsc_2, pattern=".cookie-;domain=", address="server.request.cookies"
-        )
-
-    def setup_cookies_with_spaces(self):
-        self.r_cws = weblog.get("/waf/", cookies={"x-attack": "var_dump ()"})
-
-    @irrelevant(library="dotnet", reason="One space in the whole value cause kestrel to erase the whole value")
-    @irrelevant(context.appsec_rules_version >= "1.2.7", reason="cookies were disabled for the time being")
-    def test_cookies_with_spaces(self):
-        """Cookie with pattern containing a space"""
-        interfaces.library.assert_waf_attack(self.r_cws, pattern="var_dump ()", address="server.request.cookies")
-
-    def setup_cookies_with_special_chars2(self):
-        self.r_cwsc2 = weblog.get("/waf/", cookies={"x-attack": 'o:4:"x":5:{d}'})
-
-    @irrelevant(library="golang", reason="not handled by the Go standard cookie parser")
-    @irrelevant(library="dotnet", reason="Quotation marks cause kestrel to erase the whole value")
-    @bug(context.library < "java@0.96.0", reason="APMRP-360")
-    @irrelevant(context.appsec_rules_version >= "1.2.7", reason="cookies were disabled for the time being")
-    def test_cookies_with_special_chars2(self):
-        """Other cookies patterns"""
-        interfaces.library.assert_waf_attack(self.r_cwsc2, pattern='o:4:"x":5:{d}', address="server.request.cookies")
-
     def setup_cookies_custom_rules(self):
         self.r_ccr = weblog.get("/waf/", cookies={"attack": ".htaccess"})
 

--- a/tests/appsec/waf/test_rules.py
+++ b/tests/appsec/waf/test_rules.py
@@ -191,14 +191,6 @@ class Test_XSS:
         for r in self.requests:
             interfaces.library.assert_waf_attack(r, waf_rules.xss)
 
-    def setup_xss2(self):
-        self.r_xss2 = weblog.get("/waf/", cookies={"value": '<vmlframe src="xss">'})
-
-    @irrelevant(context.appsec_rules_version >= "1.2.7", reason="cookies were disabled for the time being")
-    def test_xss2(self):
-        """XSS patterns in cookie, with special char"""
-        interfaces.library.assert_waf_attack(self.r_xss2, waf_rules.xss)
-
 
 @features.waf_rules
 class Test_SQLI:
@@ -210,14 +202,6 @@ class Test_SQLI:
     def test_sqli(self):
         interfaces.library.assert_waf_attack(self.r_1, waf_rules.sql_injection.crs_942_160)
 
-    def setup_sqli1(self):
-        self.r_2 = weblog.get("/waf/", params={"value": "0000012345"})
-
-    @irrelevant(context.appsec_rules_version >= "1.2.6", reason="crs-942-220 has been removed")
-    def test_sqli1(self):
-        """AppSec catches SQLI attacks"""
-        interfaces.library.assert_waf_attack(self.r_2, "crs-942-220")
-
     def setup_sqli2(self):
         self.r_3 = weblog.get("/waf/", params={"value": "alter d char set f"})
         self.r_4 = weblog.get("/waf/", params={"value": "merge using("})
@@ -228,39 +212,10 @@ class Test_SQLI:
         interfaces.library.assert_waf_attack(self.r_3, waf_rules.sql_injection.crs_942_240)
         interfaces.library.assert_waf_attack(self.r_4, waf_rules.sql_injection.crs_942_250)
 
-    def setup_sqli3(self):
-        self.r_5 = weblog.get("/waf/", cookies={"value": "%3Bshutdown--"})
-
-    @bug(context.library < "dotnet@2.1.0", reason="APMRP-360")
-    @bug(library="java", reason="under Valentin's investigations")
-    @missing_feature(library="golang", reason="cookies are not url-decoded and this attack works with a ;")
-    @irrelevant(context.appsec_rules_version >= "1.2.7", reason="cookies were disabled for the time being")
-    def test_sqli3(self):
-        """SQLI patterns in cookie"""
-        interfaces.library.assert_waf_attack(self.r_5, waf_rules.sql_injection.crs_942_280)
-
-    def setup_sqli_942_140(self):
-        self.r_6 = weblog.get("/waf/", cookies={"value": "db_name("})
-
-    @irrelevant(context.appsec_rules_version >= "1.2.6", reason="crs-942-140 has been removed")
-    def test_sqli_942_140(self):
-        """AppSec catches SQLI attacks"""
-        interfaces.library.assert_waf_attack(self.r_6, "crs-942-140")
-
 
 @features.waf_rules
 class Test_NoSqli:
     """ Appsec WAF tests on NoSQLi rules """
-
-    def setup_nosqli_value(self):
-        self.r_1 = weblog.get("/waf/", params={"value": "[$ne]"})
-        self.r_2 = weblog.get("/waf/", headers={"x-attack": "$nin"})
-
-    @irrelevant(context.appsec_rules_version >= "1.3.0", reason="rules run only on keys starting 1.3.0")
-    def test_nosqli_value(self):
-        """AppSec catches NoSQLI attacks in values"""
-        interfaces.library.assert_waf_attack(self.r_1, waf_rules.nosql_injection)
-        interfaces.library.assert_waf_attack(self.r_2, waf_rules.nosql_injection)
 
     def setup_nosqli_keys(self):
         self.r_3 = weblog.get("/waf/", params={"[$ne]": "value"})
@@ -268,7 +223,6 @@ class Test_NoSqli:
 
     @missing_feature(context.library in ["php"], reason="Need to use last WAF version")
     @missing_feature(context.library < "java@0.96.0", reason="Was using a too old WAF version")
-    @irrelevant(context.appsec_rules_version < "1.3.0", reason="before 1.3.0, keys was not supported")
     @irrelevant(library="nodejs", reason="brackets are interpreted as arrays and thus truncated")
     def test_nosqli_keys(self):
         """AppSec catches NoSQLI attacks in keys"""


### PR DESCRIPTION
## Motivation

* Clean test code base
* Open the way of removing the `appsec_rules_version` proeprty, as it's tighed to library version.

## Changes

Remove test that are not relevant for `appsec_rules_version >= 1.2.7`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
