### PR TITLE
Patch docker daemon to not use ddbuild runner IP range

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,6 +80,7 @@ onboarding_nodejs:
     - when: manual
   variables:
     TEST_LIBRARY: "nodejs"
+    SKIP_AMI_CACHE: "true"
   parallel:
       matrix:
         - ONBOARDING_FILTER_ENV: [dev, prod]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,7 +80,6 @@ onboarding_nodejs:
     - when: manual
   variables:
     TEST_LIBRARY: "nodejs"
-    SKIP_AMI_CACHE: "true"
   parallel:
       matrix:
         - ONBOARDING_FILTER_ENV: [dev, prod]

--- a/utils/build/virtual_machine/provisions/auto-inject-ld-preload/provision.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject-ld-preload/provision.yml
@@ -14,7 +14,7 @@ provision_steps:
   - init-config # Init the VM configuration
   - prepare-docker # Install docker
   - amazon-ecr-credential-helper # Install AWS ECR helper to download images from ECR
-  - patch-docker-daemon #Patch the docker daemon to allow the auto-injection
+  - patch-docker-daemon #Patch the docker daemon to avoid networking issues/ip conflicts incident-31160
   - ld-so-preload # Add some staff to the ld.so.preload before install dd software
   - install-installer # Install the installer
 
@@ -30,6 +30,10 @@ prepare-docker:
 amazon-ecr-credential-helper:
   cache: true
   install: !include utils/build/virtual_machine/provisions/auto-inject/docker/amazon-ecr-credential-helper.yml
+
+patch-docker-daemon:
+  cache: true
+  install: !include utils/build/virtual_machine/provisions/auto-inject/docker/patch-docker-daemon.yml
 
 ld-so-preload:
   install: !include utils/build/virtual_machine/provisions/auto-inject-ld-preload/ld-preload.yml

--- a/utils/build/virtual_machine/provisions/auto-inject-ld-preload/provision.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject-ld-preload/provision.yml
@@ -14,6 +14,7 @@ provision_steps:
   - init-config # Init the VM configuration
   - prepare-docker # Install docker
   - amazon-ecr-credential-helper # Install AWS ECR helper to download images from ECR
+  - patch-docker-daemon #Patch the docker daemon to allow the auto-injection
   - ld-so-preload # Add some staff to the ld.so.preload before install dd software
   - install-installer # Install the installer
 

--- a/utils/build/virtual_machine/provisions/auto-inject/docker/patch-docker-daemon.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/docker/patch-docker-daemon.yml
@@ -1,0 +1,4 @@
+    - os_type: linux
+      remote-command: |
+        # Patch docker daemon to avoid conflicts with ddbuild runners IP
+        sudo mkdir -p /etc/docker && echo '{"bip": "192.168.16.1/24", "default-address-pools":[{"base":"192.168.32.0/24", "size":24}]}' | sudo tee /etc/docker/daemon.json

--- a/utils/build/virtual_machine/provisions/container-auto-inject-install-script/provision.yml
+++ b/utils/build/virtual_machine/provisions/container-auto-inject-install-script/provision.yml
@@ -10,6 +10,7 @@ provision_steps:
   - init-config #Very first machine actions, like disable auto updates
   - prepare-docker #Prepare the docker environment
   - amazon-ecr-credential-helper # Install AWS ECR helper to download images from ECR
+  - patch-docker-daemon #Patch the docker daemon to allow the auto-injection
   - install-agent #Install the agent (allways latest release)
   - autoinjection_install_script #Install the auto-injection softaware 'datadog-apm-inject' and 'datadog-apm-library-$DD_LANG'
 

--- a/utils/build/virtual_machine/provisions/container-auto-inject-install-script/provision.yml
+++ b/utils/build/virtual_machine/provisions/container-auto-inject-install-script/provision.yml
@@ -10,7 +10,7 @@ provision_steps:
   - init-config #Very first machine actions, like disable auto updates
   - prepare-docker #Prepare the docker environment
   - amazon-ecr-credential-helper # Install AWS ECR helper to download images from ECR
-  - patch-docker-daemon #Patch the docker daemon to allow the auto-injection
+  - patch-docker-daemon #Patch the docker daemon to avoid networking issues/ip conflicts incident-31160
   - install-agent #Install the agent (allways latest release)
   - autoinjection_install_script #Install the auto-injection softaware 'datadog-apm-inject' and 'datadog-apm-library-$DD_LANG'
 
@@ -26,6 +26,10 @@ prepare-docker:
 amazon-ecr-credential-helper:
   cache: true
   install: !include utils/build/virtual_machine/provisions/auto-inject/docker/amazon-ecr-credential-helper.yml
+
+patch-docker-daemon:
+  cache: true
+  install: !include utils/build/virtual_machine/provisions/auto-inject/docker/patch-docker-daemon.yml
 
 install-agent:
   install:

--- a/utils/build/virtual_machine/provisions/installer-auto-inject/provision.yml
+++ b/utils/build/virtual_machine/provisions/installer-auto-inject/provision.yml
@@ -14,6 +14,7 @@ provision_steps:
   - init-config # Init the VM configuration
   - prepare-docker # Install docker
   - amazon-ecr-credential-helper # Install AWS ECR helper to download images from ECR
+  - patch-docker-daemon #Patch the docker daemon to allow the auto-injection
   - pre-install-installer # we install only the installer and we cached it. The goal is to force download the required deps for the installer and cache them
   - install-installer # Install the installer
 

--- a/utils/build/virtual_machine/provisions/installer-auto-inject/provision.yml
+++ b/utils/build/virtual_machine/provisions/installer-auto-inject/provision.yml
@@ -14,7 +14,7 @@ provision_steps:
   - init-config # Init the VM configuration
   - prepare-docker # Install docker
   - amazon-ecr-credential-helper # Install AWS ECR helper to download images from ECR
-  - patch-docker-daemon #Patch the docker daemon to allow the auto-injection
+  - patch-docker-daemon #Patch the docker daemon to avoid networking issues/ip conflicts incident-31160
   - pre-install-installer # we install only the installer and we cached it. The goal is to force download the required deps for the installer and cache them
   - install-installer # Install the installer
 
@@ -31,6 +31,10 @@ amazon-ecr-credential-helper:
   cache: true
   install: !include utils/build/virtual_machine/provisions/auto-inject/docker/amazon-ecr-credential-helper.yml
 
+patch-docker-daemon:
+  cache: true
+  install: !include utils/build/virtual_machine/provisions/auto-inject/docker/patch-docker-daemon.yml
+  
 pre-install-installer:
   cache: true
   install: !include utils/build/virtual_machine/provisions/auto-inject/auto-inject_pre_installer_manual.yml


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
