### PR TITLE
[Tracing] Refactor DD_TAGS test cases for clarity

### DIFF
--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -281,30 +281,36 @@ class Test_Config_RateLimit:
         ), "Expected at least one trace to be rate-limited with sampling priority -1."
 
 
-def tag_scenarios():
-    env1: dict = {"DD_TAGS": "key1:value1,key2:value2"}
-    env2: dict = {"DD_TAGS": "key1:value1 key2:value2"}
-    env3: dict = {"DD_TAGS": "env:test aKey:aVal bKey:bVal cKey:"}
-    env4: dict = {"DD_TAGS": "env:test,aKey:aVal,bKey:bVal,cKey:"}
-    env5: dict = {"DD_TAGS": "env:test,aKey:aVal bKey:bVal cKey:"}
-    env6: dict = {"DD_TAGS": "env:test     bKey :bVal dKey: dVal cKey:"}
-    env7: dict = {"DD_TAGS": "env :test, aKey : aVal bKey:bVal cKey:"}
-    env8: dict = {"DD_TAGS": "env:keyWithA:Semicolon bKey:bVal cKey"}
-    env9: dict = {"DD_TAGS": "env:keyWith:  , ,   Lots:Of:Semicolons "}
-    env10: dict = {"DD_TAGS": "a:b,c,d"}
-    env11: dict = {"DD_TAGS": "a,1"}
-    env12: dict = {"DD_TAGS": "a:b:c:d"}
-    return parametrize("library_env", [env1, env2, env3, env4, env5, env6, env7, env8, env9, env10, env11, env12])
+tag_scenarios: dict = {
+    "key1:value1,key2:value2": [("key1", "value1"), ("key2", "value2")],
+    "key1:value1 key2:value2": [("key1", "value1"), ("key2", "value2")],
+    "env:test aKey:aVal bKey:bVal cKey:": [("env", "test"), ("aKey", "aVal"), ("bKey", "bVal"), ("cKey", "")],
+    "env:test,aKey:aVal,bKey:bVal,cKey:": [("env", "test"), ("aKey", "aVal"), ("bKey", "bVal"), ("cKey", "")],
+    "env:test,aKey:aVal bKey:bVal cKey:": [("env", "test"), ("aKey", "aVal bKey:bVal cKey:")],
+    "env:test     bKey :bVal dKey: dVal cKey:": [
+        ("env", "test"),
+        ("bKey", ""),
+        ("dKey", ""),
+        ("dVal", ""),
+        ("cKey", ""),
+    ],
+    "env :test, aKey : aVal bKey:bVal cKey:": [("env", "test"), ("aKey", "aVal bKey:bVal cKey:")],
+    "env:keyWithA:Semicolon bKey:bVal cKey": [("env", "keyWithA:Semicolon"), ("bKey", "bVal"), ("cKey", "")],
+    "env:keyWith:  , ,   Lots:Of:Semicolons ": [("env", "keyWith:"), ("Lots", "Of:Semicolons")],
+    "a:b,c,d": [("a", "b"), ("c", ""), ("d", "")],
+    "a,1": [("a", ""), ("1", "")],
+    "a:b:c:d": [("a", "b:c:d")],
+}
 
 
 @scenarios.parametric
 @features.tracing_configuration_consistency
 class Test_Config_Tags:
-    @tag_scenarios()
+    @parametrize("library_env", [{"DD_TAGS": key} for key in tag_scenarios.keys()])
     def test_comma_space_tag_separation(self, library_env, test_agent, test_library):
         expected_local_tags = []
         if "DD_TAGS" in library_env:
-            expected_local_tags = _parse_dd_tags(library_env["DD_TAGS"])
+            expected_local_tags = tag_scenarios[library_env["DD_TAGS"]]
         with test_library:
             with test_library.dd_start_span(name="sample_span"):
                 pass
@@ -334,20 +340,6 @@ class Test_Config_Tags:
         assert span["meta"]["env"] == "dev"
         assert "version" in span["meta"]
         assert span["meta"]["version"] == "5.2.0"
-
-
-def _parse_dd_tags(tags):
-    result = []
-    key_value_pairs = tags.split(",") if "," in tags else tags.split()  # First try to split by comma, then by space
-    for pair in key_value_pairs:
-        if ":" in pair:
-            key, value = pair.split(":", 1)
-        else:
-            key, value = pair, ""
-        key, value = key.strip(), value.strip()
-        if key:
-            result.append((key, value))
-    return result
 
 
 @scenarios.parametric


### PR DESCRIPTION
## Motivation

The tracing libraries are expected to parse `DD_TAGS` and assign them as span tags. Since this is both an agent setting and a tracer setting, the parsing logic is not trivial.

## Changes

This PR refactors the test cases to indicate what the single `DD_TAGS` environment variable is and the resulting pairs of tags set on the spans.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
