### PR TITLE
[java] Avoid apt-get for libarchive-tools

### DIFF
--- a/utils/build/docker/java/akka-http.Dockerfile
+++ b/utils/build/docker/java/akka-http.Dockerfile
@@ -2,9 +2,6 @@ FROM maven:3.8-jdk-11 as build
 
 ENV JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=true"
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 
 WORKDIR /app

--- a/utils/build/docker/java/play.Dockerfile
+++ b/utils/build/docker/java/play.Dockerfile
@@ -2,9 +2,6 @@ FROM maven:3.6-jdk-11 as build
 
 ENV JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=true"
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 WORKDIR /app
 
 COPY ./utils/build/docker/java/play/pom.xml .

--- a/utils/build/docker/java/vertx4.Dockerfile
+++ b/utils/build/docker/java/vertx4.Dockerfile
@@ -2,9 +2,6 @@ FROM maven:3.6-jdk-11 as build
 
 ENV JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=true"
 
-RUN apt-get update && \
-	apt-get install -y libarchive-tools
-
 COPY ./utils/build/docker/java/iast-common/src /iast-common/src
 
 WORKDIR /app


### PR DESCRIPTION
## Motivation

Avoid installing libarchive-tools, not needed anymore (it was previously used to extract jars, but we now use java). This avoids apt-get flakiness, and a superfluous setup step.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
