### PR TITLE
Disable irrelevant Python 3.6 test_crash test

### DIFF
--- a/tests/docker_ssi/test_docker_ssi_crash.py
+++ b/tests/docker_ssi/test_docker_ssi_crash.py
@@ -2,6 +2,7 @@ from urllib.parse import urlparse
 
 from utils import (
     bug,
+    irrelevant,
     scenarios,
     features,
     context,
@@ -31,6 +32,7 @@ class TestDockerSSICrash:
 
     @features.ssi_crashtracking
     @bug(condition=context.library != "python", reason="INPLAT-11")
+    @irrelevant(context.library == "python" and context.installed_language_runtime < "3.7.0")
     def test_crash(self):
         """Validate that a crash report is generated when the application crashes"""
         logger.info(f"Testing Docker SSI crash tracking: {context.scenario.library.library}")


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
