### PR TITLE
[cpp] Enable test_dynamic_configuration.py::TestDynamicConfigV1_EmptyServiceTargets test cases

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -14,7 +14,7 @@ tests/:
       Test_Stable_Config_Default: missing_feature
     test_crashtracking.py: missing_feature
     test_dynamic_configuration.py:
-      TestDynamicConfigV1_EmptyServiceTargets: missing_feature
+      TestDynamicConfigV1_EmptyServiceTargets: v1.1.0
     test_headers_b3multi.py:
       Test_Headers_B3multi: v1.0.1.dev
     test_headers_baggage.py:

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -14,7 +14,7 @@ tests/:
       Test_Stable_Config_Default: missing_feature
     test_crashtracking.py: missing_feature
     test_dynamic_configuration.py:
-      TestDynamicConfigV1_EmptyServiceTargets: v1.1.0
+      TestDynamicConfigV1_EmptyServiceTargets: v1.0.1.dev
     test_headers_b3multi.py:
       Test_Headers_B3multi: v1.0.1.dev
     test_headers_baggage.py:


### PR DESCRIPTION
## Motivation

Fix a known issue where remote config payloads get rejected by the C++ tracer

## Changes

Runs the associated test, the feature work is implemented in https://github.com/DataDog/dd-trace-cpp/pull/177

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
