### PR TITLE
[ruby] Skip test failing for APPSEC-56056 on the good version range

### DIFF
--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -222,7 +222,7 @@ class Test_CustomBlockingResponse:
     def setup_custom_status_code(self):
         self.r_cst = weblog.get("/waf/", headers={"User-Agent": "Canary/v1"})
 
-    @bug(context.library == "ruby@2.7.1-dev", reason="APPSEC-56056")
+    @bug(context.library >= "ruby@2.7.1-dev", reason="APPSEC-56056")
     def test_custom_status_code(self):
         """Block with a custom HTTP status code"""
         assert self.r_cst.status_code == 401
@@ -230,7 +230,7 @@ class Test_CustomBlockingResponse:
     def setup_custom_redirect(self):
         self.r_cr = weblog.get("/waf/", headers={"User-Agent": "Canary/v2"}, allow_redirects=False)
 
-    @bug(context.library == "ruby@2.7.1-dev", reason="APPSEC-56056")
+    @bug(context.library >= "ruby@2.7.1-dev", reason="APPSEC-56056")
     def test_custom_redirect(self):
         """Block with an HTTP redirection"""
         assert self.r_cr.status_code == 301
@@ -239,7 +239,7 @@ class Test_CustomBlockingResponse:
     def setup_custom_redirect_wrong_status_code(self):
         self.r_cr = weblog.get("/waf/", headers={"User-Agent": "Canary/v3"}, allow_redirects=False)
 
-    @bug(context.library == "ruby@2.7.1-dev", reason="APPSEC-56056")
+    @bug(context.library >= "ruby@2.7.1-dev", reason="APPSEC-56056")
     def test_custom_redirect_wrong_status_code(self):
         """Block with an HTTP redirection but default to 303 status code, because the configured status code is not a valid redirect status code"""
         assert self.r_cr.status_code == 303


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
