### PR TITLE
[java] Enable API Security tests for path parameters

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -50,8 +50,14 @@ tests/:
         Test_Schema_Request_Json_Body:
           '*': missing_feature
           ratpack: v1.36.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           vertx3: v1.36.0
-        Test_Schema_Request_Path_Parameters: missing_feature
+        Test_Schema_Request_Path_Parameters:
+          '*': v1.36.0
+          akka-http: missing_feature (path parameters not suported)
+          jersey-grizzly2: bug (APPSEC-56846)
+          resteasy-netty3: bug (APPSEC-56846)
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         Test_Schema_Request_Query_Parameters:
           '*': v1.31.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)

--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
@@ -53,14 +53,14 @@ object AppSecRoutes {
           }
         }
       } ~
-      path("tag_value" / Segment / """\d{3}""".r) { (value, code) =>
+      path("tag_value" / Segment / """\d{3}""".r) { (tag_value, status_code) =>
         get {
           parameter("content-language".?) { clo =>
-            setRootSpanTag("appsec.events.system_tests_appsec_event.value", value)
+            setRootSpanTag("appsec.events.system_tests_appsec_event.value", tag_value)
 
             val resp = complete(
               HttpResponse(
-                status = StatusCodes.custom(code.toInt, "some reason"),
+                status = StatusCodes.custom(status_code.toInt, "some reason"),
                 entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "Value tagged")
               )
             )
@@ -73,10 +73,10 @@ object AppSecRoutes {
         } ~
           post {
             formFieldMap { _ =>
-              setRootSpanTag("appsec.events.system_tests_appsec_event.value", value)
+              setRootSpanTag("appsec.events.system_tests_appsec_event.value", tag_value)
               complete(
                 HttpResponse(
-                  status = StatusCodes.custom(code.toInt, "some reason"),
+                  status = StatusCodes.custom(status_code.toInt, "some reason"),
                   entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "Value tagged")
                 )
               )

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
@@ -90,8 +90,8 @@ public class MyResource {
     }
 
     @GET
-    @Path("/tag_value/{value}/{code}")
-    public Response tagValue(@PathParam("value") String value, @PathParam("code") int code) {
+    @Path("/tag_value/{tag_value}/{status_code}")
+    public Response tagValue(@PathParam("tag_value") String value, @PathParam("status_code") int code) {
         setRootSpanTag("appsec.events.system_tests_appsec_event.value", value);
         return Response.status(code)
                 .header("content-type", "text/plain")
@@ -99,15 +99,15 @@ public class MyResource {
     }
 
     @OPTIONS
-    @Path("/tag_value/{value}/{code}")
-    public Response tagValueOptions(@PathParam("value") String value, @PathParam("code") int code) {
+    @Path("/tag_value/{tag_value}/{status_code}")
+    public Response tagValueOptions(@PathParam("tag_value") String value, @PathParam("status_code") int code) {
         return tagValue(value, code);
     }
 
     @POST
-    @Path("/tag_value/{value}/{code}")
+    @Path("/tag_value/{tag_value}/{status_code}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public Response tagValuePost(@PathParam("value") String value, @PathParam("code") int code, MultivaluedMap<String, String> form) {
+    public Response tagValuePost(@PathParam("tag_value") String value, @PathParam("status_code") int code, MultivaluedMap<String, String> form) {
         return tagValue(value, code);
     }
 

--- a/utils/build/docker/java/play/conf/routes
+++ b/utils/build/docker/java/play/conf/routes
@@ -1,8 +1,8 @@
 GET  /                         controllers.AppSecController.index
 GET  /healthcheck              controllers.AppSecController.healthcheck
 GET  /headers                  controllers.AppSecController.headers
-GET  /tag_value/:value/:code   controllers.AppSecController.tagValue(value: String, code: Int)
-POST /tag_value/:value/:code   controllers.AppSecController.tagValuePost(value: String, code: Int)
+GET  /tag_value/:tag_value/:status_code   controllers.AppSecController.tagValue(tag_value: String, status_code: Int)
+POST /tag_value/:tag_value/:status_code   controllers.AppSecController.tagValuePost(tag_value: String, status_code: Int)
 GET  /params/*segments         controllers.AppSecController.params(segments: Seq[String])
 GET  /waf                      controllers.AppSecController.waf
 GET  /waf/                      controllers.AppSecController.waf

--- a/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
+++ b/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
@@ -169,9 +169,9 @@ public class Main {
                                     response.send("application/json", r);
                                 });
                             })
-                            .path("tag_value/:value/:code", ctx -> {
-                                final String value = ctx.getPathTokens().get("value");
-                                final int code = Integer.parseInt(ctx.getPathTokens().get("code"));
+                            .path("tag_value/:tag_value/:status_code", ctx -> {
+                                final String value = ctx.getPathTokens().get("tag_value");
+                                final int code = Integer.parseInt(ctx.getPathTokens().get("status_code"));
                                 WafPostHandler.consumeParsedBody(ctx).then(v -> {
                                     setRootSpanTag("appsec.events.system_tests_appsec_event.value", value);
                                     ctx.getResponse().status(code).send("Value tagged");

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
@@ -90,8 +90,8 @@ public class MyResource {
     }
 
     @GET
-    @Path("/tag_value/{value}/{code}")
-    public Response tagValue(@PathParam("value") String value, @PathParam("code") int code) {
+    @Path("/tag_value/{tag_value}/{status_code}")
+    public Response tagValue(@PathParam("tag_value") String value, @PathParam("status_code") int code) {
         setRootSpanTag("appsec.events.system_tests_appsec_event.value", value);
         return Response.status(code)
                 .header("content-type", "text/plain")
@@ -99,15 +99,15 @@ public class MyResource {
     }
 
     @OPTIONS
-    @Path("/tag_value/{value}/{code}")
-    public Response tagValueOptions(@PathParam("value") String value, @PathParam("code") int code) {
+    @Path("/tag_value/{tag_value}/{status_code}")
+    public Response tagValueOptions(@PathParam("tag_value") String value, @PathParam("status_code") int code) {
         return tagValue(value, code);
     }
 
     @POST
-    @Path("/tag_value/{value}/{code}")
+    @Path("/tag_value/{tag_value}/{status_code}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public Response tagValuePost(@PathParam("value") String value, @PathParam("code") int code, MultivaluedMap<String, String> form) {
+    public Response tagValuePost(@PathParam("tag_value") String value, @PathParam("status_code") int code, MultivaluedMap<String, String> form) {
         return tagValue(value, code);
     }
 

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -180,16 +180,16 @@ public class App {
         return "012345678901234567890123456789012345678901";
     }
 
-    @RequestMapping(value = "/tag_value/{value}/{code}", method = {RequestMethod.GET, RequestMethod.OPTIONS}, headers = "accept=*")
-    ResponseEntity<String> tagValue(@PathVariable final String value, @PathVariable final int code) {
-        setRootSpanTag("appsec.events.system_tests_appsec_event.value", value);
-        return ResponseEntity.status(code).body("Value tagged");
+    @RequestMapping(value = "/tag_value/{tag_value}/{status_code}", method = {RequestMethod.GET, RequestMethod.OPTIONS}, headers = "accept=*")
+    ResponseEntity<String> tagValue(@PathVariable final String tag_value, @PathVariable final int status_code) {
+        setRootSpanTag("appsec.events.system_tests_appsec_event.value", tag_value);
+        return ResponseEntity.status(status_code).body("Value tagged");
     }
 
-    @PostMapping(value = "/tag_value/{value}/{code}", headers = "accept=*",
+    @PostMapping(value = "/tag_value/{tag_value}/{status_code}", headers = "accept=*",
             consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    ResponseEntity<String> tagValueWithUrlencodedBody(@PathVariable final String value, @PathVariable final int code, @RequestParam MultiValueMap<String, String> body) {
-        return tagValue(value, code);
+    ResponseEntity<String> tagValueWithUrlencodedBody(@PathVariable final String tag_value, @PathVariable final int status_code, @RequestParam MultiValueMap<String, String> body) {
+        return tagValue(tag_value, status_code);
     }
 
     @RequestMapping("/waf/**")

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
@@ -87,14 +87,14 @@ public class Main {
                         .putHeader("content-length", "42")
                         .putHeader("content-language", "en-US")
                         .end("012345678901234567890123456789012345678901"));
-        router.routeWithRegex("/tag_value/(?<value>[^/]+)/(?<code>[0-9]+)")
+        router.route("/tag_value/:tag_value/:status_code")
                 .handler(BodyHandler.create())
                 .produces("text/plain")
                 .handler(ctx -> {
                     consumeParsedBody(ctx);
-                    setRootSpanTag("appsec.events.system_tests_appsec_event.value", ctx.pathParam("value"));
+                    setRootSpanTag("appsec.events.system_tests_appsec_event.value", ctx.pathParam("tag_value"));
                     ctx.response()
-                            .setStatusCode(Integer.parseInt(ctx.pathParam("code")))
+                            .setStatusCode(Integer.parseInt(ctx.pathParam("status_code")))
                             .end("Value tagged");
                 });
         router.getWithRegex("/params(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?")

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
@@ -84,14 +84,14 @@ public class Main {
                         .putHeader("content-length", "42")
                         .putHeader("content-language", "en-US")
                         .end("012345678901234567890123456789012345678901"));
-        router.routeWithRegex("/tag_value/(?<value>[^/]+)/(?<code>[0-9]+)")
+        router.route("/tag_value/:tag_value/:status_code")
                 .handler(BodyHandler.create())
                 .produces("text/plain")
                 .handler(ctx -> {
                     consumeParsedBody(ctx);
-                    setRootSpanTag("appsec.events.system_tests_appsec_event.value", ctx.pathParam("value"));
+                    setRootSpanTag("appsec.events.system_tests_appsec_event.value", ctx.pathParam("tag_value"));
                     ctx.response()
-                            .setStatusCode(Integer.parseInt(ctx.pathParam("code")))
+                            .setStatusCode(Integer.parseInt(ctx.pathParam("status_code")))
                             .end("Value tagged");
                 });
         router.getWithRegex("/params(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?")


### PR DESCRIPTION
## Changes

* Enable tests for API Security schema extraction for path parameters.
* Modified the `tag_value` endpoints in all weblogs to conform to the tests (path params must be named `tag_value` and `status_code`, respectively.
* Mark resteasy-netty3 and jersey-grizzly2 as bugged ([APPSEC-56846](https://datadoghq.atlassian.net/browse/APPSEC-56846)), because all path params are inferred as strings, which will make the test fail.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-56846]: https://datadoghq.atlassian.net/browse/APPSEC-56846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ