### PR TITLE
Remove Test_Agent from test_remote_configuration.py

### DIFF
--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -22,29 +22,6 @@ from utils import (
 from utils.tools import logger
 
 
-@features.agent_remote_configuration
-class Test_Agent:
-    """misc test on agent/remote config features"""
-
-    @irrelevant(library="nodejs", reason="nodejs tracer does not call /info")
-    @irrelevant(library="php", reason="PHP tracer does not call /info")
-    @missing_feature(library="ruby", reason="ruby tracer does not call /info")
-    @irrelevant(library="cpp")
-    @scenarios.remote_config_mocked_backend_asm_dd
-    def test_agent_provide_config_endpoint(self):
-        """Check that agent exposes /v0.7/config endpoint"""
-        all_data = list(interfaces.library.get_data("/info"))
-
-        assert len(all_data) > 0, "The library didn't make any /info request to the agent"
-
-        for data in all_data:
-            for endpoint in data["response"]["content"]["endpoints"]:
-                if endpoint == "/v0.7/config":
-                    return
-
-        raise ValueError("Agent did not provide /v0.7/config endpoint")
-
-
 @rfc("https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit#heading=h.octuyiil30ph")
 @features.remote_config_object_supported
 class RemoteConfigurationFieldsBasicTests:


### PR DESCRIPTION
## Motivation

This test was an easy win for Ruby but there was no manifest declaration. When talking about it with Charles, it was clarified that this test is testing nothing, except the /info endpoint but it should be rewritten somewhere else.

## Changes

It removes Test_Agent from test_remote_configuration.py

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
