### PR TITLE
set AWS variables on runner docker container

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -212,6 +212,8 @@ function run_scenario() {
               -e SYSTEM_TESTS_WEBLOG_PORT=7777
               -e SYSTEM_TESTS_WEBLOG_GRPC_PORT=7778
               -e SYSTEM_TESTS_HOST_PROJECT_DIR="${PWD}"
+              -e SYSTEM_TESTS_AWS_ACCESS_KEY_ID="${SYSTEM_TESTS_AWS_ACCESS_KEY_ID}"
+              -e SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY="${SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY}"
               --name system-tests-runner
               system_tests/runner
               venv/bin/pytest

--- a/run.sh
+++ b/run.sh
@@ -204,7 +204,7 @@ function run_scenario() {
                 -v "${PWD}"/.env:/app/.env
               )
             fi
-            cmd=(
+            cmd+=(
                 -v /var/run/docker.sock:/var/run/docker.sock
                 -v "${PWD}/${log_dir}":"/app/${log_dir}"
                 -e SYSTEM_TESTS_PROXY_HOST=proxy

--- a/run.sh
+++ b/run.sh
@@ -217,7 +217,7 @@ function run_scenario() {
             # Loop through all environment variables for AWS_ and SYSTEM_TESTS_AWS_
             for var in $(printenv | grep -E '^(AWS_|SYSTEM_TESTS_AWS_)'); do
                 # Extract the variable name
-                var_name=$(echo $var | cut -d '=' -f 1)
+                var_name=$(echo "$var" | cut -d '=' -f 1)
                 # Add it to the command
                 cmd+=(-e "$var_name=${!var_name}")
             done


### PR DESCRIPTION
## Motivation
Sets AWS env on runner docker container, I previously only covered the case where the runner was on the local machine. This fixes a bug in Ruby tracer CI where AWS authentication environment variables weren't set on the runner docker container, causing an error message and for tests to fail. 

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
