### PR TITLE
Enable Test_Config_LogInjection_128Bit_TradeId tests

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -581,7 +581,7 @@ tests/:
     Test_Config_ClientIPHeaderEnabled_False: v1.70.1
     Test_Config_ClientIPHeader_Configured: v1.60.0
     Test_Config_ClientIPHeader_Precedence: v1.69.0
-    Test_Config_ClientTagQueryString_Configured: missing_feature (supports DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED)
+    Test_Config_ClientTagQueryString_Configured: v1.70.0
     Test_Config_ClientTagQueryString_Empty: bug (APMAPI-966) # DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING is disabled by default
     Test_Config_HttpClientErrorStatuses_Default: v1.69.0
     Test_Config_HttpClientErrorStatuses_FeatureFlagCustom: v1.69.0
@@ -590,12 +590,12 @@ tests/:
       "*": v1.69.0
       echo: missing_feature
       uds-echo: missing_feature
-    Test_Config_IntegrationEnabled_False: irrelevant (not applicable to Go because of how they do auto instrumentation)
-    Test_Config_IntegrationEnabled_True: irrelevant (not applicable to Go because of how they do auto instrumentation)
+    Test_Config_IntegrationEnabled_False: irrelevant (not applicable due to lack of autoinstrumentation)
+    Test_Config_IntegrationEnabled_True: irrelevant (not applicable due to lack of autoinstrumentation)
     Test_Config_LogInjection_128Bit_TradeId_Default: v1.72.0-dev
     Test_Config_LogInjection_128Bit_TradeId_Disabled: v1.72.0-dev
-    Test_Config_LogInjection_Default: incomplete_test_app (weblog endpoint not implemented)
-    Test_Config_LogInjection_Enabled: incomplete_test_app (weblog endpoint not implemented)
+    Test_Config_LogInjection_Default: irrelevant (due to lack of autoinstrumentation)
+    Test_Config_LogInjection_Enabled: irrelevant (due to lack of autoinstrumentation)
     Test_Config_ObfuscationQueryStringRegexp_Configured: v1.67.0
     Test_Config_ObfuscationQueryStringRegexp_Default: v1.67.0
     Test_Config_ObfuscationQueryStringRegexp_Empty: v1.67.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -592,7 +592,7 @@ tests/:
       uds-echo: missing_feature
     Test_Config_IntegrationEnabled_False: irrelevant (not applicable to Go because of how they do auto instrumentation)
     Test_Config_IntegrationEnabled_True: irrelevant (not applicable to Go because of how they do auto instrumentation)
-    Test_Config_LogInjection_128Bit_TradeId_Default: missing_feature (disabled by default)
+    Test_Config_LogInjection_128Bit_TradeId_Default: v1.72.0-dev
     Test_Config_LogInjection_128Bit_TradeId_Disabled: incomplete_test_app (weblog endpoint not implemented)
     Test_Config_LogInjection_Default: incomplete_test_app (weblog endpoint not implemented)
     Test_Config_LogInjection_Enabled: incomplete_test_app (weblog endpoint not implemented)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -593,7 +593,7 @@ tests/:
     Test_Config_IntegrationEnabled_False: irrelevant (not applicable to Go because of how they do auto instrumentation)
     Test_Config_IntegrationEnabled_True: irrelevant (not applicable to Go because of how they do auto instrumentation)
     Test_Config_LogInjection_128Bit_TradeId_Default: v1.72.0-dev
-    Test_Config_LogInjection_128Bit_TradeId_Disabled: incomplete_test_app (weblog endpoint not implemented)
+    Test_Config_LogInjection_128Bit_TradeId_Disabled: v1.72.0-dev
     Test_Config_LogInjection_Default: incomplete_test_app (weblog endpoint not implemented)
     Test_Config_LogInjection_Enabled: incomplete_test_app (weblog endpoint not implemented)
     Test_Config_ObfuscationQueryStringRegexp_Configured: v1.67.0

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -541,10 +541,7 @@ class Test_Config_LogInjection_128Bit_TradeId_Disabled:
 
     def test_log_injection_128bit_traceid_disabled(self):
         assert self.r.status_code == 200
-        pattern = r'"dd":\{[^}]*\}'
-        stdout.assert_presence(pattern)
-        dd = parse_log_injection_message(self.message)
-        trace_id = dd.get("trace_id")
+        trace_id = parse_log_trace_id()
         assert re.match(r"^\d{1,20}$", trace_id), f"Invalid 64-bit trace_id: {trace_id}"
 
 
@@ -591,7 +588,8 @@ def parse_log_injection_message(log_message):
         if message.get("dd") and message.get(log_injection_fields[context.library.library]["message"]) == log_message:
             dd = message.get("dd")
             return dd
-        
+
+
 def parse_log_trace_id():
     for data in stdout.get_data():
         try:
@@ -603,7 +601,8 @@ def parse_log_trace_id():
         if message.get("dd"):
             dd = message.get("dd")
             return dd.get("trace_id")
-        
+
+
 def get_log_regex():
     pattern = r'"dd":\{[^}]*\}'
     if context.library == "golang":

--- a/utils/build/docker/golang/app/go.mod
+++ b/utils/build/docker/golang/app/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/graphql-go/handler v0.2.3
 	github.com/labstack/echo/v4 v4.11.1
 	github.com/mattn/go-sqlite3 v1.14.18
+	github.com/sirupsen/logrus v1.9.3
 	github.com/vektah/gqlparser/v2 v2.5.16
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
 	go.opentelemetry.io/otel v1.20.0
@@ -28,6 +29,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.3.0 // indirect
 	github.com/DataDog/go-libddwaf/v3 v3.4.0 // indirect
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/gostackparse v0.7.0 // indirect
 	github.com/DataDog/sketches-go v1.4.5 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
@@ -53,6 +55,7 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b // indirect
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -83,9 +86,11 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/richardartoul/molecule v1.0.1-0.20240531184615-7ca0df43c0b3 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/tinylib/msgp v1.2.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect

--- a/utils/build/docker/golang/app/go.sum
+++ b/utils/build/docker/golang/app/go.sum
@@ -111,6 +111,7 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b h1:h9U78+dx9a4BKdQkBBos92HalKpaGKHrp+3Uo6yTodo=
@@ -232,6 +233,8 @@ github.com/secure-systems-lab/go-securesystemslib v0.7.0/go.mod h1:/2gYnlnHVQ6xe
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -242,6 +245,7 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -322,6 +326,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -371,6 +376,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 lukechampine.com/uint128 v1.3.0 h1:cDdUVfRwDUDovz610ABgFD17nXD4/uDgVHl2sC3+sbo=
 lukechampine.com/uint128 v1.3.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 modernc.org/cc/v3 v3.41.0 h1:QoR1Sn3YWlmA1T4vLaKZfawdVtSiGx8H+cEojbC7v1Q=

--- a/utils/build/docker/golang/app/net-http/main.go
+++ b/utils/build/docker/golang/app/net-http/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +21,7 @@ import (
 	"weblog/internal/rasp"
 
 	"github.com/Shopify/sarama"
+	"github.com/sirupsen/logrus"
 
 	saramatrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/Shopify/sarama"
 	"gopkg.in/DataDog/dd-trace-go.v1/datastreams"
@@ -35,6 +35,7 @@ import (
 
 	"gopkg.in/DataDog/dd-trace-go.v1/appsec"
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	dd_logrus "gopkg.in/DataDog/dd-trace-go.v1/contrib/sirupsen/logrus"
 	ddotel "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentelemetry"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	ddtracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -42,6 +43,14 @@ import (
 )
 
 func main() {
+	// Optional: Change log format to use JSON (Cf. Go Log Collection)
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetOutput(os.Stdout)
+	logrus.SetLevel(logrus.DebugLevel)
+
+	// Add Datadog context log hook
+	logrus.AddHook(&dd_logrus.DDContextLogHook{})
+
 	ddtracer.Start()
 	defer ddtracer.Stop()
 
@@ -54,7 +63,7 @@ func main() {
 	)
 
 	if err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 	defer profiler.Stop()
 
@@ -172,7 +181,7 @@ func main() {
 		req, _ := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
 		res, err := client.Do(req)
 		if err != nil {
-			log.Fatalln("client.Do", err)
+			logrus.Fatalln("client.Do", err)
 		}
 
 		defer res.Body.Close()
@@ -194,7 +203,7 @@ func main() {
 			ResponseHeaders map[string]string `json:"response_headers"`
 		}{URL: url, StatusCode: res.StatusCode, RequestHeaders: requestHeaders, ResponseHeaders: responseHeaders})
 		if err != nil {
-			log.Fatalln(err)
+			logrus.Fatalln(err)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(jsonResponse)
@@ -377,7 +386,7 @@ func main() {
 			// the system-tests/weblog request id and the traces/spans
 			receivedSpan.SetAttributes(tags...)
 			if receivedSpan.SpanContext().TraceID() != parentSpan.SpanContext().TraceID() {
-				log.Fatalln("error in distributed tracing: Datadog OTel API and Otel net/http package span are not connected")
+				logrus.Fatalln("error in distributed tracing: Datadog OTel API and Otel net/http package span are not connected")
 				w.WriteHeader(500)
 				return
 			}
@@ -390,14 +399,14 @@ func main() {
 		c := http.Client{Transport: otelhttp.NewTransport(nil, otelhttp.WithSpanOptions(oteltrace.WithAttributes(tags...)))}
 		req, err := http.NewRequestWithContext(parentCtx, http.MethodGet, testServer.URL, nil)
 		if err != nil {
-			log.Fatalln(err)
+			logrus.Fatalln(err)
 			w.WriteHeader(500)
 			return
 		}
 		resp, err := c.Do(req)
 		_ = resp.Body.Close() // Need to close body to cause otel span to end
 		if err != nil {
-			log.Fatalln(err)
+			logrus.Fatalln(err)
 			w.WriteHeader(500)
 			return
 		}
@@ -411,7 +420,7 @@ func main() {
 		content, err := os.ReadFile(path)
 
 		if err != nil {
-			log.Fatalln(err)
+			logrus.Fatalln(err)
 			w.WriteHeader(500)
 			return
 		}
@@ -552,6 +561,26 @@ func main() {
 		appsec.TrackUserLoginSuccessEvent(r.Context(), user, map[string]string{}, tracer.WithUserSessionID(cookie.Value))
 	})
 
+	mux.HandleFunc("/log/library", func(w http.ResponseWriter, r *http.Request) {
+		msg := r.URL.Query().Get("msg")
+		if msg == "" {
+			msg = "msg"
+		}
+		ctx := r.Context()
+		switch r.URL.Query().Get("level") {
+		case "warn":
+			logrus.WithContext(ctx).Warn(msg)
+		case "error":
+			logrus.WithContext(ctx).Error(msg)
+		case "debug":
+			logrus.WithContext(ctx).Debug(msg)
+		default:
+			logrus.WithContext(ctx).Info(msg)
+		}
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	})
+
 	mux.HandleFunc("/requestdownstream", common.Requestdownstream)
 	mux.HandleFunc("/returnheaders", common.Returnheaders)
 
@@ -568,7 +597,7 @@ func main() {
 	go grpc.ListenAndServe()
 	go func() {
 		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			log.Fatal(err)
+			logrus.Fatal(err)
 		}
 	}()
 
@@ -579,7 +608,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatalf("HTTP shutdown error: %v", err)
+		logrus.Fatalf("HTTP shutdown error: %v", err)
 	}
 }
 
@@ -637,7 +666,7 @@ func kafkaProduce(topic, message string) (int32, int64, error) {
 		return 0, 0, err
 	}
 
-	log.Printf("PRODUCER SENT MESSAGE TO (partition offset): %d %d", partition, offset)
+	logrus.Printf("PRODUCER SENT MESSAGE TO (partition offset): %d %d", partition, offset)
 	return partition, offset, nil
 }
 
@@ -660,16 +689,16 @@ func kafkaConsume(topic string, timeout int64) (string, int, error) {
 
 	timeOutTimer := time.NewTimer(time.Duration(timeout) * time.Second)
 	defer timeOutTimer.Stop()
-	log.Printf("CONSUMING MESSAGES from topic: %s", topic)
+	logrus.Printf("CONSUMING MESSAGES from topic: %s", topic)
 	for {
 		select {
 		case receivedMsg := <-partitionConsumer.Messages():
 			responseOutput := fmt.Sprintf("Consumed message.\n\tOffset: %s\n\tMessage: %s\n", fmt.Sprint(receivedMsg.Offset), string(receivedMsg.Value))
-			log.Print(responseOutput)
+			logrus.Print(responseOutput)
 			return responseOutput, 200, nil
 		case <-timeOutTimer.C:
 			timedOutMessage := "TimeOut"
-			log.Print(timedOutMessage)
+			logrus.Print(timedOutMessage)
 			return timedOutMessage, 408, nil
 		}
 	}

--- a/utils/build/docker/golang/app/net-http/main.go
+++ b/utils/build/docker/golang/app/net-http/main.go
@@ -43,7 +43,6 @@ import (
 )
 
 func main() {
-	// Optional: Change log format to use JSON (Cf. Go Log Collection)
 	logrus.SetFormatter(&logrus.JSONFormatter{})
 	logrus.SetOutput(os.Stdout)
 	logrus.SetLevel(logrus.DebugLevel)

--- a/utils/interfaces/_logs.py
+++ b/utils/interfaces/_logs.py
@@ -96,8 +96,6 @@ class _LogsInterfaceValidator(InterfaceValidator):
 
     def validate(self, validator, *, success_by_default=False):
         for data in self.get_data():
-            print("MTOFF - data")
-            print(data)
             try:
                 if validator(data) is True:
                     return
@@ -264,19 +262,12 @@ class _LogPresence:
         self.extra_conditions = {k: re.compile(pattern) for k, pattern in extra_conditions.items()}
 
     def check(self, data):
-        print("in check")
-        print(data)
-        if "message" in data or 'message' in data:
-            print("message exists")
-        if self.pattern.search(data["message"]):
-            print("pattern double")
-        if self.pattern.search(data['message']):
-            print("pattern single")
-        print(self.pattern)
-        if "message" in data or 'message' in data and self.pattern.search(data['message']) or self.pattern.search(data["message"]):
+        if (
+            'message' in data
+            or ("message" in data and self.pattern.search(data['message']))
+            or self.pattern.search(data["message"])
+        ):
             for key, extra_pattern in self.extra_conditions.items():
-                print("key is", key)
-                print("data is", data)
                 if key not in data:
                     logger.info(f"For {self}, {self.pattern.pattern!r} was found, but [{key}] field is missing")
                     logger.info(f"-> Log line is {data['message']}")

--- a/utils/interfaces/_logs.py
+++ b/utils/interfaces/_logs.py
@@ -96,6 +96,8 @@ class _LogsInterfaceValidator(InterfaceValidator):
 
     def validate(self, validator, *, success_by_default=False):
         for data in self.get_data():
+            print("MTOFF - data")
+            print(data)
             try:
                 if validator(data) is True:
                     return
@@ -262,8 +264,19 @@ class _LogPresence:
         self.extra_conditions = {k: re.compile(pattern) for k, pattern in extra_conditions.items()}
 
     def check(self, data):
-        if "message" in data and self.pattern.search(data["message"]):
+        print("in check")
+        print(data)
+        if "message" in data or 'message' in data:
+            print("message exists")
+        if self.pattern.search(data["message"]):
+            print("pattern double")
+        if self.pattern.search(data['message']):
+            print("pattern single")
+        print(self.pattern)
+        if "message" in data or 'message' in data and self.pattern.search(data['message']) or self.pattern.search(data["message"]):
             for key, extra_pattern in self.extra_conditions.items():
+                print("key is", key)
+                print("data is", data)
                 if key not in data:
                     logger.info(f"For {self}, {self.pattern.pattern!r} was found, but [{key}] field is missing")
                     logger.info(f"-> Log line is {data['message']}")

--- a/utils/interfaces/_logs.py
+++ b/utils/interfaces/_logs.py
@@ -263,8 +263,8 @@ class _LogPresence:
 
     def check(self, data):
         if (
-            'message' in data
-            or ("message" in data and self.pattern.search(data['message']))
+            "message" in data
+            or ("message" in data and self.pattern.search(data["message"]))
             or self.pattern.search(data["message"])
         ):
             for key, extra_pattern in self.extra_conditions.items():


### PR DESCRIPTION
## Motivation
128bit trace ID logging will be enabled by default in dd-trace-go as of this PR: https://github.com/DataDog/dd-trace-go/pull/3086

## Changes
- Enables `Test_Config_LogInjection_128Bit_TradeId_Default` and `Test_Config_LogInjection_128Bit_TradeId_Disabled` tests for dd-trace-go v1.72.0-dev+
- Modifies test logic for parsing the resulting log message, since the previous regex did not match the pattern for go (Go prints trace id and span id as separate entities, `dd.trace_id` and `dd.span_id`, instead of sub-entities of a great `dd` field e.g. `"dd": {"trace_id": val, "span_id": val}`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
