### PR TITLE
Enable dotnet for probe budget tests

### DIFF
--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -157,7 +157,6 @@ class Test_Debugger_Probe_Snaphots(debugger.Base_Debugger_Test):
         )
 
     @features.debugger_probe_budgets
-    @missing_feature(context.library == "dotnet", reason="Probe snapshot budgets are not yet implemented")
     @missing_feature(context.library == "nodejs", reason="Probe snapshot budgets are not yet implemented")
     @missing_feature(context.library == "ruby", reason="Probe snapshot budgets are not yet implemented")
     def test_log_line_probe_snaphots_budgets(self):

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -91,7 +91,7 @@ class Base_Debugger_Test:
     def method_and_language_to_line_number(self, method, language):
         """method_and_language_to_line_number returns the respective line number given the method and language"""
         return {
-            "Budgets": {"python": [142], "java": [138]},
+            "Budgets": {"java": [138], "dotnet": [136], "python": [142]},
             "Expression": {"java": [71], "dotnet": [74], "python": [72]},
             # The `@exception` variable is not available in the context of line probes.
             "ExpressionException": {},

--- a/utils/build/docker/dotnet/weblog/Controllers/DebuggerController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/DebuggerController.cs
@@ -133,7 +133,7 @@ namespace weblog
         {
             for (int i = 0; i < loops; i++)
             {
-                _ = i; // No-op
+                int j = i; // Capture snapshot here to test budgets.
             }
             return Content("Budgets");
         }

--- a/utils/build/docker/dotnet/weblog/Controllers/DebuggerController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/DebuggerController.cs
@@ -126,5 +126,16 @@ namespace weblog
 
             return Content($"Pii is null {pii is null}. intValue is null {intValue is null}. strValue is null {strValue is null}.");
         }
+
+        [HttpGet("budgets/{loops}")]
+        [Consumes("application/json", "application/xml")]
+        public IActionResult Budgets(int loops)
+        {
+            for (int i = 0; i < loops; i++)
+            {
+                _ = i; // No-op
+            }
+            return Content("Budgets");
+        }
     }
 }


### PR DESCRIPTION
## Motivation

This pull request includes several changes to enhance the support for probe snapshot budgets and add new functionality to the `DebuggerController` in the dotnet weblog. The most important changes include the addition of a new endpoint in `DebuggerController`, updating the method-to-line number mapping, and removing a missing feature decorator for dotnet.

## Changes

Enhancements to probe snapshot budgets and debugger functionality:

* [`utils/build/docker/dotnet/weblog/Controllers/DebuggerController.cs`](diffhunk://#diff-8730c1c3eaa537de2a49726bd572c01f72363ae0bd1fcba9bb949412b46bab93R129-R139): Added a new endpoint `Budgets` that accepts an integer parameter `loops` and returns a content response after performing a no-operation loop.
* [`tests/debugger/utils.py`](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821L94-R94): Updated the `method_and_language_to_line_number` method to include the line number for "Budgets" in dotnet.
* [`tests/debugger/test_debugger_probe_snapshot.py`](diffhunk://#diff-838dccab9204ff2351b256cb32211afd0bd44a0cf4ff368044354f987b8dd462L160): Removed the `@missing_feature` decorator for dotnet in the `test_log_line_probe_snaphots_budgets` method, indicating that probe snapshot budgets are now implemented for dotnet.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
