### PR TITLE
[java] Bump GraalVM system test to JDK 22

### DIFF
--- a/utils/build/docker/java/spring-boot-3-native.Dockerfile
+++ b/utils/build/docker/java/spring-boot-3-native.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:21.0.0 as build
+FROM ghcr.io/graalvm/native-image-community:22.0.0 as build
 
 ENV JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=true"
 


### PR DESCRIPTION
## Motivation

We would like to focus on JDK 22+ based GraalVM for first-class profiling support. Following this PR, we'll be able to ensure that the tracer and profiler are building correctly as part of `dd-trace-java`'s CI. We will also duplicate the Docker images into `relenv`.

## Changes

This is just a bump of the base Graal image used by this test. I have spoken with @cbeauchesne and plan on following-fast with an identical weblog build that is based on JDK 21 (as our "LTS").

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
