### PR TITLE
parametric: remove unused method

### DIFF
--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -410,13 +410,6 @@ class _TestOtelSpan:
     def set_baggage(self, key: str, value: str):
         self._client.otel_set_baggage(self.span_id, key, value)
 
-    ### Do not use the below methods in parametric tests, they will be removed in a future PR ####
-    ### The parametric apps will not expose endpoints for retrieving span data ###
-    ### Span data will be retrieved from the agent ###
-
-    def get_attribute(self, key: str):
-        return self._client.otel_get_attribute(self.span_id, key)
-
 
 class APMLibrary:
     def __init__(self, client: APMLibraryClient, lang):


### PR DESCRIPTION
## Motivation

- Clean up

## Changes

- Delete `_OtelSpan.get_attribute()`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
