### PR TITLE
[skipci] apm-ecosystems as CODEOWNERS for static files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,3 +27,6 @@
 /manifests/php.yml @DataDog/apm-php @DataDog/asm-php
 /manifests/python.yml @DataDog/apm-python @DataDog/asm-python
 /manifests/ruby.yml @DataDog/ruby-guild @DataDog/asm-ruby
+
+# Allows everyone to easily make changes
+/tests/telemetry_intake/static/ @DataDog/apm-ecosystems

--- a/tests/telemetry_intake/update.sh
+++ b/tests/telemetry_intake/update.sh
@@ -7,7 +7,7 @@ set -e
 # If this script deletes the JSON files in system-tests, it's likely this is no longer valid
 SUBDIR="trace/apps/tracer-telemetry-intake/telemetry-payload/static/"
 # The "main" branch in dd-go
-BRANCH="bm1549/more-missing-configs" # This should ALWAYS be "prod" in master. Please revert changes before merging
+BRANCH="prod" # This should ALWAYS be "prod" in master. Please revert changes before merging
 
 # These variables will probably never change
 REPO_URL="https://github.com/DataDog/dd-go.git"


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Simplifies the review cycle for updating these files by making it so that anyone can approve

These should only be copy-pasta from dd-go so it should be non-impactful

## Changes

<!-- A brief description of the change being made with this pull request. -->
Just updates CODEOWNERS

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
