### PR TITLE
[ASM][ATO] deactivate old login to be able to merge 

### DIFF
--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -745,7 +745,9 @@ class Test_V2_Login_Events:
             "/login?auth=local", data={self.username_key: self.INVALID_USER, self.password_key: self.PASSWORD}
         )
 
-    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now it's ...failure.usr.login")
+    @irrelevant(
+        context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now it's ...failure.usr.login"
+    )
     def test_login_wrong_user_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -768,7 +770,9 @@ class Test_V2_Login_Events:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
-    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now it's ...failure.usr.login")
+    @irrelevant(
+        context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now it's ...failure.usr.login"
+    )
     def test_login_wrong_user_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -790,7 +794,9 @@ class Test_V2_Login_Events:
             "/login?auth=local", data={self.username_key: self.USER, self.password_key: "12345"}
         )
 
-    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now exists ...failure.usr.login")
+    @irrelevant(
+        context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now exists ...failure.usr.login"
+    )
     def test_login_wrong_password_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -819,7 +825,9 @@ class Test_V2_Login_Events:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
-    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now exists ...failure.usr.login")
+    @irrelevant(
+        context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now exists ...failure.usr.login"
+    )
     def test_login_wrong_password_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -1012,7 +1020,10 @@ class Test_V2_Login_Events_Anon:
             "/login?auth=local", data={self.username_key: "invalidUser", self.password_key: self.PASSWORD}
         )
 
-    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now login reported when user exists is false")
+    @irrelevant(
+        context.library >= "dotnet@3.7.0",
+        reason="Released v3 with logins from 3.7, now login reported when user exists is false",
+    )
     def test_login_wrong_user_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -1034,7 +1045,10 @@ class Test_V2_Login_Events_Anon:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
-    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now login reported when user exists is false")
+    @irrelevant(
+        context.library >= "dotnet@3.7.0",
+        reason="Released v3 with logins from 3.7, now login reported when user exists is false",
+    )
     def test_login_wrong_user_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -745,6 +745,7 @@ class Test_V2_Login_Events:
             "/login?auth=local", data={self.username_key: self.INVALID_USER, self.password_key: self.PASSWORD}
         )
 
+    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now it's ...failure.usr.login")
     def test_login_wrong_user_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -767,6 +768,7 @@ class Test_V2_Login_Events:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now it's ...failure.usr.login")
     def test_login_wrong_user_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -788,6 +790,7 @@ class Test_V2_Login_Events:
             "/login?auth=local", data={self.username_key: self.USER, self.password_key: "12345"}
         )
 
+    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now exists ...failure.usr.login")
     def test_login_wrong_password_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -816,6 +819,7 @@ class Test_V2_Login_Events:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now exists ...failure.usr.login")
     def test_login_wrong_password_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -1008,6 +1012,7 @@ class Test_V2_Login_Events_Anon:
             "/login?auth=local", data={self.username_key: "invalidUser", self.password_key: self.PASSWORD}
         )
 
+    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now login reported when user exists is false")
     def test_login_wrong_user_failure_local(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):
@@ -1029,6 +1034,7 @@ class Test_V2_Login_Events_Anon:
         )
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @irrelevant(context.library >= "dotnet@3.7.0", reason="Released v3 with logins from 3.7, now login reported when user exists is false")
     def test_login_wrong_user_failure_basic(self):
         assert self.r_wrong_user_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_wrong_user_failure):


### PR DESCRIPTION
## Motivation
 To be able to merge: 
https://github.com/DataDog/dd-trace-dotnet/pull/6302/
as per rfc 
https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw/
## Changes

Deactivate old tests, and when new ones exist, activate them

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
