### PR TITLE
DEBUG-2334 fix running documentation with scenario

### DIFF
--- a/docs/execute/run.md
+++ b/docs/execute/run.md
@@ -15,10 +15,10 @@
 If the test contains `@scenarios.SCENARIO_NAME` such as `@scenarios.integrations`, then the `./run.sh` needs to be adjusted to the following:
 
 ```bash
-./run.sh SCENARIO_NAME tests/path_to_test.py
+./run.sh +S SCENARIO_NAME tests/path_to_test.py
 
 # Example: for @scenarios.integrations in tests/integrations/test_sql.py
-./run.sh INTEGRATIONS tests/integrations/test_sql.py
+./run.sh +S integrations tests/integrations/test_sql.py
 ```
 
 ## Run only one class, or one method


### PR DESCRIPTION

## Motivation
Current documentation mixes upper and lower case for scenario name in the instructions for running a single file with a scenario.
<!-- What inspired you to submit this pull request? -->

## Changes
Change the instructions to use +S option to pass the actual scenario name as specified in the test file (in lower case). Now the instructions can be followed as written.

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
