### PR TITLE
Exclude files not tracked by git from format.sh

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -44,23 +44,11 @@ else
 fi
 pylint utils  # pylint does not have a fix mode
 
-# not py, as it's handled by black
-INCLUDE_EXTENSIONS=("*.md" "*.yml" "*.yaml" "*.sh" "*.cs" "*.Dockerfile" "*.java" "*.sql" "*.ts" "*.js" "*.php")
-EXCLUDE_DIRS=("logs*" "*/node_modules/*" "./venv/*" "./utils/build/virtual_machine/*" "./binaries/*")
-
-INCLUDE_ARGS=()
-for ext in "${INCLUDE_EXTENSIONS[@]}"; do
-  INCLUDE_ARGS+=(-name "$ext" -o)
-done
-unset 'INCLUDE_ARGS[${#INCLUDE_ARGS[@]}-1]'  # remove last -o
-
-EXCLUDE_ARGS=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
-  EXCLUDE_ARGS+=(-not -path "$dir")
-done
-
-echo "Checking tailing whitespaces..."
-FILES="$(find . "${EXCLUDE_ARGS[@]}" \( "${INCLUDE_ARGS[@]}" \) -exec grep -l ' $' {} \;)"
+echo "Checking trailing whitespaces..."
+INCLUDE_PATTERN='.*\.(md|yml|yaml|sh|cs|Dockerfile|java|sql|ts|js|php)$'
+EXCLUDE_PATTERN='utils/build/virtual_machine'
+# Check all files tracked by git, and matching include/exclude patterns
+FILES="$(git ls-files | grep -v -E "$EXCLUDE_PATTERN" | grep -E "$INCLUDE_PATTERN" | while read f ; do grep -l ' $' "$f" || true ; done)"
 
 # shim for sed -i on GNU sed (Linux) and BSD sed (macOS)
 _sed_i() {
@@ -73,14 +61,14 @@ _sed_i() {
 
 if [ "$COMMAND" == "fix" ]; then
   echo "$FILES" | while read file ; do
-    if [ "$FILES" ]; then
+    if [[ -n "$file" ]]; then
       echo "Fixing $file"
       _sed_i 's/  *$//g' "$file"
     fi
   done
 else
   if [ -n "$FILES" ]; then
-    echo "Some tailing white spaces has been found, please fix them 💥 💔 💥"
+    echo "Some trailing white spaces has been found, please fix them 💥 💔 💥"
     echo "$FILES"
     exit 1
   fi


### PR DESCRIPTION
## Motivation

Having a large number of non-git files within the system-tests directory, if not covered by the exclude patterns, leads to slower format.sh, and possibly unexpected results.

## Changes

* Use `git ls-files` instead of `find` to check the files to be formatted for trailing spaces.
* To simplify the change, I removed the additional excludes/includes args that were introduced by https://github.com/DataDog/system-tests/pull/2579 since it seems they are not used within the repo. But I can add them back if they are actually in use.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
