### PR TITLE
Fix IAST vulnerabilities StackTrace tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -37,11 +37,11 @@ tests/:
         test_command_injection.py:
           TestCommandInjection: v2.28.0
           TestCommandInjection_ExtendedLocation: missing_feature
-          TestCommandInjection_StackTrace: missing_feature
+          TestCommandInjection_StackTrace: v3.3.0
         test_email_html_injection.py:
           TestEmailHtmlInjection: v3.2.0
           TestEmailHtmlInjection_ExtendedLocation: missing_feature
-          TestEmailHtmlInjection_StackTrace: missing_feature
+          TestEmailHtmlInjection_StackTrace: v3.3.0
         test_hardcoded_passwords.py:
           Test_HardcodedPasswords: missing_feature
           Test_HardcodedPasswords_ExtendedLocation: missing_feature
@@ -58,55 +58,55 @@ tests/:
           TestHeaderInjectionExclusionPragma: missing_feature
           TestHeaderInjectionExclusionTransferEncoding: missing_feature
           TestHeaderInjection_ExtendedLocation: missing_feature
-          TestHeaderInjection_StackTrace: missing_feature
+          TestHeaderInjection_StackTrace: missing_feature (APPSEC-56196)
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: v2.44.0
           Test_HstsMissingHeader_ExtendedLocation: missing_feature
-          Test_HstsMissingHeader_StackTrace: missing_feature
+          Test_HstsMissingHeader_StackTrace: missing_feature (APPSEC-56196)
         test_insecure_auth_protocol.py:
           Test_InsecureAuthProtocol: v2.49.0
           Test_InsecureAuthProtocol_ExtendedLocation: missing_feature
-          Test_InsecureAuthProtocol_StackTrace: missing_feature
+          Test_InsecureAuthProtocol_StackTrace: missing_feature (APPSEC-56196)
         test_insecure_cookie.py:
           TestInsecureCookie: v2.39.0
           TestInsecureCookieNameFilter: missing_feature
           TestInsecureCookie_ExtendedLocation: missing_feature
-          TestInsecureCookie_StackTrace: missing_feature
+          TestInsecureCookie_StackTrace: missing_feature (APPSEC-56196)
         test_ldap_injection.py:
           TestLDAPInjection: v2.36.0
           TestLDAPInjection_ExtendedLocation: missing_feature
-          TestLDAPInjection_StackTrace: missing_feature
+          TestLDAPInjection_StackTrace: v3.3.0
         test_no_httponly_cookie.py:
           TestNoHttponlyCookie: v2.39.0
           TestNoHttponlyCookieNameFilter: missing_feature
           TestNoHttponlyCookie_ExtendedLocation: missing_feature
-          TestNoHttponlyCookie_StackTrace: missing_feature
+          TestNoHttponlyCookie_StackTrace: missing_feature (APPSEC-56196)
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie: v2.39.0
           TestNoSamesiteCookieNameFilter: missing_feature
           TestNoSamesiteCookie_ExtendedLocation: missing_feature
-          TestNoSamesiteCookie_StackTrace: missing_feature
+          TestNoSamesiteCookie_StackTrace: missing_feature (APPSEC-56196)
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection: v2.47.0
           TestNoSqlMongodbInjection_ExtendedLocation: missing_feature
-          TestNoSqlMongodbInjection_StackTrace: missing_feature
+          TestNoSqlMongodbInjection_StackTrace: v3.3.0
         test_path_traversal.py:
           TestPathTraversal: v2.31.0
           TestPathTraversal_ExtendedLocation: missing_feature
-          TestPathTraversal_StackTrace: missing_feature
+          TestPathTraversal_StackTrace: v3.3.0
         test_reflection_injection.py:
           TestReflectionInjection: v2.48.0
           TestReflectionInjection_ExtendedLocation: missing_feature
-          TestReflectionInjection_StackTrace: missing_feature
+          TestReflectionInjection_StackTrace: v3.3.0
         test_sql_injection.py:
           TestSqlInjection:
             '*': v2.23.0
           TestSqlInjection_ExtendedLocation: missing_feature
-          TestSqlInjection_StackTrace: missing_feature
+          TestSqlInjection_StackTrace: v3.3.0
         test_ssrf.py:
           TestSSRF: v2.36.0
           TestSSRF_ExtendedLocation: missing_feature
-          TestSSRF_StackTrace: missing_feature
+          TestSSRF_StackTrace: v3.3.0
         test_stacktrace_leak.py:
           TestStackTraceLeak: missing_feature
         test_template_injection.py:
@@ -115,7 +115,7 @@ tests/:
         test_trust_boundary_violation.py:
           Test_TrustBoundaryViolation: v2.43.0
           Test_TrustBoundaryViolation_ExtendedLocation: missing_feature
-          Test_TrustBoundaryViolation_StackTrace: missing_feature
+          Test_TrustBoundaryViolation_StackTrace: v3.3.0
         test_untrusted_deserialization.py:
           TestUntrustedDeserialization: missing_feature
           TestUntrustedDeserialization_ExtendedLocation: missing_feature
@@ -123,10 +123,10 @@ tests/:
         test_unvalidated_redirect.py:
           TestUnvalidatedHeader: v2.44.0
           TestUnvalidatedHeader_ExtendedLocation: missing_feature
-          TestUnvalidatedHeader_StackTrace: missing_feature
+          TestUnvalidatedHeader_StackTrace: missing_feature (APPSEC-56196)
           TestUnvalidatedRedirect: v2.44.0
           TestUnvalidatedRedirect_ExtendedLocation: missing_feature
-          TestUnvalidatedRedirect_StackTrace: missing_feature
+          TestUnvalidatedRedirect_StackTrace: v3.3.0
         test_unvalidated_redirect_forward.py:
           TestUnvalidatedForward: missing_feature
           TestUnvalidatedForward_ExtendedLocation: missing_feature
@@ -134,16 +134,16 @@ tests/:
         test_weak_cipher.py:
           TestWeakCipher: v2.24.0
           TestWeakCipher_ExtendedLocation: missing_feature
-          TestWeakCipher_StackTrace: missing_feature
+          TestWeakCipher_StackTrace: irrelevant (APPSEC-56196)
         test_weak_hash.py:
           TestDeduplication: v2.24.0
           TestWeakHash: v2.24.0
           TestWeakHash_ExtendedLocation: missing_feature
-          TestWeakHash_StackTrace: missing_feature
+          TestWeakHash_StackTrace: v3.3.0
         test_weak_randomness.py:
           TestWeakRandomness: v2.39.0
           TestWeakRandomness_ExtendedLocation: missing_feature
-          TestWeakRandomness_StackTrace: missing_feature
+          TestWeakRandomness_StackTrace: missing_feature (APPSEC-56196)
         test_xcontent_sniffing.py:
           Test_XContentSniffing: missing_feature
           Test_XContentSniffing_ExtendedLocation: missing_feature
@@ -151,7 +151,7 @@ tests/:
         test_xpath_injection.py:
           TestXPathInjection: v2.47.0
           TestXPathInjection_ExtendedLocation: missing_feature
-          TestXPathInjection_StackTrace: missing_feature
+          TestXPathInjection_StackTrace: v3.3.0
         test_xss.py:
           TestXSS: missing_feature
           TestXSS_ExtendedLocation: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -58,11 +58,11 @@ tests/:
           TestHeaderInjectionExclusionPragma: missing_feature
           TestHeaderInjectionExclusionTransferEncoding: missing_feature
           TestHeaderInjection_ExtendedLocation: missing_feature
-          TestHeaderInjection_StackTrace: missing_feature (APPSEC-56196)
+          TestHeaderInjection_StackTrace: irrelevant (not expected to have a stack trace)
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: v2.44.0
           Test_HstsMissingHeader_ExtendedLocation: missing_feature
-          Test_HstsMissingHeader_StackTrace: missing_feature (APPSEC-56196)
+          Test_HstsMissingHeader_StackTrace: irrelevant (not expected to have a stack trace)
         test_insecure_auth_protocol.py:
           Test_InsecureAuthProtocol: v2.49.0
           Test_InsecureAuthProtocol_ExtendedLocation: missing_feature
@@ -71,7 +71,7 @@ tests/:
           TestInsecureCookie: v2.39.0
           TestInsecureCookieNameFilter: missing_feature
           TestInsecureCookie_ExtendedLocation: missing_feature
-          TestInsecureCookie_StackTrace: missing_feature (APPSEC-56196)
+          TestInsecureCookie_StackTrace: irrelevant (not expected to have a stack trace)
         test_ldap_injection.py:
           TestLDAPInjection: v2.36.0
           TestLDAPInjection_ExtendedLocation: missing_feature
@@ -80,12 +80,12 @@ tests/:
           TestNoHttponlyCookie: v2.39.0
           TestNoHttponlyCookieNameFilter: missing_feature
           TestNoHttponlyCookie_ExtendedLocation: missing_feature
-          TestNoHttponlyCookie_StackTrace: missing_feature (APPSEC-56196)
+          TestNoHttponlyCookie_StackTrace: irrelevant (not expected to have a stack trace)
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie: v2.39.0
           TestNoSamesiteCookieNameFilter: missing_feature
           TestNoSamesiteCookie_ExtendedLocation: missing_feature
-          TestNoSamesiteCookie_StackTrace: missing_feature (APPSEC-56196)
+          TestNoSamesiteCookie_StackTrace: irrelevant (not expected to have a stack trace)
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection: v2.47.0
           TestNoSqlMongodbInjection_ExtendedLocation: missing_feature
@@ -134,7 +134,7 @@ tests/:
         test_weak_cipher.py:
           TestWeakCipher: v2.24.0
           TestWeakCipher_ExtendedLocation: missing_feature
-          TestWeakCipher_StackTrace: irrelevant (APPSEC-56196)
+          TestWeakCipher_StackTrace: missing_feature (APPSEC-56196)
         test_weak_hash.py:
           TestDeduplication: v2.24.0
           TestWeakHash: v2.24.0
@@ -143,7 +143,7 @@ tests/:
         test_weak_randomness.py:
           TestWeakRandomness: v2.39.0
           TestWeakRandomness_ExtendedLocation: missing_feature
-          TestWeakRandomness_StackTrace: missing_feature (APPSEC-56196)
+          TestWeakRandomness_StackTrace: v3.3.0
         test_xcontent_sniffing.py:
           Test_XContentSniffing: missing_feature
           Test_XContentSniffing_ExtendedLocation: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -77,7 +77,7 @@ tests/:
             vertx4: v1.12.0
           TestCommandInjection_ExtendedLocation: missing_feature
           TestCommandInjection_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             play: missing_feature
             ratpack: missing_feature
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
@@ -94,7 +94,7 @@ tests/:
             vertx4: missing_feature (No endpoint implemented)
           TestEmailHtmlInjection_ExtendedLocation: missing_feature
           TestEmailHtmlInjection_StackTrace:
-            '*': v1.47.0
+            '*': missing_feature
             akka-http: missing_feature (No endpoint implemented)
             jersey-grizzly2: missing_feature (No endpoint implemented)
             play: missing_feature (No endpoint implemented)
@@ -137,13 +137,13 @@ tests/:
           TestHeaderInjection_ExtendedLocation: missing_feature
           TestHeaderInjection_StackTrace:
             '*': missing_feature
-            spring-boot: v1.43.0
-            spring-boot-jetty: v1.43.0
-            spring-boot-openliberty: v1.43.0
-            spring-boot-payara: v1.43.0
-            spring-boot-undertow: v1.43.0
-            spring-boot-wildfly: v1.43.0
-            uds-spring-boot: v1.43.0
+#            spring-boot: v1.43.0
+#            spring-boot-jetty: v1.43.0
+#            spring-boot-openliberty: v1.43.0
+#            spring-boot-payara: v1.43.0
+#            spring-boot-undertow: v1.43.0
+#            spring-boot-wildfly: v1.43.0
+#            uds-spring-boot: v1.43.0
         test_hsts_missing_header.py:
           Test_HstsMissingHeader:
             '*': v1.20.0
@@ -168,7 +168,7 @@ tests/:
             spring-boot-openliberty: bug (APPSEC-54981)
           Test_InsecureAuthProtocol_ExtendedLocation: missing_feature
           Test_InsecureAuthProtocol_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
@@ -184,7 +184,7 @@ tests/:
           TestInsecureCookieNameFilter: missing_feature
           TestInsecureCookie_ExtendedLocation: missing_feature
           TestInsecureCookie_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
@@ -202,7 +202,7 @@ tests/:
             vertx4: v1.12.0
           TestLDAPInjection_ExtendedLocation: missing_feature
           TestLDAPInjection_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             play: missing_feature (endpoint not implemented)
             ratpack: missing_feature (endpoint not implemented)
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
@@ -216,7 +216,7 @@ tests/:
           TestNoHttponlyCookieNameFilter: missing_feature
           TestNoHttponlyCookie_ExtendedLocation: missing_feature
           TestNoHttponlyCookie_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
@@ -231,7 +231,7 @@ tests/:
           TestNoSamesiteCookieNameFilter: missing_feature
           TestNoSamesiteCookie_ExtendedLocation: missing_feature
           TestNoSamesiteCookie_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
@@ -252,7 +252,7 @@ tests/:
             vertx3: v1.12.0
           TestPathTraversal_ExtendedLocation: missing_feature
           TestPathTraversal_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             play: missing_feature
             ratpack: missing_feature
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
@@ -265,7 +265,7 @@ tests/:
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           TestReflectionInjection_ExtendedLocation: missing_feature
           TestReflectionInjection_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
@@ -282,7 +282,7 @@ tests/:
             vertx3: v1.12.0
           TestSqlInjection_ExtendedLocation: missing_feature
           TestSqlInjection_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             play: missing_feature
             ratpack: missing_feature
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
@@ -296,7 +296,7 @@ tests/:
             vertx4: missing_feature (No endpoint implemented)
           TestSSRF_ExtendedLocation: missing_feature
           TestSSRF_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: missing_feature (No endpoint implemented)
             play: missing_feature (No endpoint implemented)
             ratpack: missing_feature (No endpoint implemented)
@@ -320,7 +320,7 @@ tests/:
             vertx4: missing_feature
           Test_TrustBoundaryViolation_ExtendedLocation: missing_feature
           Test_TrustBoundaryViolation_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: missing_feature
             jersey-grizzly2: missing_feature
             play: missing_feature
@@ -342,7 +342,7 @@ tests/:
             vertx4: missing_feature (No endpoint implemented)
           TestUntrustedDeserialization_ExtendedLocation: missing_feature
           TestUntrustedDeserialization_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: missing_feature (No endpoint implemented)
             jersey-grizzly2: missing_feature (No endpoint implemented)
             play: missing_feature (No endpoint implemented)
@@ -363,7 +363,7 @@ tests/:
             vertx4: v1.17.0
           TestUnvalidatedHeader_ExtendedLocation: missing_feature
           TestUnvalidatedHeader_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
@@ -378,7 +378,7 @@ tests/:
             vertx4: v1.17.0
           TestUnvalidatedRedirect_ExtendedLocation: missing_feature
           TestUnvalidatedRedirect_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
@@ -396,7 +396,7 @@ tests/:
             vertx4: v1.17.0
           TestUnvalidatedForward_ExtendedLocation: missing_feature
           TestUnvalidatedForward_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: irrelevant (No forward)
             jersey-grizzly2: irrelevant (No forward)
             play: missing_feature (No endpoint implemented)
@@ -410,7 +410,7 @@ tests/:
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           TestWeakCipher_ExtendedLocation: missing_feature
           TestWeakCipher_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             play: missing_feature (no endpoint)
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         test_weak_hash.py:
@@ -424,7 +424,7 @@ tests/:
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           TestWeakHash_ExtendedLocation: missing_feature
           TestWeakHash_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             play: missing_feature (no endpoint)
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         test_weak_randomness.py:
@@ -434,7 +434,7 @@ tests/:
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           TestWeakRandomness_ExtendedLocation: missing_feature
           TestWeakRandomness_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             play: missing_feature (no endpoint)
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         test_xcontent_sniffing.py:
@@ -459,7 +459,7 @@ tests/:
             spring-boot-3-native: missing_feature
           TestXPathInjection_ExtendedLocation: missing_feature
           TestXPathInjection_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             play: missing_feature
             ratpack: missing_feature
             spring-boot-3-native: missing_feature
@@ -476,7 +476,7 @@ tests/:
             vertx4: missing_feature
           TestXSS_ExtendedLocation: missing_feature
           TestXSS_StackTrace:
-            '*': v1.43.0
+            '*': missing_feature
             akka-http: missing_feature
             jersey-grizzly2: missing_feature
             play: missing_feature
@@ -671,7 +671,7 @@ tests/:
           '*': v1.45.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         Test_Cmdi_StackTrace:
-          '*': v1.45.0
+          '*': missing_feature
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
         Test_Cmdi_Telemetry:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -103,7 +103,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestCodeInjection_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_command_injection.py:
           TestCommandInjection:
@@ -113,7 +113,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestCommandInjection_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_email_html_injection.py:
           TestEmailHtmlInjection: missing_feature
@@ -162,7 +162,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestHeaderInjection_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_hsts_missing_header.py:
           Test_HstsMissingHeader:
@@ -187,7 +187,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestInsecureCookie_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_ldap_injection.py:
           TestLDAPInjection:
@@ -197,7 +197,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestLDAPInjection_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_no_httponly_cookie.py:
           TestNoHttponlyCookie:
@@ -210,7 +210,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestNoHttponlyCookie_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie:
@@ -223,7 +223,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestNoSamesiteCookie_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection:
@@ -233,7 +233,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestNoSqlMongodbInjection_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_path_traversal.py:
           TestPathTraversal:
@@ -243,7 +243,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestPathTraversal_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_reflection_injection.py:
           TestReflectionInjection: missing_feature
@@ -257,7 +257,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestSqlInjection_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_ssrf.py:
           TestSSRF:
@@ -267,7 +267,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestSSRF_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_stacktrace_leak.py:
           TestStackTraceLeak: missing_feature
@@ -290,7 +290,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestUntrustedDeserialization_StackTrace:
-            '*': *ref_5_32_0
+            '*': missing_feature
             nextjs: missing_feature
         test_unvalidated_redirect.py:
           TestUnvalidatedHeader:
@@ -300,7 +300,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestUnvalidatedHeader_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
           TestUnvalidatedRedirect:
             '*': *ref_4_3_0
@@ -309,7 +309,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestUnvalidatedRedirect_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_unvalidated_redirect_forward.py:
           TestUnvalidatedForward: missing_feature
@@ -323,7 +323,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestWeakCipher_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_weak_hash.py:
           TestDeduplication:
@@ -336,7 +336,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestWeakHash_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_weak_randomness.py:
           TestWeakRandomness:
@@ -346,7 +346,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           TestWeakRandomness_StackTrace:
-            '*': *ref_5_33_0
+            '*': missing_feature
             nextjs: missing_feature
         test_xcontent_sniffing.py:
           Test_XContentSniffing:
@@ -432,7 +432,7 @@ tests/:
         Test_Cmdi_Optional_SpanTags: *ref_5_30_0
         Test_Cmdi_Rules_Version: *ref_5_30_0
         Test_Cmdi_StackTrace:
-          '*': *ref_5_30_0
+          '*': missing_feature
           nextjs: missing_feature
         Test_Cmdi_Telemetry:
           '*': *ref_5_30_0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -52,13 +52,13 @@ tests/:
         test_code_injection.py:
           TestCodeInjection: v2.20.0
           TestCodeInjection_ExtendedLocation: missing_feature
-          TestCodeInjection_StackTrace: v2.20.0
+          TestCodeInjection_StackTrace: missing_feature
         test_command_injection.py:
           TestCommandInjection:
             '*': v2.10.0
             fastapi: v2.15.0
           TestCommandInjection_ExtendedLocation: missing_feature
-          TestCommandInjection_StackTrace: v2.19.0.dev
+          TestCommandInjection_StackTrace: missing_feature
         test_email_html_injection.py:
           TestEmailHtmlInjection: missing_feature
           TestEmailHtmlInjection_ExtendedLocation: missing_feature
@@ -82,8 +82,8 @@ tests/:
           TestHeaderInjectionExclusionTransferEncoding: missing_feature
           TestHeaderInjection_ExtendedLocation: missing_feature
           TestHeaderInjection_StackTrace:
-            '*': v2.19.0.dev
-            fastapi: v2.20.0.dev
+            '*': missing_feature
+            fastapi: missing_feature
         test_hsts_missing_header.py:
           Test_HstsMissingHeader: missing_feature
           Test_HstsMissingHeader_ExtendedLocation: missing_feature
@@ -126,7 +126,7 @@ tests/:
             '*': v2.10.0
             fastapi: v2.15.0
           TestPathTraversal_ExtendedLocation: missing_feature
-          TestPathTraversal_StackTrace: v2.19.0.dev
+          TestPathTraversal_StackTrace: missing_feature
         test_reflection_injection.py:
           TestReflectionInjection: missing_feature
           TestReflectionInjection_ExtendedLocation: missing_feature
@@ -139,13 +139,13 @@ tests/:
             pylons: missing_feature
             python3.12: v1.18.0
           TestSqlInjection_ExtendedLocation: missing_feature
-          TestSqlInjection_StackTrace: v2.19.0.dev
+          TestSqlInjection_StackTrace: missing_feature
         test_ssrf.py:
           TestSSRF:
             '*': v2.10.0
             fastapi: v2.15.0
           TestSSRF_ExtendedLocation: missing_feature
-          TestSSRF_StackTrace: v2.19.0.dev
+          TestSSRF_StackTrace: missing_feature
         test_stacktrace_leak.py:
           TestStackTraceLeak:
             '*': v3.1.0.dev
@@ -176,19 +176,19 @@ tests/:
             '*': v1.18.0
             fastapi: v2.15.0
           TestWeakCipher_ExtendedLocation: missing_feature
-          TestWeakCipher_StackTrace: v2.19.0.dev
+          TestWeakCipher_StackTrace: missing_feature
         test_weak_hash.py:
           TestDeduplication:
             '*': v1.18.0
           TestWeakHash:
             '*': v1.18.0
           TestWeakHash_ExtendedLocation: missing_feature
-          TestWeakHash_StackTrace: v2.19.0.dev
+          TestWeakHash_StackTrace: missing_feature
         test_weak_randomness.py:
           TestWeakRandomness:
             '*': v2.0.0
           TestWeakRandomness_ExtendedLocation: missing_feature
-          TestWeakRandomness_StackTrace: v2.19.0.dev
+          TestWeakRandomness_StackTrace: missing_feature
         test_xcontent_sniffing.py:
           Test_XContentSniffing: missing_feature
           Test_XContentSniffing_ExtendedLocation: missing_feature

--- a/tests/appsec/iast/utils.py
+++ b/tests/appsec/iast/utils.py
@@ -220,6 +220,7 @@ def validate_stack_traces(request):
 
     assert vuln["location"], "no 'location' present'"
     assert vuln["location"]["stackId"], "no 'stack_id's present'"
+    assert isinstance(vuln["location"]["stackId"], str), "'stackId' is not a string"
     assert "meta_struct" in span, "'meta_struct' not found in span"
     assert "_dd.stack" in span["meta_struct"], "'_dd.stack' not found in 'meta_struct'"
     assert "vulnerability" in span["meta_struct"]["_dd.stack"], "'vulnerability' not found in '_dd.stack'"

--- a/tests/appsec/iast/utils.py
+++ b/tests/appsec/iast/utils.py
@@ -210,7 +210,6 @@ def validate_stack_traces(request):
     ), "'_dd.stack' not found in 'meta_struct'. Please check if the test should be marked as irrelevant (not expected to have a stack trace)"
     stack_traces = span["meta_struct"]["_dd.stack"]["vulnerability"]
     stack_trace = stack_traces[0]
-    logger.debug(f"Stack trace: {iast["vulnerabilities"]}")
     vulns = [
         i for i in iast["vulnerabilities"] if i.get("location") and i["location"].get("stackId") == stack_trace["id"]
     ]

--- a/tests/appsec/iast/utils.py
+++ b/tests/appsec/iast/utils.py
@@ -199,22 +199,24 @@ def validate_stack_traces(request):
     assert spans, "No root span found"
     span = spans[0]
     meta = span.get("meta", {})
-    assert "_dd.iast.json" in meta, "No iast event in root span"
-    iast = meta["_dd.iast.json"]
+    meta_struct = span.get("meta_struct", {})
+    iast = meta.get("_dd.iast.json") or meta_struct.get("iast")
+    assert iast is not None, "No iast event in root span"
     assert iast["vulnerabilities"], "Expected at least one vulnerability"
 
     stack_traces = span["meta_struct"]["_dd.stack"]["vulnerability"]
     stack_trace = stack_traces[0]
-    vulns = [i for i in iast["vulnerabilities"] if i.get("stackId") == stack_trace["id"]]
+    vulns = [i for i in iast["vulnerabilities"] if i.get("location").get("stackId") == stack_trace["id"]]
     assert (
         len(vulns) == 1
     ), f"Expected a single vulnerability with the stack trace Id.\nVulnerabilities: {vulns}\nStack trace: {stack_traces}"
     vuln = vulns[0]
 
-    assert vuln["stackId"], "no 'stack_id's present'"
+    assert vuln["location"], "no 'location' present'"
+    assert vuln["location"]["stackId"], "no 'stack_id's present'"
     assert "meta_struct" in span, "'meta_struct' not found in span"
     assert "_dd.stack" in span["meta_struct"], "'_dd.stack' not found in 'meta_struct'"
-    assert "vulnerability" in span["meta_struct"]["_dd.stack"], "'exploit' not found in '_dd.stack'"
+    assert "vulnerability" in span["meta_struct"]["_dd.stack"], "'vulnerability' not found in '_dd.stack'"
 
     assert stack_trace, "No stack traces to validate"
 
@@ -229,7 +231,7 @@ def validate_stack_traces(request):
         "ruby",
     ), "unexpected language"
 
-    # Ensure the stack ID corresponds to an appsec event
+    # Ensure the stack ID corresponds to an iast event
     assert "id" in stack_trace, "'id' not found in stack trace"
     assert "frames" in stack_trace, "'frames' not found in stack trace"
     assert len(stack_trace["frames"]) <= 32, "stack trace above size limit (32 frames)"
@@ -240,19 +242,33 @@ def validate_stack_traces(request):
     assert "path" in location, "This vulnerability is not expected to have a stack trace"
 
     locationFrame = None
+    logger.debug(location)
+    logger.debug(len(stack_trace["frames"]))
     for frame in stack_trace["frames"]:
         # We are looking for the frame that corresponds to the location of the vulnerability, we will need to update this to cover all tracers
         # currently support: Java, Python, Node.js
+        logger.debug(frame)
         if (
-            stack_trace["language"] == "java"
-            and (
-                location["path"] in frame["class_name"]
-                and location["method"] in frame["function"]
-                and location["line"] == frame["line"]
+            (
+                stack_trace["language"] == "java"
+                and (
+                    location["path"] in frame["class_name"]
+                    and location["method"] in frame["function"]
+                    and location["line"] == frame["line"]
+                )
             )
-        ) or (
-            stack_trace["language"] in ("python", "nodejs")
-            and (frame.get("file", "").endswith(location["path"]) and location["line"] == frame["line"])
+            or (
+                stack_trace["language"] in ("python", "nodejs")
+                and (frame.get("file", "").endswith(location["path"]) and location["line"] == frame["line"])
+            )
+            or (
+                stack_trace["language"] == "dotnet"
+                and (
+                    f"{frame.get('namespace', '')}.{frame.get('class_name', '')}" == location["path"]
+                    and location["method"] in frame["function"]
+                    and location["line"] == frame["line"]
+                )
+            )
         ):
             locationFrame = frame
     assert locationFrame is not None, "location not found in stack trace"


### PR DESCRIPTION
## Motivation

The RFC specifies that `stackId` should be placed into the vulnerability location and not into the vulnerability itself, so the test are wrong implemented.

A bug was found in java, nodejs and python tracers related with that so they should be disabled

In addition dotNet is the only one that implements this feature properly so we want to enable for those test to double check 

## Changes

 - Modify test to check the `stackId` into the vulnerability location
 - Make test compatible with dotnet
 - Disable test for java, python and nodejs
 - Enable test for dotnet



<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
