### PR TITLE
[parametric] add remote config tests with empty `DD_SERVICE` or `DD_ENV`

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -154,6 +154,8 @@ tests/:
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v1.1.0
     test_crashtracking.py: missing_feature
+    test_dynamic_configuration.py:
+      TestDynamicConfigV1_EmptyServiceTargets: missing_feature
     test_headers_b3multi.py:
       Test_Headers_B3multi: missing_feature (parametric app does not support trace/span/extract endpoint)
     test_headers_baggage.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -417,6 +417,7 @@ tests/:
       TestDynamicConfigSamplingRules: v2.53.2
       TestDynamicConfigTracingEnabled: v2.49.0
       TestDynamicConfigV1: v2.33.0
+      TestDynamicConfigV1_EmptyServiceTargets: v2.33.0
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: v2.44.0
     test_headers_baggage.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -521,6 +521,7 @@ tests/:
       TestDynamicConfigSamplingRules: v1.64.0
       TestDynamicConfigTracingEnabled: v1.61.0
       TestDynamicConfigV1: v1.59.0
+      TestDynamicConfigV1_EmptyServiceTargets: missing_feature
       TestDynamicConfigV1_ServiceTargets: v1.59.0
       TestDynamicConfigV2: v1.59.0
     test_headers_baggage.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1596,6 +1596,7 @@ tests/:
       TestDynamicConfigSamplingRules: v1.34.0
       TestDynamicConfigTracingEnabled: v1.32.0
       TestDynamicConfigV1: v1.17.0
+      TestDynamicConfigV1_EmptyServiceTargets: missing_feature
       TestDynamicConfigV1_ServiceTargets: v1.31.0
       TestDynamicConfigV2: v1.31.0
     test_headers_baggage.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -752,6 +752,7 @@ tests/:
       TestDynamicConfigSamplingRules: *ref_5_16_0
       TestDynamicConfigTracingEnabled: *ref_5_4_0
       TestDynamicConfigV1: *ref_4_11_0
+      TestDynamicConfigV1_EmptyServiceTargets: *ref_5_4_0
       TestDynamicConfigV1_ServiceTargets: *ref_5_4_0
       TestDynamicConfigV2: *ref_4_23_0
     test_headers_baggage.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -331,6 +331,7 @@ tests/:
       TestDynamicConfigSamplingRules: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: missing_feature
+      TestDynamicConfigV1_EmptyServiceTargets: v1.5.1 # version unknown
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_headers_baggage.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -331,7 +331,7 @@ tests/:
       TestDynamicConfigSamplingRules: missing_feature
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: missing_feature
-      TestDynamicConfigV1_EmptyServiceTargets: v1.5.1 # version unknown
+      TestDynamicConfigV1_EmptyServiceTargets: v1.4.0
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_headers_baggage.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -785,6 +785,7 @@ tests/:
       TestDynamicConfigSamplingRules: v2.9.0
       TestDynamicConfigTracingEnabled: flaky (APMAPI-734)
       TestDynamicConfigV1: missing_feature (failure 2.8.0)
+      TestDynamicConfigV1_EmptyServiceTargets: v2.18.1 # version unknown
       TestDynamicConfigV1_ServiceTargets: missing_feature (failure 2.8.0)
       TestDynamicConfigV2: flaky (APMAPI-734)
     test_headers_b3.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -410,6 +410,7 @@ tests/:
       TestDynamicConfigSamplingRules: v2.0.0
       TestDynamicConfigTracingEnabled: missing_feature
       TestDynamicConfigV1: bug (APMAPI-867)  # theorical version is v1.13.0
+      TestDynamicConfigV1_EmptyServiceTargets: v2.8.0 # version unknown
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_headers_baggage.py:


### PR DESCRIPTION
## Motivation

Some tracing libraries added checks for matching `service` and `env` in remote config payloads. For example, https://github.com/DataDog/dd-trace-java/pull/6636/. This causes issues in scenarios like SSI where the `env` (aka `DD_ENV`) is configured in the agent, but not on the tracer. The Java tracer is rejecting remote sampling rules in SSI, which prevents Adaptive Sampling from working correctly.

See also [APM_TRACING matching & SSI](https://docs.google.com/document/d/1lcrWRvd3n7Yxa-GiFq7GV1le2a43nfAvw5Iah1ACHzI/) 🔒

## Changes

Add a new test that asserts that the tracing library accepts a remote config payload without checking for matching `service` or `env`, since that is already handled by the agent.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
