### PR TITLE
[Java] Enable session fingerprinting tests in vertx

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1322,8 +1322,8 @@ tests/:
         spring-boot-jetty: missing_feature (missing addresses)
         spring-boot-undertow: missing_feature (missing addresses)
         spring-boot-wildfly: missing_feature (missing addresses)
-        vertx3: missing_feature (endpoint not implemented)
-        vertx4: missing_feature (endpoint not implemented)
+        vertx3: v1.46.0
+        vertx4: v1.46.0
       Test_Fingerprinting_Session_Capability:
         '*': v1.40.0
         spring-boot-3-native: irrelevant (GraalVM. Tracing support only)

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
@@ -7,6 +7,7 @@ import com.datadoghq.vertx3.iast.routes.IastSinkRouteProvider;
 import com.datadoghq.vertx3.iast.routes.IastSourceRouteProvider;
 import com.datadoghq.vertx3.rasp.RaspRouteProvider;
 import datadog.appsec.api.blocking.Blocking;
+import datadog.trace.api.EventTracker;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
@@ -14,6 +15,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.http.HttpClient;
@@ -24,6 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.http.HttpResponse;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -36,6 +40,9 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
+import io.vertx.ext.web.handler.CookieHandler;
+import io.vertx.ext.web.handler.SessionHandler;
+import io.vertx.ext.web.sstore.LocalSessionStore;
 import okhttp3.*;
 
 public class Main {
@@ -241,6 +248,24 @@ public class Main {
                     setRootSpanTag("service", serviceName);
                     ctx.response().end("ok");
                 });
+        Router sessionRouter = Router.router(vertx);
+        sessionRouter.get().handler(CookieHandler.create());
+        sessionRouter.get().handler(SessionHandler.create(LocalSessionStore.create(vertx)));
+        sessionRouter.get("/new")
+                .handler(ctx -> {
+                    final Session session = ctx.session();
+                    ctx.response().end(session.id());
+                });
+        sessionRouter.get("/user")
+                .handler(ctx -> {
+                    final Session session = ctx.session();
+                    final String sdkUser = ctx.request().getParam("sdk_user");
+                    EventTracker tracker = datadog.trace.api.GlobalTracer.getEventTracker();
+                    tracker.trackLoginSuccessEvent(sdkUser, Collections.emptyMap());
+                    ctx.response().end(session.id());
+                });
+        router.mountSubRouter("/session", sessionRouter);
+
 
         iastRouteProviders().forEach(provider -> provider.accept(router));
         raspRouteProviders().forEach(provider -> provider.accept(router));

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
@@ -7,6 +7,7 @@ import com.datadoghq.vertx4.iast.routes.IastSinkRouteProvider;
 import com.datadoghq.vertx4.iast.routes.IastSourceRouteProvider;
 import com.datadoghq.vertx4.rasp.RaspRouteProvider;
 import datadog.appsec.api.blocking.Blocking;
+import datadog.trace.api.EventTracker;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
@@ -14,6 +15,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.http.HttpClient;
@@ -23,6 +25,7 @@ import javax.sql.DataSource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -35,6 +38,8 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
+import io.vertx.ext.web.handler.SessionHandler;
+import io.vertx.ext.web.sstore.LocalSessionStore;
 import okhttp3.*;
 
 public class Main {
@@ -240,6 +245,23 @@ public class Main {
                     setRootSpanTag("service", serviceName);
                     ctx.response().end("ok");
                 });
+
+        Router sessionRouter = Router.router(vertx);
+        sessionRouter.get().handler(SessionHandler.create(LocalSessionStore.create(vertx)));
+        sessionRouter.get("/new")
+                .handler(ctx -> {
+                    final Session session = ctx.session();
+                    ctx.response().end(session.id());
+                });
+        sessionRouter.get("/user")
+                .handler(ctx -> {
+                    final Session session = ctx.session();
+                    final String sdkUser = ctx.request().getParam("sdk_user");
+                    EventTracker tracker = datadog.trace.api.GlobalTracer.getEventTracker();
+                    tracker.trackLoginSuccessEvent(sdkUser, Collections.emptyMap());
+                    ctx.response().end(session.id());
+                });
+        router.get("/session/*").subRouter(sessionRouter);
 
         iastRouteProviders().forEach(provider -> provider.accept(router));
         raspRouteProviders().forEach(provider -> provider.accept(router));


### PR DESCRIPTION
## Motivation

Test session tracking support in Vert.x 3.x and 4.x

## Changes

Add required endpoints to weblogs and enable tests in the manifest.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
