### PR TITLE
[golang] standalone appsec propagation (v1) was released in v1.71.0

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -308,7 +308,7 @@ tests/:
         echo: v1.36.0
         gin: v1.37.0
     test_asm_standalone.py:
-      Test_AppSecStandalone_UpstreamPropagation: v1.72.0-dev
+      Test_AppSecStandalone_UpstreamPropagation: v1.71.0
       Test_AppSecStandalone_UpstreamPropagation_V2: missing_feature
       Test_IastStandalone_UpstreamPropagation: missing_feature
       Test_IastStandalone_UpstreamPropagation_V2: missing_feature


### PR DESCRIPTION
## Motivation

Initially planned for 1.72.0, standalone ASM v1 was able to make it into v1.71.0.

## Changes

Updates the manifest to enable the Standalone ASM propagation v1 test on v1.71.0.

## Reviewer checklist

* [X] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [X] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
