### PR TITLE
Typo in telemetry logs disablement scenario env var

### DIFF
--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -112,8 +112,8 @@ class _Scenarios:
 
     telemetry_log_generation_disabled = EndToEndScenario(
         "TELEMETRY_LOG_GENERATION_DISABLED",
-        weblog_env={"DD_TELEMETRY_LOGS_COLLECTION_ENABLED": "false"},
-        doc="Test env var `DD_TELEMETRY_LOGS_COLLECTION_ENABLED=false`",
+        weblog_env={"DD_TELEMETRY_LOG_COLLECTION_ENABLED": "false"},
+        doc="Test env var `DD_TELEMETRY_LOG_COLLECTION_ENABLED=false`",
         scenario_groups=[ScenarioGroup.TELEMETRY],
     )
     telemetry_metric_generation_disabled = EndToEndScenario(


### PR DESCRIPTION
## Changes

This PR fixes a typo I found while enabling some system-tests about telemetry following the instrumentation telemetry client full revamp in dd-trace-go. Here are the places that mention the env var without a S:

* The instrumentation telemetry api docs: https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/development.md#telemetry-environment-variables
* dd-trace-rb docs: https://datadoghq.dev/dd-trace-rb/Datadog/Core/Configuration/Settings/DSL/Telemetry.html
* dd-trace-js config: https://github.com/DataDog/dd-trace-js/blob/fd425151b56f41cc71a2b39ba088b72491283ae8/packages/dd-trace/test/config.spec.js#L1729

#### Why this did not fail before ?

No tracer has the only test running in this scenario enabled.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
