### PR TITLE
[ASM][ASTO] Acitvate some tests: headers are now collected on login events

### DIFF
--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -577,7 +577,7 @@ class Test_Login_Events_Extended:
             headers=self.HEADERS,
         )
 
-    @missing_feature(library="dotnet")
+    @missing_feature(context.library < "dotnet@3.7.0")
     @missing_feature(context.library < "nodejs@5.18.0")
     @missing_feature(library="php")
     @missing_feature(library="ruby")
@@ -601,7 +601,7 @@ class Test_Login_Events_Extended:
             headers=self.HEADERS,
         )
 
-    @missing_feature(library="dotnet")
+    @missing_feature(context.library < "dotnet@3.7.0")
     @missing_feature(context.library < "nodejs@5.18.0")
     @missing_feature(library="php")
     @missing_feature(library="ruby")
@@ -1172,7 +1172,7 @@ class Test_V2_Login_Events_Anon:
             headers=self.HEADERS,
         )
 
-    @missing_feature(library="dotnet")
+    @missing_feature(context.library < "dotnet@3.7.0")
     def test_login_success_headers(self):
         # Validate that all relevant headers are included on user login success on extended mode
 
@@ -1193,7 +1193,7 @@ class Test_V2_Login_Events_Anon:
             headers=self.HEADERS,
         )
 
-    @missing_feature(library="dotnet")
+    @missing_feature(context.library < "dotnet@3.7.0")
     def test_login_failure_headers(self):
         # Validate that all relevant headers are included on user login failure on extended mode
 

--- a/tests/appsec/test_event_tracking.py
+++ b/tests/appsec/test_event_tracking.py
@@ -115,7 +115,7 @@ class Test_UserLoginFailureEvent:
     def setup_user_login_failure_header_collection(self):
         self.r = weblog.get("/user_login_failure_event", headers=HEADERS)
 
-    @missing_feature(library="dotnet")
+    @missing_feature(context.library < "dotnet@3.7.0")
     @missing_feature(context.library < "nodejs@5.18.0")
     @missing_feature(library="ruby")
     def test_user_login_failure_header_collection(self):


### PR DESCRIPTION
## Motivation

Dotnet was missing the collection of headers on login manual /auto events
cf https://github.com/DataDog/dd-trace-dotnet/pull/6225
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
