### PR TITLE
[ruby] Enable IP blocking tests for Ruby

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -306,7 +306,7 @@ tests/:
       Test_ExternalWafRequestsIdentification: v1.22.0
       Test_RetainTraces: v0.54.2
     test_user_blocking_full_denylist.py:
-      Test_UserBlocking_FullDenylist: missing_feature
+      Test_UserBlocking_FullDenylist: v2.9.0
     test_versions.py:
       Test_Events: v0.54.2
   debugger/:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -275,7 +275,7 @@ tests/:
     test_identify.py:
       Test_Basic: v1.0.0
     test_ip_blocking_full_denylist.py:
-      Test_AppSecIPBlockingFullDenylist: missing_feature (Ruby supported denylists of 2500 entries but it fails to block this those 15000)
+      Test_AppSecIPBlockingFullDenylist: v2.9.0
     test_logs.py:
       Test_Standardization: missing_feature
       Test_StandardizationBlockMode: missing_feature
@@ -306,7 +306,7 @@ tests/:
       Test_ExternalWafRequestsIdentification: v1.22.0
       Test_RetainTraces: v0.54.2
     test_user_blocking_full_denylist.py:
-      Test_UserBlocking_FullDenylist: missing_feature (Ruby supported denylists of 2500 entries but it fails to block this those 15000)
+      Test_UserBlocking_FullDenylist: missing_feature
     test_versions.py:
       Test_Events: v0.54.2
   debugger/:

--- a/tests/appsec/test_ip_blocking_full_denylist.py
+++ b/tests/appsec/test_ip_blocking_full_denylist.py
@@ -26,6 +26,7 @@ class Test_AppSecIPBlockingFullDenylist(BaseFullDenyListTest):
 
     @missing_feature(weblog_variant="spring-boot" and context.library < "java@0.111.0")
     @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
+    @bug(context.library < "ruby@2.11.0-dev", reason="APMRP-56691")
     def test_blocked_ips(self):
         """Test blocked ips are enforced"""
 

--- a/tests/appsec/test_ip_blocking_full_denylist.py
+++ b/tests/appsec/test_ip_blocking_full_denylist.py
@@ -2,8 +2,6 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-import time
-
 from utils import weblog, context, interfaces, rfc, bug, scenarios, missing_feature, features
 
 from .utils import BaseFullDenyListTest
@@ -30,8 +28,6 @@ class Test_AppSecIPBlockingFullDenylist(BaseFullDenyListTest):
     @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
     def test_blocked_ips(self):
         """Test blocked ips are enforced"""
-
-        time.sleep(10)
 
         self.assert_protocol_is_respected()
 

--- a/tests/appsec/test_ip_blocking_full_denylist.py
+++ b/tests/appsec/test_ip_blocking_full_denylist.py
@@ -2,6 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
+import time
 
 from utils import weblog, context, interfaces, rfc, bug, scenarios, missing_feature, features
 
@@ -29,6 +30,8 @@ class Test_AppSecIPBlockingFullDenylist(BaseFullDenyListTest):
     @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
     def test_blocked_ips(self):
         """Test blocked ips are enforced"""
+
+        time.sleep(10)
 
         self.assert_protocol_is_respected()
 

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -34,6 +34,7 @@ class Test_UserBlocking_FullDenylist(BaseFullDenyListTest):
     @bug(context.library < "ruby@1.12.1", reason="APMRP-360")
     @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
     @bug(library="java", weblog_variant="spring-boot-payara", reason="APPSEC-56006")
+    @bug(context.library < "ruby@2.11.0-dev", reason="APMRP-56691")
     def test_blocking_test(self):
         """Test with a denylisted user"""
 

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -211,7 +211,7 @@ class _Scenarios:
     appsec_blocking_full_denylist = EndToEndScenario(
         "APPSEC_BLOCKING_FULL_DENYLIST",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None},
+        weblog_env={"DD_APPSEC_RULES": None, "RAILS_MAX_THREADS": "1"},
         doc="""
             The spec says that if  DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
             In this scenario, we use remote config. By the spec, whem remote config is available, rules file

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -211,7 +211,7 @@ class _Scenarios:
     appsec_blocking_full_denylist = EndToEndScenario(
         "APPSEC_BLOCKING_FULL_DENYLIST",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None, "RAILS_MAX_THREADS": "1"},
+        weblog_env={"DD_APPSEC_RULES": None},
         doc="""
             The spec says that if  DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
             In this scenario, we use remote config. By the spec, whem remote config is available, rules file


### PR DESCRIPTION
## Motivation

We are now supporting IP Blocking in ruby with the full denylist.

## Changes

This PR enables IP Blocking tests for Ruby.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
