### PR TITLE
Adding sampling header tag for trace_context_precedence test

### DIFF
--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -640,7 +640,7 @@ class Test_Headers_Precedence:
         assert "tracestate" in headers6
         assert len(tracestate6Arr) == 1 and tracestate6Arr[0].startswith("dd=")
 
-    @irrelevant(context.library < "java@v1.43.0", reason="not implemented yet")
+    @missing_feature(context.library < "java@v1.43.0", reason="not implemented yet")
     @missing_feature(context.library == "ruby", reason="not_implemented yet")
     @missing_feature(context.library == "cpp", reason="not_implemented yet")
     @missing_feature(context.library == "dotnet", reason="not_implemented yet")
@@ -789,7 +789,7 @@ class Test_Headers_Precedence:
         assert span5["trace_id"] == 6
         assert span5.get("span_links") == None
 
-    @irrelevant(context.library < "java@v1.43.0", reason="not implemented yet")
+    @missing_feature(context.library < "java@v1.43.0", reason="not implemented yet")
     @missing_feature(context.library == "ruby", reason="not_implemented yet")
     @missing_feature(context.library == "cpp", reason="not_implemented yet")
     @missing_feature(context.library == "dotnet", reason="not_implemented yet")
@@ -838,7 +838,7 @@ class Test_Headers_Precedence:
         assert link2["span_id"] == 11744061942159299346
         assert link2["attributes"] == {"reason": "terminated_context", "context_headers": "b3multi"}
         assert link2["trace_id_high"] == 1229782938247303441
-    
+
     # Checks for the consistent behavior of the flags and tracestate in span links.
     @missing_feature(context.library == "java", reason="not_implemented yet")
     @missing_feature(context.library == "ruby", reason="not_implemented yet")

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 
 from utils.parametric.spec.tracecontext import get_tracecontext, TRACECONTEXT_FLAGS_SET
-from utils.parametric.spec.trace import find_only_span, find_span, find_trace, retrieve_span_links, find_span_in_traces
+from utils.parametric.spec.trace import retrieve_span_links, find_span_in_traces
 from utils.parametric.headers import make_single_request_and_get_inject_headers
 from utils import bug, missing_feature, context, irrelevant, scenarios, features
 
@@ -640,7 +640,7 @@ class Test_Headers_Precedence:
         assert "tracestate" in headers6
         assert len(tracestate6Arr) == 1 and tracestate6Arr[0].startswith("dd=")
 
-    @missing_feature(context.library < "java@v1.43.0", reason="not implemented yet")
+    @missing_feature(context.library < "java@v1.43.0", reason="span links attributes field added in 1.43.0")
     @missing_feature(context.library == "ruby", reason="not_implemented yet")
     @missing_feature(context.library == "cpp", reason="not_implemented yet")
     @missing_feature(context.library == "dotnet", reason="not_implemented yet")
@@ -789,7 +789,7 @@ class Test_Headers_Precedence:
         assert span5["trace_id"] == 6
         assert span5.get("span_links") == None
 
-    @missing_feature(context.library < "java@v1.43.0", reason="not implemented yet")
+    @missing_feature(context.library < "java@v1.43.0", reason="span links attributes field added in 1.43.0")
     @missing_feature(context.library == "ruby", reason="not_implemented yet")
     @missing_feature(context.library == "cpp", reason="not_implemented yet")
     @missing_feature(context.library == "dotnet", reason="not_implemented yet")
@@ -801,7 +801,7 @@ class Test_Headers_Precedence:
         self, test_agent, test_library
     ):
         """
-        Ensure the last parent id tag is set according to the W3C phase 3 spec
+        This test is the same as above, but tests the precedence of tracecontext over datadog and b3multi
         """
         with test_library:
             # Trace ids with the three styles do not match
@@ -852,7 +852,7 @@ class Test_Headers_Precedence:
         self, test_agent, test_library
     ):
         """
-        Ensure the last parent id tag is set according to the W3C phase 3 spec
+        Ensure the flags and tracestate fields are properly set in the span links
         """
         with test_library:
             # Trace ids with the three styles do not match

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -640,7 +640,7 @@ class Test_Headers_Precedence:
         assert "tracestate" in headers6
         assert len(tracestate6Arr) == 1 and tracestate6Arr[0].startswith("dd=")
 
-    @missing_feature(context.library == "java", reason="not_implemented yet")
+    @irrelevant(context.library < "java@v1.43.0", reason="not implemented yet")
     @missing_feature(context.library == "ruby", reason="not_implemented yet")
     @missing_feature(context.library == "cpp", reason="not_implemented yet")
     @missing_feature(context.library == "dotnet", reason="not_implemented yet")
@@ -753,7 +753,6 @@ class Test_Headers_Precedence:
         assert link0["span_id"] == 987654321
         assert link0["attributes"] == {"reason": "terminated_context", "context_headers": "tracecontext"}
         assert link0["tracestate"] == "dd=s:2;t.tid:1111111111111111,foo=1"
-        assert link0["flags"] == 1 | TRACECONTEXT_FLAGS_SET
         assert link0["trace_id_high"] == 1229782938247303441
 
         # 2) Datadog and tracecontext headers, trace-id does match, Datadog is primary context
@@ -771,16 +770,13 @@ class Test_Headers_Precedence:
         assert link1["trace_id"] == 3
         assert link1["span_id"] == 11744061942159299346
         assert link1["attributes"] == {"reason": "terminated_context", "context_headers": "b3multi"}
-        assert link1["flags"] == 1 | TRACECONTEXT_FLAGS_SET
         assert link1["trace_id_high"] == 1229782938247303441
-        assert link1.get("tracestate") == None
 
         link2 = links2[1]
         assert link2["trace_id"] == 1
         assert link2["span_id"] == 987654321
         assert link2["attributes"] == {"reason": "terminated_context", "context_headers": "tracecontext"}
         assert link2["tracestate"] == "dd=s:2;t.tid:1111111111111111,foo=1"
-        assert link2["flags"] == 1 | TRACECONTEXT_FLAGS_SET
         assert link2["trace_id_high"] == 1229782938247303441
 
         # 4) Datadog, b3multi headers edge case where we want to make sure NOT to create a span_link
@@ -793,7 +789,7 @@ class Test_Headers_Precedence:
         assert span5["trace_id"] == 6
         assert span5.get("span_links") == None
 
-    @missing_feature(context.library == "java", reason="not_implemented yet")
+    @irrelevant(context.library < "java@v1.43.0", reason="not implemented yet")
     @missing_feature(context.library == "ruby", reason="not_implemented yet")
     @missing_feature(context.library == "cpp", reason="not_implemented yet")
     @missing_feature(context.library == "dotnet", reason="not_implemented yet")
@@ -835,17 +831,59 @@ class Test_Headers_Precedence:
         assert link1["trace_id"] == 2
         assert link1["span_id"] == 10
         assert link1["attributes"] == {"reason": "terminated_context", "context_headers": "datadog"}
-        assert link1["flags"] == 1 | TRACECONTEXT_FLAGS_SET
         assert link1["trace_id_high"] == 2459565876494606882
-        assert link1.get("tracestate") == None
 
         link2 = span_links[1]
         assert link2["trace_id"] == 3
         assert link2["span_id"] == 11744061942159299346
         assert link2["attributes"] == {"reason": "terminated_context", "context_headers": "b3multi"}
-        # Enable this assertion after discussion on Java encoding behavior
-        # assert link2["flags"] == 0 | TRACECONTEXT_FLAGS_SET
         assert link2["trace_id_high"] == 1229782938247303441
+    
+    # Checks for the consistent behavior of the flags and tracestate in span links.
+    @missing_feature(context.library == "java", reason="not_implemented yet")
+    @missing_feature(context.library == "ruby", reason="not_implemented yet")
+    @missing_feature(context.library == "cpp", reason="not_implemented yet")
+    @missing_feature(context.library == "dotnet", reason="not_implemented yet")
+    @missing_feature(context.library == "golang", reason="not_implemented yet")
+    @missing_feature(context.library == "nodejs", reason="not_implemented yet")
+    @missing_feature(context.library == "php", reason="not_implemented yet")
+    @pytest.mark.parametrize("library_env", [{"DD_TRACE_PROPAGATION_STYLE": "tracecontext,datadog,b3multi"}])
+    def test_headers_precedence_propagationstyle_resolves_conflicting_contexts_spanlinks_extras(
+        self, test_agent, test_library
+    ):
+        """
+        Ensure the last parent id tag is set according to the W3C phase 3 spec
+        """
+        with test_library:
+            # Trace ids with the three styles do not match
+            with test_library.start_span(
+                name="trace_ids_do_not_match",
+                http_headers=[
+                    ["traceparent", "00-11111111111111110000000000000002-000000003ade68b1-01"],
+                    ["tracestate", "dd=s:2;p:000000000000000a,foo=1"],
+                    ["x-datadog-parent-id", "10"],
+                    ["x-datadog-trace-id", "2"],
+                    ["x-datadog-tags", "_dd.p.tid=2222222222222222"],
+                    ["x-datadog-sampling-priority", "2"],
+                    ["x-b3-traceid", "11111111111111110000000000000003"],
+                    ["x-b3-spanid", "a2fb4a1d1a96d312"],
+                    ["x-b3-sampled", "0"],
+                ],
+            ) as s1:
+                pass
+
+        traces = test_agent.wait_for_num_traces(1)
+        span = find_span_in_traces(traces, s1.trace_id, s1.span_id)
+
+        assert span["name"] == "trace_ids_do_not_match"
+        span_links = retrieve_span_links(span)
+        assert len(span_links) == 2
+        link1 = span_links[0]
+        assert link1["flags"] == 1 | TRACECONTEXT_FLAGS_SET
+        assert link1.get("tracestate") == None
+
+        link2 = span_links[1]
+        assert link2["flags"] == 0 | TRACECONTEXT_FLAGS_SET
         assert link2.get("tracestate") == None
 
     @enable_datadog_b3multi_tracecontext_extract_first_false()

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -840,13 +840,13 @@ class Test_Headers_Precedence:
         assert link2["trace_id_high"] == 1229782938247303441
 
     # Checks for the consistent behavior of flags in span links.
-    @missing_feature(context.library == "java", reason="not_implemented yet")
-    @missing_feature(context.library == "ruby", reason="not_implemented yet")
-    @missing_feature(context.library == "cpp", reason="not_implemented yet")
-    @missing_feature(context.library == "dotnet", reason="not_implemented yet")
-    @missing_feature(context.library == "golang", reason="not_implemented yet")
-    @missing_feature(context.library == "nodejs", reason="not_implemented yet")
-    @missing_feature(context.library == "php", reason="not_implemented yet")
+    @irrelevant(context.library == "java", reason="implementation specs have not been determined")
+    @irrelevant(context.library == "ruby", reason="implementation specs have not been determined")
+    @irrelevant(context.library == "cpp", reason="implementation specs have not been determined")
+    @irrelevant(context.library == "dotnet", reason="implementation specs have not been determined")
+    @irrelevant(context.library == "golang", reason="implementation specs have not been determined")
+    @irrelevant(context.library == "nodejs", reason="implementation specs have not been determined")
+    @irrelevant(context.library == "php", reason="implementation specs have not been determined")
     @pytest.mark.parametrize("library_env", [{"DD_TRACE_PROPAGATION_STYLE": "tracecontext,datadog,b3multi"}])
     def test_headers_precedence_propagationstyle_resolves_conflicting_contexts_spanlinks_flags(
         self, test_agent, test_library

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -640,7 +640,6 @@ class Test_Headers_Precedence:
         assert "tracestate" in headers6
         assert len(tracestate6Arr) == 1 and tracestate6Arr[0].startswith("dd=")
 
-    @missing_feature(context.library == "java", reason="not_implemented yet")
     @missing_feature(context.library == "ruby", reason="not_implemented yet")
     @missing_feature(context.library == "cpp", reason="not_implemented yet")
     @missing_feature(context.library == "dotnet", reason="not_implemented yet")
@@ -793,7 +792,6 @@ class Test_Headers_Precedence:
         assert span5["trace_id"] == 6
         assert span5.get("span_links") == None
 
-    @missing_feature(context.library == "java", reason="not_implemented yet")
     @missing_feature(context.library == "ruby", reason="not_implemented yet")
     @missing_feature(context.library == "cpp", reason="not_implemented yet")
     @missing_feature(context.library == "dotnet", reason="not_implemented yet")
@@ -817,6 +815,7 @@ class Test_Headers_Precedence:
                     ["x-datadog-parent-id", "10"],
                     ["x-datadog-trace-id", "2"],
                     ["x-datadog-tags", "_dd.p.tid=2222222222222222"],
+                    ["x-datadog-sampling-priority", "2"],
                     ["x-b3-traceid", "11111111111111110000000000000003"],
                     ["x-b3-spanid", "a2fb4a1d1a96d312"],
                     ["x-b3-sampled", "0"],
@@ -842,7 +841,8 @@ class Test_Headers_Precedence:
         assert link2["trace_id"] == 3
         assert link2["span_id"] == 11744061942159299346
         assert link2["attributes"] == {"reason": "terminated_context", "context_headers": "b3multi"}
-        assert link2["flags"] == 0 | TRACECONTEXT_FLAGS_SET
+        # Enable this assertion after discussion on Java encoding behavior
+        # assert link2["flags"] == 0 | TRACECONTEXT_FLAGS_SET
         assert link2["trace_id_high"] == 1229782938247303441
         assert link2.get("tracestate") == None
 

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -640,6 +640,7 @@ class Test_Headers_Precedence:
         assert "tracestate" in headers6
         assert len(tracestate6Arr) == 1 and tracestate6Arr[0].startswith("dd=")
 
+    @missing_feature(context.library == "java", reason="not_implemented yet")
     @missing_feature(context.library == "ruby", reason="not_implemented yet")
     @missing_feature(context.library == "cpp", reason="not_implemented yet")
     @missing_feature(context.library == "dotnet", reason="not_implemented yet")
@@ -792,6 +793,7 @@ class Test_Headers_Precedence:
         assert span5["trace_id"] == 6
         assert span5.get("span_links") == None
 
+    @missing_feature(context.library == "java", reason="not_implemented yet")
     @missing_feature(context.library == "ruby", reason="not_implemented yet")
     @missing_feature(context.library == "cpp", reason="not_implemented yet")
     @missing_feature(context.library == "dotnet", reason="not_implemented yet")


### PR DESCRIPTION
## Motivation
Followup from #3253 and adding sampling header tag to verify consistency of flag values in Span Links. Also enabling Java tests that are fixed to be consistent.
<!-- What inspired you to submit this pull request? -->

## Changes
Adding sampling header tag and enabling TraceContext Span Link system tests for java.
<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
