### PR TITLE
Exclude 'tracers' from product checked in "everything disabled" scenario

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -702,6 +702,7 @@ class Test_ProductsDisabled:
         telemetry_data = interfaces.library.get_telemetry_data()
 
         for data in telemetry_data:
+            logger.debug(f"Checking {data['log_filename']}")
             data_found = True
 
             if get_request_type(data) != "app-started":
@@ -711,13 +712,20 @@ class Test_ProductsDisabled:
 
             payload = data["request"]["content"]["payload"]
 
-            assert (
-                "products" in payload
-            ), f"Product information was expected in app-started event, but was missing in {data['log_filename']}"
+            assert "products" in payload, "Product information was expected in app-started event, but was missing"
 
+            logger.debug(json.dumps(payload["products"], indent=2))
             for product, details in payload["products"].items():
+                if product == "tracers":
+                    # tracers is enabled, otherwise, nothing is reported to the agent
+                    # to be confirmed it's the good behaviour
+                    continue
+
                 assert (
-                    details.get("enabled") is False
+                    "enabled" in details
+                ), f"Product information expected to indicate {product} is disabled, but missing"
+                assert (
+                    details["enabled"] is False
                 ), f"Product information expected to indicate {product} is disabled, but found enabled"
 
         if not data_found:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
