### PR TITLE
[cpp] Fix all-jobs-are-green-job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
       with:
         python-version: '3.11'
     - run: pip install requests
-    - run: python utils/scripts/get-workflow-summary.py ${{ github.run_id }} >> $GITHUB_STEP_SUMMARY
+    - run: python utils/scripts/get-workflow-summary.py DataDog/system-tests ${{ github.run_id }} -o $GITHUB_STEP_SUMMARY
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/utils/scripts/get-workflow-summary.py
+++ b/utils/scripts/get-workflow-summary.py
@@ -1,4 +1,6 @@
+import argparse
 from collections import defaultdict
+import logging
 import os
 import sys
 
@@ -34,10 +36,13 @@ def get_jobs(session, repo_slug: str, run_id: int) -> list:
     return jobs
 
 
-def main(repo_slug: str, run_id: int) -> None:
+def main(repo_slug: str, run_id: int, output: str) -> None:
+    logging.info(f"Getting workflow summary for https://github.com/{repo_slug}/actions/runs/{run_id}")
     environ = get_environ()
 
     has_failure = False
+
+    result: list[str] = []
 
     with requests.Session() as session:
         if "GH_TOKEN" in environ:
@@ -49,9 +54,11 @@ def main(repo_slug: str, run_id: int) -> None:
 
         for job in jobs:
             if job["name"] in ("all-jobs-are-green", "fancy-report"):
+                logging.info(f"Skipping job {job['name']}")
                 continue
 
             if job["conclusion"] not in ["skipped", "success"]:
+                logging.info(f"Job {job['name']} conclusion: {job['conclusion']}")
                 has_failure = True
 
             if job["conclusion"] != "failure":
@@ -62,11 +69,20 @@ def main(repo_slug: str, run_id: int) -> None:
                     failing_steps[step["name"]].append((job, step))
 
         for step_name, items in failing_steps.items():
-            print(f"❌ **Failures for `{step_name}`**\n")
+            result.append(f"❌ **Failures for `{step_name}`**\n")
             for job, step in sorted(items, key=lambda x: x[0]["name"]):
                 url = job["html_url"]
-                print(f"* [{job['name']}]({url}#step:{step['number']})")
+                result.append(f"* [{job['name']}]({url}#step:{step['number']})")
 
+            result.append("")
+
+        if output:
+            logging.info(f"Writing output to {output}")
+            with open(output, "w") as f:
+                f.write("\n".join(result))
+        else:
+            logging.info("Writing output to stdout")
+            print("\n".join(result))
             print()
 
     if has_failure:
@@ -74,4 +90,27 @@ def main(repo_slug: str, run_id: int) -> None:
 
 
 if __name__ == "__main__":
-    main("DataDog/system-tests", int(sys.argv[1]))
+    parser = argparse.ArgumentParser(
+        prog="get-workflow-summary", description="List all failing step of a github workflow, and pretty print them"
+    )
+
+    parser.add_argument("repo_slug", type=str, help="Repo slug of the workflow")
+
+    parser.add_argument("run_id", type=int, help="Run Id of the workflow")
+
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default="",
+        help="Output file. If not provided, output to stdout",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s", stream=sys.stderr)
+
+    main(
+        repo_slug=args.repo_slug,
+        run_id=args.run_id,
+        output=args.output,
+    )


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
