### PR TITLE
[ASM][ATO][dotnet] Activate session blocking test

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -318,7 +318,7 @@ tests/:
       Test_V3_Login_Events_Blocking: v3.10.0
       Test_V3_Login_Events_RC: v3.10.0
     test_automated_user_and_session_tracking.py:
-      Test_Automated_Session_Blocking: missing_feature
+      Test_Automated_Session_Blocking: v3.11.0
       Test_Automated_User_Blocking: v3.10.0
       Test_Automated_User_Tracking: v3.10.0
     test_blocking_addresses.py:

--- a/utils/build/docker/dotnet/weblog/Controllers/SessionController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/SessionController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using Microsoft.AspNetCore.Routing;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Datadog.Trace.Appsec;
+using Datadog.Trace.AppSec;
 
 namespace weblog
 {

--- a/utils/build/docker/dotnet/weblog/Controllers/SessionController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/SessionController.cs
@@ -27,7 +27,7 @@ namespace weblog
         {
             if (sdk_user != null)
             {
-                EventTrackingSdk.TrackUserLoginSuccessEvent(sdk_user, null);
+                EventTrackingSdk.TrackUserLoginSuccessEvent(sdk_user);
             }
 
             return Content($"Hello, set the user to {sdk_user}");

--- a/utils/build/docker/dotnet/weblog/Controllers/SessionController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/SessionController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using Microsoft.AspNetCore.Routing;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Datadog.Trace;
+using Datadog.Trace.Appsec;
 
 namespace weblog
 {
@@ -27,11 +27,7 @@ namespace weblog
         {
             if (sdk_user != null)
             {
-                var userDetails = new UserDetails()
-                {
-                    Id = sdk_user,
-                };
-                Tracer.Instance.ActiveScope?.Span.SetUser(userDetails);
+                EventTrackingSdk.TrackUserLoginSuccessEvent(sdk_user, null);
             }
 
             return Content($"Hello, set the user to {sdk_user}");


### PR DESCRIPTION
## Motivation

Activate session blocking test, as we now collect session id every time
Adapt weblog as per documentation

```
### \[GET\] /session/user

Once a session has been established, a new call to `/session/user` must be made in order to generate a session fingerprint with the session id provided by the web client (e.g. cookie) and the user id provided as a parameter.

Query parameters required in the `GET` method:
- `sdk_user`: user id used in the WAF login event triggered during the execution of the request.

```

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
