### PR TITLE
[java] Enable test for fixed issue in jersey-grizzly2

### DIFF
--- a/tests/appsec/iast/source/test_parameter_name.py
+++ b/tests/appsec/iast/source/test_parameter_name.py
@@ -38,7 +38,7 @@ class TestParameterName(BaseSourceTest):
         self.validate_request_reported(self.requests["GET"])
 
     @missing_feature(weblog_variant="express4", reason="Tainted as request body")
-    @bug(context.library < "java@1.40.0" and context.weblog_variant == "jersey-grizzly2", reason="Not reported")
+    @bug(context.library < "java@1.40.0" and context.weblog_variant == "jersey-grizzly2", reason="APPSEC-55387")
     @bug(weblog_variant="resteasy-netty3", reason="Not reported")
     @bug(library="python", reason="Python frameworks need a header, if not, 415 status code")
     @missing_feature(library="dotnet", reason="Tainted as request body")

--- a/tests/appsec/iast/source/test_parameter_name.py
+++ b/tests/appsec/iast/source/test_parameter_name.py
@@ -31,14 +31,14 @@ class TestParameterName(BaseSourceTest):
 
     setup_source_get_reported = BaseSourceTest.setup_source_reported
 
-    @bug(weblog_variant="jersey-grizzly2", reason="Not reported")
+    @bug(context.library < "java@1.40.0" and context.weblog_variant == "jersey-grizzly2", reason="Not reported")
     @bug(weblog_variant="resteasy-netty3", reason="Not reported")
     def test_source_get_reported(self):
         """ for use case where only one is reported, we want to keep a test on the one reported """
         self.validate_request_reported(self.requests["GET"])
 
     @missing_feature(weblog_variant="express4", reason="Tainted as request body")
-    @bug(weblog_variant="jersey-grizzly2", reason="Not reported")
+    @bug(context.library < "java@1.40.0" and context.weblog_variant == "jersey-grizzly2", reason="Not reported")
     @bug(weblog_variant="resteasy-netty3", reason="Not reported")
     @bug(library="python", reason="Python frameworks need a header, if not, 415 status code")
     @missing_feature(library="dotnet", reason="Tainted as request body")

--- a/tests/appsec/iast/source/test_parameter_name.py
+++ b/tests/appsec/iast/source/test_parameter_name.py
@@ -31,7 +31,7 @@ class TestParameterName(BaseSourceTest):
 
     setup_source_get_reported = BaseSourceTest.setup_source_reported
 
-    @bug(context.library < "java@1.40.0" and context.weblog_variant == "jersey-grizzly2", reason="Not reported")
+    @bug(context.library < "java@1.40.0" and context.weblog_variant == "jersey-grizzly2", reason="APPSEC-55387")
     @bug(weblog_variant="resteasy-netty3", reason="Not reported")
     def test_source_get_reported(self):
         """ for use case where only one is reported, we want to keep a test on the one reported """


### PR DESCRIPTION
## Motivation

See https://github.com/DataDog/dd-trace-java/pull/7619

[APPSEC-55387](https://datadoghq.atlassian.net/browse/APPSEC-55387)

[APPSEC-54879](https://datadoghq.atlassian.net/browse/APPSEC-54879)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-54879]: https://datadoghq.atlassian.net/browse/APPSEC-54879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APPSEC-55387]: https://datadoghq.atlassian.net/browse/APPSEC-55387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ