### PR TITLE
chore(parametric): validate telemetry schema

### DIFF
--- a/utils/telemetry_utils.py
+++ b/utils/telemetry_utils.py
@@ -1,3 +1,47 @@
+import glob
+import json
+import os
+from pathlib import Path
+from jsonschema.validators import Draft7Validator, RefResolver
+import typing
+
+ROOT_PROJECT = Path(__file__).parent.parent
+
+
+class TelemetryV2Validator:
+    def __init__(self) -> None:
+        schema_store = {}
+
+        schema_dir = os.path.join(ROOT_PROJECT, "utils/interfaces/schemas/miscs/telemetry")
+        for schema_path in glob.iglob("**/*.json", root_dir=schema_dir, recursive=True):
+            with open(schema_dir + "/" + schema_path, "r") as f:
+                schema = json.load(f)
+                schema_store[schema["$id"]] = schema
+
+        main_schema = None
+        with open(schema_dir + "/v2/telemetry_request.json", "r") as f:
+            main_schema = json.load(f)
+
+        self.resolver = RefResolver.from_schema(main_schema, store=schema_store)
+        self.validator = Draft7Validator(
+            schema=main_schema,
+            resolver=self.resolver,
+        )
+
+    def validate(self, data: str) -> bool:
+        try:
+            self.validator.validate(data)
+            return True
+        except Exception:
+            return False
+
+    def get_errors(self, data: str) -> list[dict[str, typing.Any]]:
+        errors = []
+        for e in sorted(self.validator.iter_errors(data), key=lambda e: e.path):
+            errors.append({"reason": e.message, "location": e.json_path, "json": e.instance})
+        return errors
+
+
 class TelemetryUtils:
     test_loaded_dependencies = {
         "dotnet": {"NodaTime": False},


### PR DESCRIPTION
## Motivation
While investigating invalid telemetry payloads for C++ and decided to solve the issue with [this PR], I decided to go the extra mile. Since I wasn't confident in my ability to assess whether telemetry payload generate by the tracer conforms to the telemetry schema, I decided to implement a validation step for system-tests using [jsonschema](https://json-schema.org/).

Fortunately, the talented engineers at ASM had already written the schemas, which greatly helped in this process.

## Changes
- Added `TelemetryV2Validator` class to validate telemetry v2 schema.
- Updated `parametric/test_telemetry.py` tests suite to integrate the validator.
- Addressed inconsistencies and fixed tests that did not conform to the telemetry schema.
