### PR TITLE
Support adding span links from extracted context in startSpan

### DIFF
--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -78,7 +78,11 @@ app.post('/trace/span/start', (req, res) => {
   }
 
   const extracted = tracer.extract('http_headers', convertedHeaders)
-  if (extracted !== null) parent = extracted
+  var extractedLinks = []
+  if (extracted !== null) {
+    parent = extracted
+    extractedLinks = parent._links
+  }
 
   const tags = { service: request.service }
   for (const [key, value] of request.span_tags) tags[key] = value
@@ -89,6 +93,10 @@ app.post('/trace/span/start', (req, res) => {
     childOf: parent,
     tags
   })
+
+  for (const link of extractedLinks || []) {
+    span.addLink(link.context, link.attributes)
+  }
 
   for (const link of request.links || []) {
     const linkParentId = link.parent_id;

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -78,7 +78,7 @@ app.post('/trace/span/start', (req, res) => {
   }
 
   const extracted = tracer.extract('http_headers', convertedHeaders)
-  var extractedLinks = []
+  let extractedLinks = []
   if (extracted !== null) {
     parent = extracted
     extractedLinks = parent._links


### PR DESCRIPTION
## Motivation

Update Node parametric app `start_span` in order to support adding span links that have been extracted from distributed tracing propagation extractions. This will allow parametric apps to properly test for the expected behavior for span links with distributed tracing headers.

## Changes

Take the span links from the extracted context and add it to the created span with `span.addLink`. 

[APMAPI-889](https://datadoghq.atlassian.net/browse/APMAPI-889)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-889]: https://datadoghq.atlassian.net/browse/APMAPI-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ