### PR TITLE
Docker SSI allow failures

### DIFF
--- a/utils/docker_ssi/docker_ssi_matrix_builder.py
+++ b/utils/docker_ssi/docker_ssi_matrix_builder.py
@@ -22,6 +22,7 @@ def generate_gitlab_pipeline(languages):
             "image": "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c",
             "tags": ["arch:amd64"],
             "stage": "parse_docker_ssi_results",
+            "allow_failure": True,
             "rules": [
                 {"if": '$PARENT_PIPELINE_SOURCE == "schedule" && $CI_COMMIT_BRANCH == "main"', "when": "always"},
                 {"when": "manual", "allow_failure": True},
@@ -37,7 +38,7 @@ def generate_gitlab_pipeline(languages):
                 "if [ -e ${filename} ]",
                 "then",
                 'echo "Processing report: ${filename}"',
-                'curl -X POST ${FP_IMPORT_URL} --fail --header "Content-Type: application/json"  --header "FP_API_KEY: ${FP_API_KEY}" --data "@${filename}" --include',
+                'curl -X POST ${FP_IMPORT_URL} --fail --header "Content-Type: application/json"  --header "FP_API_KEY: ${FP_API_KEY}" --data "@${filename}" --include || true',
                 "fi",
                 "done",
                 "done",


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Docker ssi parse results and push dato to FPD should allow failures on CI 

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
