### PR TITLE
[weblog] Add test for Datadog distributed tracing headers where x-datadog parent-id is set to 0

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -585,6 +585,7 @@ tests/:
     Test_LibraryHeaders: v1.60.0.dev0
   test_distributed.py:
     Test_DistributedHttp: missing_feature
+    Test_Synthetics_APM_Datadog: bug (APMAPI-901) # the incoming headers are considered invalid
   test_identify.py:
     Test_Basic: v1.37.0
     Test_Propagate: v1.48.0-rc.1

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -755,6 +755,9 @@ tests/:
     Test_Config_UnifiedServiceTagging_Default: *ref_5_25_0
   test_distributed.py:
     Test_DistributedHttp: missing_feature
+    Test_Synthetics_APM_Datadog:
+      '*': *ref_5_25_0
+      nextjs: bug (APMAPI-939) # the nextjs weblog application changes the sampling priority from 1.0 to 2.0
   test_identify.py:
     Test_Basic: v2.4.0
     Test_Propagate: *ref_3_2_0

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -35,7 +35,7 @@ class Test_Synthetics_APM_Datadog:
         self.r = weblog.get(
             "/",
             headers={
-                "x-datadog-trace-id": "123456789",
+                "x-datadog-trace-id": "1234567890",
                 "x-datadog-parent-id": "0",
                 "x-datadog-sampling-priority": "1",
                 "x-datadog-origin": "synthetics",
@@ -48,7 +48,7 @@ class Test_Synthetics_APM_Datadog:
         assert len(spans) == 1, "Agent received the incorrect amount of spans"
 
         span = spans[0]
-        assert span.get("traceID") == "123456789"
+        assert span.get("traceID") == "1234567890"
         assert "parentID" not in span or span.get("parentID") == 0 or span.get("parentID") is None
         assert span.get("meta")[ORIGIN] == "synthetics"
         assert span.get("metrics")[SAMPLING_PRIORITY_KEY] == 1
@@ -57,7 +57,7 @@ class Test_Synthetics_APM_Datadog:
         self.r = weblog.get(
             "/",
             headers={
-                "x-datadog-trace-id": "123456789",
+                "x-datadog-trace-id": "1234567891",
                 "x-datadog-parent-id": "0",
                 "x-datadog-sampling-priority": "1",
                 "x-datadog-origin": "synthetics-browser",
@@ -70,7 +70,7 @@ class Test_Synthetics_APM_Datadog:
         assert len(spans) == 1, "Agent received the incorrect amount of spans"
 
         span = spans[0]
-        assert span.get("traceID") == "123456789"
+        assert span.get("traceID") == "1234567891"
         assert "parentID" not in span or span.get("parentID") == 0 or span.get("parentID") is None
         assert span.get("meta")[ORIGIN] == "synthetics-browser"
         assert span.get("metrics")[SAMPLING_PRIORITY_KEY] == 1

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -3,6 +3,7 @@
 # Copyright 2022 Datadog, Inc.
 
 import json
+from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
 from utils import weblog, interfaces, scenarios, features
 
 
@@ -25,3 +26,51 @@ class Test_DistributedHttp:
         assert "x-datadog-sampling-priority" not in data["request_headers"]
         assert "x-datadog-tags" not in data["request_headers"]
         assert "x-datadog-trace-id" not in data["request_headers"]
+
+
+@scenarios.default
+@features.datadog_headers_propagation
+class Test_Synthetics_APM_Datadog:
+    def setup_synthetics(self):
+        self.r = weblog.get(
+            "/",
+            headers={
+                "x-datadog-trace-id": "123456789",
+                "x-datadog-parent-id": "0",
+                "x-datadog-sampling-priority": "1",
+                "x-datadog-origin": "synthetics",
+            },
+        )
+
+    def test_synthetics(self):
+        interfaces.library.assert_trace_exists(self.r)
+        spans = interfaces.agent.get_spans_list(self.r)
+        assert len(spans) == 1, "Agent received the incorrect amount of spans"
+
+        span = spans[0]
+        assert span.get("traceID") == "123456789"
+        assert "parentID" not in span or span.get("parentID") == 0 or span.get("parentID") is None
+        assert span.get("meta")[ORIGIN] == "synthetics"
+        assert span.get("metrics")[SAMPLING_PRIORITY_KEY] == 1
+
+    def setup_synthetics_browser(self):
+        self.r = weblog.get(
+            "/",
+            headers={
+                "x-datadog-trace-id": "123456789",
+                "x-datadog-parent-id": "0",
+                "x-datadog-sampling-priority": "1",
+                "x-datadog-origin": "synthetics-browser",
+            },
+        )
+
+    def test_synthetics_browser(self):
+        interfaces.library.assert_trace_exists(self.r)
+        spans = interfaces.agent.get_spans_list(self.r)
+        assert len(spans) == 1, "Agent received the incorrect amount of spans"
+
+        span = spans[0]
+        assert span.get("traceID") == "123456789"
+        assert "parentID" not in span or span.get("parentID") == 0 or span.get("parentID") is None
+        assert span.get("meta")[ORIGIN] == "synthetics-browser"
+        assert span.get("metrics")[SAMPLING_PRIORITY_KEY] == 1


### PR DESCRIPTION
## Motivation
[To connect Synthetics to APM traces](https://docs.datadoghq.com/tracing/other_telemetry/synthetics/?tab=datadog#how-are-traces-linked-to-tests), the following Datadog headers are set:
- `x-datadog-trace-id`
- `x-datadog-parent-id: 0`
- `x-datadog-origin: synthetics` or `x-datadog-origin: synthetics-browser`
- `x-datadog-sampling-priority: 1`

This weblog test asserts that library tracers continue the trace when they receive this set of headers.

## Changes
Adds new tests:
- `tests/test_distributed.py::Test_Synthetics_APM_Datadog::test_synthetics`
- `tests/test_distributed.py::Test_Synthetics_APM_Datadog::test_synthetics_browser`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
