### PR TITLE
Change ddtrace install script for parametric

### DIFF
--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -429,7 +429,7 @@ COPY {golang_reldir}/go.mod /app
 COPY {golang_reldir}/go.sum /app
 COPY {golang_reldir}/. /app
 # download the proper tracer version
-COPY utils/build/docker/golang/install_ddtrace.sh binaries* /binaries/
+COPY utils/build/docker/golang/parametric/install_ddtrace.sh binaries* /binaries/
 COPY utils/build/docker/golang/parametric/system_tests_library_version.sh system_tests_library_version.sh
 RUN /binaries/install_ddtrace.sh
 RUN mkdir /parametric-tracer-logs

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -430,6 +430,7 @@ COPY {golang_reldir}/go.sum /app
 COPY {golang_reldir}/. /app
 # download the proper tracer version
 COPY utils/build/docker/golang/parametric/install_ddtrace.sh binaries* /binaries/
+RUN chmod +x /binaries/install_ddtrace.sh
 COPY utils/build/docker/golang/parametric/system_tests_library_version.sh system_tests_library_version.sh
 RUN /binaries/install_ddtrace.sh
 RUN mkdir /parametric-tracer-logs

--- a/utils/build/docker/golang/parametric/install_ddtrace.sh
+++ b/utils/build/docker/golang/parametric/install_ddtrace.sh
@@ -7,10 +7,8 @@ go mod tidy
 
 # Read the library version out of the version.go file
 lib_mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)
-version=$(sed -nrE 's#.*"v(.*)".*#\1#p' $lib_mod_dir/internal/version/version.go) # Parse the version string content "v.*"
-echo $version > SYSTEM_TESTS_LIBRARY_VERSION
-
-rules_mod_dir=$(go list -f '{{.Dir}}' -m github.com/DataDog/appsec-internal-go)
+version=$(sed -nrE 's#.*"v(.*)".*#\1#p' "$lib_mod_dir"/internal/version/version.go) # Parse the version string content "v.*"
+echo "$version" > SYSTEM_TESTS_LIBRARY_VERSION
 
 
 echo "dd-trace-go version: $(cat /app/SYSTEM_TESTS_LIBRARY_VERSION)"

--- a/utils/build/docker/golang/parametric/install_ddtrace.sh
+++ b/utils/build/docker/golang/parametric/install_ddtrace.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euv
+
+# Downloading a newer version of the tracer may require to resolve again all dependencies
+go mod tidy
+
+# Read the library version out of the version.go file
+lib_mod_dir=$(go list -f '{{.Dir}}' -m gopkg.in/DataDog/dd-trace-go.v1)
+version=$(sed -nrE 's#.*"v(.*)".*#\1#p' $lib_mod_dir/internal/version/version.go) # Parse the version string content "v.*"
+echo $version > SYSTEM_TESTS_LIBRARY_VERSION
+
+rules_mod_dir=$(go list -f '{{.Dir}}' -m github.com/DataDog/appsec-internal-go)
+
+
+echo "dd-trace-go version: $(cat /app/SYSTEM_TESTS_LIBRARY_VERSION)"


### PR DESCRIPTION
## Motivation
We've previously updated the [parametric app instructions](https://github.com/DataDog/system-tests/blob/main/docs/execute/binaries.md#golang-library) to say, "just run go get with the specific library version you'd like to run the tests with," and yet the install script would install a conflicting version, effectively blocking us from using a non-default version of dd-trace-go in parametric tests.

## Changes
This PR makes a new script file, parametric/ddtrace_install.sh, for managing ddtrace installations in parametric app. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
