### PR TITLE
[nodejs] Enable DI line probe snapshot tests

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -630,7 +630,9 @@ tests/:
         "*": irrelevant
         express4: v5.32.0
     test_debugger_probe_snapshot.py:
-      Test_Debugger_Probe_Snaphots: missing_feature (feature not implented)
+      Test_Debugger_Probe_Snaphots:
+        "*": irrelevant
+        express4: v5.32.0
     test_debugger_probe_status.py:
       Test_Debugger_Probe_Statuses:
         "*": irrelevant

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -49,6 +49,7 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
     def setup_log_method_probe_snaphots(self):
         self._setup("probe_snapshot_log_method", "/debugger/log")
 
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented")
     def test_log_method_probe_snaphots(self):
         self._assert()
         self._validate_snapshots()
@@ -58,6 +59,7 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
         self._setup("probe_snapshot_span_method", "/debugger/span")
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented")
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented")
     def test_span_method_probe_snaphots(self):
         self._assert()
         self._validate_spans()
@@ -67,6 +69,7 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
         self._setup("probe_snapshot_span_decoration_method", "/debugger/span-decoration/asd/1")
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented")
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented")
     def test_span_decoration_method_probe_snaphots(self):
         self._assert()
         self._validate_spans()
@@ -85,6 +88,7 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
         self._setup("probe_snapshot_span_decoration_line", "/debugger/span-decoration/asd/1")
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented")
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented")
     def test_span_decoration_line_probe_snaphots(self):
         self._assert()
         self._validate_spans()
@@ -94,6 +98,7 @@ class Test_Debugger_Probe_Snaphots(debugger._Base_Debugger_Test):
     def setup_mix_probe(self):
         self._setup("probe_snapshot_log_mixed", "/debugger/mix/asd/1")
 
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented")
     def test_mix_probe(self):
         self._assert()
         self._validate_snapshots()


### PR DESCRIPTION
## Motivation

More test coverage.

## Changes

Enable the `express4` Node.js tests for `Test_Debugger_Probe_Snaphots` (Dynamic Instrumentation)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
