### PR TITLE
[python] fix iast standalone manifest, and django poc

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -425,7 +425,6 @@ tests/:
         uwsgi-poc: v2.17.1
       Test_IastStandalone_UpstreamPropagation:
         '*': v2.18.0.dev
-        django-poc: missing_feature
       Test_SCAStandalone_Telemetry: missing_feature
     test_automated_login_events.py:
       Test_Login_Events: irrelevant (was v2.10.0 but will be replaced by V2)

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -810,6 +810,8 @@ urlpatterns = [
     path("waf", waf),
     path("waf/", waf),
     path("waf/<url>", waf),
+    path("vulnerablerequestdownstream", vulnerable_request_downstream),
+    path("vulnerablerequestdownstream/", vulnerable_request_downstream),
     path("requestdownstream", request_downstream),
     path("requestdownstream/", request_downstream),
     path("returnheaders", return_headers),


### PR DESCRIPTION
## Motivation

The manifest lines for iast standalone were incorrect. Also fix django poc by adding the missing routes

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
