### PR TITLE
[python] deactivate v2 ATO tests

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -459,9 +459,9 @@ tests/:
     test_automated_login_events.py:
       Test_Login_Events: irrelevant (was v2.10.0 but will be replaced by V2)
       Test_Login_Events_Extended: irrelevant (was v2.10.0 but will be replaced by V2)
-      Test_V2_Login_Events: v2.11.0
-      Test_V2_Login_Events_Anon: v2.11.0
-      Test_V2_Login_Events_RC: v2.11.0
+      Test_V2_Login_Events: irrelevant (was v2.11.0 but will be replaced by V3)
+      Test_V2_Login_Events_Anon: irrelevant (was v2.11.0 but will be replaced by V3)
+      Test_V2_Login_Events_RC: irrelevant (was v2.11.0 but will be replaced by V3)
       Test_V3_Auto_User_Instrum_Mode_Capability: v2.11.0
       Test_V3_Login_Events: missing_feature
       Test_V3_Login_Events_Anon: missing_feature


### PR DESCRIPTION
## Motivation

Support for V3 (last RFC) will be merged soon in dd-trace-py.
As those changes are incompatible with V2 tests, V2 tests need to be disabled first.
V3 tests will be enabled after that.

APPPSEC-56315

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
