### PR TITLE
Update test_metric_waf_requests with new valid tags

### DIFF
--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -98,7 +98,7 @@ class Test_TelemetryMetrics:
             "waf_error",
             "block_failure",
             "rate_limited",
-            "input_truncated"
+            "input_truncated",
         }
         mandatory_tag_prefixes = {
             "waf_version",

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -95,6 +95,10 @@ class Test_TelemetryMetrics:
             "waf_timeout",
             "version",
             "lib_language",
+            "waf_error",
+            "block_failure",
+            "rate_limited",
+            "input_truncated"
         }
         mandatory_tag_prefixes = {
             "waf_version",


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

This adds new tags to the `appsec.waf.requests` test which is necessary for the consolidation of ASM Span Tags, Metrics, and Logs across all supported languages.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Add to the `valid_tag_prefixes` the new tags.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
