### PR TITLE
[ruby] Add -dev to healthcheck when not using gem from Rubygems

### DIFF
--- a/utils/build/docker/ruby/graphql23/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/graphql23/app/controllers/system_test_controller.rb
@@ -8,11 +8,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rack/config.ru
+++ b/utils/build/docker/ruby/rack/config.ru
@@ -61,11 +61,14 @@ end
 # /healthcheck
 class Healthcheck
   def self.run
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     response = {
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
 

--- a/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
@@ -10,11 +10,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
@@ -11,11 +11,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/rails71/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails71/app/controllers/system_test_controller.rb
@@ -11,11 +11,14 @@ class SystemTestController < ApplicationController
   end
 
   def healthcheck
+    gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+    version = gemspec.version.to_s
+    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     render json: { 
       status: 'ok',
       library: {
         language: 'ruby',
-        version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+        version: version
       }
     }
   end

--- a/utils/build/docker/ruby/sinatra14/app.rb
+++ b/utils/build/docker/ruby/sinatra14/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra20/app.rb
+++ b/utils/build/docker/ruby/sinatra20/app.rb
@@ -37,11 +37,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra21/app.rb
+++ b/utils/build/docker/ruby/sinatra21/app.rb
@@ -37,11 +37,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra22/app.rb
+++ b/utils/build/docker/ruby/sinatra22/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra30/app.rb
+++ b/utils/build/docker/ruby/sinatra30/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra31/app.rb
+++ b/utils/build/docker/ruby/sinatra31/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra32/app.rb
+++ b/utils/build/docker/ruby/sinatra32/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 

--- a/utils/build/docker/ruby/sinatra40/app.rb
+++ b/utils/build/docker/ruby/sinatra40/app.rb
@@ -36,11 +36,14 @@ end
 get '/healthcheck' do
   content_type :json
 
+  gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
+  version = gemspec.version.to_s
+  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {
       language: 'ruby',
-      version: defined?(Datadog::VERSION) ? Datadog::VERSION::STRING : DDTrace::VERSION::STRING
+      version: version
     }
   }.to_json
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

This will enable the activation of system-tests on ruby dev environment for the upcoming version (e.g.: current version is 2.4.0, healthcheck will return 2.4.0-dev and system-tests will increment the patch number, so tests can be activated by declaring 2.4.1-dev in the manifest)

## Changes

This adds -dev to the version given by healthchecks when not using datadog/ddtrace gem from Rubygems by verifying that the source of a Rubygems is a Bundler::Source::Rubygems object

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
