### PR TITLE
Remove ancient /session/user endpoint

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -875,16 +875,6 @@ c377db41-b664-4e30-af57-5df2e803bec7
 Examples:
 - `GET`: `/session/new`
 
-### \[GET\] /session/user
-
-Once a session has been established, a new call to `/session/user` must be made in order to generate a session fingerprint with the session id provided by the web client (e.g. cookie) and the user id provided as a parameter.
-
-Query parameters required in the `GET` method:
-- `sdk_user`: user id used in the WAF login event triggered during the execution of the request.
-
-Examples:
-- `GET`: `/session/user?sdk_user=sdkUser`
-
 ### \[GET\] /mock_s3/put_object
 
 This endpoint is used to test the s3 integration. It creates a bucket if

--- a/utils/build/docker/golang/app/chi/main.go
+++ b/utils/build/docker/golang/app/chi/main.go
@@ -281,16 +281,6 @@ func main() {
 		w.Header().Add("Set-Cookie", "session="+sessionID+"; Path=/; Max-Age=3600; Secure; HttpOnly")
 	})
 
-	mux.HandleFunc("/session/user", func(w http.ResponseWriter, r *http.Request) {
-		user := r.URL.Query().Get("sdk_user")
-		cookie, err := r.Cookie("session")
-		if err != nil {
-			w.WriteHeader(500)
-			w.Write([]byte("missing session cookie"))
-		}
-		appsec.TrackUserLoginSuccessEvent(r.Context(), user, map[string]string{}, tracer.WithUserSessionID(cookie.Value))
-	})
-
 	mux.HandleFunc("/rasp/lfi", rasp.LFI)
 	mux.HandleFunc("/rasp/ssrf", rasp.SSRF)
 	mux.HandleFunc("/rasp/sqli", rasp.SQLi)

--- a/utils/build/docker/golang/app/echo/main.go
+++ b/utils/build/docker/golang/app/echo/main.go
@@ -255,16 +255,6 @@ func main() {
 		return ctx.NoContent(200)
 	})
 
-	r.GET("/session/user", func(ctx echo.Context) error {
-		user := ctx.Request().URL.Query().Get("sdk_user")
-		cookie, err := ctx.Request().Cookie("session")
-		if err != nil {
-			return ctx.String(500, "no session cookie")
-		}
-		appsec.TrackUserLoginSuccessEvent(ctx.Request().Context(), user, map[string]string{}, tracer.WithUserSessionID(cookie.Value))
-		return ctx.NoContent(200)
-	})
-
 	r.GET("/inferred-proxy/span-creation", func(ctx echo.Context) error {
 		statusCodeStr := ctx.Request().URL.Query().Get("status_code")
 		statusCode := 200

--- a/utils/build/docker/golang/app/gin/main.go
+++ b/utils/build/docker/golang/app/gin/main.go
@@ -232,15 +232,6 @@ func main() {
 		ctx.SetCookie("session", sessionID, 3600, "/", "", false, true)
 	})
 
-	r.GET("/session/user", func(ctx *gin.Context) {
-		user := ctx.Query("sdk_user")
-		cookie, err := ctx.Request.Cookie("session")
-		if err != nil {
-			ctx.Writer.WriteHeader(500)
-		}
-		appsec.TrackUserLoginSuccessEvent(ctx.Request.Context(), user, map[string]string{}, tracer.WithUserSessionID(cookie.Value))
-	})
-
 	r.GET("/inferred-proxy/span-creation", func(ctx *gin.Context) {
 		statusCodeStr := ctx.Query("status_code")
 		statusCode := 200

--- a/utils/build/docker/golang/app/net-http-orchestrion/main.go
+++ b/utils/build/docker/golang/app/net-http-orchestrion/main.go
@@ -519,16 +519,6 @@ func main() {
 		w.Header().Add("Set-Cookie", "session="+sessionID+"; Path=/; Max-Age=3600; Secure; HttpOnly")
 	})
 
-	mux.HandleFunc("/session/user", func(w http.ResponseWriter, r *http.Request) {
-		user := r.URL.Query().Get("sdk_user")
-		cookie, err := r.Cookie("session")
-		if err != nil {
-			w.WriteHeader(500)
-			w.Write([]byte("missing session cookie"))
-		}
-		appsec.TrackUserLoginSuccessEvent(r.Context(), user, map[string]string{}, tracer.WithUserSessionID(cookie.Value))
-	})
-
 	mux.HandleFunc("/inferred-proxy/span-creation", func(w http.ResponseWriter, r *http.Request) {
 		statusCodeStr := r.URL.Query().Get("status_code")
 		statusCode := 200

--- a/utils/build/docker/golang/app/net-http/main.go
+++ b/utils/build/docker/golang/app/net-http/main.go
@@ -616,16 +616,6 @@ func main() {
 		w.Header().Add("Set-Cookie", "session="+sessionID+"; Path=/; Max-Age=3600; Secure; HttpOnly")
 	})
 
-	mux.HandleFunc("/session/user", func(w http.ResponseWriter, r *http.Request) {
-		user := r.URL.Query().Get("sdk_user")
-		cookie, err := r.Cookie("session")
-		if err != nil {
-			w.WriteHeader(500)
-			w.Write([]byte("missing session cookie"))
-		}
-		appsec.TrackUserLoginSuccessEvent(r.Context(), user, map[string]string{}, tracer.WithUserSessionID(cookie.Value))
-	})
-
 	mux.HandleFunc("/inferred-proxy/span-creation", func(w http.ResponseWriter, r *http.Request) {
 		statusCodeStr := r.URL.Query().Get("status_code")
 		statusCode := 200

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -221,13 +221,6 @@ public class App {
         return ResponseEntity.ok(session.getId());
     }
 
-    @GetMapping(value = "/session/user")
-    ResponseEntity<String> userSession(@RequestParam("sdk_user") final String sdkUser, final HttpServletRequest request) {
-        EventTracker tracker = datadog.trace.api.GlobalTracer.getEventTracker();
-        tracker.trackLoginSuccessEvent(sdkUser, Collections.emptyMap());
-        return ResponseEntity.ok(request.getRequestedSessionId());
-    }
-
     @RequestMapping("/status")
     ResponseEntity<String> status(@RequestParam Integer code) {
         return new ResponseEntity<>(HttpStatus.valueOf(code));

--- a/utils/build/docker/java_otel/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java_otel/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -205,13 +205,6 @@ public class App {
         return ResponseEntity.ok(session.getId());
     }
 
-    @GetMapping(value = "/session/user")
-    ResponseEntity<String> userSession(@RequestParam("sdk_user") final String sdkUser, final HttpServletRequest request) {
-        EventTracker tracker = datadog.trace.api.GlobalTracer.getEventTracker();
-        tracker.trackLoginSuccessEvent(sdkUser, Collections.emptyMap());
-        return ResponseEntity.ok(request.getRequestedSessionId());
-    }
-
     @RequestMapping("/status")
     ResponseEntity<String> status(@RequestParam Integer code) {
         return new ResponseEntity<>(HttpStatus.valueOf(code));

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -673,14 +673,6 @@ async def session_new(request: Request):
     return response
 
 
-@app.get("/session/user")
-async def session_user(request: Request):
-    user = request.query_params.get("sdk_user", "")
-    if user and request.cookies.get("session_id", "") == MAGIC_SESSION_KEY:
-        appsec_trace_utils.track_user_login_success_event(tracer, user_id=user, session_id=f"session_{user}")
-    return PlainTextResponse("OK")
-
-
 _TRACK_CUSTOM_EVENT_NAME = "system_tests_event"
 
 

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -568,14 +568,6 @@ def session_new():
     return response
 
 
-@app.route("/session/user")
-def session_user():
-    user = flask_request.args.get("sdk_user", "")
-    if user and flask_request.cookies.get("session_id", "") == MAGIC_SESSION_KEY:
-        appsec_trace_utils.track_user_login_success_event(tracer, user_id=user, session_id=f"session_{user}")
-    return Response("OK")
-
-
 @app.route("/stub_dbm")
 async def stub_dbm():
     integration = flask_request.args.get("integration")


### PR DESCRIPTION
## Changes

Removes `/session/user` endpoint that is no longer in use.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
