### PR TITLE
Add debugger system tests for rate limiting and probes on the same location

### DIFF
--- a/tests/debugger/probes/probe_snapshot_rate_limiting.json
+++ b/tests/debugger/probes/probe_snapshot_rate_limiting.json
@@ -1,0 +1,14 @@
+[
+    {
+        "language": "",
+        "type": "",
+        "id": "log170aa-acda-4453-9111-1478a6ratelimit",
+        "captureSnapshot": true,
+        "where": {
+            "typeName": "ACTUAL_TYPE_NAME",
+            "methodName": "LogProbe",
+            "sourceFile": null
+        },
+        "evaluateAt": "EXIT"
+    }
+]

--- a/tests/debugger/probes/probe_snapshot_same_location.json
+++ b/tests/debugger/probes/probe_snapshot_same_location.json
@@ -1,0 +1,26 @@
+[
+    {
+        "language": "",
+        "type": "",
+        "id": "log170aa-acda-4453-9111-1478a6sameloc1",
+        "captureSnapshot": true,
+        "where": {
+            "typeName": "ACTUAL_TYPE_NAME",
+            "methodName": "LogProbe",
+            "sourceFile": null
+        },
+        "evaluateAt": "EXIT"
+    },
+    {
+        "language": "",
+        "type": "",
+        "id": "log170aa-acda-4453-9111-1478a6sameloc2",
+        "captureSnapshot": true,
+        "where": {
+            "typeName": "ACTUAL_TYPE_NAME",
+            "methodName": "LogProbe",
+            "sourceFile": null
+        },
+        "evaluateAt": "EXIT"
+    }
+]

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -9,8 +9,8 @@ from utils import scenarios, interfaces, weblog, features, remote_config as rc, 
 
 @features.debugger
 @scenarios.debugger_method_probes_snapshot
-class Test_Debugger_Method_Probe_Snaphots(base._Base_Debugger_Test):
-    def setup_method_probe_snaphots(self):
+class Test_Debugger_Method_Probe_Snapshots(base._Base_Debugger_Test):
+    def setup_method_probe_snapshots(self):
         probes = base.read_probes("probe_snapshot_method")
         self.expected_probe_ids = base.extract_probe_ids(probes)
         self.rc_state = rc.send_debugger_command(probes, version=1)
@@ -23,7 +23,7 @@ class Test_Debugger_Method_Probe_Snaphots(base._Base_Debugger_Test):
         ]
 
     @bug(library="python", reason="DEBUG-2708, DEBUG-2709")
-    def test_method_probe_snaphots(self):
+    def test_method_probe_snapshots(self):
         self.assert_all_states_not_error()
         self.assert_all_probes_are_installed()
         self.assert_all_weblog_responses_ok()

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -5,6 +5,7 @@
 import tests.debugger.utils as base
 
 from utils import scenarios, interfaces, weblog, features, remote_config as rc, bug
+from utils.tools import logger
 
 
 @features.debugger
@@ -34,26 +35,25 @@ class Test_Debugger_Method_Probe_Snapshots(base._Base_Debugger_Test):
         _validate_snapshots(expected_snapshots)
         _validate_spans(expected_spans)
 
-    def setup_rate_limiting(self):
-        probes = base.read_probes("probe_snapshot_method")
+@features.debugger
+@scenarios.debugger_method_probes_snapshot
+class Test_Debugger_Snapshot_Probe_Rate_Limiting(base._Base_Debugger_Test):
+    def setup_snapshot_probe_rate_limiting(self):
+        probes = base.read_probes("probe_snapshot_rate_limiting")
         self.expected_probe_ids = base.extract_probe_ids(probes)
         self.rc_state = rc.send_debugger_command(probes, version=1)
 
         interfaces.agent.wait_for(self.wait_for_all_probes_installed, timeout=30)
         # call the log endpoint multiple times
-        self.weblog_responses = [
-            weblog.get("/debugger/log"),
-            weblog.get("/debugger/log"),
-            weblog.get("/debugger/log"),
-            weblog.get("/debugger/log"),
-        ]
+        self.weblog_responses = []
+        for _ in range(10):
+            self.weblog_responses.append(weblog.get("/debugger/log"))
 
-    def test_rate_limiting(self):
+    def test_snapshot_probe_rate_limiting(self):
         self.assert_all_states_not_error()
         self.assert_all_probes_are_installed()
         self.assert_all_weblog_responses_ok()
 
-        # expect a single snapshot
         agent_logs_endpoint_requests = list(interfaces.agent.get_data(base._LOGS_PATH))
         snapshot_count = 0
         for request in agent_logs_endpoint_requests:
@@ -62,11 +62,12 @@ class Test_Debugger_Method_Probe_Snapshots(base._Base_Debugger_Test):
                 if content:
                     snapshot = item.get("debugger", {}).get("snapshot") or item.get("debugger.snapshot")
                     if snapshot:
+                        logger.debug(f"Found snapshot with id {snapshot["id"]}")
                         probe_id = snapshot["probe"]["id"]
-                        if probe_id == "log170aa-acda-4453-9111-1478a6method":
+                        if probe_id == "log170aa-acda-4453-9111-1478a6ratelimit":
                             snapshot_count += 1
 
-        assert snapshot_count == 99
+        assert snapshot_count == 1
 
 @features.debugger
 @scenarios.debugger_line_probes_snapshot

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -70,6 +70,28 @@ class Test_Debugger_Snapshot_Probe_Rate_Limiting(base._Base_Debugger_Test):
         assert snapshot_count == 1
 
 @features.debugger
+@scenarios.debugger_method_probes_snapshot
+class Test_Debugger_Snapshot_Probes_Same_Location(base._Base_Debugger_Test):
+    def setup_snapshot_probes_same_location(self):
+        probes = base.read_probes("probe_snapshot_same_location")
+        self.expected_probe_ids = base.extract_probe_ids(probes)
+        self.rc_state = rc.send_debugger_command(probes, version=1)
+
+        interfaces.agent.wait_for(self.wait_for_all_probes_installed, timeout=30)
+        self.weblog_responses = [weblog.get("/debugger/log")]
+
+    def test_snapshot_probes_same_location(self):
+        self.assert_all_states_not_error()
+        self.assert_all_probes_are_installed()
+        self.assert_all_weblog_responses_ok()
+
+        expected_snapshots = [
+            "log170aa-acda-4453-9111-1478a6sameloc1",
+            "log170aa-acda-4453-9111-1478a6sameloc2",
+        ]
+        _validate_snapshots(expected_snapshots)
+
+@features.debugger
 @scenarios.debugger_line_probes_snapshot
 class Test_Debugger_Line_Probe_Snaphots(base._Base_Debugger_Test):
     def setup_line_probe_snaphots(self):

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -176,7 +176,7 @@ class _Base_Debugger_Test:
                 errors.append(f"ID {full_id} not found in state")
             else:
                 apply_state = self.rc_state[full_id]["apply_state"]
-                logger.debug(f"RC stace for {full_id} is {apply_state}")
+                logger.debug(f"RC state for {full_id} is {apply_state}")
 
                 if apply_state == ApplyState.ERROR:
                     errors.append(f"State for {full_id} is error: {self.rc_state[full_id]['apply_error']}")


### PR DESCRIPTION
## Motivation

In this PR we add two new tests to the `DEBUGGER_METHOD_PROBES_SNAPSHOT` scenario:

* one test for rate limiting that calls the same endpoint 10 times in a row and asserts that we only capture one snapshot (the rate limiting for snapshot capture should be 1/s).
* one test for multiple probes on the same location, where we assert that both probes generate a snapshot.

Disclaimer: these are the first system tests I've written, they were made during a system tests workshop with my team in NYC.

## Changes

Add two new tests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* N/A If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* N/A A docker base image is modified?
* N/A A scenario is added (or removed)?
