### PR TITLE
K8s Lib Injection: Parametrize cluster agent image

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -57,7 +57,12 @@ def pytest_addoption(parser):
     )
     parser.addoption("--k8s-injector-img", type=str, action="store", help="Set injector image on the docker registry")
     parser.addoption("--k8s-weblog-img", type=str, action="store", help="Set test app image on the docker registry")
-    parser.addoption("--k8s-cluster-version", type=str, action="store", help="Set the datadog agent version")
+    parser.addoption(
+        "--k8s-cluster-version", type=str, action="store", help="DEPRECATED. Set the datadog cluster version"
+    )
+    parser.addoption(
+        "--k8s-cluster-img", type=str, action="store", help="Set the datadog cluster image on the docker registry"
+    )
 
     # Onboarding scenarios mandatory parameters
     parser.addoption("--vm-weblog", type=str, action="store", help="Set virtual machine weblog")

--- a/utils/_context/_scenarios/k8s_lib_injection.py
+++ b/utils/_context/_scenarios/k8s_lib_injection.py
@@ -69,6 +69,8 @@ class K8sScenario(Scenario):
         # Cluster version
         self.k8s_cluster_version = config.option.k8s_cluster_version
         self.components["cluster_agent"] = self.k8s_cluster_version
+        # Cluster image
+        # k8s-cluster-img
 
         # Injector image version
         self.k8s_injector_img = (

--- a/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
+++ b/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
@@ -122,6 +122,7 @@ class K8sDatadog:
 
         # Add the cluster agent tag version
         self.dd_cluster_feature["clusterAgent.image.tag"] = self.dd_cluster_version
+        self.dd_cluster_feature["clusterAgent.image.repository"] = "docker.io/datadog/cluster-agent-dev"
         helm_install_chart(
             self.k8s_cluster_info,
             "datadog",

--- a/utils/k8s_lib_injection/resources/operator/datadog-operator.yaml
+++ b/utils/k8s_lib_injection/resources/operator/datadog-operator.yaml
@@ -24,3 +24,9 @@ spec:
     apm:
       instrumentation:
         enabled: true
+  override:
+    clusterAgent:
+      image:
+        #name: docker.io/datadog/cluster-agent-dev:master SNAPSHOT X64
+        #name: registry.ddbuild.io/ci/datadog-agent/cluster-agent-nightly:v53517362-6c02020c83-arm64
+        name: gcr.io/datadoghq/cluster-agent:7.60.0


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
So far the cluster agent is only parametrizable for the tag of the release.
With this PR we added the choice to select the image from the registry. For example use the latest version or the latest_snapshot
docker.io/datadog/cluster-agent-dev:master 

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
