### PR TITLE
enable config consistency system tests dotnet

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -325,8 +325,8 @@ tests/:
       TestAdmisionControllerProfiling: missing_feature
   parametric/:
     test_config_consistency.py:
-      Test_Config_RateLimit: missing_feature
-      Test_Config_TraceAgentURL: missing_feature
+      Test_Config_RateLimit: v3.4.1
+      Test_Config_TraceAgentURL: v3.4.1
       Test_Config_TraceEnabled: v3.3.0
       Test_Config_TraceLogDirectory: v3.3.0
       Test_Config_UnifiedServiceTagging: v3.3.0
@@ -388,8 +388,8 @@ tests/:
     test_miscs.py:
       Test_Miscs: missing_feature
   test_config_consistency.py:
-    Test_Config_ClientIPHeader_Configured: missing_feature (Not actually passing telemetry test so disabling until I do)
-    Test_Config_ClientIPHeader_Precedence: missing_feature (all headers listed in the RFC are not supported)
+    Test_Config_ClientIPHeader_Configured: v3.4.1
+    Test_Config_ClientIPHeader_Precedence: v3.4.1
     Test_Config_ClientTagQueryString_Configured: missing_feature (configuration DNE)
     Test_Config_ClientTagQueryString_Empty: missing_feature (Not actually passing telemetry test so disabling until I do)
     Test_Config_HttpClientErrorStatuses_Default: missing_feature
@@ -398,8 +398,8 @@ tests/:
     Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
     Test_Config_IntegrationEnabled_False: missing_feature (Need to update the casing of the integration to Upper case)
     Test_Config_IntegrationEnabled_True: missing_feature (Need to update the casing of the integration to Upper case)
-    Test_Config_ObfuscationQueryStringRegexp_Configured: missing_feature
-    Test_Config_ObfuscationQueryStringRegexp_Empty: missing_feature
+    Test_Config_ObfuscationQueryStringRegexp_Configured: v3.4.1
+    Test_Config_ObfuscationQueryStringRegexp_Empty: v3.4.1
     Test_Config_UnifiedServiceTagging_CustomService: v3.3.0
     Test_Config_UnifiedServiceTagging_Default: v3.3.0
   test_data_integrity.py:

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -485,8 +485,6 @@ ENV DD_TRACE_AspNetCore_ENABLED=false
 ENV DD_TRACE_Process_ENABLED=false
 ENV DD_TRACE_OTEL_ENABLED=false
 
-# "disable" rate limiting by default by setting it to a large value
-ENV DD_TRACE_RATE_LIMIT=10000000
 
 COPY --from=build /app/out /app
 COPY --from=build /app/SYSTEM_TESTS_LIBRARY_VERSION /app/SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
+++ b/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
@@ -295,6 +295,8 @@ public abstract class ApmTestApi
             { "dd_trace_debug", debugEnabled ? "true" : "false" },
             { "dd_trace_otel_enabled", isOtelEnabled.ToString().ToLowerInvariant() },
             { "dd_log_level", null },
+            { "dd_trace_agent_url", tracerSettings.AgentUri },
+            { "dd_trace_rate_limit", tracerSettings.MaxTracesSubmittedPerSecond },
             // { "dd_trace_sample_ignore_parent", "null" }, // Not supported
         };
 

--- a/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
+++ b/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
@@ -296,7 +296,7 @@ public abstract class ApmTestApi
             { "dd_trace_otel_enabled", isOtelEnabled.ToString().ToLowerInvariant() },
             { "dd_log_level", null },
             { "dd_trace_agent_url", tracerSettings.AgentUri },
-            { "dd_trace_rate_limit", tracerSettings.MaxTracesSubmittedPerSecond },
+            { "dd_trace_rate_limit", tracerSettings.MaxTracesSubmittedPerSecond.ToString() },
             // { "dd_trace_sample_ignore_parent", "null" }, // Not supported
         };
 


### PR DESCRIPTION
## Motivation

Enable config consistency tests for dotnet

## Changes

makes updates to dotnet.yml to enable certain config consistency tests