### PR TITLE
[dotnet] change how we get library version

### DIFF
--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -160,7 +160,7 @@ class ParametricScenario(Scenario):
             self._clean_networks()
 
         # https://github.com/DataDog/system-tests/issues/2799
-        if library in ("nodejs", "python", "golang", "ruby"):
+        if library in ("nodejs", "python", "golang", "ruby", "dotnet"):
             output = _get_client().containers.run(
                 self.apm_test_server_definition.container_tag,
                 remove=True,
@@ -454,14 +454,11 @@ def dotnet_library_factory():
         container_name="dotnet-test-api",
         container_tag="dotnet8_0-test-api",
         container_img=f"""
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-app
 WORKDIR /app
 
 # `binutils` is required by 'install_ddtrace.sh' to call 'strings' command
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y binutils
-
-COPY utils/build/docker/dotnet/install_ddtrace.sh binaries/ /binaries/
-RUN /binaries/install_ddtrace.sh
 
 # dotnet restore
 COPY {dotnet_reldir}/ApmTestApi.csproj {dotnet_reldir}/nuget.config ./
@@ -470,6 +467,14 @@ RUN dotnet restore "./ApmTestApi.csproj"
 # dotnet publish
 COPY {dotnet_reldir} ./
 RUN dotnet publish --no-restore -c Release -o out
+
+##################
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-version-tool
+WORKDIR /app
+
+COPY {dotnet_reldir}/../GetAssemblyVersion ./
+RUN dotnet publish -c Release -o out
 
 ##################
 
@@ -492,12 +497,18 @@ ENV DD_TRACE_AspNetCore_ENABLED=false
 ENV DD_TRACE_Process_ENABLED=false
 ENV DD_TRACE_OTEL_ENABLED=false
 
+# copy custom tool used to get library version (built above)
+COPY utils/build/docker/dotnet/parametric/system_tests_library_version.sh ./
+COPY --from=build-version-tool /app/out /app
 
-COPY --from=build /app/out /app
-COPY --from=build /app/SYSTEM_TESTS_LIBRARY_VERSION /app/SYSTEM_TESTS_LIBRARY_VERSION
-COPY --from=build /opt/datadog /opt/datadog
+# copy the dotnet app (built above)
+COPY --from=build-app /app/out /app
+
+# install dd-trace-dotnet
+COPY utils/build/docker/dotnet/install_ddtrace.sh binaries/ /binaries/
+RUN /binaries/install_ddtrace.sh
+
 RUN mkdir /parametric-tracer-logs
-
 CMD ["./ApmTestApi"]
 """,
         container_cmd=[],

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -457,9 +457,6 @@ def dotnet_library_factory():
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-app
 WORKDIR /app
 
-# `binutils` is required by 'install_ddtrace.sh' to call 'strings' command
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y binutils
-
 # dotnet restore
 COPY {dotnet_reldir}/ApmTestApi.csproj {dotnet_reldir}/nuget.config ./
 RUN dotnet restore "./ApmTestApi.csproj"

--- a/utils/build/docker/dotnet/GetAssemblyVersion/GetAssemblyVersion.csproj
+++ b/utils/build/docker/dotnet/GetAssemblyVersion/GetAssemblyVersion.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/utils/build/docker/dotnet/GetAssemblyVersion/Program.cs
+++ b/utils/build/docker/dotnet/GetAssemblyVersion/Program.cs
@@ -1,0 +1,10 @@
+﻿if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+{
+    Console.WriteLine("Usage: GetAssemblyVersion <path-to-assembly>");
+    return;
+}
+
+var fullPath = Path.GetFullPath(args[0]);
+var assembly = System.Reflection.Assembly.LoadFile(fullPath);
+var version = assembly.GetName().Version?.ToString(3);
+Console.Write(version);

--- a/utils/build/docker/dotnet/install_ddtrace.sh
+++ b/utils/build/docker/dotnet/install_ddtrace.sh
@@ -31,10 +31,3 @@ else
 
     tar xzf $(ls datadog-dotnet-apm*.tar.gz) -C /opt/datadog
 fi
-
-# use 'strings' command from 'binutils' package to extract assembly version
-version=$(strings /opt/datadog/net6.0/Datadog.Trace.dll | egrep '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$')
-echo "${version:0:-2}" > /app/SYSTEM_TESTS_LIBRARY_VERSION
-
-echo "dd-trace version: $(cat /app/SYSTEM_TESTS_LIBRARY_VERSION)"
-

--- a/utils/build/docker/dotnet/parametric/system_tests_library_version.sh
+++ b/utils/build/docker/dotnet/parametric/system_tests_library_version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/app/GetAssemblyVersion /opt/datadog/net6.0/Datadog.Trace.dll

--- a/utils/build/docker/dotnet/poc.Dockerfile
+++ b/utils/build/docker/dotnet/poc.Dockerfile
@@ -1,9 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 
-# `binutils` is required by 'install_ddtrace.sh' to call 'strings' command
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y binutils
-
 COPY utils/build/docker/dotnet/install_ddtrace.sh binaries/ /binaries/
 RUN /binaries/install_ddtrace.sh
 

--- a/utils/build/docker/dotnet/poc.Dockerfile
+++ b/utils/build/docker/dotnet/poc.Dockerfile
@@ -9,15 +9,11 @@ RUN /binaries/install_ddtrace.sh
 
 # dotnet restore
 COPY utils/build/docker/dotnet/weblog/app.csproj app.csproj
-
-RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") \
-    dotnet restore
+RUN dotnet restore
 
 # dotnet publish
 COPY utils/build/docker/dotnet/weblog/* .
-
-RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") \
-    dotnet publish --no-restore -c Release -f net8.0 -o out
+RUN dotnet publish --no-restore -c Release -f net8.0 -o out
 
 #########
 

--- a/utils/build/docker/dotnet/uds.Dockerfile
+++ b/utils/build/docker/dotnet/uds.Dockerfile
@@ -1,9 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 
-# `binutils` is required by 'install_ddtrace.sh' to call 'strings' command
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y binutils
-
 COPY utils/build/docker/dotnet/install_ddtrace.sh binaries/ /binaries/
 RUN /binaries/install_ddtrace.sh
 

--- a/utils/build/docker/dotnet/uds.Dockerfile
+++ b/utils/build/docker/dotnet/uds.Dockerfile
@@ -9,15 +9,11 @@ RUN /binaries/install_ddtrace.sh
 
 # dotnet restore
 COPY utils/build/docker/dotnet/weblog/app.csproj app.csproj
-
-RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") \
-    dotnet restore
+RUN dotnet restore
 
 # dotnet publish
 COPY utils/build/docker/dotnet/weblog/* .
-
-RUN DDTRACE_VERSION=$(cat /app/SYSTEM_TESTS_LIBRARY_VERSION | sed -n -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/p") \
-    dotnet publish --no-restore -c Release -f net8.0 -o out
+RUN dotnet publish --no-restore -c Release -f net8.0 -o out
 
 #########
 

--- a/utils/build/docker/dotnet/weblog/Endpoints/HealthcheckEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/HealthcheckEndpoint.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using System;
-using System.IO;
+using System.Reflection;
 using System.Text.Json;
 
 namespace weblog
@@ -12,17 +11,15 @@ namespace weblog
         {
             routeBuilder.MapGet("/healthcheck", async context =>
             {
-                string dd_version = "";
-                using (StreamReader reader = new StreamReader("SYSTEM_TESTS_LIBRARY_VERSION"))
-                {
-                    dd_version = reader.ReadToEnd().Trim( new Char[] { '\n' } );
-                }
+                var version = Assembly.Load("Datadog.Trace").GetName().Version?.ToString(4);
 
-                var data = new {
+                var data = new
+                {
                     status = "ok",
-                    library = new {
+                    library = new
+                    {
                         language = "dotnet",
-                        version = dd_version
+                        version
                     }
                 };
 

--- a/utils/build/docker/dotnet/weblog/Endpoints/HealthcheckEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/HealthcheckEndpoint.cs
@@ -11,7 +11,7 @@ namespace weblog
         {
             routeBuilder.MapGet("/healthcheck", async context =>
             {
-                var version = Assembly.Load("Datadog.Trace").GetName().Version?.ToString(4);
+                var version = Assembly.Load("Datadog.Trace").GetName().Version?.ToString(3);
 
                 var data = new
                 {

--- a/utils/build/docker/dotnet/weblog/app.csproj
+++ b/utils/build/docker/dotnet/weblog/app.csproj
@@ -9,9 +9,6 @@
         <Nullable>enable</Nullable>
         <CheckEolTargetFramework>false</CheckEolTargetFramework>
 
-        <!-- set a default value for DDTRACE_VERSION property if not provided -->
-        <DDTRACE_VERSION Condition="'$(DDTRACE_VERSION)' == ''">2.23.0</DDTRACE_VERSION>
-
         <!--
           Ignore the following warnings:
             NU1902: Package 'System.Data.SqlClient' 4.6.1 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-8g2p-5pqh-5jmc
@@ -21,10 +18,8 @@
         <NoWarn>NU1902;NU1903;CA1416</NoWarn>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(DDTRACE_VERSION)' != '' and '$(DDTRACE_VERSION)' >= '2.7.0'">
+    <PropertyGroup>
         <DefineConstants>$(DefineConstants);DDTRACE_2_7_0_OR_GREATER</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(DDTRACE_VERSION)' != '' and '$(DDTRACE_VERSION)' >= '2.23.0'">
         <DefineConstants>$(DefineConstants);DDTRACE_2_23_0_OR_GREATER</DefineConstants>
     </PropertyGroup>
 


### PR DESCRIPTION
## Motivation

We had an issue in .NET where we reported the wrong library version (or it was in an invalid format, unclear). I couldn't reproduce this issue, but while we were all looking into it, we noticed we could make several improvements to how we detect and report the library version to prevent this from happening and making everything less brittle.

The main issue is that we currently use the `strings` tool from the `binutils` package and a regular expression to extract the first `a.b.c.d` version string from `Datadog.Trace.dll`. This is not great since a string in that format could be found multiple times all over the file and we have no guarantee that we are using the correct one. Also, we were saving this string into a file and reading it from several places, even though in .NET we can access the assembly version directly.

## Changes

tl;dr
- library version is no longer required at build time or saved to disk
- we use `Assembly.LoadFile()` to get the library version
- `weblog` tests retrieve the version using the `/healthcheck` endpoint
- `parametric` tests uses a custom .NET tool to extract the version

full details
- stop installing the `binutils` package and using the `strings` tool
- stop saving the library version to a file in `install_ddtrace.sh`
- `weblog`
  - always define the build-time constants `DDTRACE_2_7_0_OR_GREATER` and `DDTRACE_2_23_0_OR_GREATER` since everything is 3.x now
  - return the correct version at runtime in the `/healthcheck` endpoint
  - TODO LATER: remove these constants and the code that uses them
- `parametric` scenario
  - runs `system_tests_library_version.sh`, which uses a custom .NET tool to load the assembly and retrieve it's version (Node.js, Python, Go, and Ruby also use a similar script)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
