### PR TITLE
[python] use backwards compatible imports for ddtrace-py

### DIFF
--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -29,8 +29,13 @@ from iast import (
 
 import ddtrace
 from ddtrace import patch_all
-from ddtrace.trace import Pin, tracer
 from ddtrace.appsec import trace_utils as appsec_trace_utils
+
+try:
+    from ddtrace.trace import Pin, tracer
+except ImportError:
+    from ddtrace import tracer, Pin
+
 
 patch_all(urllib3=True)
 

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -28,10 +28,15 @@ import urllib3
 import xmltodict
 
 import ddtrace
-from ddtrace.trace import Pin
 from ddtrace import patch_all
-from ddtrace.trace import tracer
 from ddtrace.appsec import trace_utils as appsec_trace_utils
+
+try:
+    from ddtrace.trace import Pin
+    from ddtrace.trace import tracer
+except ImportError:
+    from ddtrace import Pin
+    from ddtrace import tracer
 
 
 patch_all(urllib3=True)

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -68,8 +68,6 @@ if os.environ.get("INCLUDE_RABBITMQ", "true") == "true":
     from integrations.messaging.rabbitmq import rabbitmq_produce
 
 import ddtrace
-from ddtrace.trace import Pin
-from ddtrace.trace import tracer
 from ddtrace.appsec import trace_utils as appsec_trace_utils
 from ddtrace.appsec.iast import ddtrace_iast_flask_patch
 from ddtrace.internal.datastreams import data_streams_processor
@@ -79,6 +77,13 @@ from ddtrace.data_streams import set_produce_checkpoint
 
 from debugger_controller import debugger_blueprint
 from exception_replay_controller import exception_replay_blueprint
+
+try:
+    from ddtrace.trace import Pin
+    from ddtrace.trace import tracer
+except ImportError:
+    from ddtrace import Pin
+    from ddtrace import tracer
 
 # Patch kombu and urllib3 since they are not patched automatically
 ddtrace.patch_all(kombu=True, urllib3=True)

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -26,17 +26,22 @@ from opentelemetry.baggage import set_baggage
 from opentelemetry.baggage import get_baggage
 
 import ddtrace
-from ddtrace.trace import Span
 from ddtrace._trace.sampling_rule import SamplingRule
 from ddtrace import config
 from ddtrace.settings.profiling import config as profiling_config
 from ddtrace.contrib.trace_utils import set_http_meta
-from ddtrace.trace import Context
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.internal.utils.version import parse_version
+
+try:
+    from ddtrace.trace import Span
+    from ddtrace.trace import Context
+except ImportError:
+    from ddtrace import Span
+    from ddtrace.context import Context
 
 log = logging.getLogger(__name__)
 

--- a/utils/build/docker/python/pylons/app/app/config/middleware.py
+++ b/utils/build/docker/python/pylons/app/app/config/middleware.py
@@ -1,6 +1,5 @@
 """Pylons middleware initialization"""
 
-from ddtrace.trace import tracer
 from ddtrace.contrib.pylons import PylonsTraceMiddleware
 
 from beaker.middleware import SessionMiddleware
@@ -13,6 +12,11 @@ from pylons.wsgiapp import PylonsApp
 from routes.middleware import RoutesMiddleware
 
 from app.config.environment import load_environment
+
+try:
+    from ddtrace.trace import tracer
+except ImportError:
+    from ddtrace import tracer
 
 
 def make_app(global_conf, full_stack=True, static_files=True, **app_conf):

--- a/utils/build/docker/python/pylons/app/app/controllers/identify.py
+++ b/utils/build/docker/python/pylons/app/app/controllers/identify.py
@@ -1,7 +1,11 @@
 from app.lib.base import BaseController
 from pylons import response
 from pylons import tmpl_context as c
-from ddtrace.trace import tracer
+
+try:
+    from ddtrace.trace import tracer
+except ImportError:
+    from ddtrace import tracer
 
 try:
     from ddtrace.contrib.trace_utils import set_user

--- a/utils/build/docker/python/pylons/app/app/controllers/waf.py
+++ b/utils/build/docker/python/pylons/app/app/controllers/waf.py
@@ -1,6 +1,9 @@
 import logging
 
-from ddtrace.trace import tracer
+try:
+    from ddtrace.trace import tracer
+except ImportError:
+    from ddtrace import tracer
 
 from pylons import request, response, session, tmpl_context as c, url
 from pylons.controllers.util import abort, redirect


### PR DESCRIPTION
## Motivation

Required to test ddtrace<2.20

## Changes

uses try/except to import ddtrace from the new place fallback to the old place

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
