### PR TITLE
parametric: remove noisy debug log

### DIFF
--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -56,8 +56,6 @@ class APMLibraryClient:
                     self._print_logs()
                     message = f"Container {self.container.name} status is {self.container.status}. Please check logs."
                     _fail(message)
-
-            logger.debug(f"Wait for {delay}s for the HTTP library to be ready")
             time.sleep(delay)
         else:
             self._print_logs()


### PR DESCRIPTION
## Motivation

The following debug log is generated every 0.01 while parametric test run wait for a parametric app to start. This log is not very actionable and it could be generated thousands of times in one test run. I think we are better off without it.

[Example](https://github.com/DataDog/system-tests/actions/runs/11978009034/job/33397503747?pr=3497):
```
18:35:03.655 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.667 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.679 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.691 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.703 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.714 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.726 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.739 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.751 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.763 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.774 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.786 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.798 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.809 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.820 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.831 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.843 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.855 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.867 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.879 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.891 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.902 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.914 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.925 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.936 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.948 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.959 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.971 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.982 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:03.994 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.005 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.016 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.027 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.039 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.050 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.061 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.073 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.085 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.096 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.108 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.120 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.132 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.144 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.156 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.168 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.180 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.192 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.203 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.215 DEBUG    Wait for 0.01s for the HTTP library to be ready
18:35:04.226 DEBUG    Wait for 0.01s for the HTTP library to be ready
```

## Changes

- Removes a debug log from startup. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
