### PR TITLE
Fix query time interval for validating profiler tests

### DIFF
--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -117,8 +117,9 @@ def _query_for_profile(runtime_id):
     headers = _headers()
     headers["Content-Type"] = "application/json"
 
-    time_to = datetime.now(timezone.utc)
-    time_from = time_to - timedelta(minutes=2)
+    now = datetime.now(timezone.utc)
+    time_to = now + timedelta(minutes=6)
+    time_from = now - timedelta(minutes=6)
     queryJson = {
         "track": "profile",
         "filter": {


### PR DESCRIPTION
## Motivation

There was a bug in #3901 that used the query interval that was okay with the old retry strategy (where we'd construct a new 2 minute interval up to current time on every request). Now, however, we only construct one query and pass it to the retrying method, so the query interval needs to cover the entirety of the retry period to be able to observe profiles arriving later.

## Changes

Instead of `[now - 2 minutes, now]` the query period is now `[now - 6 minutes, now + 6 minutes]` for good measure. Technically, `[now, now + 5 minutes]` should be sufficient, but let's be conservative, event platform doesn't break a sweat querying a 12 minute interval instead of 5.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

JIRA: [PROF-11237]

[PROF-11237]: https://datadoghq.atlassian.net/browse/PROF-11237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ