### PR TITLE
[java] Enable new AppSec obfuscation test

### DIFF
--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -184,7 +184,7 @@ class Test_AppSecObfuscator:
             params={"payload": sensitive_raw_payload},
         )
 
-    @missing_feature(library="java")
+    @missing_feature(context.library < "java@1.39.0", reason="APPSEC-54498")
     def test_appsec_obfuscator_value(self):
         """Obfuscation test of a matching rule parameter value containing a sensitive keyword."""
         # Validate that the AppSec event do not contain VALUE_WITH_SECRET value.


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

[APPSEC-54498](https://datadoghq.atlassian.net/browse/APPSEC-54498)
[APPSEC-54879](https://datadoghq.atlassian.net/browse/APPSEC-54879)

## Changes

Enable XPASS test.

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* ~[ ] A docker base image is modified?~
    * ~[ ] the relevant `build-XXX-image` label is present~
* ~[ ] A scenario is added (or removed)?~
    * ~[ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)~


[APPSEC-54498]: https://datadoghq.atlassian.net/browse/APPSEC-54498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-54879]: https://datadoghq.atlassian.net/browse/APPSEC-54879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ