### PR TITLE
[PHP] Enable SSRF tests 

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -205,17 +205,17 @@ tests/:
         Test_Sqli_UrlQuery: missing_feature
         Test_Sqli_Waf_Version:  v1.6.2
       test_ssrf.py:
-        Test_Ssrf_BodyJson: v1.6.3
-        Test_Ssrf_BodyUrlEncoded: v1.6.3
-        Test_Ssrf_BodyXml: v1.6.3
-        Test_Ssrf_Capability: v1.6.3
-        Test_Ssrf_Mandatory_SpanTags: v1.6.3
-        Test_Ssrf_Optional_SpanTags: v1.6.3
-        Test_Ssrf_Rules_Version:  v1.6.2
-        Test_Ssrf_StackTrace: v1.6.3
+        Test_Ssrf_BodyJson: v1.7.0
+        Test_Ssrf_BodyUrlEncoded: v1.7.0
+        Test_Ssrf_BodyXml: v1.7.0
+        Test_Ssrf_Capability: v1.7.0
+        Test_Ssrf_Mandatory_SpanTags: v1.7.0
+        Test_Ssrf_Optional_SpanTags: v1.7.0
+        Test_Ssrf_Rules_Version: v1.7.0
+        Test_Ssrf_StackTrace: v1.7.0
         Test_Ssrf_Telemetry: missing_feature
-        Test_Ssrf_UrlQuery: v1.6.3
-        Test_Ssrf_Waf_Version:  v1.6.2
+        Test_Ssrf_UrlQuery: v1.7.0
+        Test_Ssrf_Waf_Version: v1.7.0
     waf/:
       test_addresses.py:
         Test_BodyJson: v0.98.1 # TODO what is the earliest version?

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -205,16 +205,16 @@ tests/:
         Test_Sqli_UrlQuery: missing_feature
         Test_Sqli_Waf_Version:  v1.6.2
       test_ssrf.py:
-        Test_Ssrf_BodyJson: missing_feature
-        Test_Ssrf_BodyUrlEncoded: missing_feature
-        Test_Ssrf_BodyXml: missing_feature
-        Test_Ssrf_Capability: missing_feature
-        Test_Ssrf_Mandatory_SpanTags: missing_feature
-        Test_Ssrf_Optional_SpanTags: missing_feature
+        Test_Ssrf_BodyJson: v1.6.3
+        Test_Ssrf_BodyUrlEncoded: v1.6.3
+        Test_Ssrf_BodyXml: v1.6.3
+        Test_Ssrf_Capability: v1.6.3
+        Test_Ssrf_Mandatory_SpanTags: v1.6.3
+        Test_Ssrf_Optional_SpanTags: v1.6.3
         Test_Ssrf_Rules_Version:  v1.6.2
-        Test_Ssrf_StackTrace: missing_feature
+        Test_Ssrf_StackTrace: v1.6.3
         Test_Ssrf_Telemetry: missing_feature
-        Test_Ssrf_UrlQuery: missing_feature
+        Test_Ssrf_UrlQuery: v1.6.3
         Test_Ssrf_Waf_Version:  v1.6.2
     waf/:
       test_addresses.py:

--- a/utils/build/docker/php/common/php.ini
+++ b/utils/build/docker/php/common/php.ini
@@ -10,6 +10,7 @@ extension=mysqli.so
 extension=pdo.so
 extension=pdo_mysql.so
 extension=pdo_pgsql.so
+extension=simplexml.so
 error_log=/var/log/system-tests/php_error.log
 error_reporting=2147483647
 display_errors=0

--- a/utils/build/docker/php/common/rasp/ssrf.php
+++ b/utils/build/docker/php/common/rasp/ssrf.php
@@ -1,1 +1,23 @@
-<?php echo "Hello, SSRF!";
+<?php
+
+$domain = null;
+$contentType = $_SERVER['CONTENT_TYPE'] ?? "";
+switch ($contentType) {
+	case 'application/json':
+		$body = file_get_contents("php://input");
+		$decoded = json_decode($body, 1);
+		$domain = $decoded["domain"];
+		break;
+	case 'application/xml':
+		$body = file_get_contents("php://input");
+		$decoded = simplexml_load_string(stripslashes($body));
+		$domain = (string)$decoded[0];
+		break;
+	default:
+		$domain = urldecode($_REQUEST["domain"]);
+		break;
+}
+
+file_get_contents('http://'.$domain);
+
+echo "Hello, SSRF!";


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
