### PR TITLE
[Java] Disable automated login events V2 tests in preparation for V3

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1026,39 +1026,9 @@ tests/:
     test_automated_login_events.py:
       Test_Login_Events: irrelevant (was v1.36.0 but will be replaced by V2)
       Test_Login_Events_Extended: irrelevant (was v1.36.0 but will be replaced by V2)
-      Test_V2_Login_Events:
-        '*': v1.38.0
-        akka-http: missing_feature (login endpoints not implemented)
-        jersey-grizzly2: missing_feature (login endpoints not implemented)
-        play: missing_feature (login endpoints not implemented)
-        ratpack: missing_feature (login endpoints not implemented)
-        resteasy-netty3: missing_feature (login endpoints not implemented)
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-openliberty: missing_feature (weblog returns error 500)
-        vertx3: missing_feature (login endpoints not implemented)
-        vertx4: missing_feature (login endpoints not implemented)
-      Test_V2_Login_Events_Anon:
-        '*': v1.38.0
-        akka-http: missing_feature (login endpoints not implemented)
-        jersey-grizzly2: missing_feature (login endpoints not implemented)
-        play: missing_feature (login endpoints not implemented)
-        ratpack: missing_feature (login endpoints not implemented)
-        resteasy-netty3: missing_feature (login endpoints not implemented)
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-openliberty: missing_feature (weblog returns error 500)
-        vertx3: missing_feature (login endpoints not implemented)
-        vertx4: missing_feature (login endpoints not implemented)
-      Test_V2_Login_Events_RC:
-        '*': v1.38.0
-        akka-http: missing_feature (login endpoints not implemented)
-        jersey-grizzly2: missing_feature (login endpoints not implemented)
-        play: missing_feature (login endpoints not implemented)
-        ratpack: missing_feature (login endpoints not implemented)
-        resteasy-netty3: missing_feature (login endpoints not implemented)
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-openliberty: missing_feature (weblog returns error 500)
-        vertx3: missing_feature (login endpoints not implemented)
-        vertx4: missing_feature (login endpoints not implemented)
+      Test_V2_Login_Events: irrelevant (v1.38.0, replaced by V3)
+      Test_V2_Login_Events_Anon: irrelevant (v1.38.0, replaced by V3)
+      Test_V2_Login_Events_RC: irrelevant (v1.38.0, replaced by V3)
       Test_V3_Auto_User_Instrum_Mode_Capability:
         '*': missing_feature
         spring-boot-3-native: flaky (APMAPI-979)


### PR DESCRIPTION
## Motivation

In preparation for enabling V3 we have to disable V2 tests first, this is the first PR part of a three way merge:

1. First disable automated login events V2 tests (this PR)
2. Add support for for the V3 in the java tracer ([PR](https://github.com/DataDog/dd-trace-java/pull/8108))
3. Enable automated login events V3 tests ([PR](https://github.com/DataDog/system-tests/pull/3730))

## Changes

Disables automated login events V2 test suite.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
4. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
5. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
