### PR TITLE
[nodejs] fix missing dd-trace module error from typescript

### DIFF
--- a/utils/build/docker/nodejs/express4-typescript/auth.ts
+++ b/utils/build/docker/nodejs/express4-typescript/auth.ts
@@ -1,6 +1,7 @@
 'use strict'
 
 import type { Express, Request, Response, NextFunction } from "express";
+ // @ts-ignore
 import type { Tracer } from "dd-trace";
 const { Strategy: LocalStrategy } = require('passport-local')
 const { BasicStrategy } = require('passport-http')


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Fix missing dd-trace module error from TypeScript.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Add TypeScript ignore rule to dd-trace since it may be installed at runtime.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
