### PR TITLE
[java] Fix missing feature decorator in data integrity test for java

### DIFF
--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -75,9 +75,8 @@ class Test_TraceHeaders:
     @missing_feature(
         context.library == "java" and "spring-boot" not in context.weblog_variant, reason="Missing endpoint"
     )
-    @missing_feature(weblog_variant="spring-boot-3-native", reason="Missing endpoint")
     @missing_feature(
-        context.library == "nodejs" and context.weblog_variant == "spring-boot-3-native", reason="Missing endpoint"
+        context.library == "java" and context.weblog_variant == "spring-boot-3-native", reason="Missing endpoint"
     )
     @missing_feature(context.library == "nodejs" and context.weblog_variant != "express4", reason="Missing endpoint")
     @missing_feature(context.library == "ruby" and context.weblog_variant != "rails70", reason="Missing endpoint")


### PR DESCRIPTION
## Motivation
Having a correct missing feature decorators in test.

`library=nodejs and weblog_variant=spring-boot-3-native` condition can never be met.

## Changes

Fix `missing_feature` decorator for `test_trace_header_container_tags`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
