### PR TITLE
config_consistency: enable xpassing tests

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -668,9 +668,9 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Configured: v1.67.0
     Test_Config_ObfuscationQueryStringRegexp_Default: v1.67.0
     Test_Config_ObfuscationQueryStringRegexp_Empty: v1.67.0
-    Test_Config_RuntimeMetrics_Default: incomplete_test_app (test needs to account for golang runtime metrics)
-    Test_Config_RuntimeMetrics_Enabled: incomplete_test_app (should be in v1.18.0 but we're not receiving series in tests)
-    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: incomplete_test_app (should be in v1.18.0 but we're not receiving series in tests)
+    Test_Config_RuntimeMetrics_Default: v1.67.0
+    Test_Config_RuntimeMetrics_Enabled: v1.67.0
+    Test_Config_RuntimeMetrics_Enabled_WithRuntimeId: v1.67.0
     Test_Config_UnifiedServiceTagging_CustomService: v1.67.0
     Test_Config_UnifiedServiceTagging_Default: v1.67.0
   test_data_integrity.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1753,7 +1753,7 @@ tests/:
       Test_NotReleased: missing_feature
   test_config_consistency.py:
     Test_Config_ClientIPHeaderEnabled_False: v1.43.0
-    Test_Config_ClientIPHeader_Configured: missing_feature
+    Test_Config_ClientIPHeader_Configured: v1.43.0
     Test_Config_ClientIPHeader_Precedence: missing_feature (does not support x-forwarded header)
     Test_Config_ClientTagQueryString_Configured:
       '*': v1.43.0
@@ -1788,7 +1788,7 @@ tests/:
     Test_Config_ObfuscationQueryStringRegexp_Configured: v1.39.0
     Test_Config_ObfuscationQueryStringRegexp_Default: v1.39.0
     Test_Config_ObfuscationQueryStringRegexp_Empty: v1.39.0
-    Test_Config_RuntimeMetrics_Default: incomplete_test_app (test needs to account for java runtime metrics)
+    Test_Config_RuntimeMetrics_Default: v0.64.0
     Test_Config_RuntimeMetrics_Enabled:
       '*': v0.64.0
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -963,11 +963,11 @@ tests/:
     Test_Config_ClientIPHeaderEnabled_False: *ref_3_13_0
     Test_Config_ClientIPHeader_Configured: *ref_3_13_0
     Test_Config_ClientIPHeader_Precedence: *ref_3_19_0
-    Test_Config_ClientTagQueryString_Configured: missing_feature (adding query string to http.url is not supported)
+    Test_Config_ClientTagQueryString_Configured: *ref_5_37_0
     Test_Config_ClientTagQueryString_Empty: missing_feature (removes query strings by default)
     Test_Config_HttpClientErrorStatuses_Default: missing_feature
     Test_Config_HttpClientErrorStatuses_FeatureFlagCustom: missing_feature
-    Test_Config_HttpServerErrorStatuses_Default: missing_feature
+    Test_Config_HttpServerErrorStatuses_Default: *ref_5_37_0
     Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: missing_feature
     Test_Config_IntegrationEnabled_False:
       '*': *ref_5_25_0

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -202,7 +202,6 @@ class Test_Config_TraceAgentURL:
         ],
     )
     @missing_feature(context.library == "ruby", reason="does not support ipv6 hostname")
-    @missing_feature(context.library == "dotnet", reason="does not support ipv6 hostname")
     @missing_feature(context.library == "php", reason="does not support ipv6 hostname")
     @missing_feature(context.library == "golang", reason="does not support ipv6 hostname")
     @missing_feature(context.library == "python", reason="does not support ipv6 hostname")


### PR DESCRIPTION
## Motivation

Enable XPassing tests

## Changes

- Enables config consistency tests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
