### PR TITLE
Fix retry logic for profiling tests by introducing a content validator

### DIFF
--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -62,9 +62,9 @@ def _make_request(
             r = requests.request(method=method, url=url, headers=headers, json=json, timeout=request_timeout)
             logger.debug(f" Backend response status for url [{url}]: [{r.status_code}]")
             if r.status_code == 200:
-                json = r.json()
-                if not validator or validator(json):
-                    return json
+                response_json = r.json()
+                if not validator or validator(response_json):
+                    return response_json
                 logger.debug(f" Backend response does not meet expectation for url [{url}]: [{r.text}]")
             if r.status_code == 429:
                 retry_after = _parse_retry_after(r.headers)

--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -129,5 +129,7 @@ def _query_for_profile(runtime_id):
     }
 
     logger.debug(f"Posting to {url} with query: {queryJson}")
-    profileId = _make_request(url, headers=headers, method="post", json=queryJson, validator=_validate_profiler_response)["data"][0]["id"]
+    profileId = _make_request(
+        url, headers=headers, method="post", json=queryJson, validator=_validate_profiler_response
+    )["data"][0]["id"]
     logger.debug(f"Found profile in the backend with ID: {profileId}")

--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -65,6 +65,7 @@ def _make_request(
                 json = r.json()
                 if not validator or validator(json):
                     return json
+                logger.debug(f" Backend response does not meet expectation for url [{url}]: [{r.text}]")
             if r.status_code == 429:
                 retry_after = _parse_retry_after(r.headers)
                 logger.debug(f" Received 429 for url [{url}], rate limit reset in: [{retry_after}]")
@@ -75,7 +76,7 @@ def _make_request(
         except requests.exceptions.RequestException as e:
             logger.error(f"Error received connecting to url: [{url}] {e} ")
 
-        logger.debug(f" Received unsuccessful status code for [{url}], retrying in: [{retry_delay}]")
+        logger.debug(f" Received unsuccessful response for [{url}], retrying in: [{retry_delay}]")
 
         # Avoid sleeping if we are going to hit the overall timeout.
         if time.perf_counter() + retry_delay - start_time >= overall_timeout:

--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -129,4 +129,5 @@ def _query_for_profile(runtime_id):
     }
 
     logger.debug(f"Posting to {url} with query: {queryJson}")
-    _make_request(url, headers=headers, method="post", json=queryJson, validator=_validate_profiler_response)
+    profileId = _make_request(url, headers=headers, method="post", json=queryJson, validator=_validate_profiler_response)["data"][0]["id"]
+    logger.debug(f"Found profile in the backend with ID: {profileId}")


### PR DESCRIPTION
## Motivation

#3847 unfortunately breaks profiling tests as they need to keep retrying even when they receive a HTTP 200 response, dependent on what's in the response body. 

## Changes

We introduce a content validator parameter for `_make_request` and have `_query_for_profile` pass in a suitable one that validates profiling API responses.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
