### PR TITLE
[Nodejs] Enable untrusted deserialization stack trace test for Node.js

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -234,7 +234,9 @@ tests/:
           TestUntrustedDeserialization:
             '*': *ref_5_32_0
             nextjs: missing_feature
-          TestUntrustedDeserialization_StackTrace: missing_feature
+          TestUntrustedDeserialization_StackTrace:
+            '*': *ref_5_32_0
+            nextjs: missing_feature
         test_unvalidated_redirect.py:
           TestUnvalidatedHeader:
             '*': *ref_4_3_0

--- a/tests/appsec/iast/sink/test_untrusted_deserialization.py
+++ b/tests/appsec/iast/sink/test_untrusted_deserialization.py
@@ -28,7 +28,7 @@ class TestUntrustedDeserialization_StackTrace:
     """Validate stack trace generation"""
 
     def setup_stack_trace(self):
-        self.r = weblog.get("/iast/untrusted_deserialization/test_insecure")
+        self.r = weblog.get("/iast/untrusted_deserialization/test_insecure?name=example")
 
     def test_stack_trace(self):
         validate_stack_traces(self.r)


### PR DESCRIPTION
## Motivation

Easy win for Node.js untrusted deserialization stack trace system test

## Changes

1. Change test URL
2. Change dd-trace-js version 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
3. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
4. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
