### PR TITLE
Clean compute-workflow-parameters, makes job_count an official parameter for parametric scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       build_buddies_images: ${{ contains(github.event.pull_request.labels.*.name, 'build-buddies-images') }}
       build_proxy_image: ${{ contains(github.event.pull_request.labels.*.name, 'build-proxy-image') }}
       build_lib_injection_app_images: ${{ contains(github.event.pull_request.labels.*.name, 'build-lib-injection-app-images') }}
-      _experimental_parametric_job_count: ${{ matrix.version == 'dev' && 2 || 1 }}  # test both use cases
+      parametric_job_count: ${{ matrix.version == 'dev' && 2 || 1 }}  # test both use cases
       skip_empty_scenarios: true
 
   system_tests_docker_mode:

--- a/.github/workflows/compute-workflow-parameters.yml
+++ b/.github/workflows/compute-workflow-parameters.yml
@@ -88,7 +88,7 @@ jobs:
         python utils/scripts/compute-workflow-parameters.py ${{ inputs.library }} \
           -s "${{ inputs.scenarios }}" \
           -g "${{ inputs.scenarios_groups }}" \
+          --parametric-job-count ${{ inputs._experimental_parametric_job_count }} \
           --ci-environment "${{ inputs._ci_environment }}" >> $GITHUB_OUTPUT
       env:
         PYTHONPATH: "."
-        _EXPERIMENTAL_PARAMETRIC_JOB_COUNT: ${{ inputs._experimental_parametric_job_count }}

--- a/.github/workflows/compute-workflow-parameters.yml
+++ b/.github/workflows/compute-workflow-parameters.yml
@@ -15,7 +15,7 @@ on:
         description: "Comma-separated list of scenarios groups to run"
         type: string
         default: ""
-      _experimental_parametric_job_count:
+      parametric_job_count:
         description: "*EXPERIMENTAL* : How many jobs should be used to run PARAMETRIC scenario"
         default: 1
         required: false
@@ -55,9 +55,9 @@ on:
       externalprocessing_scenarios:
         description: ""
         value: ${{ jobs.main.outputs.externalprocessing_scenarios }}
-      _experimental_parametric_job_matrix:
+      parametric_job_matrix:
         description: ""
-        value: ${{ jobs.main.outputs._experimental_parametric_job_matrix }}
+        value: ${{ jobs.main.outputs.parametric_job_matrix }}
 
 jobs:
   main:
@@ -73,7 +73,8 @@ jobs:
       opentelemetry_weblogs: ${{ steps.main.outputs.opentelemetry_weblogs }}
       parametric_scenarios: ${{ steps.main.outputs.parametric_scenarios }}
       externalprocessing_scenarios: ${{ steps.main.outputs.externalprocessing_scenarios }}
-      _experimental_parametric_job_matrix: ${{ steps.main.outputs._experimental_parametric_job_matrix }}
+      parametric_job_matrix: ${{ steps.main.outputs.parametric_job_matrix }}
+      parametric_job_count: ${{ steps.main.outputs.parametric_job_count }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -88,7 +89,7 @@ jobs:
         python utils/scripts/compute-workflow-parameters.py ${{ inputs.library }} \
           -s "${{ inputs.scenarios }}" \
           -g "${{ inputs.scenarios_groups }}" \
-          --parametric-job-count ${{ inputs._experimental_parametric_job_count }} \
+          --parametric-job-count ${{ inputs.parametric_job_count }} \
           --ci-environment "${{ inputs._ci_environment }}" >> $GITHUB_OUTPUT
       env:
         PYTHONPATH: "."

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -16,15 +16,25 @@ on:
         default: 'custom'
         required: false
         type: string
-      _experimental_job_count:
+      job_count:
         description: "How many job should be spawned for the parametric test"
         default: 1
         required: false
         type: number
-      _experimental_job_matrix:
+      job_matrix:
         # github action syntax is not very powerfull, it require a job to compute this.
         # => save on job, by asking the caller to compute this list
-        description: "Job matrix, JSON array of number from 1 to _experimental_job_count"
+        description: "Job matrix, JSON array of number from 1 to job_count"
+        default: '[1]'
+        required: false
+        type: string
+      _experimental_job_count:
+        description: "DEPRECATED"
+        default: 1
+        required: false
+        type: number
+      _experimental_job_matrix:
+        description: "DEPRECATED"
         default: '[1]'
         required: false
         type: string
@@ -39,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job_instance: ${{ fromJson( inputs._experimental_job_matrix ) }}
+        job_instance: ${{ fromJson( inputs.job_matrix ) }}
     env:
       SYSTEM_TESTS_REPORT_ENVIRONMENT: ${{ inputs.ci_environment }}
       SYSTEM_TESTS_REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -57,7 +67,7 @@ jobs:
           name: ${{ inputs.binaries_artifact }}
           path: binaries/
       - name: Run PARAMETRIC scenario
-        run: ./run.sh PARAMETRIC -L ${{ inputs.library }} --splits=${{ inputs._experimental_job_count }} --group=${{ matrix.job_instance }}
+        run: ./run.sh PARAMETRIC -L ${{ inputs.library }} --splits=${{ inputs.job_count }} --group=${{ matrix.job_instance }}
       - name: Compress logs
         id: compress_logs
         if: always()

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -56,8 +56,13 @@ on:
         default: false
         required: false
         type: boolean
+      parametric_job_count:
+        description: "How many jobs should be used to run PARAMETRIC scenario"
+        default: 1
+        required: false
+        type: number
       _experimental_parametric_job_count:
-        description: "*EXPERIMENTAL* : How many jobs should be used to run PARAMETRIC scenario"
+        description: "*DEPRECATED*"
         default: 1
         required: false
         type: number
@@ -70,7 +75,7 @@ jobs:
       library: ${{ inputs.library }}
       scenarios: ${{ inputs.scenarios }}
       scenarios_groups: ${{ inputs.scenarios_groups }}
-      _experimental_parametric_job_count: ${{ inputs._experimental_parametric_job_count }}
+      parametric_job_count: ${{ inputs.parametric_job_count }}
       _ci_environment: ${{ inputs.ci_environment }}
 
   parametric:
@@ -83,8 +88,8 @@ jobs:
       library: ${{ inputs.library }}
       binaries_artifact: ${{ inputs.binaries_artifact }}
       ci_environment: ${{ inputs.ci_environment }}
-      _experimental_job_count: ${{ inputs._experimental_parametric_job_count }}
-      _experimental_job_matrix: ${{ needs.compute_parameters.outputs._experimental_parametric_job_matrix }}
+      job_count: ${{ inputs.parametric_job_count }}
+      job_matrix: ${{ needs.compute_parameters.outputs.parametric_job_matrix }}
 
   graphql:
     needs:

--- a/utils/_context/_scenarios/core.py
+++ b/utils/_context/_scenarios/core.py
@@ -19,7 +19,6 @@ class ScenarioGroup(Enum):
     IPV6 = "ipv6"
     LIB_INJECTION = "lib-injection"
     OPEN_TELEMETRY = "open-telemetry"
-    PARAMETRIC = "parametric"
     PROFILING = "profiling"
     SAMPLING = "sampling"
     ONBOARDING = "onboarding"
@@ -51,7 +50,7 @@ class Scenario:
         self.replay = False
         self.doc = doc
         self.rc_api_enabled = False
-        self.github_workflow = github_workflow
+        self.github_workflow = github_workflow  # TODO: rename this to workflow, as it may not be a github workflow
         self.scenario_groups = scenario_groups or []
 
         self.scenario_groups = list(set(self.scenario_groups))  # removes duplicates

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -120,7 +120,7 @@ class ParametricScenario(Scenario):
             name,
             doc=doc,
             github_workflow="parametric",
-            scenario_groups=[ScenarioGroup.ALL, ScenarioGroup.PARAMETRIC, ScenarioGroup.PARAMETRIC],
+            scenario_groups=[ScenarioGroup.ALL],
         )
         self._parametric_tests_confs = ParametricScenario.PersistentParametricTestConf(self)
 

--- a/utils/scripts/compute-workflow-parameters.py
+++ b/utils/scripts/compute-workflow-parameters.py
@@ -132,7 +132,6 @@ def main(
     #  the value is also a dict, where the key/value pair is the parameter name/value.
     scenario_map = get_github_workflow_map(scenarios.split(","), groups.split(","))
 
-    print(groups)
     for github_workflow, scenario_list in scenario_map.items():
         result[github_workflow]["scenarios"] = scenario_list
 
@@ -143,7 +142,6 @@ def main(
     result["parametric"]["job_matrix"] = list(range(1, parametric_job_count + 1))
 
     _print_output(result, output_format)
-    print(f"_experimental_parametric_job_matrix={result['parametric']['job_matrix']!s}")  # legacy
 
 
 if __name__ == "__main__":

--- a/utils/scripts/compute_impacted_scenario.py
+++ b/utils/scripts/compute_impacted_scenario.py
@@ -41,7 +41,7 @@ class Result:
             if "run-open-telemetry-scenarios" in labels:
                 self.add_scenario_group(ScenarioGroup.OPEN_TELEMETRY.value)
             if "run-parametric-scenario" in labels:
-                self.add_scenario_group(ScenarioGroup.PARAMETRIC.value)
+                self.add_scenario(scenarios.parametric.name)
             if "run-graphql-scenarios" in labels:
                 self.add_scenario_group(ScenarioGroup.GRAPHQL.value)
             if "run-docker-ssi-scenarios" in labels:
@@ -140,7 +140,7 @@ def main() -> None:
                     r"\.circleci/.*": None,  # nothing to do
                     r"\.vscode/.*": None,  # nothing to do
                     ## .github folder
-                    r"\.github/workflows/run-parametric\.yml": ScenarioGroup.PARAMETRIC,
+                    r"\.github/workflows/run-parametric\.yml": scenarios.parametric,
                     r"\.github/workflows/run-lib-injection\.yml": ScenarioGroup.LIB_INJECTION,
                     r"\.github/workflows/run-docker-ssi\.yml": ScenarioGroup.DOCKER_SSI,
                     r"\.github/workflows/run-graphql\.yml": ScenarioGroup.GRAPHQL,
@@ -166,10 +166,10 @@ def main() -> None:
                     r"utils/_context/_scenarios/auto_injection\.py": None,
                     r"utils/_context/virtual_machine\.py": None,
                     #### Parametric case
-                    r"utils/build/docker/\w+/parametric/.*": ScenarioGroup.PARAMETRIC,
-                    r"utils/_context/_scenarios/parametric\.py": ScenarioGroup.PARAMETRIC,
-                    r"utils/parametric/.*": ScenarioGroup.PARAMETRIC,
-                    r"utils/scripts/parametric/.*": ScenarioGroup.PARAMETRIC,
+                    r"utils/build/docker/\w+/parametric/.*": scenarios.parametric,
+                    r"utils/_context/_scenarios/parametric\.py": scenarios.parametric,
+                    r"utils/parametric/.*": scenarios.parametric,
+                    r"utils/scripts/parametric/.*": scenarios.parametric,
                     #### Docker SSI case
                     r"utils/docker_ssi/.*": ScenarioGroup.DOCKER_SSI,
                     ### other scenarios def


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
