### PR TITLE
Add Suspicious Request Blocking test without path_params

### DIFF
--- a/tests/appsec/blocking_rule.json
+++ b/tests/appsec/blocking_rule.json
@@ -576,6 +576,76 @@
       ]
     },
     {
+      "id": "tst-037-013",
+      "name": "Test block on multiple request addresses (without path_params)",
+      "tags": {
+        "type": "lfi",
+        "crs_id": "000013",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.method"
+              }
+            ],
+            "regex": "GET"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.uri.raw"
+              }
+            ],
+            "regex": "wX1GdUiWdVdoklf0pYBi5kQApO9i77tN"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "regex": "T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "siDzyETAdkvKahD3PxlvIqcE0fMIVywE"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              }
+            ],
+            "regex": "qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "block"
+      ]
+    },
+    {
       "id": "monitor-resolvers",
       "name": "Monitor Resolvers",
       "tags": {

--- a/tests/appsec/blocking_rule.json
+++ b/tests/appsec/blocking_rule.json
@@ -521,7 +521,7 @@
                 "address": "server.request.uri.raw"
               }
             ],
-            "regex": "ypMrmzrWATkLrPKLblvpRGGltBSgHWrK"
+            "regex": "malicious-uri-ypMrmzrWATkLrPKLblvpRGGltBSgHWrK"
           },
           "operator": "match_regex"
         },
@@ -532,7 +532,7 @@
                 "address": "server.request.path_params"
               }
             ],
-            "regex": "cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc"
+            "regex": "malicious-path-cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc"
           },
           "operator": "match_regex"
         },
@@ -543,7 +543,7 @@
                 "address": "server.request.query"
               }
             ],
-            "regex": "SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ"
+            "regex": "malicious-query-SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ"
           },
           "operator": "match_regex"
         },
@@ -554,7 +554,7 @@
                 "address": "server.request.headers.no_cookies"
               }
             ],
-            "regex": "kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"
+            "regex": "malicious-header-kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"
           },
           "operator": "match_regex"
         },
@@ -565,7 +565,7 @@
                 "address": "server.request.cookies"
               }
             ],
-            "regex": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"
+            "regex": "malicious-cookie-PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"
           },
           "operator": "match_regex"
         }
@@ -602,7 +602,7 @@
                 "address": "server.request.uri.raw"
               }
             ],
-            "regex": "wX1GdUiWdVdoklf0pYBi5kQApO9i77tN"
+            "regex": "malicious-uri-wX1GdUiWdVdoklf0pYBi5kQApO9i77tN"
           },
           "operator": "match_regex"
         },
@@ -613,7 +613,7 @@
                 "address": "server.request.query"
               }
             ],
-            "regex": "T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ"
+            "regex": "malicious-query-T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ"
           },
           "operator": "match_regex"
         },
@@ -624,7 +624,7 @@
                 "address": "server.request.headers.no_cookies"
               }
             ],
-            "regex": "siDzyETAdkvKahD3PxlvIqcE0fMIVywE"
+            "regex": "malicious-header-siDzyETAdkvKahD3PxlvIqcE0fMIVywE"
           },
           "operator": "match_regex"
         },
@@ -635,7 +635,7 @@
                 "address": "server.request.cookies"
               }
             ],
-            "regex": "qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"
+            "regex": "malicious-cookie-qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"
           },
           "operator": "match_regex"
         }

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -556,6 +556,41 @@ class Test_Suspicious_Request_Blocking:
         interfaces.library.assert_waf_attack(self.block_req2, rule="tst-037-012")
         interfaces.library.validate_spans(self.block_req2, _assert_custom_event_tag_absence())
 
+    def setup_blocking_without_path_params(self):
+        self.rm_req_block = weblog.get(
+            f"/tag_value/path_param_wX1GdUiWdVdoklf0pYBi5kQApO9i77tN/200?attack=T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ",
+            cookies={"foo": "qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"},
+            headers={"content-type": "text/plain", "client": "siDzyETAdkvKahD3PxlvIqcE0fMIVywE"},
+        )
+
+    def test_blocking_without_path_params(self):
+        """Test if requests that should be blocked are blocked"""
+        assert self.rm_req_block.status_code == 403, self.rm_req_block.request.url
+        interfaces.library.assert_waf_attack(self.rm_req_block, rule="tst-037-013")
+    
+    def setup_blocking_before_without_path_params(self):
+        self.set_req1 = weblog.post(
+            "/tag_value/clean_value_3882/200?attack=T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ",
+            data={"good": "value"},
+            cookies={"foo": "qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"},
+        )
+        self.block_req2 = weblog.get(
+            f"/tag_value/path_param_wX1GdUiWdVdoklf0pYBi5kQApO9i77tN/200?attack=T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ",
+            cookies={"foo": "qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"},
+            headers={"content-type": "text/plain", "client": "siDzyETAdkvKahD3PxlvIqcE0fMIVywE"},
+        )
+
+    def test_blocking_before_without_path_params(self):
+        """Test that blocked requests are blocked before being processed"""
+        # first request should not block and must set the tag in span accordingly
+        assert self.set_req1.status_code == 200
+        assert self.set_req1.text == "Value tagged"
+        interfaces.library.validate_spans(self.set_req1, _assert_custom_event_tag_presence("clean_value_3882"))
+        """Test that blocked requests are blocked before being processed"""
+        assert self.block_req2.status_code == 403
+        interfaces.library.assert_waf_attack(self.block_req2, rule="tst-037-013")
+        interfaces.library.validate_spans(self.block_req2, _assert_custom_event_tag_absence())
+
 
 @scenarios.graphql_appsec
 @features.appsec_request_blocking

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -551,6 +551,7 @@ class Test_Suspicious_Request_Blocking:
         assert self.set_req1.status_code == 200
         assert self.set_req1.text == "Value tagged"
         interfaces.library.validate_spans(self.set_req1, _assert_custom_event_tag_presence("clean_value_3882"))
+
         """Test that blocked requests are blocked before being processed"""
         assert self.block_req2.status_code == 403
         interfaces.library.assert_waf_attack(self.block_req2, rule="tst-037-012")
@@ -586,6 +587,7 @@ class Test_Suspicious_Request_Blocking:
         assert self.set_req1.status_code == 200
         assert self.set_req1.text == "Value tagged"
         interfaces.library.validate_spans(self.set_req1, _assert_custom_event_tag_presence("clean_value_3882"))
+
         """Test that blocked requests are blocked before being processed"""
         assert self.block_req2.status_code == 403
         interfaces.library.assert_waf_attack(self.block_req2, rule="tst-037-013")

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -567,7 +567,7 @@ class Test_Suspicious_Request_Blocking:
         """Test if requests that should be blocked are blocked"""
         assert self.rm_req_block.status_code == 403, self.rm_req_block.request.url
         interfaces.library.assert_waf_attack(self.rm_req_block, rule="tst-037-013")
-    
+
     def setup_blocking_before_without_path_params(self):
         self.set_req1 = weblog.post(
             "/tag_value/clean_value_3882/200?attack=T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ",

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -515,9 +515,9 @@ class Test_Suspicious_Request_Blocking:
 
     def setup_blocking(self):
         self.rm_req_block = weblog.get(
-            f"/tag_value/cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc_ypMrmzrWATkLrPKLblvpRGGltBSgHWrK/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ",
-            cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"},
-            headers={"content-type": "text/plain", "client": "kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"},
+            f"/tag_value/malicious-path-cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc_malicious-uri-ypMrmzrWATkLrPKLblvpRGGltBSgHWrK/200?attack=malicious-query-SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ",
+            cookies={"foo": "malicious-cookie-PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"},
+            headers={"content-type": "text/plain", "client": "malicious-header-kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"},
         )
 
     @irrelevant(
@@ -531,14 +531,14 @@ class Test_Suspicious_Request_Blocking:
 
     def setup_blocking_before(self):
         self.set_req1 = weblog.post(
-            "/tag_value/clean_value_3882/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ",
+            "/tag_value/clean_value_3882/200?attack=malicious-query-SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ",
             data={"good": "value"},
-            cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"},
+            cookies={"foo": "malicious-cookie-PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"},
         )
         self.block_req2 = weblog.get(
-            f"/tag_value/cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc_ypMrmzrWATkLrPKLblvpRGGltBSgHWrK/200?attack=SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ",
-            cookies={"foo": "PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"},
-            headers={"content-type": "text/plain", "client": "kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"},
+            f"/tag_value/malicious-path-cGDgSRJvklxGOKMTNfQMViBPpKAvpFoc_malicious-uri-ypMrmzrWATkLrPKLblvpRGGltBSgHWrK/200?attack=malicious-query-SAGihOkuSwXXFDXNqAWJzNuZEdKNunrJ",
+            cookies={"foo": "malicious-cookie-PwXuEQEdeAjzWpCDqAzPqiUAdXJMHwtS"},
+            headers={"content-type": "text/plain", "client": "malicious-header-kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"},
         )
 
     @irrelevant(
@@ -559,9 +559,9 @@ class Test_Suspicious_Request_Blocking:
 
     def setup_blocking_without_path_params(self):
         self.rm_req_block = weblog.get(
-            f"/tag_value/path_param_wX1GdUiWdVdoklf0pYBi5kQApO9i77tN/200?attack=T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ",
-            cookies={"foo": "qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"},
-            headers={"content-type": "text/plain", "client": "siDzyETAdkvKahD3PxlvIqcE0fMIVywE"},
+            f"/tag_value/path_param_malicious-uri-wX1GdUiWdVdoklf0pYBi5kQApO9i77tN/200?attack=malicious-query-T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ",
+            cookies={"foo": "malicious-cookie-qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"},
+            headers={"content-type": "text/plain", "client": "malicious-header-siDzyETAdkvKahD3PxlvIqcE0fMIVywE"},
         )
 
     def test_blocking_without_path_params(self):
@@ -571,14 +571,14 @@ class Test_Suspicious_Request_Blocking:
 
     def setup_blocking_before_without_path_params(self):
         self.set_req1 = weblog.post(
-            "/tag_value/clean_value_3882/200?attack=T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ",
+            "/tag_value/clean_value_3882/200?attack=malicious-query-T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ",
             data={"good": "value"},
-            cookies={"foo": "qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"},
+            cookies={"foo": "malicious-cookie-qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"},
         )
         self.block_req2 = weblog.get(
-            f"/tag_value/path_param_wX1GdUiWdVdoklf0pYBi5kQApO9i77tN/200?attack=T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ",
-            cookies={"foo": "qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"},
-            headers={"content-type": "text/plain", "client": "siDzyETAdkvKahD3PxlvIqcE0fMIVywE"},
+            f"/tag_value/path_param_malicious-uri-wX1GdUiWdVdoklf0pYBi5kQApO9i77tN/200?attack=malicious-query-T3d1nKdkTWIG03q03ix9c9UlhbGigvwQ",
+            cookies={"foo": "malicious-cookie-qU4sV2r6ac2nfETV7aJP9Fdt1NaWC9wB"},
+            headers={"content-type": "text/plain", "client": "malicious-header-siDzyETAdkvKahD3PxlvIqcE0fMIVywE"},
         )
 
     def test_blocking_before_without_path_params(self):


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Rack does not send anything to the path_params address (Rails and Sinatra does) but we still want to test blocking on multiple request addresses

## Changes

<!-- A brief description of the change being made with this pull request. -->

On the advice of @christophe-papazian I wrote a similar test without path-params. All the weblogs that passes these tests with path_params should also pass them without, but it will also enable testing that feature on a pure Rack app 

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
