### PR TITLE
Add test to check absence of client computed stats

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -113,6 +113,9 @@ jobs:
     - name: Run APPSEC_STANDALONE_V2 scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"APPSEC_STANDALONE_V2"')
       run: ./run.sh APPSEC_STANDALONE_V2
+    - name: Run APPSEC_NO_STATS scenario
+      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"APPSEC_NO_STATS"')
+      run: ./run.sh APPSEC_NO_STATS
     - name: Run IAST_STANDALONE scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"IAST_STANDALONE"')
       run: ./run.sh IAST_STANDALONE

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -263,6 +263,7 @@ tests/:
       test_telemetry.py:
         Test_TelemetryMetrics: missing_feature
     test_asm_standalone.py:
+      Test_AppSecStandalone_NotEnabled: v1.6.2
       Test_AppSecStandalone_UpstreamPropagation: v1.6.0
       Test_AppSecStandalone_UpstreamPropagation_V2: missing_feature
       Test_IastStandalone_UpstreamPropagation: missing_feature

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -742,6 +742,30 @@ class SCAStandalone_Telemetry_Base:
 
 @rfc("https://docs.google.com/document/d/12NBx-nD-IoQEMiCRnJXneq4Be7cbtSc6pJLOFUWTpNE/edit")
 @features.appsec_standalone
+@scenarios.appsec_no_stats
+class Test_AppSecStandalone_NotEnabled:
+    """Test expected behaviour when standalone is not enabled."""
+
+    def setup_client_computed_stats_header_is_not_present(self):
+        trace_id = 1212121212121212122
+        self.r = weblog.get(
+            "/",
+            headers={
+                "x-datadog-trace-id": str(trace_id),
+            },
+        )
+
+    def test_client_computed_stats_header_is_not_present(self):
+        spans_checked = 0
+        for data, _, span in interfaces.library.get_spans(request=self.r):
+            assert span["trace_id"] == 1212121212121212122
+            assert "datadog-client-computed-stats" not in [x.lower() for x, y in data["request"]["headers"]]
+            spans_checked += 1
+        assert spans_checked == 1
+
+
+@rfc("https://docs.google.com/document/d/12NBx-nD-IoQEMiCRnJXneq4Be7cbtSc6pJLOFUWTpNE/edit")
+@features.appsec_standalone
 @scenarios.appsec_standalone
 class Test_AppSecStandalone_UpstreamPropagation(AppSecStandalone_UpstreamPropagation_Base):
     """APPSEC correctly propagates AppSec events in distributing tracing with DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED=true."""

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -748,10 +748,12 @@ class Test_AppSecStandalone_NotEnabled:
 
     def setup_client_computed_stats_header_is_not_present(self):
         trace_id = 1212121212121212122
+        parent_id = 34343434
         self.r = weblog.get(
             "/",
             headers={
                 "x-datadog-trace-id": str(trace_id),
+                "x-datadog-parent-id": str(parent_id),
             },
         )
 

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -64,6 +64,12 @@ class _Scenarios:
 
     profiling = ProfilingScenario("PROFILING")
 
+    asm_e2e = EndToEndScenario(
+        "End to end testing with default values",
+        doc="End to end testing with default values",
+        scenario_groups=[ScenarioGroup.APPSEC],
+    )
+
     sampling = EndToEndScenario(
         "SAMPLING",
         tracer_sampling_rate=0.5,

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -66,7 +66,10 @@ class _Scenarios:
 
     asm_e2e = EndToEndScenario(
         "End to end testing with default values",
-        doc="End to end testing with default values",
+        doc=(
+            "End to end testing with default values. Default scenario has DD_TRACE_COMPUTE_STATS=true."
+            "This scenario let that env to use its default"
+        ),
         scenario_groups=[ScenarioGroup.APPSEC],
     )
 

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -64,8 +64,8 @@ class _Scenarios:
 
     profiling = ProfilingScenario("PROFILING")
 
-    asm_e2e = EndToEndScenario(
-        "End to end testing with default values",
+    appsec_no_stats = EndToEndScenario(
+        "End to end tests with default value of DD_TRACE_COMPUTE_STATS",
         doc=(
             "End to end testing with default values. Default scenario has DD_TRACE_COMPUTE_STATS=true."
             "This scenario let that env to use its default"


### PR DESCRIPTION
## Motivation

The added test is a regression test which caused a incident on PHP. When ASM Standalone was implemented, it was required to send the header `Datadog-Client-Computed-Stats` as `yes` when it was a ASM Standalone request. However the way it was implemented in PHP was to add the header `Datadog-Client-Computed-Stats` always. Then the value  of the header was `yes` when it was a ASM Standalone request and `no` when not. This was generating the agent to never compute stats as it was interpreting the value `no` as if it was `yes`.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
