### PR TITLE
[Debugger] Enable python tests

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -594,7 +594,7 @@ tests/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay: missing_feature
     test_debugger_expression_language.py:
-      Test_Debugger_Expression_Language: 
+      Test_Debugger_Expression_Language:
         '*': missing_feature
         flask-poc: v2.11.0
         uds-flask: v2.11.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -594,7 +594,11 @@ tests/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay: missing_feature
     test_debugger_expression_language.py:
-      Test_Debugger_Expression_Language: bug (DEBUG-2898)
+      Test_Debugger_Expression_Language: 
+        '*': missing_feature
+        flask-poc: v2.11.0
+        uds-flask: v2.11.0
+        uwsgi-poc: v2.11.0
     test_debugger_pii.py:
       Test_Debugger_PII_Redaction:
         '*': missing_feature

--- a/tests/debugger/test_debugger_expression_language.py
+++ b/tests/debugger/test_debugger_expression_language.py
@@ -313,7 +313,7 @@ class Test_Debugger_Expression_Language(debugger._Base_Debugger_Test):
     ## at the app there are 3 types of collections are created - array, list and hash.
     ## the number at the end of variable means the length of the collection
     ## all collection are filled with incremented number values (e.g at the [0] = 0; [1] = 1)
-    
+
     def setup_expression_language_collection_operations(self):
         message_map, probes = self._create_expression_probes(
             methodName="CollectionOperations",
@@ -382,7 +382,7 @@ class Test_Debugger_Expression_Language(debugger._Base_Debugger_Test):
     @bug(library="dotnet", reason="DEBUG-2602")
     def test_expression_language_collection_operations(self):
         self._assert(expected_response=200)
-        
+
     def setup_expression_language_hash_operations(self):
         message_map, probes = self._create_expression_probes(
             methodName="CollectionOperations",

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -46,7 +46,6 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
     def setup_log_method_probe_snaphots(self):
         self._setup("probe_snapshot_log_method", "/debugger/log")
 
-    @bug(library="python", reason="DEBUG-2708, DEBUG-2709")
     def test_log_method_probe_snaphots(self):
         self._assert()
         self._validate_snapshots()
@@ -55,7 +54,6 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
     def setup_span_method_probe_snaphots(self):
         self._setup("probe_snapshot_span_method", "/debugger/span")
 
-    @bug(library="python", reason="DEBUG-2708, DEBUG-2709")
     def test_span_method_probe_snaphots(self):
         self._assert()
         self._validate_spans()
@@ -64,7 +62,6 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
     def setup_span_decoration_method_probe_snaphots(self):
         self._setup("probe_snapshot_span_decoration_method", "/debugger/span-decoration/asd/1")
 
-    @bug(library="python", reason="DEBUG-2708, DEBUG-2709")
     @missing_feature(context.library == "ruby", reason="Not yet implemented")
     def test_span_decoration_method_probe_snaphots(self):
         self._assert()
@@ -93,7 +90,6 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
     def setup_mix_probe(self):
         self._setup("probe_snapshot_log_mixed", "/debugger/mix/asd/1")
 
-    @bug(library="python", reason="DEBUG-2710")
     def test_mix_probe(self):
         self._assert()
         self._validate_snapshots()

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -21,10 +21,6 @@ class Test_library:
             ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[]"),
             ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload"),  # APPSEC-52845
             ("/telemetry/proxy/api/v2/apmtelemetry", "$.payload.configuration[].value"),  # APMS-12697
-            ("/debugger/v1/input", "$[].dd.span_id"),  # DEBUG-2743
-            ("/debugger/v1/input", "$[].dd.trace_id"),  # DEBUG-2743
-            ("/debugger/v1/input", "$[].debugger.snapshot.probe.location.lines[]"),  # DEBUG-2743
-            ("/debugger/v1/input", "$[].debugger.snapshot.captures"),  # DEBUG-2743
             ("/debugger/v1/diagnostics", "$[].content"),  # DEBUG-2864
         ]
 
@@ -48,7 +44,6 @@ class Test_library:
     def test_library_diagnostics_content(self):
         interfaces.library.assert_schema_point("/debugger/v1/diagnostics", "$[].content")
 
-    @bug(context.library == "python", reason="DEBUG-2743")
     def test_library_schema_debugger(self):
         interfaces.library.assert_schema_point("/debugger/v1/input", "$[].dd.span_id")
         interfaces.library.assert_schema_point("/debugger/v1/input", "$[].dd.trace_id")

--- a/utils/build/docker/dotnet/weblog/Controllers/DebuggerController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/DebuggerController.cs
@@ -83,9 +83,11 @@ namespace weblog
 
         [HttpGet("expression/operators")]
         [Consumes("application/json", "application/xml")]
-        public IActionResult ExpressionOperators(int intValue, float floatValue, string strValue)
+        public async Task<IActionResult> ExpressionOperators(int intValue, float floatValue, string strValue)
         {
-            return Content($"Int value {intValue}. Float value {floatValue}. String value {strValue}");
+            PiiBase? pii = await Task.FromResult<PiiBase>(new Pii());
+            var piiValue = pii?.TestValue;
+            return Content($"Int value {intValue}. Float value {floatValue}. String value {strValue}. Pii value {piiValue}");
         }
 
         [HttpGet("expression/strings")]
@@ -114,9 +116,14 @@ namespace weblog
 
         [HttpGet("expression/null")]
         [Consumes("application/json", "application/xml")]
-        public async Task<IActionResult> Nulls(int? intValue = null, string strValue = null)
+        public async Task<IActionResult> Nulls(int? intValue = null, string strValue = null, bool? boolValue = null)
         {
-            PiiBase? pii = await Task.FromResult<PiiBase>(null);
+            PiiBase pii = null;
+            if (boolValue == true)
+            {
+                pii = await Task.FromResult<PiiBase>(null);
+            }
+
             return Content($"Pii is null {pii is null}. intValue is null {intValue is null}. strValue is null {strValue is null}.");
         }
     }

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/DebuggerController.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/DebuggerController.java
@@ -76,6 +76,7 @@ public class DebuggerController {
 
     @GetMapping("/expression/operators")
     public String expressionOperators(@RequestParam int intValue, @RequestParam float floatValue, @RequestParam String strValue) {
+        PiiBase pii = new Pii();
         return "Int value " + intValue + ". Float value " + floatValue + ". String value is " + strValue + ".";
     }
 
@@ -114,11 +115,18 @@ public class DebuggerController {
     @GetMapping("/expression/null")
      public String nulls(
             @RequestParam(required = false) Integer intValue,
-            @RequestParam(required = false) String strValue) {
+            @RequestParam(required = false) String strValue,
+            @RequestParam(required = false) Boolean boolValue
+            ) {
+
         PiiBase pii = null;
 
-        return "Pii is null " + (pii == null) +
-                ". intValue is null " + (intValue == null) +
-                ". strValue is null " + (strValue == null) + ".";
+        if (Boolean.TRUE.equals(boolValue)) {
+            pii = new Pii();
+        }
+
+        return "Pii is null: " + (pii == null) +
+            ". intValue is null: " + (intValue == null) +
+            ". strValue is null: " + (strValue == null) + ".";
     }
 }

--- a/utils/build/docker/python/flask/debugger_controller.py
+++ b/utils/build/docker/python/flask/debugger_controller.py
@@ -63,10 +63,10 @@ def pii():
 
 @debugger_blueprint.route("/expression", methods=["GET"])
 def expression():
-    input_value = request.args.get("inputValue", type=str)
-    test_struct = ExpressionTestStruct()
-    local_value = len(input_value)
-    return f"Great success number {local_value}"
+    inputValue = request.args.get("inputValue", type=str)
+    testStruct = ExpressionTestStruct()
+    localValue = len(inputValue)
+    return f"Great success number {localValue}"
 
 
 @debugger_blueprint.route("/expression/exception", methods=["GET"])
@@ -76,20 +76,21 @@ def expression_exception():
 
 @debugger_blueprint.route("/expression/operators", methods=["GET"])
 def expression_operators():
-    int_value = request.args.get("intValue", type=int)
-    float_value = request.args.get("floatValue", type=float)
-    str_value = request.args.get("strValue", type=str)
+    intValue = request.args.get("intValue", type=int)
+    floatValue = request.args.get("floatValue", type=float)
+    strValue = request.args.get("strValue", type=str)
+    pii = Pii()
 
-    return f"Int value {int_value}. Float value {float_value}. String value is {str_value}."
+    return f"Int value {intValue}. Float value {floatValue}. String value is {strValue}."
 
 
 @debugger_blueprint.route("/expression/strings", methods=["GET"])
 def string_operations():
-    str_value = request.args.get("strValue", type=str)
-    empty_string = request.args.get("emptyString", default="")
-    null_string = request.args.get("nullString")
+    strValue = request.args.get("strValue", type=str)
+    emptyString = request.args.get("emptyString", default="")
+    nullString = request.args.get("nullString")
 
-    return f"strValue {str_value}. emptyString {empty_string}. {null_string}."
+    return f"strValue {strValue}. emptyString {emptyString}. {nullString}."
 
 
 @debugger_blueprint.route("/expression/collections", methods=["GET"])
@@ -121,8 +122,12 @@ def collection_operations():
 
 @debugger_blueprint.route("/expression/null", methods=["GET"])
 def nulls():
-    int_value = request.args.get("intValue", type=int)
-    str_value = request.args.get("strValue")
-    pii = None
+    intValue = request.args.get("intValue", type=int)
+    strValue = request.args.get("strValue", type = str)
+    boolValue = request.args.get("boolValue", type=bool)
 
-    return f"Pii is null {pii is None}. intValue is null {int_value is None}. strValue is null {str_value is None}."
+    pii = None
+    if boolValue:
+        pii = Pii()
+
+    return f"Pii is null {pii is None}. intValue is null {intValue is None}. strValue is null {strValue is None}."

--- a/utils/build/docker/python/flask/debugger_controller.py
+++ b/utils/build/docker/python/flask/debugger_controller.py
@@ -123,7 +123,7 @@ def collection_operations():
 @debugger_blueprint.route("/expression/null", methods=["GET"])
 def nulls():
     intValue = request.args.get("intValue", type=int)
-    strValue = request.args.get("strValue", type = str)
+    strValue = request.args.get("strValue", type=str)
     boolValue = request.args.get("boolValue", type=bool)
 
     pii = None


### PR DESCRIPTION
## Motivation
The `python` bugs have been resolved, so this PR restores the relevant system tests

## Changes
Removed all Python test decorators marked with `bug`.
Split hash tests into a separate group, as this feature is still under discussion.
Adjusted tests and controller to ensure consistent behavior across all libraries.

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
