### PR TITLE
[python] replace os.kill(os.getpid()) with ctypes.string_at(0)

### DIFF
--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -1,4 +1,4 @@
-import signal
+import ctypes
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -74,7 +74,7 @@ class StartSpanReturn(BaseModel):
 
 @app.get("/trace/crash")
 def trace_crash() -> None:
-    os.kill(os.getpid(), signal.SIGSEGV.value)
+    ctypes.string_at(0)
 
 
 @app.post("/trace/span/start")


### PR DESCRIPTION
## Motivation

For scenarios which need to segfault, it is better and more realistic to create an actual segfault rather than hacking the behavior.

We noticed with a change to crashtracking that `os.kill(os.getpid(), SIGSEGV)` behaved differently, and the application would not actually crash. This is expected behavior with how linux and signal handling is meant to work when the process is PID 1.

## Changes

Cause a crash by actually segfaulting instead of using external signals.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
