### PR TITLE
Avoid false xpass on test_exclusions.py

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -211,7 +211,17 @@ tests/:
       test_custom_rules.py:
         Test_CustomRules: v1.12.0
       test_exclusions.py:
-        Test_Exclusions: v1.11.0
+        Test_Exclusions:
+          '*': v1.11.0
+          sinatra14: missing_feature (endpoint not implemented)
+          sinatra20: missing_feature (endpoint not implemented)
+          sinatra21: missing_feature (endpoint not implemented)
+          sinatra22: missing_feature (endpoint not implemented)
+          sinatra30: missing_feature (endpoint not implemented)
+          sinatra31: missing_feature (endpoint not implemented)
+          sinatra32: missing_feature (endpoint not implemented)
+          sinatra40: missing_feature (endpoint not implemented)
+          uds-sinatra: missing_feature (endpoint not implemented)
       test_miscs.py:
         Test_MultipleAttacks: v0.54.2
         Test_MultipleHighlight: v1.0.0.beta1

--- a/tests/appsec/waf/test_exclusions.py
+++ b/tests/appsec/waf/test_exclusions.py
@@ -12,6 +12,8 @@ class Test_Exclusions:
 
     @bug(context.library <= "ruby@1.12.1", reason="APMRP-360")
     def test_input_exclusion_negative_test(self):
+        assert self.r_iexnt1.status_code == 200, "Request failed"
+        assert self.r_iexnt2.status_code == 200, "Request failed"
         interfaces.library.assert_waf_attack(self.r_iexnt1, pattern="true", address="server.request.query")
         interfaces.library.assert_waf_attack(self.r_iexnt2, pattern="true", address="server.request.query")
 
@@ -19,6 +21,10 @@ class Test_Exclusions:
         self.r_iexpt = weblog.get("/waf/", params={"excluded_key": "true", "activate_exclusion": "true"})
 
     def test_input_exclusion_positive_test(self):
+        assert self.r_iexpt.status_code == 200, "Request failed"
+        spans = [span for _, _, span in interfaces.library.get_spans(request=self.r_iexpt)]
+        assert spans, "No spans to validate"
+        assert any("_dd.appsec.enabled" in s.get("metrics", {}) for s in spans), "No appsec-enabled spans found"
         interfaces.library.assert_no_appsec_event(self.r_iexpt)
 
     def setup_rule_exclusion_negative_test(self):
@@ -26,6 +32,8 @@ class Test_Exclusions:
         self.r_rent2 = weblog.get("/waf/", params={"foo": "bbbb", "activate_exclusion": "false"})
 
     def test_rule_exclusion_negative_test(self):
+        assert self.r_rent1.status_code == 200, "Request failed"
+        assert self.r_rent2.status_code == 200, "Request failed"
         interfaces.library.assert_waf_attack(self.r_rent1, pattern="bbbb", address="server.request.query")
         interfaces.library.assert_waf_attack(self.r_rent2, pattern="bbbb", address="server.request.query")
 
@@ -34,4 +42,8 @@ class Test_Exclusions:
 
     @bug(context.library <= "ruby@1.12.1", reason="APMRP-360")
     def test_rule_exclusion_positive_test(self):
+        assert self.r_rept.status_code == 200, "Request failed"
+        spans = [span for _, _, span in interfaces.library.get_spans(request=self.r_rept)]
+        assert spans, "No spans to validate"
+        assert any("_dd.appsec.enabled" in s.get("metrics", {}) for s in spans), "No appsec-enabled spans found"
         interfaces.library.assert_no_appsec_event(self.r_rept)


### PR DESCRIPTION
## Motivation

as observed in spring-boot-3-native.

Skip on sinatra, since the endpoint is not implemented

[APPSEC-54879](https://datadoghq.atlassian.net/browse/APPSEC-54879)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-54879]: https://datadoghq.atlassian.net/browse/APPSEC-54879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ