### PR TITLE
Fix unclear instructions in parametric.md

### DIFF
--- a/docs/scenarios/parametric.md
+++ b/docs/scenarios/parametric.md
@@ -129,7 +129,7 @@ By default you will be on the `master` branch, but if you'd like to run system-t
 ./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar
 ```
 
-3. You should now have a Java tracer agent artifact called `dd-java-agent-*.jar` under the `dd-java-agent/build/libs/` folder and a Java tracer public API artifact called `dd-trace-api-*.jar` under the `dd-trace-api/build/libs/` folder (Note: the * is a placeholder for the version snapshot you built locally, so the files won't literally be called e.g,`dd-java-agent-*.jar`). Move these files into the `system-tests/binaries/` folder.
+3. You should now have a Java tracer agent artifact called `dd-java-agent-*.jar` under the `dd-trace-java/dd-java-agent/build/libs/` folder and a Java tracer public API artifact called `dd-trace-api-*.jar` under the `dd-trace-java/dd-trace-api/build/libs/` folder (Note: the * is a placeholder for the version snapshot you built locally, so the files won't literally be called e.g,`dd-java-agent-*.jar`). Move these files into the system tests repo under its `/binaries` folder: `system-tests/binaries/`.
 
 *Note*, you should have only TWO jar files in `system-tests/binaries`. Do NOT copy sources or javadoc jars.
 


### PR DESCRIPTION
Java instructions had a typo, this makes it clearer.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
