### PR TITLE
[Debugger] Remove message field from diagnostics schema

### DIFF
--- a/utils/interfaces/schemas/library/debugger/v1/diagnostics-request.json
+++ b/utils/interfaces/schemas/library/debugger/v1/diagnostics-request.json
@@ -39,14 +39,12 @@
                 "diagnostics"
               ]
             },
-            "message": { "type": "string" },
             "service": { "type": "string" },
             "timestamp": { "type": "number" }
           },
           "required": [
             "ddsource",
             "debugger",
-            "message",
             "service"
           ]
         }


### PR DESCRIPTION
## Motivation

Update the diagnostics schema to match the [RFC](https://docs.google.com/document/d/1mAyR2LHKE8W89BoLZ5qFpQNTJ6l6t9QQiDPC-YoGD4Y/edit).

## Changes

The root `message` property is not expected.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
