### PR TITLE
[java] Enable new API Security sampling tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -28,41 +28,102 @@ tests/:
       test_api_security_rc.py:
         Test_API_Security_RC_ASM_DD_processors:
           '*': v1.38.0
+          akka-http: bug (APPSEC-56888)
+          play: bug (APPSEC-56869)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
         Test_API_Security_RC_ASM_DD_scanners:
           '*': v1.38.0
+          akka-http: bug (APPSEC-56888)
+          play: bug (APPSEC-56869)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      test_apisec_sampling.py: missing_feature
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
+      test_apisec_sampling.py:
+        Test_API_Security_Sampling_Different_Endpoints:
+          '*': v1.48.0
+          akka-http: bug (APPSEC-56888)
+          play: bug (APPSEC-56869)
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
+        Test_API_Security_Sampling_Different_Paths:
+          '*': v1.48.0
+          akka-http: bug (APPSEC-56888)
+          play: bug (APPSEC-56869)
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
+        Test_API_Security_Sampling_Different_Status:
+          '*': v1.48.0
+          akka-http: bug (APPSEC-56888)
+          play: bug (APPSEC-56869)
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
+        Test_API_Security_Sampling_Rate: irrelevant (new sampling algorithm implemented)
+        Test_API_Security_Sampling_With_Delay:
+          '*': v1.48.0
+          akka-http: bug (APPSEC-56888)
+          play: bug (APPSEC-56869)
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
       test_schemas.py:
         Test_Scanners:
           '*': v1.31.0
+          akka-http: bug (APPSEC-56888)
+          play: bug (APPSEC-56869)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
         Test_Schema_Request_Cookies:
           '*': v1.31.0
+          akka-http: bug (APPSEC-56888)
+          play: bug (APPSEC-56869)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
         Test_Schema_Request_FormUrlEncoded_Body:
           '*': v1.31.0
+          akka-http: bug (APPSEC-56888)
+          play: bug (APPSEC-56869)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
         Test_Schema_Request_Headers:
           '*': v1.31.0
+          akka-http: bug (APPSEC-56888)
+          play: bug (APPSEC-56869)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
         Test_Schema_Request_Json_Body:
           '*': v1.36.0
-          akka-http: missing_feature
+          akka-http: bug (APPSEC-56888)
           jersey-grizzly2: missing_feature
-          play: missing_feature
+          play: bug (APPSEC-56869)
           resteasy-netty3: missing_feature
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          vertx4: v1.47.0
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
         Test_Schema_Request_Path_Parameters:
           '*': v1.36.0
-          akka-http: missing_feature (path parameters not suported)
+          akka-http: missing_feature (path parameters not suported & APPSEC-56888)
           jersey-grizzly2: bug (APPSEC-56846)
+          play: bug (APPSEC-56869)
           resteasy-netty3: bug (APPSEC-56846)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
         Test_Schema_Request_Query_Parameters:
           '*': v1.31.0
+          akka-http: bug (APPSEC-56888)
+          play: bug (APPSEC-56869)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: bug (APPSEC-56870)
+          vertx4: bug (APPSEC-56871)
         Test_Schema_Response_Body: missing_feature
         Test_Schema_Response_Body_env_var: missing_feature
         Test_Schema_Response_Headers: missing_feature

--- a/utils/telemetry/intake/static/config_norm_rules.json
+++ b/utils/telemetry/intake/static/config_norm_rules.json
@@ -323,6 +323,7 @@
     "agent_transport": "agent_transport",
     "agent_url": "trace_agent_url",
     "analytics_enabled": "analytics_enabled",
+    "api-security_sample_delay": "api_security_sample_delay",
     "apm.tracing.enabled": "apm_tracing_enabled",
     "apmTracingEnabled": "apm_tracing_enabled",
     "appsec.apiSecurity.enabled": "api_security_enabled",


### PR DESCRIPTION
## Motivation

Tests will pass after merging this one: https://github.com/DataDog/dd-trace-java/pull/8178
(needs to be done in lock-step).

[APPSEC-54874](https://datadoghq.atlassian.net/browse/APPSEC-54874)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-54874]: https://datadoghq.atlassian.net/browse/APPSEC-54874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ