### PR TITLE
Fix RC product name in `Test_Lfi_RC_CustomAction`

### DIFF
--- a/tests/appsec/rasp/utils.py
+++ b/tests/appsec/rasp/utils.py
@@ -127,6 +127,6 @@ class RC_CONSTANTS:
     )
 
     RULES = (
-        "datadog/2/ASM/rules/config",
+        "datadog/2/ASM_DD/rules/config",
         _load_file("./tests/appsec/rasp/rasp_ruleset.json"),
     )


### PR DESCRIPTION
## Motivation

Rulesets are sent through ASM_DD product, not ASM

## Changes

Change RC config product name 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
