### PR TITLE
Fix job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           exit 1
 
   system_tests:
-    name: System Tests ${{ needs.get_dev_artifacts.outputs.target-branch != '' && format('({0} branch)', needs.get_dev_artifacts.outputs.target-branch) || '' }}
+    name: System Tests
     needs:
     - lint
     - test_the_test


### PR DESCRIPTION
## Motivation

Get back the language aggregation in github action

Before : all langs are aggregated on a single "System Tests" job

<img width="330" alt="image" src="https://github.com/user-attachments/assets/c714b167-b3e2-40f6-81aa-a4597ca7516e" />

After : each lang + dev/prod got it single group : 

<img width="327" alt="image" src="https://github.com/user-attachments/assets/b0a37cd9-c329-4d71-a5a0-f9d6986d2f55" />


## Changes

Small  revert on job name from #3675 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
