### PR TITLE
Add a test to verify that crashtracking properly times out

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -142,6 +142,7 @@ tests/:
       Test_Config_TraceEnabled: v1.1.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v1.1.0
+    test_crashtracking.py: missing_feature
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
     test_headers_baggage.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -330,8 +330,7 @@ tests/:
       Test_Config_TraceEnabled: v3.3.0
       Test_Config_TraceLogDirectory: v3.3.0
       Test_Config_UnifiedServiceTagging: v3.3.0
-    test_crashtracking.py:
-      Test_Crashtracking: v3.2.0
+    test_crashtracking.py: v3.2.0
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigSamplingRules: v2.53.2

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -330,7 +330,8 @@ tests/:
       Test_Config_TraceEnabled: v3.3.0
       Test_Config_TraceLogDirectory: v3.3.0
       Test_Config_UnifiedServiceTagging: v3.3.0
-    test_crashtracking.py: v3.2.0
+    test_crashtracking.py:
+      Test_Crashtracking: v3.2.0
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigSamplingRules: v2.53.2

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -452,6 +452,7 @@ tests/:
       Test_Config_TraceEnabled: v1.67.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: bug (APMAPI-746)
+    test_crashtracking.py: missing_feature
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigSamplingRules: v1.64.0-dev

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -566,6 +566,7 @@ tests/:
       Test_Config_TraceEnabled: missing_feature
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: missing_feature
+    test_crashtracking.py: missing_feature
     test_dynamic_configuration.py:
       TestDynamicConfigHeaderTags: missing_feature
       TestDynamicConfigSamplingRules: *ref_5_16_0

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -133,6 +133,12 @@ class _TestAgentAPI:
         )
         assert resp.status_code == 202
 
+    def set_trace_delay(self, delay):
+        resp = self._session.post(
+            self._url("/test/settings"), json={"trace_request_delay": delay},
+        )
+        assert resp.status_code == 202
+
     def raw_telemetry(self, clear=False, **kwargs):
         raw_reqs = self.requests()
         reqs = []

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -134,9 +134,7 @@ class _TestAgentAPI:
         assert resp.status_code == 202
 
     def set_trace_delay(self, delay):
-        resp = self._session.post(
-            self._url("/test/settings"), json={"trace_request_delay": delay},
-        )
+        resp = self._session.post(self._url("/test/settings"), json={"trace_request_delay": delay})
         assert resp.status_code == 202
 
     def raw_telemetry(self, clear=False, **kwargs):

--- a/tests/parametric/test_crashtracking.py
+++ b/tests/parametric/test_crashtracking.py
@@ -31,7 +31,7 @@ class Test_Crashtracking:
             if event["request_type"] == "logs":
                 assert self.is_crash_report(test_library, event) is False
 
-    @bug(library="java", reason="Java does not currently enforce the timeout")
+    @bug(library="java", reason="APMLP-302")
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "true"}])
     def test_telemetry_timeout(self, test_agent, test_library, apm_test_server):
         test_agent.set_trace_delay(60)

--- a/tests/parametric/test_crashtracking.py
+++ b/tests/parametric/test_crashtracking.py
@@ -12,9 +12,6 @@ from utils import bug, context, features, irrelevant, missing_feature, rfc, scen
 @scenarios.parametric
 @features.crashtracking
 class Test_Crashtracking:
-    @missing_feature(context.library == "golang", reason="Not implemented")
-    @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @missing_feature(context.library == "cpp", reason="Not implemented")
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "true"}])
     def test_report_crash(self, test_agent, test_library):
         test_library.crash()
@@ -22,9 +19,6 @@ class Test_Crashtracking:
         event = test_agent.wait_for_telemetry_event("logs", wait_loops=400)
         assert self.is_crash_report(test_library, event)
 
-    @missing_feature(context.library == "golang", reason="Not implemented")
-    @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @missing_feature(context.library == "cpp", reason="Not implemented")
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "false"}])
     def test_disable_crashtracking(self, test_agent, test_library):
         test_library.crash()
@@ -37,9 +31,6 @@ class Test_Crashtracking:
             if event["request_type"] == "logs":
                 assert self.is_crash_report(test_library, event) is False
 
-    @missing_feature(context.library == "golang", reason="Not implemented")
-    @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @missing_feature(context.library == "cpp", reason="Not implemented")
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "true"}])
     def test_telemetry_timeout(self, test_agent, test_library, apm_test_server):
         test_agent.set_trace_delay(60)

--- a/tests/parametric/test_crashtracking.py
+++ b/tests/parametric/test_crashtracking.py
@@ -31,6 +31,7 @@ class Test_Crashtracking:
             if event["request_type"] == "logs":
                 assert self.is_crash_report(test_library, event) is False
 
+    @bug(library="java", reason="Java does not currently enforce the timeout")
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "true"}])
     def test_telemetry_timeout(self, test_agent, test_library, apm_test_server):
         test_agent.set_trace_delay(60)

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -75,7 +75,7 @@ class APMLibraryTestServer:
 
 
 class ParametricScenario(Scenario):
-    TEST_AGENT_IMAGE = "ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.17.0"
+    TEST_AGENT_IMAGE = "ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.20.0"
     apm_test_server_definition: APMLibraryTestServer
 
     class PersistentParametricTestConf(dict):

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -965,7 +965,7 @@ class OpenTelemetryCollectorContainer(TestedContainer):
 class APMTestAgentContainer(TestedContainer):
     def __init__(self, host_log_folder) -> None:
         super().__init__(
-            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.18.0",
+            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.20.0",
             name="ddapm-test-agent",
             host_log_folder=host_log_folder,
             environment={"SNAPSHOT_CI": "0", "DD_APM_RECEIVER_SOCKET": "/var/run/datadog/apm.socket"},

--- a/utils/build/docker/ruby/parametric/server.rb
+++ b/utils/build/docker/ruby/parametric/server.rb
@@ -712,10 +712,7 @@ class MyApp
 
   def handle_trace_crash(_req, res)
     STDOUT.puts "Crashing server..."
-    fork do
-      Process.kill('SEGV', Process.pid)
-    end
-
+    Process.kill('SEGV', Process.pid)
     Process.wait2
   end
 


### PR DESCRIPTION
## Motivation

Add a test to verify that crashtracking properly times out when the telemetry endpoint takes too much time to reply.

## Changes

Added a new test that sets an artificial delay on the telemetry endpoint, crashes the application, then verifies the container exits within 10 seconds.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
