### PR TITLE
chore: fix formatting for DD_TAGS

### DIFF
--- a/utils/build/docker/set-system-tests-weblog-env.Dockerfile
+++ b/utils/build/docker/set-system-tests-weblog-env.Dockerfile
@@ -3,7 +3,7 @@ FROM system_tests/weblog
 # Datadog setup
 ENV DD_SERVICE=weblog
 ENV DD_VERSION=1.0.0
-ENV DD_TAGS='key1:val1, key2 : val2 '
+ENV DD_TAGS='key1:val1,key2:val2'
 ENV DD_ENV=system-tests
 ENV DD_TRACE_LOG_DIRECTORY=/var/log/system-tests
 


### PR DESCRIPTION
## Motivation

Resolve the `Malformed tag in tag pair ':' from tag string 'key***:val***, key2 : val2'` error that is raised when running  weblog apps.

## Changes

- Removes whitespace from comma delimited tags. DD_TAGS should be delimited by commas or whitespace NOT both. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
