### PR TITLE
[python][mlob] config norm rule for auto span linking

### DIFF
--- a/tests/telemetry_intake/static/config_norm_rules.json
+++ b/tests/telemetry_intake/static/config_norm_rules.json
@@ -293,6 +293,7 @@
     "_dd_iast_lazy_taint": "iast_lazy_taint",
     "_dd_iast_propagation_debug": "iast_propagation_debug",
     "_dd_inject_was_attempted": "trace_inject_was_attempted",
+    "_dd_llmobs_auto_span_linking_enabled": "llmobs_auto_span_linking_enabled",
     "_dd_llmobs_evaluator_sampling_rules": "llmobs_evaluator_sampling_rules",
     "aas_app_type": "aas_app_type",
     "aas_configuration_error": "aas_configuration_error",


### PR DESCRIPTION
## Motivation
adds config norm rule for auto span linking

dd-go pr https://github.com/DataDog/dd-go/pull/170061

want to make this test pass: https://github.com/DataDog/system-tests/blob/main/docs/edit/runbook.md#test_config_telemetry_completeness

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
