### PR TITLE
k8s documentation fix lint

### DIFF
--- a/docs/scenarios/k8s_lib_injection.md
+++ b/docs/scenarios/k8s_lib_injection.md
@@ -405,7 +405,7 @@ These are the main important log/data files:
 
 ## How to debug your kubernetes environment at runtime
 
-So far there is no parameter that allows to keep the kubernetes cluster alive after launching the tests. But we can make some temporary tweaks to do that. 
+So far there is no parameter that allows to keep the kubernetes cluster alive after launching the tests. But we can make some temporary tweaks to do that.
 
 You only need to comment the line that stops the cluster after the test case. You can do this here:
 https://github.com/DataDog/system-tests/blob/fd8766cd45687d2be4b858df611435da7f41c6d6/tests/k8s_lib_injection/conftest.py#L43C5-L43C17
@@ -434,5 +434,5 @@ def test_k8s_instance(request):
     logger.info("K8sInstance destroyed")
 ```
 
-Although it is not very practical, we recommend to run only one test, commenting the rest of the methods/tests case the tests class. 
-For example, if you want to debug at runtime the k8s profiling scenario, we recommend to keep only one test case in the class "TestAdmisionControllerProfiling" (you can skip a test method adding the character "_" before the method name) https://github.com/DataDog/system-tests/blob/fd8766cd45687d2be4b858df611435da7f41c6d6/tests/k8s_lib_injection/test_k8s_manual_inject.py#L79 
+Although it is not very practical, we recommend to run only one test, commenting the rest of the methods/tests case the tests class.
+For example, if you want to debug at runtime the k8s profiling scenario, we recommend to keep only one test case in the class "TestAdmisionControllerProfiling" (you can skip a test method adding the character "_" before the method name) https://github.com/DataDog/system-tests/blob/fd8766cd45687d2be4b858df611435da7f41c6d6/tests/k8s_lib_injection/test_k8s_manual_inject.py#L79


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Fix the lint failures on the k8s documentation


## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
