### PR TITLE
[python] remove deprecated module from parametric app

### DIFF
--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -29,7 +29,7 @@ import ddtrace
 from ddtrace.trace import Span
 from ddtrace import config
 from ddtrace.contrib.trace_utils import set_http_meta
-from ddtrace.context import Context
+from ddtrace.trace import Context
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE


### PR DESCRIPTION
## Motivation

`ddtrace/context.py` will be removed in v3.0. This change ensures parametric tests do not rely on deprecated logic.

## Changes

- Import Context from `ddtrace.trace.Context`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
