### PR TITLE
Use a fake API key of length 32

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -20,7 +20,8 @@ from utils.tools import logger
 from utils import interfaces
 from utils.k8s_lib_injection.k8s_weblog import K8sWeblog
 
-_FAKE_DD_API_KEY = "fakekey"
+# fake key of length 32
+_FAKE_DD_API_KEY = "0123456789abcdef0123456789abcdef"
 
 
 @lru_cache


### PR DESCRIPTION
## Motivation

When the key is not length 32, the agent can stops itself : 

https://github.com/DataDog/datadog-agent/blob/90535e90a71d31df934738c8b5738c806ffea8eb/pkg/api/security/security.go#L166
https://github.com/DataDog/system-tests-dashboard/actions/runs/12044074813/job/33580719639#step:49:86
https://datadoghq.atlassian.net/browse/APMSP-1600

## Changes

Use a fake key with a length of 32 characters

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
