### PR TITLE
Adding Parametric tests for DOGSTATSD Configurations

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -146,12 +146,12 @@ tests/:
     test_128_bit_traceids.py:
       Test_128_Bit_Traceids: missing_feature (parametric app does not support trace/span/extract endpoint)
     test_config_consistency.py:
+      Test_Config_Dogstatsd: missing_feature
       Test_Config_RateLimit: v1.1.0
       Test_Config_TraceAgentURL: v1.1.0
       Test_Config_TraceEnabled: v1.1.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v1.1.0
-      Test_Config_Dogstatsd: missing_feature
     test_crashtracking.py: missing_feature
     test_headers_b3multi.py:
       Test_Headers_B3multi: missing_feature (parametric app does not support trace/span/extract endpoint)

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -151,6 +151,7 @@ tests/:
       Test_Config_TraceEnabled: v1.1.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v1.1.0
+      Test_Config_Dogstatsd: missing_feature
     test_crashtracking.py: missing_feature
     test_headers_b3multi.py:
       Test_Headers_B3multi: missing_feature (parametric app does not support trace/span/extract endpoint)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -400,6 +400,7 @@ tests/:
       Test_Config_TraceEnabled: v3.3.0
       Test_Config_TraceLogDirectory: v3.3.0
       Test_Config_UnifiedServiceTagging: v3.3.0
+      Test_Config_Dogstatsd: missing_feature (does not support hostname)
     test_crashtracking.py:
       Test_Crashtracking: v3.2.0
     test_dynamic_configuration.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -395,12 +395,12 @@ tests/:
       TestAdmisionControllerProfiling: missing_feature
   parametric/:
     test_config_consistency.py:
+      Test_Config_Dogstatsd: missing_feature (does not support hostname)
       Test_Config_RateLimit: v3.4.1
       Test_Config_TraceAgentURL: v3.4.1
       Test_Config_TraceEnabled: v3.3.0
       Test_Config_TraceLogDirectory: v3.3.0
       Test_Config_UnifiedServiceTagging: v3.3.0
-      Test_Config_Dogstatsd: missing_feature (does not support hostname)
     test_crashtracking.py:
       Test_Crashtracking: v3.2.0
     test_dynamic_configuration.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -505,6 +505,7 @@ tests/:
       Test_Config_TraceEnabled: v1.67.0
       Test_Config_TraceLogDirectory: v1.70.0-dev
       Test_Config_UnifiedServiceTagging: bug (APMAPI-746)
+      Test_Config_Dogstatsd: missing_feature
     test_crashtracking.py: missing_feature
     test_dynamic_configuration.py:
       TestDynamicConfigSamplingRules: v1.64.0-dev

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -500,12 +500,12 @@ tests/:
       Test_Otel_Drop_In: missing_feature
   parametric/:
     test_config_consistency.py:
+      Test_Config_Dogstatsd: missing_feature
       Test_Config_RateLimit: v1.67.0
       Test_Config_TraceAgentURL: v1.70.0-dev
       Test_Config_TraceEnabled: v1.67.0
       Test_Config_TraceLogDirectory: v1.70.0-dev
       Test_Config_UnifiedServiceTagging: bug (APMAPI-746)
-      Test_Config_Dogstatsd: missing_feature
     test_crashtracking.py: missing_feature
     test_dynamic_configuration.py:
       TestDynamicConfigSamplingRules: v1.64.0-dev

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1448,12 +1448,12 @@ tests/:
       TestAdmisionControllerProfiling: v1.39.0
   parametric/:
     test_config_consistency.py:
+      Test_Config_Dogstatsd: missing_feature (default hostname is inconsistent)
       Test_Config_RateLimit: v1.41.1
       Test_Config_TraceAgentURL: v1.41.1
       Test_Config_TraceEnabled: v1.39.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v1.41.1
-      Test_Config_Dogstatsd: missing_feature (default hostname is inconsistent)
     test_crashtracking.py:
       Test_Crashtracking: v1.38.0
     test_dynamic_configuration.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1453,6 +1453,7 @@ tests/:
       Test_Config_TraceEnabled: v1.39.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v1.41.1
+      Test_Config_Dogstatsd: missing_feature (default hostname is inconsistent)
     test_crashtracking.py:
       Test_Crashtracking: v1.38.0
     test_dynamic_configuration.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -659,7 +659,7 @@ tests/:
       TestAdmisionControllerProfiling: *ref_5_22_0
   parametric/:
     test_config_consistency.py:
-      Test_Config_Dogstatsd: missing_feature (uses DD_DOGSTATSD_HOSTNAME instead of DD_DOGSTATSD_HOST)
+      Test_Config_Dogstatsd: *ref_5_29_0
       Test_Config_RateLimit: *ref_5_25_0
       Test_Config_TraceAgentURL: *ref_5_25_0
       Test_Config_TraceEnabled: *ref_4_3_0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -659,12 +659,12 @@ tests/:
       TestAdmisionControllerProfiling: *ref_5_22_0
   parametric/:
     test_config_consistency.py:
+      Test_Config_Dogstatsd: missing_feature (uses DD_DOGSTATSD_HOSTNAME instead of DD_DOGSTATSD_HOST)
       Test_Config_RateLimit: *ref_5_25_0
       Test_Config_TraceAgentURL: *ref_5_25_0
       Test_Config_TraceEnabled: *ref_4_3_0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: *ref_5_25_0
-      Test_Config_Dogstatsd: missing_feature (uses DD_DOGSTATSD_HOSTNAME instead of DD_DOGSTATSD_HOST)
     test_crashtracking.py:
       Test_Crashtracking: *ref_5_27_0
     test_dynamic_configuration.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -664,6 +664,7 @@ tests/:
       Test_Config_TraceEnabled: *ref_4_3_0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: *ref_5_25_0
+      Test_Config_Dogstatsd: missing_feature (uses DD_DOGSTATSD_HOSTNAME instead of DD_DOGSTATSD_HOST)
     test_crashtracking.py:
       Test_Crashtracking: *ref_5_27_0
     test_dynamic_configuration.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -314,6 +314,7 @@ tests/:
       Test_Config_TraceEnabled: v1.3.0 # Unknown initial version
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v1.5.0
+      Test_Config_Dogstatsd: missing_feature
     test_crashtracking.py:
       Test_Crashtracking: v1.3.0
     test_dynamic_configuration.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -309,12 +309,12 @@ tests/:
     test_128_bit_traceids.py:
       Test_128_Bit_Traceids: v0.84.0
     test_config_consistency.py:
+      Test_Config_Dogstatsd: missing_feature
       Test_Config_RateLimit: v1.5.0
       Test_Config_TraceAgentURL: v1.4.0
       Test_Config_TraceEnabled: v1.3.0 # Unknown initial version
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v1.5.0
-      Test_Config_Dogstatsd: missing_feature
     test_crashtracking.py:
       Test_Crashtracking: v1.3.0
     test_dynamic_configuration.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -761,12 +761,12 @@ tests/:
     test_128_bit_traceids.py:
       Test_128_Bit_Traceids: v2.6.0
     test_config_consistency.py:
+      Test_Config_Dogstatsd: missing_feature
       Test_Config_RateLimit: v2.15.0
       Test_Config_TraceAgentURL: v2.0.0
       Test_Config_TraceEnabled: v2.12.2
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v2.12.2
-      Test_Config_Dogstatsd: missing_feature
     test_crashtracking.py:
       Test_Crashtracking: v2.11.2
     test_dynamic_configuration.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -766,6 +766,7 @@ tests/:
       Test_Config_TraceEnabled: v2.12.2
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v2.12.2
+      Test_Config_Dogstatsd: missing_feature
     test_crashtracking.py:
       Test_Crashtracking: v2.11.2
     test_dynamic_configuration.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -383,6 +383,7 @@ tests/:
       Test_Config_TraceEnabled: v2.0.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v2.5.0
+      Test_Config_Dogstatsd: missing_feature
     test_crashtracking.py:
       Test_Crashtracking: v2.3.0
     test_dynamic_configuration.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -378,12 +378,12 @@ tests/:
       TestAdmisionControllerProfiling: missing_feature
   parametric/:
     test_config_consistency.py:
+      Test_Config_Dogstatsd: missing_feature
       Test_Config_RateLimit: v2.0.0
       Test_Config_TraceAgentURL: v2.5.0
       Test_Config_TraceEnabled: v2.0.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v2.5.0
-      Test_Config_Dogstatsd: missing_feature
     test_crashtracking.py:
       Test_Crashtracking: v2.3.0
     test_dynamic_configuration.py:

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -234,7 +234,9 @@ class Test_Config_RateLimit:
 @scenarios.parametric
 @features.tracing_configuration_consistency
 class Test_Config_Dogstatsd:
-    @parametrize("library_env", [{}])
+    @parametrize(
+        "library_env", [{"DD_AGENT_HOST": "localhost"}]
+    )  # Adding DD_AGENT_HOST because some SDKs use DD_AGENT_HOST to set the dogstatsd host if unspecified
     def test_dogstatsd_default(self, library_env, test_agent, test_library):
         with test_library as t:
             resp = t.config()

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -229,3 +229,32 @@ class Test_Config_RateLimit:
         assert any(
             trace[0]["metrics"]["_sampling_priority_v1"] == -1 for trace in traces
         ), "Expected at least one trace to be rate-limited with sampling priority -1."
+
+
+@scenarios.parametric
+@features.tracing_configuration_consistency
+class Test_Config_Dogstatsd:
+    @parametrize("library_env", [{}])
+    def test_dogstatsd_default(self, library_env, test_agent, test_library):
+        with test_library as t:
+            resp = t.config()
+        assert resp["dd_dogstatsd_host"] == "localhost"
+        assert resp["dd_dogstatsd_port"] == "8125"
+
+    @parametrize("library_env", [{"DD_DOGSTATSD_HOST": "192.168.10.1"}])
+    def test_dogstatsd_custom_ip_address(self, library_env, test_agent, test_library):
+        with test_library as t:
+            resp = t.config()
+        assert resp["dd_dogstatsd_host"] == "192.168.10.1"
+
+    @parametrize("library_env", [{"DD_DOGSTATSD_HOST": "randomname"}])
+    def test_dogstatsd_custom_hostname(self, library_env, test_agent, test_library):
+        with test_library as t:
+            resp = t.config()
+        assert resp["dd_dogstatsd_host"] == "randomname"
+
+    @parametrize("library_env", [{"DD_DOGSTATSD_PORT": "8150"}])
+    def test_dogstatsd_custom_port(self, library_env, test_agent, test_library):
+        with test_library as t:
+            resp = t.config()
+        assert resp["dd_dogstatsd_port"] == "8150"

--- a/tests/parametric/test_parametric_endpoints.py
+++ b/tests/parametric/test_parametric_endpoints.py
@@ -290,6 +290,8 @@ class Test_Parametric_DDTrace_Config:
                 "dd_version",
                 "dd_trace_agent_url",
                 "dd_trace_rate_limit",
+                "dd_dogstatsd_host",
+                "dd_dogstatsd_port",
             ]
 
 

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
@@ -53,6 +53,8 @@ public class TraceController {
         Method getLogLevel = configClass.getMethod("getLogLevel");
         Method getAgentUrl = configClass.getMethod("getAgentUrl");
         Method getTraceRateLimit = configClass.getMethod("getTraceRateLimit");
+        Method getJmxFetchStatsdPort = configClass.getMethod("getJmxFetchStatsdPort");
+        Method getJmxFetchStatsdHost = configClass.getMethod("getJmxFetchStatsdHost");
 
         Method isTraceOtelEnabled = instrumenterConfigClass.getMethod("isTraceOtelEnabled");
 
@@ -66,6 +68,7 @@ public class TraceController {
         configMap.put("dd_trace_debug", isDebugEnabled.invoke(configObject).toString());
         configMap.put("dd_trace_otel_enabled", isTraceOtelEnabled.invoke(instrumenterConfigObject).toString());
         configMap.put("dd_trace_agent_url", getAgentUrl.invoke(configObject).toString());
+        configMap.put("dd_dogstatsd_host", getJmxFetchStatsdHost.invoke(configObject).toString());
         // configMap.put("dd_trace_sample_ignore_parent", Config.get());
 
         Object sampleRate = getTraceSampleRate.invoke(configObject);
@@ -76,6 +79,11 @@ public class TraceController {
         Object rateLimit = getTraceRateLimit.invoke(configObject);
         if (rateLimit instanceof Integer) {
           configMap.put("dd_trace_rate_limit", Integer.toString((int)rateLimit));
+        }
+
+        Object statsPort = getJmxFetchStatsdPort.invoke(configObject);
+        if (statsPort instanceof Integer) {
+          configMap.put("dd_dogstatsd_port", Integer.toString((int)statsPort));
         }
 
         Object globalTags = getGlobalTags.invoke(configObject);

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
@@ -68,8 +68,12 @@ public class TraceController {
         configMap.put("dd_trace_debug", isDebugEnabled.invoke(configObject).toString());
         configMap.put("dd_trace_otel_enabled", isTraceOtelEnabled.invoke(instrumenterConfigObject).toString());
         configMap.put("dd_trace_agent_url", getAgentUrl.invoke(configObject).toString());
-        configMap.put("dd_dogstatsd_host", getJmxFetchStatsdHost.invoke(configObject).toString());
         // configMap.put("dd_trace_sample_ignore_parent", Config.get());
+
+        Object dogstatsdHost = getJmxFetchStatsdHost.invoke(configObject);
+        if (dogstatsdHost != null){
+          configMap.put("dd_dogstatsd_host", getJmxFetchStatsdHost.invoke(configObject).toString());
+        }
 
         Object sampleRate = getTraceSampleRate.invoke(configObject);
         if (sampleRate instanceof Double) {

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -289,7 +289,9 @@ app.get('/trace/config', (req, res) => {
       'dd_env': config?.tags?.env !== undefined ? `${config.tags.env}` : 'null',
       'dd_version': config?.tags?.version !== undefined ? `${config.tags.version}` : 'null',
       'dd_trace_agent_url': config?.url !== undefined ? `${config.url.href}` : 'null',
-      'dd_trace_rate_limit': config?.sampler?.rateLimit !== undefined ? `${config?.sampler?.rateLimit}` :'null'
+      'dd_trace_rate_limit': config?.sampler?.rateLimit !== undefined ? `${config?.sampler?.rateLimit}` : 'null',
+      'dd_dogstatsd_host': config?.dogstatsd?.hostname !== undefined ? `${config.dogstatsd.hostname}` : 'null',
+      'dd_dogstatsd_port': config?.dogstatsd?.port !== undefined ? `${config.dogstatsd.port}` : 'null',
     }
   });
 });

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -120,6 +120,8 @@ def trace_config() -> TraceConfigReturn:
             "dd_version": config.version,
             "dd_trace_rate_limit": str(config._trace_rate_limit),
             "dd_trace_agent_url": config._trace_agent_url,
+            "dd_dogstatsd_host": config._stats_agent_hostname,
+            "dd_dogstatsd_port": config._stats_agent_port,
         }
     )
 

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -326,6 +326,8 @@ class APMLibraryClient:
             "dd_version": config_dict.get("dd_version", None),
             "dd_trace_agent_url": config_dict.get("dd_trace_agent_url", None),
             "dd_trace_rate_limit": config_dict.get("dd_trace_rate_limit", None),
+            "dd_dogstatsd_host": config_dict.get("dd_dogstatsd_host", None),
+            "dd_dogstatsd_port": config_dict.get("dd_dogstatsd_port", None),
         }
 
     def otel_current_span(self) -> Union[SpanResponse, None]:


### PR DESCRIPTION
## Motivation

Adding tests for tracing configs to make sure implementation across all languages are consistent, based upon the following [RFC](https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit?tab=t.bkepxflevyzs#heading=h.1j9ifwq5at9y).

## Changes

- Add test cases for when `DD_DOGSTATSD_HOST` and `DD_DOGSTATSD_PORT` are specified, as well as when neither are included.
- Updated `test_library` `tracing/config` endpoint helper to include these fields for parametric apps
- Updated Java, Python, and NodeJS `tracing/config` endpoint in parametric apps to support the behavior
- Updated all manifest files in order to reflect the current expected behavior of the tests

[APMAPI-948](https://datadoghq.atlassian.net/browse/APMAPI-948)
[APMAPI-949](https://datadoghq.atlassian.net/browse/APMAPI-949)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-948]: https://datadoghq.atlassian.net/browse/APMAPI-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMAPI-949]: https://datadoghq.atlassian.net/browse/APMAPI-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ