### PR TITLE
Add a new integration test for "Custom Instrumentation Telemetry RFC"

### DIFF
--- a/.shellcheck
+++ b/.shellcheck
@@ -17,6 +17,7 @@ TODO=(
   utils/build/docker/golang/install_ddtrace.sh
   utils/build/docker/java/app.sh
   utils/build/docker/java/install_ddtrace.sh
+  utils/build/docker/java/install_drop_in.sh
   utils/build/docker/java/spring-boot/app.sh
   utils/build/docker/java_otel/spring-boot/app.sh
   utils/build/docker/php/apache-mod/build.sh

--- a/docs/execute/binaries.md
+++ b/docs/execute/binaries.md
@@ -83,6 +83,17 @@ To run a custom tracer version from a remote branch:
 2. Open the details of the test in CircleCi and click on the `Artifacts` tab.
 3. Download the `libs/dd-java-agent-*-SNAPSHOT.jar` and `libs/dd-trace-api-*-SNAPSHOT.jar` and move them into the `system-tests/binaries/` folder.
 4. Follow Step 4 from above to run the Parametric tests.
+
+Follow these steps to run the OpenTelemetry drop-in test with a custom drop-in version:
+
+1. Download the custom version from https://repo1.maven.org/maven2/io/opentelemetry/javaagent/instrumentation/opentelemetry-javaagent-r2dbc-1.0/
+2. Copy the downloaded `opentelemetry-javaagent-r2dbc-1.0-{version}.jar` into the `system-tests/binaries/` folder
+
+Then run the OpenTelemetry drop-in test from the repo root folder:
+
+- `./build.sh java`
+- `TEST_LIBRARY=java ./run.sh INTEGRATIONS -k Test_Otel_Drop_In`
+
 ## NodeJS library
 
 There are three ways to run system-tests with a custom node tracer.

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -136,6 +136,8 @@ tests/:
       Test_DsmSQS: missing_feature
       Test_Dsm_Manual_Checkpoint_Inter_Process: missing_feature
       Test_Dsm_Manual_Checkpoint_Intra_Process: missing_feature
+    test_otel_drop_in.py:
+      Test_Otel_Drop_In: missing_feature
   parametric/:
     test_128_bit_traceids.py:
       Test_128_Bit_Traceids: missing_feature (parametric app does not support trace/span/extract endpoint)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -358,6 +358,8 @@ tests/:
       Test_DsmSQS: v2.48.0
       Test_Dsm_Manual_Checkpoint_Inter_Process: missing_feature
       Test_Dsm_Manual_Checkpoint_Intra_Process: missing_feature
+    test_otel_drop_in.py:
+      Test_Otel_Drop_In: missing_feature
   k8s_lib_injection/:
     test_k8s_manual_inject.py:
       TestAdmisionControllerProfiling: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -480,6 +480,8 @@ tests/:
       Test_Dsm_Manual_Checkpoint_Intra_Process:
         "*": irrelevant
         net-http: missing_feature (Endpoint not implemented)
+    test_otel_drop_in.py:
+      Test_Otel_Drop_In: missing_feature
   parametric/:
     test_config_consistency.py:
       Test_Config_RateLimit: v1.67.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1419,6 +1419,10 @@ tests/:
         spring-boot: bug (AIDM-325)
     test_mongo.py:
       Test_Mongo: bug (APMAPI-729)
+    test_otel_drop_in.py:
+      Test_Otel_Drop_In:
+        '*': missing_feature
+        spring-boot: v1.39.0
     test_sql.py:
       Test_Sql: bug (APMAPI-729)
   k8s_lib_injection/:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -624,6 +624,8 @@ tests/:
       Test_Dsm_Manual_Checkpoint_Intra_Process:
         '*': irrelevant
         express4: *ref_5_20_0
+    test_otel_drop_in.py:
+      Test_Otel_Drop_In: missing_feature
   k8s_lib_injection/:
     test_k8s_manual_inject.py:
       TestAdmisionControllerProfiling: *ref_5_22_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -294,6 +294,8 @@ tests/:
       Test_DsmSQS: missing_feature
       Test_Dsm_Manual_Checkpoint_Inter_Process: missing_feature
       Test_Dsm_Manual_Checkpoint_Intra_Process: missing_feature
+    test_otel_drop_in.py:
+      Test_Otel_Drop_In: missing_feature
   parametric/:
     test_128_bit_traceids.py:
       Test_128_Bit_Traceids: v0.84.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -721,6 +721,8 @@ tests/:
       Test_Dsm_Manual_Checkpoint_Intra_Process:
         '*': irrelevant
         flask-poc: v2.8.0
+    test_otel_drop_in.py:
+      Test_Otel_Drop_In: missing_feature
   k8s_lib_injection/:
     test_k8s_manual_inject.py:
       TestAdmisionControllerProfiling: v2.12.2

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -362,6 +362,8 @@ tests/:
       Test_Dsm_Manual_Checkpoint_Intra_Process:
         '*': irrelevant
         rails70: missing_feature (Endpoint not implemented)
+    test_otel_drop_in.py:
+      Test_Otel_Drop_In: missing_feature
   k8s_lib_injection/:
     test_k8s_manual_inject.py:
       TestAdmisionControllerProfiling: missing_feature

--- a/tests/integrations/test_otel_drop_in.py
+++ b/tests/integrations/test_otel_drop_in.py
@@ -10,8 +10,10 @@ from utils import weblog, interfaces, scenarios, features
 class Test_Otel_Drop_In:
     """ Verify telemetry data for OpenTelemetry drop-in support """
 
-    def setup_otel_drop_in_telemetry_data(self):
+    def exercise_otel_drop_in(self):
         self.r = weblog.get("/otel_drop_in")
+
+    setup_otel_drop_in_telemetry_data = exercise_otel_drop_in
 
     def test_otel_drop_in_telemetry_data(self):
         def has_otel_integration(integrations):
@@ -24,6 +26,8 @@ class Test_Otel_Drop_In:
                 integration_found = True
                 break
         assert integration_found, "Otel drop-in telemetry data not found"
+
+    setup_otel_drop_in_span_metrics = exercise_otel_drop_in
 
     def test_otel_drop_in_span_metrics(self):
         def has_otel_library_tag(tags):

--- a/tests/integrations/test_otel_drop_in.py
+++ b/tests/integrations/test_otel_drop_in.py
@@ -1,0 +1,38 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2024 Datadog, Inc.
+
+from utils import weblog, interfaces, context, missing_feature, scenarios, features
+
+
+@features.f_otel_interoperability
+@missing_feature(condition=context.library != "java", reason="Endpoint is not implemented on weblog")
+@scenarios.integrations
+class Test_Otel_Drop_In:
+    """ Verify telemetry data for OpenTelemetry drop-in support """
+
+    def setup_otel_drop_in_telemetry_data(self):
+        self.r = weblog.get("/otel_drop_in")
+
+    def test_otel_drop_in_telemetry_data(self):
+        def has_otel_integration(integrations):
+            return any(item["name"].startswith("otel.") and item["enabled"] for item in integrations)
+
+        integration_found = False
+        for data in interfaces.library.get_telemetry_data():
+            payload = data["request"]["content"].get("payload")
+            if payload and has_otel_integration(payload.get("integrations", [])):
+                integration_found = True
+                break
+        assert integration_found, "Otel drop-in telemetry data not found"
+
+    def test_otel_drop_in_span_metrics(self):
+        def has_otel_library_tag(tags):
+            return any(tag.startswith("integration_name:otel.") for tag in tags)
+
+        span_metric_found = False
+        for metric in interfaces.library.get_telemetry_metric_series("tracers", "spans_created"):
+            if has_otel_library_tag(metric.get("tags", [])):
+                span_metric_found = True
+                break
+        assert span_metric_found, "Otel drop-in span metric not found"

--- a/tests/integrations/test_otel_drop_in.py
+++ b/tests/integrations/test_otel_drop_in.py
@@ -2,11 +2,10 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2024 Datadog, Inc.
 
-from utils import weblog, interfaces, context, missing_feature, scenarios, features
+from utils import weblog, interfaces, scenarios, features
 
 
 @features.f_otel_interoperability
-@missing_feature(condition=context.library != "java", reason="Endpoint is not implemented on weblog")
 @scenarios.integrations
 class Test_Otel_Drop_In:
     """ Verify telemetry data for OpenTelemetry drop-in support """

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -193,6 +193,7 @@ class EndToEndScenario(DockerScenario):
         include_rabbitmq=False,
         include_mysql_db=False,
         include_sqlserver=False,
+        include_otel_drop_in=False,
         include_buddies=False,
         require_api_key=False,
     ) -> None:
@@ -237,6 +238,7 @@ class EndToEndScenario(DockerScenario):
                 "INCLUDE_RABBITMQ": str(include_rabbitmq).lower(),
                 "INCLUDE_MYSQL": str(include_mysql_db).lower(),
                 "INCLUDE_SQLSERVER": str(include_sqlserver).lower(),
+                "INCLUDE_OTEL_DROP_IN": str(include_otel_drop_in).lower(),
             }
         )
 

--- a/utils/_context/_scenarios/integrations.py
+++ b/utils/_context/_scenarios/integrations.py
@@ -43,7 +43,8 @@ class IntegrationsScenario(EndToEndScenario):
             include_rabbitmq=True,
             include_mysql_db=True,
             include_sqlserver=True,
-            doc="Spawns tracer, agent, and a full set of database. Test the intgrations of those databases with tracers",
+            include_otel_drop_in=True,
+            doc="Spawns tracer, agent, and a full set of database. Test the integrations of those databases with tracers",
             scenario_groups=[ScenarioGroup.INTEGRATIONS, ScenarioGroup.APPSEC, ScenarioGroup.ESSENTIALS],
         )
 

--- a/utils/build/docker/java/app.sh
+++ b/utils/build/docker/java/app.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 set -eu
 # shellcheck disable=SC2086
-exec java -Xmx362m -javaagent:/app/dd-java-agent.jar -jar /app/app.jar ${APP_EXTRA_ARGS:-}
+
+if [ "${INCLUDE_OTEL_DROP_IN:-}" = "true" ]; then
+  JAVA_OPTS="${JAVA_OPTS:-} -Ddd.trace.otel.enabled=true -Dotel.javaagent.extensions=/app/opentelemetry-javaagent-r2dbc.jar"
+fi
+
+exec java -Xmx362m ${JAVA_OPTS:-} -javaagent:/app/dd-java-agent.jar -jar /app/app.jar ${APP_EXTRA_ARGS:-}

--- a/utils/build/docker/java/install_drop_in.sh
+++ b/utils/build/docker/java/install_drop_in.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eu
+
+if [ $(ls /binaries/opentelemetry-javaagent-r2dbc*.jar | wc -l) = 0 ]; then
+    LIBRARY_URL='https://repo1.maven.org/maven2/io/opentelemetry/javaagent/instrumentation/opentelemetry-javaagent-r2dbc-1.0/2.5.0-alpha/opentelemetry-javaagent-r2dbc-1.0-2.5.0-alpha.jar'
+    echo "install from Maven central: $LIBRARY_URL"
+    curl  -Lf -o /dd-tracer/opentelemetry-javaagent-r2dbc.jar $LIBRARY_URL
+
+elif [ $(ls /binaries/opentelemetry-javaagent-r2dbc*.jar | wc -l) = 1 ]; then
+    echo "Install local file $(ls /binaries/opentelemetry-javaagent-r2dbc*.jar)"
+    cp $(ls /binaries/opentelemetry-javaagent-r2dbc*.jar) /dd-tracer/opentelemetry-javaagent-r2dbc.jar
+
+else
+    echo "Too many jar files in binaries"
+    exit 1
+fi
+
+echo "Installed OpenTelemetry drop-in library"

--- a/utils/build/docker/java/spring-boot.Dockerfile
+++ b/utils/build/docker/java/spring-boot.Dockerfile
@@ -10,8 +10,9 @@ RUN mkdir /maven && mvn -Dmaven.repo.local=/maven -B dependency:go-offline
 COPY ./utils/build/docker/java/spring-boot/src ./src
 RUN mvn -Dmaven.repo.local=/maven package
 
-COPY ./utils/build/docker/java/install_ddtrace.sh binaries* /binaries/
+COPY ./utils/build/docker/java/install_*.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
+RUN /binaries/install_drop_in.sh
 
 FROM eclipse-temurin:11-jre
 
@@ -19,6 +20,7 @@ WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
 
 COPY --from=build /app/target/myproject-0.0.1-SNAPSHOT.jar /app/app.jar
+COPY --from=build /dd-tracer/opentelemetry-javaagent-r2dbc.jar .
 COPY --from=build /dd-tracer/dd-java-agent.jar .
 
 COPY ./utils/build/docker/java/app.sh /app/app.sh

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -1086,6 +1086,13 @@ public class App {
         return "OK";
     }
 
+    @RequestMapping("/otel_drop_in")
+    public String otelDropInSpan() {
+        // exercise OpenTelemetry's R2DBC support on Java
+        db_sql_integrations("reactive_postgresql", "init");
+        return "OK";
+    }
+
     @GetMapping(value = "/requestdownstream")
     public String requestdownstream(HttpServletResponse response) throws IOException {
         String url = "http://localhost:7777/returnheaders";

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -1090,6 +1090,7 @@ public class App {
     public String otelDropInSpan() {
         // exercise OpenTelemetry's R2DBC support on Java
         db_sql_integrations("reactive_postgresql", "init");
+        db_sql_integrations("reactive_postgresql", "select");
         return "OK";
     }
 


### PR DESCRIPTION
## Motivation

Add a new integration test for "Custom Instrumentation Telemetry RFC"

## Changes

Tests the following changes from the "Custom Instrumentation Telemetry RFC" on Java:
* OpenTelemetry drop-in libraries have integration names starting with 'otel.'
* Spans created by drop-in libraries are tagged with names starting with 'otel.'

Also includes some fixes due to R2DBC syntax differing slightly from JDBC

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
