### PR TITLE
Pass additional env vars to docker mode container

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -199,6 +199,31 @@ function run_scenario() {
                 -e DD_API_KEY="${DD_API_KEY}"
               )
             fi
+            if [[ -n "${DD_API_KEY_2:-}" ]]; then
+              cmd+=(
+                -e DD_API_KEY_2="${DD_API_KEY_2}"
+              )
+            fi
+            if [[ -n "${DD_API_KEY_3:-}" ]]; then
+              cmd+=(
+                -e DD_API_KEY_3="${DD_API_KEY_3}"
+              )
+            fi
+            if [[ -n "${DD_APP_KEY:-}" ]]; then
+              cmd+=(
+                -e DD_APP_KEY="${DD_APP_KEY}"
+              )
+            fi
+            if [[ -n "${DD_APP_KEY_2:-}" ]]; then
+              cmd+=(
+                -e DD_APP_KEY_2="${DD_APP_KEY_2}"
+              )
+            fi
+            if [[ -n "${DD_APP_KEY_3:-}" ]]; then
+              cmd+=(
+                -e DD_APP_KEY_3="${DD_APP_KEY_3}"
+              )
+            fi
             if [[ -n "${SYSTEM_TESTS_AWS_ACCESS_KEY_ID:-}" ]]; then
               cmd+=(
                 -e SYSTEM_TESTS_AWS_ACCESS_KEY_ID="${SYSTEM_TESTS_AWS_ACCESS_KEY_ID}"

--- a/run.sh
+++ b/run.sh
@@ -199,6 +199,16 @@ function run_scenario() {
                 -e DD_API_KEY="${DD_API_KEY}"
               )
             fi
+            if [[ -n "${SYSTEM_TESTS_AWS_ACCESS_KEY_ID:-}" ]]; then
+              cmd+=(
+                -e SYSTEM_TESTS_AWS_ACCESS_KEY_ID="${SYSTEM_TESTS_AWS_ACCESS_KEY_ID}"
+              )
+            fi
+            if [[ -n "${SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY_ID:-}" ]]; then
+              cmd+=(
+                -e SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY_ID="${SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY_ID}"
+              )
+            fi
             if [[ -f .env ]]; then
               cmd+=(
                 -v "${PWD}"/.env:/app/.env


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

New AWS env vars were not passed properly in Docker mode.

## Changes

<!-- A brief description of the change being made with this pull request. -->

- Add AWS env vars automatically
- Add additional DD_API_KEY and DD_APP_KEY env vars automatically

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
