### PR TITLE
[java] API Security sampling endpoints

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -90,6 +90,8 @@ Hello world!\n
 
 This endpoint is used for API security sampling and must accept a parameter `i` as an integer.
 
+The response status code must be `i`.
+
 The response body may contain the following text:
 
 ```

--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
@@ -83,6 +83,26 @@ object AppSecRoutes {
             }
           }
       } ~
+      path("api_security/sampling" / """\d{3}""".r) { (i) =>
+        get {
+          complete(
+            HttpResponse(
+              status = StatusCodes.custom(i.toInt, "some reason"),
+              entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "Hello!\n")
+            )
+          )
+        }
+      } ~
+      path("api_security_sampling" / """\d{2,3}""".r) { (i) =>
+        get {
+          complete(
+            HttpResponse(
+              status = StatusCodes.OK,
+              entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "OK!\n")
+            )
+          )
+        }
+      } ~
       path("params" / Segments) { segments: Seq[String] =>
         get {
           complete(segments.toString())

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
@@ -112,6 +112,22 @@ public class MyResource {
     }
 
     @GET
+    @Path("/api_security/sampling/{i}")
+    public Response apiSecuritySamplingWithStatus(@PathParam("i") int i) {
+        return Response.status(i)
+                .header("content-type", "text/plain")
+                .entity("Hello!\n").build();
+    }
+
+    @GET
+    @Path("/api_security_sampling/{i}")
+    public Response apiSecuritySampling(@PathParam("i") int i) {
+        return Response.status(200)
+                .header("content-type", "text/plain")
+                .entity("Hello!\n").build();
+    }
+
+    @GET
     @Path("/params/{params: .*}")
     public String params(@PathParam("params") List<PathSegment> params) {
         return params.toString();

--- a/utils/build/docker/java/play/app/controllers/AppSecController.scala
+++ b/utils/build/docker/java/play/app/controllers/AppSecController.scala
@@ -94,6 +94,16 @@ class AppSecController @Inject()(cc: MessagesControllerComponents, ws: WSClient,
       .as("text/plain; charset=utf-8")
   }
 
+  def apiSecuritySamplingWithStatus(code: Int) = Action { request =>
+    Results.Status(code)("Hello!\n")
+      .as("text/plain; charset=utf-8")
+  }
+
+  def apiSecuritySampling(code: Int) = Action { request =>
+    Results.Status(200)("OK!\n")
+      .as("text/plain; charset=utf-8")
+  }
+
   def params(segments: Seq[String]) = Action {
     Results.Ok(segments.toString())
   }

--- a/utils/build/docker/java/play/conf/routes
+++ b/utils/build/docker/java/play/conf/routes
@@ -3,6 +3,8 @@ GET  /healthcheck              controllers.AppSecController.healthcheck
 GET  /headers                  controllers.AppSecController.headers
 GET  /tag_value/:tag_value/:status_code   controllers.AppSecController.tagValue(tag_value: String, status_code: Int)
 POST /tag_value/:tag_value/:status_code   controllers.AppSecController.tagValuePost(tag_value: String, status_code: Int)
+GET  /api_security/sampling/:i controllers.AppSecController.apiSecuritySamplingWithStatus(i: Int)
+GET  /api_security_sampling/:i controllers.AppSecController.apiSecuritySampling(i: Int)
 GET  /params/*segments         controllers.AppSecController.params(segments: Seq[String])
 GET  /waf                      controllers.AppSecController.waf
 GET  /waf/                      controllers.AppSecController.waf

--- a/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
+++ b/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
@@ -177,6 +177,14 @@ public class Main {
                                     ctx.getResponse().status(code).send("Value tagged");
                                 });
                             })
+                            .get("api_security/sampling/:i", ctx -> {
+                                final int i = Integer.parseInt(ctx.getPathTokens().get("i"));
+                                ctx.getResponse().status(i).send("Hello!\n");
+                            })
+                            .get("api_security_sampling/:i", ctx -> {
+                                final int i = Integer.parseInt(ctx.getPathTokens().get("i"));
+                                ctx.getResponse().status(200).send("OK!\n");
+                            })
                             .path("waf/:params?", ctx -> {
                                 HttpMethod method = ctx.getRequest().getMethod();
                                 if (method.equals(HttpMethod.GET)) {

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
@@ -112,6 +112,22 @@ public class MyResource {
     }
 
     @GET
+    @Path("/api_security/sampling/{i}")
+    public Response apiSecuritySamplingWithStatus(@PathParam("i") int i) {
+        return Response.status(i)
+                .header("content-type", "text/plain")
+                .entity("Hello!\n").build();
+    }
+
+    @GET
+    @Path("/api_security_sampling/{i}")
+    public Response apiSecuritySampling(@PathParam("i") int i) {
+        return Response.status(200)
+                .header("content-type", "text/plain")
+                .entity("Hello!\n").build();
+    }
+
+    @GET
     @Path("/params/{params: .*}")
     public String params(@PathParam("params") List<PathSegment> params) {
         return params.toString();

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -192,6 +192,16 @@ public class App {
         return tagValue(tag_value, status_code);
     }
 
+    @GetMapping("/api_security/sampling/{i}")
+    ResponseEntity<String> apiSecuritySamplingWithStatus(@PathVariable final int i) {
+        return ResponseEntity.status(i).body("Hello!\n");
+    }
+
+    @GetMapping("/api_security_sampling/{i}")
+    ResponseEntity<String> apiSecuritySampling(@PathVariable final int i) {
+        return ResponseEntity.status(200).body("OK!\n");
+    }
+
     @RequestMapping("/waf/**")
     String waf() {
         return "Hello World!";

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
@@ -97,6 +97,21 @@ public class Main {
                             .setStatusCode(Integer.parseInt(ctx.pathParam("status_code")))
                             .end("Value tagged");
                 });
+        router.get("/api_security/sampling/:i")
+                .produces("text/plain")
+                .handler(ctx -> {
+                    ctx.response()
+                            .setStatusCode(Integer.parseInt(ctx.pathParam("i")))
+                            .end("Hello!\n");
+                });
+        router.get("/api_security_sampling/:i")
+                .produces("text/plain")
+                .handler(ctx -> {
+                    final int i = Integer.parseInt(ctx.pathParam("i"));
+                    ctx.response()
+                            .setStatusCode(200)
+                            .end("Hello!\n");
+                });
         router.getWithRegex("/params(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?")
                 .produces("text/plain")
                 .handler(ctx ->

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
@@ -94,6 +94,21 @@ public class Main {
                             .setStatusCode(Integer.parseInt(ctx.pathParam("status_code")))
                             .end("Value tagged");
                 });
+        router.get("/api_security/sampling/:i")
+                .produces("text/plain")
+                .handler(ctx -> {
+                    ctx.response()
+                            .setStatusCode(Integer.parseInt(ctx.pathParam("i")))
+                            .end("Hello!\n");
+                });
+        router.get("/api_security_sampling/:i")
+                .produces("text/plain")
+                .handler(ctx -> {
+                    final int i = Integer.parseInt(ctx.pathParam("i"));
+                    ctx.response()
+                            .setStatusCode(200)
+                            .end("Hello!\n");
+                });
         router.getWithRegex("/params(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?(?:/([^/]*))?")
                 .produces("text/plain")
                 .handler(ctx ->


### PR DESCRIPTION
## Motivation

Addding missing weblog endpoints for API Security sampling endpoints.

I'll enable tests as needed in separate PR at https://github.com/DataDog/system-tests/pull/4195. For now, I want to get the endpoints merged, to avoid the other PRs for the manifest automatically triggering all scenarios in CI on every push.

[APPSEC-54874](https://datadoghq.atlassian.net/browse/APPSEC-54874)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-54874]: https://datadoghq.atlassian.net/browse/APPSEC-54874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ