### PR TITLE
[Debugger] Wait for probe to be EMITTING + temporary disable exception replay

### DIFF
--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -13,6 +13,7 @@ _SCRUB_VALUES = True
 
 @features.debugger_exception_replay
 @scenarios.debugger_exception_replay
+@bug(True, reason="DEBUG-3188")
 class Test_Debugger_Exception_Replay(debugger._Base_Debugger_Test):
     ############ setup ############
     def _setup(self, request_path, method_name):

--- a/tests/debugger/test_debugger_expression_language.py
+++ b/tests/debugger/test_debugger_expression_language.py
@@ -18,9 +18,11 @@ class Test_Debugger_Expression_Language(debugger._Base_Debugger_Test):
         self.send_rc_probes()
         self.wait_for_all_probes_installed()
         self.send_weblog_request(request_path)
+        self.wait_for_all_probes_emitting()
 
     ############ assert ############
     def _assert(self, expected_response: int):
+
         self.collect()
 
         self.assert_rc_state_not_error()
@@ -32,20 +34,21 @@ class Test_Debugger_Expression_Language(debugger._Base_Debugger_Test):
         not_found_ids = set(self.probe_ids)
         error_messages = []
 
-        for probe_id, snapshot in self.probe_snapshots.items():
-            if probe_id in expected_message_map:
-                not_found_ids.remove(probe_id)
+        for probe_id, snapshots in self.probe_snapshots.items():
+            for snapshot in snapshots:
+                if probe_id in expected_message_map:
+                    not_found_ids.remove(probe_id)
 
-                if not re.search(expected_message_map[probe_id], snapshot[0]["message"]):
-                    error_messages.append(
-                        f"Message for probe id {probe_id} is wrong. \n Expected: {expected_message_map[probe_id]}. \n Found: {snapshot['message']}."
-                    )
-
-                    evaluation_errors = snapshot["debugger"]["snapshot"].get("evaluationErrors", [])
-                    for error in evaluation_errors:
+                    if not re.search(expected_message_map[probe_id], snapshot["message"]):
                         error_messages.append(
-                            f" Evaluation error in probe id {probe_id}: {error['expr']} - {error['message']}\n"
+                            f"Message for probe id {probe_id} is wrong. \n Expected: {expected_message_map[probe_id]}. \n Found: {snapshot['message']}."
                         )
+
+                        evaluation_errors = snapshot["debugger"]["snapshot"].get("evaluationErrors", [])
+                        for error in evaluation_errors:
+                            error_messages.append(
+                                f" Evaluation error in probe id {probe_id}: {error['expr']} - {error['message']}\n"
+                            )
 
         not_found_list = "\n".join(not_found_ids)
         assert not error_messages, "Errors occurred during validation:\n" + "\n".join(error_messages)
@@ -490,7 +493,6 @@ class Test_Debugger_Expression_Language(debugger._Base_Debugger_Test):
         self._setup(probes, "/debugger/expression/collections")
 
     @bug(library="dotnet", reason="DEBUG-2602")
-    @bug(library="java", reason="DEBUG-3131")
     def test_expression_language_collection_operations(self):
         self._assert(expected_response=200)
 

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -127,7 +127,6 @@ class Test_Debugger_PII_Redaction(debugger._Base_Debugger_Test):
         self.send_weblog_request("/debugger/pii")
         self.wait_for_all_probes_emitting()
 
-
     ############ assert ############
     def _assert(self, redacted_keys, redacted_types, line_probe=False):
         self.collect()

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -125,6 +125,8 @@ class Test_Debugger_PII_Redaction(debugger._Base_Debugger_Test):
         self.send_rc_probes()
         self.wait_for_all_probes_installed()
         self.send_weblog_request("/debugger/pii")
+        self.wait_for_all_probes_emitting()
+
 
     ############ assert ############
     def _assert(self, redacted_keys, redacted_types, line_probe=False):

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -20,6 +20,7 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
         self.send_rc_probes()
         self.wait_for_all_probes_installed()
         self.send_weblog_request(request_path)
+        self.wait_for_all_probes_emitting()
 
     ########### assert ############
     def _assert(self):

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -127,7 +127,6 @@ class _Base_Debugger_Test:
 
         self.probe_definitions = _enrich_probes(probes)
         self.probe_ids = _extract_probe_ids(probes)
-        self._installed_ids = set()
 
     ###### send #####
     _rc_version = 0
@@ -147,51 +146,54 @@ class _Base_Debugger_Test:
 
     ###### wait for #####
     _last_read = 0
-    _installed_ids = set()
 
     def wait_for_all_probes_installed(self, timeout=30):
-        interfaces.agent.wait_for(self._wait_for_all_probes_installed, timeout=timeout)
+        interfaces.agent.wait_for(lambda data: self._wait_for_all_probes(data, status="INSTALLED"), timeout=timeout)
 
-    def _wait_for_all_probes_installed(self, data):
-        def _check_all_probes_installed(self, probe_diagnostics):
-            logger.debug(f"Waiting for these probes to be installed: {self.probe_ids}")
+    def wait_for_all_probes_emitting(self, timeout=30):
+        interfaces.agent.wait_for(lambda data: self._wait_for_all_probes(data, status="EMITTING"), timeout=timeout)
+
+    def _wait_for_all_probes(self, data, status):
+        found_ids = set()
+
+        def _check_all_probes_status(probe_diagnostics, status):
+            logger.debug(f"Waiting for these probes to be {status}: {self.probe_ids}")
 
             for expected_id in self.probe_ids:
                 if expected_id in probe_diagnostics:
-                    status = probe_diagnostics[expected_id]["status"]
+                    probe_status = probe_diagnostics[expected_id]["status"]
 
-                    logger.debug(f"Probe {expected_id} observed status is {status}")
-                    if status == "INSTALLED":
-                        self._installed_ids.add(expected_id)
+                    logger.debug(f"Probe {expected_id} observed status is {probe_status}")
+                    if probe_status == status or probe_status == "ERROR":
+                        found_ids.add(expected_id)
 
-            if set(self.probe_ids).issubset(self._installed_ids):
-                logger.debug(f"Succes: found all probes")
+            if set(self.probe_ids).issubset(found_ids):
+                logger.debug(f"Success: all probes are {status}")
                 return True
 
             return False
 
-        all_probes_installed = False
+        all_probes_ready = False
 
         log_filename_found = re.search(r"/(\d+)__", data["log_filename"])
         if not log_filename_found:
             return False
 
         log_number = int(log_filename_found.group(1))
-        if log_number > _Base_Debugger_Test._last_read:
+        if log_number >= _Base_Debugger_Test._last_read:
             _Base_Debugger_Test._last_read = log_number
 
-            if data["path"] == _DEBUGGER_PATH or data["path"] == _LOGS_PATH:
+        if data["path"] in [_DEBUGGER_PATH, _LOGS_PATH]:
+            probe_diagnostics = self._process_diagnostics_data([data])
+            logger.debug(probe_diagnostics)
 
-                probe_diagnostics = self._process_diagnostics_data([data])
-                logger.debug(probe_diagnostics)
+            if not probe_diagnostics:
+                logger.debug("Probes diagnostics is empty")
+                return False
 
-                if not probe_diagnostics:
-                    logger.debug("Probes diagnostics is empty")
-                    return False
+            all_probes_ready = _check_all_probes_status(probe_diagnostics, status)
 
-                all_probes_installed = _check_all_probes_installed(self, probe_diagnostics)
-
-        return all_probes_installed
+        return all_probes_ready
 
     _method_name = None
     _exception_message = None

--- a/utils/build/docker/python/flask/debugger_controller.py
+++ b/utils/build/docker/python/flask/debugger_controller.py
@@ -93,7 +93,7 @@ def string_operations():
 
 
 @debugger_blueprint.route("/expression/collections", methods=["GET"])
-def collections_operations():
+def collection_operations():
     factory = CollectionFactory()
 
     a0 = factory.get_collection(0, "array")


### PR DESCRIPTION
## Motivation
Remove inconsistency in EL tests
Disable exception replay tests

## Changes
After sending requests, wait for all probes have "EMITTING" status

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
