### PR TITLE
Improve parametric scenario output

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -540,6 +540,7 @@ def test_agent(
                     Stop the agent on port {test_agent_port} and try again."""
                     pytest.fail(message, pytrace=False)
 
+                logger.info("Test agent is ready")
                 break
         else:
             with open(test_agent_log_file.name) as f:

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -7,12 +7,19 @@ from typing import Generator, List, Optional, Tuple, TypedDict, Union, Dict
 from docker.models.containers import Container
 import grpc
 import pytest
+from _pytest.outcomes import Failed
 import requests
 
 from utils.parametric.protos import apm_test_client_pb2 as pb
 from utils.parametric.protos import apm_test_client_pb2_grpc
 from utils.parametric.spec.otel_trace import OtelSpanContext, convert_to_proto
 from utils.tools import logger
+
+
+def _fail(message):
+    """ Used to mak a test as failed """
+    logger.error(message)
+    raise Failed(message, pytrace=False) from None
 
 
 class StartSpanResponse(TypedDict):
@@ -191,11 +198,23 @@ class APMLibraryClientHTTP(APMLibraryClient):
             except Exception:
                 self.container.reload()
                 if self.container.status != "running":
-                    message = f"Container {self.container.name} status is {self.container.status}"
-                    raise RuntimeError(message)
+                    self._print_logs()
+                    message = f"Container {self.container.name} status is {self.container.status}. Please check logs."
+                    _fail(message)
+
+            logger.debug(f"Wait for {delay}s for the HTTP library to be ready")
             time.sleep(delay)
         else:
-            raise RuntimeError(f"Timeout of {timeout} seconds exceeded waiting for HTTP server to start")
+            self._print_logs()
+            message = f"Timeout of {timeout} seconds exceeded waiting for HTTP server to start. Please check logs."
+            _fail(message)
+
+    def _print_logs(self):
+        try:
+            logs = self.container.logs().decode("utf-8")
+            logger.debug(f"Logs from container {self.container.name}:\n\n{logs}")
+        except Exception:
+            logger.error(f"Failed to get logs from container {self.container.name}")
 
     def _url(self, path: str) -> str:
         return urllib.parse.urljoin(self._base_url, path)

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -71,6 +71,9 @@ logging.Logger.stdout = stdout
 def get_logger(name="tests", use_stdout=False):
     result = logging.getLogger(name)
 
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
     if use_stdout:
         stdout_handler = logging.StreamHandler(sys.stdout)
         stdout_handler.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Motivation

When container failed to start in parametric tests, the output is too verbose

## Changes

* remove debug and info logs from requests/urllib3 modules
* remove warning from chained exception
* print container logs in stdout

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
