### PR TITLE
[dotnet] Enable FP and Suspicious attacker tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -231,13 +231,13 @@ tests/:
       Test_UserLoginFailureEvent: v2.27.0
       Test_UserLoginSuccessEvent: v2.27.0
     test_fingerprinting.py:
-      Test_Fingerprinting_Endpoint: missing_feature
-      Test_Fingerprinting_Endpoint_Capability: missing_feature
-      Test_Fingerprinting_Header_And_Network: missing_feature
-      Test_Fingerprinting_Header_Capability: missing_feature
-      Test_Fingerprinting_Network_Capability: missing_feature
+      Test_Fingerprinting_Endpoint: v3.4.0
+      Test_Fingerprinting_Endpoint_Capability: v3.4.0
+      Test_Fingerprinting_Header_And_Network: v3.4.0
+      Test_Fingerprinting_Header_Capability: v3.4.0
+      Test_Fingerprinting_Network_Capability: v3.4.0
       Test_Fingerprinting_Session: missing_feature
-      Test_Fingerprinting_Session_Capability: missing_feature
+      Test_Fingerprinting_Session_Capability: v3.4.0
     test_identify.py:
       Test_Basic: v2.7.0
     test_ip_blocking_full_denylist.py:
@@ -262,7 +262,7 @@ tests/:
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:
-      Test_Suspicious_Attacker_Blocking: missing_feature
+      Test_Suspicious_Attacker_Blocking: v3.4.0
     test_traces.py:
       Test_AppSecEventSpanTags: v1.29.0
       Test_AppSecObfuscator: v2.7.0

--- a/utils/build/docker/dotnet/weblog/Controllers/RaspController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/RaspController.cs
@@ -68,15 +68,15 @@ namespace weblog
         [HttpGet("lfi")]
         public IActionResult lfiGet(string file)
         {
-			try
-			{
+            try
+            {
                 var result = System.IO.File.ReadAllText(file);
                 return Content(result);
-			}
-			catch (System.IO.FileNotFoundException ex)
-			{
-				return Content("File not found");
-			}
+            }
+            catch (System.IO.FileNotFoundException ex)
+            {
+                return Content("File not found");
+            }
         }
         
         // e

--- a/utils/build/docker/dotnet/weblog/Controllers/RaspController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/RaspController.cs
@@ -78,8 +78,6 @@ namespace weblog
                 return Content("File not found");
             }
         }
-        
-        // e
 
         [XmlRoot("file")]
         public class FileModel

--- a/utils/build/docker/dotnet/weblog/Controllers/RaspController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/RaspController.cs
@@ -68,9 +68,18 @@ namespace weblog
         [HttpGet("lfi")]
         public IActionResult lfiGet(string file)
         {
-            var result = System.IO.File.ReadAllText(file);
-            return Content(result);
+			try
+			{
+                var result = System.IO.File.ReadAllText(file);
+                return Content(result);
+			}
+			catch (System.IO.FileNotFoundException ex)
+			{
+				return Content("File not found");
+			}
         }
+        
+        // e
 
         [XmlRoot("file")]
         public class FileModel

--- a/utils/build/docker/dotnet/weblog/Controllers/SessionController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/SessionController.cs
@@ -1,0 +1,39 @@
+#if DDTRACE_2_7_0_OR_GREATER
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.AspNetCore.Routing;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Datadog.Trace;
+
+namespace weblog
+{
+    [ApiController]
+    [Route("session")]
+    public class SessionController : Controller
+    {
+	    [HttpGet("new")]
+        public IActionResult New()
+        {
+            return Content($"Session created");
+        }
+		
+        [HttpGet("user")]
+        public IActionResult User(string sdk_user)
+        {
+            if (sdk_user != null)
+            {
+                var userDetails = new UserDetails()
+                {
+                    Id = sdk_user,
+                };
+                Tracer.Instance.ActiveScope?.Span.SetUser(userDetails);
+            }
+
+            return Content($"Hello, set the user to {sdk_user}");
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Motivation

This PR enables the FP and suspicious attacker system tests that are supported in the latest version of the tracer.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
