### PR TITLE
OnBoarding: debug -  remote command exited without exit status or exi…

### DIFF
--- a/utils/build/virtual_machine/weblogs/common/create_and_run_app_container.sh
+++ b/utils/build/virtual_machine/weblogs/common/create_and_run_app_container.sh
@@ -31,7 +31,8 @@ then
     echo "APP VARIABLES CONFIGURED FROM THE SCENARIO:"
     cat scenario_app.env
 fi
-sudo -E docker-compose -f docker-compose.yml up -d test-app
+echo "STARTING test-app CONTAINER"
+sudo -E docker-compose -f docker-compose.yml up -d test-app || sudo docker-compose logs
 
 echo "..:: RUNNING DOCKER SERVICES ::.." 
 sudo docker-compose ps

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-buildpack/test-app-java_docker_compose_run_buildpack.sh
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-buildpack/test-app-java_docker_compose_run_buildpack.sh
@@ -39,7 +39,8 @@ then
     echo "APP VARIABLES CONFIGURED FROM THE SCENARIO:"
     cat scenario_app.env
 fi
-sudo -E docker-compose -f docker-compose.yml up -d test-app
+echo "STARTING test-app CONTAINER"
+sudo -E docker-compose -f docker-compose.yml up -d test-app || sudo docker-compose logs
 
 echo "**************** RUNNING DOCKER SERVICES *****************" 
 sudo docker-compose ps

--- a/utils/virtual_machine/aws_provider.py
+++ b/utils/virtual_machine/aws_provider.py
@@ -105,6 +105,7 @@ class AWSPulumiProvider(VmProvider):
             user=vm.aws_config.user,
             private_key=self.pulumi_ssh.private_key_pem,
             dial_error_limit=-1,
+            per_dial_timeout=30,
         )
         # Install provision on the started server
         self.install_provision(


### PR DESCRIPTION
…t signal

## Motivation

The onboarding tests are failing randomly when we startup the app container. The error is:
`Error: remote command exited without exit status or exit signal:` 

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
