### PR TITLE
[python] Fix weblog code to removes exception in stdout

### DIFF
--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -965,7 +965,7 @@ def view_iast_source_parametername_get():
 
 @app.route("/iast/source/parametername/test", methods=["POST"])
 def view_iast_source_parametername_post():
-    param = [key for key in flask_request.json.keys() if key == "user"]
+    param = [key for key in flask_request.form.keys() if key == "user"]
     _sink_point_sqli(id=param[0])
     return Response("OK")
 
@@ -975,7 +975,7 @@ def view_iast_source_parameter():
     if flask_request.args:
         table = flask_request.args.get("table")
     else:
-        table = flask_request.json.get("table")
+        table = flask_request.form.get("table")
     _sink_point_sqli(table=table)
     return Response("OK")
 


### PR DESCRIPTION
## Motivation

`POST /iast/source/parametername/test` requires a JSON body. The current code does not set the `content-type` headers, and this is not liked by some framworks (fastapi)

## Changes

Set the content-type (by using the `json` parameter)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
