### PR TITLE
[php] Use healthcheck to get version

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -698,7 +698,7 @@ class WeblogContainer(TestedContainer):
         )
 
         # https://github.com/DataDog/system-tests/issues/2799
-        if self.library in ("cpp", "dotnet", "nodejs", "python", "golang", "ruby"):
+        if self.library in ("cpp", "dotnet", "nodejs", "php", "python", "golang", "ruby"):
             self.healthcheck = {
                 "test": f"curl --fail --silent --show-error --max-time 2 localhost:{self.port}/healthcheck",
                 "retries": 60,
@@ -727,7 +727,7 @@ class WeblogContainer(TestedContainer):
 
         # new way of getting info from the weblog. Only working for nodejs and python right now
         # https://github.com/DataDog/system-tests/issues/2799
-        if self.library in ("cpp", "dotnet", "nodejs", "python", "golang", "ruby"):
+        if self.library in ("cpp", "dotnet", "nodejs", "python", "php", "golang", "ruby"):
             with open(self.healthcheck_log_file, mode="r", encoding="utf-8") as f:
                 data = json.load(f)
                 lib = data["library"]

--- a/utils/build/docker/dotnet/install_ddtrace.sh
+++ b/utils/build/docker/dotnet/install_ddtrace.sh
@@ -37,3 +37,4 @@ version=$(strings /opt/datadog/net6.0/Datadog.Trace.dll | egrep '^[0-9]+\.[0-9]+
 echo "${version:0:-2}" > /app/SYSTEM_TESTS_LIBRARY_VERSION
 
 echo "dd-trace version: $(cat /app/SYSTEM_TESTS_LIBRARY_VERSION)"
+

--- a/utils/build/docker/php/apache-mod/php.conf
+++ b/utils/build/docker/php/apache-mod/php.conf
@@ -3,6 +3,7 @@
     <VirtualHost *:7777>
         RewriteEngine on
         RewriteRule "^/waf$" "/waf/"
+        RewriteRule "^/healthcheck$" "/healthcheck/"
         RewriteRule "^/identify$" "/identify/"
         RewriteRule "^/identify-propagate$" "/identify-propagate/"
         RewriteRule "^/headers$" "/headers/"

--- a/utils/build/docker/php/common/healthcheck.php
+++ b/utils/build/docker/php/common/healthcheck.php
@@ -1,0 +1,5 @@
+<?php
+
+header('content-type: application/json');
+$version=phpversion("ddtrace");
+echo '{"status": "ok", "library": {"language": "php", "version": "' . $version . '"}}';

--- a/utils/build/docker/php/php-fpm/php-fpm.conf
+++ b/utils/build/docker/php/php-fpm/php-fpm.conf
@@ -8,6 +8,7 @@
     <VirtualHost *:7777>
         RewriteEngine on
         ProxyErrorOverride on 404
+        RewriteRule "^/healthcheck$" "/healthcheck/"
         RewriteRule "^/waf$" "/waf/"
         RewriteRule "^/identify$" "/identify/"
         RewriteRule "^/identify-propagate$" "/identify-propagate/"


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
