### PR TITLE
Remove env token from DI PII lists in each tracer app

### DIFF
--- a/utils/build/docker/dotnet/weblog/Models/Debugger/Pii.cs
+++ b/utils/build/docker/dotnet/weblog/Models/Debugger/Pii.cs
@@ -42,7 +42,6 @@ namespace weblog.Models.Debugger
         public string? dburl { get; set; } = PiiBase.Value;
         public string? encryptionkey { get; set; } = PiiBase.Value;
         public string? encryptionkeyid { get; set; } = PiiBase.Value;
-        public string? env { get; set; } = PiiBase.Value;
         public string? geolocation { get; set; } = PiiBase.Value;
         public string? gpgkey { get; set; } = PiiBase.Value;
         public string? ipaddress { get; set; } = PiiBase.Value;

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/Pii.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/Pii.java
@@ -33,7 +33,6 @@ public class Pii  extends PiiBase {
     public String dburl = VALUE;
     public String encryptionkey = VALUE;
     public String encryptionkeyid = VALUE;
-    public String env = VALUE;
     public String geolocation = VALUE;
     public String gpgkey = VALUE;
     public String ipaddress = VALUE;

--- a/utils/build/docker/java_otel/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/Pii.java
+++ b/utils/build/docker/java_otel/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/Pii.java
@@ -33,7 +33,6 @@ public class Pii  extends PiiBase {
     public String dburl = VALUE;
     public String encryptionkey = VALUE;
     public String encryptionkeyid = VALUE;
-    public String env = VALUE;
     public String geolocation = VALUE;
     public String gpgkey = VALUE;
     public String ipaddress = VALUE;

--- a/utils/build/docker/python/flask/debugger/pii.py
+++ b/utils/build/docker/python/flask/debugger/pii.py
@@ -40,7 +40,6 @@ class Pii(PiiBase):
         self.dburl = self.VALUE
         self.encryptionkey = self.VALUE
         self.encryptionkeyid = self.VALUE
-        self.env = self.VALUE
         self.geolocation = self.VALUE
         self.gpgkey = self.VALUE
         self.ipaddress = self.VALUE

--- a/utils/build/docker/ruby/rails70/app/models/pii.rb
+++ b/utils/build/docker/ruby/rails70/app/models/pii.rb
@@ -34,7 +34,6 @@ REDACTED_KEYS = [
     "dburl",
     "encryptionkey",
     "encryptionkeyid",
-    "env",
     "geolocation",
     "gpgkey",
     "ipaddress",


### PR DESCRIPTION
## Motivation

Align the individual test apps for the different programming languages with the main test file.

This has already been removed in the PII test file in the following PR: https://github.com/DataDog/system-tests/pull/3827

## Changes

Remove `env` from the following language apps:

- Python
- Ruby
- .NET
- Java

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
