### PR TITLE
[Tracing] Implement initial weblog tests for the runtime metrics feature

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -253,6 +253,7 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Empty: missing_feature
     Test_Config_RuntimeMetrics_Default: missing_feature
     Test_Config_RuntimeMetrics_Enabled: missing_feature
+    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: missing_feature
     Test_Config_UnifiedServiceTagging_CustomService: missing_feature
     Test_Config_UnifiedServiceTagging_Default: missing_feature
   test_distributed.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -496,7 +496,8 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Default: v3.4.1
     Test_Config_ObfuscationQueryStringRegexp_Empty: v3.4.1
     Test_Config_RuntimeMetrics_Default: incomplete_test_app (test needs to account for dotnet runtime metrics)
-    Test_Config_RuntimeMetrics_Enabled: incomplete_test_app (test needs to account for dotnet runtime metrics)
+    Test_Config_RuntimeMetrics_Enabled: v2.0.0
+    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: v2.0.0
     Test_Config_UnifiedServiceTagging_CustomService: v3.3.0
     Test_Config_UnifiedServiceTagging_Default: v3.3.0
   test_data_integrity.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -600,7 +600,8 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Default: v1.67.0
     Test_Config_ObfuscationQueryStringRegexp_Empty: v1.67.0
     Test_Config_RuntimeMetrics_Default: incomplete_test_app (test needs to account for golang runtime metrics)
-    Test_Config_RuntimeMetrics_Enabled: incomplete_test_app (test needs to account for golang runtime metrics)
+    Test_Config_RuntimeMetrics_Enabled: incomplete_test_app (should be in v1.18.0 but we're not receiving series in tests)
+    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: incomplete_test_app (should be in v1.18.0 but we're not receiving series in tests)
     Test_Config_UnifiedServiceTagging_CustomService: v1.67.0
     Test_Config_UnifiedServiceTagging_Default: v1.67.0
   test_data_integrity.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1712,6 +1712,8 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Empty: v1.39.0
     Test_Config_RuntimeMetrics_Default: incomplete_test_app (test needs to account for java runtime metrics)
     Test_Config_RuntimeMetrics_Enabled: incomplete_test_app (test needs to account for java runtime metrics)
+    Test_Config_RuntimeMetrics_Enabled: v0.64.0
+    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: v0.64.0
     Test_Config_UnifiedServiceTagging_CustomService: v1.39.0
     Test_Config_UnifiedServiceTagging_Default: v1.39.0
   test_data_integrity.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1711,9 +1711,16 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Default: v1.39.0
     Test_Config_ObfuscationQueryStringRegexp_Empty: v1.39.0
     Test_Config_RuntimeMetrics_Default: incomplete_test_app (test needs to account for java runtime metrics)
-    Test_Config_RuntimeMetrics_Enabled: incomplete_test_app (test needs to account for java runtime metrics)
-    Test_Config_RuntimeMetrics_Enabled: v0.64.0
-    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: v0.64.0
+    Test_Config_RuntimeMetrics_Enabled:
+      '*': v0.64.0
+      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-openliberty: incomplete_test_app (needs investigation to understand why test is failing)
+      spring-boot-wildfly: incomplete_test_app (needs investigation to understand why test is failing)
+    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId:
+      '*': v0.64.0
+      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-openliberty: incomplete_test_app (needs investigation to understand why test is failing)
+      spring-boot-wildfly: incomplete_test_app (needs investigation to understand why test is failing)
     Test_Config_UnifiedServiceTagging_CustomService: v1.39.0
     Test_Config_UnifiedServiceTagging_Default: v1.39.0
   test_data_integrity.py:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -860,6 +860,7 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Empty: *ref_3_0_0
     Test_Config_RuntimeMetrics_Default: *ref_3_0_0
     Test_Config_RuntimeMetrics_Enabled: *ref_3_0_0
+    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: missing_feature
     Test_Config_UnifiedServiceTagging_CustomService: *ref_5_25_0
     Test_Config_UnifiedServiceTagging_Default: *ref_5_25_0
   test_distributed.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -479,6 +479,7 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Empty: v1.5.0
     Test_Config_RuntimeMetrics_Default: missing_feature
     Test_Config_RuntimeMetrics_Enabled: missing_feature
+    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: missing_feature
     Test_Config_UnifiedServiceTagging_CustomService: v1.4.0
     Test_Config_UnifiedServiceTagging_Default: v1.4.0
   test_distributed.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -894,7 +894,6 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Configured: v2.0.0
     Test_Config_ObfuscationQueryStringRegexp_Empty: v2.15.0
     Test_Config_RuntimeMetrics_Default: incomplete_test_app (test needs to account for python runtime metrics)
-    Test_Config_RuntimeMetrics_Enabled: incomplete_test_app (test needs to account for python runtime metrics)
     Test_Config_RuntimeMetrics_Enabled: incomplete_test_app (Python seems to send sketches instead of gauges/counters)
     Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: missing_feature
     Test_Config_UnifiedServiceTagging_CustomService: v2.0.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -895,6 +895,8 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Empty: v2.15.0
     Test_Config_RuntimeMetrics_Default: incomplete_test_app (test needs to account for python runtime metrics)
     Test_Config_RuntimeMetrics_Enabled: incomplete_test_app (test needs to account for python runtime metrics)
+    Test_Config_RuntimeMetrics_Enabled: incomplete_test_app (Python seems to send sketches instead of gauges/counters)
+    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: missing_feature
     Test_Config_UnifiedServiceTagging_CustomService: v2.0.0
     Test_Config_UnifiedServiceTagging_Default: v2.0.0
   test_data_integrity.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -498,7 +498,8 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Default: bug (APMAPI-1013)
     Test_Config_ObfuscationQueryStringRegexp_Empty: missing_feature (environment variable is not supported)
     Test_Config_RuntimeMetrics_Default: incomplete_test_app (test needs to account for ruby runtime metrics)
-    Test_Config_RuntimeMetrics_Enabled: incomplete_test_app (test needs to account for ruby runtime metrics)
+    Test_Config_RuntimeMetrics_Enabled: missing_feature (should be in v0.44.0 but we're not receiving series in tests)
+    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: missing_feature
     Test_Config_UnifiedServiceTagging_CustomService: v2.0.0
     Test_Config_UnifiedServiceTagging_Default: v2.0.0
   test_distributed.py:

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -4,12 +4,14 @@
 
 import re
 import json
+import time
 from utils import weblog, interfaces, scenarios, features, rfc, irrelevant, context, bug, missing_feature
 from utils.tools import logger
 
 # get the default log output
 stdout = interfaces.library_stdout if context.library != "dotnet" else interfaces.library_dotnet_managed
 runtime_metrics = {"nodejs": "runtime.node.mem.heap_total"}
+runtime_metrics_langs = [".NET", "go", "nodejs", "python", "ruby"]
 log_injection_fields = {"nodejs": {"message": "msg"}}
 
 
@@ -555,19 +557,51 @@ class Test_Config_LogInjection_128Bit_TradeId_Disabled:
 @scenarios.runtime_metrics_enabled
 @features.tracing_configuration_consistency
 class Test_Config_RuntimeMetrics_Enabled:
-    """Verify runtime metrics are enabled when DD_RUNTIME_METRICS_ENABLED=true"""
+    """Verify runtime metrics are enabled when DD_RUNTIME_METRICS_ENABLED=true and that they have the proper tags"""
 
-    # This test verifies runtime metrics by asserting the prescene of a metric in the dogstatsd endpoint
-    def test_config_runtimemetrics_enabled(self):
-        for data in interfaces.library.get_data("/dogstatsd/v2/proxy"):
-            lines = data["request"]["content"].split("\n")
-            metric_found = False
-            for line in lines:
-                if runtime_metrics[context.library.library] in line:
-                    metric_found = True
-                    break
-            assert metric_found, f"The metric {runtime_metrics[context.library.library]} was not found in any line"
-            break
+    def setup_main(self):
+        self.req = weblog.get("/")
+
+    def test_main(self):
+        assert self.req.status_code == 200
+
+        time.sleep(12)
+        runtime_metrics = [metric for _, metric in interfaces.agent.get_metrics(request=self.req) if metric["metric"].startswith("runtime.") or metric["metric"].startswith("jvm.")]
+        assert len(runtime_metrics) > 0
+
+        for metric in runtime_metrics:
+            tags = {tag.split(":")[0]: tag.split(":")[1] for tag in metric["tags"] }
+            assert tags.get("lang") in runtime_metrics_langs or tags.get("lang") is None
+
+            # Test that Unified Service Tags are added to the runtime metrics
+            assert tags["service"] == "weblog"
+            assert tags["env"] == "system-tests"
+            assert tags["version"] == "1.0.0"
+
+            # Test that DD_TAGS are added to the runtime metrics
+            # DD_TAGS=key1:val1,key2:val2 in default weblog containers
+            assert tags["key1"] == "val1"
+            assert tags["key2"] == "val2"
+
+
+@scenarios.runtime_metrics_enabled
+@features.tracing_configuration_consistency
+class Test_Config_RuntimeMetrics_Enabled_WithRuntimeId:
+    """Verify runtime metrics are enabled when DD_RUNTIME_METRICS_ENABLED=true and that they have the runtime-id tag"""
+
+    def setup_main(self):
+        self.req = weblog.get("/")
+
+    def test_main(self):
+        assert self.req.status_code == 200
+
+        time.sleep(12)
+        runtime_metrics = [metric for _, metric in interfaces.agent.get_metrics(request=self.req) if metric["metric"].startswith("runtime.") or metric["metric"].startswith("jvm.")]
+        assert len(runtime_metrics) > 0
+
+        for metric in runtime_metrics:
+            tags = {tag.split(":")[0]: tag.split(":")[1] for tag in metric["tags"] }
+            assert "runtime-id" in tags
 
 
 @rfc("https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit#heading=h.8v16cioi7qxp")

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -562,10 +562,12 @@ class Test_Config_RuntimeMetrics_Enabled:
     def setup_main(self):
         self.req = weblog.get("/")
 
+        # Wait for 10s to allow the tracer to send runtime metrics on the default 10s interval
+        time.sleep(10)
+
     def test_main(self):
         assert self.req.status_code == 200
 
-        time.sleep(12)
         runtime_metrics = [
             metric
             for _, metric in interfaces.agent.get_metrics()
@@ -596,10 +598,12 @@ class Test_Config_RuntimeMetrics_Enabled_WithRuntimeId:
     def setup_main(self):
         self.req = weblog.get("/")
 
+        # Wait for 10s to allow the tracer to send runtime metrics on the default 10s interval
+        time.sleep(10)
+
     def test_main(self):
         assert self.req.status_code == 200
 
-        time.sleep(12)
         runtime_metrics = [
             metric
             for _, metric in interfaces.agent.get_metrics()

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -566,11 +566,15 @@ class Test_Config_RuntimeMetrics_Enabled:
         assert self.req.status_code == 200
 
         time.sleep(12)
-        runtime_metrics = [metric for _, metric in interfaces.agent.get_metrics(request=self.req) if metric["metric"].startswith("runtime.") or metric["metric"].startswith("jvm.")]
+        runtime_metrics = [
+            metric
+            for _, metric in interfaces.agent.get_metrics()
+            if metric["metric"].startswith("runtime.") or metric["metric"].startswith("jvm.")
+        ]
         assert len(runtime_metrics) > 0
 
         for metric in runtime_metrics:
-            tags = {tag.split(":")[0]: tag.split(":")[1] for tag in metric["tags"] }
+            tags = {tag.split(":")[0]: tag.split(":")[1] for tag in metric["tags"]}
             assert tags.get("lang") in runtime_metrics_langs or tags.get("lang") is None
 
             # Test that Unified Service Tags are added to the runtime metrics
@@ -596,11 +600,15 @@ class Test_Config_RuntimeMetrics_Enabled_WithRuntimeId:
         assert self.req.status_code == 200
 
         time.sleep(12)
-        runtime_metrics = [metric for _, metric in interfaces.agent.get_metrics(request=self.req) if metric["metric"].startswith("runtime.") or metric["metric"].startswith("jvm.")]
+        runtime_metrics = [
+            metric
+            for _, metric in interfaces.agent.get_metrics()
+            if metric["metric"].startswith("runtime.") or metric["metric"].startswith("jvm.")
+        ]
         assert len(runtime_metrics) > 0
 
         for metric in runtime_metrics:
-            tags = {tag.split(":")[0]: tag.split(":")[1] for tag in metric["tags"] }
+            tags = {tag.split(":")[0]: tag.split(":")[1] for tag in metric["tags"]}
             assert "runtime-id" in tags
 
 

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -784,6 +784,7 @@ class _Scenarios:
     runtime_metrics_enabled = EndToEndScenario(
         "RUNTIME_METRICS_ENABLED",
         runtime_metrics_enabled=True,
+        use_proxy_for_weblog=False,
         doc="Test runtime metrics",
     )
 

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -785,6 +785,9 @@ class _Scenarios:
         "RUNTIME_METRICS_ENABLED",
         weblog_env={"DD_DOGSTATSD_START_DELAY": "0"},
         runtime_metrics_enabled=True,
+        # Disable the proxy in between weblog and the agent so that we can send metrics (via UDP) to the agent.
+        # The mitmproxy can only proxy UDP traffic by doing a host-wide transparent proxy, but we currently
+        # via specific ports. As a result, with the proxy enabled all UDP traffic is being dropped.
         use_proxy_for_weblog=False,
         doc="Test runtime metrics",
     )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -783,6 +783,7 @@ class _Scenarios:
 
     runtime_metrics_enabled = EndToEndScenario(
         "RUNTIME_METRICS_ENABLED",
+        weblog_env={"DD_DOGSTATSD_START_DELAY": "0"},
         runtime_metrics_enabled=True,
         use_proxy_for_weblog=False,
         doc="Test runtime metrics",

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -783,6 +783,9 @@ class _Scenarios:
 
     runtime_metrics_enabled = EndToEndScenario(
         "RUNTIME_METRICS_ENABLED",
+        # Add environment variable DD_DOGSTATSD_START_DELAY=0 to avoid the default 30s startup delay in the Java tracer.
+        # That delay is used in production to reduce the impact on startup and other side-effects on various application
+        # servers. These considerations do not apply to the system-tests environment so we can reduce it to 0s.
         weblog_env={"DD_DOGSTATSD_START_DELAY": "0"},
         runtime_metrics_enabled=True,
         # Disable the proxy in between weblog and the agent so that we can send metrics (via UDP) to the agent.

--- a/utils/build/docker/agent.Dockerfile
+++ b/utils/build/docker/agent.Dockerfile
@@ -10,6 +10,7 @@ RUN set -eux;\
 # Datadog agent conf
 RUN echo '\
 log_level: DEBUG\n\
+dogstatsd_non_local_traffic: true\n\
 apm_config:\n\
   apm_non_local_traffic: true\n\
   trace_buffer: 5\n\

--- a/utils/build/docker/java/spring-boot-openliberty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-openliberty.Dockerfile
@@ -22,7 +22,6 @@ COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VE
 COPY --from=build /app/target/myproject-0.0.1-SNAPSHOT.jar /app/app.jar
 COPY --from=build /dd-tracer/dd-java-agent.jar .
 
-ENV DD_JMXFETCH_ENABLED=false
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 # FIXME: Fails on APPSEC_BLOCKING, see APPSEC-51405
 # ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true

--- a/utils/build/docker/java/spring-boot-wildfly.Dockerfile
+++ b/utils/build/docker/java/spring-boot-wildfly.Dockerfile
@@ -26,6 +26,7 @@ COPY --from=build /dd-tracer/dd-java-agent.jar .
 COPY ./utils/build/docker/java/app.sh /app/app.sh
 RUN chmod +x /app/app.sh
 
+ENV DD_APP_CUSTOMLOGMANAGER=true
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
 ENV APP_EXTRA_ARGS="-Djboss.http.port=7777 -b=0.0.0.0"

--- a/utils/interfaces/_agent.py
+++ b/utils/interfaces/_agent.py
@@ -143,6 +143,22 @@ class AgentInterfaceValidator(ProxyBasedInterfaceValidator):
     def get_spans_list(self, request):
         return [span for _, span in self.get_spans(request)]
 
+    def get_metrics(self, request=None):
+        """Attempts to fetch the spans the agent will submit to the backend.
+
+        When a valid request is given, then we filter the spans to the ones sampled
+        during that request's execution, and only return those.
+        """
+
+        for data in self.get_data(path_filters="/api/v2/series"):
+            if "series" not in data["request"]["content"]:
+                raise ValueError("series property is missing in agent payload")
+
+            content = data["request"]["content"]["series"]
+
+            for point in content:
+                yield data, point
+
     def get_dsm_data(self):
         return self.get_data(path_filters="/api/v0.1/pipeline_stats")
 

--- a/utils/interfaces/_agent.py
+++ b/utils/interfaces/_agent.py
@@ -143,7 +143,7 @@ class AgentInterfaceValidator(ProxyBasedInterfaceValidator):
     def get_spans_list(self, request):
         return [span for _, span in self.get_spans(request)]
 
-    def get_metrics(self, request=None):
+    def get_metrics(self):
         """Attempts to fetch the spans the agent will submit to the backend.
 
         When a valid request is given, then we filter the spans to the ones sampled

--- a/utils/interfaces/_agent.py
+++ b/utils/interfaces/_agent.py
@@ -144,11 +144,7 @@ class AgentInterfaceValidator(ProxyBasedInterfaceValidator):
         return [span for _, span in self.get_spans(request)]
 
     def get_metrics(self):
-        """Attempts to fetch the spans the agent will submit to the backend.
-
-        When a valid request is given, then we filter the spans to the ones sampled
-        during that request's execution, and only return those.
-        """
+        """Attempts to fetch the metrics the agent will submit to the backend."""
 
         for data in self.get_data(path_filters="/api/v2/series"):
             if "series" not in data["request"]["content"]:


### PR DESCRIPTION
"dogstatsd_non_local_traffic: true" to the agent image and start testing runtime metrics by observing what metrics the agent is sending to the backend

## Motivation

We need to assert some basic functionalities of the Runtime Metrics feature across various tracing libraries.

## Changes

- Adds the config `dogstatsd_non_local_traffic: true` to the Datadog agent container
- Adds a method in the Agent interface to get the metrics it submits to the `/api/v2/series` backend API
- Implements new tests in classes `Test_Config_RuntimeMetrics_Enabled` and `Test_Config_RuntimeMetrics_Enabled_WithRuntimeId`. Each test case hits an endpoint, waits 10s (that is the default interval for submitting runtime metrics), and asserts properties of the submitted metrics

The end result is that the .NET Tracer and the Java Tracer are fully passing the initial tests

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
