### PR TITLE
[python] Skip bugs for 2.16.0 release

### DIFF
--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -143,6 +143,7 @@ class Test_Debugger_PII_Redaction(base._Base_Debugger_Test):
 
     @missing_feature(context.library < "java@1.34", reason="keywords are not fully redacted")
     @missing_feature(context.library < "dotnet@2.51", reason="keywords are not fully redacted")
+    @bug(context.library == "python@2.16.0", reason="APMRP-360")
     def test_pii_redaction_full(self):
         self._test(REDACTED_KEYS, REDACTED_TYPES)
 

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -4,7 +4,7 @@
 
 import tests.debugger.utils as base
 
-from utils import scenarios, features, remote_config as rc
+from utils import scenarios, features, remote_config as rc, bug, context
 
 
 @features.debugger
@@ -27,6 +27,7 @@ class Test_Debugger_Probe_Statuses(base._Base_Debugger_Test):
 
         self._setup(probes)
 
+    @bug(context.library == "python@2.16.0", reason="APMRP-360")
     def test_probe_status_log(self):
         self._assert()
 
@@ -36,6 +37,7 @@ class Test_Debugger_Probe_Statuses(base._Base_Debugger_Test):
 
         self._setup(probes)
 
+    @bug(context.library == "python@2.16.0", reason="APMRP-360")
     def test_probe_status_metric(self):
         self._assert()
 
@@ -54,6 +56,7 @@ class Test_Debugger_Probe_Statuses(base._Base_Debugger_Test):
 
         self._setup(probes)
 
+    @bug(context.library == "python@2.16.0", reason="APMRP-360")
     def test_probe_status_spandecoration(self):
         self._assert()
 


### PR DESCRIPTION
## Motivation

[dd-trace-py 2.16](https://github.com/DataDog/dd-trace-py/releases/tag/v2.16.0) release may have introduced bugs on debugger feature.

## Changes

Skip failing test. As the bug is not on the main branch, probably nothing to fix (appart maybe the release process ? TBD), so I set the "cold case" ticket as reason. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
