### PR TITLE
fix Context Propagation: Extraction feature_id

### DIFF
--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2351,7 +2351,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=353
         """
-        pytest.mark.features(feature_id=343)(test_object)
+        pytest.mark.features(feature_id=353)(test_object)
         return test_object
 
     @staticmethod


### PR DESCRIPTION
## Motivation

Context Propagation: Extraction has the same feature_id as Security Controls and therefore
FPD is marking as bug a lot of tests not related with Security Controls :sweat_smile:

![image](https://github.com/user-attachments/assets/0ed11b27-ca39-4cac-8a8b-b3fc4b72b636)

cc: @zacharycmontoya 

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
