### PR TITLE
Add a warning when DD_API-KEY is not 32 char long

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -7,7 +7,6 @@ from subprocess import run
 import time
 from functools import lru_cache
 from threading import RLock, Thread
-from time import sleep
 
 import docker
 from docker.errors import APIError, DockerException
@@ -546,6 +545,12 @@ class AgentContainer(TestedContainer):
         )
 
         self.agent_version = ""
+
+    def configure(self, replay):
+        super().configure(replay)
+
+        if len(self.environment["DD_API_KEY"]) != 32:
+            logger.stdout("⚠️⚠️⚠️ DD_API_KEY is not 32 characters long, agent startup may be unstable")
 
     def get_image_list(self, library: str, weblog: str) -> list[str]:
         try:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
