### PR TITLE
[java] Enabled xpass tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -883,10 +883,10 @@ tests/:
         Test_PathParams:
           '*': v0.95.1
           akka-http: missing_feature (unclear how to implement; matching doesn't happen in one go)
-          jersey-grizzly2: missing_feature
+          jersey-grizzly2: v1.46.0
           play: v1.22.0
           ratpack: v0.99.0
-          resteasy-netty3: missing_feature
+          resteasy-netty3: v1.46.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           vertx3: v0.99.0
         Test_ResponseStatus:
@@ -1332,9 +1332,9 @@ tests/:
         ratpack: missing_feature (endpoint not implemented)
         resteasy-netty3: missing_feature (endpoint not implemented)
         spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
-        spring-boot-jetty: missing_feature (missing addresses)
-        spring-boot-undertow: missing_feature (missing addresses)
-        spring-boot-wildfly: missing_feature (missing addresses)
+        spring-boot-jetty: v1.46.0
+        spring-boot-undertow: v1.46.0
+        spring-boot-wildfly: v1.46.0
         vertx3: v1.46.0
         vertx4: v1.46.0
       Test_Fingerprinting_Session_Capability:
@@ -1357,7 +1357,10 @@ tests/:
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_StandardizationBlockMode: missing_feature
-    test_metastruct.py: missing_feature
+    test_metastruct.py:
+      Test_SecurityEvents_Appsec_Metastruct_Disabled:
+        '*': v1.46.0
+      Test_SecurityEvents_Iast_Metastruct_Disabled: missing_feature
     test_rate_limiter.py:
       Test_Main:
         akka-http: v1.22.0
@@ -1797,6 +1800,7 @@ tests/:
       '*': missing_feature
       spring-boot: v0.102.0
       spring-boot-jetty: v0.102.0
+      spring-boot-wildfly: v1.46.0
     Test_StandardTagsStatusCode: v0.102.0
     Test_StandardTagsUrl: v0.107.1
     Test_StandardTagsUserAgent: v0.107.1

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1332,9 +1332,9 @@ tests/:
         ratpack: missing_feature (endpoint not implemented)
         resteasy-netty3: missing_feature (endpoint not implemented)
         spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
-        spring-boot-jetty: v1.46.0
-        spring-boot-undertow: v1.46.0
-        spring-boot-wildfly: v1.46.0
+        spring-boot-jetty: v1.42.0
+        spring-boot-undertow: v1.42.0
+        spring-boot-wildfly: v1.42.0
         vertx3: v1.46.0
         vertx4: v1.46.0
       Test_Fingerprinting_Session_Capability:
@@ -1791,7 +1791,7 @@ tests/:
       '*': missing_feature
       spring-boot: v0.102.0
       spring-boot-jetty: v0.102.0
-      spring-boot-wildfly: v1.46.0
+      spring-boot-wildfly: v0.102.0
     Test_StandardTagsStatusCode: v0.102.0
     Test_StandardTagsUrl: v0.107.1
     Test_StandardTagsUserAgent: v0.107.1

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -883,10 +883,10 @@ tests/:
         Test_PathParams:
           '*': v0.95.1
           akka-http: missing_feature (unclear how to implement; matching doesn't happen in one go)
-          jersey-grizzly2: v1.46.0
+          jersey-grizzly2: v1.15.0
           play: v1.22.0
           ratpack: v0.99.0
-          resteasy-netty3: v1.46.0
+          resteasy-netty3: v1.15.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           vertx3: v0.99.0
         Test_ResponseStatus:
@@ -1453,14 +1453,8 @@ tests/:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist:
-        '*': v0.111.0
-        jersey-grizzly2: v1.7.0
-        ratpack: v1.7.0
-        resteasy-netty3: v1.7.0
-        spring-boot: v0.110.0
+        '*': v1.37.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        spring-boot-openliberty: v0.115.0
-        vertx3: v1.7.0
     test_versions.py:
       Test_Events: v0.90.0
   debugger/:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1453,8 +1453,14 @@ tests/:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist:
-        '*': v1.37.0
+        '*': v0.111.0
+        jersey-grizzly2: v1.7.0
+        ratpack: v1.7.0
+        resteasy-netty3: v1.7.0
+        spring-boot: v0.110.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-openliberty: v0.115.0
+        vertx3: v1.7.0
     test_versions.py:
       Test_Events: v0.90.0
   debugger/:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1357,10 +1357,7 @@ tests/:
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_StandardizationBlockMode: missing_feature
-    test_metastruct.py:
-      Test_SecurityEvents_Appsec_Metastruct_Disabled:
-        '*': v1.46.0
-      Test_SecurityEvents_Iast_Metastruct_Disabled: missing_feature
+    test_metastruct.py: missing_feature (APPSEC-4766)
     test_rate_limiter.py:
       Test_Main:
         akka-http: v1.22.0

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -33,7 +33,7 @@ class Test_UserBlocking_FullDenylist(BaseFullDenyListTest):
 
     @bug(context.library < "ruby@1.12.1", reason="APMRP-360")
     @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
-    @bug(library="java", reason="APPSEC-56006")
+    @bug(context.library < "java@1.36.0", reason="APPSEC-56006")
     def test_blocking_test(self):
         """Test with a denylisted user"""
 

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -32,7 +32,8 @@ class Test_UserBlocking_FullDenylist(BaseFullDenyListTest):
         ]
 
     @bug(context.library < "ruby@1.12.1", reason="APMRP-360")
-    # @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
+    @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
+    @bug(library="java", reason="APPSEC-56006")
     def test_blocking_test(self):
         """Test with a denylisted user"""
 

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -32,7 +32,7 @@ class Test_UserBlocking_FullDenylist(BaseFullDenyListTest):
         ]
 
     @bug(context.library < "ruby@1.12.1", reason="APMRP-360")
-    @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
+    # @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
     def test_blocking_test(self):
         """Test with a denylisted user"""
 

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -33,6 +33,7 @@ class Test_UserBlocking_FullDenylist(BaseFullDenyListTest):
 
     @bug(context.library < "ruby@1.12.1", reason="APMRP-360")
     @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
+    @bug(library="java", weblog_variant="spring-boot-payara", reason="APPSEC-56006")
     def test_blocking_test(self):
         """Test with a denylisted user"""
 

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -33,7 +33,6 @@ class Test_UserBlocking_FullDenylist(BaseFullDenyListTest):
 
     @bug(context.library < "ruby@1.12.1", reason="APMRP-360")
     @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
-    @bug(context.library < "java@1.36.0", reason="APPSEC-56006")
     def test_blocking_test(self):
         """Test with a denylisted user"""
 

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -33,7 +33,6 @@ class Test_UserBlocking_FullDenylist(BaseFullDenyListTest):
 
     @bug(context.library < "ruby@1.12.1", reason="APMRP-360")
     @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
-    @bug(library="java", reason="APPSEC-56006")
     def test_blocking_test(self):
         """Test with a denylisted user"""
 

--- a/utils/scripts/check_version.sh
+++ b/utils/scripts/check_version.sh
@@ -7,6 +7,7 @@ weblog_variant="spring-boot"
 scenario="DEFAULT"
 build_prefix="dd-java-agent"
 build_suffix="jar"
+test_name="tests/appsec/waf/test_addresses.py::Test_PathParams" # leave empty for all tests
 
 readonly OUTPUT_DIR=version-check-output/$library
 mkdir -p "$OUTPUT_DIR"
@@ -103,7 +104,7 @@ for v in "${versions[@]}"; do
         echo "Building $library $v $weblog_variant"
         ./build.sh --library $library --weblog-variant $weblog_variant &> /dev/null
         echo "Running $library $v $weblog_variant"
-        ./run.sh --scenario $scenario &> "$OUTPUT_DIR/$scenario/$weblog_variant/$library-$v.txt" || true
+        ./run.sh --scenario $scenario $test_name &> "$OUTPUT_DIR/$scenario/$weblog_variant/$library-$v.txt" || true
     fi
 
     declare -A seen_xpass


### PR DESCRIPTION
## Changes

Fix easy wins in following tests:
- `tests/appsec/waf/test_addresses.py::Test_PathParams`
- `tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Session`
- `tests/appsec/test_metastruct.py::Test_SecurityEvents_Appsec_Metastruct_Disabled`
- `tests/test_standard_tags.py::Test_StandardTagsRoute`

[APPSEC-54879](https://datadoghq.atlassian.net/browse/APPSEC-54879)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-54879]: https://datadoghq.atlassian.net/browse/APPSEC-54879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ