### PR TITLE
[NodeJS] skip failing baggage tests

### DIFF
--- a/tests/parametric/test_headers_baggage.py
+++ b/tests/parametric/test_headers_baggage.py
@@ -1,5 +1,5 @@
 from utils.parametric.spec.trace import find_only_span
-from utils import features, scenarios
+from utils import features, scenarios, missing_feature
 from typing import Any
 import pytest
 
@@ -37,7 +37,7 @@ class Test_Headers_Baggage:
         assert headers["baggage"] == "foo=bar"
 
     @only_baggage_enabled()
-    @missing_feature(context.library == "nodejs", reason="pausing on this feature to avoid app crashes, looking to restore it soon - Feb 5, 2024")
+    @missing_feature(context.library == "nodejs", reason="pausing on this feature to avoid app crashes")
     def test_headers_baggage_only_D002(self, test_library):
         """Ensure that only baggage headers are injected when baggage is the only enabled propagation style."""
         with test_library:
@@ -84,7 +84,7 @@ class Test_Headers_Baggage:
         assert "serverNode=DF%2028" in baggage_items
         assert "%22%2C%3B%5C%28%29%2F%3A%3C%3D%3E%3F%40%5B%5D%7B%7D=%22%2C%3B%5C" in baggage_items
 
-    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage, will fix later - Feb 6, 2024")
+    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage")
     def test_baggage_extract_header_D005(self, test_library):
         """Testing baggage header extraction and decoding"""
 
@@ -130,7 +130,7 @@ class Test_Headers_Baggage:
             headers = test_library.dd_inject_headers(span.span_id)
         assert not any("baggage" in item for item in headers)
 
-    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage, will fix later - Feb 6, 2024")
+    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage")
     def test_baggage_get_D008(self, test_library):
         """Testing baggage API get_baggage"""
         with test_library.dd_extract_headers_and_make_child_span(
@@ -143,7 +143,7 @@ class Test_Headers_Baggage:
             assert span.get_baggage("userId") == "Amélie"
             assert span.get_baggage("serverNode") == "DF 28"
 
-    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage, will fix later - Feb 6, 2024")
+    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage")
     def test_baggage_get_all_D009(self, test_library):
         """Testing baggage API get_all_baggage"""
         with test_library.dd_extract_headers_and_make_child_span(

--- a/tests/parametric/test_headers_baggage.py
+++ b/tests/parametric/test_headers_baggage.py
@@ -90,7 +90,9 @@ class Test_Headers_Baggage:
         assert "serverNode=DF%2028" in baggage_items
         assert "%22%2C%3B%5C%28%29%2F%3A%3C%3D%3E%3F%40%5B%5D%7B%7D=%22%2C%3B%5C" in baggage_items
 
-    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage")
+    @missing_feature(
+        context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage"
+    )
     def test_baggage_extract_header_D005(self, test_library):
         """Testing baggage header extraction and decoding"""
 
@@ -140,7 +142,9 @@ class Test_Headers_Baggage:
             headers = test_library.dd_inject_headers(span.span_id)
         assert not any("baggage" in item for item in headers)
 
-    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage")
+    @missing_feature(
+        context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage"
+    )
     def test_baggage_get_D008(self, test_library):
         """Testing baggage API get_baggage"""
         with test_library.dd_extract_headers_and_make_child_span(
@@ -153,7 +157,9 @@ class Test_Headers_Baggage:
             assert span.get_baggage("userId") == "Amélie"
             assert span.get_baggage("serverNode") == "DF 28"
 
-    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage")
+    @missing_feature(
+        context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage"
+    )
     def test_baggage_get_all_D009(self, test_library):
         """Testing baggage API get_all_baggage"""
         with test_library.dd_extract_headers_and_make_child_span(

--- a/tests/parametric/test_headers_baggage.py
+++ b/tests/parametric/test_headers_baggage.py
@@ -37,6 +37,7 @@ class Test_Headers_Baggage:
         assert headers["baggage"] == "foo=bar"
 
     @only_baggage_enabled()
+    @missing_feature(context.library == "nodejs", reason="pausing on this feature to avoid app crashes, looking to restore it soon - Feb 5, 2024")
     def test_headers_baggage_only_D002(self, test_library):
         """Ensure that only baggage headers are injected when baggage is the only enabled propagation style."""
         with test_library:
@@ -83,6 +84,7 @@ class Test_Headers_Baggage:
         assert "serverNode=DF%2028" in baggage_items
         assert "%22%2C%3B%5C%28%29%2F%3A%3C%3D%3E%3F%40%5B%5D%7B%7D=%22%2C%3B%5C" in baggage_items
 
+    @missing_feature(context.library == "nodejs", reason="spanContext is null when header only includes baggage, will fix it in a later PR - Feb 6, 2024")
     def test_baggage_extract_header_D005(self, test_library):
         """Testing baggage header extraction and decoding"""
 

--- a/tests/parametric/test_headers_baggage.py
+++ b/tests/parametric/test_headers_baggage.py
@@ -84,7 +84,7 @@ class Test_Headers_Baggage:
         assert "serverNode=DF%2028" in baggage_items
         assert "%22%2C%3B%5C%28%29%2F%3A%3C%3D%3E%3F%40%5B%5D%7B%7D=%22%2C%3B%5C" in baggage_items
 
-    @missing_feature(context.library == "nodejs", reason="spanContext is null when header only includes baggage, will fix it in a later PR - Feb 6, 2024")
+    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage, will fix later - Feb 6, 2024")
     def test_baggage_extract_header_D005(self, test_library):
         """Testing baggage header extraction and decoding"""
 
@@ -130,6 +130,7 @@ class Test_Headers_Baggage:
             headers = test_library.dd_inject_headers(span.span_id)
         assert not any("baggage" in item for item in headers)
 
+    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage, will fix later - Feb 6, 2024")
     def test_baggage_get_D008(self, test_library):
         """Testing baggage API get_baggage"""
         with test_library.dd_extract_headers_and_make_child_span(
@@ -142,6 +143,7 @@ class Test_Headers_Baggage:
             assert span.get_baggage("userId") == "Amélie"
             assert span.get_baggage("serverNode") == "DF 28"
 
+    @missing_feature(context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage, will fix later - Feb 6, 2024")
     def test_baggage_get_all_D009(self, test_library):
         """Testing baggage API get_all_baggage"""
         with test_library.dd_extract_headers_and_make_child_span(

--- a/tests/parametric/test_headers_baggage.py
+++ b/tests/parametric/test_headers_baggage.py
@@ -1,5 +1,5 @@
 from utils.parametric.spec.trace import find_only_span
-from utils import features, scenarios, missing_feature
+from utils import features, scenarios, context, missing_feature
 from typing import Any
 import pytest
 


### PR DESCRIPTION
## Motivation
Made [this temporary change](https://github.com/DataDog/dd-trace-js/pull/5209) to avoid [crashes](https://github.com/DataDog/dd-trace-js/issues/5111), as a result, some baggage functionalities are not working (i.e. we do not support having `baggage` as the only propagation style, or extracting headers which only include baggage).
The disabled tests will be enabled shortly following a later PR creating a different implementation of baggage propagation, which will avoid crashes without compromising on functionality.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
