### PR TITLE
[nodejs] skip docker_ssi telemetry_abort test for unsupported node.js versions

### DIFF
--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -94,6 +94,10 @@ class TestDockerSSIFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime >= "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime >= "7.0")
     @irrelevant(context.library == "python" and context.installed_language_runtime >= "3.7.0")
+    @irrelevant(
+        context.library == "nodejs" and context.installed_language_runtime >= "12.17.0",
+        reason="Telemetry reporting is not supported on Node.js < 12.17.0"
+    )
     def test_telemetry_abort(self):
         # There is telemetry data about the auto instrumentation injector. We only validate there is data
         telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject()

--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -96,7 +96,7 @@ class TestDockerSSIFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime >= "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime >= "7.0")
     @irrelevant(context.library == "python" and context.installed_language_runtime >= "3.7.0")
-    @bug(context.library == "nodejs" and context.installed_language_runtime >= "12.17.0", reason="INPLAT-252")
+    @bug(context.library == "nodejs" and context.installed_language_runtime < "12.17.0", reason="INPLAT-252")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime >= "17.0")
     def test_telemetry_abort(self):
         # There is telemetry data about the auto instrumentation injector. We only validate there is data


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/dd-trace-js/blob/d6d23d6a359d7ac757e36d6210948658d1ccb133/init.js#L9-L16

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
