### PR TITLE
Remove X-Forwarded from client IP resolution

### DIFF
--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -236,20 +236,12 @@ class Test_Config_ClientIPHeader_Precedence:
     """Verify headers containing ips are tagged when DD_TRACE_CLIENT_IP_ENABLED=true 
     and headers are used to set http.client_ip in order of precedence"""
 
-    # The value of the x-forwarded header expected by PHP is based on RFC 7239
-    # https://datatracker.ietf.org/doc/html/rfc7239#section-4
-    if context.library == "php":
-        x_forwarded_value = "for=5.6.7.4"
-    else:
-        x_forwarded_value = "5.6.7.4"
-
     # Supported ip headers in order of precedence
     IP_HEADERS = (
         ("x-forwarded-for", "5.6.7.0"),
         ("x-real-ip", "8.7.6.5"),
         ("true-client-ip", "5.6.7.2"),
         ("x-client-ip", "5.6.7.3"),
-        ("x-forwarded", x_forwarded_value),  # Note: APPSEC is currently discussing the correct values for this header
         ("forwarded-for", "5.6.7.5"),
         ("x-cluster-client-ip", "5.6.7.6"),
         ("fastly-client-ip", "5.6.7.7"),

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -231,7 +231,6 @@ class Test_StandardTagsClientIp:
         "true-client-ip": PUBLIC_IP,
         "x-client-ip": PUBLIC_IP,
         "forwarded-for": PUBLIC_IP,
-        "x-forwarded": PUBLIC_IP,
         "x-cluster-client-ip": f"10.42.42.42, {PUBLIC_IP}, fe80::1",
     }
     FORWARD_HEADERS_VENDOR = {
@@ -261,10 +260,6 @@ class Test_StandardTagsClientIp:
 
     def _test_client_ip(self, forward_headers):
         for header, _ in forward_headers.items():
-            if header == "x-forwarded":
-                # TODO: Java currently handles X-Forwarded as Forwarded, while other tracers handle it as X-Forwarded-For.
-                # Keeping this case out until it's clear how to handle it.
-                continue
             request = self.requests_without_attack[header]
             meta = self._get_root_span_meta(request)
             assert "http.client_ip" in meta, f"Missing http.client_ip for {header}"


### PR DESCRIPTION
## Motivation

We removed `X-Forwarded` from client IP resolution (but not header collection for AppSec), since its correct format is unclear, and its usage in the wild in doubt.

## Changes



## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
