### PR TITLE
[python] skip tests for deprecated b3 envvar

### DIFF
--- a/tests/parametric/test_128_bit_traceids.py
+++ b/tests/parametric/test_128_bit_traceids.py
@@ -1,7 +1,7 @@
 import pytest
 
 from utils.parametric.spec.trace import find_first_span_in_trace_payload, find_trace, find_only_span
-from utils import missing_feature, context, scenarios, features
+from utils import missing_feature, irrelevant, context, scenarios, features
 
 parametrize = pytest.mark.parametrize
 POWER_2_64 = 18446744073709551616
@@ -213,6 +213,7 @@ class Test_128_Bit_Traceids:
 
     @missing_feature(context.library == "cpp", reason="propagation style not supported")
     @missing_feature(context.library == "ruby", reason="not implemented")
+    @irrelevant(context.library > "python@2.20.0", reason="3.x set `b3` instead of `B3 single header`")
     @pytest.mark.parametrize(
         "library_env",
         [{"DD_TRACE_PROPAGATION_STYLE": "B3 single header", "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": "false"}],
@@ -236,6 +237,7 @@ class Test_128_Bit_Traceids:
 
     @missing_feature(context.library == "cpp", reason="propagation style not supported")
     @missing_feature(context.library == "ruby", reason="not implemented")
+    @irrelevant(context.library > "python@2.20.0", reason="3.x set `b3` instead of `B3 single header`")
     @pytest.mark.parametrize(
         "library_env",
         [{"DD_TRACE_PROPAGATION_STYLE": "B3 single header", "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": "true"}],
@@ -257,6 +259,7 @@ class Test_128_Bit_Traceids:
     @missing_feature(
         context.library == "ruby", reason="Issue: Ruby doesn't support case-insensitive distributed headers"
     )
+    @irrelevant(context.library > "python@2.20.0", reason="3.x set `b3` instead of `B3 single header`")
     @pytest.mark.parametrize(
         "library_env",
         [{"DD_TRACE_PROPAGATION_STYLE": "B3 single header", "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": "false"}],
@@ -274,6 +277,7 @@ class Test_128_Bit_Traceids:
 
     @missing_feature(context.library == "cpp", reason="propagation style not supported")
     @missing_feature(context.library == "ruby", reason="not implemented")
+    @irrelevant(context.library > "python@2.20.0", reason="3.x set `b3` instead of `B3 single header`")
     @pytest.mark.parametrize(
         "library_env",
         [{"DD_TRACE_PROPAGATION_STYLE": "B3 single header", "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": "true"}],

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -46,6 +46,7 @@ def enable_migrated_b3_single_key() -> Any:
 class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
+    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_extract_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
@@ -65,6 +66,7 @@ class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
     def test_headers_b3_extract_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted."""
         with test_library:
@@ -78,6 +80,7 @@ class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
     def test_headers_b3_inject_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are injected properly."""
         with test_library:
@@ -99,6 +102,7 @@ class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
     def test_headers_b3_propagate_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and injected properly.
@@ -123,6 +127,7 @@ class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
+    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
     def test_headers_b3_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted
         and the new span context is injected properly.
@@ -151,6 +156,7 @@ class Test_Headers_B3:
         context.library > "ruby@1.99.0",
         reason="Added DD_TRACE_PROPAGATION_STYLE config in version 1.8.0 but the name is no longer recognized in 2.x",
     )
+    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
     def test_headers_b3_single_key_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3_propagate_valid(test_agent, test_library)
 

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -5,7 +5,7 @@ import pytest
 from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
 from utils.parametric.spec.trace import span_has_no_parent
 from utils.parametric.spec.trace import find_only_span
-from utils import missing_feature, context, scenarios, features, bug
+from utils import missing_feature, context, scenarios, features, bug, irrelevant
 from utils.tools import logger
 
 parametrize = pytest.mark.parametrize
@@ -46,7 +46,7 @@ def enable_migrated_b3_single_key() -> Any:
 class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
-    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
+    @irrelevant(context.library > "python@2.20.0", reason="Deprecated in 3.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
     def test_headers_b3_extract_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
@@ -66,7 +66,7 @@ class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
+    @irrelevant(context.library > "python@2.20.0", reason="Deprecated in 3.x")
     def test_headers_b3_extract_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted."""
         with test_library:
@@ -80,7 +80,7 @@ class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
+    @irrelevant(context.library > "python@2.20.0", reason="Deprecated in 3.x")
     def test_headers_b3_inject_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are injected properly."""
         with test_library:
@@ -102,7 +102,7 @@ class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
+    @irrelevant(context.library > "python@2.20.0", reason="Deprecated in 3.x")
     def test_headers_b3_propagate_valid(self, test_agent, test_library):
         """Ensure that b3 distributed tracing headers are extracted
         and injected properly.
@@ -127,7 +127,7 @@ class Test_Headers_B3:
     @enable_b3()
     @missing_feature(context.library > "ruby@1.99.0", reason="Missing for 2.x")
     @missing_feature(context.library == "cpp", reason="format of DD_TRACE_PROPAGATION_STYLE_EXTRACT not supported")
-    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
+    @irrelevant(context.library > "python@2.20.0", reason="Deprecated in 3.x")
     def test_headers_b3_propagate_invalid(self, test_agent, test_library):
         """Ensure that invalid b3 distributed tracing headers are not extracted
         and the new span context is injected properly.
@@ -156,7 +156,7 @@ class Test_Headers_B3:
         context.library > "ruby@1.99.0",
         reason="Added DD_TRACE_PROPAGATION_STYLE config in version 1.8.0 but the name is no longer recognized in 2.x",
     )
-    @missing_feature(context.library > "python@2.20.0", reason="Missing for 3.x")
+    @irrelevant(context.library > "python@2.20.0", reason="Deprecated in 3.x")
     def test_headers_b3_single_key_propagate_valid(self, test_agent, test_library):
         self.test_headers_b3_propagate_valid(test_agent, test_library)
 


### PR DESCRIPTION
## Motivation

ddtrace v3.0 drops support for the deprecated `B3 single header` propagation style. `b3` should be used instead.

## Changes

- Skips tests and unblocks: https://github.com/DataDog/dd-trace-py/pull/12167

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
