### PR TITLE
Activate profiling test on lib supporting it

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -246,8 +246,6 @@ tests/:
   test_identify.py: irrelevant
   test_library_conf.py: irrelevant
   test_miscs.py: irrelevant
-  test_profiling.py:
-    Test_Profile: bug (No Content-Disposition, tests do not parse the content correcly)
   test_scrubbing.py: irrelevant
   test_standard_tags.py: irrelevant
   test_telemetry.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -474,8 +474,6 @@ tests/:
     Test_HeaderTags_Whitespace_Tag: bug (AIT-8308)
     Test_HeaderTags_Whitespace_Val_Long: v2.1.0
     Test_HeaderTags_Whitespace_Val_Short: v2.1.0
-  test_profiling.py:
-    Test_Profile: missing_feature (Not receiving profiles)
   test_scrubbing.py:
     Test_UrlField: v2.29.0
     Test_UrlQuery: v2.13.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -589,8 +589,6 @@ tests/:
     Test_HeaderTags_Whitespace_Tag: v1.53.0
     Test_HeaderTags_Whitespace_Val_Long: v1.53.0
     Test_HeaderTags_Whitespace_Val_Short: v1.53.0
-  test_profiling.py:
-    Test_Profile: bug (Not receiving profiles)
   test_scrubbing.py:
     Test_UrlQuery: v1.40.0
   test_semantic_conventions.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -415,8 +415,6 @@ tests/:
     Test_HeaderTags_Whitespace_Tag: v1.5.0
     Test_HeaderTags_Whitespace_Val_Long: v1.5.0
     Test_HeaderTags_Whitespace_Val_Short: v0.74.0
-  test_profiling.py:
-    Test_Profile: bug (Not receiving profiles)
   test_sampling_rates.py:
     Test_SamplingDecisions: v0.71.0
   test_scrubbing.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -485,8 +485,6 @@ tests/:
     Test_HeaderTags_Whitespace_Tag: bug (AIT-8599)
     Test_HeaderTags_Whitespace_Val_Long: v1.13.0
     Test_HeaderTags_Whitespace_Val_Short: v1.13.0
-  test_profiling.py:
-    Test_Profile: bug (Not receiving profiles)
   test_sampling_rates.py:
     Test_SamplingDecisions: missing_feature (Endpoint /sample_rate_route not implemented)
   test_scrubbing.py:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,6 @@ allow_no_jira_ticket_for_bugs = [
     # all but cpp/nodejs
     "tests/parametric/test_span_sampling.py::Test_Span_Sampling.test_multi_rule_independent_rate_limiters_sss013",
 
-    # cpp, olang, php, ruby , an error was in the deserialize function, probably no issue
-    "tests/test_profiling.py::Test_Profile",
-
     # all, test must be either removed or fixed
     "tests/test_telemetry.py::Test_Telemetry.test_status_ok",
     


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
