### PR TITLE
[python] add support for SHi and CMDi tests for python

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -245,17 +245,17 @@ tests/:
           TestURI: missing_feature
     rasp/:
       test_cmdi.py:
-        Test_Cmdi_BodyJson: missing_feature
-        Test_Cmdi_BodyUrlEncoded: missing_feature
-        Test_Cmdi_BodyXml: missing_feature
-        Test_Cmdi_Capability: missing_feature
-        Test_Cmdi_Mandatory_SpanTags: missing_feature
-        Test_Cmdi_Optional_SpanTags: missing_feature
+        Test_Cmdi_BodyJson: v2.20.0.dev
+        Test_Cmdi_BodyUrlEncoded: v2.20.0.dev
+        Test_Cmdi_BodyXml: v2.20.0.dev
+        Test_Cmdi_Capability: v2.20.0.dev
+        Test_Cmdi_Mandatory_SpanTags: v2.20.0.dev
+        Test_Cmdi_Optional_SpanTags: v2.20.0.dev
         Test_Cmdi_Rules_Version: v2.18.0.dev
-        Test_Cmdi_StackTrace: missing_feature
-        Test_Cmdi_Telemetry: missing_feature
+        Test_Cmdi_StackTrace: v2.20.0.dev
+        Test_Cmdi_Telemetry: v2.20.0.dev
         Test_Cmdi_Telemetry_Variant_Tag: missing_feature
-        Test_Cmdi_UrlQuery: missing_feature
+        Test_Cmdi_UrlQuery: v2.20.0.dev
         Test_Cmdi_Waf_Version: v2.18.0.dev
       test_lfi.py:
         Test_Lfi_BodyJson: v2.10.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -254,7 +254,7 @@ tests/:
         Test_Cmdi_Rules_Version: v2.18.0.dev
         Test_Cmdi_StackTrace: v2.20.0.dev
         Test_Cmdi_Telemetry: v2.20.0.dev
-        Test_Cmdi_Telemetry_Variant_Tag: missing_feature
+        Test_Cmdi_Telemetry_Variant_Tag: v2.20.0.dev
         Test_Cmdi_UrlQuery: v2.20.0.dev
         Test_Cmdi_Waf_Version: v2.18.0.dev
       test_lfi.py:
@@ -280,7 +280,7 @@ tests/:
         Test_Shi_Rules_Version: v2.15.0
         Test_Shi_StackTrace: v2.11.0-rc2
         Test_Shi_Telemetry: v2.11.0-rc2
-        Test_Shi_Telemetry_Variant_Tag: missing_feature
+        Test_Shi_Telemetry_Variant_Tag: v2.20.0.dev
         Test_Shi_UrlQuery: v2.11.0-rc2
         Test_Shi_Waf_Version: v2.15.0
       test_sqli.py:

--- a/tests/appsec/rasp/test_cmdi.py
+++ b/tests/appsec/rasp/test_cmdi.py
@@ -24,7 +24,7 @@ class Test_Cmdi_UrlQuery:
         self.r = weblog.get("/rasp/cmdi", params={"command": "/usr/bin/touch /tmp/passwd"})
 
     def test_cmdi_get(self):
-        # assert self.r.status_code == 403
+        assert self.r.status_code == 403
 
         interfaces.library.assert_rasp_attack(
             self.r,

--- a/tests/appsec/rasp/test_cmdi.py
+++ b/tests/appsec/rasp/test_cmdi.py
@@ -24,7 +24,7 @@ class Test_Cmdi_UrlQuery:
         self.r = weblog.get("/rasp/cmdi", params={"command": "/usr/bin/touch /tmp/passwd"})
 
     def test_cmdi_get(self):
-        assert self.r.status_code == 403
+        # assert self.r.status_code == 403
 
         interfaces.library.assert_rasp_attack(
             self.r,

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -257,6 +257,32 @@ def rasp_shi(request, *args, **kwargs):
         return HttpResponse(f"Shell command failure: {e!r}", status=201)
 
 
+@csrf_exempt
+def rasp_cmdi(request, *args, **kwargs):
+    cmd = None
+    if request.method == "GET":
+        cmd = request.GET.get("command")
+    elif request.method == "POST":
+        try:
+            cmd = (request.POST or json.loads(request.body)).get("command")
+        except Exception as e:
+            print(repr(e), file=sys.stderr)
+        try:
+            if cmd is None:
+                cmd = xmltodict.parse(request.body).get("command").get("cmd")
+        except Exception as e:
+            print(repr(e), file=sys.stderr)
+            pass
+
+    if cmd is None:
+        return HttpResponse("missing command parameter", status=400)
+    try:
+        res = subprocess.run(cmd, capture_output=True)
+        return HttpResponse(f"Exec command [{cmd}] with result: {res}")
+    except Exception as e:
+        return HttpResponse(f"Shell command [{cmd}] failure: {e!r}", status=201)
+
+
 ### END EXPLOIT PREVENTION
 
 
@@ -853,6 +879,7 @@ urlpatterns = [
     path("returnheaders", return_headers),
     path("returnheaders/", return_headers),
     path("set_cookie", set_cookie),
+    path("rasp/cmdi", rasp_cmdi),
     path("rasp/lfi", rasp_lfi),
     path("rasp/shi", rasp_shi),
     path("rasp/sqli", rasp_sqli),

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -367,7 +367,7 @@ def rasp_cmdi(*args, **kwargs):
             print(repr(e), file=sys.stderr)
         try:
             if cmd is None:
-                cmd = xmltodict.parse(flask_request.data).get("command")
+                cmd = xmltodict.parse(flask_request.data).get("command").get("cmd")
         except Exception as e:
             print(repr(e), file=sys.stderr)
             pass
@@ -378,8 +378,7 @@ def rasp_cmdi(*args, **kwargs):
         res = subprocess.run(cmd, capture_output=True)
         return f"Exec command [{cmd}] with result: [{res.returncode}]: {res.stdout}", 200
     except Exception as e:
-        print(f"Exec command failure: {e!r}", file=sys.stderr)
-        return f"Exec command failure: {e!r}", 201
+        return f"Exec command [{cmd}] yfailure: {e!r}", 201
 
 
 ### END EXPLOIT PREVENTION

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -345,7 +345,7 @@ def rasp_shi(*args, **kwargs):
             pass
 
     if list_dir is None:
-        return "missing user_id parameter", 400
+        return "missing list_dir parameter", 400
     try:
         command = f"ls {list_dir}"
         res = os.system(command)
@@ -353,6 +353,33 @@ def rasp_shi(*args, **kwargs):
     except Exception as e:
         print(f"Shell command failure: {e!r}", file=sys.stderr)
         return f"Shell command failure: {e!r}", 201
+
+
+@app.route("/rasp/cmdi", methods=["GET", "POST"])
+def rasp_cmdi(*args, **kwargs):
+    cmd = None
+    if request.method == "GET":
+        cmd = flask_request.args.get("command")
+    elif request.method == "POST":
+        try:
+            cmd = (request.form or request.json or {}).get("command")
+        except Exception as e:
+            print(repr(e), file=sys.stderr)
+        try:
+            if cmd is None:
+                cmd = xmltodict.parse(flask_request.data).get("command")
+        except Exception as e:
+            print(repr(e), file=sys.stderr)
+            pass
+
+    if cmd is None:
+        return "missing cmd parameter", 400
+    try:
+        res = subprocess.run(cmd, capture_output=True)
+        return f"Exec command [{cmd}] with result: [{res.returncode}]: {res.stdout}", 200
+    except Exception as e:
+        print(f"Exec command failure: {e!r}", file=sys.stderr)
+        return f"Exec command failure: {e!r}", 201
 
 
 ### END EXPLOIT PREVENTION

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -452,7 +452,7 @@ class LibraryInterfaceValidator(ProxyBasedInterfaceValidator):
 
             trigger = triggers[0]
             obtained_rule_id = trigger["rule"]["id"]
-            assert obtained_rule_id == rule, f"incorrect rule id, expected {rule}"
+            assert obtained_rule_id == rule, f"incorrect rule id, expected {rule}, got {obtained_rule_id}"
 
             if parameters is not None:
                 rule_matches = trigger["rule_matches"]


### PR DESCRIPTION
APPSEC-56275

Once https://github.com/DataDog/dd-trace-py/pull/11870 merged, this PR will enable all missing tests for Exploit Prevention for python


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
