### PR TITLE
[Debugger] Allow root array in request JSON to be optional

### DIFF
--- a/utils/interfaces/schemas/agent/api/v2/debugger-request.json
+++ b/utils/interfaces/schemas/agent/api/v2/debugger-request.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties":{
       "content": {
-        "type": "array"
+        "type": ["object", "array"]
       }
     },
     "required": ["content"]

--- a/utils/interfaces/schemas/library/debugger/v1/diagnostics-request.json
+++ b/utils/interfaces/schemas/library/debugger/v1/diagnostics-request.json
@@ -11,48 +11,74 @@
         }
       },
       "content": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "ddsource": { "type": "string" },
-            "debugger": { 
-              "type": "object",
-              "properties": {
-                "diagnostics" : {
-                  "type": "object",
-                  "properties": {
-                    "probeId": { "type": "string" },
-                    "probeVersion": { "type": "number" },
-                    "runtimeId": { "type": "string" },
-                    "status": { "enum": ["RECEIVED", "INSTALLED", "EMITTING", "ERROR", "BLOCKED"] }
-                  },
-                  "required": [
-                    "probeId",
-                    "probeVersion",
-                    "runtimeId",
-                    "status"
-                  ]
-                }
-              },
-              "required": [
-                "diagnostics"
-              ]
+        "allOf": [
+          {
+            "if": {
+              "type": "object"
             },
-            "service": { "type": "string" },
-            "timestamp": { "type": "number" }
+            "then": {
+              "type": "object",
+              "$ref": "#/$defs/diagnosticsObject"
+            }
           },
-          "required": [
-            "ddsource",
-            "debugger",
-            "service"
-          ]
-        }
+          {
+            "if": {
+              "type": "array"
+            },
+            "then": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/diagnosticsObject"
+              }
+            }
+          },
+          {
+            "type": ["object", "array"]
+          }
+        ]
       }
     },
     "required": [
       "headers",
       "content"
     ]
+  },
+  "$defs": {
+    "diagnosticsObject": {
+      "type": "object",
+      "properties": {
+        "ddsource": { "type": "string" },
+        "debugger": {
+          "type": "object",
+          "properties": {
+            "diagnostics" : {
+              "type": "object",
+              "properties": {
+                "probeId": { "type": "string" },
+                "probeVersion": { "type": "number" },
+                "runtimeId": { "type": "string" },
+                "status": { "enum": ["RECEIVED", "INSTALLED", "EMITTING", "ERROR", "BLOCKED"] }
+              },
+              "required": [
+                "probeId",
+                "probeVersion",
+                "runtimeId",
+                "status"
+              ]
+            }
+          },
+          "required": [
+            "diagnostics"
+          ]
+        },
+        "service": { "type": "string" },
+        "timestamp": { "type": "number" }
+      },
+      "required": [
+        "ddsource",
+        "debugger",
+        "service"
+      ]
+    }
   }
 }

--- a/utils/interfaces/schemas/library/debugger/v1/input-request.json
+++ b/utils/interfaces/schemas/library/debugger/v1/input-request.json
@@ -1,56 +1,81 @@
 {
   "$id": "/library/debugger/v1/input-request.json",
-  "type": "array",
-  "items": {
-    "properties": {
-      "dd.span_id": { "type": "string" },
-      "dd.trace_id": { "type": "string" },
-      "ddsource": { "type": "string" },
-      "duration": { "type": "number" },
-      "logger.method": { "type": "string" },
-      "logger.name": { "type": "string" },
-      "logger.thread_id": { "type": "number" },
-      "logger.thread_name": { "type": "string" },
-      "logger.version": { "type": "number" },
-      "service": { "type": "string" },
-      "timestamp": { "type": "number" },
-      "debugger": {
+  "allOf": [
+    {
+      "if": {
+        "type": "object"
+      },
+      "then": {
         "type": "object",
-        "properties": {
-          "snapshot": {
-            "type": "object",
-            "properties": {
-              "captures": { "type": "object" },
-              "id": { "type": "string" },
-              "language": { "type": "string" },
-              "timestamp": { "type": "number" },
-              "probe": {
-                "type": "object",
-                "properties": {
-                  "id": { "type": "string" },
-                  "version": { "type": "number" },
-
-                  "location": {
-                    "type": "object",
-                    "properties": {
-                      "file": { "type": "string" },
-                      "lines": {
-                        "type": "array",
-                        "items": { "type": "string" }
-                      },
-                      "method": { "type": "string" },
-                      "type": { "type": "string" }
+        "$ref": "#/$defs/inputObject"
+      }
+    },
+    {
+      "if": {
+        "type": "array"
+      },
+      "then": {
+        "type": "array",
+        "items": {
+          "$ref": "#/$defs/inputObject"
+        }
+      }
+    },
+    {
+      "type": ["object", "array"]
+    }
+  ],
+  "$defs": {
+    "inputObject": {
+      "properties": {
+        "dd.span_id": { "type": "string" },
+        "dd.trace_id": { "type": "string" },
+        "ddsource": { "type": "string" },
+        "duration": { "type": "number" },
+        "logger.method": { "type": "string" },
+        "logger.name": { "type": "string" },
+        "logger.thread_id": { "type": "number" },
+        "logger.thread_name": { "type": "string" },
+        "logger.version": { "type": "number" },
+        "service": { "type": "string" },
+        "timestamp": { "type": "number" },
+        "debugger": {
+          "type": "object",
+          "properties": {
+            "snapshot": {
+              "type": "object",
+              "properties": {
+                "captures": { "type": "object" },
+                "id": { "type": "string" },
+                "language": { "type": "string" },
+                "timestamp": { "type": "number" },
+                "probe": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "version": { "type": "number" },
+                    "location": {
+                      "type": "object",
+                      "properties": {
+                        "file": { "type": "string" },
+                        "lines": {
+                          "type": "array",
+                          "items": { "type": "string" }
+                        },
+                        "method": { "type": "string" },
+                        "type": { "type": "string" }
+                      }
                     }
                   }
-                }
-              },
-              "stack": {
-                "type": "array",
-                "items": {
-                  "properties": {
-                    "fileName": { "type": "string" },
-                    "lineNumber": { "type": "number" },
-                    "function": { "type": "string" }
+                },
+                "stack": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "fileName": { "type": "string" },
+                      "lineNumber": { "type": "number" },
+                      "function": { "type": "string" }
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## Motivation

The two Debugger endpoints `/debugger/v1/input` and `/debugger/v1/diagnostics` both accept an object optionally wrapped in an array. However, the system tests currently expects the array-wrapper. The intent of this PR is to update the system tests to also make the outer array-wrapper optional.

## Changes

This is done my modifying the two JSON Schemas governing the two endpoints to use a `oneOf` to make the containing body either be as-is, or wrapped in an array.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
