### PR TITLE
Fix DEBUGGER_SYMDB scenario

### DIFF
--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -385,11 +385,14 @@ class _Base_Debugger_Test:
                     probe_diagnostics[probe_id] = diagnostics
 
         for data in datas:
+            logger.debug(f"Processing data: {data['log_filename']}")
             contents = data["request"].get("content", []) or []  # Ensures contents is a list
 
             for content in contents:
-                if "content" in content:
+                if "content" in content and isinstance(content["content"], list):
+                    # content["content"] may be a dict, and not a list ?
                     for d_content in content["content"]:
+                        assert isinstance(d_content, dict), f"Unexpected content: {json.dumps(content, indent=2)}"
                         _process_debugger(d_content["debugger"])
                 elif "debugger" in content:
                     _process_debugger(content["debugger"])


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
