### PR TITLE
[python] backwards compatible imports for dd-trace-py 2.19

### DIFF
--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -26,7 +26,6 @@ from opentelemetry.baggage import set_baggage
 from opentelemetry.baggage import get_baggage
 
 import ddtrace
-from ddtrace._trace.sampling_rule import SamplingRule
 from ddtrace import config
 from ddtrace.settings.profiling import config as profiling_config
 from ddtrace.contrib.trace_utils import set_http_meta
@@ -39,9 +38,11 @@ from ddtrace.internal.utils.version import parse_version
 try:
     from ddtrace.trace import Span
     from ddtrace.trace import Context
+    from ddtrace._trace.sampling_rule import SamplingRule
 except ImportError:
     from ddtrace import Span
     from ddtrace.context import Context
+    from ddtrace.sampling_rule import SamplingRule
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Motivation

These failures when running system-tests on dd-trace-py 2.19 branch:
https://github.com/DataDog/dd-trace-py/actions/runs/13303603625/job/37159774564?pr=12306#step:5:48817


## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
