### PR TITLE
Onboarding: change install_script_agent7 url

### DIFF
--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
@@ -53,7 +53,7 @@
     export $(cat scenario_agent.env | xargs)
 
     sudo -E sh -c "sudo mkdir -p /etc/datadog-agent && printf \"api_key: ${DD_API_KEY}\nsite: datadoghq.com\n\" > /etc/datadog-agent/datadog.yaml"
-    DD_REPO_URL=${DD_injection_repo_url} bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+    DD_REPO_URL=${DD_injection_repo_url} bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
     
     sudo cp /tmp/datadog-installer-*.log /var/log/datadog
 

--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject_pre_installer_manual.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject_pre_installer_manual.yml
@@ -1,4 +1,4 @@
 # Installs the installer package (only, no agent no ssi)
 #Our goal is to cache the installer and its dependencies, in the next steps (no cached steps) we will get a fresh copy of the installer
 - os_type: linux
-  remote-command: DD_INSTALL_ONLY=true DD_INSTALLER=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+  remote-command: DD_INSTALL_ONLY=true DD_INSTALLER=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"

--- a/utils/build/virtual_machine/provisions/auto-inject/repositories/autoinstall/execute_install_script.sh
+++ b/utils/build/virtual_machine/provisions/auto-inject/repositories/autoinstall/execute_install_script.sh
@@ -3,7 +3,7 @@
 # This script is needed only for this reason: https://datadoghq.atlassian.net/browse/AP-2165
 
 if [ -z "$INSTALLER_URL" ]; then
-    INSTALLER_URL="https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh"
+    INSTALLER_URL="https://install.datadoghq.com/scripts/install_script_agent7.sh"
 fi
 
 if [ "$DD_APM_INSTRUMENTATION_ENABLED" == "docker" ]; then

--- a/utils/build/virtual_machine/provisions/local-auto-inject-install-script/provision.yml
+++ b/utils/build/virtual_machine/provisions/local-auto-inject-install-script/provision.yml
@@ -25,7 +25,7 @@ install-agent:
   install:
     - os_type: linux
       remote-command: |
-        REPO_URL=$DD_agent_repo_url DD_AGENT_DIST_CHANNEL=$DD_agent_dist_channel DD_AGENT_MAJOR_VERSION=$DD_agent_major_version bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+        REPO_URL=$DD_agent_repo_url DD_AGENT_DIST_CHANNEL=$DD_agent_dist_channel DD_AGENT_MAJOR_VERSION=$DD_agent_major_version bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
 
 autoinjection_install_script:
   install: !include utils/build/virtual_machine/provisions/host-auto-inject-install-script/auto-inject_host_script.yml


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Often we lose the connection to S3 and the installation fails.

## Changes

replace https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh  to https://install.datadoghq.com/scripts/install_script_agent7.sh

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
