### PR TITLE
add node 0.8 test for installer not supported

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ onboarding_nodejs:
         - ONBOARDING_FILTER_WEBLOG: [test-app-nodejs,test-app-nodejs-container]
           SCENARIO: [INSTALLER_AUTO_INJECTION,SIMPLE_AUTO_INJECTION_PROFILING]
           DEFAULT_VMS: ["True", "False"]
-        - ONBOARDING_FILTER_WEBLOG: [test-app-nodejs-16, test-app-nodejs-unsupported-defaults]
+        - ONBOARDING_FILTER_WEBLOG: [test-app-nodejs-08, test-app-nodejs-16, test-app-nodejs-unsupported-defaults]
           SCENARIO: [INSTALLER_NOT_SUPPORTED_AUTO_INJECTION]
           DEFAULT_VMS: ["True", "False"]
         - ONBOARDING_FILTER_WEBLOG: [test-app-nodejs]

--- a/lib-injection/build/docker/nodejs/sample-app/child.js
+++ b/lib-injection/build/docker/nodejs/sample-app/child.js
@@ -1,6 +1,6 @@
 console.log('Child process started');
 
-setTimeout(() => {
+setTimeout(function () {
   console.log('Child process exiting after 5 seconds');
   process.kill(process.pid, 'SIGSEGV');
 }, 5000); // Add a delay before crashing otherwise the telemetry forwarder leaves a zombie behind

--- a/lib-injection/build/docker/nodejs/sample-app/index.js
+++ b/lib-injection/build/docker/nodejs/sample-app/index.js
@@ -1,50 +1,52 @@
-const fs = require('fs');
-const path = require('path');
-const { fork } = require('child_process');
+var fs = require('fs');
+var path = require('path');
+var fork = require('child_process').fork;
 
-process.on('SIGTERM', (signal) => {
+process.on('SIGTERM', function (signal) {
   process.exit(0);
 });
 
 function crashme(req, res) {
-  setTimeout(() => {
+  setTimeout(function () {
     process.kill(process.pid, 'SIGSEGV');
 
     res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.end(`Crashing process ${process.pid}`);
+    res.end('Crashing process ' + process.pid);
   }, 2000); // Add a delay before crashing otherwise the telemetry forwarder leaves a zombie behind
 }
 
 function forkAndCrash(req, res) {
-  const child = fork('child.js');
+  var child = fork('child.js');
 
-  child.on('close', (code, signal) => {
+  child.on('close', function (code, signal) {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.end(`Child process ${child.pid} exited with code ${code}, signal ${signal}`);
+    res.end('Child process ' + child.pid + ' exited with code ' + code + ', signal ' + signal);
   });
 }
 
 function getChildPids(req, res) {
-  const currentPid = process.pid;
+  var currentPid = process.pid;
 
   try {
     // Get the list of all process directories in /proc
-    const procDir = '/proc';
-    const procFiles = fs.readdirSync(procDir).filter(file => /^\d+$/.test(file));
+    var procDir = '/proc';
+    var procFiles = fs.readdirSync(procDir).filter(function (file) {
+      return /^\d+$/.test(file)
+    });
 
-    let childPids = [];
+    var childPids = [];
 
     // Iterate through each process directory
-    procFiles.forEach(pid => {
-      const statusPath = path.join(procDir, pid, 'status');
+    procFiles.forEach(function (pid) {
+      var statusPath = path.join(procDir, pid, 'status');
       try {
         if (fs.existsSync(statusPath)) {
-          const statusContent = fs.readFileSync(statusPath, 'utf8');
+          var statusContent = fs.readFileSync(statusPath, 'utf8');
 
           // Find the PPid line in the status file
-          const ppidMatch = statusContent.match(/^PPid:\s+(\d+)/m);
+          var ppidMatch = statusContent.match(/^PPid:\s+(\d+)/m);
           if (ppidMatch) {
-            const ppid = parseInt(ppidMatch[1], 10);
+            var ppid = parseInt(ppidMatch[1], 10);
             if (ppid === currentPid) {
               childPids.push(pid);
             }
@@ -60,39 +62,41 @@ function getChildPids(req, res) {
 
     // Send response back
     res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.end(`${childPids.join(', ')}`);
+    res.end(childPids.join(', '));
   } catch (error) {
     res.writeHead(500, { 'Content-Type': 'text/plain' });
-    res.end(`Error: ${error.message}`);
+    res.end('Error: ' + error.message);
   }
 }
 
 function getZombies(req, res) {
   try {
-    const procDir = '/proc';
-    const procFiles = fs.readdirSync(procDir).filter(file => /^\d+$/.test(file));
-    let zombieProcesses = [];
+    var procDir = '/proc';
+    var procFiles = fs.readdirSync(procDir).filter(function (file) {
+      return /^\d+$/.test(file)
+    });
+    var zombieProcesses = [];
 
     // Iterate through each process directory
-    procFiles.forEach(pid => {
-      const statusPath = path.join(procDir, pid, 'status');
+    procFiles.forEach(function (pid) {
+      var statusPath = path.join(procDir, pid, 'status');
       try {
         if (fs.existsSync(statusPath)) {
-          const statusContent = fs.readFileSync(statusPath, 'utf8');
+          var statusContent = fs.readFileSync(statusPath, 'utf8');
 
           // Find the Name, State, and PPid lines in the status file
-          const nameMatch = statusContent.match(/^Name:\s+(\S+)/m);
-          const stateMatch = statusContent.match(/^State:\s+(\w)/m);
-          const ppidMatch = statusContent.match(/^PPid:\s+(\d+)/m);
+          var nameMatch = statusContent.match(/^Name:\s+(\S+)/m);
+          var stateMatch = statusContent.match(/^State:\s+(\w)/m);
+          var ppidMatch = statusContent.match(/^PPid:\s+(\d+)/m);
 
           if (nameMatch && stateMatch && ppidMatch) {
-            const name = nameMatch[1];
-            const state = stateMatch[1];
-            const ppid = ppidMatch[1];
+            var name = nameMatch[1];
+            var state = stateMatch[1];
+            var ppid = ppidMatch[1];
 
             // Check if the process state is 'Z' (zombie)
             if (state === 'Z') {
-              zombieProcesses.push(`${name} (PID: ${pid}, PPID: ${ppid})`);
+              zombieProcesses.push(name + ' (PID: ' + pid + ', PPID: ' + ppid + ')');
             }
           }
         }
@@ -106,14 +110,14 @@ function getZombies(req, res) {
 
     // Send response back
     res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.end(`${zombieProcesses.join(', ')}`);
+    res.end(zombieProcesses.join(', '));
   } catch (error) {
     res.writeHead(500, { 'Content-Type': 'text/plain' });
-    res.end(`Error: ${error.message}`);
+    res.end('Error: ' + error.message);
   }
 }
 
-require('http').createServer((req, res) => {
+require('http').createServer(function (req, res) {
   if (req.url === '/crashme') {
     crashme(req, res);
   } else if (req.url === '/fork_and_crash') {
@@ -125,6 +129,6 @@ require('http').createServer((req, res) => {
   } else {
     res.end('Hello, world!\n')
   }
-}).listen(18080, () => {
+}).listen(18080, function () {
   console.log('listening on port 18080') // eslint-disable-line no-console
 })

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-08.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-08.yml
@@ -1,0 +1,34 @@
+lang_variant:
+    name: node08
+    version: 0.8
+    cache: true
+    install: 
+      - os_type: linux
+        remote-command: |
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+          [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+          nvm install --no-progress 0.8
+          nvm use node
+          n=$(which node);n=${n%/bin/node}; chmod -R 755 $n/bin/*; sudo cp -r $n/{bin,lib,share} /usr/local
+
+weblog:
+    name: test-app-nodejs-08
+    excluded_os_branches: [centos_7_amd64]
+    install: 
+      - os_type: linux
+        copy_files:
+          - name: copy-service
+            local_path: utils/build/virtual_machine/weblogs/common/test-app.service
+
+          - name: copy-service-run-script
+            local_path: utils/build/virtual_machine/weblogs/common/create_and_run_app_service.sh
+
+          - name: copy-run-weblog-script
+            local_path: utils/build/virtual_machine/weblogs/nodejs/test-app-nodejs/test-app-nodejs_run.sh
+
+          - name: copy-binary
+            local_path: lib-injection/build/docker/nodejs/sample-app/index.js
+
+        remote-command: sh test-app-nodejs_run.sh

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-08.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-08.yml
@@ -15,7 +15,7 @@ lang_variant:
 
 weblog:
     name: test-app-nodejs-08
-    excluded_os_branches: [centos_7_amd64]
+    exact_os_branches: [ubuntu20_amd64, centos_7_amd64]
     install: 
       - os_type: linux
         copy_files:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

We found an issue a while back that Node 10 would crash when dd-trace-js was injected. Even though that version has not been supported for a while, it's possible to encounter it in some environments where SSI would be applied. We initially added a complete bailout for versions 0.8 to 10, but now we've added proper bailout with telemetry and logging, so we can now safely run that test on those older versions.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Add Node 0.8 test for installer not supported.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
