### PR TITLE
bugfix(ssi): fix profiling result checking

### DIFF
--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -9,10 +9,14 @@ from utils.tools import logger
 API_HOST = "https://dd.datadoghq.com"
 
 
+class ProfileNotFoundError(Exception):
+    pass
+
+
 def wait_backend_trace_id(trace_id, profile: bool = False, validator=None):
     runtime_id = _query_for_trace_id(trace_id, validator=validator)
-    if profile:
-        _query_for_profile(runtime_id)
+    if profile and not _query_for_profile(runtime_id):
+        raise ProfileNotFoundError("Profile events not found for runtime_id: {runtime_id}")
 
 
 def _headers():


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

The original code would provide a non-zero exit code, which would cause the loop to retry and eventually time out:
```
            if isinstance(data, list) and len(data) > 0:
                return r.status_code
            return -1
```

I missed this behavior given it wasn't explicit. This change explicitly checks the result when querying for a profile and raises a typed exception if it does not exist.

## Changes

<!-- A brief description of the change being made with this pull request. -->
This commit resolves an issue where my refactor no longer checked the result when querying for a profile. This changes resolves that issue.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
