### PR TITLE
OnBoarding: Remove vm amazonlinux2dotnet6 and skip reason for centos7…

### DIFF
--- a/utils/_context/_scenarios/auto_injection.py
+++ b/utils/_context/_scenarios/auto_injection.py
@@ -19,7 +19,6 @@ from utils._context.virtual_machines import (
     Ubuntu18amd64,
     AmazonLinux2023arm64,
     AmazonLinux2023amd64,
-    AmazonLinux2DotNet6,
     AmazonLinux2amd64,
     AmazonLinux2arm64,
     Centos7amd64,
@@ -68,7 +67,6 @@ class _VirtualMachineScenario(Scenario):
         include_ubuntu_18_amd64=False,
         include_amazon_linux_2_amd64=False,
         include_amazon_linux_2_arm64=False,
-        include_amazon_linux_2_dotnet_6=False,
         include_amazon_linux_2023_amd64=False,
         include_amazon_linux_2023_arm64=False,
         include_centos_7_amd64=False,
@@ -133,8 +131,6 @@ class _VirtualMachineScenario(Scenario):
             self.required_vms.append(AmazonLinux2amd64())
         if include_amazon_linux_2_arm64:
             self.required_vms.append(AmazonLinux2arm64())
-        if include_amazon_linux_2_dotnet_6:
-            self.required_vms.append(AmazonLinux2DotNet6())
         if include_amazon_linux_2023_amd64:
             self.required_vms.append(AmazonLinux2023amd64())
         if include_amazon_linux_2023_arm64:
@@ -336,7 +332,6 @@ class InstallerAutoInjectionScenario(_VirtualMachineScenario):
             include_ubuntu_18_amd64=True,
             include_amazon_linux_2_amd64=True,
             include_amazon_linux_2_arm64=True,
-            include_amazon_linux_2_dotnet_6=True,
             include_amazon_linux_2023_amd64=True,
             include_amazon_linux_2023_arm64=True,
             include_centos_7_amd64=True,

--- a/utils/_context/virtual_machines.py
+++ b/utils/_context/virtual_machines.py
@@ -297,21 +297,6 @@ class AmazonLinux2arm64(_VirtualMachine):
         )
 
 
-class AmazonLinux2DotNet6(_VirtualMachine):
-    def __init__(self, **kwargs) -> None:
-        super().__init__(
-            "Amazon_Linux_2_DotNet6",
-            aws_config=_AWSConfig(ami_id="ami-005b11f8b84489615", ami_instance_type="t2.medium", user="ec2-user"),
-            vagrant_config=None,
-            krunvm_config=None,
-            os_type="linux",
-            os_distro="rpm",
-            os_branch="amazon_linux2_dotnet6",
-            os_cpu="amd64",
-            **kwargs,
-        )
-
-
 class AmazonLinux2023amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(

--- a/utils/build/virtual_machine/weblogs/dotnet/provision_test-app-dotnet-container.yml
+++ b/utils/build/virtual_machine/weblogs/dotnet/provision_test-app-dotnet-container.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-dotnet-container
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, ubuntu22_arm64]
+    excluded_os_branches: [amazon_linux2023_amd64, ubuntu22_arm64]
     # Alma Linux 8 ARM64 fails also without the SSI. It fails when we execute 'dotnet restore' in the Dockerfile
     # Same for RedHat 8.6 ARM64 (segfault)
     excluded_os_names: [AlmaLinux_8_arm64, RedHat_8_6_arm64]

--- a/utils/build/virtual_machine/weblogs/dotnet/provision_test-app-dotnet.yml
+++ b/utils/build/virtual_machine/weblogs/dotnet/provision_test-app-dotnet.yml
@@ -54,16 +54,17 @@ lang_variant:
           sudo ./dotnet-install.sh --channel 6.0 -InstallDir /opt
           sudo ln -s /opt/dotnet /usr/local/bin/dotnet
           sudo ln -s /opt/dotnet /usr/bin/dotnet
+
       - os_type: linux
         os_distro: rpm
         remote-command: dotnet --info || sudo yum install -y dotnet-sdk-6.0
 
 weblog:
     name: test-app-dotnet
-    #amazon_linux2_dotnet6 excluded due to https://datadoghq.atlassian.net/browse/AIT-10335
     #Ubuntu 21 (arm64) excluded due to there is not installable cadidate for dotnet-sdk-6.0
     #Ubuntu 21 (amd64) excluded due to there is not installable cadidate for dotnet-sdk-6.0
-    excluded_os_branches: [ubuntu18_amd64, amazon_linux2_dotnet6, centos_7_amd64, ubuntu20_arm64,ubuntu21, debian]
+    #Centos 7. I can't find the libicu60 package for centos 7. Only available version 50.2
+    excluded_os_branches: [ubuntu18_amd64, ubuntu20_arm64,ubuntu21, centos_7_amd64, debian]
     excluded_os_names: [OracleLinux_7_9_amd64]
     install:
       - os_type: linux

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine-jdk15.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine-jdk15.yml
@@ -26,7 +26,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-alpine-jdk15
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2, ubuntu22_arm64, amazon_linux2023_arm64]
+    excluded_os_branches: [amazon_linux2, ubuntu22_arm64, amazon_linux2023_arm64]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine-jdk21.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine-jdk21.yml
@@ -26,7 +26,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-alpine-jdk21
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2]
+    excluded_os_branches: [amazon_linux2]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine.yml
@@ -20,7 +20,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-alpine
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2]
+    excluded_os_branches: [ amazon_linux2]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-buildpack.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-buildpack.yml
@@ -12,7 +12,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-buildpack
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2, ubuntu22_arm64, amazon_linux2023_arm64]
+    excluded_os_branches: [ amazon_linux2, ubuntu22_arm64, amazon_linux2023_arm64]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-container-jdk15.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-container-jdk15.yml
@@ -21,7 +21,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-container-jdk15
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2]
+    excluded_os_branches: [ amazon_linux2]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-container.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-container.yml
@@ -20,7 +20,7 @@ lang_variant:
 
 weblog:
     name: test-app-java-container
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2]
+    excluded_os_branches: [ amazon_linux2]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java.yml
@@ -25,7 +25,6 @@ lang_variant:
 
 weblog:
     name: test-app-java
-    excluded_os_branches: [amazon_linux2_dotnet6]
     install:
       - os_type: linux
 

--- a/utils/build/virtual_machine/weblogs/java/provision_test-shell-script.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-shell-script.yml
@@ -12,7 +12,7 @@ lang_variant:
 
 weblog:
     name: test-shell-script
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
+    excluded_os_branches: [amazon_linux2023_amd64]
     install:
       - os_type: linux
         remote-command: |

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-16.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-16.yml
@@ -19,7 +19,7 @@ lang_variant:
 
 weblog:
     name: test-app-nodejs-16
-    excluded_os_branches: [amazon_linux2_dotnet6, centos_7_amd64]
+    excluded_os_branches: [centos_7_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-alpine.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-alpine.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-nodejs-alpine
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2023_amd64, centos_7_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-container.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-container.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-nodejs-container
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, centos_7_amd64]
+    excluded_os_branches: [ amazon_linux2023_amd64, centos_7_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs.yml
@@ -20,7 +20,7 @@ lang_variant:
 weblog:
     name: test-app-nodejs
     #Excluded because we can not run node18 due to gclib version
-    excluded_os_branches: [amazon_linux2_dotnet6, ubuntu18_amd64, amazon_linux2, centos_7_amd64]
+    excluded_os_branches: [ubuntu18_amd64, amazon_linux2, centos_7_amd64]
     excluded_os_names: [OracleLinux_7_9_amd64]
     install: 
       - os_type: linux

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-shell-script.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-shell-script.yml
@@ -20,7 +20,7 @@ lang_variant:
 weblog:
     name: test-shell-script
     # Requires libc6 >= 2.28, not available in ubuntu18_amd64 / centos_7_amd64 / amazon_linux2
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, amazon_linux2, ubuntu18_amd64, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2023_amd64, amazon_linux2, ubuntu18_amd64, centos_7_amd64]
     install:
       - os_type: linux
         remote-command: |

--- a/utils/build/virtual_machine/weblogs/php/provision_test-app-php-container-56.yml
+++ b/utils/build/virtual_machine/weblogs/php/provision_test-app-php-container-56.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-php-container-56
-    excluded_os_branches: [amazon_linux2, amazon_linux2_dotnet6, centos_7_amd64]
+    excluded_os_branches: [amazon_linux2, centos_7_amd64]
     install:
       - os_type: linux
 

--- a/utils/build/virtual_machine/weblogs/php/provision_test-app-php-container-83.yml
+++ b/utils/build/virtual_machine/weblogs/php/provision_test-app-php-container-83.yml
@@ -1,6 +1,5 @@
 weblog:
     name: test-app-php-container-83
-    excluded_os_branches: [amazon_linux2_dotnet6]
     install:
       - os_type: linux
 

--- a/utils/build/virtual_machine/weblogs/php/provision_test-app-php-container-alpine.yml
+++ b/utils/build/virtual_machine/weblogs/php/provision_test-app-php-container-alpine.yml
@@ -1,6 +1,5 @@
 weblog:
     name: test-app-php-container-alpine
-    excluded_os_branches: [amazon_linux2_dotnet6]
     install:
       - os_type: linux
 

--- a/utils/build/virtual_machine/weblogs/php/provision_test-app-php.yml
+++ b/utils/build/virtual_machine/weblogs/php/provision_test-app-php.yml
@@ -24,8 +24,7 @@ lang_variant:
 
 weblog:
     name: test-app-php
-    #Amazon Linux 2 is installing an old verison of PHP and it's not supported by SSI
-    excluded_os_branches: [ amazon_linux2_dotnet6, centos_7_amd64]
+    excluded_os_branches: [ centos_7_amd64]
     excluded_os_names: [OracleLinux_7_9_amd64]
     install:
       - os_type: linux

--- a/utils/build/virtual_machine/weblogs/php/provision_test-shell-script.yml
+++ b/utils/build/virtual_machine/weblogs/php/provision_test-shell-script.yml
@@ -18,7 +18,7 @@ lang_variant:
 
 weblog:
     name: test-shell-script
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
+    excluded_os_branches: [amazon_linux2023_amd64]
     install:
       - os_type: linux
         remote-command: |

--- a/utils/build/virtual_machine/weblogs/python/provision_test-app-python-alpine.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-app-python-alpine.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-python-alpine
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
+    excluded_os_branches: [ amazon_linux2023_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/python/provision_test-app-python-container.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-app-python-container.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-python-container
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
+    excluded_os_branches: [ amazon_linux2023_amd64]
     install: 
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/python/provision_test-app-python.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-app-python.yml
@@ -24,7 +24,6 @@ lang_variant:
 
 weblog:
     name: test-app-python
-    excluded_os_branches: [amazon_linux2_dotnet6]
     install:
       - os_type: linux
 

--- a/utils/build/virtual_machine/weblogs/python/provision_test-shell-script.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-shell-script.yml
@@ -20,7 +20,7 @@ lang_variant:
 
 weblog:
     name: test-shell-script
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64]
+    excluded_os_branches: [amazon_linux2023_amd64]
     install:
       - os_type: linux
         remote-command: |

--- a/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby-container.yml
+++ b/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby-container.yml
@@ -1,6 +1,6 @@
 weblog:
     name: test-app-ruby-container
-    excluded_os_branches: [amazon_linux2_dotnet6,amazon_linux2, ubuntu21, fedora]
+    excluded_os_branches: [amazon_linux2, ubuntu21, fedora]
     install:
       - os_type: linux
 

--- a/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby.yml
+++ b/utils/build/virtual_machine/weblogs/ruby/provision_test-app-ruby.yml
@@ -27,7 +27,7 @@ weblog:
     name: test-app-ruby
     # centos_7_amd64, redhat_8_6, & fedora are excluded because they do not provide the right Ruby versions
     # TODO oracle_linux and alma_linux. Failed when we run the app. Related with how we install Ruby
-    excluded_os_branches: [amazon_linux2_dotnet6, ubuntu18_amd64, amazon_linux2, centos_7_amd64, oracle_linux, alma_linux, ubuntu24, ubuntu20_amd64,ubuntu20_arm64, ubuntu21, ubuntu23, redhat_8_6, fedora]
+    excluded_os_branches: [ubuntu18_amd64, amazon_linux2, centos_7_amd64, oracle_linux, alma_linux, ubuntu24, ubuntu20_amd64,ubuntu20_arm64, ubuntu21, ubuntu23, redhat_8_6, fedora]
     install:
       - os_type: linux
 

--- a/utils/build/virtual_machine/weblogs/ruby/provision_test-shell-script.yml
+++ b/utils/build/virtual_machine/weblogs/ruby/provision_test-shell-script.yml
@@ -24,7 +24,7 @@ lang_variant:
 weblog:
     name: test-shell-script
     # centos_7_amd64 is excluded because it does not provides the right Ruby versions
-    excluded_os_branches: [amazon_linux2_dotnet6, amazon_linux2023_amd64, centos_7_amd64]
+    excluded_os_branches: [ amazon_linux2023_amd64, centos_7_amd64]
     install:
       - os_type: linux
         remote-command: |


### PR DESCRIPTION
…-dotnet

## Motivation

<!-- What inspired you to submit this pull request? -->
Machine amazonlinux2dotnet6 not longer used. Remplazed by amazonlinux2. We install the dotnet6 from our provision.
After try to enable centos7 for dotnet, I added in this PR the skip reason

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
