### PR TITLE
utils/virtual_machine/aws_provider.py: get cached AMI asynchronously.

### DIFF
--- a/utils/virtual_machine/aws_provider.py
+++ b/utils/virtual_machine/aws_provider.py
@@ -19,7 +19,8 @@ from utils import context
 from utils.virtual_machine.vm_logger import vm_logger
 
 from utils.virtual_machine.virtual_machine_provider import VmProvider, Commander
-
+import asyncio
+import time
 
 class AWSPulumiProvider(VmProvider):
     def __init__(self):
@@ -41,6 +42,8 @@ class AWSPulumiProvider(VmProvider):
         logger.info(f"Starting AWS VMs: {self.vms}")
 
         def pulumi_start_program():
+            start_time = time.time()
+            logger.stdout(f"--------- pulumi_start_program Starting AWS VMS: {self.vms} -----------")
             # Static loading of keypairs for ec2 machines
             self.pulumi_ssh = PulumiSSH()
             self.pulumi_ssh.load(self.vms)
@@ -49,6 +52,8 @@ class AWSPulumiProvider(VmProvider):
             for vm in self.vms:
                 logger.info(f"--------- Starting AWS VM: {vm.name} -----------")
                 self._start_vm(vm)
+            end_time = time.time()
+            logger.stdout(f"--------- pulumi_start_program Finished Starting AWS VMS: {end_time - start_time}s -----------")
 
         project_name = "system-tests-vms"
         try:
@@ -75,7 +80,7 @@ class AWSPulumiProvider(VmProvider):
     def _start_vm(self, vm):
         # Check for cached ami, before starting a new one
         should_skip_ami_cache = os.getenv("SKIP_AMI_CACHE", "False").lower() == "true"
-        ami_id = self._get_cached_ami(vm) if not should_skip_ami_cache else None
+        ami_id = pulumi.Output.from_input(asyncio.to_thread(self._get_cached_ami, vm))) if not should_skip_ami_cache else None
         logger.info(f"Cache AMI: {vm.get_cache_name()}")
         # Startup VM and prepare connection
         ec2_server = aws.ec2.Instance(

--- a/utils/virtual_machine/aws_provider.py
+++ b/utils/virtual_machine/aws_provider.py
@@ -21,6 +21,7 @@ from utils.virtual_machine.vm_logger import vm_logger
 
 from utils.virtual_machine.virtual_machine_provider import VmProvider, Commander
 
+
 class AWSPulumiProvider(VmProvider):
     def __init__(self):
         super().__init__()

--- a/utils/virtual_machine/aws_provider.py
+++ b/utils/virtual_machine/aws_provider.py
@@ -80,7 +80,7 @@ class AWSPulumiProvider(VmProvider):
     def _start_vm(self, vm):
         # Check for cached ami, before starting a new one
         should_skip_ami_cache = os.getenv("SKIP_AMI_CACHE", "False").lower() == "true"
-        ami_id = pulumi.Output.from_input(asyncio.to_thread(self._get_cached_ami, vm))) if not should_skip_ami_cache else None
+        ami_id = pulumi.Output.from_input(asyncio.to_thread(self._get_cached_ami, vm)) if not should_skip_ami_cache else None
         logger.info(f"Cache AMI: {vm.get_cache_name()}")
         # Startup VM and prepare connection
         ec2_server = aws.ec2.Instance(


### PR DESCRIPTION
## Motivation

The `_get_cached_ami` function takes a significant amount of time and is executed in sequence during the launch of the VMs.

## Changes

This PR changes the `_get_cached_ami` call to run asynchronously, speeding up the VM provisioning.
<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
