### PR TITLE
Remove legacy mention of libddwaf_version

### DIFF
--- a/tests/appsec/test_alpha.py
+++ b/tests/appsec/test_alpha.py
@@ -5,7 +5,6 @@
 from utils import context, weblog, interfaces, missing_feature, bug, features
 
 
-@missing_feature(context.library == "ruby" and context.libddwaf_version is None)
 @features.threats_alpha_preview
 class Test_Basic:
     """ Detect attacks on raw URI and headers with default rules """

--- a/tests/appsec/test_reports.py
+++ b/tests/appsec/test_reports.py
@@ -65,7 +65,6 @@ class Test_Info:
 
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2186870984/HTTP+header+collection")
-@missing_feature(context.library == "ruby" and context.libddwaf_version is None)
 @bug(context.library == "python@1.1.0", reason="APMRP-360")
 @features.security_events_metadata
 class Test_RequestHeaders:

--- a/tests/appsec/waf/test_rules.py
+++ b/tests/appsec/waf/test_rules.py
@@ -258,7 +258,6 @@ class Test_SSRF:
         interfaces.library.assert_waf_attack(self.r, waf_rules.ssrf.sqr_000_001)
 
 
-@missing_feature(context.library == "ruby" and context.libddwaf_version is None)
 @features.waf_rules
 class Test_DiscoveryScan:
     """AppSec WAF Tests on Discovery Scan rules"""


### PR DESCRIPTION
## Motivation



## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
