### PR TITLE
Add tests for user and session tracking/blocking

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -785,6 +785,12 @@ This endpoint get a `name` and a `value` form the query string, and adds a heade
 
 This endpoint is the initial endpoint used to test session fingerprints, consequently it must initialize a new session and the web client should be able to deal with the persistence mechanism (e.g. cookies).
 
+Returns the identifier of the created session id. Example :
+
+```text
+c377db41-b664-4e30-af57-5df2e803bec7
+```
+
 Examples:
 - `GET`: `/session/new`
 

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -71,6 +71,7 @@ tests/:
     test_alpha.py: irrelevant (ASM is not implemented in C++)
     test_asm_standalone.py: irrelevant (ASM is not implemented in C++)
     test_automated_login_events.py: irrelevant (ASM is not implemented in C++)
+    test_automated_user_and_session_tracking.py: irrelevant (ASM is not implemented in C++)
     test_blocking_addresses.py: irrelevant (ASM is not implemented in C++)
     test_client_ip.py: irrelevant (ASM is not implemented in C++)
     test_conf.py: irrelevant (ASM is not implemented in C++)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -271,7 +271,6 @@ tests/:
       Test_V2_Login_Events_RC: v3.1.0
     test_automated_user_and_session_tracking.py:
       Test_Automated_Session_Blocking: missing_feature
-      Test_Automated_Session_Tracking: missing_feature
       Test_Automated_User_Blocking: missing_feature
       Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -269,6 +269,11 @@ tests/:
       Test_V2_Login_Events: v3.1.0
       Test_V2_Login_Events_Anon: v3.1.0
       Test_V2_Login_Events_RC: v3.1.0
+    test_automated_user_and_session_tracking.py:
+      Test_Automated_Session_Blocking: missing_feature
+      Test_Automated_Session_Tracking: missing_feature
+      Test_Automated_User_Blocking: missing_feature
+      Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
       Test_Blocking_client_ip: v2.27.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -312,7 +312,6 @@ tests/:
       Test_V2_Login_Events_RC: missing_feature
     test_automated_user_and_session_tracking.py:
       Test_Automated_Session_Blocking: missing_feature
-      Test_Automated_Session_Tracking: missing_feature
       Test_Automated_User_Blocking: missing_feature
       Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -310,6 +310,11 @@ tests/:
       Test_V2_Login_Events: missing_feature
       Test_V2_Login_Events_Anon: missing_feature
       Test_V2_Login_Events_RC: missing_feature
+    test_automated_user_and_session_tracking.py:
+      Test_Automated_Session_Blocking: missing_feature
+      Test_Automated_Session_Tracking: missing_feature
+      Test_Automated_User_Blocking: missing_feature
+      Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
       Test_Blocking_client_ip: v1.51.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -960,7 +960,6 @@ tests/:
         vertx4: missing_feature (login endpoints not implemented)
     test_automated_user_and_session_tracking.py:
       Test_Automated_Session_Blocking: missing_feature
-      Test_Automated_Session_Tracking: missing_feature
       Test_Automated_User_Blocking: missing_feature
       Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -958,6 +958,11 @@ tests/:
         spring-boot-openliberty: missing_feature (weblog returns error 500)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)
+    test_automated_user_and_session_tracking.py:
+      Test_Automated_Session_Blocking: missing_feature
+      Test_Automated_Session_Tracking: missing_feature
+      Test_Automated_User_Blocking: missing_feature
+      Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
       Test_Blocking_client_ip:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -482,6 +482,10 @@ tests/:
       Test_V2_Login_Events: irrelevant
       Test_V2_Login_Events_Anon: irrelevant
       Test_V2_Login_Events_RC: irrelevant
+    test_automated_user_and_session_tracking.py:
+      Test_Automated_Session_Blocking: missing_feature
+      Test_Automated_User_Blocking: missing_feature
+      Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers:
         '*': *ref_4_22_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -207,6 +207,11 @@ tests/:
       Test_V2_Login_Events: v1.3.0-dev
       Test_V2_Login_Events_Anon: v1.3.0-dev
       Test_V2_Login_Events_RC: missing_feature
+    test_automated_user_and_session_tracking.py:
+      Test_Automated_Session_Blocking: missing_feature
+      Test_Automated_Session_Tracking: missing_feature
+      Test_Automated_User_Blocking: missing_feature
+      Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
       Test_Blocking_request_body: irrelevant (Php does not accept url encoded entries without key)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -209,7 +209,6 @@ tests/:
       Test_V2_Login_Events_RC: missing_feature
     test_automated_user_and_session_tracking.py:
       Test_Automated_Session_Blocking: missing_feature
-      Test_Automated_Session_Tracking: missing_feature
       Test_Automated_User_Blocking: missing_feature
       Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -452,6 +452,11 @@ tests/:
       Test_V2_Login_Events: v2.11.0
       Test_V2_Login_Events_Anon: v2.11.0
       Test_V2_Login_Events_RC: v2.11.0
+    test_automated_user_and_session_tracking.py:
+      Test_Automated_Session_Blocking: missing_feature
+      Test_Automated_Session_Tracking: missing_feature
+      Test_Automated_User_Blocking: missing_feature
+      Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
       Test_Blocking_client_ip:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -454,7 +454,6 @@ tests/:
       Test_V2_Login_Events_RC: v2.11.0
     test_automated_user_and_session_tracking.py:
       Test_Automated_Session_Blocking: missing_feature
-      Test_Automated_Session_Tracking: missing_feature
       Test_Automated_User_Blocking: missing_feature
       Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -219,7 +219,6 @@ tests/:
       Test_V2_Login_Events_RC: missing_feature
     test_automated_user_and_session_tracking.py:
       Test_Automated_Session_Blocking: missing_feature
-      Test_Automated_Session_Tracking: missing_feature
       Test_Automated_User_Blocking: missing_feature
       Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -217,6 +217,11 @@ tests/:
       Test_V2_Login_Events: missing_feature
       Test_V2_Login_Events_Anon: missing_feature
       Test_V2_Login_Events_RC: missing_feature
+    test_automated_user_and_session_tracking.py:
+      Test_Automated_Session_Blocking: missing_feature
+      Test_Automated_Session_Tracking: missing_feature
+      Test_Automated_User_Blocking: missing_feature
+      Test_Automated_User_Tracking: missing_feature
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: v2.3.1-dev
       Test_Blocking_client_ip: v1.0.0

--- a/tests/appsec/test_automated_user_and_session_tracking.py
+++ b/tests/appsec/test_automated_user_and_session_tracking.py
@@ -35,7 +35,7 @@ class Test_Automated_User_Tracking:
             meta = span.get("meta", {})
             assert meta["usr.id"] == "social-security-id"
             assert meta["_dd.appsec.usr.id"] == "social-security-id"
-            assert meta["_dd.appsec.user.collection_mode"] == "ident"
+            assert meta["_dd.appsec.user.collection_mode"] == "identification"
 
     def setup_user_tracking_sdk_overwrite(self):
         self.r_login = weblog.post("/login?auth=local&sdk_event=success&sdk_user=sdkUser", data=login_data(context))

--- a/tests/appsec/test_automated_user_and_session_tracking.py
+++ b/tests/appsec/test_automated_user_and_session_tracking.py
@@ -1,0 +1,187 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2024 Datadog, Inc.
+
+from utils import context
+from utils import features
+from utils import interfaces
+from utils import remote_config as rc
+from utils import rfc
+from utils import scenarios
+from utils import weblog
+
+
+def login_data(context):
+    """In Rails the parameters are group by scope. In the case of the test the scope is user.
+   The syntax to group parameters in a POST request is scope[parameter]
+   """
+    username_key = "user[username]" if "rails" in context.weblog_variant else "username"
+    password_key = "user[password]" if "rails" in context.weblog_variant else "password"
+    return {username_key: "test", password_key: "1234"}
+
+
+@rfc("https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw")
+@features.user_monitoring
+class Test_Automated_User_Tracking:
+    def setup_user_tracking_auto(self):
+        self.r_login = weblog.post("/login?auth=local", data=login_data(context))
+        self.r_home = weblog.get("/", cookies=self.r_login.cookies,)
+
+    def test_user_tracking_auto(self):
+        assert self.r_login.status_code == 200
+
+        assert self.r_home.status_code == 200
+        for _, trace, span in interfaces.library.get_spans(request=self.r_home):
+            meta = span.get("meta", {})
+            assert meta["usr.id"] == "social-security-id"
+            assert meta["_dd.appsec.usr.id"] == "social-security-id"
+            assert meta["_dd.appsec.user.collection_mode"] == "ident"
+
+    def setup_user_tracking_sdk_overwrite(self):
+        self.r_login = weblog.post("/login?auth=local&sdk_event=success&sdk_user=sdkUser", data=login_data(context))
+
+    def test_user_tracking_sdk_overwrite(self):
+        assert self.r_login.status_code == 200
+        for _, trace, span in interfaces.library.get_spans(request=self.r_login):
+            meta = span.get("meta", {})
+            assert meta["usr.id"] == "sdkUser"
+            assert meta["_dd.appsec.usr.id"] == "social-security-id"
+            assert meta["_dd.appsec.user.collection_mode"] == "sdk"
+
+
+CONFIG_ENABLED = (
+    "datadog/2/ASM_FEATURES/asm_features_activation/config",
+    {"asm": {"enabled": True}},
+)
+
+BLOCK_USER = (
+    "datadog/2/ASM_DD/rules/config",
+    {
+        "version": "2.1",
+        "metadata": {"rules_version": "1.2.6"},
+        "rules": [
+            {
+                "id": "block-users",
+                "name": "Block User Addresses",
+                "tags": {"type": "block_user", "category": "security_response"},
+                "conditions": [
+                    {
+                        "parameters": {"inputs": [{"address": "usr.id"}], "data": "blocked_users"},
+                        "operator": "exact_match",
+                    }
+                ],
+                "transformers": [],
+                "on_match": ["block"],
+            }
+        ],
+        "rules_data": [
+            {
+                "id": "blocked_users",
+                "type": "data_with_expiration",
+                "data": [{"value": "social-security-id", "expiration": 0}, {"value": "sdkUser", "expiration": 0}],
+            },
+        ],
+    },
+)
+
+
+@rfc("https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw")
+@features.user_monitoring
+@scenarios.appsec_runtime_activation
+class Test_Automated_User_Blocking:
+    def setup_user_blocking_auto(self):
+        rc.rc_state.reset().apply()
+
+        self.config_state_1 = rc.rc_state.set_config(*CONFIG_ENABLED).apply()
+        self.r_login = weblog.post("/login?auth=local", data=login_data(context))
+
+        self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER).apply()
+        self.r_home_blocked = weblog.get("/", cookies=self.r_login.cookies,)
+
+    def test_user_blocking_auto(self):
+        assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+        assert self.r_login.status_code == 200
+
+        assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+        interfaces.library.assert_waf_attack(self.r_home_blocked, rule="block-users")
+        assert self.r_home_blocked.status_code == 403
+
+    def setup_user_blocking_sdk(self):
+        rc.rc_state.reset().apply()
+
+        self.config_state_1 = rc.rc_state.set_config(*CONFIG_ENABLED).apply()
+        self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER).apply()
+        self.r_login_blocked = weblog.post(
+            "/login?auth=local&sdk_event=success&sdk_user=sdkUser", data=login_data(context)
+        )
+
+    def test_user_blocking_sdk(self):
+        assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+        assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+        interfaces.library.assert_waf_attack(self.r_login_blocked, rule="block-users")
+        assert self.r_login_blocked.status_code == 403
+
+
+@rfc("https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw")
+@features.user_monitoring
+class Test_Automated_Session_Tracking:
+    def setup_session_tracking(self):
+        self.r_create_session = weblog.get("/session/new")
+        self.r_home = weblog.get("/", cookies=self.r_create_session.cookies,)
+
+    def test_session_tracking(self):
+        assert self.r_create_session.status_code == 200
+        expected_session = self.r_create_session.text
+
+        assert self.r_home.status_code == 200
+        for _, trace, span in interfaces.library.get_spans(request=self.r_home):
+            meta = span.get("meta", {})
+            assert meta["usr.session_id"] == expected_session
+
+
+BLOCK_SESSION = (
+    "datadog/2/ASM_DD/rules/config",
+    {
+        "version": "2.1",
+        "metadata": {"rules_version": "1.2.6"},
+        "rules": [
+            {
+                "id": "block-sessions",
+                "name": "Block Session Addresses",
+                "tags": {"type": "block_user", "category": "security_response"},
+                "conditions": [
+                    {
+                        "parameters": {"inputs": [{"address": "usr.session_id"}], "data": "blocked_sessions"},
+                        "operator": "exact_match",
+                    }
+                ],
+                "transformers": [],
+                "on_match": ["block"],
+            }
+        ],
+        "rules_data": [{"id": "blocked_sessions", "type": "data_with_expiration", "data": []},],
+    },
+)
+
+
+@rfc("https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw")
+@features.user_monitoring
+@scenarios.appsec_runtime_activation
+class Test_Automated_Session_Blocking:
+    def setup_session_blocking(self):
+        rc.rc_state.reset().apply()
+
+        self.config_state_1 = rc.rc_state.set_config(*CONFIG_ENABLED).apply()
+        self.r_create_session = weblog.get("/session/new")
+
+        BLOCK_SESSION[1]["rules_data"][0]["data"].append({"value": self.r_create_session.text, "expiration": 0})
+        self.config_state_2 = rc.rc_state.set_config(*BLOCK_SESSION).apply()
+        self.r_home_blocked = weblog.get("/", cookies=self.r_create_session.cookies,)
+
+    def test_session_blocking(self):
+        assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+        assert self.r_create_session.status_code == 200
+
+        assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+        interfaces.library.assert_waf_attack(self.r_home_blocked, rule="block-sessions")
+        assert self.r_home_blocked.status_code == 403

--- a/tests/appsec/test_automated_user_and_session_tracking.py
+++ b/tests/appsec/test_automated_user_and_session_tracking.py
@@ -32,8 +32,8 @@ PASSWORD = "1234"
 
 def login_data(context, user, password):
     """In Rails the parameters are group by scope. In the case of the test the scope is user.
-   The syntax to group parameters in a POST request is scope[parameter]
-   """
+    The syntax to group parameters in a POST request is scope[parameter]
+    """
     username_key = "user[username]" if "rails" in context.weblog_variant else "username"
     password_key = "user[password]" if "rails" in context.weblog_variant else "password"
     return {username_key: user, password_key: password}
@@ -44,7 +44,10 @@ def login_data(context, user, password):
 class Test_Automated_User_Tracking:
     def setup_user_tracking_auto(self):
         self.r_login = weblog.post("/login?auth=local", data=login_data(context, USER, PASSWORD))
-        self.r_home = weblog.get("/", cookies=self.r_login.cookies,)
+        self.r_home = weblog.get(
+            "/",
+            cookies=self.r_login.cookies,
+        )
 
     def test_user_tracking_auto(self):
         assert self.r_login.status_code == 200
@@ -117,7 +120,10 @@ class Test_Automated_User_Blocking:
         self.r_login = weblog.post("/login?auth=local", data=login_data(context, USER, PASSWORD))
 
         self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER).apply()
-        self.r_home_blocked = weblog.get("/", cookies=self.r_login.cookies,)
+        self.r_home_blocked = weblog.get(
+            "/",
+            cookies=self.r_login.cookies,
+        )
 
     def test_user_blocking_auto(self):
         assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
@@ -167,7 +173,9 @@ BLOCK_SESSION = (
                 "on_match": ["block"],
             }
         ],
-        "rules_data": [{"id": "blocked_sessions", "type": "data_with_expiration", "data": []},],
+        "rules_data": [
+            {"id": "blocked_sessions", "type": "data_with_expiration", "data": []},
+        ],
     },
 )
 
@@ -185,7 +193,10 @@ class Test_Automated_Session_Blocking:
 
         BLOCK_SESSION[1]["rules_data"][0]["data"].append({"value": self.session_id, "expiration": 0})
         self.config_state_2 = rc.rc_state.set_config(*BLOCK_SESSION).apply()
-        self.r_home_blocked = weblog.get("/", cookies=self.r_create_session.cookies,)
+        self.r_home_blocked = weblog.get(
+            "/",
+            cookies=self.r_create_session.cookies,
+        )
 
     def test_session_blocking(self):
         assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED

--- a/tests/appsec/test_automated_user_and_session_tracking.py
+++ b/tests/appsec/test_automated_user_and_session_tracking.py
@@ -10,39 +10,60 @@ from utils import rfc
 from utils import scenarios
 from utils import weblog
 
+# User entries in the internal DB:
+# users = [
+#     {
+#         id: 'social-security-id',
+#         username: 'test',
+#         password: '1234',
+#         email: 'testuser@ddog.com'
+#     },
+#     {
+#         id: '591dc126-8431-4d0f-9509-b23318d3dce4',
+#         username: 'testuuid',
+#         password: '1234',
+#         email: 'testuseruuid@ddog.com'
+#     }
+# ]
+USER = "test"
+UUID_USER = "testuuid"
+PASSWORD = "1234"
 
-def login_data(context):
+
+def login_data(context, user, password):
     """In Rails the parameters are group by scope. In the case of the test the scope is user.
    The syntax to group parameters in a POST request is scope[parameter]
    """
     username_key = "user[username]" if "rails" in context.weblog_variant else "username"
     password_key = "user[password]" if "rails" in context.weblog_variant else "password"
-    return {username_key: "test", password_key: "1234"}
+    return {username_key: user, password_key: password}
 
 
 @rfc("https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw")
 @features.user_monitoring
 class Test_Automated_User_Tracking:
     def setup_user_tracking_auto(self):
-        self.r_login = weblog.post("/login?auth=local", data=login_data(context))
+        self.r_login = weblog.post("/login?auth=local", data=login_data(context, USER, PASSWORD))
         self.r_home = weblog.get("/", cookies=self.r_login.cookies,)
 
     def test_user_tracking_auto(self):
         assert self.r_login.status_code == 200
 
         assert self.r_home.status_code == 200
-        for _, trace, span in interfaces.library.get_spans(request=self.r_home):
+        for _, _, span in interfaces.library.get_spans(request=self.r_home):
             meta = span.get("meta", {})
             assert meta["usr.id"] == "social-security-id"
             assert meta["_dd.appsec.usr.id"] == "social-security-id"
             assert meta["_dd.appsec.user.collection_mode"] == "identification"
 
     def setup_user_tracking_sdk_overwrite(self):
-        self.r_login = weblog.post("/login?auth=local&sdk_event=success&sdk_user=sdkUser", data=login_data(context))
+        self.r_login = weblog.post(
+            "/login?auth=local&sdk_event=success&sdk_user=sdkUser", data=login_data(context, USER, PASSWORD)
+        )
 
     def test_user_tracking_sdk_overwrite(self):
         assert self.r_login.status_code == 200
-        for _, trace, span in interfaces.library.get_spans(request=self.r_login):
+        for _, _, span in interfaces.library.get_spans(request=self.r_login):
             meta = span.get("meta", {})
             assert meta["usr.id"] == "sdkUser"
             assert meta["_dd.appsec.usr.id"] == "social-security-id"
@@ -93,7 +114,7 @@ class Test_Automated_User_Blocking:
         rc.rc_state.reset().apply()
 
         self.config_state_1 = rc.rc_state.set_config(*CONFIG_ENABLED).apply()
-        self.r_login = weblog.post("/login?auth=local", data=login_data(context))
+        self.r_login = weblog.post("/login?auth=local", data=login_data(context, USER, PASSWORD))
 
         self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER).apply()
         self.r_home_blocked = weblog.get("/", cookies=self.r_login.cookies,)
@@ -111,32 +132,19 @@ class Test_Automated_User_Blocking:
 
         self.config_state_1 = rc.rc_state.set_config(*CONFIG_ENABLED).apply()
         self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER).apply()
+        self.r_login = weblog.post("/login?auth=local", data=login_data(context, UUID_USER, PASSWORD))
         self.r_login_blocked = weblog.post(
-            "/login?auth=local&sdk_event=success&sdk_user=sdkUser", data=login_data(context)
+            "/login?auth=local&sdk_event=success&sdk_user=sdkUser", data=login_data(context, UUID_USER, PASSWORD)
         )
 
     def test_user_blocking_sdk(self):
         assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
         assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+
+        assert self.r_login.status_code == 200
+
         interfaces.library.assert_waf_attack(self.r_login_blocked, rule="block-users")
         assert self.r_login_blocked.status_code == 403
-
-
-@rfc("https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw")
-@features.user_monitoring
-class Test_Automated_Session_Tracking:
-    def setup_session_tracking(self):
-        self.r_create_session = weblog.get("/session/new")
-        self.r_home = weblog.get("/", cookies=self.r_create_session.cookies,)
-
-    def test_session_tracking(self):
-        assert self.r_create_session.status_code == 200
-        expected_session = self.r_create_session.text
-
-        assert self.r_home.status_code == 200
-        for _, trace, span in interfaces.library.get_spans(request=self.r_home):
-            meta = span.get("meta", {})
-            assert meta["usr.session_id"] == expected_session
 
 
 BLOCK_SESSION = (
@@ -173,8 +181,9 @@ class Test_Automated_Session_Blocking:
 
         self.config_state_1 = rc.rc_state.set_config(*CONFIG_ENABLED).apply()
         self.r_create_session = weblog.get("/session/new")
+        self.session_id = self.r_create_session.text
 
-        BLOCK_SESSION[1]["rules_data"][0]["data"].append({"value": self.r_create_session.text, "expiration": 0})
+        BLOCK_SESSION[1]["rules_data"][0]["data"].append({"value": self.session_id, "expiration": 0})
         self.config_state_2 = rc.rc_state.set_config(*BLOCK_SESSION).apply()
         self.r_home_blocked = weblog.get("/", cookies=self.r_create_session.cookies,)
 
@@ -183,5 +192,5 @@ class Test_Automated_Session_Blocking:
         assert self.r_create_session.status_code == 200
 
         assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
-        interfaces.library.assert_waf_attack(self.r_home_blocked, rule="block-sessions")
+        interfaces.library.assert_waf_attack(self.r_home_blocked, pattern=self.session_id, rule="block-sessions")
         assert self.r_home_blocked.status_code == 403


### PR DESCRIPTION
## Motivation

Add tests to validate the user and session tracking/blocking functionality as described in the [RFC](https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
