### PR TITLE
Fix meta struct key for iast events

### DIFF
--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -64,7 +64,7 @@ class AsmStandalone_UpstreamPropagation_Base:
     def assert_product_is_enabled(request, product):
         product_enabled = False
         tags = "_dd.iast.json" if product == "iast" else "_dd.appsec.json"
-        meta_struct_key = "vulnerability" if product == "iast" else "appsec"
+        meta_struct_key = "iast" if product == "iast" else "appsec"
         for data, trace, span in interfaces.library.get_spans(request=request):
             # Check if the product is enabled in meta
             meta = span["meta"]


### PR DESCRIPTION
## Motivation

The meta struct key for iast event wasn't the right one.
[RFC](https://docs.google.com/document/d/1iWQsOfT6Lg_IFyvQeqry9wVmXOE2Yav0X4MgOTk7mks/edit?pli=1&tab=t.0#heading=h.o5gstqo08gu5)

## Changes

Change from `vulnerability` to `iast`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
