### PR TITLE
kafka cluster id test update

### DIFF
--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -49,7 +49,9 @@ class Test_DsmKafka:
     def setup_dsm_kafka(self):
         self.r = weblog.get(f"/dsm?integration=kafka&queue={DSM_QUEUE}&group={DSM_CONSUMER_GROUP}")
 
-    @irrelevant(context.library in ["python", "java", "nodejs", "dotnet"], reason="New behavior with cluster id not merged yet.")
+    @irrelevant(
+        context.library in ["python", "java", "nodejs", "dotnet"], reason="New behavior with cluster id not merged yet."
+    )
     def test_dsm_kafka(self):
         assert self.r.text == "ok"
 
@@ -58,10 +60,7 @@ class Test_DsmKafka:
         # There is currently no FNV-1 library availble for node.js
         # So we are using a different algorithm for node.js for now
         language_hashes = {
-            "nodejs": {
-                "producer": 7021878731777772655,
-                "consumer": 4591800307942911915,
-            },
+            "nodejs": {"producer": 7021878731777772655, "consumer": 4591800307942911915,},
             # we are not using a group consumer for testing go as setup is complex, so no group edge_tag is included in hashing
             "golang": {
                 "producer": 4463699290244539355,

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -562,8 +562,7 @@ class Test_Dsm_Manual_Checkpoint_Intra_Process:
         )
 
     @bug(
-        library="nodejs",
-        reason="NodeJS doesn't sort the DSM edge tags and has different hashes.",
+        library="nodejs", reason="NodeJS doesn't sort the DSM edge tags and has different hashes.",
     )
     def test_dsm_manual_checkpoint_intra_process(self):
         assert self.produce.status_code == 200
@@ -642,8 +641,7 @@ class Test_Dsm_Manual_Checkpoint_Inter_Process:
         )
 
     @bug(
-        library="nodejs",
-        reason="NodeJS doesn't sort the DSM edge tags and has different hashes.",
+        library="nodejs", reason="NodeJS doesn't sort the DSM edge tags and has different hashes.",
     )
     def test_dsm_manual_checkpoint_inter_process(self):
         assert self.produce_threaded.status_code == 200

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -561,7 +561,7 @@ class Test_Dsm_Manual_Checkpoint_Intra_Process:
             timeout=DSM_REQUEST_TIMEOUT,
         )
 
-    @bug(
+    @irrelevant(
         library="nodejs", reason="NodeJS doesn't sort the DSM edge tags and has different hashes.",
     )
     def test_dsm_manual_checkpoint_intra_process(self):
@@ -640,7 +640,7 @@ class Test_Dsm_Manual_Checkpoint_Inter_Process:
             timeout=DSM_REQUEST_TIMEOUT,
         )
 
-    @bug(
+    @irrelevant(
         library="nodejs", reason="NodeJS doesn't sort the DSM edge tags and has different hashes.",
     )
     def test_dsm_manual_checkpoint_inter_process(self):

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -63,13 +63,13 @@ class Test_DsmKafka:
                 "edge_tags_in": (
                     "direction:in",
                     f"group:{DSM_CONSUMER_GROUP}",
-                    "kafka.cluster_id:5L6g3nShT-eMCtK--X86sw",
+                    "kafka_cluster_id:5L6g3nShT-eMCtK--X86sw",
                     f"topic:{DSM_QUEUE}",
                     "type:kafka",
                 ),
                 "edge_tags_out": (
                     "direction:out",
-                    "kafka.cluster_id:5L6g3nShT-eMCtK--X86sw",
+                    "kafka_cluster_id:5L6g3nShT-eMCtK--X86sw",
                     f"topic:{DSM_QUEUE}",
                     "type:kafka",
                 ),

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -63,13 +63,13 @@ class Test_DsmKafka:
                 "edge_tags_in": (
                     "direction:in",
                     f"group:{DSM_CONSUMER_GROUP}",
-                    "kafka.cluster_id:r4zt_wrqTRuT7W2NJsB_GA",
+                    "kafka.cluster_id:5L6g3nShT-eMCtK--X86sw",
                     f"topic:{DSM_QUEUE}",
                     "type:kafka",
                 ),
                 "edge_tags_out": (
                     "direction:out",
-                    "kafka.cluster_id:r4zt_wrqTRuT7W2NJsB_GA",
+                    "kafka.cluster_id:5L6g3nShT-eMCtK--X86sw",
                     f"topic:{DSM_QUEUE}",
                     "type:kafka",
                 ),

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -561,6 +561,10 @@ class Test_Dsm_Manual_Checkpoint_Intra_Process:
             timeout=DSM_REQUEST_TIMEOUT,
         )
 
+    @bug(
+        library="nodejs",
+        reason="NodeJS doesn't sort the DSM edge tags and has different hashes.",
+    )
     def test_dsm_manual_checkpoint_intra_process(self):
         assert self.produce.status_code == 200
         assert self.produce.text == "ok"
@@ -637,6 +641,10 @@ class Test_Dsm_Manual_Checkpoint_Inter_Process:
             timeout=DSM_REQUEST_TIMEOUT,
         )
 
+    @bug(
+        library="nodejs",
+        reason="NodeJS doesn't sort the DSM edge tags and has different hashes.",
+    )
     def test_dsm_manual_checkpoint_inter_process(self):
         assert self.produce_threaded.status_code == 200
         assert self.produce_threaded.text == "ok"

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -49,6 +49,7 @@ class Test_DsmKafka:
     def setup_dsm_kafka(self):
         self.r = weblog.get(f"/dsm?integration=kafka&queue={DSM_QUEUE}&group={DSM_CONSUMER_GROUP}")
 
+    @irrelevant(context.library in ["python", "java", "nodejs", "dotnet"], reason="New behavior with cluster id not merged yet.")
     def test_dsm_kafka(self):
         assert self.r.text == "ok"
 
@@ -60,6 +61,17 @@ class Test_DsmKafka:
             "nodejs": {
                 "producer": 7021878731777772655,
                 "consumer": 4591800307942911915,
+            },
+            # we are not using a group consumer for testing go as setup is complex, so no group edge_tag is included in hashing
+            "golang": {
+                "producer": 4463699290244539355,
+                "consumer": 13758451224913876939,
+                "edge_tags_in": ("direction:in", f"topic:{DSM_QUEUE}", "type:kafka"),
+                "edge_tags_out": ("direction:out", f"topic:{DSM_QUEUE}", "type:kafka"),
+            },
+            "default": {
+                "producer": 14216899112169674443,
+                "consumer": 4247242616665718048,
                 "edge_tags_in": (
                     "direction:in",
                     f"group:{DSM_CONSUMER_GROUP}",
@@ -73,19 +85,6 @@ class Test_DsmKafka:
                     f"topic:{DSM_QUEUE}",
                     "type:kafka",
                 ),
-            },
-            # we are not using a group consumer for testing go as setup is complex, so no group edge_tag is included in hashing
-            "golang": {
-                "producer": 4463699290244539355,
-                "consumer": 13758451224913876939,
-                "edge_tags_in": ("direction:in", f"topic:{DSM_QUEUE}", "type:kafka"),
-                "edge_tags_out": ("direction:out", f"topic:{DSM_QUEUE}", "type:kafka"),
-            },
-            "default": {
-                "producer": 4463699290244539355,
-                "consumer": 3735318893869752335,
-                "edge_tags_in": ("direction:in", f"group:{DSM_CONSUMER_GROUP}", f"topic:{DSM_QUEUE}", "type:kafka"),
-                "edge_tags_out": ("direction:out", f"topic:{DSM_QUEUE}", "type:kafka"),
             },
         }
 

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -60,30 +60,35 @@ class Test_DsmKafka:
             "nodejs": {
                 "producer": 2931833227331067675,
                 "consumer": 271115008390912609,
-                "edge_tags": ("direction:in", f"group:{DSM_CONSUMER_GROUP}", f"topic:{DSM_QUEUE}", "type:kafka"),
+                "edge_tags_in": ("direction:in", f"group:{DSM_CONSUMER_GROUP}", "kafka.cluster_id:r4zt_wrqTRuT7W2NJsB_GA",f"topic:{DSM_QUEUE}", "type:kafka"),
+                "edge_tags_out": ("direction:out", "kafka.cluster_id:r4zt_wrqTRuT7W2NJsB_GA", f"topic:{DSM_QUEUE}", "type:kafka"),
             },
             # we are not using a group consumer for testing go as setup is complex, so no group edge_tag is included in hashing
             "golang": {
                 "producer": 4463699290244539355,
                 "consumer": 13758451224913876939,
-                "edge_tags": ("direction:in", f"topic:{DSM_QUEUE}", "type:kafka"),
+                "edge_tags_in": ("direction:in", f"topic:{DSM_QUEUE}", "type:kafka"),
+                "edge_tags_out": ("direction:out", f"topic:{DSM_QUEUE}", "type:kafka"),
             },
             "default": {
                 "producer": 4463699290244539355,
                 "consumer": 3735318893869752335,
-                "edge_tags": ("direction:in", f"group:{DSM_CONSUMER_GROUP}", f"topic:{DSM_QUEUE}", "type:kafka"),
+                "edge_tags_in": ("direction:in", f"group:{DSM_CONSUMER_GROUP}", f"topic:{DSM_QUEUE}", "type:kafka"),
+                "edge_tags_out": ("direction:out", f"topic:{DSM_QUEUE}", "type:kafka"),
             },
         }
 
         producer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["producer"]
         consumer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["consumer"]
-        edge_tags = language_hashes.get(context.library.library, language_hashes.get("default"))["edge_tags"]
+        edge_tags_in = language_hashes.get(context.library.library, language_hashes.get("default"))["edge_tags_in"]
+        edge_tags_out = language_hashes.get(context.library.library, language_hashes.get("default"))["edge_tags_out"]
+
 
         DsmHelper.assert_checkpoint_presence(
-            hash_=producer_hash, parent_hash=0, tags=("direction:out", f"topic:{DSM_QUEUE}", "type:kafka"),
+            hash_=producer_hash, parent_hash=0, tags=edge_tags_in,
         )
         DsmHelper.assert_checkpoint_presence(
-            hash_=consumer_hash, parent_hash=producer_hash, tags=edge_tags,
+            hash_=consumer_hash, parent_hash=producer_hash, tags=edge_tags_out,
         )
 
 
@@ -558,7 +563,7 @@ class Test_Dsm_Manual_Checkpoint_Intra_Process:
 
         language_hashes = {
             # nodejs uses a different hashing algorithm and therefore has different hashes than the default
-            "nodejs": {"producer": 2991387329420856704, "consumer": 2932594615174135112,},
+            "nodejs": {"producer": 16586338448658789200, "consumer": 9706550123902107656,},
             # for some reason, Java assigns earlier HTTP in checkpoint as parent
             # Parent HTTP Checkpoint: 3883033147046472598, 0, ('direction:in', 'type:http')
             "java": {
@@ -634,7 +639,7 @@ class Test_Dsm_Manual_Checkpoint_Inter_Process:
 
         language_hashes = {
             # nodejs uses a different hashing algorithm and therefore has different hashes than the default
-            "nodejs": {"producer": 1168055216783445015, "consumer": 18123432526286354806,},
+            "nodejs": {"producer": 5168239543453408764, "consumer": 1957306998450816025,},
             # for some reason, Java assigns earlier HTTP in checkpoint as parent
             # Parent HTTP Checkpoint: 3883033147046472598, 0, ('direction:in', 'type:http')
             "java": {

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -91,14 +91,14 @@ class Test_DsmKafka:
 
         producer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["producer"]
         consumer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["consumer"]
-        edge_tags_in = language_hashes.get(context.library.library, language_hashes.get("default"))["edge_tags_in"]
         edge_tags_out = language_hashes.get(context.library.library, language_hashes.get("default"))["edge_tags_out"]
+        edge_tags_in = language_hashes.get(context.library.library, language_hashes.get("default"))["edge_tags_in"]
 
         DsmHelper.assert_checkpoint_presence(
-            hash_=producer_hash, parent_hash=0, tags=edge_tags_in,
+            hash_=producer_hash, parent_hash=0, tags=edge_tags_out,
         )
         DsmHelper.assert_checkpoint_presence(
-            hash_=consumer_hash, parent_hash=producer_hash, tags=edge_tags_out,
+            hash_=consumer_hash, parent_hash=producer_hash, tags=edge_tags_in,
         )
 
 

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -58,10 +58,21 @@ class Test_DsmKafka:
         # So we are using a different algorithm for node.js for now
         language_hashes = {
             "nodejs": {
-                "producer": 2931833227331067675,
-                "consumer": 271115008390912609,
-                "edge_tags_in": ("direction:in", f"group:{DSM_CONSUMER_GROUP}", "kafka.cluster_id:r4zt_wrqTRuT7W2NJsB_GA",f"topic:{DSM_QUEUE}", "type:kafka"),
-                "edge_tags_out": ("direction:out", "kafka.cluster_id:r4zt_wrqTRuT7W2NJsB_GA", f"topic:{DSM_QUEUE}", "type:kafka"),
+                "producer": 7021878731777772655,
+                "consumer": 4591800307942911915,
+                "edge_tags_in": (
+                    "direction:in",
+                    f"group:{DSM_CONSUMER_GROUP}",
+                    "kafka.cluster_id:r4zt_wrqTRuT7W2NJsB_GA",
+                    f"topic:{DSM_QUEUE}",
+                    "type:kafka",
+                ),
+                "edge_tags_out": (
+                    "direction:out",
+                    "kafka.cluster_id:r4zt_wrqTRuT7W2NJsB_GA",
+                    f"topic:{DSM_QUEUE}",
+                    "type:kafka",
+                ),
             },
             # we are not using a group consumer for testing go as setup is complex, so no group edge_tag is included in hashing
             "golang": {
@@ -82,7 +93,6 @@ class Test_DsmKafka:
         consumer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["consumer"]
         edge_tags_in = language_hashes.get(context.library.library, language_hashes.get("default"))["edge_tags_in"]
         edge_tags_out = language_hashes.get(context.library.library, language_hashes.get("default"))["edge_tags_out"]
-
 
         DsmHelper.assert_checkpoint_presence(
             hash_=producer_hash, parent_hash=0, tags=edge_tags_in,

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -799,7 +799,7 @@ class KafkaContainer(TestedContainer):
                 "KAFKA_LISTENERS": "PLAINTEXT://:9092,CONTROLLER://:9093",
                 "KAFKA_CONTROLLER_QUORUM_VOTERS": "1@kafka:9093",
                 "KAFKA_CONTROLLER_LISTENER_NAMES": "CONTROLLER",
-                "KAFKA_CLUSTER_ID": "r4zt_wrqTRuT7W2NJsB_GA",
+                "CLUSTER_ID": "5L6g3nShT-eMCtK--X86sw",
                 "KAFKA_ADVERTISED_LISTENERS": "PLAINTEXT://kafka:9092",
                 "KAFKA_INTER_BROKER_LISTENER_NAME": "PLAINTEXT",
                 "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP": "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT",


### PR DESCRIPTION
## Motivation

This PR updates Kafka DSM tests to include the new kafka cluster id. It also disables the test for now for all languages where cluster id is being added, and will be re-enabled in different PR's for each language once the implementation work is done.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
