### PR TITLE
Revert "OnBoarding: Force full tracing without limits"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,7 +118,6 @@ onboarding_java:
   script:
       - ./build.sh -i runner
       - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env ${ONBOARDING_FILTER_ENV} --vm-library ${TEST_LIBRARY} --vm-provider aws --report-run-url ${CI_PIPELINE_URL} --report-environment ${ONBOARDING_FILTER_ENV} --vm-default-vms ${DEFAULT_VMS}
-
 onboarding_python:
   extends: .base_job_onboarding_system_tests
   stage: python_tracer

--- a/utils/_context/_scenarios/auto_injection.py
+++ b/utils/_context/_scenarios/auto_injection.py
@@ -366,16 +366,11 @@ class InstallerAutoInjectionScenario(_VirtualMachineScenario):
         scenario_groups=None,
         github_workflow=None,
     ) -> None:
-        # Force full tracing without limits
-        app_env_defaults = {"DD_TRACE_RATE_LIMIT": "1000000000000", "DD_TRACE_SAMPLING_RULES": "[{'sample_rate':1}]"}
-        if app_env is not None:
-            app_env_defaults.update(app_env)
-
         super().__init__(
             name,
             vm_provision=vm_provision,
             agent_env=agent_env,
-            app_env=app_env_defaults,
+            app_env=app_env,
             doc=doc,
             github_workflow=github_workflow,
             include_ubuntu_20_amd64=True,
@@ -436,16 +431,11 @@ class InstallerAutoInjectionScenarioProfiling(_VirtualMachineScenario):
         scenario_groups=None,
         github_workflow=None,
     ) -> None:
-        # Force full tracing without limits
-        app_env_defaults = {"DD_TRACE_RATE_LIMIT": "1000000000000", "DD_TRACE_SAMPLING_RULES": "[{'sample_rate':1}]"}
-        if app_env is not None:
-            app_env_defaults.update(app_env)
-
         super().__init__(
             name,
             vm_provision=vm_provision,
             agent_env=agent_env,
-            app_env=app_env_defaults,
+            app_env=app_env,
             doc=doc,
             github_workflow=github_workflow,
             include_ubuntu_22_amd64=True,


### PR DESCRIPTION
Reverts DataDog/system-tests#3432 as its failing python injection tests, the syntax needs to be changed 
```
raphael_gavache_datadoghq_com@raphael-debian12:~$ DD_APM_INSTRUMENTATION_DEBUG=true DD_TRACE_DEBUG=true DD_TRACE_SAMPLING_RULES=[{'sample_rate':1}]  python3
...
[2024-11-12 16:36:04] [ERROR] datadog.autoinstrumentation(pid: 943923): failed to load ddtrace module: cannot access local variable 'json_rules' where it is not associated with a value

raphael_gavache_datadoghq_com@raphael-debian12:~$ DD_APM_INSTRUMENTATION_DEBUG=true DD_TRACE_DEBUG=true DD_TRACE_SAMPLING_RULES="[{'sample_rate':1}]"  python3
...
[2024-11-12 16:36:04] [ERROR] datadog.autoinstrumentation(pid: 943923): failed to load ddtrace module: cannot access local variable 'json_rules' where it is not associated with a value
```