### PR TITLE
[ruby] Remove hacks on ruby bundle info output

### DIFF
--- a/tests/test_the_test/test_version.py
+++ b/tests/test_the_test/test_version.py
@@ -39,23 +39,23 @@ def test_version_comparizon():
 
 def test_ruby_version():
 
-    v = LibraryVersion("ruby", "  * ddtrace (0.53.0.appsec.180045)")
+    v = LibraryVersion("ruby", "0.53.0.appsec.180045")
     assert str(v.version) == "0.53.1-appsec+180045"
 
-    v = LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1 de82857)")
+    v = LibraryVersion("ruby", "1.0.0.beta1 de82857")
     assert v.version == Version("1.0.1-beta1+de82857")
 
-    v = LibraryVersion("ruby", "  * datadog (2.3.0 7dbcc40)")
+    v = LibraryVersion("ruby", "2.3.0 7dbcc40")
     assert str(v.version) == "2.3.1-z+7dbcc40"
 
-    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1)") == "ruby@1.0.1-z+beta1"
-    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1 de82857)") == "ruby@1.0.1-beta1+de82857"
+    assert LibraryVersion("ruby", "1.0.0.beta1") == "ruby@1.0.1-z+beta1"
+    assert LibraryVersion("ruby", "1.0.0.beta1 de82857") == "ruby@1.0.1-beta1+de82857"
 
     # very particular use case, because we hack the path for dev versions
-    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.beta1 de82857)") < "ruby@1.0.1"
-    assert LibraryVersion("ruby", "  * ddtrace (1.0.0.rc1)") < "ruby@1.0.1"
+    assert LibraryVersion("ruby", "1.0.0.beta1 de82857") < "ruby@1.0.1"
+    assert LibraryVersion("ruby", "1.0.0.rc1") < "ruby@1.0.1"
 
-    assert LibraryVersion("ruby", "  * datadog (2.3.0 7dbcc40)") >= "ruby@2.3.1-dev"
+    assert LibraryVersion("ruby", "2.3.0 7dbcc40") >= "ruby@2.3.1-dev"
 
 
 def test_library_version_comparizon():

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -149,7 +149,7 @@ class ParametricScenario(Scenario):
             self._clean_networks()
 
         # https://github.com/DataDog/system-tests/issues/2799
-        if library in ("nodejs", "python", "golang"):
+        if library in ("nodejs", "python", "golang", "ruby"):
             output = _get_client().containers.run(
                 self.apm_test_server_definition.container_tag,
                 remove=True,
@@ -588,6 +588,7 @@ def ruby_library_factory() -> APMLibraryTestServer:
             WORKDIR /app
             COPY {ruby_reldir} .
             COPY {ruby_reldir}/../install_ddtrace.sh binaries* /binaries/
+            COPY {ruby_reldir}/system_tests_library_version.sh system_tests_library_version.sh
             RUN bundle install
             RUN /binaries/install_ddtrace.sh
             COPY {ruby_reldir}/apm_test_client.proto /app/

--- a/utils/build/docker/ruby/graphql23/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/graphql23/app/controllers/system_test_controller.rb
@@ -8,11 +8,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/install_ddtrace.sh
+++ b/utils/build/docker/ruby/install_ddtrace.sh
@@ -48,7 +48,3 @@ fi
 bundle config set --local without test development
 
 bundle install
-
-bundle info $GEM_NAME | grep -m 1 $GEM_NAME > SYSTEM_TESTS_LIBRARY_VERSION
-
-echo "dd-trace version: $(cat SYSTEM_TESTS_LIBRARY_VERSION)"

--- a/utils/build/docker/ruby/parametric/Gemfile
+++ b/utils/build/docker/ruby/parametric/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem 'ddtrace' # To be overwrite by the script
 gem 'grpc'
 gem 'grpc-tools'
 

--- a/utils/build/docker/ruby/parametric/system_tests_library_version.sh
+++ b/utils/build/docker/ruby/parametric/system_tests_library_version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ruby -rbundler/setup -e 'puts Gem::Specification.find_all.find {|x| x.name == "ddtrace" || x.name == "datadog"}.version'

--- a/utils/build/docker/ruby/rack/config.ru
+++ b/utils/build/docker/ruby/rack/config.ru
@@ -61,11 +61,14 @@ end
 # /healthcheck
 class Healthcheck
   def self.run
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     response = {
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
 

--- a/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
@@ -11,11 +11,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails71/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails71/app/controllers/system_test_controller.rb
@@ -11,11 +11,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/sinatra14/app.rb
+++ b/utils/build/docker/ruby/sinatra14/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra20/app.rb
+++ b/utils/build/docker/ruby/sinatra20/app.rb
@@ -37,11 +37,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra21/app.rb
+++ b/utils/build/docker/ruby/sinatra21/app.rb
@@ -37,11 +37,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra22/app.rb
+++ b/utils/build/docker/ruby/sinatra22/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra30/app.rb
+++ b/utils/build/docker/ruby/sinatra30/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra31/app.rb
+++ b/utils/build/docker/ruby/sinatra31/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra32/app.rb
+++ b/utils/build/docker/ruby/sinatra32/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra40/app.rb
+++ b/utils/build/docker/ruby/sinatra40/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 


### PR DESCRIPTION
## Motivation

We get ruby version from pure ruby threw healthcheck, so we don't need anymore all the clean done in library version

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
