### PR TITLE
[nodejs] Use --import instead of --require in nextjs app

### DIFF
--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -26,5 +26,5 @@ ENV PORT=7777
 ENV HOSTNAME=0.0.0.0
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN printf './node_modules/.bin/next start' >> app.sh
-ENV NODE_OPTIONS="--require dd-trace/init.js"
+ENV NODE_OPTIONS="--import dd-trace/initialize.mjs"
 CMD ./app.sh


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/dd-trace-js/pull/5012 will start using esm loader, which is executed in a different worker and makes some test failures because there are more RC calls than expected.
With this change that behaviour will be fixed.

## Changes
use `--import` instead of `--require` to initialize the tracer.
<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
