### PR TITLE
[NodeJS] skip more failing baggage tests

### DIFF
--- a/tests/parametric/test_headers_baggage.py
+++ b/tests/parametric/test_headers_baggage.py
@@ -199,6 +199,10 @@ class Test_Headers_Baggage:
             headers = test_library.dd_make_child_span_and_get_headers([["baggage", "foo=valid"]])
             assert "baggage" in headers
 
+    @missing_feature(
+        context.library == "nodejs",
+        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage"
+    )
     def test_baggage_malformed_headers_D012(self, test_library):
         """Ensure that malformed baggage headers are handled properly. Unable to use get_baggage functions because it does not return anything"""
         Test_Headers_Baggage._assert_valid_baggage(self, test_library)
@@ -210,6 +214,10 @@ class Test_Headers_Baggage:
 
             assert "baggage" not in headers
 
+    @missing_feature(
+        context.library == "nodejs",
+        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage"
+    )
     def test_baggage_malformed_headers_D013(self, test_library):
         """Ensure that malformed baggage headers are handled properly. Unable to use get_baggage functions because it does not return anything"""
         Test_Headers_Baggage._assert_valid_baggage(self, test_library)
@@ -219,6 +227,10 @@ class Test_Headers_Baggage:
 
             assert "baggage" not in headers
 
+    @missing_feature(
+        context.library == "nodejs",
+        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage"
+    )
     def test_baggage_malformed_headers_D014(self, test_library):
         Test_Headers_Baggage._assert_valid_baggage(self, test_library)
 
@@ -227,6 +239,10 @@ class Test_Headers_Baggage:
 
             assert "baggage" not in headers
 
+    @missing_feature(
+        context.library == "nodejs",
+        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage"
+    )
     def test_baggage_malformed_headers_D015(self, test_library):
         Test_Headers_Baggage._assert_valid_baggage(self, test_library)
 

--- a/tests/parametric/test_headers_baggage.py
+++ b/tests/parametric/test_headers_baggage.py
@@ -201,7 +201,7 @@ class Test_Headers_Baggage:
 
     @missing_feature(
         context.library == "nodejs",
-        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage"
+        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage",
     )
     def test_baggage_malformed_headers_D012(self, test_library):
         """Ensure that malformed baggage headers are handled properly. Unable to use get_baggage functions because it does not return anything"""
@@ -216,7 +216,7 @@ class Test_Headers_Baggage:
 
     @missing_feature(
         context.library == "nodejs",
-        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage"
+        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage",
     )
     def test_baggage_malformed_headers_D013(self, test_library):
         """Ensure that malformed baggage headers are handled properly. Unable to use get_baggage functions because it does not return anything"""
@@ -229,7 +229,7 @@ class Test_Headers_Baggage:
 
     @missing_feature(
         context.library == "nodejs",
-        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage"
+        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage",
     )
     def test_baggage_malformed_headers_D014(self, test_library):
         Test_Headers_Baggage._assert_valid_baggage(self, test_library)
@@ -241,7 +241,7 @@ class Test_Headers_Baggage:
 
     @missing_feature(
         context.library == "nodejs",
-        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage"
+        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage",
     )
     def test_baggage_malformed_headers_D015(self, test_library):
         Test_Headers_Baggage._assert_valid_baggage(self, test_library)


### PR DESCRIPTION
## Motivation
Skip tests that were not skipped by this [PR](https://github.com/DataDog/system-tests/pull/4015)
Did not realize `dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which is made temporarily not working by this [PR](https://github.com/DataDog/dd-trace-js/pull/5209)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
