### PR TITLE
update weblog sampling_test use sampling rules instead of deprecated envvar

### DIFF
--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -277,7 +277,7 @@ class Test_Environment:
     @missing_feature(context.library == "php", reason="Not implemented")
     @missing_feature(context.library == "cpp", reason="Not implemented")
     @missing_feature(
-        context.library < "python@3.0", reason="OTEL Sampling config is mapped to a different datadog config"
+        context.library <= "python@3.1.0", reason="OTEL Sampling config is mapped to a different datadog config"
     )
     @pytest.mark.parametrize(
         "library_env",
@@ -370,7 +370,7 @@ class Test_Environment:
     @missing_feature(context.library == "php", reason="Not implemented")
     @missing_feature(context.library == "cpp", reason="Not implemented")
     @missing_feature(
-        context.library < "python@3.0", reason="OTEL Sampling config is mapped to a different datadog config"
+        context.library <= "python@3.1.0", reason="OTEL Sampling config is mapped to a different datadog config"
     )
     @missing_feature(
         context.library == "nodejs", reason="does not collect otel_env.invalid metrics for otel_resource_attributes"

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -67,7 +67,7 @@ class _Scenarios:
     sampling = EndToEndScenario(
         "SAMPLING",
         tracer_sampling_rate=0.5,
-        weblog_env={"DD_TRACE_RATE_LIMIT": "10000000", "DD_TRACE_SAMPLING_RULES": json.dumps([{"sample_rate": 0.5}])},
+        weblog_env={"DD_TRACE_RATE_LIMIT": "10000000"},
         doc="Test sampling mechanism. Not included in default scenario because it's a little bit too flaky",
         scenario_groups=[ScenarioGroup.SAMPLING],
     )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -67,7 +67,7 @@ class _Scenarios:
     sampling = EndToEndScenario(
         "SAMPLING",
         tracer_sampling_rate=0.5,
-        weblog_env={"DD_TRACE_RATE_LIMIT": "10000000"},
+        weblog_env={"DD_TRACE_RATE_LIMIT": "10000000", "DD_TRACE_SAMPLING_RULES": json.dumps([{"sample_rate": 0.5}])},
         doc="Test sampling mechanism. Not included in default scenario because it's a little bit too flaky",
         scenario_groups=[ScenarioGroup.SAMPLING],
     )

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -718,10 +718,6 @@ class WeblogContainer(TestedContainer):
             base_environment["DD_IAST_DEDUPLICATION_ENABLED"] = "false"
 
         if tracer_sampling_rate:
-            if context.library == "python":
-                # python3.x dropped support for DD_TRACE_SAMPLE_RATE
-                base_environment["DD_TRACE_SAMPLING_RULES"] = str([{"sample_rate": tracer_sampling_rate}])
-            else:
                 base_environment["DD_TRACE_SAMPLE_RATE"] = str(tracer_sampling_rate)
 
         if use_proxy:

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -671,7 +671,7 @@ class WeblogContainer(TestedContainer):
         use_proxy=True,
         volumes=None,
     ) -> None:
-        from utils import weblog, context
+        from utils import weblog
 
         self.host_port = weblog.port
         self.container_port = 7777
@@ -718,7 +718,8 @@ class WeblogContainer(TestedContainer):
             base_environment["DD_IAST_DEDUPLICATION_ENABLED"] = "false"
 
         if tracer_sampling_rate:
-                base_environment["DD_TRACE_SAMPLE_RATE"] = str(tracer_sampling_rate)
+            base_environment["DD_TRACE_SAMPLE_RATE"] = str(tracer_sampling_rate)
+            base_environment["DD_TRACE_SAMPLING_RULES"] = json.dumps([{"sample_rate": tracer_sampling_rate}])
 
         if use_proxy:
             # set the tracer to send data to runner (it will forward them to the agent)


### PR DESCRIPTION
## Motivation

- Resolve the following test failure: https://github.com/DataDog/dd-trace-py/actions/runs/13144020351/job/36678122864?pr=12176
- Fix telemetry version introduced in an earlier sampling PR


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
