### PR TITLE
enable Python & NodeJS Kafka DSM test with new Cluster ID tag

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -37,6 +37,7 @@ refs:
   - &ref_5_22_0 '>=5.22.0 || ^4.46.0'
   - &ref_5_23_0 '>=5.23.0 || ^4.47.0'
   - &ref_5_24_0 '>=5.24.0 || ^4.48.0'
+  - &ref_5_25_0 '>=5.25.0 || ^4.49.0'
 
 tests/:
   apm_tracing_e2e/:
@@ -526,7 +527,7 @@ tests/:
         express4: *ref_5_6_0
       Test_DsmHttp: missing_feature
       Test_DsmKafka:
-        '*': *ref_4_4_0
+        '*': *ref_5_25_0
         nextjs: missing_feature (missing endpoint)
       Test_DsmKinesis:
         '*': irrelevant

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -654,7 +654,7 @@ tests/:
       Test_DsmHttp: missing_feature
       Test_DsmKafka:
         '*': irrelevant
-        flask-poc: v1.20.3
+        flask-poc: v2.16.0
       Test_DsmKinesis:
         '*': irrelevant
         flask-poc: v2.8.0.dev

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -53,7 +53,7 @@ class Test_DsmKafka:
         self.r = weblog.get(f"/dsm?integration=kafka&queue={DSM_QUEUE}&group={DSM_CONSUMER_GROUP}")
 
     @irrelevant(
-        context.library in ["python", "java", "nodejs", "dotnet"], reason="New behavior with cluster id not merged yet."
+        context.library in ["java", "nodejs", "dotnet"], reason="New behavior with cluster id not merged yet."
     )
     def test_dsm_kafka(self):
         assert self.r.text == "ok"

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -90,8 +90,12 @@ class Test_DsmKafka:
 
         producer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["producer"]
         consumer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["consumer"]
-        edge_tags_out = language_hashes.get(context.library.library, language_hashes.get("default"))["edge_tags_out"]
-        edge_tags_in = language_hashes.get(context.library.library, language_hashes.get("default"))["edge_tags_in"]
+        edge_tags_out = language_hashes.get(context.library.library, language_hashes.get("default")).get(
+            "edge_tags_out", language_hashes.get("default")["edge_tags_out"]
+        )
+        edge_tags_in = language_hashes.get(context.library.library, language_hashes.get("default")).get(
+            "edge_tags_in", language_hashes.get("default")["edge_tags_in"]
+        )
 
         DsmHelper.assert_checkpoint_presence(
             hash_=producer_hash, parent_hash=0, tags=edge_tags_out,

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -52,9 +52,7 @@ class Test_DsmKafka:
     def setup_dsm_kafka(self):
         self.r = weblog.get(f"/dsm?integration=kafka&queue={DSM_QUEUE}&group={DSM_CONSUMER_GROUP}")
 
-    @irrelevant(
-        context.library in ["java", "dotnet"], reason="New behavior with cluster id not merged yet."
-    )
+    @irrelevant(context.library in ["java", "dotnet"], reason="New behavior with cluster id not merged yet.")
     def test_dsm_kafka(self):
         assert self.r.text == "ok"
 

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -53,7 +53,7 @@ class Test_DsmKafka:
         self.r = weblog.get(f"/dsm?integration=kafka&queue={DSM_QUEUE}&group={DSM_CONSUMER_GROUP}")
 
     @irrelevant(
-        context.library in ["java", "nodejs", "dotnet"], reason="New behavior with cluster id not merged yet."
+        context.library in ["java", "dotnet"], reason="New behavior with cluster id not merged yet."
     )
     def test_dsm_kafka(self):
         assert self.r.text == "ok"


### PR DESCRIPTION
## Motivation

Enables Kafka DSM test that includes Cluster ID in DSM tags. 

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
