### PR TITLE
Enabling .NET Consistent Configs

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -401,13 +401,13 @@ tests/:
     Test_Config_ClientIPHeader_Configured: v3.4.1
     Test_Config_ClientIPHeader_Precedence: v3.4.1
     Test_Config_ClientTagQueryString_Configured: missing_feature (configuration DNE)
-    Test_Config_ClientTagQueryString_Empty: missing_feature (Not actually passing telemetry test so disabling until I do)
-    Test_Config_HttpClientErrorStatuses_Default: missing_feature
-    Test_Config_HttpClientErrorStatuses_FeatureFlagCustom: missing_feature
-    Test_Config_HttpServerErrorStatuses_Default: missing_feature
-    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
-    Test_Config_IntegrationEnabled_False: missing_feature (Need to update the casing of the integration to Upper case)
-    Test_Config_IntegrationEnabled_True: missing_feature (Need to update the casing of the integration to Upper case)
+    Test_Config_ClientTagQueryString_Empty: v3.5.0
+    Test_Config_HttpClientErrorStatuses_Default: v3.5.0
+    Test_Config_HttpClientErrorStatuses_FeatureFlagCustom: v3.5.0
+    Test_Config_HttpServerErrorStatuses_Default: v3.5.0
+    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: v3.5.0
+    Test_Config_IntegrationEnabled_False: v3.5.0
+    Test_Config_IntegrationEnabled_True: v3.5.0
     Test_Config_ObfuscationQueryStringRegexp_Configured: v3.4.1
     Test_Config_ObfuscationQueryStringRegexp_Empty: v3.4.1
     Test_Config_UnifiedServiceTagging_CustomService: v3.3.0


### PR DESCRIPTION
## Motivation

Effort to make sure .NET configuration is consistent and kept like that: [APMAPI-473](https://datadoghq.atlassian.net/browse/APMAPI-473)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-473]: https://datadoghq.atlassian.net/browse/APMAPI-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ