### PR TITLE
OnBoardin: Fix git sources when gitlab tag

### DIFF
--- a/utils/virtual_machine/virtual_machine_provider.py
+++ b/utils/virtual_machine/virtual_machine_provider.py
@@ -89,11 +89,11 @@ class VmProvider:
             logger_name="tested_components",
             output_callback=output_callback,
         )
-        # Before install weblog, if we set the env variable: CI_COMMIT_BRANCH, we need to checkout this branch
+        # Before install weblog, if we set the env variable: GITLAB_CI, we need to checkout the CI_COMMIT_BRANCH branch
         # (we are going to copy weblog sources from git instead from local machine)
         # We commit the branch reference of the CI_COMMIT_BRANCH env variable only if the gitlab project is system-tests
-        # Proabably we need to change this in the future, and translate this logic to the pipelines
-        ci_commit_branch = os.getenv("CI_COMMIT_BRANCH")
+        # Proabably we need to change this in the future, and translate this logic to the pipelines or another class
+        ci_commit_branch = os.getenv("GITLAB_CI")
         if ci_commit_branch:
             ci_commit_branch = (
                 os.getenv("CI_COMMIT_BRANCH") if os.getenv("CI_PROJECT_NAME", "") == "system-tests" else "main"

--- a/utils/virtual_machine/virtual_machine_provisioner.py
+++ b/utils/virtual_machine/virtual_machine_provisioner.py
@@ -215,7 +215,7 @@ class VirtualMachineProvisioner:
         weblog = weblog_raw_data["weblog"]
         assert weblog["name"] == weblog_name, f"Weblog name {weblog_name} does not match the provision file name"
         installations = weblog["install"]
-        ci_commit_branch = os.getenv("CI_COMMIT_BRANCH")
+        ci_commit_branch = os.getenv("GITLAB_CI")
         installation = self._get_installation(
             env,
             library_name,


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
we are only using the CI_COMMIT_BRANCH variable to use the git system-tests sources instead of copy remotely all the weblog files. When we are creating a tag the CI_COMMIT_BRANCH is emptly and we are not using the git (we are copying the files remotely, and this is taking time).


## Changes
Use GITLAB_CI variable instead CI_COMMIT_BRANCH
<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
