### PR TITLE
[JAVA]Enable XPASSED test_extended_location_data for some vulnerabilities

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -334,16 +334,7 @@ tests/:
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
             vertx3: missing_feature
             vertx4: missing_feature
-          Test_TrustBoundaryViolation_ExtendedLocation:
-            '*': v1.22.0
-            akka-http: missing_feature
-            jersey-grizzly2: missing_feature
-            play: missing_feature
-            ratpack: missing_feature
-            resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-            vertx3: missing_feature
-            vertx4: missing_feature
+          Test_TrustBoundaryViolation_ExtendedLocation: missing_feature
           Test_TrustBoundaryViolation_StackTrace:
             '*': v1.47.0
             akka-http: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -162,7 +162,17 @@ tests/:
             spring-boot-openliberty: bug (APPSEC-51483)
             vertx3: missing_feature
             vertx4: missing_feature
-          Test_HstsMissingHeader_ExtendedLocation: missing_feature
+          Test_HstsMissingHeader_ExtendedLocation:
+            '*': v1.20.0
+            akka-http: missing_feature
+            jersey-grizzly2: missing_feature
+            play: missing_feature
+            ratpack: missing_feature
+            resteasy-netty3: missing_feature
+            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-openliberty: bug (APPSEC-51483)
+            vertx3: missing_feature
+            vertx4: missing_feature
           Test_HstsMissingHeader_StackTrace: irrelevant (not expected to have a stack trace)
         test_insecure_auth_protocol.py:
           Test_InsecureAuthProtocol:
@@ -324,7 +334,16 @@ tests/:
             spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
             vertx3: missing_feature
             vertx4: missing_feature
-          Test_TrustBoundaryViolation_ExtendedLocation: missing_feature
+          Test_TrustBoundaryViolation_ExtendedLocation:
+            '*': v1.22.0
+            akka-http: missing_feature
+            jersey-grizzly2: missing_feature
+            play: missing_feature
+            ratpack: missing_feature
+            resteasy-netty3: missing_feature
+            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            vertx3: missing_feature
+            vertx4: missing_feature
           Test_TrustBoundaryViolation_StackTrace:
             '*': v1.47.0
             akka-http: missing_feature
@@ -455,7 +474,17 @@ tests/:
             spring-boot-openliberty: bug (APPSEC-54981)
             vertx3: missing_feature
             vertx4: missing_feature
-          Test_XContentSniffing_ExtendedLocation: missing_feature
+          Test_XContentSniffing_ExtendedLocation:
+            '*': v1.22.0
+            akka-http: missing_feature
+            jersey-grizzly2: missing_feature
+            play: missing_feature
+            ratpack: missing_feature
+            resteasy-netty3: missing_feature
+            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-openliberty: bug (APPSEC-54981)
+            vertx3: missing_feature
+            vertx4: missing_feature
           Test_XContentSniffing_StackTrace: irrelevant (not expected to have a stack trace)
         test_xpath_injection.py:
           TestXPathInjection:

--- a/tests/appsec/iast/sink/test_trust_boundary_violation.py
+++ b/tests/appsec/iast/sink/test_trust_boundary_violation.py
@@ -59,4 +59,4 @@ class Test_TrustBoundaryViolation_ExtendedLocation:
         )
 
     def test_extended_location_data(self):
-        validate_extended_location_data(self.r, self.vulnerability_type, is_expected_location_required=False)
+        validate_extended_location_data(self.r, self.vulnerability_type, is_expected_location_required=True)


### PR DESCRIPTION
## Motivation

The test_extended_location_data tests are reporting XPASS for vulnerabilities where is_expected_location_required=False.

It needs to be enabled for the same versions as the original vulnerability test, since for these vulnerabilities, location is not relevant, and the test only verifies the presence of that vulnerability type.

[APPSEC-54879]

## Changes

- Enable Test_XContentSniffing_ExtendedLocation, Test_HstsMissingHeader_ExtendedLocation 

- TrustBoundaryViolation produce a vulnerability with location so Test_TrustBoundaryViolation_ExtendedLocation is_expected_location_required should be True

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-54879]: https://datadoghq.atlassian.net/browse/APPSEC-54879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ