### PR TITLE
nodejs: fix AWS bug where messages aren't being consumed

### DIFF
--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -286,6 +286,10 @@ class Test_DsmSQS:
             if context.library.library != "nodejs":
                 delete_sqs_queue(self.queue)
 
+    @bug(
+        library="nodejs",
+        reason="NodeJS sometimes fails to consume the correct sqs message.",
+    )
     def test_dsm_sqs(self):
         assert self.r.text == "ok"
 
@@ -347,6 +351,10 @@ class Test_DsmSNS:
                 delete_sns_topic(self.topic)
                 delete_sqs_queue(self.queue)
 
+    @bug(
+        library="nodejs",
+        reason="NodeJS sometimes fails to consume the correct sns message.",
+    )
     def test_dsm_sns(self):
         assert self.r.text == "ok"
 

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -286,10 +286,6 @@ class Test_DsmSQS:
             if context.library.library != "nodejs":
                 delete_sqs_queue(self.queue)
 
-    @bug(
-        library="nodejs",
-        reason="AIDM-377",
-    )
     def test_dsm_sqs(self):
         assert self.r.text == "ok"
 
@@ -351,10 +347,6 @@ class Test_DsmSNS:
                 delete_sns_topic(self.topic)
                 delete_sqs_queue(self.queue)
 
-    @bug(
-        library="nodejs",
-        reason="AIDM-377",
-    )
     def test_dsm_sns(self):
         assert self.r.text == "ok"
 

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -288,7 +288,7 @@ class Test_DsmSQS:
 
     @bug(
         library="nodejs",
-        reason="NodeJS sometimes fails to consume the correct sqs message.",
+        reason="AIDM-377",
     )
     def test_dsm_sqs(self):
         assert self.r.text == "ok"
@@ -353,7 +353,7 @@ class Test_DsmSNS:
 
     @bug(
         library="nodejs",
-        reason="NodeJS sometimes fails to consume the correct sns message.",
+        reason="AIDM-377",
     )
     def test_dsm_sns(self):
         assert self.r.text == "ok"

--- a/utils/build/docker/nodejs/express4/integrations/messaging/aws/kinesis.js
+++ b/utils/build/docker/nodejs/express4/integrations/messaging/aws/kinesis.js
@@ -98,14 +98,14 @@ const kinesisConsume = (stream, timeout = 60000, message, sequenceNumber) => {
             kinesis.getShardIterator(params, (err, response) => {
               if (err) {
                 console.log(`[Kinesis] Error during Kinesis get shard iterator: ${err}`)
-                setTimeout(consumeMessage, 1000)
+                setTimeout(consumeMessage, 200)
               } else {
                 console.log(`[Kinesis] Found Kinesis Shard Iterator: ${response.ShardIterator} for stream: ${stream}`)
 
                 kinesis.getRecords({ ShardIterator: response.ShardIterator }, (err, recordsResponse) => {
                   if (err) {
                     console.log(`[Kinesis] Error during Kinesis get records: ${err}`)
-                    setTimeout(consumeMessage, 1000)
+                    setTimeout(consumeMessage, 200)
                   } else {
                     if (recordsResponse && recordsResponse.Records && recordsResponse.Records.length > 0) {
                       for (const actualMessage of recordsResponse.Records) {
@@ -125,13 +125,13 @@ const kinesisConsume = (stream, timeout = 60000, message, sequenceNumber) => {
                         }
                       }
                     }
-                    setTimeout(consumeMessage, 1000)
+                    setTimeout(consumeMessage, 50)
                   }
                 })
               }
             })
           } else {
-            setTimeout(consumeMessage, 1000)
+            setTimeout(consumeMessage, 200)
           }
         }
       })

--- a/utils/build/docker/nodejs/express4/integrations/messaging/aws/sns.js
+++ b/utils/build/docker/nodejs/express4/integrations/messaging/aws/sns.js
@@ -142,13 +142,13 @@ const snsConsume = async (queue, timeout, expectedMessage) => {
             if (!messageFound) {
               setTimeout(() => {
                 receiveMessage()
-              }, 1000)
+              }, 50)
             }
           } else {
             console.log('[SNS->SQS] No messages received')
             setTimeout(() => {
               receiveMessage()
-            }, 1000)
+            }, 200)
           }
         } catch (error) {
           console.error('[SNS->SQS] Error while consuming messages: ', error)

--- a/utils/build/docker/nodejs/express4/integrations/messaging/aws/sqs.js
+++ b/utils/build/docker/nodejs/express4/integrations/messaging/aws/sqs.js
@@ -83,13 +83,13 @@ const sqsConsume = async (queue, timeout, expectedMessage) => {
             if (!messageFound) {
               setTimeout(() => {
                 receiveMessage()
-              }, 1000)
+              }, 50)
             }
           } else {
             console.log('[SQS] No messages received')
             setTimeout(() => {
               receiveMessage()
-            }, 1000)
+            }, 200)
           }
         } catch (error) {
           console.error('[SQS] Error while consuming messages: ', error)


### PR DESCRIPTION
## Motivation

Changes nodejs weblog tests for SQS / SNS / Kinesis to loop faster between messages. Previously looping was too slow and was causing requests to time out before finding the correct message in the queue.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
