### PR TITLE
[Java] Implemented missing endpoints for SSRF

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -507,33 +507,19 @@ tests/:
       test_ssrf.py:
         Test_Ssrf_BodyJson:
           '*': v1.39.0
-          akka-http: missing_feature (APPSEC-55781)
-          jersey-grizzly2: missing_feature (APPSEC-55781)
-          play: missing_feature (APPSEC-55781)
-          ratpack: missing_feature (APPSEC-55781)
-          resteasy-netty3: missing_feature (APPSEC-55781)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781, APPSEC-55785)
         Test_Ssrf_BodyUrlEncoded:
           '*': v1.39.0
-          akka-http: missing_feature (APPSEC-55781)
-          jersey-grizzly2: missing_feature (APPSEC-55781)
-          play: missing_feature (APPSEC-55781)
-          ratpack: missing_feature (APPSEC-55781)
-          resteasy-netty3: missing_feature (APPSEC-55781)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781)
         Test_Ssrf_BodyXml:
           '*': v1.39.0
-          akka-http: missing_feature (APPSEC-55781)
-          jersey-grizzly2: missing_feature (APPSEC-55781)
-          play: missing_feature (APPSEC-55781)
-          ratpack: missing_feature (APPSEC-55781)
-          resteasy-netty3: missing_feature (APPSEC-55781)
+          akka-http: missing_feature (APPSEC-55780)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781, APPSEC-55788)
@@ -543,55 +529,28 @@ tests/:
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         Test_Ssrf_Mandatory_SpanTags:
           '*': v1.39.0
-          akka-http: missing_feature (APPSEC-55781)
-          jersey-grizzly2: missing_feature (APPSEC-55781)
-          play: missing_feature (APPSEC-55781)
-          ratpack: missing_feature (APPSEC-55781)
-          resteasy-netty3: missing_feature (APPSEC-55781)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
-          vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781)
         Test_Ssrf_Optional_SpanTags:
           '*': v1.39.0
-          akka-http: missing_feature (APPSEC-55781)
-          jersey-grizzly2: missing_feature (APPSEC-55781)
-          play: missing_feature (APPSEC-55781)
-          ratpack: missing_feature (APPSEC-55781)
-          resteasy-netty3: missing_feature (APPSEC-55781)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
-          vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781)
         Test_Ssrf_StackTrace:
           '*': v1.39.0
-          akka-http: missing_feature (APPSEC-55781)
-          jersey-grizzly2: missing_feature (APPSEC-55781)
-          play: missing_feature (APPSEC-55781)
-          ratpack: missing_feature (APPSEC-55781)
-          resteasy-netty3: missing_feature (APPSEC-55781)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781)
         Test_Ssrf_Telemetry:
           '*': v1.39.0
-          akka-http: missing_feature (APPSEC-55781)
-          jersey-grizzly2: missing_feature (APPSEC-55781)
-          play: missing_feature (APPSEC-55781)
-          ratpack: missing_feature (APPSEC-55781)
-          resteasy-netty3: missing_feature (APPSEC-55781)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781)
         Test_Ssrf_UrlQuery:
           '*': v1.39.0
-          akka-http: missing_feature (APPSEC-55781)
-          jersey-grizzly2: missing_feature (APPSEC-55781)
-          play: missing_feature (APPSEC-55781)
-          ratpack: missing_feature (APPSEC-55781)
-          resteasy-netty3: missing_feature (APPSEC-55781)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781)

--- a/utils/build/docker/java/play/conf/routes
+++ b/utils/build/docker/java/play/conf/routes
@@ -15,8 +15,10 @@ GET  /user_login_failure_event controllers.AppSecController.loginFailure(event_u
 GET  /custom_event             controllers.AppSecController.customEvent(event_name: Option[String])
 GET  /rasp/sqli                controllers.RaspController.sqli
 POST /rasp/sqli                controllers.RaspController.sqli
-GET  /rasp/lfi                controllers.RaspController.lfi
-POST /rasp/lfi                controllers.RaspController.lfi
+GET  /rasp/lfi                 controllers.RaspController.lfi
+POST /rasp/lfi                 controllers.RaspController.lfi
+GET  /rasp/ssrf                controllers.RaspController.ssrf
+POST /rasp/ssrf                controllers.RaspController.ssrf
 GET  /requestdownstream        controllers.AppSecController.requestdownstream
 GET  /vulnerablerequestdownstream        controllers.AppSecController.vulnerableRequestdownstream
 GET  /returnheaders            controllers.AppSecController.returnheaders

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rasp/RaspController.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/rasp/RaspController.java
@@ -63,12 +63,12 @@ public class RaspController {
 
     @RequestMapping(value = "/lfi", method = {GET, POST})
     public ResponseEntity<String> lfi(@RequestParam("file") final String file) {
-        return execFli(file);
+        return execLfi(file);
     }
 
     @PostMapping(value = "/lfi", consumes = {APPLICATION_XML_VALUE, APPLICATION_JSON_VALUE})
     public ResponseEntity<String> lfi(@RequestBody final FileDTO body) throws SQLException {
-        return execFli(body.getFile());
+        return execLfi(body.getFile());
     }
 
 
@@ -102,7 +102,7 @@ public class RaspController {
         }
     }
 
-    private ResponseEntity<String> execFli(final String file)  {
+    private ResponseEntity<String> execLfi(final String file)  {
         new File(file);
         return ResponseEntity.ok("OK");
     }


### PR DESCRIPTION
## Motivation

Implemented missing endpoints for SSRF in:
- akka-http
- jersey-grizzly2
- play
- ratpack
- resteasy-netty3
- vertx3

[APPSEC-55650](https://datadoghq.atlassian.net/browse/APPSEC-55650)
[APPSEC-55781](https://datadoghq.atlassian.net/browse/APPSEC-55781)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-55650]: https://datadoghq.atlassian.net/browse/APPSEC-55650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APPSEC-55781]: https://datadoghq.atlassian.net/browse/APPSEC-55781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ