### PR TITLE
Add tests to check libddwaf and rules versions in waf.init metric

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -54,6 +54,7 @@ tests/:
         test_uri.py: irrelevant (ASM is not implemented in C++)
     rasp/:
       test_lfi.py: irrelevant (ASM is not implemented in C++)
+      test_libddwaf.py: irrelevant (ASM is not implemented in C++)
       test_shi.py: irrelevant (ASM is not implemented in C++)
       test_sqli.py: irrelevant (ASM is not implemented in C++)
       test_ssrf.py: irrelevant (ASM is not implemented in C++)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -130,6 +130,7 @@ tests/:
         Test_Lfi_StackTrace: v2.51.0
         Test_Lfi_Telemetry: v2.51.0
         Test_Lfi_UrlQuery: v2.51.0
+      test_libddwaf.py: missing_feature
       test_shi.py:
         Test_Shi_BodyJson: v3.2.0
         Test_Shi_BodyUrlEncoded: v3.2.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -125,6 +125,7 @@ tests/:
         Test_Lfi_Capability: v3.3.0
         Test_Lfi_Mandatory_SpanTags: v2.52.0
         Test_Lfi_Optional_SpanTags: v2.52.0
+        Test_Lfi_Rules_Version: missing_feature
         Test_Lfi_RC_CustomAction: missing_feature
         Test_Lfi_StackTrace: v2.51.0
         Test_Lfi_Telemetry: v2.51.0
@@ -136,6 +137,7 @@ tests/:
         Test_Shi_Capability: v3.3.0
         Test_Shi_Mandatory_SpanTags: v3.2.0
         Test_Shi_Optional_SpanTags: v3.2.0
+        Test_Shi_Rules_Version: missing_feature
         Test_Shi_StackTrace: v3.2.0
         Test_Shi_Telemetry: v3.3.0
         Test_Shi_UrlQuery: v3.2.0
@@ -146,6 +148,7 @@ tests/:
         Test_Sqli_Capability: v3.3.0
         Test_Sqli_Mandatory_SpanTags: v2.54.0
         Test_Sqli_Optional_SpanTags: v2.54.0
+        Test_Sqli_Rules_Version: missing_feature
         Test_Sqli_StackTrace: v2.54.0
         Test_Sqli_Telemetry: v2.54.0
         Test_Sqli_UrlQuery: v2.54.0
@@ -156,6 +159,7 @@ tests/:
         Test_Ssrf_Capability: v3.3.0
         Test_Ssrf_Mandatory_SpanTags: v2.51.0
         Test_Ssrf_Optional_SpanTags: v2.51.0
+        Test_Ssrf_Rules_Version: missing_feature
         Test_Ssrf_StackTrace: v2.51.0
         Test_Ssrf_Telemetry: v2.51.0
         Test_Ssrf_UrlQuery: v2.51.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -125,8 +125,8 @@ tests/:
         Test_Lfi_Capability: v3.3.0
         Test_Lfi_Mandatory_SpanTags: v2.52.0
         Test_Lfi_Optional_SpanTags: v2.52.0
-        Test_Lfi_Rules_Version: missing_feature
         Test_Lfi_RC_CustomAction: missing_feature
+        Test_Lfi_Rules_Version: missing_feature
         Test_Lfi_StackTrace: v2.51.0
         Test_Lfi_Telemetry: v2.51.0
         Test_Lfi_UrlQuery: v2.51.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -127,6 +127,7 @@ tests/:
           TestURI: missing_feature
     rasp/:
       test_lfi.py: missing_feature
+      test_libddwaf.py: missing_feature
       test_shi.py: irrelevant (there is no equivalent to system(3) in go)
       test_sqli.py:
         Test_Sqli_BodyJson: v1.66.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -135,6 +135,7 @@ tests/:
         Test_Sqli_Capability: v1.69.0-dev
         Test_Sqli_Mandatory_SpanTags: v1.69.0-dev
         Test_Sqli_Optional_SpanTags: missing_feature
+        Test_Sqli_Rules_Version: missing_feature
         Test_Sqli_StackTrace: v1.66.0
         Test_Sqli_Telemetry: missing_feature
         Test_Sqli_UrlQuery: v1.66.0
@@ -145,6 +146,7 @@ tests/:
         Test_Ssrf_Capability: v1.69.0-dev
         Test_Ssrf_Mandatory_SpanTags: v1.69.0-dev
         Test_Ssrf_Optional_SpanTags: missing_feature
+        Test_Ssrf_Rules_Version: missing_feature
         Test_Ssrf_StackTrace: v1.65.1
         Test_Ssrf_Telemetry: missing_feature
         Test_Ssrf_UrlQuery: v1.65.1

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -443,6 +443,7 @@ tests/:
         Test_Lfi_Optional_SpanTags:
           '*': v1.40.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_Lfi_Rules_Version: missing_feature
         Test_Lfi_RC_CustomAction: missing_feature (APPSEC-54930)
         Test_Lfi_StackTrace:
           '*': v1.40.0
@@ -490,6 +491,7 @@ tests/:
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           vertx3: v1.40.0 # issue in context propagation in 1.39.0
           vertx4: v1.40.0 # issue in context propagation in 1.39.0
+        Test_Sqli_Rules_Version: missing_feature
         Test_Sqli_StackTrace:
           '*': v1.39.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
@@ -567,6 +569,7 @@ tests/:
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781)
+        Test_Ssrf_Rules_Version: missing_feature
         Test_Ssrf_StackTrace:
           '*': v1.39.0
           akka-http: missing_feature (APPSEC-55781)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -457,6 +457,7 @@ tests/:
           '*': v1.40.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
+      test_libddwaf.py: missing_feature
       test_shi.py: missing_feature (Not support in Java)
       # SQLi was introduced in v1.38.0 (with RASP disabled by default, but was flaky)
       test_sqli.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -443,8 +443,8 @@ tests/:
         Test_Lfi_Optional_SpanTags:
           '*': v1.40.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_Lfi_Rules_Version: missing_feature
         Test_Lfi_RC_CustomAction: missing_feature (APPSEC-54930)
+        Test_Lfi_Rules_Version: missing_feature
         Test_Lfi_StackTrace:
           '*': v1.40.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -314,6 +314,7 @@ tests/:
         Test_Ssrf_Capability: *ref_5_23_0
         Test_Ssrf_Mandatory_SpanTags: *ref_5_18_0
         Test_Ssrf_Optional_SpanTags: *ref_5_18_0
+        Test_Ssrf_Rules_Version: *ref_5_25_0
         Test_Ssrf_StackTrace:
           '*': *ref_5_20_0
           nextjs: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -251,6 +251,7 @@ tests/:
         Test_Lfi_RC_CustomAction:
           '*': *ref_5_24_0
           nextjs: missing_feature
+        Test_Lfi_Rules_Version: missing_feature
         Test_Lfi_StackTrace:
           '*': *ref_5_24_0
           nextjs: missing_feature
@@ -271,6 +272,7 @@ tests/:
         Test_Shi_Capability: *ref_5_25_0
         Test_Shi_Mandatory_SpanTags: *ref_5_25_0
         Test_Shi_Optional_SpanTags: *ref_5_25_0
+        Test_Shi_Rules_Version: *ref_5_24_0
         Test_Shi_StackTrace:
           '*': *ref_5_25_0
           nextjs: missing_feature
@@ -291,6 +293,7 @@ tests/:
         Test_Sqli_Capability: *ref_5_23_0
         Test_Sqli_Mandatory_SpanTags: *ref_5_23_0
         Test_Sqli_Optional_SpanTags: *ref_5_23_0
+        Test_Sqli_Rules_Version: *ref_5_25_0
         Test_Sqli_StackTrace:
           '*': *ref_5_23_0
           nextjs: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -261,6 +261,7 @@ tests/:
         Test_Lfi_UrlQuery:
           '*': *ref_5_24_0
           nextjs: missing_feature
+      test_libddwaf.py: *ref_5_25_0
       test_shi.py:
         Test_Shi_BodyJson:
           '*': *ref_5_25_0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -261,7 +261,8 @@ tests/:
         Test_Lfi_UrlQuery:
           '*': *ref_5_24_0
           nextjs: missing_feature
-      test_libddwaf.py: *ref_5_25_0
+      test_libddwaf.py:
+        Test_Libddwaf_Version: *ref_5_25_0
       test_shi.py:
         Test_Shi_BodyJson:
           '*': *ref_5_25_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -118,6 +118,7 @@ tests/:
           TestURI: missing_feature
     rasp/:
       test_lfi.py: missing_feature
+      test_libddwaf.py: missing_feature
       test_shi.py: missing_feature
       test_sqli.py: missing_feature
       test_ssrf.py: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -212,6 +212,7 @@ tests/:
         Test_Lfi_Capability: v2.11.0
         Test_Lfi_Mandatory_SpanTags: v2.10.0
         Test_Lfi_Optional_SpanTags: v2.10.0
+        Test_Lfi_Rules_Version: missing_feature
         Test_Lfi_RC_CustomAction: v2.14.0
         Test_Lfi_StackTrace: v2.10.0
         Test_Lfi_Telemetry: v2.10.0
@@ -223,6 +224,7 @@ tests/:
         Test_Shi_Capability: v2.11.0
         Test_Shi_Mandatory_SpanTags: v2.11.0-rc2
         Test_Shi_Optional_SpanTags: v2.11.0-rc2
+        Test_Shi_Rules_Version: missing_feature
         Test_Shi_StackTrace: v2.11.0-rc2
         Test_Shi_Telemetry: v2.11.0-rc2
         Test_Shi_UrlQuery: v2.11.0-rc2
@@ -233,6 +235,7 @@ tests/:
         Test_Sqli_Capability: v2.11.0
         Test_Sqli_Mandatory_SpanTags: v2.10.0
         Test_Sqli_Optional_SpanTags: v2.10.0
+        Test_Sqli_Rules_Version: missing_feature
         Test_Sqli_StackTrace: v2.10.0
         Test_Sqli_Telemetry: v2.10.0
         Test_Sqli_UrlQuery: v2.10.0
@@ -243,6 +246,7 @@ tests/:
         Test_Ssrf_Capability: v2.11.0
         Test_Ssrf_Mandatory_SpanTags: v2.10.0
         Test_Ssrf_Optional_SpanTags: v2.10.0
+        Test_Ssrf_Rules_Version: missing_feature
         Test_Ssrf_StackTrace: v2.10.0
         Test_Ssrf_Telemetry: v2.10.0
         Test_Ssrf_UrlQuery: v2.10.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -217,6 +217,7 @@ tests/:
         Test_Lfi_StackTrace: v2.10.0
         Test_Lfi_Telemetry: v2.10.0
         Test_Lfi_UrlQuery: v2.10.0
+      test_libddwaf.py: missing_feature
       test_shi.py:
         Test_Shi_BodyJson: v2.11.0-rc2
         Test_Shi_BodyUrlEncoded: v2.11.0-rc2

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -212,8 +212,8 @@ tests/:
         Test_Lfi_Capability: v2.11.0
         Test_Lfi_Mandatory_SpanTags: v2.10.0
         Test_Lfi_Optional_SpanTags: v2.10.0
-        Test_Lfi_Rules_Version: missing_feature
         Test_Lfi_RC_CustomAction: v2.14.0
+        Test_Lfi_Rules_Version: missing_feature
         Test_Lfi_StackTrace: v2.10.0
         Test_Lfi_Telemetry: v2.10.0
         Test_Lfi_UrlQuery: v2.10.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -119,6 +119,7 @@ tests/:
           TestURI: missing_feature
     rasp/:
       test_lfi.py: missing_feature
+      test_libddwaf.py: missing_feature
       test_shi.py: missing_feature
       test_sqli.py: missing_feature
       test_ssrf.py: missing_feature

--- a/tests/appsec/rasp/test_lfi.py
+++ b/tests/appsec/rasp/test_lfi.py
@@ -10,7 +10,9 @@ from tests.appsec.rasp.utils import (
     validate_stack_traces,
     find_series,
     validate_metric,
+    validate_metric_tag_version,
     RC_CONSTANTS,
+    Base_Rules_Version,
 )
 
 
@@ -259,3 +261,10 @@ class Test_Lfi_Capability:
 
     def test_lfi_capability(self):
         interfaces.library.assert_rc_capability(Capabilities.ASM_RASP_LFI)
+
+
+@features.rasp_local_file_inclusion
+class Test_Lfi_Rules_Version(Base_Rules_Version):
+    """Test lfi min rules version"""
+
+    min_version = "1.13.3"

--- a/tests/appsec/rasp/test_lfi.py
+++ b/tests/appsec/rasp/test_lfi.py
@@ -10,7 +10,6 @@ from tests.appsec.rasp.utils import (
     validate_stack_traces,
     find_series,
     validate_metric,
-    validate_metric_tag_version,
     RC_CONSTANTS,
     Base_Rules_Version,
 )

--- a/tests/appsec/rasp/test_libddwaf.py
+++ b/tests/appsec/rasp/test_libddwaf.py
@@ -3,7 +3,8 @@
 # Copyright 2021 Datadog, Inc.
 
 from utils import features
-from tests.appsec.rasp.utils import (find_series, validate_metric_tag_version)
+from tests.appsec.rasp.utils import find_series, validate_metric_tag_version
+
 
 @features.rasp_local_file_inclusion
 @features.rasp_sql_injection

--- a/tests/appsec/rasp/test_libddwaf.py
+++ b/tests/appsec/rasp/test_libddwaf.py
@@ -1,0 +1,21 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+from utils import features
+from tests.appsec.rasp.utils import (find_series, validate_metric_tag_version)
+
+@features.rasp_local_file_inclusion
+@features.rasp_sql_injection
+@features.rasp_shell_injection
+@features.rasp_server_side_request_forgery
+class Test_Libddwaf_Version:
+    """Test libddwaf version"""
+
+    def test_min_version(self):
+        """Checks data in waf.init metric to verify waf version"""
+        min_version = [1, 20, 1]
+
+        series = find_series(True, "appsec", "waf.init")
+        assert series
+        assert any(validate_metric_tag_version("waf_version", min_version, s) for s in series)

--- a/tests/appsec/rasp/test_shi.py
+++ b/tests/appsec/rasp/test_shi.py
@@ -9,6 +9,7 @@ from tests.appsec.rasp.utils import (
     validate_stack_traces,
     find_series,
     validate_metric,
+    Base_Rules_Version,
 )
 
 
@@ -180,3 +181,10 @@ class Test_Shi_Capability:
 
     def test_shi_capability(self):
         interfaces.library.assert_rc_capability(Capabilities.ASM_RASP_SHI)
+
+
+@features.rasp_local_file_inclusion
+class Test_Shi_Rules_Version(Base_Rules_Version):
+    """Test shi min rules version"""
+
+    min_version = "1.13.1"

--- a/tests/appsec/rasp/test_sqli.py
+++ b/tests/appsec/rasp/test_sqli.py
@@ -9,6 +9,7 @@ from tests.appsec.rasp.utils import (
     validate_stack_traces,
     find_series,
     validate_metric,
+    Base_Rules_Version,
 )
 
 
@@ -184,3 +185,10 @@ class Test_Sqli_Capability:
 
     def test_sqli_capability(self):
         interfaces.library.assert_rc_capability(Capabilities.ASM_RASP_SQLI)
+
+
+@features.rasp_local_file_inclusion
+class Test_Sqli_Rules_Version(Base_Rules_Version):
+    """Test Sqli min rules version"""
+
+    min_version = "1.13.2"

--- a/tests/appsec/rasp/test_ssrf.py
+++ b/tests/appsec/rasp/test_ssrf.py
@@ -9,6 +9,7 @@ from tests.appsec.rasp.utils import (
     validate_stack_traces,
     find_series,
     validate_metric,
+    Base_Rules_Version,
 )
 
 
@@ -192,3 +193,10 @@ class Test_Ssrf_Capability:
 
     def test_ssrf_capability(self):
         interfaces.library.assert_rc_capability(Capabilities.ASM_RASP_SSRF)
+
+
+@features.rasp_local_file_inclusion
+class Test_Ssrf_Rules_Version(Base_Rules_Version):
+    """Test ssrf min rules version"""
+
+    min_version = "1.13.2"

--- a/tests/appsec/rasp/utils.py
+++ b/tests/appsec/rasp/utils.py
@@ -93,6 +93,16 @@ def validate_metric(name, type, metric):
     )
 
 
+def validate_metric_tag_version (tag_prefix, min_version, metric):
+    for tag in metric['tags']:
+        if tag.startswith(tag_prefix + ":"):
+            version_str = tag.split(":")[1]
+            current_version = list(map(int, version_str.split(".")))
+            if current_version >= min_version:
+                return True
+    return False
+
+
 def _load_file(file_path):
     with open(file_path, "r") as f:
         return json.load(f)
@@ -130,3 +140,16 @@ class RC_CONSTANTS:
         "datadog/2/ASM_DD/rules/config",
         _load_file("./tests/appsec/rasp/rasp_ruleset.json"),
     )
+
+class Base_Rules_Version:
+    """Test libddwaf version"""
+
+    min_version = "1.13.3"
+
+    def test_min_version(self):
+        """Checks data in waf.init metric to verify waf version"""
+
+        min_version_array = list(map(int, self.min_version.split(".")))
+        series = find_series(True, "appsec", "waf.init")
+        assert series
+        assert any(validate_metric_tag_version("event_rules_version", min_version_array, s) for s in series)

--- a/tests/appsec/rasp/utils.py
+++ b/tests/appsec/rasp/utils.py
@@ -93,8 +93,8 @@ def validate_metric(name, type, metric):
     )
 
 
-def validate_metric_tag_version (tag_prefix, min_version, metric):
-    for tag in metric['tags']:
+def validate_metric_tag_version(tag_prefix, min_version, metric):
+    for tag in metric["tags"]:
         if tag.startswith(tag_prefix + ":"):
             version_str = tag.split(":")[1]
             current_version = list(map(int, version_str.split(".")))
@@ -140,6 +140,7 @@ class RC_CONSTANTS:
         "datadog/2/ASM_DD/rules/config",
         _load_file("./tests/appsec/rasp/rasp_ruleset.json"),
     )
+
 
 class Base_Rules_Version:
     """Test libddwaf version"""


### PR DESCRIPTION
## Motivation
<!-- What inspired you to submit this pull request? -->
Check that the rules and libddwaf versions are the expected for the GA.

## Changes
<!-- A brief description of the change being made with this pull request. -->
Adds a test checking that the libddwaf version is the expected, and one check by exploit checking that the rules version in the tracer is bigger than the min supported version.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
