### PR TITLE
[python] use last patch version of python for django weblogs

### DIFF
--- a/utils/build/build_python_base_images.sh
+++ b/utils/build/build_python_base_images.sh
@@ -4,17 +4,17 @@
 
 
 
-docker buildx build --load --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v0 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v1 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/fastapi.base.Dockerfile -t datadog/system-tests:fastapi.base-v4 .
-docker buildx build --load --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v5 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v6 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v4 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/flask-poc.base.Dockerfile -t datadog/system-tests:flask-poc.base-v8 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/uwsgi-poc.base.Dockerfile -t datadog/system-tests:uwsgi-poc.base-v4 .
 
 if [ "$1" = "--push" ]; then
-      docker push datadog/system-tests:django-py3.13.base-v0
+      docker push datadog/system-tests:django-py3.13.base-v1
       docker push datadog/system-tests:fastapi.base-v4
-      docker push datadog/system-tests:python3.12.base-v5
+      docker push datadog/system-tests:python3.12.base-v6
       docker push datadog/system-tests:django-poc.base-v4
       docker push datadog/system-tests:flask-poc.base-v8
       docker push datadog/system-tests:uwsgi-poc.base-v4

--- a/utils/build/docker/python/django-py3.13.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:django-py3.13.base-v0
+FROM datadog/system-tests:django-py3.13.base-v1
 
 WORKDIR /app
 

--- a/utils/build/docker/python/django-py3.13.base.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.base.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.1-slim
+FROM python:3.13-slim
 
 # install bin dependancies
 RUN apt-get update && apt-get install -y curl git gcc g++ make cmake

--- a/utils/build/docker/python/django-py3.13.base.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.base.Dockerfile
@@ -15,6 +15,6 @@ RUN pip install django pycryptodome gunicorn gevent requests boto3==1.34.141 'mo
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
 ENV PATH="/root/.cargo/bin:$PATH"
 
-# docker build --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v0 .
-# docker push datadog/system-tests:django-py3.13.base-v0
+# docker build --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v1 .
+# docker push datadog/system-tests:django-py3.13.base-v1
 

--- a/utils/build/docker/python/python3.12.Dockerfile
+++ b/utils/build/docker/python/python3.12.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:python3.12.base-v5
+FROM datadog/system-tests:python3.12.base-v6
 
 WORKDIR /app
 

--- a/utils/build/docker/python/python3.12.base.Dockerfile
+++ b/utils/build/docker/python/python3.12.base.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.1-slim
+FROM python:3.12-slim
 
 # install bin dependancies
 RUN apt-get update && apt-get install -y curl git gcc g++ make cmake

--- a/utils/build/docker/python/python3.12.base.Dockerfile
+++ b/utils/build/docker/python/python3.12.base.Dockerfile
@@ -15,6 +15,6 @@ RUN pip install django pycryptodome gunicorn gevent requests boto3==1.34.141 'mo
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
 ENV PATH="/root/.cargo/bin:$PATH"
 
-# docker build --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v2 .
-# docker push datadog/system-tests:python3.12.base-v2
+# docker build --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v6 .
+# docker push datadog/system-tests:python3.12.base-v6
 


### PR DESCRIPTION
Use the last patch version of python in the Django weblogs to benefits from the bug fixes.

Also related to APPSEC-56375

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
