### PR TITLE
[Debugger] Make `source_file` optional + make sure debugger controller exists in symbols

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -305,6 +305,9 @@ jobs:
     - name: Run DEBUGGER_EXCEPTION_REPLAY scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"DEBUGGER_EXCEPTION_REPLAY"')
       run: ./run.sh DEBUGGER_EXCEPTION_REPLAY
+    - name: Run DEBUGGER_SYMDB scenario
+      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"DEBUGGER_SYMDB"')
+      run: ./run.sh DEBUGGER_SYMDB
     - name: Run all scenarios in replay mode
       run: utils/scripts/replay_scenarios.sh
       env:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1515,9 +1515,7 @@ tests/:
         spring-boot: v1.38.0
         spring-boot-jetty: v1.38.0
         spring-boot-openliberty: v1.38.0
-        spring-boot-payara: v1.38.0
         spring-boot-undertow: v1.38.0
-        spring-boot-wildfly: v1.38.0
         uds-spring-boot: v1.38.0
   integrations/:
     crossed_integrations/:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1510,6 +1510,7 @@ tests/:
         spring-boot-wildfly: v1.38.0
         uds-spring-boot: v1.38.0
     test_debugger_symdb.py:
+      Test_Debugger_SymDb:
         '*': missing_feature
         spring-boot: v1.38.0
         spring-boot-jetty: v1.38.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1510,7 +1510,14 @@ tests/:
         spring-boot-wildfly: v1.38.0
         uds-spring-boot: v1.38.0
     test_debugger_symdb.py:
-      Test_Debugger_SymDb: v1.38.0
+        '*': missing_feature
+        spring-boot: v1.38.0
+        spring-boot-jetty: v1.38.0
+        spring-boot-openliberty: v1.38.0
+        spring-boot-payara: v1.38.0
+        spring-boot-undertow: v1.38.0
+        spring-boot-wildfly: v1.38.0
+        uds-spring-boot: v1.38.0
   integrations/:
     crossed_integrations/:
       test_kafka.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -625,6 +625,7 @@ tests/:
         uds-flask: v2.11.0
         uwsgi-poc: v2.11.0
     test_debugger_symdb.py:
+      Test_Debugger_SymDb:
         '*': missing_feature
         flask-poc: v2.11.0
         uds-flask: v2.11.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -625,7 +625,10 @@ tests/:
         uds-flask: v2.11.0
         uwsgi-poc: v2.11.0
     test_debugger_symdb.py:
-      Test_Debugger_SymDb: v2.11.0
+        '*': missing_feature
+        flask-poc: v2.11.0
+        uds-flask: v2.11.0
+        uwsgi-poc: v2.11.0
   integrations/:
     crossed_integrations/:
       test_kafka.py:

--- a/tests/debugger/test_debugger_symdb.py
+++ b/tests/debugger/test_debugger_symdb.py
@@ -59,7 +59,7 @@ class Test_Debugger_SymDb(debugger._Base_Debugger_Test):
                     if check_scope(scope):
                         return
 
-        assert False, "No scope containing debugger controller with scope_type CLASS or MODULE was found in the symbols"
+        raise ValueError("No scope containing debugger controller with scope_type CLASS or MODULE was found in the symbols")
 
     ############ test ############
     def setup_symdb_upload(self):

--- a/tests/debugger/test_debugger_symdb.py
+++ b/tests/debugger/test_debugger_symdb.py
@@ -59,7 +59,9 @@ class Test_Debugger_SymDb(debugger._Base_Debugger_Test):
                     if check_scope(scope):
                         return
 
-        raise ValueError("No scope containing debugger controller with scope_type CLASS or MODULE was found in the symbols")
+        raise ValueError(
+            "No scope containing debugger controller with scope_type CLASS or MODULE was found in the symbols"
+        )
 
     ############ test ############
     def setup_symdb_upload(self):

--- a/utils/interfaces/schemas/library/symdb/v1/input-request.json
+++ b/utils/interfaces/schemas/library/symdb/v1/input-request.json
@@ -3,7 +3,7 @@
   "definitions": {
     "scope": {
       "type": "object",
-      "required": ["end_line", "scope_type", "source_file", "start_line"],
+      "required": ["end_line", "scope_type", "start_line"],
       "properties": {
         "end_line": { "type": "integer" },
         "language_specifics": { "type": ["object", "null"] },


### PR DESCRIPTION
## Motivation
Make `source_file` optional + make sure debugger controller exists in symbols

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
