### PR TITLE
Better stdout for TRACING_CONFIG_NONDEFAULT test

### DIFF
--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -4,6 +4,7 @@
 
 import json
 from utils import weblog, interfaces, scenarios, features, rfc, irrelevant, context, bug, missing_feature
+from utils.tools import logger
 
 
 @scenarios.default
@@ -261,27 +262,44 @@ class Test_Config_ClientIPHeader_Precedence:
 
     def test_ip_headers_precedence(self):
         # Ensures that at least one span stores each ip header in the http.client_ip tag
-        # Note - system tests may obfuscate the actual ip address, we may need to update the test to take this into account
+        # Note - system tests may obfuscate the actual ip address, we may need to update
+        # the test to take this into account.
         assert len(self.requests) == len(self.IP_HEADERS), "Number of requests and ip headers do not match, check setup"
-        for i in range(len(self.IP_HEADERS)):
+        for i, header in enumerate(self.IP_HEADERS):
             req = self.requests[i]
-            ip = self.IP_HEADERS[i][1]
-            trace = [span for _, _, span in interfaces.library.get_spans(req, full_trace=True)]
+            header_name, ip = header
+
+            assert req.status_code == 200, f"Request with {header} is not succesful"
+
+            logger.info(f"Checking request with header {header_name}={ip}")
+
             if ip.startswith("for="):
                 ip = ip[4:]
+
+            trace = [span for _, _, span in interfaces.library.get_spans(req, full_trace=True)]
             expected_tags = {"http.client_ip": ip}
             assert _get_span_by_tags(trace, expected_tags), f"Span with tags {expected_tags} not found in {trace}"
 
 
 def _get_span_by_tags(spans, tags):
+    logger.info(f"Try to find span with metag tags {tags}")
+
     for span in spans:
         # Avoids retrieving the client span by the operation/resource name, this value varies between languages
         # Use the expected tags to identify the span
         for k, v in tags.items():
-            if span["meta"].get(k) != v:
+            meta = span["meta"]
+
+            if k not in meta:
+                logger.debug(f"Span {span['span_id']} does not have tag {k}")
+            elif meta[k] != v:
+                logger.debug(f"Span {span['span_id']} has tag {k}={meta[k]} instead of {v}")
                 break
         else:
+            logger.info(f"Span found: {span['span_id']}")
             return span
+
+    logger.warning("No span with those tags has been found")
     return {}
 
 


### PR DESCRIPTION
## Motivation

Easier to understand the error by looking stdout

## Changes

More useful logs

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
