### PR TITLE
Add before/after to login tests

### DIFF
--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -1459,7 +1459,7 @@ class Test_V3_Login_Events:
             for trigger in SDK_TRIGGERS
         ]
 
-    @bug(context.library == "java", reason="APPSEC-56744")
+    @bug(context.library < "java@1.47.0", reason="APPSEC-56744")
     def test_login_sdk_failure_local(self):
         for request in self.r_sdk_failure:
             assert request.status_code == 401
@@ -1485,7 +1485,7 @@ class Test_V3_Login_Events:
         ]
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
-    @bug(context.library == "java", reason="APPSEC-56744")
+    @bug(context.library < "java@1.47.0", reason="APPSEC-56744")
     def test_login_sdk_failure_basic(self):
         for request in self.r_sdk_failure:
             assert request.status_code == 401
@@ -1772,7 +1772,7 @@ class Test_V3_Login_Events_Anon:
             for trigger in SDK_TRIGGERS
         ]
 
-    @bug(context.library == "java", reason="APPSEC-56744")
+    @bug(context.library < "java@1.47.0", reason="APPSEC-56744")
     def test_login_sdk_failure_local(self):
         for request in self.r_sdk_failure:
             assert request.status_code == 401
@@ -1798,7 +1798,7 @@ class Test_V3_Login_Events_Anon:
         ]
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
-    @bug(context.library == "java", reason="APPSEC-56744")
+    @bug(context.library < "java@1.47.0", reason="APPSEC-56744")
     def test_login_sdk_failure_basic(self):
         for request in self.r_sdk_failure:
             assert request.status_code == 401

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -62,6 +62,9 @@ HEADERS = {
     "True-Client-IP": "42.42.42.42, 43.43.43.43",
 }
 
+# when to trigger the SDK in login endpoints (before/after automated instrumentation)
+SDK_TRIGGERS = ["before", "after"]
+
 
 @rfc("https://docs.google.com/document/d/1-trUpphvyZY7k5ldjhW-MgqWl0xOm7AMEQDJEAZ63_Q/edit#heading=h.8d3o7vtyu1y1")
 @features.user_monitoring
@@ -1391,98 +1394,112 @@ class Test_V3_Login_Events:
                 assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
     def setup_login_sdk_success_local(self):
-        self.r_sdk_success = weblog.post(
-            "/login?auth=local&sdk_event=success&sdk_user=sdkUser",
-            data=login_data(context, USER, PASSWORD),
-        )
+        self.r_sdk_success = [
+            weblog.post(
+                f"/login?auth=local&sdk_trigger={trigger}&sdk_event=success&sdk_user=sdkUser",
+                data=login_data(context, USER, PASSWORD),
+            )
+            for trigger in SDK_TRIGGERS
+        ]
 
     def test_login_sdk_success_local(self):
-        # before/after
-        assert self.r_sdk_success.status_code == 200
-        for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_success):
-            assert_priority(span, trace)
-            meta = span.get("meta", {})
+        for request in self.r_sdk_success:
+            assert request.status_code == 200
+            for _, trace, span in interfaces.library.get_spans(request=request):
+                assert_priority(span, trace)
+                meta = span.get("meta", {})
 
-            # mandatory
-            assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
-            assert meta["_dd.appsec.usr.login"] == USER
-            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
-            assert meta["appsec.events.users.login.success.track"] == "true"
-            assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
+                # mandatory
+                assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
+                assert meta["_dd.appsec.usr.login"] == USER
+                assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
+                assert meta["appsec.events.users.login.success.track"] == "true"
+                assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
 
-            # optional (to review for each library)
-            if context.library not in libs_without_user_id:
-                assert meta["usr.id"] == "sdkUser"
-                assert meta["_dd.appsec.usr.id"] == "social-security-id"
+                # optional (to review for each library)
+                if context.library not in libs_without_user_id:
+                    assert meta["usr.id"] == "sdkUser"
+                    assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
     def setup_login_sdk_success_basic(self):
-        self.r_sdk_success = weblog.get(
-            "/login?auth=basic&sdk_event=success&sdk_user=sdkUser",
-            headers={"Authorization": BASIC_AUTH_USER_HEADER},
-        )
+        self.r_sdk_success = [
+            weblog.get(
+                f"/login?auth=basic&sdk_trigger={trigger}&sdk_event=success&sdk_user=sdkUser",
+                headers={"Authorization": BASIC_AUTH_USER_HEADER},
+            )
+            for trigger in SDK_TRIGGERS
+        ]
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
     def test_login_sdk_success_basic(self):
-        # before/after
-        assert self.r_sdk_success.status_code == 200
-        for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_success):
-            assert_priority(span, trace)
-            meta = span.get("meta", {})
+        for request in self.r_sdk_success:
+            assert request.status_code == 200
+            for _, trace, span in interfaces.library.get_spans(request=request):
+                assert_priority(span, trace)
+                meta = span.get("meta", {})
 
-            # mandatory
-            assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
-            assert meta["_dd.appsec.usr.login"] == USER
-            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
-            assert meta["appsec.events.users.login.success.track"] == "true"
-            assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
+                # mandatory
+                assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
+                assert meta["_dd.appsec.usr.login"] == USER
+                assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
+                assert meta["appsec.events.users.login.success.track"] == "true"
+                assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
 
-            # optional (to review for each library)
-            if context.library not in libs_without_user_id:
-                assert meta["usr.id"] == "sdkUser"
-                assert meta["_dd.appsec.usr.id"] == "social-security-id"
+                # optional (to review for each library)
+                if context.library not in libs_without_user_id:
+                    assert meta["usr.id"] == "sdkUser"
+                    assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
     def setup_login_sdk_failure_local(self):
-        self.r_sdk_failure = weblog.post(
-            "/login?auth=local&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
-            data=login_data(context, INVALID_USER, PASSWORD),
-        )
+        self.r_sdk_failure = [
+            weblog.post(
+                f"/login?auth=local&sdk_trigger={trigger}&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
+                data=login_data(context, INVALID_USER, PASSWORD),
+            )
+            for trigger in SDK_TRIGGERS
+        ]
 
+    @bug(context.library == "java", reason="APPSEC-56744")
     def test_login_sdk_failure_local(self):
-        # before/after
-        assert self.r_sdk_failure.status_code == 401
-        for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_failure):
-            assert_priority(span, trace)
-            meta = span.get("meta", {})
+        for request in self.r_sdk_failure:
+            assert request.status_code == 401
+            for _, trace, span in interfaces.library.get_spans(request=request):
+                assert_priority(span, trace)
+                meta = span.get("meta", {})
 
-            # mandatory
-            assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
-            assert meta["_dd.appsec.usr.login"] == INVALID_USER
-            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
-            assert meta["appsec.events.users.login.failure.track"] == "true"
-            assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
-            assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+                # mandatory
+                assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
+                assert meta["_dd.appsec.usr.login"] == INVALID_USER
+                assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
+                assert meta["appsec.events.users.login.failure.track"] == "true"
+                assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
+                assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
 
     def setup_login_sdk_failure_basic(self):
-        self.r_sdk_failure = weblog.get(
-            "/login?auth=basic&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
-            headers={"Authorization": BASIC_AUTH_INVALID_USER_HEADER},
-        )
+        self.r_sdk_failure = [
+            weblog.get(
+                f"/login?auth=basic&sdk_trigger={trigger}&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
+                headers={"Authorization": BASIC_AUTH_INVALID_USER_HEADER},
+            )
+            for trigger in SDK_TRIGGERS
+        ]
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @bug(context.library == "java", reason="APPSEC-56744")
     def test_login_sdk_failure_basic(self):
-        # before/after
-        assert self.r_sdk_failure.status_code == 401
-        for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_failure):
-            assert_priority(span, trace)
-            meta = span.get("meta", {})
+        for request in self.r_sdk_failure:
+            assert request.status_code == 401
+            for _, trace, span in interfaces.library.get_spans(request=request):
+                assert_priority(span, trace)
+                meta = span.get("meta", {})
 
-            # mandatory
-            assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
-            assert meta["_dd.appsec.usr.login"] == INVALID_USER
-            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
-            assert meta["appsec.events.users.login.failure.track"] == "true"
-            assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
-            assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+                # mandatory
+                assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
+                assert meta["_dd.appsec.usr.login"] == INVALID_USER
+                assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
+                assert meta["appsec.events.users.login.failure.track"] == "true"
+                assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
+                assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
 
     def setup_signup_local(self):
         self.r_success = weblog.post("/signup", data=login_data(context, NEW_USER, PASSWORD))
@@ -1689,99 +1706,113 @@ class Test_V3_Login_Events_Anon:
                 assert meta["appsec.events.users.login.failure.usr.id"] == USER_HASH
                 assert meta["_dd.appsec.usr.id"] == USER_HASH
 
-        # before/after
     def setup_login_sdk_success_local(self):
-        self.r_sdk_success = weblog.post(
-            "/login?auth=local&sdk_event=success&sdk_user=sdkUser",
-            data=login_data(context, USER, PASSWORD),
-        )
+        self.r_sdk_success = [
+            weblog.post(
+                f"/login?auth=local&sdk_trigger={trigger}&sdk_event=success&sdk_user=sdkUser",
+                data=login_data(context, USER, PASSWORD),
+            )
+            for trigger in SDK_TRIGGERS
+        ]
 
     def test_login_sdk_success_local(self):
-        assert self.r_sdk_success.status_code == 200
-        for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_success):
-            assert_priority(span, trace)
-            meta = span.get("meta", {})
+        for request in self.r_sdk_success:
+            assert request.status_code == 200
+            for _, trace, span in interfaces.library.get_spans(request=request):
+                assert_priority(span, trace)
+                meta = span.get("meta", {})
 
-            # mandatory
-            assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
-            assert meta["_dd.appsec.usr.login"] == USERNAME_HASH
-            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
-            assert meta["appsec.events.users.login.success.track"] == "true"
-            assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
+                # mandatory
+                assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
+                assert meta["_dd.appsec.usr.login"] == USERNAME_HASH
+                assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
+                assert meta["appsec.events.users.login.success.track"] == "true"
+                assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
 
-            # optional (to review for each library)
-            if context.library not in libs_without_user_id:
-                assert meta["usr.id"] == "sdkUser"
-                assert meta["_dd.appsec.usr.id"] == USER_HASH
+                # optional (to review for each library)
+                if context.library not in libs_without_user_id:
+                    assert meta["usr.id"] == "sdkUser"
+                    assert meta["_dd.appsec.usr.id"] == USER_HASH
 
-        # before/after
     def setup_login_sdk_success_basic(self):
-        self.r_sdk_success = weblog.get(
-            "/login?auth=basic&sdk_event=success&sdk_user=sdkUser",
-            headers={"Authorization": BASIC_AUTH_USER_HEADER},
-        )
+        self.r_sdk_success = [
+            weblog.get(
+                f"/login?auth=basic&sdk_trigger={trigger}&sdk_event=success&sdk_user=sdkUser",
+                headers={"Authorization": BASIC_AUTH_USER_HEADER},
+            )
+            for trigger in SDK_TRIGGERS
+        ]
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
     def test_login_sdk_success_basic(self):
-        assert self.r_sdk_success.status_code == 200
-        for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_success):
-            assert_priority(span, trace)
-            meta = span.get("meta", {})
+        for request in self.r_sdk_success:
+            assert request.status_code == 200
+            for _, trace, span in interfaces.library.get_spans(request=request):
+                assert_priority(span, trace)
+                meta = span.get("meta", {})
 
-            # mandatory
-            assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
-            assert meta["_dd.appsec.usr.login"] == USERNAME_HASH
-            assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
-            assert meta["appsec.events.users.login.success.track"] == "true"
-            assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
+                # mandatory
+                assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
+                assert meta["_dd.appsec.usr.login"] == USERNAME_HASH
+                assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
+                assert meta["appsec.events.users.login.success.track"] == "true"
+                assert meta["_dd.appsec.events.users.login.success.sdk"] == "true"
 
-            # optional (to review for each library)
-            if context.library not in libs_without_user_id:
-                assert meta["usr.id"] == "sdkUser"
-                assert meta["_dd.appsec.usr.id"] == USER_HASH
+                # optional (to review for each library)
+                if context.library not in libs_without_user_id:
+                    assert meta["usr.id"] == "sdkUser"
+                    assert meta["_dd.appsec.usr.id"] == USER_HASH
 
-        # before/after
     def setup_login_sdk_failure_local(self):
-        self.r_sdk_failure = weblog.post(
-            "/login?auth=local&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
-            data=login_data(context, INVALID_USER, PASSWORD),
-        )
+        self.r_sdk_failure = [
+            weblog.post(
+                f"/login?auth=local&sdk_trigger={trigger}&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
+                data=login_data(context, INVALID_USER, PASSWORD),
+            )
+            for trigger in SDK_TRIGGERS
+        ]
 
+    @bug(context.library == "java", reason="APPSEC-56744")
     def test_login_sdk_failure_local(self):
-        assert self.r_sdk_failure.status_code == 401
-        for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_failure):
-            assert_priority(span, trace)
-            meta = span.get("meta", {})
+        for request in self.r_sdk_failure:
+            assert request.status_code == 401
+            for _, trace, span in interfaces.library.get_spans(request=request):
+                assert_priority(span, trace)
+                meta = span.get("meta", {})
 
-            # mandatory
-            assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
-            assert meta["_dd.appsec.usr.login"] == INVALID_USER_HASH
-            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
-            assert meta["appsec.events.users.login.failure.track"] == "true"
-            assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
-            assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+                # mandatory
+                assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
+                assert meta["_dd.appsec.usr.login"] == INVALID_USER_HASH
+                assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
+                assert meta["appsec.events.users.login.failure.track"] == "true"
+                assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
+                assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
 
-        # before/after
     def setup_login_sdk_failure_basic(self):
-        self.r_sdk_failure = weblog.get(
-            "/login?auth=basic&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
-            headers={"Authorization": BASIC_AUTH_INVALID_USER_HEADER},
-        )
+        self.r_sdk_failure = [
+            weblog.get(
+                f"/login?auth=basic&sdk_trigger={trigger}&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
+                headers={"Authorization": BASIC_AUTH_INVALID_USER_HEADER},
+            )
+            for trigger in SDK_TRIGGERS
+        ]
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
+    @bug(context.library == "java", reason="APPSEC-56744")
     def test_login_sdk_failure_basic(self):
-        assert self.r_sdk_failure.status_code == 401
-        for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_failure):
-            assert_priority(span, trace)
-            meta = span.get("meta", {})
+        for request in self.r_sdk_failure:
+            assert request.status_code == 401
+            for _, trace, span in interfaces.library.get_spans(request=request):
+                assert_priority(span, trace)
+                meta = span.get("meta", {})
 
-            # mandatory
-            assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
-            assert meta["_dd.appsec.usr.login"] == INVALID_USER_HASH
-            assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
-            assert meta["appsec.events.users.login.failure.track"] == "true"
-            assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
-            assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
+                # mandatory
+                assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
+                assert meta["_dd.appsec.usr.login"] == INVALID_USER_HASH
+                assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
+                assert meta["appsec.events.users.login.failure.track"] == "true"
+                assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
+                assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
 
     def setup_signup_local(self):
         self.r_success = weblog.post("/signup", data=login_data(context, NEW_USER, PASSWORD))
@@ -1964,29 +1995,38 @@ class Test_V3_Login_Events_Blocking:
         interfaces.library.assert_waf_attack(self.r_login_blocked, rule="block-user-login")
         assert self.r_login_blocked.status_code == 403
 
-        # before/after
     def setup_login_event_blocking_sdk(self):
         rc.rc_state.reset().apply()
 
         self.config_state_1 = rc.rc_state.set_config(*CONFIG_ENABLED).apply()
-        self.r_login = weblog.post(
-            "/login?auth=local&sdk_event=success&sdk_user=sdkUser", data=login_data(context, UUID_USER, PASSWORD)
-        )
+        self.r_login = [
+            weblog.post(
+                f"/login?auth=local&sdk_trigger={trigger}&sdk_event=success&sdk_user=sdkUser",
+                data=login_data(context, UUID_USER, PASSWORD),
+            )
+            for trigger in SDK_TRIGGERS
+        ]
 
         self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER_RULE).apply()
         self.config_state_3 = rc.rc_state.set_config(*BLOCK_USER_ID).apply()
-        self.r_login_blocked = weblog.post(
-            "/login?auth=local&sdk_event=success&sdk_user=sdkUser", data=login_data(context, UUID_USER, PASSWORD)
-        )
+        self.r_login_blocked = [
+            weblog.post(
+                f"/login?auth=local&sdk_trigger={trigger}&sdk_event=success&sdk_user=sdkUser",
+                data=login_data(context, UUID_USER, PASSWORD),
+            )
+            for trigger in SDK_TRIGGERS
+        ]
 
     def test_login_event_blocking_sdk(self):
         assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
-        assert self.r_login.status_code == 200
+        for request in self.r_login:
+            assert request.status_code == 200
 
         assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
         assert self.config_state_3[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
-        interfaces.library.assert_waf_attack(self.r_login_blocked, rule="block-user-id")
-        assert self.r_login_blocked.status_code == 403
+        for request in self.r_login_blocked:
+            interfaces.library.assert_waf_attack(request, rule="block-user-id")
+            assert request.status_code == 403
 
 
 @rfc("https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw")

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -1397,6 +1397,7 @@ class Test_V3_Login_Events:
         )
 
     def test_login_sdk_success_local(self):
+        # before/after
         assert self.r_sdk_success.status_code == 200
         for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_success):
             assert_priority(span, trace)
@@ -1422,6 +1423,7 @@ class Test_V3_Login_Events:
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
     def test_login_sdk_success_basic(self):
+        # before/after
         assert self.r_sdk_success.status_code == 200
         for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_success):
             assert_priority(span, trace)
@@ -1446,6 +1448,7 @@ class Test_V3_Login_Events:
         )
 
     def test_login_sdk_failure_local(self):
+        # before/after
         assert self.r_sdk_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_failure):
             assert_priority(span, trace)
@@ -1467,6 +1470,7 @@ class Test_V3_Login_Events:
 
     @missing_feature(context.library == "php", reason="Basic auth not implemented")
     def test_login_sdk_failure_basic(self):
+        # before/after
         assert self.r_sdk_failure.status_code == 401
         for _, trace, span in interfaces.library.get_spans(request=self.r_sdk_failure):
             assert_priority(span, trace)
@@ -1685,6 +1689,7 @@ class Test_V3_Login_Events_Anon:
                 assert meta["appsec.events.users.login.failure.usr.id"] == USER_HASH
                 assert meta["_dd.appsec.usr.id"] == USER_HASH
 
+        # before/after
     def setup_login_sdk_success_local(self):
         self.r_sdk_success = weblog.post(
             "/login?auth=local&sdk_event=success&sdk_user=sdkUser",
@@ -1709,6 +1714,7 @@ class Test_V3_Login_Events_Anon:
                 assert meta["usr.id"] == "sdkUser"
                 assert meta["_dd.appsec.usr.id"] == USER_HASH
 
+        # before/after
     def setup_login_sdk_success_basic(self):
         self.r_sdk_success = weblog.get(
             "/login?auth=basic&sdk_event=success&sdk_user=sdkUser",
@@ -1734,6 +1740,7 @@ class Test_V3_Login_Events_Anon:
                 assert meta["usr.id"] == "sdkUser"
                 assert meta["_dd.appsec.usr.id"] == USER_HASH
 
+        # before/after
     def setup_login_sdk_failure_local(self):
         self.r_sdk_failure = weblog.post(
             "/login?auth=local&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
@@ -1754,6 +1761,7 @@ class Test_V3_Login_Events_Anon:
             assert meta["_dd.appsec.events.users.login.failure.sdk"] == "true"
             assert meta["appsec.events.users.login.failure.usr.exists"] == "true"
 
+        # before/after
     def setup_login_sdk_failure_basic(self):
         self.r_sdk_failure = weblog.get(
             "/login?auth=basic&sdk_event=failure&sdk_user=sdkUser&sdk_user_exists=true",
@@ -1956,6 +1964,7 @@ class Test_V3_Login_Events_Blocking:
         interfaces.library.assert_waf_attack(self.r_login_blocked, rule="block-user-login")
         assert self.r_login_blocked.status_code == 403
 
+        # before/after
     def setup_login_event_blocking_sdk(self):
         rc.rc_state.reset().apply()
 


### PR DESCRIPTION
## Motivation

The SDK should take priority over automated login events, this PR ensures that we test both when the SDK event is triggered before and after the automated one.

## Changes

9 tests are modified:
2 (success/failure) * 2 (local/basic auth) * 2 (identification/anonymous mode) + 1 RC test

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
