### PR TITLE
docs: Improve binaries documentation

### DIFF
--- a/docs/execute/binaries.md
+++ b/docs/execute/binaries.md
@@ -1,6 +1,6 @@
-By default, system tests will build a [weblog](../edit/weblog.md) image that ships the production version of all components.
+By default, system tests will build a [weblog](../edit/weblog.md) image that ships the latest production version of the specified tracer language library.
 
-But, obviously, testing validated versions of components is not really interesting, we need to have a way to install a specific version of at least one component. Here is recipes for each components:
+But we often want to run system tests against unmerged changes. The general approach is to identify the git commit hash that contains your changes and use this commit has to download a targeted build of the tracer. Note: ensure that the commit has been pushed to a remote branch first, and when taking the commit hash, ensure it is the full hash. You can identify the commit hash using `git log` or from the github UI.
 
 
 ## Agent
@@ -28,8 +28,12 @@ There are two ways for running the C++ library tests with a custom tracer:
 
 ## Golang library
 
-To test unmerged PRs locally, you'll first need to identify a git commit hash that contains your changes. Ensure that your commit has been pushed to your remote branch. Then, you can capture the latest (or most relevant) commit hash from the github UI on your open PR.
-Then, use the commit hash to run the following commands inside of the system-tests/utils/build/docker/golang/parametric directory:
+For "regular" system tests (weblog), create a file `golang-load-from-go-get` under the `binaries` directory that specifies the target build. The content of this file will be installed by the weblog via `go get`. Content example:
+    * `gopkg.in/DataDog/dd-trace-go.v1@main` Test the main branch
+    * `gopkg.in/DataDog/dd-trace-go.v1@v1.67.0` Test the 1.67.0 release
+    * `gopkg.in/DataDog/dd-trace-go.v1@<commit_hash>` Test un-merged changes
+
+For parametric tests, run the following commands inside of the system-tests/utils/build/docker/golang/parametric directory:
 
 ```sh
 go get -u gopkg.in/DataDog/dd-trace-go.v1@<commit_hash>
@@ -40,7 +44,6 @@ go mod tidy
     * `gopkg.in/DataDog/dd-trace-go.v1@main` Test the main branch
     * `gopkg.in/DataDog/dd-trace-go.v1@v1.67.0` Test the 1.67.0 release
 
-* When running a test on a specific commit_hash, make sure to use the full hash.
 
 ## Java library
 


### PR DESCRIPTION
## Motivation
This [PR](https://github.com/DataDog/system-tests/pull/3210) updated the Golang section of the binaries docs but mistakenly deleted the weblog instructions. 

## Changes

- Updates Golang section of binaries doc with instructions for both weblog and parametric tests
- Makes doc introduction clearer

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
