### PR TITLE
[nodejs] Enable test_telemetry_sca_enabled_propagated for nextjs

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -428,9 +428,7 @@ tests/:
     test_asm_standalone.py:
       Test_AppSecStandalone_UpstreamPropagation: *ref_5_18_0
       Test_IastStandalone_UpstreamPropagation: missing_feature # was supposed to be released in 5.18.0
-      Test_SCAStandalone_Telemetry:
-        '*': *ref_5_18_0
-        nextjs: missing_feature
+      Test_SCAStandalone_Telemetry: *ref_5_18_0
     test_automated_login_events.py:
       Test_Login_Events:
         '*': *ref_4_4_0

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -3,7 +3,7 @@ import json
 from requests.structures import CaseInsensitiveDict
 
 from utils.telemetry_utils import TelemetryUtils
-from utils import context, weblog, interfaces, scenarios, features, rfc, bug, flaky
+from utils import context, weblog, interfaces, scenarios, features, rfc, bug, flaky, missing_feature
 
 
 class AsmStandalone_UpstreamPropagation_Base:
@@ -711,6 +711,7 @@ class Test_SCAStandalone_Telemetry:
     def setup_app_dependencies_loaded(self):
         self.r = weblog.get("/load_dependency")
 
+    @missing_feature(context.library == "nodejs" and context.weblog_variant == "nextjs")
     def test_app_dependencies_loaded(self):
         self.assert_standalone_is_enabled(self.r)
 


### PR DESCRIPTION
## Motivation

Remove one easy win

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
