### PR TITLE
Init docker SSI tests for PHP

### DIFF
--- a/.github/workflows/run-docker-ssi.yml
+++ b/.github/workflows/run-docker-ssi.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   docker-ssi-check-injection:
-    if: inputs.library == 'java'
+    if: ${{ inputs.library == 'java' || inputs.library == 'php' }}
     strategy:
       matrix: ${{ fromJson(inputs.weblogs) }}
       fail-fast: false

--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -1,7 +1,7 @@
 import time
 from urllib.parse import urlparse
 
-from utils import scenarios, features, context, irrelevant, bug, interfaces
+from utils import scenarios, features, context, irrelevant, bug, interfaces, missing_feature
 from utils import weblog
 from utils.tools import logger, get_rid_from_request
 
@@ -65,6 +65,9 @@ class TestDockerSSIFeatures:
         condition="centos-7" in context.scenario.weblog_variant and context.scenario.library.library == "java",
         reason="APMON-1490",
     )
+    @missing_feature(library="java", reason="INPLAT-11")
+    @missing_feature(library="python", reason="INPLAT-11")
+    @missing_feature(library="ruby", reason="INPLAT-11")
     def test_telemetry(self):
         # There is telemetry data about the auto instrumentation injector. We only validate there is data
         telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject()

--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -8,8 +8,8 @@ from utils.tools import logger, get_rid_from_request
 
 @scenarios.docker_ssi
 class TestDockerSSIFeatures:
-    """ Test the ssi in a simulated host injection environment (docker container + test agent) 
-    We test that the injection is performed and traces and telemetry are generated. 
+    """ Test the ssi in a simulated host injection environment (docker container + test agent)
+    We test that the injection is performed and traces and telemetry are generated.
     If the language version is not supported, we only check that we don't break the app and telemetry is generated."""
 
     _r = None
@@ -60,7 +60,7 @@ class TestDockerSSIFeatures:
         )
         assert self.r.status_code == 200, f"Failed to get response from {context.scenario.weblog_url}"
 
-        # There is telemetry data about the auto instrumentation. We only validate there is data
+        # There is telemetry data about the auto instrumentation injector. We only validate there is data
         telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject()
         assert len(telemetry_autoinject_data) >= 1
         inject_success = False
@@ -69,6 +69,16 @@ class TestDockerSSIFeatures:
                 inject_success = True
                 break
         assert inject_success, "No telemetry data found for inject.success"
+
+        # There is telemetry data about the library entrypoint. We only validate there is data
+        telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject_library_entrypoint()
+        assert len(telemetry_autoinject_data) >= 1
+        inject_success = False
+        for data in telemetry_autoinject_data:
+            if data["metric"] == "library_entrypoint.complete":
+                inject_success = True
+                break
+        assert inject_success, "No telemetry data found for library_entrypoint.complete"
 
     def setup_service_name(self):
         self._setup_all()

--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -60,6 +60,12 @@ class TestDockerSSIFeatures:
         )
         assert self.r.status_code == 200, f"Failed to get response from {context.scenario.weblog_url}"
 
+    @features.ssi_guardrails
+    @bug(
+        condition="centos-7" in context.scenario.weblog_variant and context.scenario.library.library == "java",
+        reason="APMON-1490",
+    )
+    def test_telemetry(self):
         # There is telemetry data about the auto instrumentation injector. We only validate there is data
         telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject()
         assert len(telemetry_autoinject_data) >= 1

--- a/utils/build/ssi/base/install_os_deps.sh
+++ b/utils/build/ssi/base/install_os_deps.sh
@@ -69,8 +69,9 @@ enabled=0
 EOF
     yum install -y which zip unzip wget
 elif [ "$OS" = "Debian" ]; then
+    export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    apt-get install --yes curl zip unzip wget
+    apt-get install --yes curl zip unzip wget git software-properties-common php-cli
 elif [ "$OS" =  "Alpine" ]; then
     apk add -U curl bash
 else

--- a/utils/build/ssi/base/php_install_runtimes.sh
+++ b/utils/build/ssi/base/php_install_runtimes.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+export PHP_VERSION=$1
+
+if [ -f /etc/debian_version ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
+    OS="Debian"
+elif [ -f /etc/redhat-release ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "Rocky" ] || [ "$DISTRIBUTION" = "AlmaLinux" ]; then
+    OS="RedHat"
+elif [ -f /etc/system-release ] || [ "$DISTRIBUTION" = "Amazon" ]; then
+    OS="RedHat"
+elif [ -f /etc/Eos-release ] || [ "$DISTRIBUTION" = "Arista" ]; then
+    OS="RedHat"
+elif [ -f /etc/SuSE-release ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "openSUSE" ]; then
+    OS="SUSE"
+elif [ -f /etc/alpine-release ]; then
+    OS="Alpine"
+fi
+
+if [ "$OS" = "Debian" ]; then
+    export DEBIAN_FRONTEND=noninteractive
+
+    # Remove the PHP installed in install_os_deps.sh
+    apt remove --yes php-cli
+    apt autoremove --yes
+
+    # FIXME: Debian
+    #curl -sSL https://packages.sury.org/php/README.txt | sudo bash -x
+
+    # Ubuntu
+    LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
+    apt update
+
+    apt install --yes "php${PHP_VERSION}-cli"
+
+    php -v
+
+elif [ "$OS" = "RedHat" ]; then
+    yum install -y php
+else
+    echo "Unknown OS"
+    exit 1
+fi

--- a/utils/build/ssi/php/php-app.Dockerfile
+++ b/utils/build/ssi/php/php-app.Dockerfile
@@ -1,0 +1,8 @@
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE}
+WORKDIR /app
+
+RUN printf "<?php\necho'hi';\n" > index.php
+
+CMD ["sh", "-c", "php -v ; php -S 0.0.0.0:18080"]

--- a/utils/docker_ssi/docker_ssi_definitions.py
+++ b/utils/docker_ssi/docker_ssi_definitions.py
@@ -62,6 +62,27 @@ class JavaRuntimeInstallableVersions:
         raise ValueError(f"Java version {version} not supported")
 
 
+class PHPRuntimeInstallableVersions:
+    """ PHP runtime versions that can be installed automatically"""
+
+    PHP74 = RuntimeInstallableVersion("PHP74", "7.4")
+    PHP83 = RuntimeInstallableVersion("PHP83", "8.3")
+
+    @staticmethod
+    def get_all_versions():
+        return [
+            PHPRuntimeInstallableVersions.PHP74,
+            PHPRuntimeInstallableVersions.PHP83,
+        ]
+
+    @staticmethod
+    def get_version_id(version):
+        for version_check in PHPRuntimeInstallableVersions.get_all_versions():
+            if version_check.version == version:
+                return version_check.version_id
+        raise ValueError(f"PHP version {version} not supported")
+
+
 # HERE ADD YOUR WEBLOG DEFINITION: SUPPORTED IMAGES AND INSTALABLE RUNTIME VERSIONS
 # Maybe a weblog app contains preinstalled language runtime, in this case we define the weblog without runtime version
 JETTY_APP = WeblogDescriptor(
@@ -117,5 +138,11 @@ JAVA7_APP = WeblogDescriptor("java7-app", "java", [SupportedImages().UBUNTU_22_A
 WEBSPHERE_APP = WeblogDescriptor("websphere-app", "java", [SupportedImages().WEBSPHERE_AMD64])
 JBOSS_APP = WeblogDescriptor("jboss-app", "java", [SupportedImages().JBOSS_AMD64])
 
+PHP_APP = WeblogDescriptor(
+    "php-app",
+    "php",
+    [SupportedImages().UBUNTU_22_AMD64.with_allowed_runtime_versions(PHPRuntimeInstallableVersions.get_all_versions())],
+)
+
 # HERE ADD YOUR WEBLOG DEFINITION TO THE LIST
-ALL_WEBLOGS = [JETTY_APP, TOMCAT_APP, JAVA7_APP, WEBSPHERE_APP, JBOSS_APP]
+ALL_WEBLOGS = [JETTY_APP, TOMCAT_APP, JAVA7_APP, WEBSPHERE_APP, JBOSS_APP, PHP_APP]

--- a/utils/docker_ssi/docker_ssi_matrix_builder.py
+++ b/utils/docker_ssi/docker_ssi_matrix_builder.py
@@ -6,7 +6,7 @@ import json
 
 def get_github_matrix(library):
     """ Matrix that will be used in the github workflow """
-    # We can call this function from a script on at runtime
+    # We can call this function from a script or at runtime
     try:
         from utils.docker_ssi.docker_ssi_definitions import ALL_WEBLOGS
     except ImportError:
@@ -38,7 +38,7 @@ def _configure_github_runner(weblog_matrix):
 
 def main():
     if not os.getenv("TEST_LIBRARY"):
-        raise ValueError("TEST_LIBRARY must be set: java,python,nodejs,dotnet,ruby")
+        raise ValueError("TEST_LIBRARY must be set: java,python,nodejs,dotnet,ruby,php")
     github_matrix = get_github_matrix(os.getenv("TEST_LIBRARY"))
     print(json.dumps(github_matrix))
 

--- a/utils/docker_ssi/docker_ssi_matrix_utils.py
+++ b/utils/docker_ssi/docker_ssi_matrix_utils.py
@@ -1,9 +1,11 @@
-from utils.docker_ssi.docker_ssi_definitions import JavaRuntimeInstallableVersions
+from utils.docker_ssi.docker_ssi_definitions import JavaRuntimeInstallableVersions, PHPRuntimeInstallableVersions
 
 
 def resolve_runtime_version(library, runtime):
     """ For installable runtimes, get the version identifier. ie JAVA_11 """
     if library == "java":
         return JavaRuntimeInstallableVersions.get_version_id(runtime)
+    elif library == "php":
+        return PHPRuntimeInstallableVersions.get_version_id(runtime)
 
     raise ValueError(f"Library {library} not supported")

--- a/utils/interfaces/_test_agent.py
+++ b/utils/interfaces/_test_agent.py
@@ -67,3 +67,15 @@ class _TestAgentInterfaceValidator(InterfaceValidator):
             if str(series["metric"]).startswith("inject.")
         ]
         return injection_metrics
+
+    def get_telemetry_for_autoinject_library_entrypoint(self):
+        logger.debug("Try to find telemetry data related to the library entrypoint")
+        injection_metrics = []
+        injection_metrics += [
+            series
+            for t in self._data_telemetry_list
+            if t["request_type"] == "generate-metrics"
+            for series in t["payload"]["series"]
+            if str(series["metric"]).startswith("library_entrypoint.")
+        ]
+        return injection_metrics


### PR DESCRIPTION
## Motivation

Init docker SSI tests for PHP
+ test that the library_entrypoint send the `library_entrypoint.complete` telemetry metric

Same as @emmettbutler [PR for Python](https://github.com/DataDog/system-tests/pull/3284) (thanks for paving the way!)

https://datadoghq.atlassian.net/browse/INPLAT-48 and https://datadoghq.atlassian.net/browse/INPLAT-11

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
