### PR TITLE
Add runbook for config telemetry completeness

### DIFF
--- a/docs/edit/runbook.md
+++ b/docs/edit/runbook.md
@@ -17,7 +17,7 @@ The impact is that these **configs are not visible** in Metabase, REDAPL, or any
 #### Runbook
 
 1. Check the test failure to see exactly which configs are missing
-2. Add config normalization rules [here](https://github.com/DataDog/dd-go/tree/prod/trace/apps/tracer-telemetry-intake/telemetry-payload/static/) following the existing pattern 
+2. Add config normalization rules [here](https://github.com/DataDog/dd-go/tree/prod/trace/apps/tracer-telemetry-intake/telemetry-payload/static/) following the existing pattern
    1. This can be merged with any review from [@apm-ecosystems](https://github.com/orgs/DataDog/teams/apm-ecosystems)
 3. After merging, update system-tests by running [update.sh](/tests/telemetry_intake/update.sh)
    1. This can be run from the root by running `./tests/telemetry_intake/update.sh`

--- a/docs/edit/runbook.md
+++ b/docs/edit/runbook.md
@@ -1,0 +1,53 @@
+⚠️ Did this test just fail, and you want to fix it? ⚠️
+
+Here's what you need to do!
+
+## test_telemetry.py
+
+### test_config_telemetry_completeness
+
+#### Summary
+
+This can be **easily fixed** in ~5 minutes
+
+This is **caused by adding a new config option** without adding the associated config normalization rules to telemetry intake
+
+The impact is that these **configs are not visible** in Metabase, REDAPL, or anywhere else
+
+#### Runbook
+
+1. Check the test failure to see exactly which configs are missing
+2. Add config normalization rules [here](https://github.com/DataDog/dd-go/tree/prod/trace/apps/tracer-telemetry-intake/telemetry-payload/static/) following the existing pattern 
+   1. This can be merged with any review from [@apm-ecosystems](https://github.com/orgs/DataDog/teams/apm-ecosystems)
+3. After merging, update system-tests by running [update.sh](/tests/telemetry_intake/update.sh)
+   1. This can be run from the root by running `./tests/telemetry_intake/update.sh`
+   2. This can be merged with any review from [@apm-ecosystems](https://github.com/orgs/DataDog/teams/apm-ecosystems)
+4. You're all set - your tests should pass 🏁
+
+#### Details
+The specific test that failed is:
+
+```python
+tests.test_telemetry.test_config_telemetry_completeness
+```
+
+This asserts that config telemetry is handled properly by telemetry intake
+
+Some files are manually copied from dd-go from/to the following paths using tests/telemetry_intake/update.sh
+from: https://github.com/DataDog/dd-go/blob/prod/trace/apps/tracer-telemetry-intake/telemetry-payload/static/
+to: tests/telemetry_intake/static
+
+If this test fails, it means that a telemetry key was found in config telemetry that does not
+exist in any of the files listed above in dd-go
+The impact is that telemetry will not be reported to the Datadog backend won't be unusable
+
+To fix this, you must update dd-go to either
+1) Add an exact config key to match config_norm_rules.json
+2) Add a prefix that matches the config keys to config_prefix_block_list.json
+3) Add a prefix rule that fits an existing prefix to config_aggregation_list.json
+4) (Discouraged) Add a language-specific rule to <lang>_config_rules.json
+
+Once dd-go is updated, you can copy over the files to this repo and merge them in as part of your changes
+This can be done by running the following from the src root
+
+Usage: ./tests/telemetry_intake/update.sh

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -602,25 +602,7 @@ class Test_TelemetryV2:
         """
         Assert that config telemetry is handled properly by telemetry intake
 
-        ⚠️ Did this test just fail? Read here! ⚠️
-        Some files are manually copied from dd-go from/to the following paths using tests/telemetry_intake/update.sh
-        from: https://github.com/DataDog/dd-go/blob/prod/trace/apps/tracer-telemetry-intake/telemetry-payload/static/
-        to: tests/telemetry_intake/static
-
-        If this test fails, it means that a telemetry key was found in config telemetry that does not
-        exist in any of the files listed above in dd-go
-        The impact is that telemetry will not be reported to the Datadog backend won't be unusable
-
-        To fix this, you must update dd-go to either
-        1) Add an exact config key to match config_norm_rules.json
-        2) Add a prefix that matches the config keys to config_prefix_block_list.json
-        3) Add a prefix rule that fits an existing prefix to config_aggregation_list.json
-        4) (Discouraged) Add a language-specific rule to <lang>_config_rules.json
-
-        Once dd-go is updated, you can copy over the files to this repo and merge them in as part of your changes
-        This can be done by running the following from the src root
-
-        Usage: ./tests/telemetry_intake/update.sh
+        Runbook: https://github.com/DataDog/system-tests/docs/edit/runbook.md#test_config_telemetry_completeness
         """
 
         def lowercase_obj(obj):
@@ -693,7 +675,7 @@ class Test_TelemetryV2:
                 # This may create a fairly large test output, but it makes the output more actionable
                 if len(missing_config_keys) != 0:
                     logger.error(json.dumps(missing_config_keys, indent=2))
-                    raise ValueError("Found unexpected config telemetry keys")
+                    raise ValueError("(NOT A FLAKE) Found unexpected config telemetry keys. Runbook: https://github.com/DataDog/system-tests/docs/edit/runbook.md#test_config_telemetry_completeness")
 
     @missing_feature(library="cpp")
     @missing_feature(context.library < "ruby@1.22.0", reason="dd-client-library-version missing")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -675,7 +675,9 @@ class Test_TelemetryV2:
                 # This may create a fairly large test output, but it makes the output more actionable
                 if len(missing_config_keys) != 0:
                     logger.error(json.dumps(missing_config_keys, indent=2))
-                    raise ValueError("(NOT A FLAKE) Found unexpected config telemetry keys. Runbook: https://github.com/DataDog/system-tests/docs/edit/runbook.md#test_config_telemetry_completeness")
+                    raise ValueError(
+                        "(NOT A FLAKE) Found unexpected config telemetry keys. Runbook: https://github.com/DataDog/system-tests/docs/edit/runbook.md#test_config_telemetry_completeness"
+                    )
 
     @missing_feature(library="cpp")
     @missing_feature(context.library < "ruby@1.22.0", reason="dd-client-library-version missing")


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Added a runbook for a new test that is likely to fail

## Changes

<!-- A brief description of the change being made with this pull request. -->
Just adds a runbook 😄 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
