### PR TITLE
Fix: Remove redundant trace wrapping on gin weblog app

### DIFF
--- a/utils/build/docker/golang/app/gin/main.go
+++ b/utils/build/docker/golang/app/gin/main.go
@@ -27,7 +27,6 @@ func main() {
 
 	r := gin.New()
 	r.Use(gintrace.Middleware("weblog"))
-	r.Use(gintrace.Middleware(""))
 
 	r.Any("/", func(ctx *gin.Context) {
 		ctx.Writer.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Motivation
The duplicate initialization of the gin integration was mistakenly included in a merged PR; it was causing duplicate spans, so this PR removes it.

## Changes


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
