### PR TITLE
[golang] rollout go 1.22 in favor of go 1.23

### DIFF
--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -425,7 +425,7 @@ def golang_library_factory():
         container_name="go-test-library",
         container_tag="go122-test-library",
         container_img=f"""
-FROM golang:1.22
+FROM golang:1.23
 
 # install jq
 RUN apt-get update && apt-get -y install jq

--- a/utils/build/docker/golang/app/go.mod
+++ b/utils/build/docker/golang/app/go.mod
@@ -1,6 +1,6 @@
 module weblog
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/99designs/gqlgen v0.17.36
@@ -28,6 +28,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.3.0 // indirect
 	github.com/DataDog/go-libddwaf/v3 v3.4.0 // indirect
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/gostackparse v0.7.0 // indirect
 	github.com/DataDog/sketches-go v1.4.5 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
@@ -53,6 +54,7 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b // indirect
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -83,9 +85,11 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/richardartoul/molecule v1.0.1-0.20240531184615-7ca0df43c0b3 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/tinylib/msgp v1.2.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect

--- a/utils/build/docker/golang/app/go.sum
+++ b/utils/build/docker/golang/app/go.sum
@@ -111,6 +111,7 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b h1:h9U78+dx9a4BKdQkBBos92HalKpaGKHrp+3Uo6yTodo=
@@ -242,6 +243,7 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -371,6 +373,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 lukechampine.com/uint128 v1.3.0 h1:cDdUVfRwDUDovz610ABgFD17nXD4/uDgVHl2sC3+sbo=
 lukechampine.com/uint128 v1.3.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 modernc.org/cc/v3 v3.41.0 h1:QoR1Sn3YWlmA1T4vLaKZfawdVtSiGx8H+cEojbC7v1Q=

--- a/utils/build/docker/golang/chi.Dockerfile
+++ b/utils/build/docker/golang/chi.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/echo.Dockerfile
+++ b/utils/build/docker/golang/echo.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/gin.Dockerfile
+++ b/utils/build/docker/golang/gin.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/go.work
+++ b/utils/build/docker/golang/go.work
@@ -1,6 +1,6 @@
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.4
+toolchain go1.23.0
 
 use (
 	./app

--- a/utils/build/docker/golang/gqlgen.Dockerfile
+++ b/utils/build/docker/golang/gqlgen.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/graph-gophers.Dockerfile
+++ b/utils/build/docker/golang/graph-gophers.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/graphql-go.Dockerfile
+++ b/utils/build/docker/golang/graphql-go.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23
 
 # print important lib versions
 RUN go version && curl --version

--- a/utils/build/docker/golang/net-http-orchestrion.Dockerfile
+++ b/utils/build/docker/golang/net-http-orchestrion.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS build
+FROM golang:1.23 AS build
 
 # print important lib versions
 RUN go version && curl --version
@@ -20,7 +20,7 @@ RUN orchestrion go build -v -tags appsec,orchestrion -o weblog ./net-http-orches
 
 # ==============================================================================
 
-FROM golang:1.22
+FROM golang:1.23
 
 COPY --from=build /app/weblog /app/weblog
 COPY --from=build /app/SYSTEM_TESTS_LIBRARY_VERSION /app/SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/golang/net-http.Dockerfile
+++ b/utils/build/docker/golang/net-http.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS build
+FROM golang:1.23 AS build
 
 # print important lib versions
 RUN go version && curl --version
@@ -20,7 +20,7 @@ RUN go build -v -tags appsec -o weblog ./net-http
 
 # ==============================================================================
 
-FROM golang:1.22
+FROM golang:1.23
 
 COPY --from=build /app/weblog /app/weblog
 COPY --from=build /app/SYSTEM_TESTS_LIBRARY_VERSION /app/SYSTEM_TESTS_LIBRARY_VERSION

--- a/utils/build/docker/golang/parametric/go.mod
+++ b/utils/build/docker/golang/parametric/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/utils/build/docker/golang/uds-echo.Dockerfile
+++ b/utils/build/docker/golang/uds-echo.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23
 
 # print important lib versions
 RUN go version && curl --version


### PR DESCRIPTION
## Motivation

Go 1.24 was released last week. As per the dd-trace-go Go version support policy, our Minimum Support Version is now go 1.23

## Changes

- [x] Change all docker base images
- [x] Change all `go.mod` and `go.work`
- [x] Run `go mod tidy` and `go work sync`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
