### PR TITLE
Disable IAST in appsec_runtime_activation scenario

### DIFF
--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -242,6 +242,7 @@ class scenarios:
         "APPSEC_RUNTIME_ACTIVATION",
         rc_api_enabled=True,
         appsec_enabled=False,
+        iast_enabled=False,
         weblog_env={"DD_APPSEC_WAF_TIMEOUT": "10000000", "DD_APPSEC_TRACE_RATE_LIMIT": "10000"},  # 10 seconds
         doc="",
         scenario_groups=[ScenarioGroup.APPSEC, ScenarioGroup.APPSEC_RASP],

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -182,7 +182,7 @@ class EndToEndScenario(DockerScenario):
         agent_env=None,
         tracer_sampling_rate=None,
         appsec_enabled=True,
-        iast_enabled=False,
+        iast_enabled=True,
         additional_trace_header_tags=(),
         library_interface_timeout=None,
         agent_interface_timeout=5,

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -182,7 +182,7 @@ class EndToEndScenario(DockerScenario):
         agent_env=None,
         tracer_sampling_rate=None,
         appsec_enabled=True,
-        iast_enabled=True,
+        iast_enabled=False,
         additional_trace_header_tags=(),
         library_interface_timeout=None,
         agent_interface_timeout=5,


### PR DESCRIPTION
## Motivation

- Having IAST enabled can lead to appsec_runtime_activation scenario behaving incorrectly, masking actual issues.
- Example:
  - When running `tests/appsec/rasp/test_lfi.py` and IAST enabled, the test passes incorrectly.
  - This happens due to a limitation in the current Java tracer implementation, which doesn't support hot instrumentation for LFI exploit prevention.
  - With IAST enabled, instrumentation for LFI prevention occurs at startup (shared with RASP), creating a false impression that the functionality works as expected when it does not.

Jira ticket: [APPSEC-55649]

## Changes

- **Disables IAST in appsec_runtime_activation** 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-55649]: https://datadoghq.atlassian.net/browse/APPSEC-55649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ