### PR TITLE
[Debugger] Scope the expected Python schema errors to just Python

### DIFF
--- a/tests/debugger/probes/expression_probe_base.json
+++ b/tests/debugger/probes/expression_probe_base.json
@@ -2,6 +2,7 @@
     {
         "language": "",
         "id": "",
+        "version": 0,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "",

--- a/tests/debugger/probes/pii.json
+++ b/tests/debugger/probes/pii.json
@@ -3,6 +3,7 @@
         "language": "",
         "pii": "",
         "id": "log170aa-acda-4453-9111-1478a6method",
+        "version": 0,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "Pii",

--- a/tests/debugger/probes/pii_line.json
+++ b/tests/debugger/probes/pii_line.json
@@ -3,6 +3,7 @@
         "language": "",
         "pii": "",
         "id": "log170aa-acda-4453-9111-1478a600line",
+        "version": 0,
         "where": {
            "typeName": null,
            "sourceFile": "ACTUAL_SOURCE_FILE",

--- a/tests/debugger/probes/probe_snapshot_log_line.json
+++ b/tests/debugger/probes/probe_snapshot_log_line.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "log170aa-acda-4453-9111-1478a697line",
+        "version": 0,
         "where": {
             "typeName": null,
             "sourceFile": "ACTUAL_SOURCE_FILE",

--- a/tests/debugger/probes/probe_snapshot_log_method.json
+++ b/tests/debugger/probes/probe_snapshot_log_method.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "log170aa-acda-4453-9111-1478a6method",
+        "version": 0,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "LogProbe",

--- a/tests/debugger/probes/probe_snapshot_log_mixed.json
+++ b/tests/debugger/probes/probe_snapshot_log_mixed.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "logfb5a-1974-4cdb-b1dd-77dba2method",
+        "version": 0,
         "captureSnapshot": true,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",
@@ -15,6 +16,7 @@
         "language": "",
         "type": "",
         "id": "logfb5a-1974-4cdb-b1dd-77dba2f1line",
+        "version": 0,
         "captureSnapshot": true,
         "where": {
             "typeName": null,

--- a/tests/debugger/probes/probe_snapshot_span_decoration_line.json
+++ b/tests/debugger/probes/probe_snapshot_span_decoration_line.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "decor0aa-acda-4453-9111-1478a697line",
+        "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {

--- a/tests/debugger/probes/probe_snapshot_span_decoration_method.json
+++ b/tests/debugger/probes/probe_snapshot_span_decoration_method.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "decor0aa-acda-4453-9111-1478a6method",
+        "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {

--- a/tests/debugger/probes/probe_snapshot_span_method.json
+++ b/tests/debugger/probes/probe_snapshot_span_method.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "span70aa-acda-4453-9111-1478a6method",
+        "version": 0,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "SpanProbe",

--- a/tests/debugger/probes/probe_status_log.json
+++ b/tests/debugger/probes/probe_status_log.json
@@ -3,6 +3,7 @@
     "language": "",
     "type": "",
     "id": "loga0cf2-meth-45cf-9f39-591received",
+    "version": 0,
     "where": {
       "typeName": "NotReallyExists",
       "methodName": "SomeMethod",
@@ -14,6 +15,7 @@
     "language": "",
     "type": "",
     "id": "loga0cf2-meth-45cf-9f39-59installed",
+    "version": 0,
     "where": {
       "typeName": "ACTUAL_TYPE_NAME",
       "methodName": "LogProbe",
@@ -25,6 +27,7 @@
     "language": "",
     "type": "",
     "id": "loga0cf2-line-45cf-9f39-59installed",
+    "version": 0,
     "where": {
       "typeName": null,
       "sourceFile": "ACTUAL_SOURCE_FILE",

--- a/tests/debugger/probes/probe_status_metric.json
+++ b/tests/debugger/probes/probe_status_metric.json
@@ -3,6 +3,7 @@
     "language": "",
     "type": "",
     "id": "metricf2-meth-45cf-9f39-591received",
+    "version": 0,
     "metricName": "MetricCountInt",
     "kind": "COUNT",
     "value": {
@@ -22,6 +23,7 @@
     "language": "",
     "type": "",
     "id": "metricf2-meth-45cf-9f39-59installed",
+    "version": 0,
     "metricName": "MetricCountInt",
     "kind": "COUNT",
     "value": {
@@ -41,6 +43,7 @@
     "language": "",
     "type": "",
     "id": "metricf2-line-45cf-9f39-59installed",
+    "version": 0,
     "kind": "COUNT",
     "metricName": "MetricCountInt",
     "value": {

--- a/tests/debugger/probes/probe_status_span.json
+++ b/tests/debugger/probes/probe_status_span.json
@@ -3,6 +3,7 @@
     "language": "",
     "type": "",
     "id": "span0cf2-meth-45cf-9f39-591received",
+    "version": 0,
     "where": {
       "typeName": "NotReallyExists",
       "methodName": "SomeMethod",
@@ -14,6 +15,7 @@
     "language": "",
     "type": "",
     "id": "span0cf2-meth-45cf-9f39-59installed",
+    "version": 0,
     "where": {
       "typeName": "ACTUAL_TYPE_NAME",
       "methodName": "SpanProbe",

--- a/tests/debugger/probes/probe_status_spandecoration.json
+++ b/tests/debugger/probes/probe_status_spandecoration.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "decorcf2-meth-45cf-9f39-591received",
+        "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {
@@ -32,6 +33,7 @@
         "language": "",
         "type": "",
         "id": "decorcf2-meth-45cf-9f39-59installed",
+        "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {
@@ -61,6 +63,7 @@
         "language": "",
         "type": "",
         "id": "decorcf2-line-45cf-9f39-59installed",
+        "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -21,11 +21,17 @@ class Test_library:
             ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]"),
             ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload"),  # APPSEC-52845
             ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[].value"),  # APMS-12697
-            ("/debugger/v1/input", "$[].dd.span_id"),  # DEBUG-2743
-            ("/debugger/v1/input", "$[].dd.trace_id"),  # DEBUG-2743
-            ("/debugger/v1/input", "$[].debugger.snapshot.probe.location.lines[]"),  # DEBUG-2743
-            ("/debugger/v1/input", "$[].debugger.snapshot.captures"),  # DEBUG-2743
         ]
+
+        if context.library == "python":  # DEBUG-2743
+            excluded_points.extend(
+                [
+                    ("/debugger/v1/input", "$[].dd.span_id"),
+                    ("/debugger/v1/input", "$[].dd.trace_id"),
+                    ("/debugger/v1/input", "$[].debugger.snapshot.probe.location.lines[]"),
+                    ("/debugger/v1/input", "$[].debugger.snapshot.captures"),
+                ]
+            )
 
         if (
             context.library in ("python@2.16.2", "python@2.16.3")

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -25,7 +25,6 @@ class Test_library:
             ("/debugger/v1/input", "$[].dd.trace_id"),  # DEBUG-2743
             ("/debugger/v1/input", "$[].debugger.snapshot.probe.location.lines[]"),  # DEBUG-2743
             ("/debugger/v1/input", "$[].debugger.snapshot.captures"),  # DEBUG-2743
-            ("/debugger/v1/diagnostics", "$[].content"),  # DEBUG-2864
         ]
 
         if (
@@ -43,10 +42,6 @@ class Test_library:
     )
     def test_python_debugger_line_number(self):
         interfaces.library.assert_schema_point("/debugger/v1/input", "$[].debugger.snapshot.stack[].lineNumber")
-
-    @bug(context.library > "nodejs@4.48.0", reason="DEBUG-2864")
-    def test_library_diagnostics_content(self):
-        interfaces.library.assert_schema_point("/debugger/v1/diagnostics", "$[].content")
 
     @bug(context.library == "python", reason="DEBUG-2743")
     def test_library_schema_debugger(self):
@@ -86,13 +81,8 @@ class Test_Agent:
                 ("/api/v2/apmtelemetry", "$.payload"),  # APPSEC-52845
                 ("/api/v2/apmtelemetry", "$"),  # the main payload sent by the agent may be an array i/o an object
                 ("/api/v2/apmtelemetry", "$.payload.configuration[].value"),  # APMS-12697
-                ("/api/v2/debugger", "$[].content"),  # DEBUG-2864
             ]
         )
-
-    @bug(context.library > "nodejs@4.46.0", reason="DEBUG-2864")  # and 5.22.0
-    def test_library_diagnostics_content(self):
-        interfaces.library.assert_schema_point("/api/v2/debugger", "$[].content")
 
     @bug(context.library >= "nodejs@2.27.1", reason="APPSEC-52805")
     @irrelevant(context.scenario is scenarios.crossed_tracing_libraries, reason="APPSEC-52805")

--- a/utils/interfaces/schemas/agent/api/v2/debugger-request.json
+++ b/utils/interfaces/schemas/agent/api/v2/debugger-request.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties":{
       "content": {
-        "type": "array"
+        "type": ["object", "array"]
       }
     },
     "required": ["content"]

--- a/utils/interfaces/schemas/library/debugger/v1/diagnostics-request.json
+++ b/utils/interfaces/schemas/library/debugger/v1/diagnostics-request.json
@@ -11,50 +11,76 @@
         }
       },
       "content": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "ddsource": { "type": "string" },
-            "debugger": { 
-              "type": "object",
-              "properties": {
-                "diagnostics" : {
-                  "type": "object",
-                  "properties": {
-                    "probeId": { "type": "string" },
-                    "probeVersion": { "type": "number" },
-                    "runtimeId": { "type": "string" },
-                    "status": { "enum": ["RECEIVED", "INSTALLED", "EMITTING", "ERROR", "BLOCKED"] }
-                  },
-                  "required": [
-                    "probeId",
-                    "probeVersion",
-                    "runtimeId",
-                    "status"
-                  ]
-                }
-              },
-              "required": [
-                "diagnostics"
-              ]
+        "allOf": [
+          {
+            "if": {
+              "type": "object"
             },
-            "message": { "type": "string" },
-            "service": { "type": "string" },
-            "timestamp": { "type": "number" }
+            "then": {
+              "type": "object",
+              "$ref": "#/$defs/diagnosticsObject"
+            }
           },
-          "required": [
-            "ddsource",
-            "debugger",
-            "message",
-            "service"
-          ]
-        }
+          {
+            "if": {
+              "type": "array"
+            },
+            "then": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/diagnosticsObject"
+              }
+            }
+          },
+          {
+            "type": ["object", "array"]
+          }
+        ]
       }
     },
     "required": [
       "headers",
       "content"
     ]
+  },
+  "$defs": {
+    "diagnosticsObject": {
+      "type": "object",
+      "properties": {
+        "ddsource": { "type": "string" },
+        "debugger": {
+          "type": "object",
+          "properties": {
+            "diagnostics" : {
+              "type": "object",
+              "properties": {
+                "probeId": { "type": "string" },
+                "probeVersion": { "type": "number" },
+                "runtimeId": { "type": "string" },
+                "status": { "enum": ["RECEIVED", "INSTALLED", "EMITTING", "ERROR", "BLOCKED"] }
+              },
+              "required": [
+                "probeId",
+                "probeVersion",
+                "runtimeId",
+                "status"
+              ]
+            }
+          },
+          "required": [
+            "diagnostics"
+          ]
+        },
+        "message": { "type": "string" },
+        "service": { "type": "string" },
+        "timestamp": { "type": "number" }
+      },
+      "required": [
+        "ddsource",
+        "debugger",
+        "message",
+        "service"
+      ]
+    }
   }
 }

--- a/utils/interfaces/schemas/library/debugger/v1/diagnostics-request.json
+++ b/utils/interfaces/schemas/library/debugger/v1/diagnostics-request.json
@@ -71,14 +71,12 @@
             "diagnostics"
           ]
         },
-        "message": { "type": "string" },
         "service": { "type": "string" },
         "timestamp": { "type": "number" }
       },
       "required": [
         "ddsource",
         "debugger",
-        "message",
         "service"
       ]
     }

--- a/utils/interfaces/schemas/library/debugger/v1/input-request.json
+++ b/utils/interfaces/schemas/library/debugger/v1/input-request.json
@@ -1,56 +1,81 @@
 {
   "$id": "/library/debugger/v1/input-request.json",
-  "type": "array",
-  "items": {
-    "properties": {
-      "dd.span_id": { "type": "string" },
-      "dd.trace_id": { "type": "string" },
-      "ddsource": { "type": "string" },
-      "duration": { "type": "number" },
-      "logger.method": { "type": "string" },
-      "logger.name": { "type": "string" },
-      "logger.thread_id": { "type": "number" },
-      "logger.thread_name": { "type": "string" },
-      "logger.version": { "type": "number" },
-      "service": { "type": "string" },
-      "timestamp": { "type": "number" },
-      "debugger": {
+  "allOf": [
+    {
+      "if": {
+        "type": "object"
+      },
+      "then": {
         "type": "object",
-        "properties": {
-          "snapshot": {
-            "type": "object",
-            "properties": {
-              "captures": { "type": "object" },
-              "id": { "type": "string" },
-              "language": { "type": "string" },
-              "timestamp": { "type": "number" },
-              "probe": {
-                "type": "object",
-                "properties": {
-                  "id": { "type": "string" },
-                  "version": { "type": "number" },
-
-                  "location": {
-                    "type": "object",
-                    "properties": {
-                      "file": { "type": "string" },
-                      "lines": {
-                        "type": "array",
-                        "items": { "type": "string" }
-                      },
-                      "method": { "type": "string" },
-                      "type": { "type": "string" }
+        "$ref": "#/$defs/inputObject"
+      }
+    },
+    {
+      "if": {
+        "type": "array"
+      },
+      "then": {
+        "type": "array",
+        "items": {
+          "$ref": "#/$defs/inputObject"
+        }
+      }
+    },
+    {
+      "type": ["object", "array"]
+    }
+  ],
+  "$defs": {
+    "inputObject": {
+      "properties": {
+        "dd.span_id": { "type": "string" },
+        "dd.trace_id": { "type": "string" },
+        "ddsource": { "type": "string" },
+        "duration": { "type": "number" },
+        "logger.method": { "type": "string" },
+        "logger.name": { "type": "string" },
+        "logger.thread_id": { "type": "number" },
+        "logger.thread_name": { "type": "string" },
+        "logger.version": { "type": "number" },
+        "service": { "type": "string" },
+        "timestamp": { "type": "number" },
+        "debugger": {
+          "type": "object",
+          "properties": {
+            "snapshot": {
+              "type": "object",
+              "properties": {
+                "captures": { "type": "object" },
+                "id": { "type": "string" },
+                "language": { "type": "string" },
+                "timestamp": { "type": "number" },
+                "probe": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "version": { "type": "number" },
+                    "location": {
+                      "type": "object",
+                      "properties": {
+                        "file": { "type": "string" },
+                        "lines": {
+                          "type": "array",
+                          "items": { "type": "string" }
+                        },
+                        "method": { "type": "string" },
+                        "type": { "type": "string" }
+                      }
                     }
                   }
-                }
-              },
-              "stack": {
-                "type": "array",
-                "items": {
-                  "properties": {
-                    "fileName": { "type": "string" },
-                    "lineNumber": { "type": "number" },
-                    "function": { "type": "string" }
+                },
+                "stack": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "fileName": { "type": "string" },
+                      "lineNumber": { "type": "number" },
+                      "function": { "type": "string" }
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## Motivation

The Python tracer expects 4 specific schema errors. In the `test_library_schema_full` test, these errors were added to the `excluded_paths` lists even for non-Python tracers, which might hide unexpected errors in other tracers.

## Changes

Move the Python only exceptions into an if-statement, so they are only applied when the Python tracer is used.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
