### PR TITLE
[ruby] Enable more easy wins

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -372,11 +372,7 @@ tests/:
     test_partial_flushing.py: # Not configurable in a standard way
       Test_Partial_Flushing: missing_feature
     test_sampling_delegation.py:
-      Test_Decisionless_Extraction: >-
-        missing_feature
-        (The "_sampling_priority_v1" numeric tag is missing from the local
-        root span when the trace was extracted without a sampling decision.
-        See <https://github.com/DataDog/system-tests/actions/runs/7629296312/job/20782693568?pr=2005>.)
+      Test_Decisionless_Extraction: v2.4.0
     test_span_links.py:
       Test_Span_Links: v2.0.0
     test_telemetry.py:
@@ -399,12 +395,13 @@ tests/:
       TestTracerFlareV1: missing_feature
   remote_config/:
     test_remote_configuration.py:
+      Test_Agent: v1.13.0
       Test_RemoteConfigurationExtraServices: missing_feature
-      Test_RemoteConfigurationUpdateSequenceASMDD: missing_feature
+      Test_RemoteConfigurationUpdateSequenceASMDD: v1.13.0
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: missing_feature
       Test_RemoteConfigurationUpdateSequenceFeatures: v1.13.0
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: missing_feature
-      Test_RemoteConfigurationUpdateSequenceLiveDebugging: missing_feature
+      Test_RemoteConfigurationUpdateSequenceLiveDebugging: v1.13.0
       Test_RemoteConfigurationUpdateSequenceLiveDebuggingNoCache: missing_feature
   serverless/:
     span_pointers/:
@@ -446,7 +443,7 @@ tests/:
   test_library_conf.py:
     Test_HeaderTags: v1.13.0
     Test_HeaderTags_Colon_Leading: v1.13.0
-    Test_HeaderTags_Colon_Trailing: bug (AIT-8602)
+    Test_HeaderTags_Colon_Trailing: v1.13.0
     Test_HeaderTags_Long: v1.13.0
     Test_HeaderTags_Short: v1.13.0
     Test_HeaderTags_Whitespace_Header: v1.13.0
@@ -462,7 +459,7 @@ tests/:
     Test_UrlQuery: v1.0.0
   test_semantic_conventions.py:
     Test_Meta: v1.7.0
-    Test_MetaDatadogTags: bug (APMAPI-735)
+    Test_MetaDatadogTags: v1.9.0
     Test_MetricsStandardTags: v1.7.0
   test_standard_tags.py:
     Test_StandardTagsClientIp: v1.10.1
@@ -476,10 +473,10 @@ tests/:
   test_telemetry.py:
     Test_DependencyEnable: v1.4.0
     Test_Log_Generation: missing_feature
-    Test_MessageBatch: missing_feature
+    Test_MessageBatch: v2.2.0
     Test_Metric_Generation_Disabled: v1.4.0
     Test_Metric_Generation_Enabled: missing_feature
-    Test_ProductsDisabled: missing_feature
+    Test_ProductsDisabled: v1.22.0
     Test_Telemetry: v1.4.0
     Test_TelemetrySCAEnvVar: missing_feature
     Test_TelemetryV2: v1.11

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -395,7 +395,6 @@ tests/:
       TestTracerFlareV1: missing_feature
   remote_config/:
     test_remote_configuration.py:
-      Test_Agent: v1.13.0
       Test_RemoteConfigurationExtraServices: missing_feature
       Test_RemoteConfigurationUpdateSequenceASMDD: v1.13.0
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: missing_feature

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -31,10 +31,6 @@ class Test_ConfigurationVariables:
         self.r_disabled = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
     @irrelevant(library="ruby", weblog_variant="rack", reason="it's not possible to auto instrument with rack")
-    @missing_feature(
-        context.weblog_variant in ["sinatra14", "sinatra20", "sinatra21", "uds-sinatra"],
-        reason="Conf is done in weblog instead of library",
-    )
     @scenarios.everything_disabled
     def test_disabled(self):
         """ test DD_APPSEC_ENABLED = false """

--- a/tests/parametric/test_headers_b3multi.py
+++ b/tests/parametric/test_headers_b3multi.py
@@ -156,9 +156,6 @@ class Test_Headers_B3multi:
         assert span["meta"].get(ORIGIN) is None
 
     @enable_b3multi_single_key()
-    @missing_feature(
-        context.library == "ruby", reason="Propagators not configured for DD_TRACE_PROPAGATION_STYLE config",
-    )
     def test_headers_b3multi_single_key_propagate_valid(self, test_agent, test_library):
         """Ensure that b3multi distributed tracing headers are extracted
         and injected properly.
@@ -166,7 +163,6 @@ class Test_Headers_B3multi:
         self.test_headers_b3multi_propagate_valid(test_agent, test_library)
 
     @enable_case_insensitive_b3multi()
-    @missing_feature(context.library == "ruby", reason="Ruby doesn't support case-insensitive distributed headers")
     def test_headers_b3multi_case_insensitive_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3multi_propagate_valid(test_agent, test_library)
 

--- a/tests/parametric/test_headers_none.py
+++ b/tests/parametric/test_headers_none.py
@@ -146,9 +146,6 @@ class Test_Headers_None:
         assert "x-datadog-tags" not in headers
 
     @enable_none_single_key()
-    @missing_feature(
-        context.library == "ruby", reason="Propagators not configured for DD_TRACE_PROPAGATION_STYLE config",
-    )
     def test_headers_none_single_key_propagate(self, test_agent, test_library):
         """Ensure that the 'none' propagator is used and
         no Datadog distributed tracing headers are extracted or injected.

--- a/tests/parametric/test_otel_tracer.py
+++ b/tests/parametric/test_otel_tracer.py
@@ -57,9 +57,6 @@ class Test_Otel_Tracer:
     @irrelevant(context.library == "cpp", reason="library does not implement OpenTelemetry")
     @missing_feature(context.library <= "java@1.23.0", reason="OTel resource naming implemented in 1.24.0")
     @missing_feature(context.library == "nodejs", reason="Not implemented")
-    @missing_feature(
-        context.library == "ruby", reason="Ruby is instrumenting telemetry calls, creating 2 spans instead of 1"
-    )
     def test_otel_force_flush(self, test_agent, test_library):
         """
         Verify that force flush flushed the spans

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -28,7 +28,6 @@ class Test_Agent:
 
     @irrelevant(library="nodejs", reason="nodejs tracer does not call /info")
     @irrelevant(library="php", reason="PHP tracer does not call /info")
-    @missing_feature(library="ruby", reason="ruby tracer does not call /info")
     @irrelevant(library="cpp")
     @scenarios.remote_config_mocked_backend_asm_dd
     def test_agent_provide_config_endpoint(self):


### PR DESCRIPTION
## Changes

Enables every classes that are entirely ok as of 7th of November 2024

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
