### PR TITLE
[python] Avoid passing global tracer to pin in weblog apps

### DIFF
--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -786,7 +786,7 @@ def get_value(request):
 def create_extra_service(request):
     new_service_name = request.GET.get("serviceName", default="")
     if new_service_name:
-        Pin.override(django, service=new_service_name, tracer=tracer)
+        Pin.override(django, service=new_service_name)
     return HttpResponse("OK")
 
 

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -876,7 +876,7 @@ async def view_iast_code_injection_secure(code: typing.Annotated[str, Form()]):
 @app.get("/createextraservice", response_class=PlainTextResponse)
 def create_extra_service(serviceName: str = ""):
     if serviceName:
-        Pin.override(fastapi, service=serviceName, tracer=tracer)
+        Pin.override(fastapi, service=serviceName)
     return "OK"
 
 

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -1379,7 +1379,7 @@ def db():
 def create_extra_service():
     new_service_name = request.args.get("serviceName", default="", type=str)
     if new_service_name:
-        Pin.override(Flask, service=new_service_name, tracer=tracer)
+        Pin.override(Flask, service=new_service_name)
     return Response("OK")
 
 

--- a/utils/build/docker/python/flask/integrations/messaging/rabbitmq.py
+++ b/utils/build/docker/python/flask/integrations/messaging/rabbitmq.py
@@ -1,13 +1,10 @@
 import kombu
 
-from ddtrace.trace import tracer, Pin
-
 
 def rabbitmq_produce(queue, exchange, routing_key, message):
     conn = kombu.Connection("amqp://rabbitmq:5672")
     conn.connect()
     producer = conn.Producer()
-    Pin.override(producer, tracer=tracer)
 
     task_queue = kombu.Queue(queue, kombu.Exchange(exchange), routing_key=routing_key)
     to_publish = {"message": message}
@@ -24,8 +21,7 @@ def rabbitmq_consume(queue, exchange, routing_key, timeout=60):
         message.ack()
         messages.append(message.payload)
 
-    with kombu.Consumer(conn, [task_queue], accept=["json"], callbacks=[process_message]) as consumer:
-        Pin.override(consumer, tracer=tracer)
+    with kombu.Consumer(conn, [task_queue], accept=["json"], callbacks=[process_message]):
         conn.drain_events(timeout=timeout)
 
     conn.close()


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/dd-trace-py/pull/12219 removes the tracer parameter from `Pin.override(...)`. In ddtrace>=3.0, the Pin object will always use the global tracer.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
