### PR TITLE
[golang] update binaries.md

### DIFF
--- a/docs/execute/binaries.md
+++ b/docs/execute/binaries.md
@@ -28,24 +28,11 @@ There are two ways for running the C++ library tests with a custom tracer:
 
 ## Golang library
 
-For "regular" system tests (weblog), create a file `golang-load-from-go-get` under the `binaries` directory that specifies the target build. The content of this file will be installed by the weblog via `go get` when you build the test image.
-
+Create a file `golang-load-from-go-get` under the `binaries` directory that specifies the target build. The content of this file will be installed by the weblog or parametric app via `go get` when the test image is built.
 * Content example:
     * `gopkg.in/DataDog/dd-trace-go.v1@main` Test the main branch
     * `gopkg.in/DataDog/dd-trace-go.v1@v1.67.0` Test the 1.67.0 release
     * `gopkg.in/DataDog/dd-trace-go.v1@<commit_hash>` Test un-merged changes
-
-For parametric tests, run the following commands inside of the system-tests/utils/build/docker/golang/parametric directory:
-
-```sh
-go get -u gopkg.in/DataDog/dd-trace-go.v1@<commit_hash>
-go mod tidy
-```
-
-* Content example:
-    * `gopkg.in/DataDog/dd-trace-go.v1@main` Test the main branch
-    * `gopkg.in/DataDog/dd-trace-go.v1@v1.67.0` Test the 1.67.0 release
-
 
 ## Java library
 


### PR DESCRIPTION
## Motivation
[A previous PR](https://github.com/DataDog/system-tests/commit/eff4b2bb85aec0110b964d9626e2fb803543c4b6) overwrote the Golang instructions under binaries.md; this PR reverts those changes after coming to the following conclusions: 
1. The instructions did not work for neither weblog nor parametric apps in the repo's current state
3. We want one set of instructions for both parametric and weblog app and the "old way" with golang-load-from-go-get achieves that

## Changes
Revert binaries.md#Golang instructions to the old " golang-load-from-go-get" way.
Closes https://github.com/DataDog/system-tests/pull/3454 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
4. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
5. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
