### PR TITLE
[java] Apply native plugins when profiling and tracing is disabled

### DIFF
--- a/utils/build/docker/java/spring-boot-3-native/pom.xml
+++ b/utils/build/docker/java/spring-boot-3-native/pom.xml
@@ -20,6 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <agent.path>/app/dd-java-agent.jar</agent.path>
         <start-class>com.datadoghq.springbootnative.App</start-class>
+        <graal.build.args>-Ob</graal.build.args>
     </properties>
 
     <dependencies>
@@ -55,50 +56,42 @@
             <version>4.0.1</version>
         </dependency>
     </dependencies>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.graalvm.buildtools</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <configuration>
+                     <buildArgs>
+                        ${graal.build.args}
+                     </buildArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>with-profiling</id>
             <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.graalvm.buildtools</groupId>
-                        <artifactId>native-maven-plugin</artifactId>
-                        <configuration>
-                             <buildArgs>
-                                -J-javaagent:${agent.path} -J-Ddd.profiling.enabled=true --enable-monitoring=jfr -Ob
-                             </buildArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
                 <directory>with-profiling</directory>
             </build>
+            <properties>
+                <graal.build.args>-J-javaagent:${agent.path} -J-Ddd.profiling.enabled=true --enable-monitoring=jfr -Ob</graal.build.args>
+            </properties>
         </profile>
         <profile>
             <id>without-profiling</id>
             <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.graalvm.buildtools</groupId>
-                        <artifactId>native-maven-plugin</artifactId>
-                        <configuration>
-                             <buildArgs>
-                                -J-javaagent:${agent.path} -Ob
-                             </buildArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
                 <directory>without-profiling</directory>
             </build>
+            <properties>
+                <graal.build.args>-J-javaagent:${agent.path} -Ob</graal.build.args>
+            </properties>
         </profile>
     </profiles>
-
 </project>


### PR DESCRIPTION
## Motivation

The build for the native application is broken when the `with-profiling` and `without-profiling` profiles are both disabled. They are both disabled when trying to run the native app without any instrumentation.

## Changes

`spring-boot-maven-plugin` and `native-maven-plugin` are defined in `<pluginManagement>` in spring-boot-parent. To activate them, they have to be defined in `<plugins>`. This PR always applies the plugins then uses the two profiles to change the build args.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
