### PR TITLE
[ruby] Add RASP SQLi endpoints to Rails weblogs

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -189,7 +189,18 @@ tests/:
       test_cmdi.py: missing_feature
       test_lfi.py: missing_feature
       test_shi.py: missing_feature
-      test_sqli.py: missing_feature
+      test_sqli.py:
+        Test_Sqli_BodyJson: missing_feature
+        Test_Sqli_BodyUrlEncoded: missing_feature
+        Test_Sqli_BodyXml: irrelevant (XML not natively supported)
+        Test_Sqli_Capability: missing_feature
+        Test_Sqli_Mandatory_SpanTags: missing_feature
+        Test_Sqli_Optional_SpanTags: missing_feature
+        Test_Sqli_Rules_Version:  missing_feature
+        Test_Sqli_StackTrace: missing_feature
+        Test_Sqli_Telemetry: missing_feature
+        Test_Sqli_UrlQuery: missing_feature
+        Test_Sqli_Waf_Version:  missing_feature
       test_ssrf.py: missing_feature
     waf/:
       test_addresses.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -190,17 +190,37 @@ tests/:
       test_lfi.py: missing_feature
       test_shi.py: missing_feature
       test_sqli.py:
-        Test_Sqli_BodyJson: missing_feature
-        Test_Sqli_BodyUrlEncoded: missing_feature
+        Test_Sqli_BodyJson:
+          "*": missing_feature
+          rails42: bug (APPSEC-56765) # ActiveRecord instrumentation with Rails < 5 and Ruby < 2.7 not working due to kwargs
+        Test_Sqli_BodyUrlEncoded:
+          "*": missing_feature
+          rails42: bug (APPSEC-56765) # ActiveRecord instrumentation with Rails < 5 and Ruby < 2.7 not working due to kwargs
         Test_Sqli_BodyXml: irrelevant (XML not natively supported)
-        Test_Sqli_Capability: missing_feature
-        Test_Sqli_Mandatory_SpanTags: missing_feature
-        Test_Sqli_Optional_SpanTags: missing_feature
-        Test_Sqli_Rules_Version:  missing_feature
-        Test_Sqli_StackTrace: missing_feature
-        Test_Sqli_Telemetry: missing_feature
-        Test_Sqli_UrlQuery: missing_feature
-        Test_Sqli_Waf_Version:  missing_feature
+        Test_Sqli_Capability:
+          "*": missing_feature
+          rails42: bug (APPSEC-56765) # ActiveRecord instrumentation with Rails < 5 and Ruby < 2.7 not working due to kwargs
+        Test_Sqli_Mandatory_SpanTags:
+          "*": missing_feature
+          rails42: bug (APPSEC-56765) # ActiveRecord instrumentation with Rails < 5 and Ruby < 2.7 not working due to kwargs
+        Test_Sqli_Optional_SpanTags:
+          "*": missing_feature
+          rails42: bug (APPSEC-56765) # ActiveRecord instrumentation with Rails < 5 and Ruby < 2.7 not working due to kwargs
+        Test_Sqli_Rules_Version:
+          "*": missing_feature
+          rails42: bug (APPSEC-56765) # ActiveRecord instrumentation with Rails < 5 and Ruby < 2.7 not working due to kwargs
+        Test_Sqli_StackTrace:
+          "*": missing_feature
+          rails42: bug (APPSEC-56765) # ActiveRecord instrumentation with Rails < 5 and Ruby < 2.7 not working due to kwargs
+        Test_Sqli_Telemetry:
+          "*": missing_feature
+          rails42: bug (APPSEC-56765) # ActiveRecord instrumentation with Rails < 5 and Ruby < 2.7 not working due to kwargs
+        Test_Sqli_UrlQuery:
+          "*": missing_feature
+          rails42: bug (APPSEC-56765) # ActiveRecord instrumentation with Rails < 5 and Ruby < 2.7 not working due to kwargs
+        Test_Sqli_Waf_Version:
+          "*": missing_feature
+          rails42: bug (APPSEC-56765) # ActiveRecord instrumentation with Rails < 5 and Ruby < 2.7 not working due to kwargs
       test_ssrf.py: missing_feature
     waf/:
       test_addresses.py:

--- a/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
@@ -204,4 +204,18 @@ class SystemTestController < ApplicationController
     end
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
+
+  def rasp_sqli
+    user_id = params[:user_id] || request.POST && request.POST['user_id']
+    if user_id
+      User.transaction do
+        # We need to manually create the query as User.where adds parenthesis around the user_id
+        query = "SELECT * FROM users WHERE id='#{user_id}'"
+        users = User.find_by_sql(query).to_a
+        render plain: "DB request with #{users.size} results"
+      end
+    else
+      render plain: 'users not found parameter', status: 400
+    end
+  end
 end

--- a/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
@@ -206,16 +206,9 @@ class SystemTestController < ApplicationController
   end
 
   def rasp_sqli
-    user_id = params[:user_id] || request.POST && request.POST['user_id']
-    if user_id
-      User.transaction do
-        # We need to manually create the query as User.where adds parenthesis around the user_id
-        query = "SELECT * FROM users WHERE id='#{user_id}'"
-        users = User.find_by_sql(query).to_a
-        render plain: "DB request with #{users.size} results"
-      end
-    else
-      render plain: 'users not found parameter', status: 400
-    end
+    # We need to manually create the query as User.where adds parenthesis around the user_id
+    query = "SELECT * FROM users WHERE id='#{params.fetch(:user_id)}'"
+    users = User.find_by_sql(query).to_a
+    render plain: "DB request with #{users.size} results"
   end
 end

--- a/utils/build/docker/ruby/rails42/config/initializers/datadog.rb
+++ b/utils/build/docker/ruby/rails42/config/initializers/datadog.rb
@@ -1,5 +1,6 @@
 Datadog.configure do |c|
   c.diagnostics.debug = true
+  c.appsec.instrument :active_record
 end
 
 # Send non-web init event

--- a/utils/build/docker/ruby/rails42/config/initializers/datadog.rb
+++ b/utils/build/docker/ruby/rails42/config/initializers/datadog.rb
@@ -1,6 +1,5 @@
 Datadog.configure do |c|
   c.diagnostics.debug = true
-  c.appsec.instrument :active_record
 end
 
 # Send non-web init event

--- a/utils/build/docker/ruby/rails42/config/routes.rb
+++ b/utils/build/docker/ruby/rails42/config/routes.rb
@@ -37,4 +37,7 @@ Rails.application.routes.draw do
 
   get '/requestdownstream' => 'system_test#request_downstream'
   get '/returnheaders' => 'system_test#return_headers'
+
+  get '/rasp/sqli' => 'system_test#rasp_sqli'
+  post '/rasp/sqli' => 'system_test#rasp_sqli'
 end

--- a/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
@@ -204,4 +204,18 @@ class SystemTestController < ApplicationController
     end
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
+
+  def rasp_sqli
+    user_id = params[:user_id] || request.POST && request.POST['user_id']
+    if user_id
+      User.transaction do
+        # We need to manually create the query as User.where adds parenthesis around the user_id
+        query = "SELECT * FROM users WHERE id='#{user_id}'"
+        users = User.find_by_sql(query).to_a
+        render plain: "DB request with #{users.size} results"
+      end
+    else
+      render plain: 'users not found parameter', status: 400
+    end
+  end
 end

--- a/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails50/app/controllers/system_test_controller.rb
@@ -206,16 +206,9 @@ class SystemTestController < ApplicationController
   end
 
   def rasp_sqli
-    user_id = params[:user_id] || request.POST && request.POST['user_id']
-    if user_id
-      User.transaction do
-        # We need to manually create the query as User.where adds parenthesis around the user_id
-        query = "SELECT * FROM users WHERE id='#{user_id}'"
-        users = User.find_by_sql(query).to_a
-        render plain: "DB request with #{users.size} results"
-      end
-    else
-      render plain: 'users not found parameter', status: 400
-    end
+    # We need to manually create the query as User.where adds parenthesis around the user_id
+    query = "SELECT * FROM users WHERE id='#{params.fetch(:user_id)}'"
+    users = User.find_by_sql(query).to_a
+    render plain: "DB request with #{users.size} results"
   end
 end

--- a/utils/build/docker/ruby/rails50/config/initializers/datadog.rb
+++ b/utils/build/docker/ruby/rails50/config/initializers/datadog.rb
@@ -1,5 +1,6 @@
 Datadog.configure do |c|
   c.diagnostics.debug = true
+  c.appsec.instrument :active_record
 end
 
 # Send non-web init event

--- a/utils/build/docker/ruby/rails50/config/routes.rb
+++ b/utils/build/docker/ruby/rails50/config/routes.rb
@@ -40,4 +40,7 @@ Rails.application.routes.draw do
 
   get '/requestdownstream' => 'system_test#request_downstream'
   get '/returnheaders' => 'system_test#return_headers'
+
+  get '/rasp/sqli' => 'system_test#rasp_sqli'
+  post '/rasp/sqli' => 'system_test#rasp_sqli'
 end

--- a/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
@@ -203,4 +203,18 @@ class SystemTestController < ApplicationController
     end
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
+
+  def rasp_sqli
+    user_id = params[:user_id] || request.POST && request.POST['user_id']
+    if user_id
+      User.transaction do
+        # We need to manually create the query as User.where adds parenthesis around the user_id
+        query = "SELECT * FROM users WHERE id='#{user_id}'"
+        users = User.find_by_sql(query).to_a
+        render plain: "DB request with #{users.size} results"
+      end
+    else
+      render plain: 'users not found parameter', status: 400
+    end
+  end
 end

--- a/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails51/app/controllers/system_test_controller.rb
@@ -205,16 +205,9 @@ class SystemTestController < ApplicationController
   end
 
   def rasp_sqli
-    user_id = params[:user_id] || request.POST && request.POST['user_id']
-    if user_id
-      User.transaction do
-        # We need to manually create the query as User.where adds parenthesis around the user_id
-        query = "SELECT * FROM users WHERE id='#{user_id}'"
-        users = User.find_by_sql(query).to_a
-        render plain: "DB request with #{users.size} results"
-      end
-    else
-      render plain: 'users not found parameter', status: 400
-    end
+    # We need to manually create the query as User.where adds parenthesis around the user_id
+    query = "SELECT * FROM users WHERE id='#{params.fetch(:user_id)}'"
+    users = User.find_by_sql(query).to_a
+    render plain: "DB request with #{users.size} results"
   end
 end

--- a/utils/build/docker/ruby/rails51/config/initializers/datadog.rb
+++ b/utils/build/docker/ruby/rails51/config/initializers/datadog.rb
@@ -1,5 +1,6 @@
 Datadog.configure do |c|
   c.diagnostics.debug = true
+  c.appsec.instrument :active_record
 end
 
 # Send non-web init event

--- a/utils/build/docker/ruby/rails51/config/routes.rb
+++ b/utils/build/docker/ruby/rails51/config/routes.rb
@@ -40,4 +40,7 @@ Rails.application.routes.draw do
 
   get '/requestdownstream' => 'system_test#request_downstream'
   get '/returnheaders' => 'system_test#return_headers'
+
+  get '/rasp/sqli' => 'system_test#rasp_sqli'
+  post '/rasp/sqli' => 'system_test#rasp_sqli'
 end

--- a/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
@@ -204,4 +204,18 @@ class SystemTestController < ApplicationController
     end
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
+
+  def rasp_sqli
+    user_id = params[:user_id] || request.POST && request.POST['user_id']
+    if user_id
+      User.transaction do
+        # We need to manually create the query as User.where adds parenthesis around the user_id
+        query = "SELECT * FROM users WHERE id='#{user_id}'"
+        users = User.find_by_sql(query).to_a
+        render plain: "DB request with #{users.size} results"
+      end
+    else
+      render plain: 'users not found parameter', status: 400
+    end
+  end
 end

--- a/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
@@ -206,16 +206,9 @@ class SystemTestController < ApplicationController
   end
 
   def rasp_sqli
-    user_id = params[:user_id] || request.POST && request.POST['user_id']
-    if user_id
-      User.transaction do
-        # We need to manually create the query as User.where adds parenthesis around the user_id
-        query = "SELECT * FROM users WHERE id='#{user_id}'"
-        users = User.find_by_sql(query).to_a
-        render plain: "DB request with #{users.size} results"
-      end
-    else
-      render plain: 'users not found parameter', status: 400
-    end
+    # We need to manually create the query as User.where adds parenthesis around the user_id
+    query = "SELECT * FROM users WHERE id='#{params.fetch(:user_id)}'"
+    users = User.find_by_sql(query).to_a
+    render plain: "DB request with #{users.size} results"
   end
 end

--- a/utils/build/docker/ruby/rails52/config/initializers/datadog.rb
+++ b/utils/build/docker/ruby/rails52/config/initializers/datadog.rb
@@ -1,5 +1,6 @@
 Datadog.configure do |c|
   c.diagnostics.debug = true
+  c.appsec.instrument :active_record
 end
 
 # Send non-web init event

--- a/utils/build/docker/ruby/rails52/config/routes.rb
+++ b/utils/build/docker/ruby/rails52/config/routes.rb
@@ -40,4 +40,7 @@ Rails.application.routes.draw do
 
   get '/requestdownstream' => 'system_test#request_downstream'
   get '/returnheaders' => 'system_test#return_headers'
+
+  get '/rasp/sqli' => 'system_test#rasp_sqli'
+  post '/rasp/sqli' => 'system_test#rasp_sqli'
 end

--- a/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
@@ -226,16 +226,9 @@ class SystemTestController < ApplicationController
   end
 
   def rasp_sqli
-    user_id = params[:user_id] || request.POST && request.POST['user_id']
-    if user_id
-      User.transaction do
-        # We need to manually create the query as User.where adds parenthesis around the user_id
-        query = "SELECT * FROM users WHERE id='#{user_id}'"
-        users = User.find_by_sql(query).to_a
-        render plain: "DB request with #{users.size} results"
-      end
-    else
-      render plain: 'users not found parameter', status: 400
-    end
+    # We need to manually create the query as User.where adds parenthesis around the user_id
+    query = "SELECT * FROM users WHERE id='#{params.fetch(:user_id)}'"
+    users = User.find_by_sql(query).to_a
+    render plain: "DB request with #{users.size} results"
   end
 end

--- a/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails60/app/controllers/system_test_controller.rb
@@ -224,4 +224,18 @@ class SystemTestController < ApplicationController
     end
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
+
+  def rasp_sqli
+    user_id = params[:user_id] || request.POST && request.POST['user_id']
+    if user_id
+      User.transaction do
+        # We need to manually create the query as User.where adds parenthesis around the user_id
+        query = "SELECT * FROM users WHERE id='#{user_id}'"
+        users = User.find_by_sql(query).to_a
+        render plain: "DB request with #{users.size} results"
+      end
+    else
+      render plain: 'users not found parameter', status: 400
+    end
+  end
 end

--- a/utils/build/docker/ruby/rails60/config/initializers/datadog.rb
+++ b/utils/build/docker/ruby/rails60/config/initializers/datadog.rb
@@ -1,5 +1,6 @@
 Datadog.configure do |c|
   c.diagnostics.debug = true
+  c.appsec.instrument :active_record
 end
 
 # Send non-web init event

--- a/utils/build/docker/ruby/rails60/config/routes.rb
+++ b/utils/build/docker/ruby/rails60/config/routes.rb
@@ -40,4 +40,7 @@ Rails.application.routes.draw do
 
   get '/requestdownstream' => 'system_test#request_downstream'
   get '/returnheaders' => 'system_test#return_headers'
+
+  get '/rasp/sqli' => 'system_test#rasp_sqli'
+  post '/rasp/sqli' => 'system_test#rasp_sqli'
 end

--- a/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
@@ -204,4 +204,18 @@ class SystemTestController < ApplicationController
     end
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
+
+  def rasp_sqli
+    user_id = params[:user_id] || request.POST && request.POST['user_id']
+    if user_id
+      User.transaction do
+        # We need to manually create the query as User.where adds parenthesis around the user_id
+        query = "SELECT * FROM users WHERE id='#{user_id}'"
+        users = User.find_by_sql(query).to_a
+        render plain: "DB request with #{users.size} results"
+      end
+    else
+      render plain: 'users not found parameter', status: 400
+    end
+  end
 end

--- a/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
@@ -206,16 +206,9 @@ class SystemTestController < ApplicationController
   end
 
   def rasp_sqli
-    user_id = params[:user_id] || request.POST && request.POST['user_id']
-    if user_id
-      User.transaction do
-        # We need to manually create the query as User.where adds parenthesis around the user_id
-        query = "SELECT * FROM users WHERE id='#{user_id}'"
-        users = User.find_by_sql(query).to_a
-        render plain: "DB request with #{users.size} results"
-      end
-    else
-      render plain: 'users not found parameter', status: 400
-    end
+    # We need to manually create the query as User.where adds parenthesis around the user_id
+    query = "SELECT * FROM users WHERE id='#{params.fetch(:user_id)}'"
+    users = User.find_by_sql(query).to_a
+    render plain: "DB request with #{users.size} results"
   end
 end

--- a/utils/build/docker/ruby/rails61/config/initializers/datadog.rb
+++ b/utils/build/docker/ruby/rails61/config/initializers/datadog.rb
@@ -1,5 +1,6 @@
 Datadog.configure do |c|
   c.diagnostics.debug = true
+  c.appsec.instrument :active_record
 end
 
 # Send non-web init event

--- a/utils/build/docker/ruby/rails61/config/routes.rb
+++ b/utils/build/docker/ruby/rails61/config/routes.rb
@@ -40,4 +40,7 @@ Rails.application.routes.draw do
 
   get '/requestdownstream' => 'system_test#request_downstream'
   get '/returnheaders' => 'system_test#return_headers'
+
+  get '/rasp/sqli' => 'system_test#rasp_sqli'
+  post '/rasp/sqli' => 'system_test#rasp_sqli'
 end

--- a/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails70/app/controllers/system_test_controller.rb
@@ -281,4 +281,18 @@ class SystemTestController < ApplicationController
     OpenTelemetry.propagation.inject(headers)
     render json: JSON.generate(headers), content_type: 'application/json'
   end
+
+  def rasp_sqli
+    user_id = params[:user_id] || request.POST && request.POST['user_id']
+    if user_id
+      User.transaction do
+        # We need to manually create the query as User.where adds parenthesis around the user_id
+        query = "SELECT * FROM users WHERE id='#{user_id}'"
+        users = User.find_by_sql(query).to_a
+        render plain: "DB request with #{users.size} results"
+      end
+    else
+      render plain: 'users not found parameter', status: 400
+    end
+  end
 end

--- a/utils/build/docker/ruby/rails70/config/initializers/datadog.rb
+++ b/utils/build/docker/ruby/rails70/config/initializers/datadog.rb
@@ -3,6 +3,7 @@ require 'datadog/opentelemetry'
 
 Datadog.configure do |c|
   c.diagnostics.debug = true
+  c.appsec.instrument :active_record
 end
 
 ::OpenTelemetry::SDK.configure do |_c|

--- a/utils/build/docker/ruby/rails70/config/routes.rb
+++ b/utils/build/docker/ruby/rails70/config/routes.rb
@@ -55,4 +55,7 @@ Rails.application.routes.draw do
   get '/debugger/pii' => 'debugger#pii'
   get '/debugger/log' => 'debugger#log_probe'
   get '/debugger/mix/:string_arg/:int_arg' => 'debugger#mix_probe'
+
+  get '/rasp/sqli' => 'system_test#rasp_sqli'
+  post '/rasp/sqli' => 'system_test#rasp_sqli'
 end

--- a/utils/build/docker/ruby/rails71/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails71/app/controllers/system_test_controller.rb
@@ -273,16 +273,9 @@ class SystemTestController < ApplicationController
   end
 
   def rasp_sqli
-    user_id = params[:user_id] || request.POST && request.POST['user_id']
-    if user_id
-      User.transaction do
-        # We need to manually create the query as User.where adds parenthesis around the user_id
-        query = "SELECT * FROM users WHERE id='#{user_id}'"
-        users = User.find_by_sql(query).to_a
-        render plain: "DB request with #{users.size} results"
-      end
-    else
-      render plain: 'users not found parameter', status: 400
-    end
+    # We need to manually create the query as User.where adds parenthesis around the user_id
+    query = "SELECT * FROM users WHERE id='#{params.fetch(:user_id)}'"
+    users = User.find_by_sql(query).to_a
+    render plain: "DB request with #{users.size} results"
   end
 end

--- a/utils/build/docker/ruby/rails71/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails71/app/controllers/system_test_controller.rb
@@ -271,4 +271,18 @@ class SystemTestController < ApplicationController
     end
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
+
+  def rasp_sqli
+    user_id = params[:user_id] || request.POST && request.POST['user_id']
+    if user_id
+      User.transaction do
+        # We need to manually create the query as User.where adds parenthesis around the user_id
+        query = "SELECT * FROM users WHERE id='#{user_id}'"
+        users = User.find_by_sql(query).to_a
+        render plain: "DB request with #{users.size} results"
+      end
+    else
+      render plain: 'users not found parameter', status: 400
+    end
+  end
 end

--- a/utils/build/docker/ruby/rails71/config/initializers/datadog.rb
+++ b/utils/build/docker/ruby/rails71/config/initializers/datadog.rb
@@ -1,5 +1,6 @@
 Datadog.configure do |c|
   c.diagnostics.debug = true
+  c.appsec.instrument :active_record
 end
 
 # Send non-web init event

--- a/utils/build/docker/ruby/rails71/config/routes.rb
+++ b/utils/build/docker/ruby/rails71/config/routes.rb
@@ -47,4 +47,7 @@ Rails.application.routes.draw do
 
   get '/requestdownstream' => 'system_test#request_downstream'
   get '/returnheaders' => 'system_test#return_headers'
+
+  get '/rasp/sqli' => 'system_test#rasp_sqli'
+  post '/rasp/sqli' => 'system_test#rasp_sqli'
 end

--- a/utils/build/docker/ruby/rails72/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/system_test_controller.rb
@@ -273,16 +273,9 @@ class SystemTestController < ApplicationController
   end
 
   def rasp_sqli
-    user_id = params[:user_id] || request.POST && request.POST['user_id']
-    if user_id
-      User.transaction do
-        # We need to manually create the query as User.where adds parenthesis around the user_id
-        query = "SELECT * FROM users WHERE id='#{user_id}'"
-        users = User.find_by_sql(query).to_a
-        render plain: "DB request with #{users.size} results"
-      end
-    else
-      render plain: 'users not found parameter', status: 400
-    end
+    # We need to manually create the query as User.where adds parenthesis around the user_id
+    query = "SELECT * FROM users WHERE id='#{params.fetch(:user_id)}'"
+    users = User.find_by_sql(query).to_a
+    render plain: "DB request with #{users.size} results"
   end
 end

--- a/utils/build/docker/ruby/rails72/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/system_test_controller.rb
@@ -271,4 +271,18 @@ class SystemTestController < ApplicationController
     end
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
+
+  def rasp_sqli
+    user_id = params[:user_id] || request.POST && request.POST['user_id']
+    if user_id
+      User.transaction do
+        # We need to manually create the query as User.where adds parenthesis around the user_id
+        query = "SELECT * FROM users WHERE id='#{user_id}'"
+        users = User.find_by_sql(query).to_a
+        render plain: "DB request with #{users.size} results"
+      end
+    else
+      render plain: 'users not found parameter', status: 400
+    end
+  end
 end

--- a/utils/build/docker/ruby/rails72/config/initializers/datadog.rb
+++ b/utils/build/docker/ruby/rails72/config/initializers/datadog.rb
@@ -1,5 +1,6 @@
 Datadog.configure do |c|
   c.diagnostics.debug = true
+  c.appsec.instrument :active_record
 end
 
 # Send non-web init event

--- a/utils/build/docker/ruby/rails72/config/routes.rb
+++ b/utils/build/docker/ruby/rails72/config/routes.rb
@@ -47,4 +47,7 @@ Rails.application.routes.draw do
 
   get '/requestdownstream' => 'system_test#request_downstream'
   get '/returnheaders' => 'system_test#return_headers'
+
+  get '/rasp/sqli' => 'system_test#rasp_sqli'
+  post '/rasp/sqli' => 'system_test#rasp_sqli'
 end

--- a/utils/build/docker/ruby/rails80/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails80/app/controllers/system_test_controller.rb
@@ -273,16 +273,9 @@ class SystemTestController < ApplicationController
   end
 
   def rasp_sqli
-    user_id = params[:user_id] || request.POST && request.POST['user_id']
-    if user_id
-      User.transaction do
-        # We need to manually create the query as User.where adds parenthesis around the user_id
-        query = "SELECT * FROM users WHERE id='#{user_id}'"
-        users = User.find_by_sql(query).to_a
-        render plain: "DB request with #{users.size} results"
-      end
-    else
-      render plain: 'users not found parameter', status: 400
-    end
+    # We need to manually create the query as User.where adds parenthesis around the user_id
+    query = "SELECT * FROM users WHERE id='#{params.fetch(:user_id)}'"
+    users = User.find_by_sql(query).to_a
+    render plain: "DB request with #{users.size} results"
   end
 end

--- a/utils/build/docker/ruby/rails80/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails80/app/controllers/system_test_controller.rb
@@ -271,4 +271,18 @@ class SystemTestController < ApplicationController
     end
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
+
+  def rasp_sqli
+    user_id = params[:user_id] || request.POST && request.POST['user_id']
+    if user_id
+      User.transaction do
+        # We need to manually create the query as User.where adds parenthesis around the user_id
+        query = "SELECT * FROM users WHERE id='#{user_id}'"
+        users = User.find_by_sql(query).to_a
+        render plain: "DB request with #{users.size} results"
+      end
+    else
+      render plain: 'users not found parameter', status: 400
+    end
+  end
 end

--- a/utils/build/docker/ruby/rails80/config/initializers/datadog.rb
+++ b/utils/build/docker/ruby/rails80/config/initializers/datadog.rb
@@ -1,5 +1,6 @@
 Datadog.configure do |c|
   c.diagnostics.debug = true
+  c.appsec.instrument :active_record
 end
 
 # Send non-web init event

--- a/utils/build/docker/ruby/rails80/config/routes.rb
+++ b/utils/build/docker/ruby/rails80/config/routes.rb
@@ -47,4 +47,7 @@ Rails.application.routes.draw do
 
   get '/requestdownstream' => 'system_test#request_downstream'
   get '/returnheaders' => 'system_test#return_headers'
+
+  get '/rasp/sqli' => 'system_test#rasp_sqli'
+  post '/rasp/sqli' => 'system_test#rasp_sqli'
 end


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
We have released SQLi Exploit Prevention for Ruby, but we don't have stack traces yet (which is why we haven't added these endpoints previously) but stack traces collection PR is open on dd-trace-rb 

## Changes

<!-- A brief description of the change being made with this pull request. -->
- Add RASP SQLi endpoints to Rails weblogs. These endpoints do not support XML as Rack and Rails don't parse XML natively.
The datadog.rb configuration files manually instruments Active Record as auto instrumentation on Active Record do not work yet

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
