### PR TITLE
Enable Test_HeaderTags_Colon_Trailing for Go

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -527,7 +527,7 @@ tests/:
   test_library_conf.py:
     Test_HeaderTags: v1.53.0
     Test_HeaderTags_Colon_Leading: v1.53.0
-    Test_HeaderTags_Colon_Trailing: bug (AIT-8571)
+    Test_HeaderTags_Colon_Trailing: v1.70.0 # v1.69.0?
     Test_HeaderTags_Long: v1.53.0
     Test_HeaderTags_Short: v1.53.0
     Test_HeaderTags_Whitespace_Header: v1.53.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -527,7 +527,7 @@ tests/:
   test_library_conf.py:
     Test_HeaderTags: v1.53.0
     Test_HeaderTags_Colon_Leading: v1.53.0
-    Test_HeaderTags_Colon_Trailing: v1.70.0 # v1.69.0?
+    Test_HeaderTags_Colon_Trailing: v1.70.0-dev
     Test_HeaderTags_Long: v1.53.0
     Test_HeaderTags_Short: v1.53.0
     Test_HeaderTags_Whitespace_Header: v1.53.0


### PR DESCRIPTION
## Motivation
Handling trailing colons in header_tags will be fixed in next dd-trace-go release, due to this change: https://github.com/DataDog/dd-trace-go/pull/2913 

## Changes
Enables Test_HeaderTags_Colon_Trailing for Go in v1.70.0

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
