### PR TITLE
[Ruby] Update docs on testing against non-released library version

### DIFF
--- a/docs/execute/binaries.md
+++ b/docs/execute/binaries.md
@@ -148,6 +148,12 @@ You have two ways to run system-tests with a custom Ruby Tracer version:
   * `gem 'datadog', git: 'https://github.com/Datadog/dd-trace-rb', branch: 'master', require: 'datadog/auto_instrument'`
 2. Clone the dd-trace-rb repo inside `binaries` and checkout the branch that you want to test against.
 
+You can also use `utils/scripts/watch.sh` script to sync your local `dd-trace-rb` repo into the `binaries` folder:
+
+```bash
+./utils/scripts/watch.sh /path/to/dd-trace-rb
+```
+
 ## WAF rule set
 
 * copy a file `waf_rule_set` in `binaries/`

--- a/docs/execute/binaries.md
+++ b/docs/execute/binaries.md
@@ -142,9 +142,11 @@ echo “ddtrace @ git+https://github.com/DataDog/dd-trace-py.git@<name-of-your-b
 
 ## Ruby library
 
-* Create an file `ruby-load-from-bundle-add` in `binaries/`, the content will be installed by `bundle add`. Content example:
-  * `gem 'datadog', git: "https://github.com/Datadog/dd-trace-rb", branch: "master", require: 'datadog/auto_instrument'`
-2. Clone the dd-trace-rb repo inside `binaries`
+You have two ways to run system-tests with a custom Ruby Tracer version:
+
+1. Create `ruby-load-from-bundle-add` in `binaries` directory with the content that should be added to `Gemfile`. Content example:
+  * `gem 'datadog', git: 'https://github.com/Datadog/dd-trace-rb', branch: 'master', require: 'datadog/auto_instrument'`
+2. Clone the dd-trace-rb repo inside `binaries` and checkout the branch that you want to test against.
 
 ## WAF rule set
 


### PR DESCRIPTION
## Motivation

I found the existing documentation confusing. It looks like I need to perform both actions - add `ruby-load-from-bundle-add` and clone the library repo to `binaries` folder.

## Changes

The documentation on how to run tests against non-released Ruby tracer library locally are updated.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
