### PR TITLE
Update test_inferred_proxy.py

### DIFF
--- a/tests/integrations/test_inferred_proxy.py
+++ b/tests/integrations/test_inferred_proxy.py
@@ -77,10 +77,6 @@ def assert_api_gateway_span(testCase, span):
     assert (
         span["meta"]["http.url"] == "system-tests-api-gateway.com/api/data"
     ), "Inferred AWS API Gateway span meta expected HTTP URL to be 'system-tests-api-gateway.com/api/data'"
-    assert "http.route" in span["meta"], "Inferred AWS API Gateway span meta should contain 'http.route'"
-    assert (
-        span["meta"]["http.route"] == "/api/data"
-    ), "Inferred AWS API Gateway span meta expected HTTP route to be '/api/data'"
     assert "stage" in span["meta"], "Inferred AWS API Gateway span meta should contain 'stage'"
     assert span["meta"]["stage"] == "staging", "Inferred AWS API Gateway span meta expected stage to be 'staging'"
     assert "start" in span, f"Inferred AWS API Gateway span should have 'startTime'"


### PR DESCRIPTION
## Motivation

`http.route` was being incorrectly set on inferred spans. It requires a low cardinality value, but the current iteration of spans cannot guarantee that so we are removing the tag from these spans.
<!-- What inspired you to submit this pull request? -->

## Changes

Removes `http.route` from system tests
<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
