### PR TITLE
[java] Fix tag_value endpoint in for JSON body

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -48,10 +48,13 @@ tests/:
           '*': v1.31.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
         Test_Schema_Request_Json_Body:
-          '*': missing_feature
-          ratpack: v1.36.0
+          '*': v1.36.0
+          akka-http: missing_feature
+          jersey-grizzly2: missing_feature
+          play: missing_feature
+          resteasy-netty3: missing_feature
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          vertx3: v1.36.0
+          vertx4: 1.47.0
         Test_Schema_Request_Path_Parameters:
           '*': v1.36.0
           akka-http: missing_feature (path parameters not suported)

--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
@@ -7,17 +7,19 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.unmarshalling._
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
-import scala.collection.JavaConverters._
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.api.interceptor.MutableSpan
 import io.opentracing.util.GlobalTracer
-import scala.concurrent.duration._
-import com.datadoghq.system_tests.iast.utils.Utils;
-import com.datadoghq.system_tests.iast.utils.CryptoExamples;
+import com.datadoghq.system_tests.iast.utils.Utils
+import com.datadoghq.system_tests.iast.utils.CryptoExamples
+
 import scala.concurrent.blocking
+import akka.http.javadsl.marshallers.jackson.Jackson
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
+import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
 
 import java.util
 import scala.concurrent.Future
@@ -26,6 +28,12 @@ import scala.xml.{Elem, XML}
 object AppSecRoutes {
 
   private val cryptoExamples = new CryptoExamples()
+
+  val objectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+  implicit val jsonNodeUnmarshaller: FromEntityUnmarshaller[JsonNode] =
+    Jackson.unmarshaller(objectMapper, classOf[JsonNode])
+      .asScala
+      .forContentTypes(MediaTypes.`application/json`)
 
   val route: Route =
     path("") {
@@ -73,6 +81,14 @@ object AppSecRoutes {
         } ~
           post {
             formFieldMap { _ =>
+              setRootSpanTag("appsec.events.system_tests_appsec_event.value", tag_value)
+              complete(
+                HttpResponse(
+                  status = StatusCodes.custom(status_code.toInt, "some reason"),
+                  entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "Value tagged")
+                )
+              )
+            } ~ (entity(as[JsonNode])) { _ =>
               setRootSpanTag("appsec.events.system_tests_appsec_event.value", tag_value)
               complete(
                 HttpResponse(

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
@@ -107,7 +107,14 @@ public class MyResource {
     @POST
     @Path("/tag_value/{tag_value}/{status_code}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public Response tagValuePost(@PathParam("tag_value") String value, @PathParam("status_code") int code, MultivaluedMap<String, String> form) {
+    public Response tagValuePostForm(@PathParam("tag_value") String value, @PathParam("status_code") int code, MultivaluedMap<String, String> form) {
+        return tagValue(value, code);
+    }
+
+    @POST
+    @Path("/tag_value/{tag_value}/{status_code}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response tagValuePostJson(@PathParam("tag_value") String value, @PathParam("status_code") int code, JsonValue body) {
         return tagValue(value, code);
     }
 

--- a/utils/build/docker/java/play/app/controllers/AppSecController.scala
+++ b/utils/build/docker/java/play/app/controllers/AppSecController.scala
@@ -86,7 +86,12 @@ class AppSecController @Inject()(cc: MessagesControllerComponents, ws: WSClient,
   }
 
   def tagValuePost(value: String, code: Int) = Action { request =>
-    request.body.asFormUrlEncoded // needs to be read, though we do nothing with it
+    // needs to be read, though we do nothing with it
+    request.body match {
+      case AnyContentAsFormUrlEncoded(data) =>
+      case AnyContentAsJson(data) =>
+      case anything =>
+    }
 
     setRootSpanTag("appsec.events.system_tests_appsec_event.value", value)
 

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
@@ -2,6 +2,7 @@ package com.datadoghq.resteasy;
 
 import com.datadoghq.system_tests.iast.utils.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
@@ -107,7 +108,14 @@ public class MyResource {
     @POST
     @Path("/tag_value/{tag_value}/{status_code}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public Response tagValuePost(@PathParam("tag_value") String value, @PathParam("status_code") int code, MultivaluedMap<String, String> form) {
+    public Response tagValuePostForm(@PathParam("tag_value") String value, @PathParam("status_code") int code, MultivaluedMap<String, String> form) {
+        return tagValue(value, code);
+    }
+
+    @POST
+    @Path("/tag_value/{tag_value}/{status_code}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response tagValuePostJson(@PathParam("tag_value") String value, @PathParam("status_code") int code, JsonNode body) {
         return tagValue(value, code);
     }
 

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -186,9 +186,13 @@ public class App {
         return ResponseEntity.status(status_code).body("Value tagged");
     }
 
-    @PostMapping(value = "/tag_value/{tag_value}/{status_code}", headers = "accept=*",
-            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    @PostMapping(value = "/tag_value/{tag_value}/{status_code}", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     ResponseEntity<String> tagValueWithUrlencodedBody(@PathVariable final String tag_value, @PathVariable final int status_code, @RequestParam MultiValueMap<String, String> body) {
+        return tagValue(tag_value, status_code);
+    }
+
+    @PostMapping(value = "/tag_value/{tag_value}/{status_code}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<String> tagValueWithJsonBody(@PathVariable final String tag_value, @PathVariable final int status_code, @RequestBody Object body) {
         return tagValue(tag_value, status_code);
     }
 


### PR DESCRIPTION
## Motivation

The `tag_value` endpoint must accept urlencoded forms and JSON. In spring-boot and akka-http it did not support JSON, which broke the corresponding API Security tests.

akka-http still does not pass the test, but spring-boot does.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
