### PR TITLE
Make Test_CollectDefaultRequestHeader stricter

### DIFF
--- a/tests/appsec/test_traces.py
+++ b/tests/appsec/test_traces.py
@@ -293,24 +293,31 @@ class Test_CollectRespondHeaders:
 @scenarios.external_processing
 @scenarios.default
 class Test_CollectDefaultRequestHeader:
-    HEADERS = ["User-Agent", "Accept", "Content-Type"]
+    HEADERS = {
+        "User-Agent": "MyBrowser",
+        "Accept": "*/*",
+        "Content-Type": "text/plain",
+    }
 
     def setup_collect_default_request_headers(self):
-        self.r = weblog.get("/headers", headers={header: "myHeaderValue" for header in self.HEADERS})
+        self.r = weblog.get("/headers", headers=self.HEADERS)
 
     def test_collect_default_request_headers(self):
         """Collect User agent and other headers and other security info when appsec is enabled."""
-
-        def assert_header_in_span_meta(span, header):
-            if header not in span["meta"]:
-                raise Exception(f"Can't find {header} in span's meta")
-
-        def validate_request_headers(span):
-            for header in self.HEADERS:
-                assert_header_in_span_meta(span, f"http.request.headers.{header.lower()}")
-            return True
-
-        interfaces.library.validate_spans(self.r, validate_request_headers)
+        if context.library != "golang":
+            # TODO(APPSEC-56898): Golang weblogs do not respond to this request.
+            assert self.r.status_code == 200
+        span = interfaces.library.get_root_span(self.r)
+        for key, value in self.HEADERS.items():
+            meta = span.get("meta", {})
+            meta_key = f"http.request.headers.{key.lower()}"
+            assert meta_key in meta
+            if key == "User-Agent":
+                # system-tests inject a request id in the user-agent, so the
+                # matching here needs to account for it.
+                assert meta[meta_key].startswith(value)
+            else:
+                assert meta[meta_key] == value
 
 
 @rfc("https://docs.google.com/document/d/1xf-s6PtSr6heZxmO_QLUtcFzY_X_rT94lRXNq6-Ghws/edit?pli=1")


### PR DESCRIPTION
## Changes

Make Test_CollectDefaultRequestHeader stricter:

* Test that the status code is 200 (avoids hiding issues with incorrect weblog implementations or bugs).
* Use legal values for headers. Some frameworks (e.g. Spring) will fail on invalid Content-Type (e.g. not containing a slash).
* Check the values of the tags, not just the keys.
* Check root spans only explicitly, since that's where these tags are expcted.
* Make assertions more explicit (e.g. no spans vs no matching span).
* See [APPSEC-56898](https://datadoghq.atlassian.net/browse/APPSEC-56898) for the golang exception.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-56898]: https://datadoghq.atlassian.net/browse/APPSEC-56898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ