### PR TITLE
[nodejs] enable crashtracking tests

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -39,6 +39,7 @@ refs:
   - &ref_5_24_0 '>=5.24.0 || ^4.48.0'
   - &ref_5_25_0 '>=5.25.0 || ^4.49.0'
   - &ref_5_26_0 '>=5.26.0 || ^4.50.0'
+  - &ref_5_27_0 '>=5.27.0 || ^4.51.0'
 
 tests/:
   apm_tracing_e2e/:
@@ -641,7 +642,7 @@ tests/:
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: *ref_5_25_0
     test_crashtracking.py:
-      Test_Crashtracking: *ref_5_26_0
+      Test_Crashtracking: *ref_5_27_0
     test_dynamic_configuration.py:
       TestDynamicConfigSamplingRules: *ref_5_16_0
       TestDynamicConfigTracingEnabled: *ref_5_4_0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -641,7 +641,7 @@ tests/:
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: *ref_5_25_0
     test_crashtracking.py:
-      Test_Crashtracking: *ref_5_23_0
+      Test_Crashtracking: *ref_5_26_0
     test_dynamic_configuration.py:
       TestDynamicConfigSamplingRules: *ref_5_16_0
       TestDynamicConfigTracingEnabled: *ref_5_4_0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -640,7 +640,8 @@ tests/:
       Test_Config_TraceEnabled: *ref_4_3_0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: *ref_5_25_0
-    test_crashtracking.py: missing_feature
+    test_crashtracking.py:
+      Test_Crashtracking: *ref_5_23_0
     test_dynamic_configuration.py:
       TestDynamicConfigSamplingRules: *ref_5_16_0
       TestDynamicConfigTracingEnabled: *ref_5_4_0

--- a/tests/parametric/test_crashtracking.py
+++ b/tests/parametric/test_crashtracking.py
@@ -12,15 +12,8 @@ from utils import bug, context, features, irrelevant, missing_feature, rfc, scen
 @scenarios.parametric
 @features.crashtracking
 class Test_Crashtracking:
-    @missing_feature(context.library == "nodejs", reason="Only enabled for SSI by default")
-    def test_report_crash(self, test_agent, test_library):
-        test_library.crash()
-
-        event = test_agent.wait_for_telemetry_event("logs", wait_loops=400)
-        assert self.is_crash_report(test_library, event)
-
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "true"}])
-    def test_enable_crashtracking(self, test_agent, test_library):
+    def test_report_crash(self, test_agent, test_library):
         test_library.crash()
 
         event = test_agent.wait_for_telemetry_event("logs", wait_loops=400)

--- a/tests/parametric/test_crashtracking.py
+++ b/tests/parametric/test_crashtracking.py
@@ -12,7 +12,6 @@ from utils import bug, context, features, irrelevant, missing_feature, rfc, scen
 @scenarios.parametric
 @features.crashtracking
 class Test_Crashtracking:
-    @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "true"}])
     @missing_feature(context.library == "nodejs", reason="Only enabled for SSI by default")
     def test_report_crash(self, test_agent, test_library):
         test_library.crash()

--- a/tests/parametric/test_crashtracking.py
+++ b/tests/parametric/test_crashtracking.py
@@ -13,10 +13,18 @@ from utils import bug, context, features, irrelevant, missing_feature, rfc, scen
 @features.crashtracking
 class Test_Crashtracking:
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "true"}])
+    @missing_feature(context.library == "nodejs", reason="Only enabled for SSI by default")
     def test_report_crash(self, test_agent, test_library):
         test_library.crash()
 
-        event = test_agent.wait_for_telemetry_event("logs", wait_loops=400)
+        event = test_agent.wait_for_telemetry_event("logs", wait_loops=1000)
+        assert self.is_crash_report(test_library, event)
+
+    @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "true"}])
+    def test_enable_crashtracking(self, test_agent, test_library):
+        test_library.crash()
+
+        event = test_agent.wait_for_telemetry_event("logs", wait_loops=1000)
         assert self.is_crash_report(test_library, event)
 
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "false"}])

--- a/tests/parametric/test_crashtracking.py
+++ b/tests/parametric/test_crashtracking.py
@@ -16,14 +16,14 @@ class Test_Crashtracking:
     def test_report_crash(self, test_agent, test_library):
         test_library.crash()
 
-        event = test_agent.wait_for_telemetry_event("logs", wait_loops=1000)
+        event = test_agent.wait_for_telemetry_event("logs", wait_loops=400)
         assert self.is_crash_report(test_library, event)
 
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "true"}])
     def test_enable_crashtracking(self, test_agent, test_library):
         test_library.crash()
 
-        event = test_agent.wait_for_telemetry_event("logs", wait_loops=1000)
+        event = test_agent.wait_for_telemetry_event("logs", wait_loops=400)
         assert self.is_crash_report(test_library, event)
 
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "false"}])

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -388,8 +388,8 @@ def node_library_factory() -> APMLibraryTestServer:
         container_name="node-test-client",
         container_tag="node-test-client",
         container_img=f"""
-FROM node:18.10-alpine
-RUN apk add --no-cache bash curl git jq
+FROM node:18.10-slim
+RUN apt-get update && apt-get -y install bash curl git jq
 WORKDIR /usr/app
 COPY {nodejs_reldir}/../app.sh /usr/app/
 RUN printf 'node server.js' >> app.sh

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -71,6 +71,11 @@ app.post('/trace/span/extract_headers', (req, res) => {
   res.json({ span_id: extractedSpanID });
 });
 
+app.get('/trace/crash', (req, res) => {
+  process.kill(process.pid, 'SIGSEGV');
+  res.json({});
+});
+
 app.post('/trace/span/start', (req, res) => {
   const request = req.body;
   let parent = spans[request.parent_id] || ddContext[request.parent_id];


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Crashtracking has now been released for Node.js

## Changes

<!-- A brief description of the change being made with this pull request. -->

Enable crashtracking tests for Node.js (only in SSI for now).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
