### PR TITLE
use ASM_DATA instead of ASM_DD for blacklists

### DIFF
--- a/tests/appsec/test_automated_user_and_session_tracking.py
+++ b/tests/appsec/test_automated_user_and_session_tracking.py
@@ -98,6 +98,12 @@ BLOCK_USER = (
                 "on_match": ["block"],
             }
         ],
+    },
+)
+
+BLOCK_USER_DATA = (
+    "datadog/2/ASM_DATA/blocked_users/config",
+    {
         "rules_data": [
             {
                 "id": "blocked_users",
@@ -120,6 +126,7 @@ class Test_Automated_User_Blocking:
         self.r_login = weblog.post("/login?auth=local", data=login_data(context, USER, PASSWORD))
 
         self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER).apply()
+        self.config_state_3 = rc.rc_state.set_config(*BLOCK_USER_DATA).apply()
         self.r_home_blocked = weblog.get(
             "/",
             cookies=self.r_login.cookies,
@@ -130,6 +137,7 @@ class Test_Automated_User_Blocking:
         assert self.r_login.status_code == 200
 
         assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+        assert self.config_state_3[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
         interfaces.library.assert_waf_attack(self.r_home_blocked, rule="block-users")
         assert self.r_home_blocked.status_code == 403
 
@@ -138,6 +146,7 @@ class Test_Automated_User_Blocking:
 
         self.config_state_1 = rc.rc_state.set_config(*CONFIG_ENABLED).apply()
         self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER).apply()
+        self.config_state_3 = rc.rc_state.set_config(*BLOCK_USER_DATA).apply()
         self.r_login = weblog.post("/login?auth=local", data=login_data(context, UUID_USER, PASSWORD))
         self.r_login_blocked = weblog.post(
             "/login?auth=local&sdk_event=success&sdk_user=sdkUser", data=login_data(context, UUID_USER, PASSWORD)
@@ -146,6 +155,7 @@ class Test_Automated_User_Blocking:
     def test_user_blocking_sdk(self):
         assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
         assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+        assert self.config_state_3[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
 
         assert self.r_login.status_code == 200
 
@@ -173,6 +183,12 @@ BLOCK_SESSION = (
                 "on_match": ["block"],
             }
         ],
+    },
+)
+
+BLOCK_SESSION_DATA = (
+    "datadog/2/ASM_DATA/blocked_sessions/config",
+    {
         "rules_data": [
             {"id": "blocked_sessions", "type": "data_with_expiration", "data": []},
         ],
@@ -191,8 +207,9 @@ class Test_Automated_Session_Blocking:
         self.r_create_session = weblog.get("/session/new")
         self.session_id = self.r_create_session.text
 
-        BLOCK_SESSION[1]["rules_data"][0]["data"].append({"value": self.session_id, "expiration": 0})
+        BLOCK_SESSION_DATA[1]["rules_data"][0]["data"].append({"value": self.session_id, "expiration": 0})
         self.config_state_2 = rc.rc_state.set_config(*BLOCK_SESSION).apply()
+        self.config_state_3 = rc.rc_state.set_config(*BLOCK_SESSION_DATA).apply()
         self.r_home_blocked = weblog.get(
             "/",
             cookies=self.r_create_session.cookies,
@@ -203,5 +220,6 @@ class Test_Automated_Session_Blocking:
         assert self.r_create_session.status_code == 200
 
         assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+        assert self.config_state_3[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
         interfaces.library.assert_waf_attack(self.r_home_blocked, pattern=self.session_id, rule="block-sessions")
         assert self.r_home_blocked.status_code == 403


### PR DESCRIPTION
## Motivation

ASM_DD is not really supposed to support the `rules_data` field.

## Changes

Move the `rules_data` WAF blacklists in appsec RC tests, from the `ASM_DD` RC product to the `ASM_DATA` one.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
