### PR TITLE
[Java] Migrating `HttpUrlConnection` to `okhttp` for Springboot `make_distant_call`

### DIFF
--- a/utils/build/docker/java/spring-boot/pom.xml
+++ b/utils/build/docker/java/spring-boot/pom.xml
@@ -219,6 +219,11 @@
             <artifactId>javax.mail</artifactId>
             <version>1.6.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.9.3</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -891,7 +891,7 @@ public class App {
         HashMap<String, String> request_headers = new HashMap<>();
 
         OkHttpClient client = new OkHttpClient.Builder()
-        .addNetworkInterceptor(chain -> {
+        .addNetworkInterceptor(chain -> { // Save request headers
             Request request = chain.request();
             Response response = chain.proceed(request);
             Headers finalHeaders = request.headers();
@@ -909,7 +909,10 @@ public class App {
                 .build();
 
         Response response = client.newCall(request).execute();
-        HashMap<String, String> response_headers = new HashMap<>();
+
+        // Save response headers and status code
+        int status_code = response.code();
+        HashMap<String, String> response_headers = new HashMap<String, String>();
         Headers headers = response.headers();
         for (String name : headers.names()) {
             response_headers.put(name, headers.get(name));
@@ -917,7 +920,7 @@ public class App {
 
         DistantCallResponse result = new DistantCallResponse();
         result.url = url;
-        result.status_code = response.code();
+        result.status_code = status_code;
         result.request_headers = request_headers;
         result.response_headers = response_headers;
 

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -894,7 +894,9 @@ public class App {
         HashMap<String, String> request_headers = new HashMap<>();
         List<String> headers = Collections.list(request.getHeaderNames());
         for (String headerName : headers) {
-            request_headers.put(headerName, request.getHeader(headerName));
+            if (headerName != null) {
+                request_headers.put(headerName, request.getHeader(headerName));
+            }
         }
 
         // Save response headers and status code

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -82,6 +82,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.Scanner;
 import java.util.LinkedHashMap;
 
@@ -883,20 +884,17 @@ public class App {
     }
 
     @RequestMapping("/make_distant_call")
-    DistantCallResponse make_distant_call(@RequestParam String url) throws Exception {
+    DistantCallResponse make_distant_call(@RequestParam String url, final HttpServletRequest request) throws Exception {
         URL urlObject = new URL(url);
 
         HttpURLConnection con = (HttpURLConnection) urlObject.openConnection();
         con.setRequestMethod("GET");
 
         // Save request headers
-        HashMap<String, String> request_headers = new HashMap<String, String>();
-        for (Map.Entry<String, List<String>> header: con.getRequestProperties().entrySet()) {
-            if (header.getKey() == null) {
-                continue;
-            }
-
-            request_headers.put(header.getKey(), header.getValue().get(0));
+        HashMap<String, String> request_headers = new HashMap<>();
+        List<String> headers = Collections.list(request.getHeaderNames());
+        for (String headerName : headers) {
+            request_headers.put(headerName, request.getHeader(headerName));
         }
 
         // Save response headers and status code

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -71,6 +71,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Headers;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -118,13 +123,6 @@ import static com.mongodb.client.model.Filters.eq;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.StatusCode.ERROR;
 import static java.time.temporal.ChronoUnit.SECONDS;
-
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.Headers;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @RestController
 @EnableAutoConfiguration(exclude = R2dbcAutoConfiguration.class)


### PR DESCRIPTION
## Motivation

Previously, the `make_distant_call` endpoint in the Springboot weblog app used `HttpUrlConnection` to fetch request headers that are being sent to the downstream request. This does not allow for injected headers from the tracer (such as through tracecontext or baggage propagation) to be added.

## Changes

Migrated from using `HttpUrlConnection` to `okhttp` and using a Network Interceptor to get the request headers for the downstream request after the injection is done. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
