### PR TITLE
[ruby] Remove special handling of GraphQL response status code

### DIFF
--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -689,10 +689,8 @@ class Test_BlockingGraphqlResolvers:
         )
 
     def test_request_block_attack(self):
-        assert self.r_attack.status_code == (
-            # We don't change the status code in Ruby
-            200 if context.library == "ruby" else 403
-        )
+        assert self.r_attack.status_code == 403
+
         for _, span in interfaces.library.get_root_spans(request=self.r_attack):
             meta = span.get("meta", {})
             meta_struct = span.get("meta_struct", {})
@@ -729,11 +727,8 @@ class Test_BlockingGraphqlResolvers:
         )
 
     def test_request_block_attack_directive(self):
-        # We don't change the status code
-        assert self.r_attack.status_code == (
-            # We don't change the status code in Ruby
-            200 if context.library == "ruby" else 403
-        )
+        assert self.r_attack.status_code == 403
+
         for _, span in interfaces.library.get_root_spans(request=self.r_attack):
             meta = span.get("meta", {})
             meta_struct = span.get("meta_struct", {})

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -688,6 +688,7 @@ class Test_BlockingGraphqlResolvers:
             ),
         )
 
+    @bug(context.library < "ruby@2.10.0-dev", reason="APPSEC-56464")
     def test_request_block_attack(self):
         assert self.r_attack.status_code == 403
 
@@ -726,6 +727,7 @@ class Test_BlockingGraphqlResolvers:
             ),
         )
 
+    @bug(context.library < "ruby@2.10.0-dev", reason="APPSEC-56464")
     def test_request_block_attack_directive(self):
         assert self.r_attack.status_code == 403
 


### PR DESCRIPTION
## Motivation

We are changing the way we are doing blocking for GraphQL in Ruby:
https://github.com/DataDog/dd-trace-rb/pull/4300

https://datadoghq.atlassian.net/browse/APPSEC-56464

## Changes

This PR removes special case for response status code assertion for Ruby when GraphQL response is being blocked.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
