### PR TITLE
Onboarding: format datadog-apm-library dep

### DIFF
--- a/utils/_context/_scenarios/auto_injection.py
+++ b/utils/_context/_scenarios/auto_injection.py
@@ -265,6 +265,9 @@ class _VirtualMachineScenario(Scenario):
                     self._datadog_apm_inject_version = f"v{self._tested_components[key]}"
                 if key.startswith("datadog-apm-library-") and self._tested_components[key]:
                     self._library.version = self._tested_components[key]
+                    # We store without the lang sufix
+                    self._tested_components["datadog-apm-library"] = self._tested_components[key]
+                    del self._tested_components[key]
 
             # Extract vm name (os) and arch
             # TODO fix os name


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
We want to remove the lang sufix from the datadog-apm-library, in order to simplify the components view from FPD

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
