### PR TITLE
[python] update telemetry configuration names

### DIFF
--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -542,8 +542,7 @@ class Test_TelemetrySCAEnvVar:
         ],
     )
     @missing_feature(
-        context.library <= "python@2.16.0",
-        reason="Converts boolean values to strings",
+        context.library <= "python@2.16.0", reason="Converts boolean values to strings",
     )
     def test_telemetry_sca_enabled_propagated(
         self, library_env, specific_libraries_support, outcome_value, test_agent, test_library
@@ -561,7 +560,10 @@ class Test_TelemetrySCAEnvVar:
         assert cfg_appsec_enabled.get("value") == outcome_value
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
-    @missing_feature(context.library <= "python@2.16.0", reason="Does not report DD_APPSEC_SCA_ENABLED configuration if the default value is used")
+    @missing_feature(
+        context.library <= "python@2.16.0",
+        reason="Does not report DD_APPSEC_SCA_ENABLED configuration if the default value is used",
+    )
     def test_telemetry_sca_enabled_not_propagated(self, library_env, test_agent, test_library):
         configuration_by_name = self.get_app_started_configuration_by_name(test_agent, test_library)
 

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -140,6 +140,7 @@ class Test_Consistent_Configs:
             }
         ],
     )
+    @missing_feature(context.library <= "python@2.16.0", reason="Reports configurations with unexpected names")
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.start_span("test"):
             pass

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -67,7 +67,7 @@ class Test_Defaults:
             }
         ],
     )
-    @missing_feature(context.library <= "python@2.16.0", reason="Reports configurations with unexpected names")
+    @missing_feature(context.library < "python@2.16.0", reason="Reports configurations with unexpected names")
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.start_span("test"):
             pass
@@ -140,7 +140,7 @@ class Test_Consistent_Configs:
             }
         ],
     )
-    @missing_feature(context.library <= "python@2.16.0", reason="Reports configurations with unexpected names")
+    @missing_feature(context.library < "python@2.16.0", reason="Reports configurations with unexpected names")
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.start_span("test"):
             pass
@@ -542,7 +542,7 @@ class Test_TelemetrySCAEnvVar:
         ],
     )
     @missing_feature(
-        context.library <= "python@2.16.0", reason="Converts boolean values to strings",
+        context.library < "python@2.16.0", reason="Converts boolean values to strings",
     )
     def test_telemetry_sca_enabled_propagated(
         self, library_env, specific_libraries_support, outcome_value, test_agent, test_library
@@ -561,7 +561,7 @@ class Test_TelemetrySCAEnvVar:
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
     @missing_feature(
-        context.library <= "python@2.16.0",
+        context.library < "python@2.16.0",
         reason="Does not report DD_APPSEC_SCA_ENABLED configuration if the default value is used",
     )
     def test_telemetry_sca_enabled_not_propagated(self, library_env, test_agent, test_library):

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -13,14 +13,34 @@ from utils import context, scenarios, rfc, features, missing_feature
 
 
 telemetry_name_mapping = {
-    "trace_sample_rate": {"dotnet": "DD_TRACE_SAMPLE_RATE", "nodejs": "DD_TRACE_SAMPLE_RATE"},
-    "logs_injection_enabled": {"dotnet": "DD_LOGS_INJECTION", "nodejs": "DD_LOG_INJECTION"},
-    "trace_header_tags": {"dotnet": "DD_TRACE_HEADER_TAGS", "nodejs": "DD_TRACE_HEADER_TAGS"},
-    "trace_tags": {"dotnet": "DD_TAGS", "nodejs": "DD_TAGS"},
-    "trace_enabled": {"dotnet": "DD_TRACE_ENABLED", "nodejs": "tracing"},
-    "profiling_enabled": {"dotnet": "DD_PROFILING_ENABLED", "nodejs": "profiling.enabled"},
-    "appsec_enabled": {"dotnet": "DD_APPSEC_ENABLED", "nodejs": "appsec.enabled"},
-    "data_streams_enabled": {"dotnet": "DD_DATA_STREAMS_ENABLED", "nodejs": "dsmEnabled"},
+    "trace_sample_rate": {
+        "dotnet": "DD_TRACE_SAMPLE_RATE",
+        "nodejs": "DD_TRACE_SAMPLE_RATE",
+        "python": "DD_TRACE_SAMPLE_RATE",
+    },
+    "logs_injection_enabled": {
+        "dotnet": "DD_LOGS_INJECTION",
+        "nodejs": "DD_LOG_INJECTION",
+        "python": "DD_LOGS_INJECTION",
+    },
+    "trace_header_tags": {
+        "dotnet": "DD_TRACE_HEADER_TAGS",
+        "nodejs": "DD_TRACE_HEADER_TAGS",
+        "python": "DD_TRACE_HEADER_TAGS",
+    },
+    "trace_tags": {"dotnet": "DD_TAGS", "nodejs": "DD_TAGS", "python": "DD_TAGS"},
+    "trace_enabled": {"dotnet": "DD_TRACE_ENABLED", "nodejs": "tracing", "python": "DD_TRACE_ENABLED"},
+    "profiling_enabled": {
+        "dotnet": "DD_PROFILING_ENABLED",
+        "nodejs": "profiling.enabled",
+        "python": "DD_PROFILING_ENABLED",
+    },
+    "appsec_enabled": {"dotnet": "DD_APPSEC_ENABLED", "nodejs": "appsec.enabled", "python": "DD_APPSEC_ENABLED"},
+    "data_streams_enabled": {
+        "dotnet": "DD_DATA_STREAMS_ENABLED",
+        "nodejs": "dsmEnabled",
+        "python": "DD_DATA_STREAMS_ENABLED",
+    },
 }
 
 
@@ -47,6 +67,7 @@ class Test_Defaults:
             }
         ],
     )
+    @missing_feature(context.library <= "python@2.16.0", reason="Reports configurations with unexpected names")
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.start_span("test"):
             pass
@@ -170,6 +191,7 @@ class Test_Environment:
             }
         ],
     )
+    @missing_feature(context.library <= "python@2.16.0", reason="Reports configurations with unexpected names")
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.start_span("test"):
             pass
@@ -510,19 +532,23 @@ class Test_TelemetrySCAEnvVar:
     @pytest.mark.parametrize(
         "library_env, specific_libraries_support, outcome_value",
         [
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "true",}, False, "true"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "True",}, ("python", "golang"), "true"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "1",}, ("python", "golang"), "true"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "false",}, False, "false"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "False",}, ("python", "golang"), "false"),
-            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "0",}, ("python", "golang"), "false"),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "true",}, False, True),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "True",}, ("python", "golang"), True),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "1",}, ("python", "golang"), True),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "false",}, False, False),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "False",}, ("python", "golang"), False),
+            ({**DEFAULT_ENVVARS, "DD_APPSEC_SCA_ENABLED": "0",}, ("python", "golang"), None),
         ],
+    )
+    @missing_feature(
+        context.library <= "python@2.16.0",
+        reason="Older versions of the Python tracer convert boolean values to strings",
     )
     def test_telemetry_sca_enabled_propagated(
         self, library_env, specific_libraries_support, outcome_value, test_agent, test_library
     ):
         if specific_libraries_support and context.library not in specific_libraries_support:
-            pytest.skip(f"unsupported value for {context.library}")
+            pytest.xfail(f"{outcome_value} unsupported value for {context.library}")
 
         configuration_by_name = self.get_app_started_configuration_by_name(test_agent, test_library)
 
@@ -530,9 +556,6 @@ class Test_TelemetrySCAEnvVar:
 
         cfg_appsec_enabled = configuration_by_name.get(DD_APPSEC_SCA_ENABLED)
         assert cfg_appsec_enabled is not None, "Missing telemetry config item for '{}'".format(DD_APPSEC_SCA_ENABLED)
-
-        if context.library in ("golang", "dotnet", "nodejs", "ruby"):
-            outcome_value = True if outcome_value == "true" else False
 
         assert cfg_appsec_enabled.get("value") == outcome_value
 
@@ -542,7 +565,7 @@ class Test_TelemetrySCAEnvVar:
 
         DD_APPSEC_SCA_ENABLED = self.get_dd_appsec_sca_enabled_str(context.library)
 
-        if context.library in ("java", "nodejs"):
+        if context.library in ("java", "nodejs", "python"):
             cfg_appsec_enabled = configuration_by_name.get(DD_APPSEC_SCA_ENABLED)
             assert cfg_appsec_enabled is not None, "Missing telemetry config item for '{}'".format(
                 DD_APPSEC_SCA_ENABLED

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -560,7 +560,7 @@ class Test_TelemetrySCAEnvVar:
         assert cfg_appsec_enabled.get("value") == outcome_value
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
-     @missing_feature(context.library <= "python@2.16.0", reason="Does not report DD_APPSEC_SCA_ENABLED configuration if the default value is used")
+    @missing_feature(context.library <= "python@2.16.0", reason="Does not report DD_APPSEC_SCA_ENABLED configuration if the default value is used")
     def test_telemetry_sca_enabled_not_propagated(self, library_env, test_agent, test_library):
         configuration_by_name = self.get_app_started_configuration_by_name(test_agent, test_library)
 

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -192,7 +192,7 @@ class Test_Environment:
             }
         ],
     )
-    @missing_feature(context.library <= "python@2.16.0", reason="Reports configurations with unexpected names")
+    @missing_feature(context.library < "python@2.16.0", reason="Reports configurations with unexpected names")
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.start_span("test"):
             pass

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -542,7 +542,7 @@ class Test_TelemetrySCAEnvVar:
     )
     @missing_feature(
         context.library <= "python@2.16.0",
-        reason="Older versions of the Python tracer convert boolean values to strings",
+        reason="Converts boolean values to strings",
     )
     def test_telemetry_sca_enabled_propagated(
         self, library_env, specific_libraries_support, outcome_value, test_agent, test_library
@@ -560,6 +560,7 @@ class Test_TelemetrySCAEnvVar:
         assert cfg_appsec_enabled.get("value") == outcome_value
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
+     @missing_feature(context.library <= "python@2.16.0", reason="Does not report DD_APPSEC_SCA_ENABLED configuration if the default value is used")
     def test_telemetry_sca_enabled_not_propagated(self, library_env, test_agent, test_library):
         configuration_by_name = self.get_app_started_configuration_by_name(test_agent, test_library)
 


### PR DESCRIPTION
## Motivation

This change to shared tests will unblock this PR: https://github.com/DataDog/dd-trace-py/pull/10987

## Changes

- Updates python telemetry name to match it's corresponding environment variable: https://github.com/DataDog/dd-trace-py/pull/10987

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
