### PR TITLE
[ASM] Fix inconsistent feature on RASP tests

### DIFF
--- a/tests/appsec/rasp/test_shi.py
+++ b/tests/appsec/rasp/test_shi.py
@@ -211,14 +211,14 @@ class Test_Shi_Capability:
         interfaces.library.assert_rc_capability(Capabilities.ASM_RASP_SHI)
 
 
-@features.rasp_local_file_inclusion
+@features.rasp_shell_injection
 class Test_Shi_Rules_Version(Base_Rules_Version):
     """Test shi min rules version"""
 
     min_version = "1.13.1"
 
 
-@features.rasp_local_file_inclusion
+@features.rasp_shell_injection
 class Test_Shi_Waf_Version(Base_WAF_Version):
     """Test shi WAF version"""
 

--- a/tests/appsec/rasp/test_sqli.py
+++ b/tests/appsec/rasp/test_sqli.py
@@ -183,14 +183,14 @@ class Test_Sqli_Capability:
         interfaces.library.assert_rc_capability(Capabilities.ASM_RASP_SQLI)
 
 
-@features.rasp_local_file_inclusion
+@features.rasp_sql_injection
 class Test_Sqli_Rules_Version(Base_Rules_Version):
     """Test Sqli min rules version"""
 
     min_version = "1.13.2"
 
 
-@features.rasp_local_file_inclusion
+@features.rasp_sql_injection
 class Test_Sqli_Waf_Version(Base_WAF_Version):
     """Test sqli WAF version"""
 

--- a/tests/appsec/rasp/test_ssrf.py
+++ b/tests/appsec/rasp/test_ssrf.py
@@ -215,14 +215,14 @@ class Test_Ssrf_Capability:
         interfaces.library.assert_rc_capability(Capabilities.ASM_RASP_SSRF)
 
 
-@features.rasp_local_file_inclusion
+@features.rasp_server_side_request_forgery
 class Test_Ssrf_Rules_Version(Base_Rules_Version):
     """Test ssrf min rules version"""
 
     min_version = "1.13.2"
 
 
-@features.rasp_local_file_inclusion
+@features.rasp_server_side_request_forgery
 class Test_Ssrf_Waf_Version(Base_WAF_Version):
     """Test ssrf WAF version"""
 


### PR DESCRIPTION
## Motivation

Some of the RASP tests were using an incorrect feature, specifically some of the ruleset version tests for each of the different vulnerabilities were all claiming to be part of the local file inclusion feature.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
