### PR TITLE
Clean Test_Monitoring

### DIFF
--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -31,24 +31,15 @@ class Test_Monitoring:
 
             meta = span["meta"]
             for m in expected_waf_monitoring_meta_tags:
-                if m not in meta:
-                    raise Exception(f"missing span meta tag `{m}` in {meta}")
+                assert m in meta, f"missing span meta tag `{m}` in meta"
 
             metrics = span["metrics"]
             for m in expected_waf_monitoring_metrics_tags:
-                if m not in metrics:
-                    raise Exception(f"missing span metric tag `{m}` in {metrics}")
+                assert m in metrics, f"missing span metric tag `{m}` in metrics"
 
             if re.match(self.expected_version_regex, meta[expected_rules_version_tag], 0) is None:
-                raise Exception(
+                raise ValueError(
                     f"the span meta tag `{meta[expected_rules_version_tag]}` doesn't match the version regex"
-                )
-
-            if meta[expected_rules_version_tag] != str(context.appsec_rules_version):
-                raise Exception(
-                    f"the event rules version `{meta[expected_rules_version_tag]}` reported in the span tag "
-                    f"{expected_rules_version_tag} isn't equal to the weblog context version "
-                    f"`{context.appsec_rules_version}`"
                 )
 
             return True


### PR DESCRIPTION


## Changes

Small test improvments
Remove test on the rules file version value : the regex already check it's a version ,and apart from someone putting hardcoded value, we almost check that 1==1 here. By utself, it's not harmful. But this allow to remove all reference to `appsec_rules_version`, that is a value that causes some complexity, and is hard to get. Furthermore, this is a dependancy tied to the library, and so have no reason to be tested separatly. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
