### PR TITLE
[Tracing] Update DD_TAGS tests to remove empty tag values

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -776,7 +776,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_Dogstatsd: missing_feature
       Test_Config_RateLimit: v2.15.0
-      Test_Config_Tags: missing_feature
+      Test_Config_Tags: v2.0.0
       Test_Config_TraceAgentURL: v2.0.0
       Test_Config_TraceEnabled: v2.12.2
       Test_Config_TraceLogDirectory: missing_feature

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -302,23 +302,27 @@ tag_scenarios: dict = {
         expected_tags=[("key1", "value1"), ("key2", "value2")], expected_discarded_keys=[]
     ),
     "env:test aKey:aVal bKey:bVal cKey:": TagTest(
-        expected_tags=[("env", "test"), ("aKey", "aVal"), ("bKey", "bVal")], expected_discarded_keys=["cKey"]
+        expected_tags=[("env", "test"), ("aKey", "aVal"), ("bKey", "bVal"), ("cKey", "")], expected_discarded_keys=[]
     ),
     "env:test,aKey:aVal,bKey:bVal,cKey:": TagTest(
-        expected_tags=[("env", "test"), ("aKey", "aVal"), ("bKey", "bVal")], expected_discarded_keys=["cKey"]
+        expected_tags=[("env", "test"), ("aKey", "aVal"), ("bKey", "bVal"), ("cKey", "")], expected_discarded_keys=[]
     ),
-    "env:test,aKey:aVal bKey:bVal cKey:": TagTest(expected_tags=[], expected_discarded_keys=["env", "aKey"]),
+    "env:test,aKey:aVal bKey:bVal cKey:": TagTest(
+        expected_tags=[("env", "test"), ("aKey", "aVal bKey:bVal cKey:")], expected_discarded_keys=[]
+    ),
     "env:test     bKey :bVal dKey: dVal cKey:": TagTest(
-        expected_tags=[("env", "test"), ("bKey", ""), ("dVal", "")],
-        expected_discarded_keys=["dKey", "cKey"],
+        expected_tags=[("env", "test"), ("bKey", ""), ("dKey", ""), ("dVal", ""), ("cKey", "")],
+        expected_discarded_keys=[],
     ),
     "env :test, aKey : aVal bKey:bVal cKey:": TagTest(
-        expected_tags=[("env", ""), ("aKey", ""), ("aVal", ""), ("bKey", "bVal")], expected_discarded_keys=[]
+        expected_tags=[("env", "test"), ("aKey", "aVal bKey:bVal cKey:")], expected_discarded_keys=[]
     ),
     "env:keyWithA:Semicolon bKey:bVal cKey": TagTest(
         expected_tags=[("env", "keyWithA:Semicolon"), ("bKey", "bVal"), ("cKey", "")], expected_discarded_keys=[]
     ),
-    "env:keyWith:  , ,   Lots:Of:Semicolons ": TagTest(expected_tags=[], expected_discarded_keys=["env", "Lots"]),
+    "env:keyWith:  , ,   Lots:Of:Semicolons ": TagTest(
+        expected_tags=[("env", "keyWith:"), ("Lots", "Of:Semicolons")], expected_discarded_keys=[]
+    ),
     "a:b,c,d": TagTest(expected_tags=[("a", "b"), ("c", ""), ("d", "")], expected_discarded_keys=[]),
     "a,1": TagTest(expected_tags=[("a", ""), ("1", "")], expected_discarded_keys=[]),
     "a:b:c:d": TagTest(expected_tags=[("a", "b:c:d")], expected_discarded_keys=[]),

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -302,27 +302,23 @@ tag_scenarios: dict = {
         expected_tags=[("key1", "value1"), ("key2", "value2")], expected_discarded_keys=[]
     ),
     "env:test aKey:aVal bKey:bVal cKey:": TagTest(
-        expected_tags=[("env", "test"), ("aKey", "aVal"), ("bKey", "bVal"), ("cKey", "")], expected_discarded_keys=[]
+        expected_tags=[("env", "test"), ("aKey", "aVal"), ("bKey", "bVal")], expected_discarded_keys=["cKey"]
     ),
     "env:test,aKey:aVal,bKey:bVal,cKey:": TagTest(
-        expected_tags=[("env", "test"), ("aKey", "aVal"), ("bKey", "bVal"), ("cKey", "")], expected_discarded_keys=[]
+        expected_tags=[("env", "test"), ("aKey", "aVal"), ("bKey", "bVal")], expected_discarded_keys=["cKey"]
     ),
-    "env:test,aKey:aVal bKey:bVal cKey:": TagTest(
-        expected_tags=[("env", "test"), ("aKey", "aVal bKey:bVal cKey:")], expected_discarded_keys=[]
-    ),
+    "env:test,aKey:aVal bKey:bVal cKey:": TagTest(expected_tags=[], expected_discarded_keys=["env", "aKey"]),
     "env:test     bKey :bVal dKey: dVal cKey:": TagTest(
-        expected_tags=[("env", "test"), ("bKey", ""), ("dKey", ""), ("dVal", ""), ("cKey", "")],
-        expected_discarded_keys=[],
+        expected_tags=[("env", "test"), ("bKey", ""), ("dVal", "")],
+        expected_discarded_keys=["dKey", "cKey"],
     ),
     "env :test, aKey : aVal bKey:bVal cKey:": TagTest(
-        expected_tags=[("env", "test"), ("aKey", "aVal bKey:bVal cKey:")], expected_discarded_keys=[]
+        expected_tags=[("env", ""), ("aKey", ""), ("aVal", ""), ("bKey", "bVal")], expected_discarded_keys=[]
     ),
     "env:keyWithA:Semicolon bKey:bVal cKey": TagTest(
         expected_tags=[("env", "keyWithA:Semicolon"), ("bKey", "bVal"), ("cKey", "")], expected_discarded_keys=[]
     ),
-    "env:keyWith:  , ,   Lots:Of:Semicolons ": TagTest(
-        expected_tags=[("env", "keyWith:"), ("Lots", "Of:Semicolons")], expected_discarded_keys=[]
-    ),
+    "env:keyWith:  , ,   Lots:Of:Semicolons ": TagTest(expected_tags=[], expected_discarded_keys=["env", "Lots"]),
     "a:b,c,d": TagTest(expected_tags=[("a", "b"), ("c", ""), ("d", "")], expected_discarded_keys=[]),
     "a,1": TagTest(expected_tags=[("a", ""), ("1", "")], expected_discarded_keys=[]),
     "a:b:c:d": TagTest(expected_tags=[("a", "b:c:d")], expected_discarded_keys=[]),

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -3,9 +3,10 @@
 # Copyright 2021 Datadog, Inc.
 
 import re
+import pprint
 from urllib.parse import urlparse
 
-from utils import context, interfaces, bug, missing_feature, features, scenarios
+from utils import context, interfaces, bug, missing_feature, features, scenarios, weblog
 
 RUNTIME_LANGUAGE_MAP = {
     "nodejs": "javascript",
@@ -321,6 +322,25 @@ class Test_MetaDatadogTags:
             return True
 
         interfaces.library.validate_spans(validator=validator)
+
+
+@scenarios.default
+@features.tracing_configuration_consistency
+class Test_Agent_DDTags:
+    """Spans carry meta tags that were set in DD_TAGS agent environment"""
+
+    def setup_main(self):
+        self.r = weblog.get("/")
+
+    def test_main(self):
+        assert self.r.status_code == 200
+
+        spans = interfaces.agent.get_spans_list(self.r)
+        assert len(spans) == 1, "Agent received the incorrect amount of spans"
+
+        host_tags = interfaces.agent.get_host_tags()
+        pprint.pprint(host_tags["system"])
+        assert False
 
 
 @features.data_integrity

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -537,6 +537,7 @@ class AgentContainer(TestedContainer):
                 "DD_APM_RECEIVER_PORT": self.apm_receiver_port,
                 "DD_DOGSTATSD_PORT": self.dogstatsd_port,
                 "DD_API_KEY": os.environ.get("DD_API_KEY", _FAKE_DD_API_KEY),
+                # To configure configure host tags, set the env variable "DD_TAGS" here
             }
         )
 

--- a/utils/interfaces/_agent.py
+++ b/utils/interfaces/_agent.py
@@ -117,6 +117,16 @@ class AgentInterfaceValidator(ProxyBasedInterfaceValidator):
             validator=validator, success_by_default=success_by_default, path_filters=r"/api/v0\.[1-9]+/traces"
         )
 
+    def get_host_tags(self):
+        for data in self.get_data(path_filters="/intake/"):
+            if "host-tags" not in data["request"]["content"]:
+                continue
+
+            if data["request"]["content"].get("host-tags"):
+                return data["request"]["content"]["host-tags"]
+
+        return {}
+
     def get_spans(self, request=None):
         """Attempts to fetch the spans the agent will submit to the backend.
 


### PR DESCRIPTION
## Motivation

As we are ensuring the consistent implementation of DD_TAGS across tracing libraries, I'm looking to clarify our edge cases.

## Changes

Changes the expected outputs of the `tests/parametric/test_config_consistency.py::Test_Config_Tags` test case

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
