### PR TITLE
[Debugger] Ensure all probes have a version property

### DIFF
--- a/tests/debugger/probes/expression_probe_base.json
+++ b/tests/debugger/probes/expression_probe_base.json
@@ -2,6 +2,7 @@
     {
         "language": "",
         "id": "",
+        "version": 0,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "",

--- a/tests/debugger/probes/pii.json
+++ b/tests/debugger/probes/pii.json
@@ -3,6 +3,7 @@
         "language": "",
         "pii": "",
         "id": "log170aa-acda-4453-9111-1478a6method",
+        "version": 0,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "Pii",

--- a/tests/debugger/probes/pii_line.json
+++ b/tests/debugger/probes/pii_line.json
@@ -3,6 +3,7 @@
         "language": "",
         "pii": "",
         "id": "log170aa-acda-4453-9111-1478a600line",
+        "version": 0,
         "where": {
            "typeName": null,
            "sourceFile": "ACTUAL_SOURCE_FILE",

--- a/tests/debugger/probes/probe_snapshot_log_line.json
+++ b/tests/debugger/probes/probe_snapshot_log_line.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "log170aa-acda-4453-9111-1478a697line",
+        "version": 0,
         "where": {
             "typeName": null,
             "sourceFile": "ACTUAL_SOURCE_FILE",

--- a/tests/debugger/probes/probe_snapshot_log_method.json
+++ b/tests/debugger/probes/probe_snapshot_log_method.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "log170aa-acda-4453-9111-1478a6method",
+        "version": 0,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "LogProbe",

--- a/tests/debugger/probes/probe_snapshot_log_mixed.json
+++ b/tests/debugger/probes/probe_snapshot_log_mixed.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "logfb5a-1974-4cdb-b1dd-77dba2method",
+        "version": 0,
         "captureSnapshot": true,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",
@@ -15,6 +16,7 @@
         "language": "",
         "type": "",
         "id": "logfb5a-1974-4cdb-b1dd-77dba2f1line",
+        "version": 0,
         "captureSnapshot": true,
         "where": {
             "typeName": null,

--- a/tests/debugger/probes/probe_snapshot_span_decoration_line.json
+++ b/tests/debugger/probes/probe_snapshot_span_decoration_line.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "decor0aa-acda-4453-9111-1478a697line",
+        "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {

--- a/tests/debugger/probes/probe_snapshot_span_decoration_method.json
+++ b/tests/debugger/probes/probe_snapshot_span_decoration_method.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "decor0aa-acda-4453-9111-1478a6method",
+        "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {

--- a/tests/debugger/probes/probe_snapshot_span_method.json
+++ b/tests/debugger/probes/probe_snapshot_span_method.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "span70aa-acda-4453-9111-1478a6method",
+        "version": 0,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "SpanProbe",

--- a/tests/debugger/probes/probe_status_log.json
+++ b/tests/debugger/probes/probe_status_log.json
@@ -3,6 +3,7 @@
     "language": "",
     "type": "",
     "id": "loga0cf2-meth-45cf-9f39-591received",
+    "version": 0,
     "where": {
       "typeName": "NotReallyExists",
       "methodName": "SomeMethod",
@@ -14,6 +15,7 @@
     "language": "",
     "type": "",
     "id": "loga0cf2-meth-45cf-9f39-59installed",
+    "version": 0,
     "where": {
       "typeName": "ACTUAL_TYPE_NAME",
       "methodName": "LogProbe",
@@ -25,6 +27,7 @@
     "language": "",
     "type": "",
     "id": "loga0cf2-line-45cf-9f39-59installed",
+    "version": 0,
     "where": {
       "typeName": null,
       "sourceFile": "ACTUAL_SOURCE_FILE",

--- a/tests/debugger/probes/probe_status_metric.json
+++ b/tests/debugger/probes/probe_status_metric.json
@@ -3,6 +3,7 @@
     "language": "",
     "type": "",
     "id": "metricf2-meth-45cf-9f39-591received",
+    "version": 0,
     "metricName": "MetricCountInt",
     "kind": "COUNT",
     "value": {
@@ -22,6 +23,7 @@
     "language": "",
     "type": "",
     "id": "metricf2-meth-45cf-9f39-59installed",
+    "version": 0,
     "metricName": "MetricCountInt",
     "kind": "COUNT",
     "value": {
@@ -41,6 +43,7 @@
     "language": "",
     "type": "",
     "id": "metricf2-line-45cf-9f39-59installed",
+    "version": 0,
     "kind": "COUNT",
     "metricName": "MetricCountInt",
     "value": {

--- a/tests/debugger/probes/probe_status_span.json
+++ b/tests/debugger/probes/probe_status_span.json
@@ -3,6 +3,7 @@
     "language": "",
     "type": "",
     "id": "span0cf2-meth-45cf-9f39-591received",
+    "version": 0,
     "where": {
       "typeName": "NotReallyExists",
       "methodName": "SomeMethod",
@@ -14,6 +15,7 @@
     "language": "",
     "type": "",
     "id": "span0cf2-meth-45cf-9f39-59installed",
+    "version": 0,
     "where": {
       "typeName": "ACTUAL_TYPE_NAME",
       "methodName": "SpanProbe",

--- a/tests/debugger/probes/probe_status_spandecoration.json
+++ b/tests/debugger/probes/probe_status_spandecoration.json
@@ -3,6 +3,7 @@
         "language": "",
         "type": "",
         "id": "decorcf2-meth-45cf-9f39-591received",
+        "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {
@@ -32,6 +33,7 @@
         "language": "",
         "type": "",
         "id": "decorcf2-meth-45cf-9f39-59installed",
+        "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {
@@ -61,6 +63,7 @@
         "language": "",
         "type": "",
         "id": "decorcf2-line-45cf-9f39-59installed",
+        "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -579,6 +579,12 @@ class EndToEndScenario(DockerScenario):
                 ticket="DEBUG-2864",
             ),
             _SchemaBug(
+                endpoint="/debugger/v1/diagnostics",
+                data_path="$[].content[].debugger.diagnostics",
+                condition=context.library == "nodejs",
+                ticket="DEBUG-3245",
+            ),
+            _SchemaBug(
                 endpoint="/debugger/v1/input",
                 data_path="$[].debugger.snapshot.stack[].lineNumber",
                 condition=context.library in ("python@2.16.2", "python@2.16.3")


### PR DESCRIPTION
## Motivation

All probes sent via Remote Config should have a root `version` property. For some reason, one was not present in our mocked probe configs located in `tests/debugger/probes`. I'm not sure why this hasn't resulted in system test errors previously since the diagnostics schema expects that a version is reported. However, without this, at least the Node.js tracer, would set `version: undefined` in the object before it was serialized to JSON, which would completely remove the `version` property from the JSON output.

Maybe they other tracers fall back to `0` if there's no `version` property in the probe config?

This is a re-creation of #3581 which had to be reverted because of changes to `tests/remote_config/rc_mocked_responses_live_debugging.json` and `tests/remote_config/rc_mocked_responses_live_debugging_nocache.json` which broke tests that because of an oversight didn't run in CI as part of that PR.

## Changes

Hardcode all mocked probe configs to contain `version: 0`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
