### PR TITLE
[nodejs] fix wrong nodejs bug versions for skipping tests

### DIFF
--- a/tests/appsec/api_security/test_apisec_sampling.py
+++ b/tests/appsec/api_security/test_apisec_sampling.py
@@ -43,7 +43,7 @@ class Test_API_Security_sampling:
     @irrelevant(
         context.library not in ["nodejs"], reason="RFC is deprecated by a newer RFC. New tests will be implemented"
     )
-    @bug(context.library > "nodejs@4.49.0", reason="APPSEC-55901")
+    @irrelevant(reason="RFC is deprecated by a newer RFC. New tests will be implemented")
     def test_sampling_rate(self):
         """can provide request header schema"""
         N = self.N

--- a/tests/appsec/api_security/test_apisec_sampling.py
+++ b/tests/appsec/api_security/test_apisec_sampling.py
@@ -40,9 +40,6 @@ class Test_API_Security_sampling:
             for _ in range(self.N ** 2)
         ]
 
-    @irrelevant(
-        context.library not in ["nodejs"], reason="RFC is deprecated by a newer RFC. New tests will be implemented"
-    )
     @irrelevant(reason="RFC is deprecated by a newer RFC. New tests will be implemented")
     def test_sampling_rate(self):
         """can provide request header schema"""

--- a/tests/appsec/api_security/test_apisec_sampling.py
+++ b/tests/appsec/api_security/test_apisec_sampling.py
@@ -43,7 +43,7 @@ class Test_API_Security_sampling:
     @irrelevant(
         context.library not in ["nodejs"], reason="RFC is deprecated by a newer RFC. New tests will be implemented"
     )
-    @bug(context.library > "nodejs@5.25.0", reason="APPSEC-55901")
+    @bug(context.library > "nodejs@4.49.0", reason="APPSEC-55901")
     def test_sampling_rate(self):
         """can provide request header schema"""
         N = self.N

--- a/tests/parametric/test_headers_precedence.py
+++ b/tests/parametric/test_headers_precedence.py
@@ -218,7 +218,7 @@ class Test_Headers_Precedence:
         assert "traceparent" not in headers6
         assert "tracestate" not in headers6
 
-    @irrelevant(context.library >= "nodejs@5.0.0", reason="Default value was switched to datadog,tracecontext")
+    @irrelevant(context.library >= "nodejs@4.0.0", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library >= "php@0.97.0", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library >= "python@2.6.0", reason="Default value was switched to datadog,tracecontext")
     @irrelevant(context.library >= "golang@1.61.0.dev", reason="Default value was switched to datadog,tracecontext")

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -86,7 +86,7 @@ class Test_Agent:
             ]
         )
 
-    @bug(context.library > "nodejs@4.46.0", reason="DEBUG-2864")
+    @bug(context.library > "nodejs@4.46.0", reason="DEBUG-2864") # and 5.22.0
     def test_library_diagnostics_content(self):
         interfaces.library.assert_schema_point("/api/v2/debugger", "$[].content")
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -86,7 +86,7 @@ class Test_Agent:
             ]
         )
 
-    @bug(context.library > "nodejs@5.22.0", reason="DEBUG-2864")
+    @bug(context.library > "nodejs@4.46.0", reason="DEBUG-2864")
     def test_library_diagnostics_content(self):
         interfaces.library.assert_schema_point("/api/v2/debugger", "$[].content")
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -86,7 +86,7 @@ class Test_Agent:
             ]
         )
 
-    @bug(context.library > "nodejs@4.46.0", reason="DEBUG-2864") # and 5.22.0
+    @bug(context.library > "nodejs@4.46.0", reason="DEBUG-2864")  # and 5.22.0
     def test_library_diagnostics_content(self):
         interfaces.library.assert_schema_point("/api/v2/debugger", "$[].content")
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

The versions that were used focused only on the latest release line and ignored v4.x.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Fix wrong Node.js bug versions for skipping tests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
