### PR TITLE
Add force_skip option

### DIFF
--- a/docs/edit/skip-tests.md
+++ b/docs/edit/skip-tests.md
@@ -1,9 +1,9 @@
 Three decorators allow you to skip test functions or classes for a library:
 
 * `@irrelevant`: The tested feature/behavior is irrelevant to the library, meaning the feature is either purposefully not supported by the lib or cannot reasonably be implemented
-* `@bug`: The lib does not implement the feature correctly/up to spec
+* `@missing_feature`: The tested feature/behavior does not exist in the library or there is a deficit in the test library that blocks this test from executing for the lib. **The test will be executed** and being ignored if it fails. If it passes, a warning will be added in thee output (`XPASS`)
+* `@bug`: The lib does not implement the feature correctly/up to spec. **The test will be executed** and being ignored if it fails. If it passes, a warning will be added in thee output (`XPASS`)
 * `@flaky` (subclass of `bug`): The feature sometimes fails, sometimes passes. It's not reliable, so don't run it.
-* `@missing_feature`: The tested feature/behavior does not exist in the library or there is a deficit in the test library that blocks this test from executing for the lib
 
 To skip specific test functions within a test class, use them as in-line decorators (Example below).
 To skip test classes or test files, use the decorator in the library's [manifest file](./manifest.md).
@@ -14,6 +14,7 @@ The decorators take several arguments:
 * `library`: provide library. version numbers are allowed e.g.`java@1.2.4`, see [versions.md](./versions.md) for more details on semantic versioning and testing against unmerged changes
 * `weblog_variant`: if you want to skip the test for a specific weblog
 * `reason`: why the test is skipped. It's especially useful for `@bug`, in which case the value should reference a JIRA ticket number.
+* `force_skip`: if you want to not execute a test maked with `missing_feature` or `bug` (main reason it entirely break the app), you can set `force_skip` to `True`
 
 
 ```python

--- a/tests/test_the_test/test_force_skip.py
+++ b/tests/test_the_test/test_force_skip.py
@@ -1,0 +1,42 @@
+from utils import bug, missing_feature, scenarios
+
+from .utils import run_system_tests
+
+FILENAME = "tests/test_the_test/test_force_skip.py"
+
+
+@scenarios.test_the_test
+class Test_ForceSkip:
+    def test_force_bug(self):
+        tests = run_system_tests(test_path=FILENAME)
+
+        nodeid = f"{FILENAME}::Test_Bug::test_bug_executed"
+        assert tests[nodeid]["outcome"] == "xpassed"
+
+        nodeid = f"{FILENAME}::Test_Bug::test_missing_feature_executed"
+        assert tests[nodeid]["outcome"] == "xpassed"
+
+        nodeid = f"{FILENAME}::Test_Bug::test_bug_not_executed"
+        assert tests[nodeid]["outcome"] == "skipped"
+
+        nodeid = f"{FILENAME}::Test_Bug::test_missing_feature_not_executed"
+        assert tests[nodeid]["outcome"] == "skipped"
+
+
+@scenarios.mock_the_test
+class Test_Bug:
+    @bug(True)
+    def test_bug_executed(self):
+        assert True
+
+    @missing_feature(True)
+    def test_missing_feature_executed(self):
+        assert True
+
+    @bug(True, force_skip=True)
+    def test_bug_not_executed(self):
+        assert True
+
+    @missing_feature(True, force_skip=True)
+    def test_missing_feature_not_executed(self):
+        assert True

--- a/utils/_decorators.py
+++ b/utils/_decorators.py
@@ -70,12 +70,15 @@ def _get_skipped_item(item, skip_reason):
     return item
 
 
-def _get_expected_failure_item(item, skip_reason):
+def _get_expected_failure_item(item, skip_reason, force_skip: bool = False):
     if inspect.isfunction(item) or inspect.isclass(item):
         if not hasattr(item, "pytestmark"):
             setattr(item, "pytestmark", [])
 
-        item.pytestmark.append(pytest.mark.xfail(reason=skip_reason))
+        if force_skip:
+            item.pytestmark.append(pytest.mark.skip(reason=skip_reason))
+        else:
+            item.pytestmark.append(pytest.mark.xfail(reason=skip_reason))
     else:
         raise ValueError(f"Unexpected skipped object: {item}")
 
@@ -111,7 +114,7 @@ def _should_skip(condition=None, library=None, weblog_variant=None):
     return True
 
 
-def missing_feature(condition: bool = None, library=None, weblog_variant=None, reason=None):
+def missing_feature(condition: bool = None, library=None, weblog_variant=None, reason=None, force_skip: bool = False):
     """decorator, allow to mark a test function/class as missing"""
 
     skip = _should_skip(library=library, weblog_variant=weblog_variant, condition=condition)
@@ -126,7 +129,7 @@ def missing_feature(condition: bool = None, library=None, weblog_variant=None, r
 
         full_reason = "missing_feature" if reason is None else f"missing_feature ({reason})"
 
-        return _get_expected_failure_item(function_or_class, full_reason)
+        return _get_expected_failure_item(function_or_class, full_reason, force_skip=force_skip)
 
     return decorator
 
@@ -150,7 +153,7 @@ def irrelevant(condition=None, library=None, weblog_variant=None, reason=None):
     return decorator
 
 
-def bug(condition=None, library=None, weblog_variant=None, reason=None):
+def bug(condition=None, library=None, weblog_variant=None, reason=None, force_skip: bool = False):
     """
     Decorator, allow to mark a test function/class as an known bug.
     The test is executed, and if it passes, and warning is reported
@@ -169,7 +172,7 @@ def bug(condition=None, library=None, weblog_variant=None, reason=None):
             return function_or_class
 
         full_reason = "bug" if reason is None else f"bug ({reason})"
-        return _get_expected_failure_item(function_or_class, full_reason)
+        return _get_expected_failure_item(function_or_class, full_reason, force_skip=force_skip)
 
     return decorator
 


### PR DESCRIPTION
## Motivation

`missing_feature` and `bug` actually execute the test, and ignore failures.

But it may happens that a test triggers a bug in the app that entirely break a payload, preventing other tests to execute. In that case, we don't want those tests to be executed (and yes, we'll loose the easy win feature).

## Changes

Adds a `force_skip` argument to `@missing_feature` and `@bug`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
