### PR TITLE
[dotnet][parametric] add baggage endpoints, enable baggage tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -421,7 +421,7 @@ tests/:
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v2.44.0
     test_headers_baggage.py:
-      Test_Headers_Baggage: missing_feature
+      Test_Headers_Baggage: v3.6.0
     test_otel_api_interoperability.py: missing_feature
     test_otel_env_vars.py:
       Test_Otel_Env_Vars: v2.53.0
@@ -433,7 +433,7 @@ tests/:
       Test_Parametric_DDSpan_Add_Link: incomplete_test_app (add_link parametric endpoint is not implemented)
       Test_Parametric_DDSpan_Set_Error: bug (APMAPI-778) # Set error endpoint does not set the error.type tag on spans
       Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource parametric endpoint is not implemented)
-      Test_Parametric_DDTrace_Baggage: incomplete_test_app (baggage endpoints are not implemented)
+      Test_Parametric_DDTrace_Baggage: v3.6.0
       Test_Parametric_DDTrace_Current_Span: incomplete_test_app (current span endpoint is not implemented)
       Test_Parametric_OtelSpan_Is_Recording: bug (APMAPI-778) # parametric endpoint attempts to retrieve spans by the `id` instead of `span_id`
       Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778) # updates the operation name of the span not the resource name

--- a/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
+++ b/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
@@ -262,19 +262,17 @@ public abstract class ApmTestApi
             static void Setter(List<string[]> headers, string key, string value) =>
                 headers.Add([key, value]);
 
-            Console.WriteLine(JsonConvert.SerializeObject(new
-            {
-                HttpHeaders = httpHeaders
-            }));
-
             // Invoke SpanContextPropagator.Inject with the HttpRequestHeaders
             _spanContextInjector.Inject(httpHeaders, Setter, span.Context);
         }
 
-        return JsonConvert.SerializeObject(new
+        var json = JsonConvert.SerializeObject(new
         {
             http_headers = httpHeaders
         });
+
+        Console.WriteLine(json);
+        return json;
     }
 
     private static async Task FinishSpan(HttpRequest request)

--- a/utils/build/docker/dotnet/parametric/appsettings.Development.json
+++ b/utils/build/docker/dotnet/parametric/appsettings.Development.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft": "Warning",
+      "Microsoft": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
   }

--- a/utils/build/docker/dotnet/parametric/appsettings.json
+++ b/utils/build/docker/dotnet/parametric/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft": "Warning",
+      "Microsoft": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },


### PR DESCRIPTION
## Motivation

Baggage is implemented in .NET library 3.6.0

## Changes

- add endpoints to .NET for baggage parametric tests
- enable baggage tests for `v3.6.0`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
