### PR TITLE
Do not run test-app-nodejs on Ubuntu24

### DIFF
--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-unsupported-defaults.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-unsupported-defaults.yml
@@ -21,8 +21,8 @@ lang_variant:
 weblog:
     name: test-app-nodejs-unsupported-defaults
     #All of these branches are going to install unsupported versions of nodejs
-    exact_os_branches: [ubuntu22_amd64, ubuntu22_arm64, ubuntu21, ubuntu20_arm64, ubuntu20_amd64, centos_7_amd64]
-    install: 
+    exact_os_branches: [ubuntu24_amd64, ubuntu24_arm64, ubuntu22_amd64, ubuntu22_arm64, ubuntu21, ubuntu20_arm64, ubuntu20_amd64, centos_7_amd64]
+    install:
       - os_type: linux
         copy_files:
           - name: copy-service

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-unsupported-defaults.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs-unsupported-defaults.yml
@@ -21,7 +21,7 @@ lang_variant:
 weblog:
     name: test-app-nodejs-unsupported-defaults
     #All of these branches are going to install unsupported versions of nodejs
-    exact_os_branches: [ubuntu24_amd64, ubuntu24_arm64, ubuntu22_amd64, ubuntu22_arm64, ubuntu21, ubuntu20_arm64, ubuntu20_amd64, centos_7_amd64]
+    exact_os_branches: [ubuntu24, ubuntu22_amd64, ubuntu22_arm64, ubuntu21, ubuntu20_arm64, ubuntu20_amd64, centos_7_amd64]
     install:
       - os_type: linux
         copy_files:

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs.yml
@@ -48,7 +48,8 @@ weblog:
     #centos 7: node 16
     #rhel_7_amd64: I can't isntall in a standard way
     #amazon_linux2: Using the amazon-linux-extras -  Error: Package: 1:nodejs-16.20.2-1.el7.x86_64 (epel)
-    excluded_os_branches: [ubuntu24_amd64, ubuntu24_arm64, ubuntu22_amd64, ubuntu22_arm64, ubuntu21, ubuntu20_arm64, ubuntu20_amd64, centos_7_amd64, rhel_7_amd64, amazon_linux2]
+    excluded_os_branches: [ubuntu22_amd64, ubuntu22_arm64, ubuntu21, ubuntu20_arm64, ubuntu20_amd64, centos_7_amd64, rhel_7_amd64, amazon_linux2]
+    excluded_os_names: [Ubuntu_24_amd64, Ubuntu_24_arm64]
 
     install: 
       - os_type: linux

--- a/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs.yml
+++ b/utils/build/virtual_machine/weblogs/nodejs/provision_test-app-nodejs.yml
@@ -40,14 +40,15 @@ lang_variant:
 
 weblog:
     name: test-app-nodejs
-    #This machines are going to install unsupported versions of nodejs. We use them in the provision_test-app-nodejs-unsupported-defaults
+    #These machines are going to install unsupported versions of nodejs. We use them in the provision_test-app-nodejs-unsupported-defaults
+    #ubuntu 24.04.01: node 18 reports abi=109 when it should be 108
     #ubuntu 22: node 12
     #ubuntu 20: node 10
     #ubuntu 21: node 12
     #centos 7: node 16
     #rhel_7_amd64: I can't isntall in a standard way
     #amazon_linux2: Using the amazon-linux-extras -  Error: Package: 1:nodejs-16.20.2-1.el7.x86_64 (epel)
-    excluded_os_branches: [ubuntu22_amd64, ubuntu22_arm64, ubuntu21, ubuntu20_arm64, ubuntu20_amd64, centos_7_amd64, rhel_7_amd64, amazon_linux2]
+    excluded_os_branches: [ubuntu24_amd64, ubuntu24_arm64, ubuntu22_amd64, ubuntu22_arm64, ubuntu21, ubuntu20_arm64, ubuntu20_amd64, centos_7_amd64, rhel_7_amd64, amazon_linux2]
 
     install: 
       - os_type: linux


### PR DESCRIPTION
Do not run `test-app-nodejs` on Ubuntu24 (really, 24.04.01 LTS) because… its packaged version of Node reports wrong ABI version.

## Motivation

Profiling tests are failing on Ubuntu24. Turns out this is a [known bug with](https://bugs.launchpad.net/ubuntu/+source/nodejs/+bug/2085804) Ubuntu 24.04.01 LTS. It reports wrong ABI version so we can't load the profiler native library (or native metrics, or IAST, etc.)

## Changes

Adds Ubuntu24 VMs to the exclusion list for `test-app-nodejs`. We'll soon follow up by also adding VMs for Ubuntu 24.10, which fix the problem.

JIRA: [PROF-11264]

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[PROF-11264]: https://datadoghq.atlassian.net/browse/PROF-11264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ