### PR TITLE
parametric: flush finished otel spans when APMLibrary contextmanager exits

### DIFF
--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -207,9 +207,15 @@ app.post('/trace/otel/end_span', (req, res) => {
 });
 
 app.post('/trace/otel/flush', async (req, res) => {
-  await tracerProvider.forceFlush()
-  otelSpans.clear();
-  res.json({ success: true });
+  tracerProvider.forceFlush().then(function() {
+    otelSpans.clear()
+    res.json({ success: true })
+  })
+  .catch(function(rej) {
+    //here when you reject the promise
+    console.log(rej)
+    res.json({ success: false })
+  });
 });
 
 app.post('/trace/otel/is_recording', (req, res) => {

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -212,7 +212,6 @@ app.post('/trace/otel/flush', async (req, res) => {
     res.json({ success: true })
   })
   .catch(function(rej) {
-    //here when you reject the promise
     console.log(rej)
     res.json({ success: false })
   });

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -413,8 +413,7 @@ class APMLibrary:
         # Only attempt a flush if there was no exception raised.
         if exc_type is None:
             self.dd_flush()
-            if self.lang not in ("cpp", "nodejs"):
-                # FIXME(munir): nodejs app does not support calling otel_flush if otel spans are not created 
+            if self.lang != "cpp":
                 # C++ does not have an otel_flush endpoint
                 self.otel_flush(1)
 

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -414,7 +414,7 @@ class APMLibrary:
         if exc_type is None:
             self.dd_flush()
             if self.lang != "cpp":
-                # C++ does not have an otel_flush endpoint
+                # C++ does not have an otel/flush endpoint
                 self.otel_flush(1)
 
     def crash(self) -> None:

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -413,6 +413,9 @@ class APMLibrary:
         # Only attempt a flush if there was no exception raised.
         if exc_type is None:
             self.dd_flush()
+            if self.lang != "cpp":
+                # C++ does not have an otel_flush endpoint
+                self.otel_flush(1)
 
     def crash(self) -> None:
         self._client.crash()

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -413,7 +413,8 @@ class APMLibrary:
         # Only attempt a flush if there was no exception raised.
         if exc_type is None:
             self.dd_flush()
-            if self.lang != "cpp":
+            if self.lang not in ("cpp", "nodejs"):
+                # FIXME(munir): nodejs app does not support calling otel_flush if otel spans are not created 
                 # C++ does not have an otel_flush endpoint
                 self.otel_flush(1)
 


### PR DESCRIPTION
## Motivation

- Improve the reliability of opentelemetry tests. This change should reduce the wait time for retrieving spans from the testagent.

## Changes

- Calls `APMLibrary.otel_flush` in `APMLibrary.__exit__()` for all libraries except cpp (which does not support the otel api).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
