### PR TITLE
[ruby] Enables a bunch of easy wins

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -197,9 +197,7 @@ tests/:
       Test_Blocking_response_headers: v1.0.0
       Test_Blocking_response_status: v1.10.0
       Test_Blocking_user_id: v1.0.0
-      Test_Suspicious_Request_Blocking:
-          '*': v1.0.0
-          rack: missing_feature (no path_params in rack)
+      Test_Suspicious_Request_Blocking: v1.0.0
     test_client_ip.py:
       Test_StandardTagsClientIp: v1.8.0
     test_customconf.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -152,7 +152,7 @@ tests/:
       test_telemetry.py:
         Test_TelemetryMetrics: missing_feature
     test_asm_standalone.py:
-      Test_AppSecStandalone_UpstreamPropagation: v2.5.0
+      Test_AppSecStandalone_UpstreamPropagation: v2.4.1-dev
     test_automated_login_events.py:
       Test_Login_Events:
         '*': v1.13.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -136,8 +136,8 @@ tests/:
         Test_gRPC: missing_feature
       test_blocking.py:
         Test_Blocking: v1.11.0
-        Test_Blocking_strip_response_headers: missing_feature
-        Test_CustomBlockingResponse: missing_feature
+        Test_Blocking_strip_response_headers: v1.13.0
+        Test_CustomBlockingResponse: v1.15.0
       test_custom_rules.py:
         Test_CustomRules: v1.12.0
       test_exclusions.py:
@@ -197,7 +197,9 @@ tests/:
       Test_Blocking_response_headers: v1.0.0
       Test_Blocking_response_status: v1.10.0
       Test_Blocking_user_id: v1.0.0
-      Test_Suspicious_Request_Blocking: missing_feature (v1.0.0 but test is not implemented)
+      Test_Suspicious_Request_Blocking:
+          '*': v1.0.0
+          rack: missing_feature (no path_params in rack)
     test_client_ip.py:
       Test_StandardTagsClientIp: v1.8.0
     test_customconf.py:
@@ -228,7 +230,7 @@ tests/:
       Test_BlockingActionChangesWithRemoteConfig: missing_feature
       Test_UpdateRuleFileWithRemoteConfig: missing_feature
     test_reports.py:
-      Test_ExtraTagsFromRule: missing_feature
+      Test_ExtraTagsFromRule: v1.15.0
     test_request_blocking.py:
       Test_AppSecRequestBlocking: v1.11.1
     test_runtime_activation.py:
@@ -390,7 +392,7 @@ tests/:
       Test_RemoteConfigurationExtraServices: missing_feature
       Test_RemoteConfigurationUpdateSequenceASMDD: missing_feature
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: missing_feature
-      Test_RemoteConfigurationUpdateSequenceFeatures: missing_feature
+      Test_RemoteConfigurationUpdateSequenceFeatures: v1.13.0
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -469,7 +469,6 @@ class Test_Blocking_response_status:
         context.library == "java" and context.weblog_variant not in ("akka-http", "play"),
         reason="Happens on a subsequent WAF run",
     )
-    @missing_feature(context.library == "ruby", reason="Not working")
     @missing_feature(context.library == "golang", reason="No blocking on server.response.*")
     def test_not_found(self):
         """can block on server.response.status"""

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -520,6 +520,10 @@ class Test_Suspicious_Request_Blocking:
             headers={"content-type": "text/plain", "client": "kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"},
         )
 
+    @irrelevant(
+        context.library == "ruby" and context.weblog_variant == "rack",
+        reason="Rack don't send anything to the server.request.path_params WAF address",
+    )
     def test_blocking(self):
         """Test if requests that should be blocked are blocked"""
         assert self.rm_req_block.status_code == 403, self.rm_req_block.request.url
@@ -537,6 +541,10 @@ class Test_Suspicious_Request_Blocking:
             headers={"content-type": "text/plain", "client": "kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"},
         )
 
+    @irrelevant(
+        context.library == "ruby" and context.weblog_variant == "rack",
+        reason="Rack don't send anything to the server.request.path_params WAF address",
+    )
     def test_blocking_before(self):
         """Test that blocked requests are blocked before being processed"""
         # first request should not block and must set the tag in span accordingly


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

We have a lot of easy-wins

## Changes

<!-- A brief description of the change being made with this pull request. -->

Add version declaration in manifest (Test_AppSecStandalone_UpstreamPropagation: v2.4.1-dev will work once #3295 is merged in main)

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
