### PR TITLE
Improve RC code for parametric scenario, clarify APMAPI-1003

### DIFF
--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List
 import pytest
 
 from utils import bug, context, features, irrelevant, missing_feature, rfc, scenarios, flaky
-from utils.dd_constants import Capabilities
+from utils.dd_constants import Capabilities, RemoteConfigApplyState
 from utils.parametric.spec.trace import (
     Span,
     assert_trace_has_tags,
@@ -86,7 +86,7 @@ def set_and_wait_rc(test_agent, config_overrides: Dict[str, Any]) -> Dict:
 
     # Wait for both the telemetry event and the RC apply status.
     test_agent.wait_for_telemetry_event("app-client-configuration-change", clear=True)
-    return test_agent.wait_for_rc_apply_state("APM_TRACING", state=2, clear=True)
+    return test_agent.wait_for_rc_apply_state("APM_TRACING", state=RemoteConfigApplyState.ACKNOWLEDGED, clear=True)
 
 
 def assert_sampling_rate(trace: List[Dict], rate: float):
@@ -154,7 +154,7 @@ class TestDynamicConfigTracingEnabled:
         # nor should it send RemoteConfig apply state
         if trace_enabled_env:
             test_agent.wait_for_telemetry_event("app-client-configuration-change", clear=True)
-            test_agent.wait_for_rc_apply_state("APM_TRACING", state=2, clear=True)
+            test_agent.wait_for_rc_apply_state("APM_TRACING", state=RemoteConfigApplyState.ACKNOWLEDGED, clear=True)
         with test_library:
             with test_library.dd_start_span("disabled"):
                 pass
@@ -171,7 +171,7 @@ class TestDynamicConfigTracingEnabled:
         _set_rc(test_agent, _create_rc_config({"tracing_enabled": False}))
         if trace_enabled_env:
             test_agent.wait_for_telemetry_event("app-client-configuration-change", clear=True)
-            test_agent.wait_for_rc_apply_state("APM_TRACING", state=2, clear=True)
+            test_agent.wait_for_rc_apply_state("APM_TRACING", state=RemoteConfigApplyState.ACKNOWLEDGED, clear=True)
 
         _set_rc(test_agent, _create_rc_config({}))
         with test_library:
@@ -222,7 +222,7 @@ class TestDynamicConfigV1:
         configuration has been applied by the tracer.
         """
         set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": 0.5})
-        cfg_state = test_agent.wait_for_rc_apply_state("APM_TRACING", state=2)
+        cfg_state = test_agent.wait_for_rc_apply_state("APM_TRACING", state=RemoteConfigApplyState.ACKNOWLEDGED)
         assert cfg_state["apply_state"] == 2
         assert cfg_state["product"] == "APM_TRACING"
 
@@ -371,7 +371,9 @@ class TestDynamicConfigV1_EmptyServiceTargets:
             # C++ make RC requests every second -> update is a bit slower to propagate.
             rc_args["wait_loops"] = 1000
 
-        cfg_state = test_agent.wait_for_rc_apply_state("APM_TRACING", state=2, **rc_args)
+        cfg_state = test_agent.wait_for_rc_apply_state(
+            "APM_TRACING", state=RemoteConfigApplyState.ACKNOWLEDGED, **rc_args
+        )
         assert cfg_state["apply_state"] == 2
 
 
@@ -403,9 +405,15 @@ class TestDynamicConfigV1_ServiceTargets:
         ],
     )
     @bug(library="nodejs", reason="APMAPI-865")
-    @bug(library="java", reason="APMAPI-1003")
+    @irrelevant(library="java", reason="APMAPI-1003")
+    @irrelevant(library="cpp", reason="APMAPI-1003")
     def test_not_match_service_target(self, library_env, test_agent, test_library):
-        """Test that the library reports an erroneous apply_state when the service targeting is not correct.
+        """
+        This is an old behavior, see APMAPI-1003
+
+        ----
+
+        Test that the library reports an erroneous apply_state when the service targeting is not correct.
 
         This can occur if the library requests Remote Configuration with an initial service + env pair and then
         one or both of the values changes.
@@ -420,8 +428,8 @@ class TestDynamicConfigV1_ServiceTargets:
             # C++ make RC requests every second -> update is a bit slower to propagate.
             rc_args["wait_loops"] = 1000
 
-        cfg_state = test_agent.wait_for_rc_apply_state("APM_TRACING", state=3, **rc_args)
-        assert cfg_state["apply_state"] == 3
+        cfg_state = test_agent.wait_for_rc_apply_state("APM_TRACING", state=RemoteConfigApplyState.ERROR, **rc_args)
+        assert cfg_state["apply_state"] == RemoteConfigApplyState.ERROR.value
         assert cfg_state["apply_error"] != ""
 
     @missing_feature(
@@ -453,7 +461,7 @@ class TestDynamicConfigV1_ServiceTargets:
         target in the RC record.
         """
         _set_rc(test_agent, _default_config(TEST_SERVICE, TEST_ENV))
-        cfg_state = test_agent.wait_for_rc_apply_state("APM_TRACING", state=2)
+        cfg_state = test_agent.wait_for_rc_apply_state("APM_TRACING", state=RemoteConfigApplyState.ACKNOWLEDGED)
         assert cfg_state["apply_state"] == 2
 
 

--- a/tests/parametric/test_tracer_flare.py
+++ b/tests/parametric/test_tracer_flare.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 import pytest
 
 from utils import rfc, scenarios, features, missing_feature, context, bug
+from utils.dd_constants import RemoteConfigApplyState
 
 
 parametrize = pytest.mark.parametrize
@@ -76,14 +77,16 @@ def _set_log_level(test_agent, log_level: str) -> str:
     test_agent.set_remote_config(
         path=f"datadog/2/AGENT_CONFIG/{cfg_id}/config", payload={"name": cfg_id, "config": {"log_level": log_level}}
     )
-    test_agent.wait_for_rc_apply_state("AGENT_CONFIG", state=2, post_only=True)
+    test_agent.wait_for_rc_apply_state("AGENT_CONFIG", state=RemoteConfigApplyState.ACKNOWLEDGED, post_only=True)
     return cfg_id
 
 
 def _clear_log_level(test_agent, cfg_id: str) -> None:
     """Helper to clear a previously set "flare-log-level" config from RC."""
     test_agent.set_remote_config(path=f"datadog/2/AGENT_CONFIG/{cfg_id}/config", payload={})
-    test_agent.wait_for_rc_apply_state("AGENT_CONFIG", state=2, clear=True, post_only=True)
+    test_agent.wait_for_rc_apply_state(
+        "AGENT_CONFIG", state=RemoteConfigApplyState.ACKNOWLEDGED, clear=True, post_only=True
+    )
 
 
 def _add_task(test_agent, task_config: Dict[str, Any]) -> int:
@@ -91,14 +94,16 @@ def _add_task(test_agent, task_config: Dict[str, Any]) -> int:
     task_config["uuid"] = uuid4().hex
     task_id = hash(json.dumps(task_config))
     test_agent.add_remote_config(path=f"datadog/2/AGENT_TASK/{task_id}/config", payload=task_config)
-    test_agent.wait_for_rc_apply_state("AGENT_TASK", state=2, post_only=True)
+    test_agent.wait_for_rc_apply_state("AGENT_TASK", state=RemoteConfigApplyState.ACKNOWLEDGED, post_only=True)
     return task_id
 
 
 def _clear_task(test_agent, task_id) -> None:
     """Helper to clear a previously created agent task config from RC."""
     test_agent.set_remote_config(path=f"datadog/2/AGENT_TASK/{task_id}/config", payload={})
-    test_agent.wait_for_rc_apply_state("AGENT_TASK", state=2, clear=True, post_only=True)
+    test_agent.wait_for_rc_apply_state(
+        "AGENT_TASK", state=RemoteConfigApplyState.ACKNOWLEDGED, clear=True, post_only=True
+    )
 
 
 def trigger_tracer_flare_and_wait(test_agent, task_overrides: Dict[str, Any]) -> Dict:
@@ -155,7 +160,7 @@ class TestTracerFlareV1:
         test_agent.set_remote_config(
             path="datadog/2/AGENT_CONFIG/configuration_order/config", payload=_flare_log_level_order()
         )
-        test_agent.wait_for_rc_apply_state("AGENT_CONFIG", state=2, post_only=True)
+        test_agent.wait_for_rc_apply_state("AGENT_CONFIG", state=RemoteConfigApplyState.ACKNOWLEDGED, post_only=True)
 
     @missing_feature(library="php", reason="APMLP-195")
     @missing_feature(library="nodejs", reason="Only plaintext files are sent presently")

--- a/utils/parametric/spec/remoteconfig.py
+++ b/utils/parametric/spec/remoteconfig.py
@@ -1,15 +1,5 @@
-from typing import Any, Literal
+from typing import Any
 from utils.dd_constants import Capabilities
-
-
-# Remote Configuration apply status is used by clients to report the application status of a Remote Configuration
-# record.
-# UNKNOWN = 0
-# UNACKNOWLEDGED = 1
-# ACKNOWLEDGED = 2
-# ERROR = 3
-# RFC: https://docs.google.com/document/d/1bUVtEpXNTkIGvLxzkNYCxQzP2X9EK9HMBLHWXr_5KLM/
-APPLY_STATUS = Literal[0, 1, 2, 3]
 
 
 def human_readable_capabilities(caps: int) -> tuple[Any, ...]:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
