### PR TITLE
[java] Enable code origin test for java

### DIFF
--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -4,7 +4,11 @@
 
 import time
 import tests.debugger.utils as debugger
+import logging
+
 from utils import scenarios, features, missing_feature, context, rfc
+
+logger = logging.getLogger(__name__)
 
 
 @features.debugger
@@ -128,7 +132,10 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
 
     @features.debugger_code_origins
     @missing_feature(context.library == "dotnet", reason="Entry spans code origins not yet implemented")
-    @missing_feature(context.library == "java", reason="Entry spans code origins not yet implemented for spring-mvc")
+    @missing_feature(
+        context.library == "java" and context.weblog_variant != "spring-boot",
+        reason="Entry spans code origins only implemented for spring-mvc",
+    )
     @missing_feature(context.library == "nodejs", reason="Entry spans code origins not yet implemented for express")
     @missing_feature(context.library == "ruby", reason="Entry spans code origins not yet implemented")
     def test_code_origin_entry_present(self):
@@ -141,6 +148,8 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
         for span in self.all_spans:
             # Web spans for the healthcheck should have code origins defined.
             resource, resource_type = span.get("resource", None), span.get("type", None)
+            logger.debug(span)
+
             if resource == "GET /healthcheck" and resource_type == "web":
                 code_origin_type = span["meta"].get("_dd.code_origin.type", "")
                 code_origins_entry_found = code_origin_type == "entry"


### PR DESCRIPTION
requires https://github.com/DataDog/dd-trace-java/pull/8416 to be merged first

## Motivation

Enable code origin tests for java.  Requires that https://github.com/DataDog/dd-trace-java/pull/8416 be merged first.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
