### PR TITLE
[java] Avoid apt-get in spring-boot-3-native

### DIFF
--- a/utils/build/docker/java/spring-boot-3-native.Dockerfile
+++ b/utils/build/docker/java/spring-boot-3-native.Dockerfile
@@ -28,9 +28,9 @@ COPY --from=agent /dd-tracer/dd-java-agent.jar .
 RUN /opt/apache-maven-3.8.6/bin/mvn -Pnative,with-profiling native:compile
 RUN /opt/apache-maven-3.8.6/bin/mvn -Pnative,without-profiling native:compile
 
-FROM ubuntu
-
-RUN apt-get update && apt-get install -y curl
+# Just use something small with glibc and curl. ubuntu:22.04 ships no curl, rockylinux:9 does.
+# This avoids apt-get update/install, which leads to flakiness on mirror upgrades.
+FROM rockylinux:9
 
 WORKDIR /app
 COPY --from=agent /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION


### PR DESCRIPTION
## Motivation

Avoid apt-get update/install, which leads to flakiness on mirror sync.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
