### PR TITLE
[python] Use local folder for "dev"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
     uses: ./.github/workflows/compute-impacted-libraries.yml
 
   get_dev_artifacts:
+    # WARNING : never include something secret inside this job, as
+    # the result of it will be stored in a public artifact
+    # For instance, do not use GH_TOKEN here
     needs:
     - impacted_libraries
     strategy:
@@ -78,18 +81,12 @@ jobs:
       - name: Get agent artifact
         run: ./utils/scripts/load-binary.sh agent
 
-      # ### appsec-event-rules is now a private repo. The GH_TOKEN provided can't read private repos.
-      # ### skipping this, waiting for a proper solution
-      # - name: Load WAF rules
-      #   if: matrix.version == 'dev'
-      #   run: ./utils/scripts/load-binary.sh waf_rule_set
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: binaries_dev_${{ matrix.library }}
           path: binaries/
+          include-hidden-files: ${{ matrix.library == 'python' }}
 
   fail-if-target-branch:
     name: Fail if target branch is specified

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -188,6 +188,12 @@ elif [ "$TARGET" = "python" ]; then
     TARGET_BRANCH="${TARGET_BRANCH:-main}"
     rm -rf dd-trace-py/
     git clone --depth 1 --branch $TARGET_BRANCH https://github.com/DataDog/dd-trace-py.git
+    # NB this is necessary to keep the checkout out of detached HEAD state, which setuptools_scm requires for
+    # proper version guessing
+    cd dd-trace-py
+    git checkout --detach
+    echo "Checking out the ref"
+    git log -1 --format=%H
 
 elif [ "$TARGET" = "ruby" ]; then
     assert_version_is_dev

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -186,8 +186,8 @@ elif [ "$TARGET" = "python" ]; then
     assert_version_is_dev
 
     TARGET_BRANCH="${TARGET_BRANCH:-main}"
-    echo "git+https://github.com/DataDog/dd-trace-py.git@$TARGET_BRANCH" > python-load-from-pip
-    echo "Using $(cat python-load-from-pip)"
+    rm -rf dd-trace-py/
+    git clone --depth 1 --branch $TARGET_BRANCH https://github.com/DataDog/dd-trace-py.git
 
 elif [ "$TARGET" = "ruby" ]; then
     assert_version_is_dev


### PR DESCRIPTION
## Motivation

* use the same build method as dd-trace-py CI (the `pip install git+https` method can produce different ddtrace version) 
* open the way to have a build that will be the same as what customer would use (building wheel from sources)

## Changes

"dev" use local folder, rather than `pip install git+https`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
