### PR TITLE
Create appsec rasp scenario group

### DIFF
--- a/.github/workflows/compute-workflow-parameters.yml
+++ b/.github/workflows/compute-workflow-parameters.yml
@@ -78,6 +78,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: 'DataDog/system-tests'
+        ref: 'ugaitz/appsec-rasp-scenario-group'
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: main

--- a/.github/workflows/compute-workflow-parameters.yml
+++ b/.github/workflows/compute-workflow-parameters.yml
@@ -78,7 +78,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: 'DataDog/system-tests'
-        ref: 'ugaitz/appsec-rasp-scenario-group'
     - name: Install runner
       uses: ./.github/actions/install_runner
     - name: main

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -259,7 +259,7 @@ class scenarios:
         rc_api_enabled=True,
         appsec_enabled=False,
         doc="",
-        scenario_groups=[ScenarioGroup.APPSEC],
+        scenario_groups=[ScenarioGroup.APPSEC, ScenarioGroup.APPSEC_RASP],
     )
 
     appsec_api_security = EndToEndScenario(
@@ -397,7 +397,12 @@ class scenarios:
             remote config. And it's okay not testing custom rule set for dev mode, as in this scenario, rules
             are always coming from remote config.
         """,
-        scenario_groups=[ScenarioGroup.APPSEC, ScenarioGroup.REMOTE_CONFIG, ScenarioGroup.ESSENTIALS],
+        scenario_groups=[
+            ScenarioGroup.APPSEC,
+            ScenarioGroup.APPSEC_RASP,
+            ScenarioGroup.REMOTE_CONFIG,
+            ScenarioGroup.ESSENTIALS,
+        ],
     )
 
     remote_config_mocked_backend_asm_features_nocache = EndToEndScenario(
@@ -714,7 +719,7 @@ class scenarios:
         weblog_volumes={"./tests/appsec/rasp/rasp_ruleset.json": {"bind": "/appsec_rasp_ruleset.json", "mode": "ro"}},
         doc="Enable APPSEC RASP",
         github_workflow="endtoend",
-        scenario_groups=[ScenarioGroup.APPSEC],
+        scenario_groups=[ScenarioGroup.APPSEC, ScenarioGroup.APPSEC_RASP],
     )
 
     external_processing = ExternalProcessingScenario("EXTERNAL_PROCESSING")

--- a/utils/_context/_scenarios/core.py
+++ b/utils/_context/_scenarios/core.py
@@ -11,6 +11,7 @@ from utils.tools import logger, get_log_formatter
 class ScenarioGroup(Enum):
     ALL = "all"
     APPSEC = "appsec"
+    APPSEC_RASP = "appsec_rasp"
     DEBUGGER = "debugger"
     END_TO_END = "end-to-end"
     GRAPHQL = "graphql"


### PR DESCRIPTION
## Motivation
Instead of adding one by one the scenarios related with the rasp in the dd-trace-js ci, it's better if we run the scenarios group for the rasp.

Working CI run in dd-trace-js: https://github.com/DataDog/dd-trace-js/actions/runs/11839366667/job/32990627845?pr=4883

## Changes

<!-- A brief description of the change being made with this pull request. -->
Create new  scenario group and link related scenarios with the new group.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


Failing test seems totally unrelated.
