### PR TITLE
Updating how to run binaries for Java

### DIFF
--- a/docs/execute/binaries.md
+++ b/docs/execute/binaries.md
@@ -46,6 +46,8 @@ go mod tidy
 
 Follow these steps to run Parametric tests with a custom Java Tracer version:
 
+To run a custom Tracer version from a local branch:
+
 1. Clone the repo and checkout to the branch you'd like to test:
 ```bash
 git clone git@github.com:DataDog/dd-trace-java.git
@@ -70,6 +72,12 @@ Note, you should have only TWO jar files in `system-tests/binaries`. Do NOT copy
 TEST_LIBRARY=java ./run.sh test_span_sampling.py::test_single_rule_match_span_sampling_sss001
 ```
 
+To run a custom tracer version from a remote branch:
+
+1. Find your remote branch on Github and navigate to the `ci/circleci: build_lib` test.
+2. Open the details of the test in CircleCi and click on the `Artifacts` tab.
+3. Download the `libs/dd-java-agent-*-SNAPSHOT.jar` and `libs/dd-trace-api-*-SNAPSHOT.jar` and move them into the `system-tests/binaries/` folder.
+4. Follow Step 4 from above to run the Parametric tests.
 ## NodeJS library
 
 1. Create a file `nodejs-load-from-npm` in `binaries/`, the content will be installed by `npm install`. Content example:


### PR DESCRIPTION
## Motivation

Add info to java binaries for running custom tracer from CI.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
