### PR TITLE
[python] fix extract headers arg

### DIFF
--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -279,7 +279,7 @@ def trace_span_inject_headers(args: SpanInjectArgs) -> SpanInjectReturn:
     return SpanInjectReturn(http_headers=[(k, v) for k, v in headers.items()])
 
 
-class SpanInjectArgs(BaseModel):
+class SpanExtractArgs(BaseModel):
     http_headers: List[Tuple[str, str]]
 
 
@@ -288,7 +288,7 @@ class SpanExtractReturn(BaseModel):
 
 
 @app.post("/trace/span/extract_headers")
-def trace_span_extract_headers(args: SpanInjectArgs) -> SpanExtractReturn:
+def trace_span_extract_headers(args: SpanExtractArgs) -> SpanExtractReturn:
     headers = {k: v for k, v in args.http_headers}
     context = HTTPPropagator.extract(headers)
     if context.span_id:


### PR DESCRIPTION
## Motivation

- Clean up duplicate class definition

## Changes

- Renames duplicate SpanInjectArgs to SpanExtractArgs.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
