### PR TITLE
add incomplete_test_app to manifest files

### DIFF
--- a/docs/RFCs/manifest.md
+++ b/docs/RFCs/manifest.md
@@ -135,7 +135,7 @@ tests/:
 
     "skipped_declaration": {
       "type": "string",
-      "pattern": "^(bug|flaky|irrelevant|missing_feature)( \\(.+\\))?$"
+      "pattern": "^(bug|flaky|irrelevant|missing_feature|incomplete_test_app)( \\(.+\\))?$"
     }
   }
 }

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -174,16 +174,16 @@ tests/:
     test_otel_span_with_baggage.py:
       Test_Otel_Span_With_Baggage: missing_feature
     test_parametric_endpoints.py:
-      Test_Parametric_DDSpan_Add_Link: missing_feature (add_link endpoint is not implemented)
+      Test_Parametric_DDSpan_Add_Link: missing_feature (add_link is not supported)
       Test_Parametric_DDSpan_Set_Error: bug (APMAPI-778)  # The expected error status is not set
       Test_Parametric_DDSpan_Set_Metric: missing_feature (Tracer does not provide a public method for directly setting a span metric)
-      Test_Parametric_DDSpan_Set_Resource: missing_feature (set_resource endpoint is not implemented)
+      Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not implemented)
       Test_Parametric_DDSpan_Start: bug (APMAPI-778)  # Cpp parametric app does not support creating a child span from a finished span
       Test_Parametric_DDTrace_Baggage: missing_feature (baggage is not supported)
-      Test_Parametric_DDTrace_Config: missing_feature (config endpoint is not implemented)
-      Test_Parametric_DDTrace_Crash: missing_feature (crash endpoint is not implemented)
-      Test_Parametric_DDTrace_Current_Span: missing_feature (current_span endpoint is not implemented)
-      Test_Parametric_DDTrace_Extract_Headers: missing_feature (extract_headers endpoint is not implemented)
+      Test_Parametric_DDTrace_Config: incomplete_test_app (config endpoint is not implemented)
+      Test_Parametric_DDTrace_Crash: incomplete_test_app (crash endpoint is not implemented)
+      Test_Parametric_DDTrace_Current_Span: incomplete_test_app (current_span endpoint is not implemented)
+      Test_Parametric_DDTrace_Extract_Headers: incomplete_test_app (extract_headers endpoint is not implemented)
       # cpp tracer does not support the OpenTelemetry API, otel parametric endpoints are not implemented
       Test_Parametric_OtelSpan_End: missing_feature (otel api is not supported)
       Test_Parametric_OtelSpan_Events: missing_feature (otel api is not supported)
@@ -255,7 +255,7 @@ tests/:
   test_library_conf.py: irrelevant
   test_miscs.py: irrelevant
   test_scrubbing.py: irrelevant
-  test_span_events.py: missing_feature (Weblog `/add_event` not implemented)
+  test_span_events.py: incomplete_test_app (Weblog `/add_event` not implemented)
   test_standard_tags.py: irrelevant
   test_telemetry.py:
     Test_Log_Generation: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -422,15 +422,15 @@ tests/:
     test_otel_tracer.py:
       Test_Otel_Tracer: v2.8.0
     test_parametric_endpoints.py:
-      Test_Parametric_DDSpan_Add_Link: missing_feature (add_link parametric endpoint is not implemented)
+      Test_Parametric_DDSpan_Add_Link: incomplete_test_app (add_link parametric endpoint is not implemented)
       Test_Parametric_DDSpan_Set_Error: bug (APMAPI-778) # Set error endpoint does not set the error.type tag on spans
-      Test_Parametric_DDSpan_Set_Resource: missing_feature (set_resource parametric endpoint is not implemented)
-      Test_Parametric_DDTrace_Baggage: missing_feature (baggage endpoints are not implemented)
-      Test_Parametric_DDTrace_Current_Span: missing_feature (otel current span endpoint is not implemented)
+      Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource parametric endpoint is not implemented)
+      Test_Parametric_DDTrace_Baggage: incomplete_test_app (baggage endpoints are not implemented)
+      Test_Parametric_DDTrace_Current_Span: incomplete_test_app (current span endpoint is not implemented)
       Test_Parametric_OtelSpan_Is_Recording: bug (APMAPI-778) # parametric endpoint attempts to retrieve spans by the `id` instead of `span_id`
       Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778) # updates the operation name of the span not the resource name
-      Test_Parametric_Otel_Baggage: missing_feature (otel baggage endpoints are not implemented)
-      Test_Parametric_Otel_Current_Span: missing_feature (otel current span endpoint are not implemented)
+      Test_Parametric_Otel_Baggage: incomplete_test_app (otel baggage endpoints are not implemented)
+      Test_Parametric_Otel_Current_Span: incomplete_test_app (otel current span endpoint are not implemented)
     test_span_events.py: missing_feature
     test_span_links.py: missing_feature
     test_telemetry.py:
@@ -518,7 +518,7 @@ tests/:
     Test_UrlQuery: v2.13.0
   test_semantic_conventions.py:
     Test_MetricsStandardTags: v2.6.0
-  test_span_events.py: missing_feature (Weblog `/add_event` not implemented)
+  test_span_events.py: incomplete_test_app (Weblog `/add_event` not implemented)
   test_standard_tags.py:
     Test_StandardTagsClientIp: v2.26.0
     Test_StandardTagsMethod: v2.0.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -615,7 +615,7 @@ tests/:
     Test_UrlQuery: v1.40.0
   test_semantic_conventions.py:
     Test_Meta: v1.45.0
-  test_span_events.py: missing_feature (Weblog `/add_event` not implemented)
+  test_span_events.py: incomplete_test_app (Weblog `/add_event` not implemented)
   test_standard_tags.py:
     Test_StandardTagsClientIp: v1.46.0
     Test_StandardTagsMethod: v1.39.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1474,11 +1474,11 @@ tests/:
     test_otel_span_with_baggage.py:
       Test_Otel_Span_With_Baggage: missing_feature
     test_parametric_endpoints.py:
-      Test_Parametric_DDSpan_Add_Link: missing_feature (add_link endpoint is not implemented)
-      Test_Parametric_DDTrace_Baggage: missing_feature (baggage endpoints are not implemented)
+      Test_Parametric_DDSpan_Add_Link: incomplete_test_app (add_link endpoint is not implemented)
+      Test_Parametric_DDTrace_Baggage: incomplete_test_app (baggage endpoints are not implemented)
       Test_Parametric_DDTrace_Crash: bug (APMAPI-778) # The crash endpoint does not kill the application
       Test_Parametric_DDTrace_Current_Span: bug (APMAPI-778) # Fails to retreive the current span after a span has finished
-      Test_Parametric_Otel_Baggage: missing_feature (baggage is not supported)
+      Test_Parametric_Otel_Baggage: missing_feature (otel baggage is not supported)
       Test_Parametric_Otel_Current_Span: bug (APMAPI-778) # Current span endpoint does not return DataDog spans created by the otel api
     test_span_events.py: missing_feature
     test_span_links.py: missing_feature
@@ -1611,7 +1611,7 @@ tests/:
     Test_Meta:
       play: irrelevant (top span is akka-http-server)
     Test_MetricsStandardTags: v1.3.0
-  test_span_events.py: missing_feature (Weblog `/add_event` not implemented)
+  test_span_events.py: incomplete_test_app (Weblog `/add_event` not implemented)
   test_standard_tags.py:
     Test_StandardTagsClientIp:
       '*': v0.114.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -752,15 +752,15 @@ tests/:
     test_otel_span_with_baggage.py:
       Test_Otel_Span_With_Baggage: missing_feature
     test_parametric_endpoints.py:
-      Test_Parametric_DDSpan_Set_Resource: missing_feature (set_resource endpoint is not implemented)
+      Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not implemented)
       Test_Parametric_DDSpan_Start: bug (APMAPI-778) # The resource name of the child span is overidden by the parent span.
-      Test_Parametric_DDTrace_Baggage: missing_feature (baggage endpoints are not implemented)
-      Test_Parametric_DDTrace_Crash: missing_feature (crash endpoint is not implemented)
-      Test_Parametric_DDTrace_Current_Span: missing_feature (otel current_span endpoint is not supported)
+      Test_Parametric_DDTrace_Baggage: incomplete_test_app (baggage endpoints are not implemented)
+      Test_Parametric_DDTrace_Crash: incomplete_test_app (crash endpoint is not implemented)
+      Test_Parametric_DDTrace_Current_Span: incomplete_test_app (current_span endpoint is not supported)
       Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778) # set_name endpoint should set the resource name on a span (not the operation name)
       Test_Parametric_OtelSpan_Start: bug (APMAPI-778) # The expected span.kind tag is not set
       Test_Parametric_Otel_Baggage: missing_feature (baggage is not supported)
-      Test_Parametric_Otel_Current_Span: missing_feature (otel baggage endpoints are not implemented)
+      Test_Parametric_Otel_Current_Span: incomplete_test_app (otel current_span endpoint is not supported)
     test_partial_flushing.py:
       Test_Partial_Flushing: bug (APMLP-270)
     test_span_events.py: missing_feature
@@ -863,7 +863,7 @@ tests/:
       '*': *ref_3_13_1
       nextjs: missing_feature # nextjs makes some internal requests and we have different tag names
     Test_MetricsStandardTags: *ref_3_13_1
-  test_span_events.py: missing_feature (Weblog `/add_event` not implemented)
+  test_span_events.py: incomplete_test_app (Weblog `/add_event` not implemented)
   test_standard_tags.py:
     Test_StandardTagsClientIp:
       '*': *ref_3_6_0

--- a/manifests/parser/schema.json
+++ b/manifests/parser/schema.json
@@ -74,7 +74,7 @@
 
     "skipped_declaration": {
       "type": "string",
-      "pattern": "^(bug|flaky|irrelevant|missing_feature)( \\(.+\\))?$"
+      "pattern": "^(bug|flaky|irrelevant|missing_feature|incomplete_test_app)( \\(.+\\))?$"
     }
   }
 }

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -437,7 +437,7 @@ tests/:
     Test_UrlQuery: v0.76.0
   test_semantic_conventions.py:
     Test_MetricsStandardTags: v0.83.1
-  test_span_events.py: missing_feature (Weblog `/add_event` not implemented)
+  test_span_events.py: incomplete_test_app (Weblog `/add_event` not implemented)
   test_standard_tags.py:
     Test_StandardTagsMethod: v0.75.0
     Test_StandardTagsRoute: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -930,7 +930,7 @@ tests/:
   test_semantic_conventions.py:
     Test_Meta: v1.80.0
     Test_MetaDatadogTags: bug (APMAPI-735)
-  test_span_events.py: missing_feature (Weblog `/add_event` not implemented)
+  test_span_events.py: incomplete_test_app (Weblog `/add_event` not implemented)
   test_standard_tags.py:
     Test_StandardTagsClientIp: v2.7.0
     Test_StandardTagsMethod: v1.2.1

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -415,12 +415,12 @@ tests/:
     test_otel_span_with_baggage.py:
       Test_Otel_Span_With_Baggage: missing_feature
     test_parametric_endpoints.py:
-      Test_Parametric_DDSpan_Set_Resource: missing_feature (set_resource endpoint is not supported)
+      Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not supported)
       Test_Parametric_DDTrace_Baggage: missing_feature (baggage is not supported)
-      Test_Parametric_DDTrace_Current_Span: missing_feature (current span endpoint is not supported)
+      Test_Parametric_DDTrace_Current_Span: incomplete_test_app (current span endpoint is not supported)
       Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778) # set_name endpoint should set the resource name on a span (not the operation name)
       Test_Parametric_Otel_Baggage: missing_feature (otel baggage is not supported)
-      Test_Parametric_Otel_Current_Span: missing_feature (current span endpoint is not supported)
+      Test_Parametric_Otel_Current_Span: incomplete_test_app (otel current span endpoint is not supported)
     test_partial_flushing.py: # Not configurable in a standard way
       Test_Partial_Flushing: missing_feature
     test_sampling_delegation.py:


### PR DESCRIPTION
## Motivation

Follow up to: https://github.com/DataDog/system-tests/pull/3551.

Use incomplete_test_app to document scenarios where test apps are not up to spec. 

Note: `incomplete_test_app` does not mean a feature is supported. It only documents the state where test apps have clear gaps.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
