### PR TITLE
[java] Activate new batch of easy wins

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1062,7 +1062,6 @@ tests/:
         ratpack: missing_feature (login endpoints not implemented)
         resteasy-netty3: missing_feature (login endpoints not implemented)
         spring-boot-3-native: flaky (APMAPI-979)
-        spring-boot-openliberty: missing_feature (weblog returns error 500)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)
     test_automated_user_and_session_tracking.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1051,7 +1051,6 @@ tests/:
         ratpack: missing_feature (login endpoints not implemented)
         resteasy-netty3: missing_feature (login endpoints not implemented)
         spring-boot-3-native: flaky (APMAPI-979)
-        spring-boot-openliberty: missing_feature (weblog returns error 500)
         spring-boot-payara: bug (APPSEC-54985)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1031,7 +1031,6 @@ tests/:
         ratpack: missing_feature (login endpoints not implemented)
         resteasy-netty3: missing_feature (login endpoints not implemented)
         spring-boot-3-native: flaky (APMAPI-979)
-        spring-boot-openliberty: missing_feature (weblog returns error 500)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)
       Test_V3_Login_Events_Anon:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1075,7 +1075,6 @@ tests/:
         ratpack: missing_feature (login endpoints not implemented)
         resteasy-netty3: missing_feature (login endpoints not implemented)
         spring-boot-3-native: flaky (APMAPI-979)
-        spring-boot-openliberty: missing_feature (weblog returns error 500)
         spring-boot-payara: bug (APPSEC-54985)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1086,7 +1086,6 @@ tests/:
         ratpack: missing_feature (login endpoints not implemented)
         resteasy-netty3: missing_feature (login endpoints not implemented)
         spring-boot-3-native: flaky (APMAPI-979)
-        spring-boot-openliberty: missing_feature (weblog returns error 500)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)
     test_blocking_addresses.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1041,7 +1041,6 @@ tests/:
         ratpack: missing_feature (login endpoints not implemented)
         resteasy-netty3: missing_feature (login endpoints not implemented)
         spring-boot-3-native: flaky (APMAPI-979)
-        spring-boot-openliberty: missing_feature (weblog returns error 500)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)
       Test_V3_Login_Events_Blocking:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1012,15 +1012,8 @@ tests/:
         '*': v1.36.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_SCAStandalone_Telemetry:
-        '*': v1.45.0
-        akka-http: missing_feature (endpoints not implemented)
-        jersey-grizzly2: missing_feature (endpoints not implemented)
-        play: missing_feature (endpoints not implemented)
-        ratpack: missing_feature (endpoints not implemented)
-        resteasy-netty3: missing_feature (endpoints not implemented)
+        '*': v1.36.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        vertx3: missing_feature (endpoints not implemented)
-        vertx4: missing_feature (endpoints not implemented)
     test_automated_login_events.py:
       Test_Login_Events: irrelevant (was v1.36.0 but will be replaced by V2)
       Test_Login_Events_Extended: irrelevant (was v1.36.0 but will be replaced by V2)

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -716,6 +716,7 @@ class Test_SCAStandalone_Telemetry:
     @missing_feature(context.weblog_variant == "vertx4", reason="missing_feature (endpoint not implemented)")
     @missing_feature(context.weblog_variant == "akka-http", reason="missing_feature (endpoint not implemented)")
     @missing_feature(context.weblog_variant == "ratpack", reason="missing_feature (endpoint not implemented)")
+    @missing_feature(context.weblog_variant == "play", reason="missing_feature (endpoint not implemented)")
     @missing_feature(context.weblog_variant == "vertx3", reason="missing_feature (endpoint not implemented)")
     @missing_feature(context.weblog_variant == "jersey-grizzly2", reason="missing_feature (endpoint not implemented)")
     def test_app_dependencies_loaded(self):

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -713,6 +713,11 @@ class Test_SCAStandalone_Telemetry:
         self.r = weblog.get("/load_dependency")
 
     @missing_feature(context.library == "nodejs" and context.weblog_variant == "nextjs")
+    @missing_feature(context.weblog_variant == "vertx4", reason="missing_feature (endpoint not implemented)")
+    @missing_feature(context.weblog_variant == "akka-http", reason="missing_feature (endpoint not implemented)")
+    @missing_feature(context.weblog_variant == "ratpack", reason="missing_feature (endpoint not implemented)")
+    @missing_feature(context.weblog_variant == "vertx3", reason="missing_feature (endpoint not implemented)")
+    @missing_feature(context.weblog_variant == "jersey-grizzly2", reason="missing_feature (endpoint not implemented)")
     def test_app_dependencies_loaded(self):
         self.assert_standalone_is_enabled(self.r)
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

We want to increase our percentage of easy wins in Java.

## Changes

<!-- A brief description of the change being made with this pull request. -->

We have activated some easy wins for the following tests:
- `tests/appsec/test_asm_standalone.py::Test_SCAStandalone_Telemetry`
- `tests/appsec/test_automated_login_events.py::Test_V3_Login_Events`
- `tests/appsec/test_automated_login_events.py::Test_V3_Login_Events_Anon`
- `tests/appsec/test_automated_login_events.py::Test_V3_Login_Events_Blocking`
- `tests/appsec/test_automated_login_events.py::Test_V3_Login_Events_RC`
- `tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_User_Blocking`
- `tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_User_Tracking`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
* [x] A scenario is added (or removed)?
    * [x] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
