### PR TITLE
Enable Test_IastStandalone_UpstreamPropagation in nodejs

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -354,7 +354,7 @@ tests/:
       Test_Basic: v2.0.0
     test_asm_standalone.py:
       Test_AppSecStandalone_UpstreamPropagation: *ref_5_18_0
-      Test_IastStandalone_UpstreamPropagation: missing_feature
+      Test_IastStandalone_UpstreamPropagation: *ref_5_18_0
     test_automated_login_events.py:
       Test_Login_Events:
         '*': *ref_4_4_0

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -342,6 +342,8 @@ class scenarios:
             "DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED": "true",
             "DD_IAST_ENABLED": "true",
             "DD_IAST_DETECTION_MODE": "FULL",
+            "DD_IAST_DEDUPLICATION_ENABLED": "false",
+            "DD_IAST_REQUEST_SAMPLING": "100"
         },
         doc="Source code vulnerability standalone mode (APM opt out)",
         scenario_groups=[ScenarioGroup.APPSEC],

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -343,7 +343,7 @@ class scenarios:
             "DD_IAST_ENABLED": "true",
             "DD_IAST_DETECTION_MODE": "FULL",
             "DD_IAST_DEDUPLICATION_ENABLED": "false",
-            "DD_IAST_REQUEST_SAMPLING": "100"
+            "DD_IAST_REQUEST_SAMPLING": "100",
         },
         doc="Source code vulnerability standalone mode (APM opt out)",
         scenario_groups=[ScenarioGroup.APPSEC],

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -5,11 +5,12 @@ import { Request, Response } from "express";
 const tracer = require('dd-trace').init({ debug: true, flushInterval: 5000 });
 
 const { promisify } = require('util')
-const app = require('express')();
-const axios = require('axios');
+const app = require('express')()
+const axios = require('axios')
 const passport = require('passport')
 const { Kafka } = require("kafkajs")
-const { spawnSync } = require('child_process');
+const { spawnSync } = require('child_process')
+const crypto = require('crypto')
 
 const multer = require('multer')
 const uploadToMemory = multer({ storage: multer.memoryStorage(), limits: { fileSize: 200000 } })
@@ -290,6 +291,16 @@ app.get('/requestdownstream', async (req: Request, res: Response) => {
 
 app.get('/returnheaders', (req: Request, res: Response) => {
   res.json({ ...req.headers })
+})
+
+app.get('/vulnerablerequestdownstream', async (req: Request, res: Response) => {
+  try {
+    crypto.createHash('md5').update('password').digest('hex')
+    const resFetch = await axios.get('http://127.0.0.1:7777/returnheaders')
+    return res.json(resFetch.data)
+  } catch (e) {
+    return res.status(500).send(e)
+  }
 })
 
 app.get('/set_cookie', (req: Request, res: Response) => {

--- a/utils/build/docker/nodejs/express4/app.js
+++ b/utils/build/docker/nodejs/express4/app.js
@@ -10,6 +10,7 @@ const app = require('express')()
 const axios = require('axios')
 const fs = require('fs')
 const passport = require('passport')
+const crypto = require('crypto')
 
 const iast = require('./iast')
 const dsm = require('./dsm')
@@ -450,6 +451,16 @@ app.get('/flush', (req, res) => {
 
 app.get('/requestdownstream', async (req, res) => {
   try {
+    const resFetch = await axios.get('http://127.0.0.1:7777/returnheaders')
+    return res.json(resFetch.data)
+  } catch (e) {
+    return res.status(500).send(e)
+  }
+})
+
+app.get('/vulnerablerequestdownstream', async (req, res) => {
+  try {
+    crypto.createHash('md5').update('password').digest('hex')
     const resFetch = await axios.get('http://127.0.0.1:7777/returnheaders')
     return res.json(resFetch.data)
   } catch (e) {

--- a/utils/build/docker/nodejs/nextjs/src/app/vulnerablerequestdownstream/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/vulnerablerequestdownstream/route.js
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import axios from 'axios'
+const crypto = require('crypto')
+
+export const dynamic = 'force-dynamic'
+
+export async function GET () {
+  try {
+    crypto.createHash('md5').update('password').digest('hex')
+    const resFetch = await axios.get('http://127.0.0.1:7777/returnheaders')
+    return NextResponse.json(resFetch.data)
+  } catch (e) {
+    return NextResponse.json({ message: e.toString(), status_code: 500 })
+  }
+}


### PR DESCRIPTION
## Motivation

Test IAST vulnerability detection with standalone mode ON

## Changes

- Implement `/vulnerablerequestdownstream`
- Add two new env var to the `IAST_STANDALONE` scenario for disabling vulnerability deduplication and enabling the IAST for all requests
  - `DD_IAST_DEDUPLICATION_ENABLED=false`
  - `DD_IAST_REQUEST_SAMPLING=100`


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
