### PR TITLE
DEBUG-3180 enable Ruby dynamic instrumentation tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -296,9 +296,9 @@ tests/:
       Test_Events: v0.54.2
   debugger/:
     test_debugger_exception_replay.py:
-      Test_Debugger_Exception_Replay: missing_feature (feature not implented)
+      Test_Debugger_Exception_Replay: missing_feature (feature not implemented)
     test_debugger_expression_language.py:
-      Test_Debugger_Expression_Language: missing_feature (feature not implented)
+      Test_Debugger_Expression_Language: missing_feature (feature not implemented)
     test_debugger_pii.py:
       Test_Debugger_PII_Redaction:
         "*": irrelevant

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -300,11 +300,11 @@ tests/:
     test_debugger_expression_language.py:
       Test_Debugger_Expression_Language: missing_feature (feature not implented)
     test_debugger_pii.py:
-      Test_Debugger_PII_Redaction: missing_feature (feature not implented)
+      Test_Debugger_PII_Redaction: v2.8.0
     test_debugger_probe_snapshot.py:
-      Test_Debugger_Probe_Snaphots: missing_feature (feature not implented)
+      Test_Debugger_Probe_Snaphots: v2.8.0
     test_debugger_probe_status.py:
-      Test_Debugger_Probe_Statuses: missing_feature (feature not implented)
+      Test_Debugger_Probe_Statuses: v2.8.0
   integrations/:
     crossed_integrations/:
       test_kafka.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -300,11 +300,17 @@ tests/:
     test_debugger_expression_language.py:
       Test_Debugger_Expression_Language: missing_feature (feature not implented)
     test_debugger_pii.py:
-      Test_Debugger_PII_Redaction: v2.8.0
+      Test_Debugger_PII_Redaction:
+        "*": irrelevant
+        rails70: v2.8.0
     test_debugger_probe_snapshot.py:
-      Test_Debugger_Probe_Snaphots: v2.8.0
+      Test_Debugger_Probe_Snaphots:
+        "*": irrelevant
+        rails70: v2.8.0
     test_debugger_probe_status.py:
-      Test_Debugger_Probe_Statuses: v2.8.0
+      Test_Debugger_Probe_Statuses:
+        "*": irrelevant
+        rails70: v2.8.0
   integrations/:
     crossed_integrations/:
       test_kafka.py:

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -144,7 +144,8 @@ class Test_Debugger_PII_Redaction(debugger._Base_Debugger_Test):
         not_found = list(set(should_redact_field_names))
 
         for probe_id in self.probe_ids:
-            snapshot = self.probe_snapshots[probe_id][0]["debugger"]["snapshot"]
+            base = self.probe_snapshots[probe_id][0]
+            snapshot = base.get("debugger", {}).get("snapshot") or base['debugger.snapshot']
 
             for field_name in should_redact_field_names:
                 if line_probe:
@@ -179,7 +180,8 @@ class Test_Debugger_PII_Redaction(debugger._Base_Debugger_Test):
         not_redacted = []
 
         for probe_id in self.probe_ids:
-            snapshot = self.probe_snapshots[probe_id][0]["debugger"]["snapshot"]
+            base = self.probe_snapshots[probe_id][0]
+            snapshot = base.get("debugger", {}).get("snapshot") or base['debugger.snapshot']
 
             for type_name in should_redact_types:
                 if line_probe:
@@ -219,7 +221,7 @@ class Test_Debugger_PII_Redaction(debugger._Base_Debugger_Test):
         context.library != "ruby", reason="Ruby DI does not provide the functionality required for the test."
     )
     def test_pii_redaction_line_full(self):
-        self._assert(REDACTED_KEYS, REDACTED_TYPES)
+        self._assert(REDACTED_KEYS, REDACTED_TYPES, line_probe=True)
 
     ############ old versions ############
     def filter(keys_to_filter):

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -132,6 +132,7 @@ class Test_Debugger_PII_Redaction(debugger._Base_Debugger_Test):
     ############ assert ############
     def _assert(self, redacted_keys, redacted_types, line_probe=False):
         self.collect()
+        self.assert_setup_ok()
         self.assert_rc_state_not_error()
         self.assert_all_probes_are_installed()
         self.assert_all_weblog_responses_ok()

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -145,7 +145,7 @@ class Test_Debugger_PII_Redaction(debugger._Base_Debugger_Test):
 
         for probe_id in self.probe_ids:
             base = self.probe_snapshots[probe_id][0]
-            snapshot = base.get("debugger", {}).get("snapshot") or base['debugger.snapshot']
+            snapshot = base.get("debugger", {}).get("snapshot") or base["debugger.snapshot"]
 
             for field_name in should_redact_field_names:
                 if line_probe:
@@ -181,7 +181,7 @@ class Test_Debugger_PII_Redaction(debugger._Base_Debugger_Test):
 
         for probe_id in self.probe_ids:
             base = self.probe_snapshots[probe_id][0]
-            snapshot = base.get("debugger", {}).get("snapshot") or base['debugger.snapshot']
+            snapshot = base.get("debugger", {}).get("snapshot") or base["debugger.snapshot"]
 
             for type_name in should_redact_types:
                 if line_probe:

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -218,7 +218,7 @@ class Test_Debugger_PII_Redaction(debugger._Base_Debugger_Test):
     @missing_feature(
         context.library != "ruby", reason="Ruby DI does not provide the functionality required for the test."
     )
-    def pii_redaction_line_full(self):
+    def test_pii_redaction_line_full(self):
         self._assert(REDACTED_KEYS, REDACTED_TYPES)
 
     ############ old versions ############

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -116,6 +116,8 @@ REDACTED_TYPES = ["customPii"]
 class Test_Debugger_PII_Redaction(debugger._Base_Debugger_Test):
     ############ setup ############
     def _setup(self, line_probe=False):
+        self.initialize_weblog_remote_config()
+
         if line_probe:
             probes = debugger.read_probes("pii_line")
         else:

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -12,6 +12,8 @@ from utils import scenarios, features, bug, missing_feature, context
 class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
     ############ setup ############
     def _setup(self, probes_name: str, request_path: str):
+        self.initialize_weblog_remote_config()
+
         ### prepare probes
         probes = debugger.read_probes(probes_name)
         self.set_probes(probes)

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -29,6 +29,7 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
         self.collect()
 
         ### assert
+        self.assert_setup_ok()
         self.assert_rc_state_not_error()
         self.assert_all_probes_are_installed()
         self.assert_all_weblog_responses_ok()

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -56,6 +56,7 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
     def setup_span_method_probe_snaphots(self):
         self._setup("probe_snapshot_span_method", "/debugger/span")
 
+    @missing_feature(context.library == "ruby", reason="Not yet implemented")
     def test_span_method_probe_snaphots(self):
         self._assert()
         self._validate_spans()

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -14,6 +14,8 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
 
     ############ setup ############
     def _setup(self, probes_name: str):
+        self.initialize_weblog_remote_config()
+
         ### prepare probes
         probes = debugger.read_probes(probes_name)
         self.set_probes(probes)

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -21,6 +21,7 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
         self.set_probes(probes)
 
         ### set expected
+        self.expected_diagnostics = {}
         for probe in self.probe_definitions:
             if probe["id"].endswith("installed"):
                 self.expected_diagnostics[probe["id"]] = "INSTALLED"
@@ -75,7 +76,7 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
-    @irrelevant(context.library == "ruby", reason="Not yet implemented")
+    @missing_feature(context.library == "ruby", reason="Not yet implemented")
     def test_probe_status_metric(self):
         self._assert()
 
@@ -83,7 +84,8 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
     def setup_probe_status_span(self):
         self._setup("probe_status_span")
 
-    @irrelevant(context.library == "ruby", reason="Not yet implemented")
+    @missing_feature(context.library == "ruby", reason="Not yet implemented")
+    
     def test_probe_status_span(self):
         self._assert()
 
@@ -93,6 +95,7 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
-    @irrelevant(context.library == "ruby", reason="Not yet implemented")
+    @missing_feature(context.library == "ruby", reason="Not yet implemented")
+
     def test_probe_status_spandecoration(self):
         self._assert()

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -85,7 +85,6 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
         self._setup("probe_status_span")
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented")
-    
     def test_probe_status_span(self):
         self._assert()
 
@@ -96,6 +95,5 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
     @missing_feature(context.library == "ruby", reason="Not yet implemented")
-
     def test_probe_status_spandecoration(self):
         self._assert()

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -4,7 +4,7 @@
 
 import tests.debugger.utils as debugger
 
-from utils import scenarios, features, bug, missing_feature, context
+from utils import scenarios, features, bug, missing_feature, context, irrelevant
 
 
 @features.debugger
@@ -75,7 +75,7 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
-    @missing_feature(context.library == "ruby", reason="Not yet implemented")
+    @irrelevant(context.library == "ruby", reason="Not yet implemented")
     def test_probe_status_metric(self):
         self._assert()
 
@@ -83,7 +83,7 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
     def setup_probe_status_span(self):
         self._setup("probe_status_span")
 
-    @missing_feature(context.library == "ruby", reason="Not yet implemented")
+    @irrelevant(context.library == "ruby", reason="Not yet implemented")
     def test_probe_status_span(self):
         self._assert()
 
@@ -93,6 +93,6 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
-    @missing_feature(context.library == "ruby", reason="Not yet implemented")
+    @irrelevant(context.library == "ruby", reason="Not yet implemented")
     def test_probe_status_spandecoration(self):
         self._assert()

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -35,6 +35,7 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
     def _assert(self):
         self.collect()
 
+        self.assert_setup_ok()
         self.assert_rc_state_not_error()
         self._validate_diagnostics()
 

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -4,7 +4,7 @@
 
 import tests.debugger.utils as debugger
 
-from utils import scenarios, features, bug, missing_feature, context, irrelevant
+from utils import scenarios, features, bug, missing_feature, context
 
 
 @features.debugger

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -70,6 +70,8 @@ class _Base_Debugger_Test:
 
     rc_state = None
     weblog_responses = []
+    
+    setup_failures = []
 
     def initialize_weblog_remote_config(self):
         if self.get_tracer()["language"] == "ruby":
@@ -78,7 +80,10 @@ class _Base_Debugger_Test:
             # Therefore, we need to issue a request to the application for
             # remote config to start.
             response = weblog.get("/debugger/init")
-            assert response.status_code == 200
+            if response.status_code != 200:
+                # This should fail the test immediately but the failure is
+                # reported after all of the setup and the test are attempted
+                self.setup_failures.append("Failed to get /debugger/init: expected status code: 200, actual status code: %d" % (response.status_code))
 
     ###### set #####
     def set_probes(self, probes):
@@ -404,6 +409,10 @@ class _Base_Debugger_Test:
             }
 
         return _Base_Debugger_Test.tracer
+
+    def assert_setup_ok(self):
+        if self.setup_failures:
+            assert "\n".join(self.setup_failures) is None
 
     ###### assert #####
     def assert_rc_state_not_error(self):

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -70,7 +70,7 @@ class _Base_Debugger_Test:
 
     rc_state = None
     weblog_responses = []
-    
+
     setup_failures = []
 
     def initialize_weblog_remote_config(self):
@@ -83,7 +83,10 @@ class _Base_Debugger_Test:
             if response.status_code != 200:
                 # This should fail the test immediately but the failure is
                 # reported after all of the setup and the test are attempted
-                self.setup_failures.append("Failed to get /debugger/init: expected status code: 200, actual status code: %d" % (response.status_code))
+                self.setup_failures.append(
+                    "Failed to get /debugger/init: expected status code: 200, actual status code: %d"
+                    % (response.status_code)
+                )
 
     ###### set #####
     def set_probes(self, probes):

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -71,6 +71,15 @@ class _Base_Debugger_Test:
     rc_state = None
     weblog_responses = []
 
+    def initialize_weblog_remote_config(self):
+        if self.get_tracer()["language"] == "ruby":
+            # Ruby tracer initializes remote configuration client from
+            # middleware that is only invoked during request processing.
+            # Therefore, we need to issue a request to the application for
+            # remote config to start.
+            response = weblog.get("/debugger/init")
+            assert response.status_code == 200
+
     ###### set #####
     def set_probes(self, probes):
         def _enrich_probes(probes):


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Initial implementation of dynamic instrumentation in Ruby.

## Changes
https://github.com/DataDog/system-tests/pull/3516 added the needed controller implementation for dynamic instrumentation system tests and adjusted the tests to work with the feature as implemented in Ruby. However, that PR did not turn on the tests for any tracer version.

Now that https://github.com/DataDog/dd-trace-rb/pull/4098 is merged, DI is usable in Ruby once the environment variable to enable it is set, and the feature will be shipped with the next tracer version (2.8.0).

This PR enables the dynamic instrumentation tests for Ruby tracer 2.8.0 or higher.
<!-- A brief description of the change being made with this pull request. -->

The companion PR to this one is https://github.com/DataDog/dd-trace-rb/pull/4146 which adds the scenarios to the list of scenarios to be executed in the Ruby tracer CI.

This PR also changes decorators for Ruby from missing_feature to irrelevant. missing_feature decorator runs the setup (and the tests and expects them to fail) which causes unsupported probes to be sent to the tracer via remote config. The tracer logs that the metric/span/span decoration probe specifications are not valid/understood (while running the log probe tests, which are supported) as an error and the system tests fail when they assert that application log does not contain any errors. To avoid logging the errors, we need to skip the setup thus mark the tests as irrelevant.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
