### PR TITLE
Remove user deny list testing since the feature is deprecated

### DIFF
--- a/tests/auto_inject/test_blocklist_auto_inject.py
+++ b/tests/auto_inject/test_blocklist_auto_inject.py
@@ -10,76 +10,12 @@ from utils.virtual_machine.utils import parametrize_virtual_machines
 class _AutoInjectBlockListBaseTest:
     """ Base class to test the block list on auto instrumentation"""
 
-    env_vars_config_mapper = {
-        "java": "DD_JAVA_IGNORED_ARGS",
-        "dotnet": "DD_DOTNET_IGNORED_ARGS",
-        "python": "DD_PYTHON_IGNORED_ARGS",
-        "nodejs": "DD_NODE_IGNORED_ARGS",
-        "ruby": "DD_RUBY_IGNORED_ARGS",
-        "php": "DD_PHP_IGNORED_ARGS",
-    }
-
-    yml_config_template = """
----
-log_level: debug
-output_paths:
-  - file:///tmp/host_injection.log
-env: dev
-config_sources: BASIC
-ignored_processes:
-        - DD_IGNORED_PROCESSES
-ignored_arguments:
-    Java:
-        - DD_JAVA_IGNORED_ARGS
-    DotNet:
-        - DD_DOTNET_IGNORED_ARGS
-    Python:
-        - DD_PYTHON_IGNORED_ARGS
-    Node:
-        - DD_NODE_IGNORED_ARGS
-    Ruby:
-        - DD_RUBY_IGNORED_ARGS
-    PHP:
-        - DD_PHP_IGNORED_ARGS
-"""
-
-    def _execute_remote_command(self, ssh_client, command, config={}, use_injection_config=False):
+    def _execute_remote_command(self, ssh_client, command):
         """ Execute remote command and get remote log file from the vm. You can use this method using env variables or using injection config file  """
 
         unique_log_name = f"host_injection_{uuid.uuid4()}.log"
 
         command_with_config = f"DD_APM_INSTRUMENTATION_DEBUG=TRUE DD_APM_INSTRUMENTATION_OUTPUT_PATHS=/var/log/datadog_weblog/{unique_log_name} {command}"
-        if use_injection_config:
-            # Use yml template and replace the key DD_<lang>_IGNORED_ARGS with the value of the config
-            test_conf_content = self.yml_config_template
-            for key in config:
-                config_values = ""
-                for conf_val in config[key].split(","):
-                    # Fix the indentation
-                    if config_values == "":
-                        config_values = "- '" + conf_val + "'\n"
-                    else:
-                        config_values = config_values + "        - '" + conf_val + "'\n"
-                test_conf_content = test_conf_content.replace("- " + key, config_values)
-
-            # Write as local file and the copy by scp to user home. by ssh copy the file to /etc/datadog-agent/inject
-            file_name = f"host_config_{uuid.uuid4()}.yml"
-            temp_file_path = context.scenario.host_log_folder + "/" + file_name
-            with open(temp_file_path, "w") as host_config_file:
-                host_config_file.write(test_conf_content)
-            SCPClient(ssh_client.get_transport()).put(temp_file_path, file_name)
-            logger.info(f"Using config {file_name}")
-            # Copy config file and read out to force wait command execution
-            _, stdout, stderr = ssh_client.exec_command(
-                f"sudo cp {file_name} /etc/datadog-agent/inject/host_config.yaml"
-            )
-            stdout.channel.set_combine_stderr(True)
-            output = stdout.readlines()
-        else:
-            # We'll use env variables instead of injection config yml
-            for key in config:
-                command_with_config = f"{key}='{config[key]}' {command_with_config}"
-
         logger.info(f"Executing command: [{command_with_config}] associated with log file: [{unique_log_name}]")
         log_local_path = context.scenario.host_log_folder + f"/{unique_log_name}"
 
@@ -97,7 +33,7 @@ ignored_arguments:
         return log_local_path
 
 
-@features.host_user_managed_block_list
+@features.host_block_list
 @scenarios.installer_auto_injection
 class TestAutoInjectBlockListInstallManualHost(_AutoInjectBlockListBaseTest):
 
@@ -134,71 +70,6 @@ class TestAutoInjectBlockListInstallManualHost(_AutoInjectBlockListBaseTest):
         "ls -la",
         "mkdir newdir",
     ]
-
-    user_args_commands = {
-        "java": [
-            {"ignored_args": "-Dtest=test", "command": "java -jar test.jar -Dtest=test", "skip": True},
-            {
-                "ignored_args": "one_param=1,-Dhey=hola,-Dtest=test",
-                "command": "java -jar test.jar -Dtest=test",
-                "skip": True,
-            },
-            {"ignored_args": "-Dtest=testXX", "command": "java -jar test.jar -Dtest=test", "skip": False},
-            {
-                "ignored_args": "-Dtest3=test2",
-                "command": "java -jar test.jar -Dtest2=test2 -Dtest=test",
-                "skip": False,
-            },
-        ],
-        "dotnet": [
-            {"ignored_args": "/Users/user/Pictures", "command": "dotnet run -- -p /Users/user/Pictures", "skip": True},
-            {
-                "ignored_args": "/Users/user/PicturesXXX",
-                "command": "dotnet run -- -p /Users/user/Pictures",
-                "skip": False,
-            },
-            {
-                "ignored_args": "/MySetting:SomeValue=123",
-                "command": "dotnet run /MySetting:SomeValue=123",
-                "skip": True,
-            },
-        ],
-        "python": [
-            {"ignored_args": "", "command": "sudo -E python myscript.py arg1 arg2 arg3", "skip": False,},
-            {"ignored_args": "arg1", "command": "sudo -E python myscript.py arg1 arg2 arg3", "skip": True,},
-            {"ignored_args": "arg12,arg2,arg44", "command": "sudo -E python myscript.py arg1 arg2 arg3", "skip": True,},
-            {
-                "ignored_args": "arg11, arg22,arg44",
-                "command": "sudo -E python myscript.py arg1 arg2 arg3",
-                "skip": False,
-            },
-            {"ignored_args": "--dosomething", "command": "sudo -E python myscript.py --dosomething yes", "skip": True,},
-            {
-                "ignored_args": "--dosomethingXXXX",
-                "command": "sudo -E python myscript.py --dosomething no",
-                "skip": False,
-            },
-        ],
-        "nodejs": [
-            {"ignored_args": "", "command": "node example.js -a -b -c", "skip": False},
-            {"ignored_args": "-c", "command": "node example.js -a -b -c", "skip": True},
-            {"ignored_args": "", "command": "node example.js -f --custom Override", "skip": False},
-            {"ignored_args": "--custom", "command": "node example.js -f --custom Override", "skip": True},
-        ],
-        "ruby": [
-            {"ignored_args": "", "command": "ruby my_cat.rb test1 test2", "skip": False},
-            {"ignored_args": "test1", "command": "ruby my_cat.rb test1 test2", "skip": True},
-            {"ignored_args": "test3,test2", "command": "ruby my_cat.rb test1 test2", "skip": True},
-            {"ignored_args": "test1,test2", "command": "ruby names.rb --name pepe", "skip": False},
-            {"ignored_args": "--name", "command": "ruby names.rb --name pepe", "skip": True},
-        ],
-        "php": [
-            {"ignored_args": "", "command": "php index.php -a -b -c", "skip": False},
-            {"ignored_args": "-c", "command": "php index.php -a -b -c", "skip": True},
-            {"ignored_args": "", "command": "php index.php -f --custom Override", "skip": False},
-            {"ignored_args": "--custom", "command": "php index.php -f --custom Override", "skip": True},
-        ],
-    }
 
     @parametrize_virtual_machines(
         bugs=[
@@ -265,44 +136,3 @@ class TestAutoInjectBlockListInstallManualHost(_AutoInjectBlockListBaseTest):
                 assert False == command_injection_skipped(
                     command, local_log_file
                 ), f"The command {command} was not instrumented, but it should be instrumented!"
-
-    def _create_remote_executable_script(self, ssh_client, script_path, content="#!/bin/bash \\n echo 'Hey!'"):
-        _, stdout, stderr = ssh_client.exec_command(
-            f"sudo sh -c 'echo \"${content}\" > {script_path}' && sudo chmod 755 {script_path}"
-        )
-        stdout.channel.set_combine_stderr(True)
-        output = stdout.readlines()
-
-    @parametrize_virtual_machines(
-        bugs=[
-            {"vm_branch": "amazon_linux2", "library": "ruby", "reason": "INPLAT-103"},
-            {"vm_branch": "centos_7_amd64", "library": "ruby", "reason": "INPLAT-103"},
-            {"vm_branch": "redhat", "vm_cpu": "arm64", "library": "ruby", "reason": "INPLAT-103"},
-            {"library": "ruby", "reason": "INPLAT-153"},
-        ]
-    )
-    @irrelevant(
-        condition="container" in context.weblog_variant
-        or "alpine" in context.weblog_variant
-        or "buildpack" in context.weblog_variant
-    )
-    def test_user_ignored_args(self, virtual_machine):
-        """ Check that we are not instrumenting the lang commands (java,ruby,dotnet,python,php) that match with args set by DD_<LANG>_IGNORED_ARGS env variable"""
-        logger.info(f"[{virtual_machine.get_ip()}] Testing args ignored by user")
-        language = context.scenario.library.library
-        if language in self.user_args_commands:
-            ssh_client = virtual_machine.ssh_config.get_ssh_connection()
-            for test_config in self.user_args_commands[language]:
-                for use_injection_file_config in [True, False]:
-                    # Apply the configuration from yml file or from env variables
-                    language_ignored_args_key = self.env_vars_config_mapper[language]
-                    args_config = {language_ignored_args_key: test_config["ignored_args"]}
-                    local_log_file = self._execute_remote_command(
-                        ssh_client,
-                        test_config["command"],
-                        config=args_config,
-                        use_injection_config=use_injection_file_config,
-                    )
-                    assert test_config["skip"] == command_injection_skipped(
-                        test_config["command"], local_log_file
-                    ), f"The command {test_config['command']} with ignored args {test_config['ignored_args']} should skip [{test_config['skip']}]!"

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2048,9 +2048,9 @@ class features:
         return test_object
 
     @staticmethod
-    def host_user_managed_block_list(test_object):
+    def host_block_list(test_object):
         """
-        A way to allow users to specify their own block lists
+        SSI block lists
 
         https://feature-parity.us1.prod.dog/#/?feature=276
         """


### PR DESCRIPTION
## Motivation

The feature tested "user deny list" is deprecated, and will be removed from the injector.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
