### PR TITLE
Add a parameter to define when to trigger SDK events

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -665,6 +665,7 @@ Body fields accepted in POST method:
 
 It also supports HTTP authentication by using GET method and the authorization header.
 Additionally, both methods support the following query parameters to use the sdk functions along with the authentication framework:
+- `sdk_trigger`: when to call the sdk function, `after` or `before` the automated login event (by default `after`)
 - `sdk_event`: login event type: `success` or `failure`.
 - `sdk_user`: user id to be used in the sdk call.
 - `sdk_mail`: user's mail to be used in the sdk call.

--- a/tests/appsec/test_automated_user_and_session_tracking.py
+++ b/tests/appsec/test_automated_user_and_session_tracking.py
@@ -67,21 +67,29 @@ class Test_Automated_User_Tracking:
             assert meta["_dd.appsec.user.collection_mode"] == "identification"
 
     def setup_user_tracking_sdk_overwrite(self):
-        self.r_login = weblog.post(
-            "/login?auth=local&sdk_event=success&sdk_user=sdkUser", data=login_data(context, USER, PASSWORD)
-        )
+        self.requests = [
+            weblog.post(
+                "/login?auth=local&sdk_trigger=before&sdk_event=success&sdk_user=sdkUser",
+                data=login_data(context, USER, PASSWORD),
+            ),
+            weblog.post(
+                "/login?auth=local&sdk_trigger=after&sdk_event=success&sdk_user=sdkUser",
+                data=login_data(context, USER, PASSWORD),
+            ),
+        ]
 
     def test_user_tracking_sdk_overwrite(self):
-        assert self.r_login.status_code == 200
-        for _, _, span in interfaces.library.get_spans(request=self.r_login):
-            meta = span.get("meta", {})
-            assert meta["usr.id"] == "sdkUser"
-            if context.library in libs_without_user_id:
-                assert meta["_dd.appsec.usr.id"] == USER
-            else:
-                assert meta["_dd.appsec.usr.id"] == "social-security-id"
+        for request in self.requests:
+            assert request.status_code == 200
+            for _, _, span in interfaces.library.get_spans(request=request):
+                meta = span.get("meta", {})
+                assert meta["usr.id"] == "sdkUser"
+                if context.library in libs_without_user_id:
+                    assert meta["_dd.appsec.usr.id"] == USER
+                else:
+                    assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
-            assert meta["_dd.appsec.user.collection_mode"] == "sdk"
+                assert meta["_dd.appsec.user.collection_mode"] == "sdk"
 
 
 CONFIG_ENABLED = (

--- a/tests/appsec/test_automated_user_and_session_tracking.py
+++ b/tests/appsec/test_automated_user_and_session_tracking.py
@@ -67,29 +67,35 @@ class Test_Automated_User_Tracking:
             assert meta["_dd.appsec.user.collection_mode"] == "identification"
 
     def setup_user_tracking_sdk_overwrite(self):
-        self.requests = [
-            weblog.post(
+        self.requests = {
+            "before": weblog.post(
                 "/login?auth=local&sdk_trigger=before&sdk_event=success&sdk_user=sdkUser",
                 data=login_data(context, USER, PASSWORD),
             ),
-            weblog.post(
+            "after": weblog.post(
                 "/login?auth=local&sdk_trigger=after&sdk_event=success&sdk_user=sdkUser",
                 data=login_data(context, USER, PASSWORD),
             ),
-        ]
+        }
 
     def test_user_tracking_sdk_overwrite(self):
-        for request in self.requests:
+        for trigger, request in self.requests.items():
             assert request.status_code == 200
             for _, _, span in interfaces.library.get_spans(request=request):
                 meta = span.get("meta", {})
-                assert meta["usr.id"] == "sdkUser"
+                assert meta["usr.id"] == "sdkUser", f"{trigger}: 'usr.id' must be set by the SDK"
                 if context.library in libs_without_user_id:
-                    assert meta["_dd.appsec.usr.id"] == USER
+                    assert (
+                        meta["_dd.appsec.usr.id"] == USER
+                    ), f"{trigger}: '_dd.appsec.usr.id' must be set by the automated instrumentation"
                 else:
-                    assert meta["_dd.appsec.usr.id"] == "social-security-id"
+                    assert (
+                        meta["_dd.appsec.usr.id"] == "social-security-id"
+                    ), f"{trigger}: '_dd.appsec.usr.id' must be set by the automated instrumentation"
 
-                assert meta["_dd.appsec.user.collection_mode"] == "sdk"
+                assert (
+                    meta["_dd.appsec.user.collection_mode"] == "sdk"
+                ), f"{trigger}: The collection mode should be 'sdk'"
 
 
 CONFIG_ENABLED = (

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecAuthenticationFilter.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecAuthenticationFilter.java
@@ -1,11 +1,14 @@
 package com.datadoghq.system_tests.springboot.security;
 
-import static java.util.Collections.emptyList;
-
+import datadog.trace.api.EventTracker;
+import datadog.trace.api.GlobalTracer;
+import org.checkerframework.checker.units.qual.A;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.util.Base64Utils;
@@ -14,8 +17,27 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AppSecAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private enum SdkTrigger {
+        BEFORE,
+        AFTER,
+        NONE;
+
+        public static SdkTrigger get(final HttpServletRequest request) {
+            if (request.getParameter("sdk_event") == null) {
+                return NONE;
+            }
+            final String trigger = request.getParameter("sdk_trigger");
+            if (trigger == null || "after".equalsIgnoreCase(trigger)) {
+                return AFTER;
+            }
+            return BEFORE;
+        }
+    }
 
     public AppSecAuthenticationFilter(String url, AuthenticationManager authenticationManager) {
         super(new AntPathRequestMatcher(url), authenticationManager);
@@ -48,15 +70,33 @@ public class AppSecAuthenticationFilter extends AbstractAuthenticationProcessing
             default:
                 return null;
         }
-        Authentication authentication;
-        String sdkEvent = request.getParameter("sdk_event");
-        if (sdkEvent != null) {
-            String sdkUser = request.getParameter("sdk_user");
-            boolean sdkUserExists = Boolean.parseBoolean(request.getParameter("sdk_user_exists"));
-            authentication = new AppSecToken(username, password, sdkEvent, sdkUser, sdkUserExists);
-        } else {
-            authentication = new AppSecToken(username, password);
+        final SdkTrigger trigger = SdkTrigger.get(request);
+        AuthenticationException sdkException = trigger == SdkTrigger.BEFORE ? triggerSdk(request) : null;
+        try {
+            return this.getAuthenticationManager().authenticate(new AppSecToken(username, password));
+        } finally {
+            sdkException = trigger == SdkTrigger.AFTER ? triggerSdk(request) : sdkException;
+            if (sdkException != null) {
+                throw sdkException;
+            }
         }
-        return this.getAuthenticationManager().authenticate(authentication);
+    }
+
+    private AuthenticationException triggerSdk(final HttpServletRequest request) {
+        final String sdkEvent = request.getParameter("sdk_event");
+        final String sdkUser = request.getParameter("sdk_user");
+        final boolean sdkUserExists = Boolean.parseBoolean(request.getParameter("sdk_user_exists"));
+        final EventTracker tracker = GlobalTracer.getEventTracker();
+        final Map<String, String> metadata = new HashMap<>();
+        switch (sdkEvent) {
+            case "success":
+                tracker.trackLoginSuccessEvent(sdkUser, metadata);
+                return null;
+            case "failure":
+                tracker.trackLoginFailureEvent(sdkUser, sdkUserExists, metadata);
+                return new BadCredentialsException(sdkUser);
+            default:
+                throw new IllegalArgumentException("Invalid SDK event: " + sdkEvent);
+        }
     }
 }

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecAuthenticationProvider.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecAuthenticationProvider.java
@@ -25,11 +25,7 @@ public class AppSecAuthenticationProvider implements AuthenticationProvider {
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         AppSecToken token = (AppSecToken) authentication;
-        if (token.getSdkEvent() == null) {
-            return loginUserPassword(token);
-        } else {
-            return loginSdk(token);
-        }
+        return loginUserPassword(token);
     }
 
     private Authentication loginUserPassword(final AppSecToken auth) {
@@ -42,26 +38,6 @@ public class AppSecAuthenticationProvider implements AuthenticationProvider {
             throw new BadCredentialsException(username);
         }
         return new AppSecToken(new AppSecUser(user), auth.getCredentials(), Collections.emptyList());
-    }
-
-    private Authentication loginSdk(final AppSecToken auth) {
-        Map<String, String> metadata = new HashMap<>();
-        EventTracker tracker = GlobalTracer.getEventTracker();
-        switch (auth.getSdkEvent()) {
-            case "success":
-                tracker.trackLoginSuccessEvent(auth.getSdkUser(), metadata);
-                return new AppSecToken(auth.getName(), auth.getCredentials(), Collections.emptyList());
-            case "failure":
-                tracker.trackLoginFailureEvent(auth.getSdkUser(), auth.isSdkUserExists(), metadata);
-                if (auth.isSdkUserExists()) {
-                    throw new BadCredentialsException(auth.getSdkUser());
-                } else {
-                    throw new UsernameNotFoundException(auth.getSdkUser());
-                }
-            default:
-                throw new IllegalArgumentException("Invalid SDK event: " + auth.getSdkEvent());
-        }
-
     }
 
     @Override

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecToken.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/security/AppSecToken.java
@@ -5,42 +5,14 @@ import org.springframework.security.core.GrantedAuthority;
 
 import java.util.Collection;
 
-/**
- * Token used to bypass appsec auto user instrumentation when using the SDK
- */
 public class AppSecToken extends UsernamePasswordAuthenticationToken {
 
-    private String sdkEvent;
-
-    private String sdkUser;
-
-    private boolean sdkUserExists;
-
     public AppSecToken(Object principal, Object credentials) {
-        this(principal, credentials, null, null, false);
-    }
-
-    public AppSecToken(Object principal, Object credentials, String sdkEvent, String sdkUser, boolean sdkUserExists) {
         super(principal, credentials);
-        this.sdkEvent = sdkEvent;
-        this.sdkUser = sdkUser;
-        this.sdkUserExists = sdkUserExists;
     }
 
     public AppSecToken(Object principal, Object credentials,
                        Collection<? extends GrantedAuthority> authorities) {
         super(principal, credentials, authorities);
-    }
-
-    public String getSdkEvent() {
-        return sdkEvent;
-    }
-
-    public String getSdkUser() {
-        return sdkUser;
-    }
-
-    public boolean isSdkUserExists() {
-        return sdkUserExists;
     }
 }


### PR DESCRIPTION
## Motivation

Customers can initiate login events via the SDK at any moment. Given that SDK-generated events should be prioritized over automated ones, we need to ensure that everything functions correctly when the SDK event occurs both first and last.

## Changes

Introduces a new optional parameter to the login endpoint, allowing tests to select when to generate the SDK event.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
