### PR TITLE
upgrade(onboarding): Stop using QA registry, use install{testing}.datad0g.com

### DIFF
--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
@@ -10,8 +10,7 @@
     if [ "${DD_env}" == "dev" ]; then
       # To force the installer to pull from dev repositories -- agent config is set manually to datadoghq.com
       export DD_SITE="datad0g.com"
-      export DD_INSTALLER_REGISTRY_URL='669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog'
-      export DD_INSTALLER_REGISTRY_AUTH='ecr'
+      export DD_INSTALLER_REGISTRY_URL='install.datad0g.com'
     else 
       export DD_SITE="datadoghq.com" 
     fi
@@ -22,26 +21,22 @@
     export DD_INSTALLER_DEFAULT_PKG_INSTALL_DATADOG_AGENT=true
 
     if [ -n "${DD_INSTALLER_LIBRARY_VERSION}" ]; then
-       export "DD_INSTALLER_REGISTRY_AUTH_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")_PACKAGE"='ecr'
-       export "DD_INSTALLER_REGISTRY_URL_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")_PACKAGE"='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+       export "DD_INSTALLER_REGISTRY_URL_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")_PACKAGE"='installtesting.datad0g.com'
        export "DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")"="${DD_INSTALLER_LIBRARY_VERSION}"
     fi
 
     if [ -n "${DD_INSTALLER_INJECTOR_VERSION}" ]; then
-      export DD_INSTALLER_REGISTRY_AUTH_APM_INJECT_PACKAGE='ecr'
-      export DD_INSTALLER_REGISTRY_URL_APM_INJECT_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+      export DD_INSTALLER_REGISTRY_URL_APM_INJECT_PACKAGE='installtesting.datad0g.com'
       export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT="${DD_INSTALLER_INJECTOR_VERSION}"
     fi
 
     if [ -n "${DD_INSTALLER_AGENT_VERSION}" ]; then
-      export DD_INSTALLER_REGISTRY_AUTH_AGENT_PACKAGE='ecr'
-      export DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+      export DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE='installtesting.datad0g.com'
       export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT="${DD_INSTALLER_AGENT_VERSION}"
     fi
 
     if [ -n "${DD_INSTALLER_INSTALLER_VERSION}" ]; then
-      export DD_INSTALLER_REGISTRY_AUTH_INSTALLER_PACKAGE='ecr'
-      export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+      export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE='installtesting.datad0g.com'
       export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER="${DD_INSTALLER_INSTALLER_VERSION}"
     fi
 

--- a/utils/build/virtual_machine/provisions/auto-inject/repositories/autoinstall/execute_install_script.sh
+++ b/utils/build/virtual_machine/provisions/auto-inject/repositories/autoinstall/execute_install_script.sh
@@ -16,8 +16,7 @@ fi
 if [ "${DD_env}" == "dev" ]; then
     # To force the installer to pull from dev repositories -- agent config is set manually to datadoghq.com
     export DD_SITE="datad0g.com"
-    export DD_INSTALLER_REGISTRY_URL='669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog'
-    export DD_INSTALLER_REGISTRY_AUTH='ecr'
+    export DD_INSTALLER_REGISTRY_URL='install.datad0g.com'
 else 
     export DD_SITE="datadoghq.com" 
 fi
@@ -27,26 +26,22 @@ export DD_APM_INSTRUMENTATION_LIBRARIES="${DD_LANG}"
 export DD_INSTALLER_DEFAULT_PKG_INSTALL_DATADOG_AGENT=true
 
 if [ -n "${DD_INSTALLER_LIBRARY_VERSION}" ]; then
-   export "DD_INSTALLER_REGISTRY_AUTH_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")_PACKAGE"='ecr'
-   export "DD_INSTALLER_REGISTRY_URL_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")_PACKAGE"='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+   export "DD_INSTALLER_REGISTRY_URL_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")_PACKAGE"='installtesting.datad0g.com'
    export "DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_LIBRARY_$(echo "$DD_LANG" | tr "[:lower:]" "[:upper:]")"="${DD_INSTALLER_LIBRARY_VERSION}" 
 fi
 
 if [ -n "${DD_INSTALLER_INJECTOR_VERSION}" ]; then
-    export DD_INSTALLER_REGISTRY_AUTH_APM_INJECT_PACKAGE='ecr'
-    export DD_INSTALLER_REGISTRY_URL_APM_INJECT_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+    export DD_INSTALLER_REGISTRY_URL_APM_INJECT_PACKAGE='installtesting.datad0g.com'
     export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT="${DD_INSTALLER_INJECTOR_VERSION}"
 fi
 
 if [ -n "${DD_INSTALLER_AGENT_VERSION}" ]; then
-    export DD_INSTALLER_REGISTRY_AUTH_AGENT_PACKAGE='ecr'
-    export DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+    export DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE='installtesting.datad0g.com'
     export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT="${DD_INSTALLER_AGENT_VERSION}"
 fi
 
 if [ -n "${DD_INSTALLER_INSTALLER_VERSION}" ]; then
-    export DD_INSTALLER_REGISTRY_AUTH_INSTALLER_PACKAGE='ecr'
-    export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE='669783387624.dkr.ecr.us-east-1.amazonaws.com'
+    export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE='installtesting.datad0g.com'
     export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER="${DD_INSTALLER_INSTALLER_VERSION}"
 fi
 


### PR DESCRIPTION
## Motivation
We want to remove the dependency on the aws ecr creds helper in the installer

## Changes
changes the registries to use public ones:
- install.datadoghq.com (default)
- install.datad0g.com
- installtesting.datad0g.com

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
