### PR TITLE
[python] remove deprecated imports

### DIFF
--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -28,7 +28,8 @@ from iast import (
 )
 
 import ddtrace
-from ddtrace import Pin, tracer, patch_all
+from ddtrace import patch_all
+from ddtrace.trace import Pin, tracer
 from ddtrace.appsec import trace_utils as appsec_trace_utils
 
 patch_all(urllib3=True)

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -28,9 +28,9 @@ import urllib3
 import xmltodict
 
 import ddtrace
-from ddtrace import Pin
+from ddtrace.trace import Pin
 from ddtrace import patch_all
-from ddtrace import tracer
+from ddtrace.trace import tracer
 from ddtrace.appsec import trace_utils as appsec_trace_utils
 
 

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -64,8 +64,8 @@ if os.environ.get("INCLUDE_RABBITMQ", "true") == "true":
     from integrations.messaging.rabbitmq import rabbitmq_produce
 
 import ddtrace
-from ddtrace import Pin
-from ddtrace import tracer
+from ddtrace.trace import Pin
+from ddtrace.trace import tracer
 from ddtrace.appsec import trace_utils as appsec_trace_utils
 from ddtrace.internal.datastreams import data_streams_processor
 from ddtrace.internal.datastreams.processor import DsmPathwayCodec

--- a/utils/build/docker/python/flask/integrations/messaging/rabbitmq.py
+++ b/utils/build/docker/python/flask/integrations/messaging/rabbitmq.py
@@ -1,6 +1,6 @@
 import kombu
 
-from ddtrace import tracer, Pin
+from ddtrace.trace import tracer, Pin
 
 
 def rabbitmq_produce(queue, exchange, routing_key, message):

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -26,7 +26,7 @@ from opentelemetry.baggage import set_baggage
 from opentelemetry.baggage import get_baggage
 
 import ddtrace
-from ddtrace import Span
+from ddtrace.trace import Span
 from ddtrace import config
 from ddtrace.contrib.trace_utils import set_http_meta
 from ddtrace.context import Context

--- a/utils/build/docker/python/pylons/app/app/config/middleware.py
+++ b/utils/build/docker/python/pylons/app/app/config/middleware.py
@@ -1,6 +1,6 @@
 """Pylons middleware initialization"""
 
-from ddtrace import tracer
+from ddtrace.trace import tracer
 from ddtrace.contrib.pylons import PylonsTraceMiddleware
 
 from beaker.middleware import SessionMiddleware

--- a/utils/build/docker/python/pylons/app/app/controllers/identify.py
+++ b/utils/build/docker/python/pylons/app/app/controllers/identify.py
@@ -1,7 +1,7 @@
 from app.lib.base import BaseController
 from pylons import response
 from pylons import tmpl_context as c
-from ddtrace import tracer
+from ddtrace.trace import tracer
 
 try:
     from ddtrace.contrib.trace_utils import set_user

--- a/utils/build/docker/python/pylons/app/app/controllers/waf.py
+++ b/utils/build/docker/python/pylons/app/app/controllers/waf.py
@@ -1,6 +1,6 @@
 import logging
 
-from ddtrace import tracer
+from ddtrace.trace import tracer
 
 from pylons import request, response, session, tmpl_context as c, url
 from pylons.controllers.util import abort, redirect


### PR DESCRIPTION
## Motivation

Prep for ddtrace v3.0

## Changes

Import tracing attributes from `ddtrace.trace` instead of `ddtrace`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
