### PR TITLE
[Debugger] Check EMITTING probe status

### DIFF
--- a/tests/debugger/test_debugger_expression_language.py
+++ b/tests/debugger/test_debugger_expression_language.py
@@ -25,7 +25,7 @@ class Test_Debugger_Expression_Language(debugger._Base_Debugger_Test):
         self.collect()
 
         self.assert_rc_state_not_error()
-        self.assert_all_probes_are_installed()
+        self.assert_all_probes_are_emitting()
         self.assert_all_weblog_responses_ok(expected_response)
         self._validate_expression_language_messages(self.message_map)
 

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -134,7 +134,7 @@ class Test_Debugger_PII_Redaction(debugger._Base_Debugger_Test):
         self.collect()
         self.assert_setup_ok()
         self.assert_rc_state_not_error()
-        self.assert_all_probes_are_installed()
+        self.assert_all_probes_are_emitting()
         self.assert_all_weblog_responses_ok()
 
         self._validate_pii_keyword_redaction(redacted_keys, line_probe)

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -31,7 +31,7 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
         ### assert
         self.assert_setup_ok()
         self.assert_rc_state_not_error()
-        self.assert_all_probes_are_installed()
+        self.assert_all_probes_are_emitting()
         self.assert_all_weblog_responses_ok()
 
     def _validate_snapshots(self):

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -45,9 +45,7 @@ class Test_Debugger_Probe_Statuses(debugger._Base_Debugger_Test):
                 return f"Probe {expected_id} was not received."
 
             actual_status = self.probe_diagnostics[expected_id]["status"]
-            if actual_status != expected_status and not (
-                expected_status == "INSTALLED" and actual_status == "EMITTING"
-            ):
+            if actual_status != expected_status:
                 return f"Received probe {expected_id} with status {actual_status}. Expected {expected_status}"
 
             return None

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -446,7 +446,9 @@ class _Base_Debugger_Test:
         expected = self.probe_ids
         received = extract_probe_ids(self.probe_diagnostics)
 
-        assert set(expected) <= set(received), f"Not all probes were received. Missing ids: {', '.join(set(expected) - set(received))}"
+        assert set(expected) <= set(
+            received
+        ), f"Not all probes were received. Missing ids: {', '.join(set(expected) - set(received))}"
 
         errors = {}
         for probe_id in self.probe_ids:

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -8,8 +8,6 @@ import os
 import os.path
 import uuid
 
-from packaging import version
-
 from utils import interfaces, remote_config, weblog, context
 from utils.tools import logger
 from utils.dd_constants import RemoteConfigApplyState as ApplyState
@@ -177,18 +175,24 @@ class _Base_Debugger_Test:
             logger.debug(f"Waiting for these probes to be {status}: {self.probe_ids}")
 
             for expected_id in self.probe_ids:
-                if expected_id in probe_diagnostics:
-                    probe_status = probe_diagnostics[expected_id]["status"]
+                if expected_id not in probe_diagnostics:
+                    continue
 
-                    logger.debug(f"Probe {expected_id} observed status is {probe_status}")
-                    if probe_status == status or probe_status == "ERROR":
+                probe_status = probe_diagnostics[expected_id]["status"]
+                logger.debug(f"Probe {expected_id} observed status is {probe_status}")
+
+                if probe_status == status or probe_status == "ERROR":
+                    found_ids.add(expected_id)
+                    continue
+
+                if self.get_tracer()["language"] == "dotnet" and status == "INSTALLED":
+                    probe = next(p for p in self.probe_definitions if p["id"] == expected_id)
+                    # EMITTING is not implemented for dotnet span probe
+                    if probe["type"] == "SPAN_PROBE":
                         found_ids.add(expected_id)
+                        continue
 
-            if set(self.probe_ids).issubset(found_ids):
-                logger.debug(f"Success: all probes are {status}")
-                return True
-
-            return False
+            return set(self.probe_ids).issubset(found_ids)
 
         all_probes_ready = False
 
@@ -438,13 +442,28 @@ class _Base_Debugger_Test:
 
         assert not errors, "\n".join(errors)
 
-    def assert_all_probes_are_installed(self):
+    def assert_all_probes_are_emitting(self):
         expected = self.probe_ids
         received = extract_probe_ids(self.probe_diagnostics)
 
-        missing_probes = set(expected) - set(received)
-        if missing_probes:
-            assert not missing_probes, f"Not all probes are installed. Missing ids: {', '.join(missing_probes)}"
+        assert set(expected) <= set(received), f"Not all probes were received. Missing ids: {', '.join(set(expected) - set(received))}"
+
+        errors = {}
+        for probe_id in self.probe_ids:
+            status = self.probe_diagnostics[probe_id]["status"]
+
+            if status == "EMITTING":
+                continue
+
+            if self.get_tracer()["language"] == "dotnet" and status == "INSTALLED":
+                probe = next(p for p in self.probe_definitions if p["id"] == probe_id)
+                # EMITTING is not implemented for dotnet span probe
+                if probe["type"] == "SPAN_PROBE":
+                    continue
+
+            errors[probe_id] = status
+
+        assert not errors, f"The following probes are not emitting: {errors}"
 
     def assert_all_weblog_responses_ok(self, expected_code=200):
         assert len(self.weblog_responses) > 0, "No responses available."


### PR DESCRIPTION
## Motivation
Check for EMITTING status instead of INSTALLED

## Changes
Recently, I introduced a feature to wait for probes to reach the emitting status, but I never actually checked if the status was emitting. This PR adds the missing check.

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
