### PR TITLE
deactivate test introduced in #3349

### DIFF
--- a/tests/integrations/test_inferred_proxy.py
+++ b/tests/integrations/test_inferred_proxy.py
@@ -1,12 +1,12 @@
 import json
 import time
 
-from utils import weblog, scenarios, features, interfaces
+from utils import weblog, interfaces
 from utils.tools import logger
 
 
-@features.aws_api_gateway_inferred_span_creation
-@scenarios.integrations
+# @features.aws_api_gateway_inferred_span_creation
+# @scenarios.integrations
 class TOBEFIXED_Test_AWS_API_Gateway_Inferred_Span_Creation:
     """ Verify DSM context is extracted using "dd-pathway-ctx-base64" """
 

--- a/tests/integrations/test_inferred_proxy.py
+++ b/tests/integrations/test_inferred_proxy.py
@@ -1,12 +1,16 @@
 import json
 import time
 
-from utils import weblog, interfaces
+from utils import weblog, scenarios, features, interfaces
 from utils.tools import logger
 
 
-# @features.aws_api_gateway_inferred_span_creation
-# @scenarios.integrations
+@features.aws_api_gateway_inferred_span_creation
+@scenarios.integrations
+class Test_AWS_API_Gateway_Inferred_Span_Creation:
+    ...
+
+
 class TOBEFIXED_Test_AWS_API_Gateway_Inferred_Span_Creation:
     """ Verify DSM context is extracted using "dd-pathway-ctx-base64" """
 

--- a/tests/integrations/test_inferred_proxy.py
+++ b/tests/integrations/test_inferred_proxy.py
@@ -7,7 +7,7 @@ from utils.tools import logger
 
 @features.aws_api_gateway_inferred_span_creation
 @scenarios.integrations
-class Test_AWS_API_Gateway_Inferred_Span_Creation:
+class TOBEFIXED_Test_AWS_API_Gateway_Inferred_Span_Creation:
     """ Verify DSM context is extracted using "dd-pathway-ctx-base64" """
 
     start_time = round(time.time() * 1e3)


### PR DESCRIPTION
## Motivation

Deactivate the test (trick : class not starting with Test are not test class

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
