### PR TITLE
Fix feature id

### DIFF
--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2402,9 +2402,9 @@ class features:
         """
         Appsec RASP rule : command injection
 
-        https://feature-parity.us1.prod.dog/#/?feature=342
+        https://feature-parity.us1.prod.dog/#/?feature=345
         """
-        pytest.mark.features(feature_id=342)(test_object)
+        pytest.mark.features(feature_id=345)(test_object)
         return test_object
 
     @staticmethod


### PR DESCRIPTION
## Motivation

The feature id of RASP command command injection should be corrected. The right feature value is 345.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
