### PR TITLE
Enable docker_ssi telemetry test for Python, Ruby and Java

### DIFF
--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -68,6 +68,7 @@ class TestDockerSSIFeatures:
     )
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.0")
+    @irrelevant(context.library == "python" and context.installed_language_runtime < "3.7.0")
     def test_telemetry(self):
         # There is telemetry data about the auto instrumentation injector. We only validate there is data
         telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject()
@@ -90,10 +91,11 @@ class TestDockerSSIFeatures:
         assert inject_success, "No telemetry data found for library_entrypoint.complete"
 
     @features.ssi_guardrails
-    @irrelevant(context.library == "python")
     @irrelevant(context.library == "java" and context.installed_language_runtime >= "1.8.0_0")
     @bug(condition=context.library == "php" and context.installed_language_runtime < "7.0", reason="INPLAT-180")
     @irrelevant(context.library == "php" and context.installed_language_runtime >= "7.0")
+    @bug(condition=context.library == "python" and context.installed_language_runtime < "3.7.0", reason="INPLAT-181")
+    @irrelevant(context.library == "python" and context.installed_language_runtime >= "3.7.0")
     def test_telemetry_abort(self):
         # There is telemetry data about the auto instrumentation injector. We only validate there is data
         telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject()

--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -33,6 +33,7 @@ class TestDockerSSIFeatures:
     )
     @bug(condition=context.library == "python", reason="INPLAT-11")
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
+    @irrelevant(context.library == "php" and context.installed_language_runtime < "7.0")
     def test_install_supported_runtime(self):
         logger.info(f"Testing Docker SSI installation on supported lang runtime: {context.scenario.library.library}")
         assert self.r.status_code == 200, f"Failed to get response from {context.scenario.weblog_url}"
@@ -65,6 +66,8 @@ class TestDockerSSIFeatures:
         condition="centos-7" in context.scenario.weblog_variant and context.scenario.library.library == "java",
         reason="APMON-1490",
     )
+    @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
+    @irrelevant(context.library == "php" and context.installed_language_runtime < "7.0")
     def test_telemetry(self):
         # There is telemetry data about the auto instrumentation injector. We only validate there is data
         telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject()
@@ -85,6 +88,32 @@ class TestDockerSSIFeatures:
                 inject_success = True
                 break
         assert inject_success, "No telemetry data found for library_entrypoint.complete"
+
+    @features.ssi_guardrails
+    @irrelevant(context.library == "python")
+    @irrelevant(context.library == "java" and context.installed_language_runtime >= "1.8.0_0")
+    @bug(condition=context.library == "php" and context.installed_language_runtime < "7.0", reason="INPLAT-180")
+    @irrelevant(context.library == "php" and context.installed_language_runtime >= "7.0")
+    def test_telemetry_abort(self):
+        # There is telemetry data about the auto instrumentation injector. We only validate there is data
+        telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject()
+        assert len(telemetry_autoinject_data) >= 1
+        inject_success = False
+        for data in telemetry_autoinject_data:
+            if data["metric"] == "inject.success":
+                inject_success = True
+                break
+        assert inject_success, "No telemetry data found for inject.success"
+
+        # There is telemetry data about the library entrypoint. We only validate there is data
+        telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject_library_entrypoint()
+        assert len(telemetry_autoinject_data) >= 1
+        abort = False
+        for data in telemetry_autoinject_data:
+            if data["metric"] == "library_entrypoint.abort":
+                abort = True
+                break
+        assert abort, "No telemetry data found for library_entrypoint.abort"
 
     def setup_service_name(self):
         self._setup_all()

--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -65,9 +65,6 @@ class TestDockerSSIFeatures:
         condition="centos-7" in context.scenario.weblog_variant and context.scenario.library.library == "java",
         reason="APMON-1490",
     )
-    @missing_feature(library="java", reason="INPLAT-11")
-    @missing_feature(library="python", reason="INPLAT-11")
-    @missing_feature(library="ruby", reason="INPLAT-11")
     def test_telemetry(self):
         # There is telemetry data about the auto instrumentation injector. We only validate there is data
         telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject()

--- a/utils/_context/_scenarios/docker_ssi.py
+++ b/utils/_context/_scenarios/docker_ssi.py
@@ -35,7 +35,7 @@ class DockerSSIScenario(Scenario):
         self._tested_components = {}
 
     def configure(self, config):
-        assert config.option.ssi_library, "library must be set: java,python,nodejs,dotnet,ruby"
+        assert config.option.ssi_library, "library must be set: java,python,nodejs,dotnet,ruby,php"
 
         self._base_weblog = config.option.ssi_weblog
         self._library = config.option.ssi_library

--- a/utils/build/ssi/base/php_install_runtimes.sh
+++ b/utils/build/ssi/base/php_install_runtimes.sh
@@ -32,6 +32,14 @@ if [ "$OS" = "Debian" ]; then
 
     apt install --yes "php${PHP_VERSION}-cli"
 
+    # Hack!
+    # The requirements.json file provided by PHP prevents PHP 5 from being injected.
+    # To be able to test the "library_entrypoint.abort" telemetry, we have to change the path.
+    if [[ "${PHP_VERSION}" == "5.6" ]]; then
+        rm -f /usr/bin/php
+        mv /usr/bin/php5.6 /usr/bin/php
+    fi
+
     php -v
 
 elif [ "$OS" = "RedHat" ]; then

--- a/utils/build/ssi/base/tested_components.sh
+++ b/utils/build/ssi/base/tested_components.sh
@@ -6,10 +6,10 @@ DD_LANG=$1
 if [ "$DD_LANG" == "java" ]; then
     java_version=$(java -version 2>&1)
     runtime_version=$(echo "$java_version" | grep version | awk '{print $3}' | tr -d '"')
-fi
-
-if [ "$DD_LANG" == "php" ]; then
+elif [ "$DD_LANG" == "php" ]; then
     runtime_version=$(php -v | grep -oP 'PHP \K[0-9]+\.[0-9]+\.[0-9]+')
+elif [ "$DD_LANG" == "python" ]; then
+    runtime_version=$(python --version | grep -oP 'Python \K[0-9]+\.[0-9]+\.[0-9]+')
 fi
 
 if [ -f /etc/debian_version ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then

--- a/utils/build/ssi/base/tested_components.sh
+++ b/utils/build/ssi/base/tested_components.sh
@@ -8,6 +8,10 @@ if [ "$DD_LANG" == "java" ]; then
     runtime_version=$(echo "$java_version" | grep version | awk '{print $3}' | tr -d '"')
 fi
 
+if [ "$DD_LANG" == "php" ]; then
+    runtime_version=$(php -v | grep -oP 'PHP \K[0-9]+\.[0-9]+\.[0-9]+')
+fi
+
 if [ -f /etc/debian_version ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
       if dpkg -s datadog-agent &> /dev/null; then
         agent_version=$(dpkg -s datadog-agent | grep Version  | head -n 1);

--- a/utils/docker_ssi/docker_ssi_definitions.py
+++ b/utils/docker_ssi/docker_ssi_definitions.py
@@ -65,12 +65,14 @@ class JavaRuntimeInstallableVersions:
 class PHPRuntimeInstallableVersions:
     """ PHP runtime versions that can be installed automatically"""
 
+    PHP56 = RuntimeInstallableVersion("PHP56", "5.6") # EOL runtime
     PHP74 = RuntimeInstallableVersion("PHP74", "7.4")
     PHP83 = RuntimeInstallableVersion("PHP83", "8.3")
 
     @staticmethod
     def get_all_versions():
         return [
+            PHPRuntimeInstallableVersions.PHP56,
             PHPRuntimeInstallableVersions.PHP74,
             PHPRuntimeInstallableVersions.PHP83,
         ]

--- a/utils/docker_ssi/docker_ssi_definitions.py
+++ b/utils/docker_ssi/docker_ssi_definitions.py
@@ -65,7 +65,7 @@ class JavaRuntimeInstallableVersions:
 class PHPRuntimeInstallableVersions:
     """ PHP runtime versions that can be installed automatically"""
 
-    PHP56 = RuntimeInstallableVersion("PHP56", "5.6") # EOL runtime
+    PHP56 = RuntimeInstallableVersion("PHP56", "5.6")  # Not supported (EOL runtime)
     PHP74 = RuntimeInstallableVersion("PHP74", "7.4")
     PHP83 = RuntimeInstallableVersion("PHP83", "8.3")
 
@@ -88,6 +88,7 @@ class PHPRuntimeInstallableVersions:
 class PythonRuntimeInstallableVersions:
     """ Python runtime versions that can be installed automatically"""
 
+    PY36 = RuntimeInstallableVersion("PY36", "3.6.15")  # Not supported (EOL runtime)
     PY37 = RuntimeInstallableVersion("PY37", "3.7.16")
     PY38 = RuntimeInstallableVersion("PY38", "3.8.20")
     PY39 = RuntimeInstallableVersion("PY39", "3.9.20")
@@ -98,6 +99,7 @@ class PythonRuntimeInstallableVersions:
     @staticmethod
     def get_all_versions():
         return [
+            PythonRuntimeInstallableVersions.PY36,
             PythonRuntimeInstallableVersions.PY37,
             PythonRuntimeInstallableVersions.PY38,
             PythonRuntimeInstallableVersions.PY39,


### PR DESCRIPTION
## Motivation

https://datadoghq.atlassian.net/browse/INPLAT-38

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
