### PR TITLE
Version check for libddwaf added to APPSEC_RASP scenario

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -605,8 +605,7 @@ tests/:
           spring-boot-payara: missing_feature (APPSEC-54966)
         Test_Lfi_Rules_Version:
           '*': v1.40.0
-      test_libddwaf.py:
-        '*': v1.40.0
+      test_libddwaf.py: v1.40.0
       test_shi.py:
         Test_Shi_UrlQuery: missing_feature (Not support in Java)
         Test_Shi_BodyUrlEncoded: missing_feature (Not support in Java)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -603,8 +603,21 @@ tests/:
           '*': v1.40.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
-      test_libddwaf.py: missing_feature
-      test_shi.py: missing_feature (Not support in Java)
+        Test_Lfi_Rules_Version: 
+          '*': v1.40.0
+      test_libddwaf.py:
+          '*': v1.40.0
+      test_shi.py: 
+        Test_Shi_UrlQuery: missing_feature (Not support in Java)
+        Test_Shi_BodyUrlEncoded: missing_feature (Not support in Java)
+        Test_Shi_BodyXml: missing_feature (Not support in Java)
+        Test_Shi_BodyJson: missing_feature (Not support in Java)
+        Test_Shi_Mandatory_SpanTags: missing_feature (Not support in Java)
+        Test_Shi_Optional_SpanTags: missing_feature (Not support in Java)
+        Test_Shi_StackTrace: missing_feature (Not support in Java)
+        Test_Shi_Telemetry: missing_feature (Not support in Java)
+        Test_Shi_Capability: missing_feature (Not support in Java)
+        Test_Shi_Rules_Version: v1.40.0
       # SQLi was introduced in v1.38.0 (with RASP disabled by default, but was flaky)
       test_sqli.py:
         Test_Sqli_BodyJson:
@@ -657,6 +670,8 @@ tests/:
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: v1.40.0 # issue in context propagation in 1.39.0
           vertx4: v1.40.0 # issue in context propagation in 1.39.0
+        Test_Sqli_Rules_Version: 
+          '*': v1.40.0
       test_ssrf.py:
         Test_Ssrf_BodyJson:
           '*': v1.39.0
@@ -709,6 +724,8 @@ tests/:
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781)
+        Test_Ssrf_Rules_Version:
+          '*': v1.40.0
     waf/:
       test_addresses.py:
         Test_BodyJson:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -603,11 +603,11 @@ tests/:
           '*': v1.40.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
-        Test_Lfi_Rules_Version: 
+        Test_Lfi_Rules_Version:
           '*': v1.40.0
       test_libddwaf.py:
           '*': v1.40.0
-      test_shi.py: 
+      test_shi.py:
         Test_Shi_UrlQuery: missing_feature (Not support in Java)
         Test_Shi_BodyUrlEncoded: missing_feature (Not support in Java)
         Test_Shi_BodyXml: missing_feature (Not support in Java)
@@ -670,7 +670,7 @@ tests/:
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: v1.40.0 # issue in context propagation in 1.39.0
           vertx4: v1.40.0 # issue in context propagation in 1.39.0
-        Test_Sqli_Rules_Version: 
+        Test_Sqli_Rules_Version:
           '*': v1.40.0
       test_ssrf.py:
         Test_Ssrf_BodyJson:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -606,7 +606,7 @@ tests/:
         Test_Lfi_Rules_Version:
           '*': v1.40.0
       test_libddwaf.py:
-          '*': v1.40.0
+        '*': v1.40.0
       test_shi.py:
         Test_Shi_UrlQuery: missing_feature (Not support in Java)
         Test_Shi_BodyUrlEncoded: missing_feature (Not support in Java)

--- a/tests/appsec/rasp/test_lfi.py
+++ b/tests/appsec/rasp/test_lfi.py
@@ -263,6 +263,7 @@ class Test_Lfi_Capability:
 
 
 @features.rasp_local_file_inclusion
+@scenarios.appsec_rasp
 class Test_Lfi_Rules_Version(Base_Rules_Version):
     """Test lfi min rules version"""
 

--- a/tests/appsec/rasp/test_libddwaf.py
+++ b/tests/appsec/rasp/test_libddwaf.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import features
+from utils import features, scenarios
 from tests.appsec.rasp.utils import find_series, validate_metric_tag_version
 
 
@@ -10,6 +10,7 @@ from tests.appsec.rasp.utils import find_series, validate_metric_tag_version
 @features.rasp_sql_injection
 @features.rasp_shell_injection
 @features.rasp_server_side_request_forgery
+@scenarios.appsec_rasp
 class Test_Libddwaf_Version:
     """Test libddwaf version"""
 

--- a/tests/appsec/rasp/test_shi.py
+++ b/tests/appsec/rasp/test_shi.py
@@ -184,6 +184,7 @@ class Test_Shi_Capability:
 
 
 @features.rasp_local_file_inclusion
+@scenarios.appsec_rasp
 class Test_Shi_Rules_Version(Base_Rules_Version):
     """Test shi min rules version"""
 

--- a/tests/appsec/rasp/test_sqli.py
+++ b/tests/appsec/rasp/test_sqli.py
@@ -188,6 +188,7 @@ class Test_Sqli_Capability:
 
 
 @features.rasp_local_file_inclusion
+@scenarios.appsec_rasp
 class Test_Sqli_Rules_Version(Base_Rules_Version):
     """Test Sqli min rules version"""
 

--- a/tests/appsec/rasp/test_ssrf.py
+++ b/tests/appsec/rasp/test_ssrf.py
@@ -196,6 +196,7 @@ class Test_Ssrf_Capability:
 
 
 @features.rasp_local_file_inclusion
+@scenarios.appsec_rasp
 class Test_Ssrf_Rules_Version(Base_Rules_Version):
     """Test ssrf min rules version"""
 


### PR DESCRIPTION
## Motivation

Check that the rules and libddwaf versions are added to `APPSEC_RASP` scenario

## Changes

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
