### PR TITLE
[Debugger] Make debugger run faster

### DIFF
--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -12,6 +12,7 @@ from .open_telemetry import OpenTelemetryScenario
 from .parametric import ParametricScenario
 from .performance import PerformanceScenario
 from .profiling import ProfilingScenario
+from .debugger import DebuggerScenario
 from .test_the_test import TestTheTestScenario
 from .auto_injection import InstallerAutoInjectionScenario
 from .k8s_lib_injection import WeblogInjectionScenario, K8sScenario, K8sSparkScenario, K8sManualInstrumentationScenario
@@ -584,82 +585,57 @@ class _Scenarios:
 
     parametric = ParametricScenario("PARAMETRIC", doc="WIP")
 
-    debugger_probes_status = EndToEndScenario(
+    debugger_probes_status = DebuggerScenario(
         "DEBUGGER_PROBES_STATUS",
-        rc_api_enabled=True,
         weblog_env={
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
-            "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_INTERNAL_RCM_POLL_INTERVAL": "2000",
-            "DD_DEBUGGER_DIAGNOSTICS_INTERVAL": "1",
         },
         doc="Test scenario for checking if method probe statuses can be successfully 'RECEIVED' and 'INSTALLED'",
-        scenario_groups=[ScenarioGroup.DEBUGGER],
     )
 
-    debugger_probes_snapshot = EndToEndScenario(
+    debugger_probes_snapshot = DebuggerScenario(
         "DEBUGGER_PROBES_SNAPSHOT",
-        rc_api_enabled=True,
         weblog_env={
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
-            "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_CODE_ORIGIN_FOR_SPANS_ENABLED": "true",
+            "DD_CODE_ORIGIN_FOR_SPANS_ENABLED": "1",
         },
-        library_interface_timeout=5,
         doc="Test scenario for checking if debugger successfully generates snapshots for probes",
-        scenario_groups=[ScenarioGroup.DEBUGGER],
     )
 
-    debugger_pii_redaction = EndToEndScenario(
+    debugger_pii_redaction = DebuggerScenario(
         "DEBUGGER_PII_REDACTION",
-        rc_api_enabled=True,
         weblog_env={
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
-            "DD_REMOTE_CONFIG_ENABLED": "true",
             "DD_DYNAMIC_INSTRUMENTATION_REDACTED_TYPES": "weblog.Models.Debugger.CustomPii,com.datadoghq.system_tests.springboot.CustomPii,CustomPii",  # noqa: E501
             "DD_DYNAMIC_INSTRUMENTATION_REDACTED_IDENTIFIERS": "customidentifier1,customidentifier2",
         },
-        library_interface_timeout=5,
         doc="Check pii redaction",
-        scenario_groups=[ScenarioGroup.DEBUGGER],
     )
 
-    debugger_expression_language = EndToEndScenario(
+    debugger_expression_language = DebuggerScenario(
         "DEBUGGER_EXPRESSION_LANGUAGE",
-        rc_api_enabled=True,
-        weblog_env={"DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1", "DD_REMOTE_CONFIG_ENABLED": "true"},
-        library_interface_timeout=5,
-        doc="Check expression language",
-        scenario_groups=[ScenarioGroup.DEBUGGER],
-    )
-
-    debugger_exception_replay = EndToEndScenario(
-        "DEBUGGER_EXCEPTION_REPLAY",
-        rc_api_enabled=True,
         weblog_env={
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
-            "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_EXCEPTION_DEBUGGING_ENABLED": "true",
-            "DD_EXCEPTION_REPLAY_CAPTURE_MAX_FRAMES": "10",
         },
-        library_interface_timeout=5,
-        doc="Check exception replay",
-        scenario_groups=[ScenarioGroup.DEBUGGER],
+        doc="Check expression language",
     )
 
-    debugger_symdb = EndToEndScenario(
+    debugger_exception_replay = DebuggerScenario(
+        "DEBUGGER_EXCEPTION_REPLAY",
+        weblog_env={
+            "DD_EXCEPTION_DEBUGGING_ENABLED": "1",
+            "DD_EXCEPTION_REPLAY_CAPTURE_MAX_FRAMES": "10",
+        },
+        doc="Check exception replay",
+    )
+
+    debugger_symdb = DebuggerScenario(
         "DEBUGGER_SYMDB",
-        rc_api_enabled=True,
         weblog_env={
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_SYMBOL_DATABASE_UPLOAD_ENABLED": "1",
-            "DD_REMOTE_CONFIG_ENABLED": "true",
-            "DD_INTERNAL_RCM_POLL_INTERVAL": "2000",
-            "DD_DEBUGGER_DIAGNOSTICS_INTERVAL": "1",
         },
-        library_interface_timeout=5,
         doc="Test scenario for checking symdb.",
-        scenario_groups=[ScenarioGroup.DEBUGGER],
     )
 
     fuzzer = DockerScenario("FUZZER", doc="Fake scenario for fuzzing (launch without pytest)", github_workflow=None)

--- a/utils/_context/_scenarios/debugger.py
+++ b/utils/_context/_scenarios/debugger.py
@@ -1,0 +1,23 @@
+from .core import ScenarioGroup
+from .endtoend import EndToEndScenario
+
+
+class DebuggerScenario(EndToEndScenario):
+    def __init__(self, name, doc, weblog_env) -> None:
+        base_weblog_env = {
+            "DD_REMOTE_CONFIG_ENABLED": "1",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "1",
+            "DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL": "100",
+            "DD_DYNAMIC_INSTRUMENTATION_DIAGNOSTICS_INTERVAL": "1",
+        }
+
+        base_weblog_env.update(weblog_env)
+
+        super().__init__(
+            name=name,
+            doc=doc,
+            rc_api_enabled=True,
+            library_interface_timeout=5,
+            weblog_env=base_weblog_env,
+            scenario_groups=[ScenarioGroup.DEBUGGER],
+        )


### PR DESCRIPTION
## Motivation
Reduce time of each debugger test running

## Changes
Introduce DebuggerScenario class, with defined polling time
Reduce default wait timeout. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
