### PR TITLE
[ssi] enable container auto_inject install for Java, Node.js, and .NET

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,9 @@ onboarding_nodejs:
           SCENARIO: [HOST_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING]
           DEFAULT_VMS: ["True", "False"]
         - ONBOARDING_FILTER_WEBLOG: [test-app-nodejs-multicontainer]
-          SCENARIO: [ CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING]
+          SCENARIO:
+            - CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT
+            - CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING
           DEFAULT_VMS: ["True", "False"]
         - ONBOARDING_FILTER_WEBLOG: [test-app-nodejs,test-app-nodejs-container]
           SCENARIO: [INSTALLER_AUTO_INJECTION,SIMPLE_AUTO_INJECTION_PROFILING]
@@ -93,7 +95,9 @@ onboarding_java:
           SCENARIO: [HOST_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING]
           DEFAULT_VMS: ["True", "False"]
         - ONBOARDING_FILTER_WEBLOG: [test-app-java-multicontainer,test-app-java-multialpine]
-          SCENARIO: [CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING]
+          SCENARIO:
+            - CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT
+            - CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING
           DEFAULT_VMS: ["True", "False"]
         - ONBOARDING_FILTER_WEBLOG: [test-app-java,test-app-java-container,test-app-java-alpine,test-app-java-buildpack]
           SCENARIO: [INSTALLER_AUTO_INJECTION]
@@ -164,7 +168,9 @@ onboarding_dotnet:
           SCENARIO: [HOST_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING]
           DEFAULT_VMS: ["True", "False"]
         - ONBOARDING_FILTER_WEBLOG: [test-app-dotnet-container]
-          SCENARIO: [ CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING]
+          SCENARIO:
+            - CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT
+            - CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING
           DEFAULT_VMS: ["True", "False"]
         - ONBOARDING_FILTER_WEBLOG: [test-app-dotnet,test-app-dotnet-container]
           SCENARIO: [INSTALLER_AUTO_INJECTION, SIMPLE_AUTO_INJECTION_PROFILING]


### PR DESCRIPTION
## Motivation

We were not running this scenario for Java, Node.js or .NET.

## Changes

Enable running missing scenario `CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
