### PR TITLE
[ruby] Add 1.x support in Ruby weblogs

### DIFF
--- a/utils/build/docker/ruby/graphql23/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/graphql23/app/controllers/system_test_controller.rb
@@ -12,7 +12,7 @@ class SystemTestController < ApplicationController
       status: 'ok',
       library: {
         language: 'ruby',
-        version: Datadog::VERSION::STRING
+        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
       }
     }
   end

--- a/utils/build/docker/ruby/parametric/server.rb
+++ b/utils/build/docker/ruby/parametric/server.rb
@@ -9,11 +9,8 @@ begin
   require 'datadog'
   puts Datadog::VERSION::STRING
 rescue LoadError
-end
-begin
   require 'ddtrace'
   puts DDTrace::VERSION::STRING
-rescue LoadError
 end
 
 require 'datadog/tracing/contrib/grpc/distributed/propagation' # Loads optional `Datadog::Tracing::Contrib::GRPC::Distributed`

--- a/utils/build/docker/ruby/rack/config.ru
+++ b/utils/build/docker/ruby/rack/config.ru
@@ -7,7 +7,15 @@ require 'json'
 
 # tracer configuration of Rack integration
 
-require 'datadog/auto_instrument'
+begin
+  require 'ddtrace/auto_instrument'
+rescue LoadError
+end
+
+begin
+  require 'datadog/auto_instrument'
+rescue LoadError
+end
 require 'datadog/kit/appsec/events'
 
 Datadog.configure do |c|

--- a/utils/build/docker/ruby/rack/config.ru
+++ b/utils/build/docker/ruby/rack/config.ru
@@ -8,13 +8,9 @@ require 'json'
 # tracer configuration of Rack integration
 
 begin
-  require 'ddtrace/auto_instrument'
-rescue LoadError
-end
-
-begin
   require 'datadog/auto_instrument'
 rescue LoadError
+  require 'ddtrace/auto_instrument'
 end
 require 'datadog/kit/appsec/events'
 

--- a/utils/build/docker/ruby/rack/config.ru
+++ b/utils/build/docker/ruby/rack/config.ru
@@ -61,7 +61,7 @@ class Healthcheck
       status: 'ok',
       library: {
         language: 'ruby',
-        version: Datadog::VERSION::STRING
+        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
       }
     }
 

--- a/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
@@ -14,7 +14,7 @@ class SystemTestController < ApplicationController
       status: 'ok',
       library: {
         language: 'ruby',
-        version: Datadog::VERSION::STRING
+        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
       }
     }
   end

--- a/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
@@ -14,7 +14,7 @@ class SystemTestController < ApplicationController
       status: 'ok',
       library: {
         language: 'ruby',
-        version: Datadog::VERSION::STRING
+        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
       }
     }
   end

--- a/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
@@ -14,7 +14,7 @@ class SystemTestController < ApplicationController
       status: 'ok',
       library: {
         language: 'ruby',
-        version: Datadog::VERSION::STRING
+        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
       }
     }
   end

--- a/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
@@ -14,7 +14,7 @@ class SystemTestController < ApplicationController
       status: 'ok',
       library: {
         language: 'ruby',
-        version: Datadog::VERSION::STRING
+        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
       }
     }
   end

--- a/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
@@ -14,7 +14,7 @@ class SystemTestController < ApplicationController
       status: 'ok',
       library: {
         language: 'ruby',
-        version: Datadog::VERSION::STRING
+        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
       }
     }
   end

--- a/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
@@ -14,7 +14,7 @@ class SystemTestController < ApplicationController
       status: 'ok',
       library: {
         language: 'ruby',
-        version: Datadog::VERSION::STRING
+        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
       }
     }
   end

--- a/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
@@ -15,7 +15,7 @@ class SystemTestController < ApplicationController
       status: 'ok',
       library: {
         language: 'ruby',
-        version: Datadog::VERSION::STRING
+        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
       }
     }
   end

--- a/utils/build/docker/ruby/rails71/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails71/app/controllers/system_test_controller.rb
@@ -15,7 +15,7 @@ class SystemTestController < ApplicationController
       status: 'ok',
       library: {
         language: 'ruby',
-        version: Datadog::VERSION::STRING
+        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
       }
     }
   end

--- a/utils/build/docker/ruby/sinatra14/app.rb
+++ b/utils/build/docker/ruby/sinatra14/app.rb
@@ -44,7 +44,7 @@ get '/healthcheck' do
     status: 'ok',
     library: {
       language: 'ruby',
-      version: Datadog::VERSION::STRING
+      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra14/app.rb
+++ b/utils/build/docker/ruby/sinatra14/app.rb
@@ -5,13 +5,9 @@ require "uri"
 require 'json'
 
 begin
-  require 'ddtrace/auto_instrument'
-rescue LoadError
-end
-
-begin
   require 'datadog/auto_instrument'
 rescue LoadError
+  require 'ddtrace/auto_instrument'
 end
 
 Datadog.configure do |c|

--- a/utils/build/docker/ruby/sinatra20/app.rb
+++ b/utils/build/docker/ruby/sinatra20/app.rb
@@ -5,13 +5,9 @@ require "uri"
 require 'json'
 
 begin
-  require 'ddtrace/auto_instrument'
-rescue LoadError
-end
-
-begin
   require 'datadog/auto_instrument'
 rescue LoadError
+  require 'ddtrace/auto_instrument'
 end
 
 

--- a/utils/build/docker/ruby/sinatra20/app.rb
+++ b/utils/build/docker/ruby/sinatra20/app.rb
@@ -45,7 +45,7 @@ get '/healthcheck' do
     status: 'ok',
     library: {
       language: 'ruby',
-      version: Datadog::VERSION::STRING
+      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra21/app.rb
+++ b/utils/build/docker/ruby/sinatra21/app.rb
@@ -5,13 +5,9 @@ require "uri"
 require 'json'
 
 begin
-  require 'ddtrace/auto_instrument'
-rescue LoadError
-end
-
-begin
   require 'datadog/auto_instrument'
 rescue LoadError
+  require 'ddtrace/auto_instrument'
 end
 
 

--- a/utils/build/docker/ruby/sinatra21/app.rb
+++ b/utils/build/docker/ruby/sinatra21/app.rb
@@ -45,7 +45,7 @@ get '/healthcheck' do
     status: 'ok',
     library: {
       language: 'ruby',
-      version: Datadog::VERSION::STRING
+      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra22/app.rb
+++ b/utils/build/docker/ruby/sinatra22/app.rb
@@ -44,7 +44,7 @@ get '/healthcheck' do
     status: 'ok',
     library: {
       language: 'ruby',
-      version: Datadog::VERSION::STRING
+      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra22/app.rb
+++ b/utils/build/docker/ruby/sinatra22/app.rb
@@ -5,13 +5,9 @@ require "uri"
 require 'json'
 
 begin
-  require 'ddtrace/auto_instrument'
-rescue LoadError
-end
-
-begin
   require 'datadog/auto_instrument'
 rescue LoadError
+  require 'ddtrace/auto_instrument'
 end
 
 Datadog.configure do |c|

--- a/utils/build/docker/ruby/sinatra30/app.rb
+++ b/utils/build/docker/ruby/sinatra30/app.rb
@@ -44,7 +44,7 @@ get '/healthcheck' do
     status: 'ok',
     library: {
       language: 'ruby',
-      version: Datadog::VERSION::STRING
+      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra30/app.rb
+++ b/utils/build/docker/ruby/sinatra30/app.rb
@@ -5,13 +5,9 @@ require "uri"
 require 'json'
 
 begin
-  require 'ddtrace/auto_instrument'
-rescue LoadError
-end
-
-begin
   require 'datadog/auto_instrument'
 rescue LoadError
+  require 'ddtrace/auto_instrument'
 end
 
 Datadog.configure do |c|

--- a/utils/build/docker/ruby/sinatra31/app.rb
+++ b/utils/build/docker/ruby/sinatra31/app.rb
@@ -44,7 +44,7 @@ get '/healthcheck' do
     status: 'ok',
     library: {
       language: 'ruby',
-      version: Datadog::VERSION::STRING
+      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra31/app.rb
+++ b/utils/build/docker/ruby/sinatra31/app.rb
@@ -5,13 +5,9 @@ require "uri"
 require 'json'
 
 begin
-  require 'ddtrace/auto_instrument'
-rescue LoadError
-end
-
-begin
   require 'datadog/auto_instrument'
 rescue LoadError
+  require 'ddtrace/auto_instrument'
 end
 
 Datadog.configure do |c|

--- a/utils/build/docker/ruby/sinatra32/app.rb
+++ b/utils/build/docker/ruby/sinatra32/app.rb
@@ -44,7 +44,7 @@ get '/healthcheck' do
     status: 'ok',
     library: {
       language: 'ruby',
-      version: Datadog::VERSION::STRING
+      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra32/app.rb
+++ b/utils/build/docker/ruby/sinatra32/app.rb
@@ -5,13 +5,9 @@ require "uri"
 require 'json'
 
 begin
-  require 'ddtrace/auto_instrument'
-rescue LoadError
-end
-
-begin
   require 'datadog/auto_instrument'
 rescue LoadError
+  require 'ddtrace/auto_instrument'
 end
 
 Datadog.configure do |c|

--- a/utils/build/docker/ruby/sinatra40/app.rb
+++ b/utils/build/docker/ruby/sinatra40/app.rb
@@ -44,7 +44,7 @@ get '/healthcheck' do
     status: 'ok',
     library: {
       language: 'ruby',
-      version: Datadog::VERSION::STRING
+      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra40/app.rb
+++ b/utils/build/docker/ruby/sinatra40/app.rb
@@ -5,13 +5,9 @@ require "uri"
 require 'json'
 
 begin
-  require 'ddtrace/auto_instrument'
-rescue LoadError
-end
-
-begin
   require 'datadog/auto_instrument'
 rescue LoadError
+  require 'ddtrace/auto_instrument'
 end
 
 Datadog.configure do |c|


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
I wanted to enable easy wins, but also wanted to add the version since it works in the manifest. Trying to run system-tests on 1.x branch was not working. 1.x branch is still active and should still be tested against system-tests

## Changes

<!-- A brief description of the change being made with this pull request. -->
Both auto instrumentation and healthcheck endpoints were using `Datadog` namespace, but 1.x is using `DDTrace`. I applied what has been done in Sinatra weblogs and parametric weblog for auto-instrumentation (require in begin/rescue block), and added a condition for getting the version in healthcheck endpoints (`defined?(Datadog::VERSION)`)

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
