### PR TITLE
Improve runtime by running onboarding_ruby parallel to child_pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -204,7 +204,9 @@ onboarding_ruby:
   extends: .base_job_onboarding_system_tests
   stage: ruby_tracer
   allow_failure: true
-  dependencies: []
+  # Set `needs: []` so we don't have to wait for `child_pipelines` to start
+  # Keep the other jobs with `dependencies: []` so they run in serial based on stage order
+  needs: []
   timeout: 90 minutes
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" && ($ONLY_TEST_LIBRARY == "" || $ONLY_TEST_LIBRARY == "ruby")


### PR DESCRIPTION
## Motivation

Right now the nightly pipeline waits for all the `DOCKER_SSI` tests/child_pipelines to complete before running the `onboarding_*` jobs.

We cannot run all of the `onboarding_*` jobs in parallel, but we can kick them off and run them at the same time as the `child_pipelines` job.

## Changes

Set the first `onboarding_*` stage (`onboarding_ruby`) to define `needs: []` so it doesn't wait for any previous stages before starting.

The remaining stages will run in serial as expected after `onboarding_ruby` and `child_pipelines` has finished.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
