### PR TITLE
Print a pretty error message if docker daemon is not running

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -42,6 +42,9 @@ def _get_client():
         except:
             pass
 
+        if "Error while fetching server API version: ('Connection aborted.'" in str(e):
+            pytest.exit("Connection refused to docker daemon, is it running?", 1)
+
         raise e
 
 


### PR DESCRIPTION
Before

```
~/repos/system-tests: ./run.sh 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/urllib3/connectionpool.py", line 716, in urlopen
INTERNALERROR>     httplib_response = self._make_request(
INTERNALERROR>                        ^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/urllib3/connectionpool.py", line 416, in _make_request
INTERNALERROR>     conn.request(method, url, **httplib_request_kw)
INTERNALERROR>   File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/http/client.py", line 1336, in request
INTERNALERROR>     self._send_request(method, url, body, headers, encode_chunked)
INTERNALERROR>   File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/http/client.py", line 1382, in _send_request
INTERNALERROR>     self.endheaders(body, encode_chunked=encode_chunked)
INTERNALERROR>   File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/http/client.py", line 1331, in endheaders
INTERNALERROR>     self._send_output(message_body, encode_chunked=encode_chunked)
INTERNALERROR>   File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/http/client.py", line 1091, in _send_output
INTERNALERROR>     self.send(msg)
INTERNALERROR>   File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/http/client.py", line 1035, in send
INTERNALERROR>     self.connect()
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/docker/transport/unixconn.py", line 30, in connect
INTERNALERROR>     sock.connect(self.unix_socket)
INTERNALERROR> ConnectionRefusedError: [Errno 61] Connection refused
INTERNALERROR> 
INTERNALERROR> During handling of the above exception, another exception occurred:
INTERNALERROR> 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/requests/adapters.py", line 489, in send
INTERNALERROR>     resp = conn.urlopen(
INTERNALERROR>            ^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/urllib3/connectionpool.py", line 802, in urlopen
INTERNALERROR>     retries = retries.increment(
INTERNALERROR>               ^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/urllib3/util/retry.py", line 552, in increment
INTERNALERROR>     raise six.reraise(type(error), error, _stacktrace)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/urllib3/packages/six.py", line 769, in reraise
INTERNALERROR>     raise value.with_traceback(tb)
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/urllib3/connectionpool.py", line 716, in urlopen
INTERNALERROR>     httplib_response = self._make_request(
INTERNALERROR>                        ^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/urllib3/connectionpool.py", line 416, in _make_request
INTERNALERROR>     conn.request(method, url, **httplib_request_kw)
INTERNALERROR>   File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/http/client.py", line 1336, in request
INTERNALERROR>     self._send_request(method, url, body, headers, encode_chunked)
INTERNALERROR>   File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/http/client.py", line 1382, in _send_request
INTERNALERROR>     self.endheaders(body, encode_chunked=encode_chunked)
INTERNALERROR>   File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/http/client.py", line 1331, in endheaders
INTERNALERROR>     self._send_output(message_body, encode_chunked=encode_chunked)
INTERNALERROR>   File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/http/client.py", line 1091, in _send_output
INTERNALERROR>     self.send(msg)
INTERNALERROR>   File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/http/client.py", line 1035, in send
INTERNALERROR>     self.connect()
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/docker/transport/unixconn.py", line 30, in connect
INTERNALERROR>     sock.connect(self.unix_socket)
INTERNALERROR> urllib3.exceptions.ProtocolError: ('Connection aborted.', ConnectionRefusedError(61, 'Connection refused'))
INTERNALERROR> 
INTERNALERROR> During handling of the above exception, another exception occurred:
INTERNALERROR> 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/docker/api/client.py", line 214, in _retrieve_server_version
INTERNALERROR>     return self.version(api_version=False)["ApiVersion"]
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/docker/api/daemon.py", line 181, in version
INTERNALERROR>     return self._result(self._get(url), json=True)
INTERNALERROR>                         ^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/docker/utils/decorators.py", line 46, in inner
INTERNALERROR>     return f(self, *args, **kwargs)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/docker/api/client.py", line 237, in _get
INTERNALERROR>     return self.get(url, **self._set_request_timeout(kwargs))
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/requests/sessions.py", line 600, in get
INTERNALERROR>     return self.request("GET", url, **kwargs)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/requests/sessions.py", line 587, in request
INTERNALERROR>     resp = self.send(prep, **send_kwargs)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/requests/sessions.py", line 701, in send
INTERNALERROR>     r = adapter.send(request, **kwargs)
INTERNALERROR>         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/requests/adapters.py", line 547, in send
INTERNALERROR>     raise ConnectionError(err, request=request)
INTERNALERROR> requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionRefusedError(61, 'Connection refused'))
INTERNALERROR> 
INTERNALERROR> During handling of the above exception, another exception occurred:
INTERNALERROR> 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/_pytest/main.py", line 264, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 996, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 277, in call_historic
INTERNALERROR>     res = self._hookexec(self.name, self.get_hookimpls(), kwargs, False)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/pluggy/_manager.py", line 80, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 60, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/pluggy/_result.py", line 60, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 39, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/conftest.py", line 116, in pytest_configure
INTERNALERROR>     context.scenario.pytest_configure(config)
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/utils/_context/_scenarios/core.py", line 117, in pytest_configure
INTERNALERROR>     self.configure(config)
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/utils/_context/_scenarios/endtoend.py", line 296, in configure
INTERNALERROR>     super().configure(config)
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/utils/_context/_scenarios/endtoend.py", line 102, in configure
INTERNALERROR>     container.configure(self.replay)
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/utils/_context/containers.py", line 776, in configure
INTERNALERROR>     super().configure(replay)
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/utils/_context/containers.py", line 117, in configure
INTERNALERROR>     self.stop_previous_container()
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/utils/_context/containers.py", line 145, in stop_previous_container
INTERNALERROR>     if old_container := self.get_existing_container():
INTERNALERROR>                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/utils/_context/containers.py", line 136, in get_existing_container
INTERNALERROR>     for container in _get_client().containers.list(all=True, filters={"name": self.container_name}):
INTERNALERROR>                      ^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/utils/_context/containers.py", line 48, in _get_client
INTERNALERROR>     raise e
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/utils/_context/containers.py", line 29, in _get_client
INTERNALERROR>     return docker.DockerClient.from_env()
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/docker/client.py", line 96, in from_env
INTERNALERROR>     return cls(
INTERNALERROR>            ^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/docker/client.py", line 45, in __init__
INTERNALERROR>     self.api = APIClient(*args, **kwargs)
INTERNALERROR>                ^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/docker/api/client.py", line 197, in __init__
INTERNALERROR>     self._version = self._retrieve_server_version()
INTERNALERROR>                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/charles.debeauchesne/repos/system-tests/venv/lib/python3.12/site-packages/docker/api/client.py", line 221, in _retrieve_server_version
INTERNALERROR>     raise DockerException(
INTERNALERROR> docker.errors.DockerException: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(61, 'Connection refused'))
~/repos/system-tests: 
```

After 

```
~/repos/system-tests: ./run.sh 
Exit: Connection refused to docker daemon, is it running?
```

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
