### PR TITLE
Removing 128bit TraceID Test Case

### DIFF
--- a/tests/parametric/test_128_bit_traceids.py
+++ b/tests/parametric/test_128_bit_traceids.py
@@ -428,30 +428,6 @@ class Test_128_Bit_Traceids:
         tid_chunk_root = first_span["meta"].get("_dd.p.tid")
         assert tid_chunk_root is not None
 
-    @missing_feature(context.library == "ruby", reason="not implemented")
-    @missing_feature(context.library == "java", reason="not implemented")
-    @pytest.mark.parametrize(
-        "library_env",
-        [{"DD_TRACE_PROPAGATION_STYLE": "tracecontext", "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": "true"}],
-    )
-    def test_w3c_128_bit_propagation_tid_only_in_chunk_root(self, test_agent, test_library):
-        """Ensure that only root span contains the tid."""
-        with test_library:
-            with test_library.dd_start_span(name="parent", service="service", resource="resource") as parent:
-                with test_library.dd_start_span(name="child", service="service", parent_id=parent.span_id) as child:
-                    pass
-
-        traces = test_agent.wait_for_num_traces(1, clear=True, sort_by_start=False)
-        trace = find_trace(traces, parent.trace_id)
-        assert len(trace) == 2
-        first_span = find_first_span_in_trace_payload(trace)
-        spans_with_tid = [span for span in trace if "_dd.p.tid" in span.get("meta", "")]
-        assert len(spans_with_tid) == 1
-        assert first_span == spans_with_tid[0]
-
-        tid_chunk_root = first_span["meta"].get("_dd.p.tid")
-        assert tid_chunk_root is not None
-
     @missing_feature(context.library == "nodejs", reason="not implemented")
     @missing_feature(context.library == "ruby", reason="not implemented")
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation

As part of our config consistency efforts, we are allowing libraries to propagate higher order bits of trace id to child spans as well. This PR removes an existing test case that checks that the higher order bits are only occurring in the root span and not the child spans. There still exists a test case that checks that the root span has the higher order bits of the trace id.

## Changes

Removes the unnecessary test case.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
