### PR TITLE
Fix @irrelevant example in test template

### DIFF
--- a/docs/architecture/test_template.py
+++ b/docs/architecture/test_template.py
@@ -13,7 +13,7 @@ from utils import weblog, interfaces
 #  - Skip for an entire library:
 #       @irrelevant(context.library != "java", reason="*ATTENTION*: The reason the language is skipped")
 #  - Skip for every library except one
-#       @irrelevant(context.library = "dotnet", reason="only for .NET")
+#       @irrelevant(context.library == "dotnet", reason="only for .NET")
 
 
 # To run an individual test: ./run.sh tests/test_traces.py::Test_Misc::test_main


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

The `@irrelevant` example in the test template uses a single `=` for comparison, where it should should two (`==`) - at least that's what I think. Please correct me if I'm wrong 😅 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
