### PR TITLE
Update docker-ssi telemetry_abort test

### DIFF
--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -93,18 +93,25 @@ class TestDockerSSIFeatures:
     @features.ssi_guardrails
     @irrelevant(context.library == "java" and context.installed_language_runtime >= "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime >= "7.0")
-    @bug(condition=context.library == "python" and context.installed_language_runtime < "3.7.0", reason="INPLAT-181")
     @irrelevant(context.library == "python" and context.installed_language_runtime >= "3.7.0")
     def test_telemetry_abort(self):
         # There is telemetry data about the auto instrumentation injector. We only validate there is data
         telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject()
         assert len(telemetry_autoinject_data) >= 1
-        inject_success = False
+        inject_result = None
         for data in telemetry_autoinject_data:
             if data["metric"] == "inject.success":
-                inject_success = True
+                inject_result = True
                 break
-        assert inject_success, "No telemetry data found for inject.success"
+            if data["metric"] == "inject.skip" or data["metric"] == "inject.error":
+                inject_result = False
+                break
+
+        assert inject_result != None, "No telemetry data found for inject.success, inject.skip or inject.error"
+
+        # The injector detected by itself that the version is not supported
+        if inject_result == False:
+            return
 
         # There is telemetry data about the library entrypoint. We only validate there is data
         telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject_library_entrypoint()


### PR DESCRIPTION
## Motivation

Test was disabled for Python because of a bug, now fixed.

But I had also to update the logic of the test because of a new behavior of the last version of the injector.

![image](https://github.com/user-attachments/assets/a7401a79-e53b-4d04-9ca0-8c35e0d38757)


## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
