### PR TITLE
[dotnet] Refactor IAST command injection tests

### DIFF
--- a/utils/build/docker/dotnet/weblog/Controllers/IastController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/IastController.cs
@@ -172,35 +172,35 @@ namespace weblog
         [HttpPost("cmdi/test_insecure")]
         public IActionResult test_insecure_cmdI([FromForm] RequestData data)
         {
-            try
-            {
-                if (!string.IsNullOrEmpty(data.cmd))
-                {
-                    var result = Process.Start(data.cmd);
-                    return Content("Process launched: " + result.ProcessName);
-                }
-                else
-                {
-                    return BadRequest("No file was provided");
-                }
-            }
-            catch
-            {
-                return StatusCode(500, "Error launching process.");
-            }
+            return ExecuteCommandInternal(data.cmd, false);
         }
 
         [HttpPost("cmdi/test_secure")]
         public IActionResult test_secure_cmdI([FromForm] RequestData data)
         {
+            return ExecuteCommandInternal("ls", false);
+        }
+        
+        private IActionResult ExecuteCommandInternal(string commandLine, bool useShell = true)
+        {
             try
             {
-                var result = Process.Start("ls");
-                return Content("Process launched: " + result.ProcessName);
+                if (!string.IsNullOrEmpty(commandLine))
+                {
+                    ProcessStartInfo startInfo = new ProcessStartInfo();
+                    startInfo.FileName = commandLine;
+                    startInfo.UseShellExecute = useShell;
+                    var result = Process.Start(startInfo);
+                    return Content($"Process launched.");
+                }
+                else
+                {
+                    return Content("No process name was provided");
+                }
             }
-            catch
+            catch (Exception)
             {
-                return StatusCode(500, "Error launching process.");
+                return Content("Non existing file.");
             }
         }
 


### PR DESCRIPTION
## Motivation

The test test_command_injection.test_secure has been reported as flaky. This test just executed a not tainted command. so IAST should not be involved, and tests that there is no IAST trace in the span.

The error that happens from time to time is that the controller cannot execute the command "ls" and returns an error code. While it is not clear why that happens, it does not seem to be related to IAST. Anyway, the command injection code that is used in RASP has been brought to IAST. The twin command injection RASP controller methods are not flaky, they handle better the error situations and are more legible.

With this change, we expect the flaky test to stop being flaky while we improve the quality of the code.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
