### PR TITLE
Add Ubuntu 24.10 VMs

### DIFF
--- a/utils/_context/_scenarios/auto_injection.py
+++ b/utils/_context/_scenarios/auto_injection.py
@@ -18,6 +18,8 @@ from utils._context.virtual_machines import (
     Ubuntu23_10_arm64,
     Ubuntu24amd64,
     Ubuntu24arm64,
+    Ubuntu24_10amd64,
+    Ubuntu24_10arm64,
     Ubuntu18amd64,
     AmazonLinux2022arm64,
     AmazonLinux2022amd64,
@@ -73,6 +75,8 @@ class _VirtualMachineScenario(Scenario):
         include_ubuntu_23_10_arm64=False,
         include_ubuntu_24_amd64=False,
         include_ubuntu_24_arm64=False,
+        include_ubuntu_24_10_amd64=False,
+        include_ubuntu_24_10_arm64=False,
         include_ubuntu_18_amd64=False,
         include_amazon_linux_2_amd64=False,
         include_amazon_linux_2_arm64=False,
@@ -138,6 +142,10 @@ class _VirtualMachineScenario(Scenario):
             self.required_vms.append(Ubuntu24amd64())
         if include_ubuntu_24_arm64:
             self.required_vms.append(Ubuntu24arm64())
+        if include_ubuntu_24_10_amd64:
+            self.required_vms.append(Ubuntu24_10amd64())
+        if include_ubuntu_24_10_arm64:
+            self.required_vms.append(Ubuntu24_10arm64())
         if include_ubuntu_18_amd64:
             self.required_vms.append(Ubuntu18amd64())
         if include_amazon_linux_2022_amd64:
@@ -395,6 +403,8 @@ class InstallerAutoInjectionScenario(_VirtualMachineScenario):
         include_ubuntu_23_10_arm64=True,
         include_ubuntu_24_amd64=True,
         include_ubuntu_24_arm64=True,
+        include_ubuntu_24_10_amd64=True,
+        include_ubuntu_24_10_arm64=True,
         include_ubuntu_18_amd64=False,
         include_amazon_linux_2_amd64=True,
         include_amazon_linux_2_arm64=True,
@@ -452,6 +462,8 @@ class InstallerAutoInjectionScenario(_VirtualMachineScenario):
             include_ubuntu_23_10_arm64=include_ubuntu_23_10_arm64,
             include_ubuntu_24_amd64=include_ubuntu_24_amd64,
             include_ubuntu_24_arm64=include_ubuntu_24_arm64,
+            include_ubuntu_24_10_amd64=include_ubuntu_24_10_amd64,
+            include_ubuntu_24_10_arm64=include_ubuntu_24_10_arm64,
             include_ubuntu_18_amd64=include_ubuntu_18_amd64,
             include_amazon_linux_2_amd64=include_amazon_linux_2_amd64,
             include_amazon_linux_2_arm64=include_amazon_linux_2_arm64,

--- a/utils/_context/virtual_machines.py
+++ b/utils/_context/virtual_machines.py
@@ -477,6 +477,37 @@ class Ubuntu24arm64(_VirtualMachine):
             **kwargs,
         )
 
+class Ubuntu24_10amd64(_VirtualMachine):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(
+            "Ubuntu_24_10_amd64",
+            aws_config=_AWSConfig(ami_id="ami-075426e0accc68b53", ami_instance_type="t3.medium", user="ubuntu"),
+            vagrant_config=None,
+            krunvm_config=None,
+            os_type="linux",
+            os_distro="deb",
+            os_branch="ubuntu24",
+            os_cpu="amd64",
+            default_vm=True,
+            **kwargs,
+        )
+
+
+class Ubuntu24_10arm64(_VirtualMachine):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(
+            "Ubuntu_24_10_arm64",
+            aws_config=_AWSConfig(ami_id="ami-0a5b3d67a84b13bf9", ami_instance_type="t4g.medium", user="ubuntu"),
+            vagrant_config=None,
+            krunvm_config=None,
+            os_type="linux",
+            os_distro="deb",
+            os_branch="ubuntu24",
+            os_cpu="arm64",
+            default_vm=False,
+            **kwargs,
+        )
+
 
 class Debian12amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:

--- a/utils/_context/virtual_machines.py
+++ b/utils/_context/virtual_machines.py
@@ -477,6 +477,7 @@ class Ubuntu24arm64(_VirtualMachine):
             **kwargs,
         )
 
+
 class Ubuntu24_10amd64(_VirtualMachine):
     def __init__(self, **kwargs) -> None:
         super().__init__(


### PR DESCRIPTION
## Motivation

Ubuntu 24.04.01 LTS unfortunately has a packaging bug for Node.js (see #4032), so in order to properly test Node.js apps we introduce the latest Ubuntu 24.10.

## Changes

Adds both an amd64 and arm64 Ubuntu 24.10 VM.

JIRA: [PROF-11264]

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[PROF-11264]: https://datadoghq.atlassian.net/browse/PROF-11264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ