### PR TITLE
chore: more span pointer tests

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -747,3 +747,31 @@ Query parameters required in the `GET` method:
 
 Examples:
 - `GET`: `/session/user?sdk_user=sdkUser`
+
+
+### \[GET\] /mock_s3/put_object
+
+This endpoint is used to test the s3 integration. It creates a bucket if
+necessary based on the `bucket` query parameter and puts an object at the `key`
+query parameter. The body of the object is just the bytes of the key, encoded
+with utf-8. Returns a result object with an `object` JSON object field containing the
+`e_tag` field with the ETag of the uploaded object. The `e_tag` field has any
+extra double-quotes stripped (accounting for a quirk in the boto3 library).
+
+Examples:
+- `GET`: `/mock_s3/put_object?bucket=somebucket&key=somekey`
+
+
+### \[GET\] /mock_s3/copy_object
+
+This endpoint is used to test the s3 integration. It creates a bucket if
+necessary based on the `original_bucket` query parameter and puts an object at
+the `original_key` query parameter. The body of the object is just the bytes of
+the key, encoded with utf-8. The method then creates another `bucket` if
+necessary and copies the object into the `key` location. Returns a result
+object with an `object` JSON object field containing the `e_tag` field with the
+ETag of the copied object. The `e_tag` field has any extra double-quotes
+stripped (accounting for a quirk in the boto3 library).
+
+Examples:
+- `GET`: `/mock_s3/copy_object?original_bucket=somebucket&original_key=somekey&bucket=someotherbucket&key=someotherkey`

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -178,6 +178,7 @@ tests/:
     span_pointers/:
       aws/:
         test_s3_span_pointers.py:
+          Test_CopyObject: missing_feature
           Test_PutObject: missing_feature
   stats/:
     test_miscs.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -383,6 +383,7 @@ tests/:
     span_pointers/:
       aws/:
         test_s3_span_pointers.py:
+          Test_CopyObject: missing_feature
           Test_PutObject: missing_feature
   stats/:
     test_miscs.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -499,6 +499,7 @@ tests/:
     span_pointers/:
       aws/:
         test_s3_span_pointers.py:
+          Test_CopyObject: missing_feature
           Test_PutObject: missing_feature
   test_config_consistency.py:
     Test_Config_ClientIPHeader_Configured: v1.60.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1381,6 +1381,7 @@ tests/:
     span_pointers/:
       aws/:
         test_s3_span_pointers.py:
+          Test_CopyObject: missing_feature
           Test_PutObject: missing_feature
   stats/:
     test_miscs.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -617,6 +617,7 @@ tests/:
     span_pointers/:
       aws/:
         test_s3_span_pointers.py:
+          Test_CopyObject: missing_feature
           Test_PutObject: missing_feature
   stats/:
     test_miscs.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -333,6 +333,7 @@ tests/:
     span_pointers/:
       aws/:
         test_s3_span_pointers.py:
+          Test_CopyObject: missing_feature
           Test_PutObject: missing_feature
   stats/:
     test_miscs.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -784,6 +784,11 @@ tests/:
             django-poc: v2.14.0
             flask-poc: v2.14.0
             python3.12: v2.14.0
+          Test_CopyObject:
+            '*': missing_feature
+            django-poc: v2.15.0-dev
+            flask-poc: v2.15.0-dev
+            python3.12: v2.15.0-dev
   stats/:
     test_miscs.py:
       Test_Miscs: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -779,16 +779,16 @@ tests/:
       aws/:
         test_s3_span_pointers.py:
           # NOTE: fastapi-based async things don't play well with moto
-          Test_PutObject:
-            '*': missing_feature
-            django-poc: v2.14.0
-            flask-poc: v2.14.0
-            python3.12: v2.14.0
           Test_CopyObject:
             '*': missing_feature
             django-poc: v2.15.0-dev
             flask-poc: v2.15.0-dev
             python3.12: v2.15.0-dev
+          Test_PutObject:
+            '*': missing_feature
+            django-poc: v2.14.0
+            flask-poc: v2.14.0
+            python3.12: v2.14.0
   stats/:
     test_miscs.py:
       Test_Miscs: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -781,9 +781,9 @@ tests/:
           # NOTE: fastapi-based async things don't play well with moto
           Test_CopyObject:
             '*': missing_feature
-            django-poc: v2.15.0-dev
-            flask-poc: v2.15.0-dev
-            python3.12: v2.15.0-dev
+            django-poc: v2.15.0
+            flask-poc: v2.15.0
+            python3.12: v2.15.0
           Test_PutObject:
             '*': missing_feature
             django-poc: v2.14.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -401,6 +401,7 @@ tests/:
     span_pointers/:
       aws/:
         test_s3_span_pointers.py:
+          Test_CopyObject: missing_feature
           Test_PutObject: missing_feature
   stats/:
     test_miscs.py:

--- a/tests/serverless/span_pointers/aws/test_s3_span_pointers.py
+++ b/tests/serverless/span_pointers/aws/test_s3_span_pointers.py
@@ -52,11 +52,14 @@ class Test_PutObject:
 @features.serverless_span_pointers
 class Test_CopyObject:
     def setup_main(self):
-        weblog.get("/mock_s3/put_object", params={"bucket": "mybucket", "key": "my-key"})
-
         self.r = weblog.get(
             "/mock_s3/copy_object",
-            params={"bucket": "mybucket", "key": "my-key-copy", "copy_source": "/mybucket/my-key"},
+            params={
+                "original_bucket": "mybucket",
+                "original_key": "my-key",
+                "bucket": "mybucket",
+                "key": "my-key-copy",
+            },
         )
 
     def test_main(self):

--- a/tests/serverless/span_pointers/aws/test_s3_span_pointers.py
+++ b/tests/serverless/span_pointers/aws/test_s3_span_pointers.py
@@ -54,7 +54,10 @@ class Test_CopyObject:
     def setup_main(self):
         weblog.get("/mock_s3/put_object", params={"bucket": "mybucket", "key": "my-key"})
 
-        self.r = weblog.get("/mock_s3/copy_object", params={"bucket": "mybucket", "key": "my-key-copy", "copy_source": "/mybucket/my-key"})
+        self.r = weblog.get(
+            "/mock_s3/copy_object",
+            params={"bucket": "mybucket", "key": "my-key-copy", "copy_source": "/mybucket/my-key"},
+        )
 
     def test_main(self):
         _validate_s3_object_pointer(self.r)

--- a/tests/serverless/span_pointers/aws/test_s3_span_pointers.py
+++ b/tests/serverless/span_pointers/aws/test_s3_span_pointers.py
@@ -9,7 +9,7 @@ from tests.serverless.span_pointers.utils import (
 )
 
 
-def _validate_s3_object_pointer(r):
+def _validate_s3_object_pointer(r, resource):
     assert r.status_code == 200
 
     response_content = json.loads(r.text)
@@ -24,6 +24,7 @@ def _validate_s3_object_pointer(r):
     interfaces.library.validate_spans(
         r,
         validator=make_single_span_link_validator(
+            resource=resource,
             pointer_kind="aws.s3.object",
             pointer_direction=POINTER_DIRECTION_DOWNSTREAM,
             pointer_hash=standard_hashing_function([bucket, key, etag]),
@@ -39,13 +40,13 @@ class Test_PutObject:
         self.r = weblog.get("/mock_s3/put_object", params={"bucket": "mybucket", "key": "my-key"})
 
     def test_main(self):
-        _validate_s3_object_pointer(self.r)
+        _validate_s3_object_pointer(self.r, resource="s3.putobject")
 
     def setup_non_ascii(self):
         self.r_non_ascii = weblog.get("/mock_s3/put_object", params={"bucket": "mybucket", "key": "some-key.你好"})
 
     def test_non_ascii(self):
-        _validate_s3_object_pointer(self.r_non_ascii)
+        _validate_s3_object_pointer(self.r_non_ascii, resource="s3.putobject")
 
 
 @rfc("https://github.com/DataDog/dd-span-pointer-rules")
@@ -63,4 +64,4 @@ class Test_CopyObject:
         )
 
     def test_main(self):
-        _validate_s3_object_pointer(self.r)
+        _validate_s3_object_pointer(self.r, resource="s3.copyobject")

--- a/tests/serverless/span_pointers/aws/test_s3_span_pointers.py
+++ b/tests/serverless/span_pointers/aws/test_s3_span_pointers.py
@@ -46,3 +46,15 @@ class Test_PutObject:
 
     def test_non_ascii(self):
         _validate_s3_object_pointer(self.r_non_ascii)
+
+
+@rfc("https://github.com/DataDog/dd-span-pointer-rules")
+@features.serverless_span_pointers
+class Test_CopyObject:
+    def setup_main(self):
+        weblog.get("/mock_s3/put_object", params={"bucket": "mybucket", "key": "my-key"})
+
+        self.r = weblog.get("/mock_s3/copy_object", params={"bucket": "mybucket", "key": "my-key-copy", "copy_source": "/mybucket/my-key"})
+
+    def test_main(self):
+        _validate_s3_object_pointer(self.r)

--- a/tests/serverless/span_pointers/utils.py
+++ b/tests/serverless/span_pointers/utils.py
@@ -36,8 +36,6 @@ def make_single_span_link_validator(
     """
 
     def validator(span):
-        print(span)
-
         if "span_links" not in span:
             return
 

--- a/tests/serverless/span_pointers/utils.py
+++ b/tests/serverless/span_pointers/utils.py
@@ -26,7 +26,7 @@ def standard_hashing_function(elements: list[bytes]) -> PointerHash:
 
 
 def make_single_span_link_validator(
-    pointer_kind: str, pointer_direction: str, pointer_hash: PointerHash,
+    resource: str, pointer_kind: str, pointer_direction: str, pointer_hash: PointerHash,
 ):
     """
     Make a validator function for use with interfaces.library.validate_spans.
@@ -36,7 +36,15 @@ def make_single_span_link_validator(
     """
 
     def validator(span):
+        print(span)
+
         if "span_links" not in span:
+            return
+
+        if "resource" not in span:
+            return
+
+        if span["resource"] != resource:
             return
 
         found_matching = False

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -734,8 +734,12 @@ def s3_put_object(request):
 def s3_copy_object(request):
     original_bucket = request.GET.get("original_bucket")
     original_key = request.GET.get("original_key")
-    copy_source = f"/{original_bucket}/{original_key}"
     body = request.GET.get("original_key")
+
+    copy_source = {
+        "Bucket": original_bucket,
+        "Key": original_key,
+    }
 
     bucket = request.GET.get("bucket")
     key = request.GET.get("key")
@@ -747,7 +751,7 @@ def s3_copy_object(request):
 
         if bucket != original_bucket:
             conn.create_bucket(Bucket=bucket)
-        response = conn.Bucket(bucket).copy_object(Bucket=bucket, Key=key, CopySource=copy_source)
+        response = conn.Bucket(bucket).copy(CopySource=copy_source, Key=key)
 
         # boto adds double quotes to the ETag
         # so we need to remove them to match what would have done AWS

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -731,6 +731,22 @@ def s3_put_object(request):
     return JsonResponse(result)
 
 
+def s3_copy_object(request):
+    bucket = request.GET.get("bucket")
+    key = request.GET.get("key")
+    copy_source = request.GET.get("copy_source")
+
+    with mock_aws():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        response = conn.Bucket(bucket).copy_object(Bucket=bucket, Key=key, CopySource=copy_source)
+
+        # boto adds double quotes to the ETag
+        # so we need to remove them to match what would have done AWS
+        result = {"result": "ok", "object": {"e_tag": response["CopyObjectResult"]["ETag"].replace('"', ""),}}
+
+    return JsonResponse(result)
+
+
 urlpatterns = [
     path("", hello_world),
     path("sample_rate_route/<int:i>", sample_rate),
@@ -801,4 +817,5 @@ urlpatterns = [
     path("custom_event", track_custom_event),
     path("read_file", read_file),
     path("mock_s3/put_object", s3_put_object),
+    path("mock_s3/copy_object", s3_copy_object),
 ]

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -751,7 +751,7 @@ def s3_copy_object(request):
 
         if bucket != original_bucket:
             conn.create_bucket(Bucket=bucket)
-        response = conn.Bucket(bucket).copy(CopySource=copy_source, Key=key)
+        response = conn.Object(bucket, key).copy_from(CopySource=copy_source)
 
         # boto adds double quotes to the ETag
         # so we need to remove them to match what would have done AWS

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -732,12 +732,21 @@ def s3_put_object(request):
 
 
 def s3_copy_object(request):
+    original_bucket = request.GET.get("original_bucket")
+    original_key = request.GET.get("original_key")
+    copy_source = f"/{original_bucket}/{original_key}"
+    body = request.GET.get("original_key")
+
     bucket = request.GET.get("bucket")
     key = request.GET.get("key")
-    copy_source = request.GET.get("copy_source")
 
     with mock_aws():
         conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket=original_bucket)
+        conn.Bucket(original_bucket).put_object(Bucket=original_bucket, Key=original_key, Body=body.encode("utf-8"))
+
+        if bucket != original_bucket:
+            conn.create_bucket(Bucket=bucket)
         response = conn.Bucket(bucket).copy_object(Bucket=bucket, Key=key, CopySource=copy_source)
 
         # boto adds double quotes to the ETag

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -1339,3 +1339,21 @@ def s3_put_object():
         result = {"result": "ok", "object": {"e_tag": response.e_tag.replace('"', ""),}}
 
     return jsonify(result)
+
+
+@app.route("/mock_s3/copy_object", methods=["GET", "POST", "OPTIONS"])
+def s3_copy_object():
+
+    bucket = flask_request.args.get("bucket")
+    key = flask_request.args.get("key")
+    copy_source = flask_request.args.get("copy_source")
+
+    with mock_aws():
+        conn = boto3.resource("s3", region_name="us-east-1")
+        response = conn.Bucket(bucket).copy_object(Bucket=bucket, Key=key, CopySource=copy_source)
+
+        # boto adds double quotes to the ETag
+        # so we need to remove them to match what would have done AWS
+        result = {"result": "ok", "object": {"e_tag": response["CopyObjectResult"]["ETag"].replace('"', ""),}}
+
+    return jsonify(result)

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -1343,13 +1343,21 @@ def s3_put_object():
 
 @app.route("/mock_s3/copy_object", methods=["GET", "POST", "OPTIONS"])
 def s3_copy_object():
+    original_bucket = flask_request.args.get("original_bucket")
+    original_key = flask_request.args.get("original_key")
+    copy_source = f"/{original_bucket}/{original_key}"
+    body: str = flask_request.args.get("original_key")
 
     bucket = flask_request.args.get("bucket")
     key = flask_request.args.get("key")
-    copy_source = flask_request.args.get("copy_source")
 
     with mock_aws():
         conn = boto3.resource("s3", region_name="us-east-1")
+        conn.create_bucket(Bucket=original_bucket)
+        conn.Bucket(original_bucket).put_object(Bucket=original_bucket, Key=original_key, Body=body.encode("utf-8"))
+
+        if bucket != original_bucket:
+            conn.create_bucket(Bucket=bucket)
         response = conn.Bucket(bucket).copy_object(Bucket=bucket, Key=key, CopySource=copy_source)
 
         # boto adds double quotes to the ETag

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -1345,8 +1345,12 @@ def s3_put_object():
 def s3_copy_object():
     original_bucket = flask_request.args.get("original_bucket")
     original_key = flask_request.args.get("original_key")
-    copy_source = f"/{original_bucket}/{original_key}"
     body: str = flask_request.args.get("original_key")
+
+    copy_source = {
+        "Bucket": original_bucket,
+        "Key": original_key,
+    }
 
     bucket = flask_request.args.get("bucket")
     key = flask_request.args.get("key")
@@ -1358,7 +1362,7 @@ def s3_copy_object():
 
         if bucket != original_bucket:
             conn.create_bucket(Bucket=bucket)
-        response = conn.Bucket(bucket).copy_object(Bucket=bucket, Key=key, CopySource=copy_source)
+        response = conn.Bucket(bucket).copy(CopySource=copy_source, Key=key)
 
         # boto adds double quotes to the ETag
         # so we need to remove them to match what would have done AWS

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -1362,7 +1362,7 @@ def s3_copy_object():
 
         if bucket != original_bucket:
             conn.create_bucket(Bucket=bucket)
-        response = conn.Bucket(bucket).copy(CopySource=copy_source, Key=key)
+        response = conn.Object(bucket, key).copy_from(CopySource=copy_source)
 
         # boto adds double quotes to the ETag
         # so we need to remove them to match what would have done AWS


### PR DESCRIPTION
## Motivation

Now that span pointers for s3 and dynamodb are going to be released and we're starting work on the javascript tracer, let's add more tests.

## Changes

Adding system tests for s3: copy object and complete multipart upload; and dynamod: put item, update item, delete item, batch write item, and transact write items.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
