### PR TITLE
Khanayan123/enable config consistency test php

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -266,10 +266,10 @@ tests/:
       Test_128_Bit_Traceids: v0.84.0
     test_config_consistency.py:
       Test_Config_RateLimit: missing_feature
-      Test_Config_TraceAgentURL: missing_feature
+      Test_Config_TraceAgentURL: v1.4.0
       Test_Config_TraceEnabled: v1.3.0 # Unknown initial version
       Test_Config_TraceLogDirectory: missing_feature
-      Test_Config_UnifiedServiceTagging: missing_feature
+      Test_Config_UnifiedServiceTagging: v1.4.0
     test_crashtracking.py:
       Test_Crashtracking: v1.3.0
     test_dynamic_configuration.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -341,16 +341,16 @@ tests/:
     test_stats.py:
       Test_Client_Stats: missing_feature
   test_config_consistency.py:
-    Test_Config_ClientIPHeader_Configured: missing_feature
-    Test_Config_ClientIPHeader_Precedence: missing_feature (all headers listed in the RFC are not supported)
+    Test_Config_ClientIPHeader_Configured: v1.4.0
+    Test_Config_ClientIPHeader_Precedence: v1.4.0
     Test_Config_ClientTagQueryString_Configured: missing_feature (supports dd_trace_http_url_query_param_allowed instead)
     Test_Config_ClientTagQueryString_Empty: v1.2.0
     Test_Config_HttpClientErrorStatuses_Default: missing_feature
     Test_Config_HttpClientErrorStatuses_FeatureFlagCustom: missing_feature
     Test_Config_HttpServerErrorStatuses_Default: v1.3.0 # Unknown initial version
     Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
-    Test_Config_IntegrationEnabled_False: missing_feature
-    Test_Config_IntegrationEnabled_True: missing_feature
+    Test_Config_IntegrationEnabled_False: v1.4.0
+    Test_Config_IntegrationEnabled_True: v1.4.0
     Test_Config_ObfuscationQueryStringRegexp_Configured: missing_feature
     Test_Config_ObfuscationQueryStringRegexp_Empty: missing_feature
     Test_Config_UnifiedServiceTagging_CustomService: missing_feature

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -353,8 +353,8 @@ tests/:
     Test_Config_IntegrationEnabled_True: v1.4.0
     Test_Config_ObfuscationQueryStringRegexp_Configured: missing_feature
     Test_Config_ObfuscationQueryStringRegexp_Empty: missing_feature
-    Test_Config_UnifiedServiceTagging_CustomService: missing_feature
-    Test_Config_UnifiedServiceTagging_Default: missing_feature
+    Test_Config_UnifiedServiceTagging_CustomService: v1.4.0
+    Test_Config_UnifiedServiceTagging_Default: v1.4.0
   test_distributed.py:
     Test_DistributedHttp: missing_feature
   test_identify.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -269,7 +269,7 @@ tests/:
       Test_Config_TraceAgentURL: v1.4.0
       Test_Config_TraceEnabled: v1.3.0 # Unknown initial version
       Test_Config_TraceLogDirectory: missing_feature
-      Test_Config_UnifiedServiceTagging: v1.4.0
+      Test_Config_UnifiedServiceTagging: v1.5.0
     test_crashtracking.py:
       Test_Crashtracking: v1.3.0
     test_dynamic_configuration.py:

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -98,10 +98,10 @@ class Test_Config_UnifiedServiceTagging:
         assert len(traces) == 2
 
         span1 = find_span_in_traces(traces, s1.trace_id, s1.span_id)
-        span2 = find_span_in_traces(traces, s2.trace_id, s2.span_id)
         assert span1["service"] == "version_test"
         assert span1["meta"]["version"] == "5.2.0"
 
+        span2 = find_span_in_traces(traces, s2.trace_id, s2.span_id)
         assert span2["service"] == "no dd_service"
         assert "version" not in span2["meta"]
 

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -98,10 +98,10 @@ class Test_Config_UnifiedServiceTagging:
         assert len(traces) == 2
 
         span1 = find_span_in_traces(traces, s1.trace_id, s1.span_id)
+        span2 = find_span_in_traces(traces, s2.trace_id, s2.span_id)
         assert span1["service"] == "version_test"
         assert span1["meta"]["version"] == "5.2.0"
 
-        span2 = find_span_in_traces(traces, s2.trace_id, s2.span_id)
         assert span2["service"] == "no dd_service"
         assert "version" not in span2["meta"]
 

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -241,7 +241,7 @@ class Test_Config_ClientIPHeader_Precedence:
         ("x-real-ip", "8.7.6.5"),
         ("true-client-ip", "5.6.7.2"),
         ("x-client-ip", "5.6.7.3"),
-        ("x-forwarded", "for=5.6.7.4"), # Note: APPSEC is currently discussing the correct values for this header
+        ("x-forwarded", "for=5.6.7.4"),  # Note: APPSEC is currently discussing the correct values for this header
         ("forwarded-for", "5.6.7.5"),
         ("x-cluster-client-ip", "5.6.7.6"),
         ("fastly-client-ip", "5.6.7.7"),
@@ -364,6 +364,7 @@ class Test_Config_IntegrationEnabled_False:
 @features.tracing_configuration_consistency
 class Test_Config_IntegrationEnabled_True:
     """ Verify behavior of integrations automatic spans """
+
     def setup_integration_enabled_true(self):
         # PHP does not have a kafka integration
         if context.library == "php":

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -241,7 +241,7 @@ class Test_Config_ClientIPHeader_Precedence:
         ("x-real-ip", "8.7.6.5"),
         ("true-client-ip", "5.6.7.2"),
         ("x-client-ip", "5.6.7.3"),
-        # ("x-forwarded", "5.6.7.4"),
+        ("x-forwarded", "5.6.7.4"),
         ("forwarded-for", "5.6.7.5"),
         ("x-cluster-client-ip", "5.6.7.6"),
         ("fastly-client-ip", "5.6.7.7"),

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -346,7 +346,7 @@ class Test_Config_IntegrationEnabled_False:
 
         nonKafkaOrPdoSpans = []
         kafkaOrPdoSpans = []
-        
+
         for _, _, span in interfaces.library.get_spans(request=self.r, full_trace=True):
             if span.get("name") != "kafka.produce":
                 nonKafkaOrPdoSpans.append(span)

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -341,22 +341,13 @@ class Test_Config_IntegrationEnabled_False:
         assert spans, "No spans found in trace"
         # Ruby kafka integration generates a span with the name "kafka.producer.*",
         # unlike python/dotnet/etc. which generates a "kafka.produce" span
-        assert (
-            list(filter(lambda span: "kafka.produce" in span.get("name"), spans)) == []
-        ), f"kafka.produce span was found in trace: {spans}"
-
-        nonKafkaOrPdoSpans = []
-        kafkaOrPdoSpans = []
-
-        for _, _, span in interfaces.library.get_spans(request=self.r, full_trace=True):
-            if span.get("name") != "kafka.produce":
-                nonKafkaOrPdoSpans.append(span)
-            elif context.library == "php" and span.get("service") != "pdo":
-                nonKafkaOrPdoSpans.append(span)
-            else:
-                kafkaOrPdoSpans.append(span)
-        assert len(nonKafkaOrPdoSpans) > 0
-        assert len(kafkaOrPdoSpans) == 0
+        if context.library == "php":
+            assert (list(filter(lambda span: "pdo" in span.get("service"), spans))  == []
+            ), f"PDO span was found in trace: {spans}"
+        else:
+            assert (
+                list(filter(lambda span: "kafka.produce" in span.get("name"), spans)) == []
+            ), f"kafka.produce span was found in trace: {spans}"
 
 
 @rfc("https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit#heading=h.8v16cioi7qxp")
@@ -376,18 +367,14 @@ class Test_Config_IntegrationEnabled_True:
         assert self.r.status_code == 200
         spans = [span for _, _, span in interfaces.library.get_spans(request=self.r, full_trace=True)]
         assert spans, "No spans found in trace"
-        # Ruby kafka integration generates a span with the name "kafka.producer.*",
-        # unlike python/dotnet/etc. which generates a "kafka.produce" span
-        assert list(
-            filter(lambda span: "kafka.produce" in span.get("name"), spans)
-        ), f"No kafka.produce span found in trace: {spans}"
-
-        nonKafkaOrPdoSpans = []
-        kafkaOrPdoSpans = []
-        for _, _, span in interfaces.library.get_spans(request=self.r, full_trace=True):
-            if span.get("name") != "kafka.produce" and span.get("service") != "pdo":
-                nonKafkaOrPdoSpans.append(span)
-            else:
-                kafkaOrPdoSpans.append(span)
-        assert len(nonKafkaOrPdoSpans) > 0
-        assert len(kafkaOrPdoSpans) > 0
+        # PHP uses the pdo integration
+        if context.library == "php":
+            assert list(
+                filter(lambda span: "pdo" in span.get("service"), spans)
+            ), f"No PDO span found in trace: {spans}"
+        else:
+            # Ruby kafka integration generates a span with the name "kafka.producer.*",
+            # unlike python/dotnet/etc. which generates a "kafka.produce" span
+            assert list(
+                filter(lambda span: "kafka.produce" in span.get("name"), spans)
+            ), f"No kafka.produce span found in trace: {spans}"

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -342,7 +342,8 @@ class Test_Config_IntegrationEnabled_False:
         # Ruby kafka integration generates a span with the name "kafka.producer.*",
         # unlike python/dotnet/etc. which generates a "kafka.produce" span
         if context.library == "php":
-            assert (list(filter(lambda span: "pdo" in span.get("service"), spans))  == []
+            assert (
+                list(filter(lambda span: "pdo" in span.get("service"), spans)) == []
             ), f"PDO span was found in trace: {spans}"
         else:
             assert (

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -241,7 +241,7 @@ class Test_Config_ClientIPHeader_Precedence:
         ("x-real-ip", "8.7.6.5"),
         ("true-client-ip", "5.6.7.2"),
         ("x-client-ip", "5.6.7.3"),
-        ("x-forwarded", "5.6.7.4"),
+        ("x-forwarded", "for=5.6.7.4"),
         ("forwarded-for", "5.6.7.5"),
         ("x-cluster-client-ip", "5.6.7.6"),
         ("fastly-client-ip", "5.6.7.7"),
@@ -267,7 +267,8 @@ class Test_Config_ClientIPHeader_Precedence:
             req = self.requests[i]
             ip = self.IP_HEADERS[i][1]
             trace = [span for _, _, span in interfaces.library.get_spans(req, full_trace=True)]
-            print(88, i)
+            if ip.startswith("for="):
+                ip = ip[4:]
             expected_tags = {"http.client_ip": ip}
             assert _get_span_by_tags(trace, expected_tags), f"Span with tags {expected_tags} not found in {trace}"
 

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -241,7 +241,7 @@ class Test_Config_ClientIPHeader_Precedence:
         ("x-real-ip", "8.7.6.5"),
         ("true-client-ip", "5.6.7.2"),
         ("x-client-ip", "5.6.7.3"),
-        ("x-forwarded", "for=5.6.7.4"),
+        ("x-forwarded", "for=5.6.7.4"), # Note: APPSEC is currently discussing the correct values for this header
         ("forwarded-for", "5.6.7.5"),
         ("x-cluster-client-ip", "5.6.7.6"),
         ("fastly-client-ip", "5.6.7.7"),

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -235,13 +235,20 @@ class Test_Config_ClientIPHeader_Precedence:
     """Verify headers containing ips are tagged when DD_TRACE_CLIENT_IP_ENABLED=true 
     and headers are used to set http.client_ip in order of precedence"""
 
+    # The value of the x-forwarded header expected by PHP is based on RFC 7239
+    # https://datatracker.ietf.org/doc/html/rfc7239#section-4
+    if context.library == "php":
+        x_forwarded_value = "for=5.6.7.4"
+    else:
+        x_forwarded_value = "5.6.7.4"
+
     # Supported ip headers in order of precedence
     IP_HEADERS = (
         ("x-forwarded-for", "5.6.7.0"),
         ("x-real-ip", "8.7.6.5"),
         ("true-client-ip", "5.6.7.2"),
         ("x-client-ip", "5.6.7.3"),
-        ("x-forwarded", "for=5.6.7.4"),  # Note: APPSEC is currently discussing the correct values for this header
+        ("x-forwarded", x_forwarded_value),  # Note: APPSEC is currently discussing the correct values for this header
         ("forwarded-for", "5.6.7.5"),
         ("x-cluster-client-ip", "5.6.7.6"),
         ("fastly-client-ip", "5.6.7.7"),

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -473,6 +473,7 @@ class scenarios:
             "DD_TRACE_KAFKA_ENABLED": "true",
             "DD_TRACE_PDO_ENABLED": "true",  # Use PDO for PHP
             "DD_TRACE_CLIENT_IP_HEADER": "custom-ip-header",
+            "DD_TRACE_CLIENT_IP_ENABLED": "true",
         },
         include_kafka=True,
         include_postgres_db=True,

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -458,8 +458,10 @@ class scenarios:
             "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES": "200-201,202",
             "DD_SERVICE": "service_test",
             "DD_TRACE_KAFKA_ENABLED": "false",  # Using Kafka as is the most common endpoint and integration(missing for PHP).
+            "DD_TRACE_PDO_ENABLED": "false",  # Use PDO for PHP,
         },
         include_kafka=True,
+        include_postgres_db=True,
         doc="",
         scenario_groups=[ScenarioGroup.ESSENTIALS],
     )
@@ -469,9 +471,11 @@ class scenarios:
         weblog_env={
             "DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP": "",
             "DD_TRACE_KAFKA_ENABLED": "true",
+            "DD_TRACE_PDO_ENABLED": "true",  # Use PDO for PHP
             "DD_TRACE_CLIENT_IP_HEADER": "custom-ip-header",
         },
         include_kafka=True,
+        include_postgres_db=True,
         doc="Test tracer configuration when a collection of non-default settings are applied",
     )
     tracing_config_nondefault_3 = EndToEndScenario(

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -151,7 +151,7 @@ $router->addRoute('POST', '/trace/span/start', new ClosureRequestHandler(functio
     }
     $span->name = arg($req, 'name');
     $service = arg($req, 'service');
-    $span->service = (!is_null($service) && $service !== '') ? $service : $span->service;
+    $span->service = !is_null($service) && $service !== '' ? $service : $span->service;
     $span->type = arg($req, 'type');
     $span->resource = arg($req, 'resource');
     $span->links = $links;

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -150,7 +150,8 @@ $router->addRoute('POST', '/trace/span/start', new ClosureRequestHandler(functio
         \DDTrace\set_distributed_tracing_context($context["trace_id"], $context["distributed_tracing_parent_id"] ?? 0, $origin);
     }
     $span->name = arg($req, 'name');
-    $span->service = arg($req, 'service');
+    $service = arg($req, 'service');
+    $span->service = (!is_null($service) && $service !== '') ? $service : $span->service;
     $span->type = arg($req, 'type');
     $span->resource = arg($req, 'resource');
     $span->links = $links;
@@ -637,6 +638,7 @@ $router->addRoute('GET', '/trace/config', new ClosureRequestHandler(function (Re
         'dd_trace_debug' => var_export(\dd_trace_env_config("DD_TRACE_DEBUG"), true),
         'dd_trace_otel_enabled' => var_export(\dd_trace_env_config("DD_TRACE_OTEL_ENABLED"), true),
         'dd_log_level' => trim(var_export(\dd_trace_env_config("DD_TRACE_LOG_LEVEL"), true), "'"),
+        'dd_trace_agent_url' => trim(var_export(\dd_trace_env_config("DD_TRACE_AGENT_URL"), true), "'"),
     );
     return jsonResponse(array(
         'config' => $config


### PR DESCRIPTION
## Motivation

Enable config consistency tests for PHP

## Changes

Enables configuration consistency tests for PHP and updates existing tests to validate PHP functionality in alignment with these configurations.