### PR TITLE
add ESM tests to lib-injection tests

### DIFF
--- a/.github/workflows/run-lib-injection.yml
+++ b/.github/workflows/run-lib-injection.yml
@@ -42,7 +42,12 @@ jobs:
           "dotnet": [{"name":"dd-lib-dotnet-init-test-app","supported":"true"}],
           "golang": [],
           "java": [{"name":"dd-lib-java-init-test-app","supported":"true"},{"name":"jdk7-app","supported":"false"}],
-          "nodejs": [{"name":"sample-app","supported":"true"},{"name":"sample-app-node13","supported":"false"}],
+          "nodejs": [
+            {"name":"sample-app","supported":"true"},
+            {"name":"sample-app-esm-20","supported":"true"},
+            {"name":"sample-app-esm-22","supported":"true"},
+            {"name":"sample-app-node13","supported":"false"}
+          ],
           "php": [],
           "python": [{"name":"dd-lib-python-init-test-django","supported":"true"},
                      {"name":"dd-lib-python-init-test-django-gunicorn", "supported":"true"},

--- a/lib-injection/build/docker/nodejs/sample-app-esm-20/Dockerfile
+++ b/lib-injection/build/docker/nodejs/sample-app-esm-20/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20.0.0
+
+# Create app directory
+WORKDIR /usr/src/app
+
+COPY . .
+
+EXPOSE 18080
+CMD [ "node", "index.mjs" ]

--- a/lib-injection/build/docker/nodejs/sample-app-esm-20/build.sh
+++ b/lib-injection/build/docker/nodejs/sample-app-esm-20/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -z "${BUILDX_PLATFORMS}" ] ; then
+    BUILDX_PLATFORMS=`docker buildx imagetools inspect --raw python:3.12 | jq -r 'reduce (.manifests[] | [ .platform.os, .platform.architecture, .platform.variant ] | join("/") | sub("\\/$"; "")) as $item (""; . + "," + $item)' | sed 's/,//'`
+fi
+echo "Build for platforms: ${BUILDX_PLATFORMS}"
+docker buildx build --platform ${BUILDX_PLATFORMS} --tag ${LIBRARY_INJECTION_TEST_APP_IMAGE} --push .

--- a/lib-injection/build/docker/nodejs/sample-app-esm-20/index.mjs
+++ b/lib-injection/build/docker/nodejs/sample-app-esm-20/index.mjs
@@ -1,0 +1,11 @@
+process.on('SIGTERM', (signal) => {
+  process.exit(0);
+});
+
+import { createServer } from 'http';
+
+createServer((req, res) => {
+  res.end('Hello, world!\n')
+}).listen(18080, () => {
+  console.log('listening on port 18080') // eslint-disable-line no-console
+})

--- a/lib-injection/build/docker/nodejs/sample-app-esm-22/Dockerfile
+++ b/lib-injection/build/docker/nodejs/sample-app-esm-22/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22
+
+# Create app directory
+WORKDIR /usr/src/app
+
+COPY . .
+
+EXPOSE 18080
+CMD [ "node", "index.mjs" ]

--- a/lib-injection/build/docker/nodejs/sample-app-esm-22/build.sh
+++ b/lib-injection/build/docker/nodejs/sample-app-esm-22/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -z "${BUILDX_PLATFORMS}" ] ; then
+    BUILDX_PLATFORMS=`docker buildx imagetools inspect --raw python:3.12 | jq -r 'reduce (.manifests[] | [ .platform.os, .platform.architecture, .platform.variant ] | join("/") | sub("\\/$"; "")) as $item (""; . + "," + $item)' | sed 's/,//'`
+fi
+echo "Build for platforms: ${BUILDX_PLATFORMS}"
+docker buildx build --platform ${BUILDX_PLATFORMS} --tag ${LIBRARY_INJECTION_TEST_APP_IMAGE} --push .

--- a/lib-injection/build/docker/nodejs/sample-app-esm-22/index.mjs
+++ b/lib-injection/build/docker/nodejs/sample-app-esm-22/index.mjs
@@ -1,0 +1,11 @@
+process.on('SIGTERM', (signal) => {
+  process.exit(0);
+});
+
+import { createServer } from 'http';
+
+createServer((req, res) => {
+  res.end('Hello, world!\n')
+}).listen(18080, () => {
+  console.log('listening on port 18080') // eslint-disable-line no-console
+})


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
ESM will be supported in an upcoming version of the injector. This needs testing.

## Changes

<!-- A brief description of the change being made with this pull request. -->
Added two sample ESM apps, each requiring different injection variables.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
