### PR TITLE
K8s Lib Injection: Profiling fixes and bugs

### DIFF
--- a/tests/k8s_lib_injection/test_k8s_lib_injection.py
+++ b/tests/k8s_lib_injection/test_k8s_lib_injection.py
@@ -14,7 +14,7 @@ from utils.onboarding.wait_for_tcp_port import wait_for_port
 class TestK8sLibInjection:
     """Test K8s lib injection"""
 
-    @bug(context.library > "python@2.21.0-dev", reason="APMSP-1750")
+    @bug(context.library >= "python@2.20.0" and context.k8s_cluster_agent_version == "7.56.2", reason="APMSP-1750")
     def test_k8s_lib_injection(self):
         traces_json = get_dev_agent_traces(context.scenario.k8s_cluster_provider.get_cluster_info())
         assert len(traces_json) > 0, "No traces found"
@@ -35,4 +35,4 @@ class TestK8sLibInjection_operator:
         warmup_weblog(context_url)
         request_uuid = make_get_request(context_url)
         logger.info(f"Http request done with uuid: [{request_uuid}] for ip [{cluster_info.cluster_host_name}]")
-        wait_backend_trace_id(request_uuid, 120.0)
+        wait_backend_trace_id(request_uuid)


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
There are failures in the nightly build:
- We are calling to profiling endpoint when we shouldn't
- A bug for python and cluster agent 7.56.2

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
