### PR TITLE
[java] Fix /shell_execution endpoint in Spring Boot when args is an array

### DIFF
--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -14,6 +14,7 @@ import com.datadoghq.system_tests.springboot.rabbitmq.RabbitmqConnectorForFanout
 import com.datadoghq.system_tests.springboot.rabbitmq.RabbitmqConnectorForTopicExchange;
 import com.datadoghq.system_tests.iast.utils.Utils;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
@@ -1033,30 +1034,32 @@ public class App {
     }
 
     @PostMapping(value = "/shell_execution", consumes = MediaType.APPLICATION_JSON_VALUE)
-    ResponseEntity<String> shellExecution(@RequestBody final ShellExecutionRequest request) throws IOException, InterruptedException {
-        Process p;
-        if (request.options.shell) {
-            throw new RuntimeException("Not implemented");
-        } else {
-            final String[] args = request.args.split("\\s+");
-            final String[] command = new String[args.length + 1];
-            command[0] = request.command;
-            System.arraycopy(args, 0, command, 1, args.length);
-            p = new ProcessBuilder(command).start();
+    ResponseEntity<String> shellExecution(@RequestBody final JsonNode request) throws IOException, InterruptedException {
+        // args can be a string or array. Just do some custom mapping here to avoid object mapping mambo.
+        if (request.get("options") != null && request.get("options").get("shell") != null && request.get("options").get("shell").asBoolean()) {
+            throw new RuntimeException("Actual shell execution is not supported");
         }
+        final String commandArg = request.get("command").asText();
+        final String[] args;
+        if (request.get("args").isTextual()) {
+            args = request.get("args").asText().split("\\s+");
+        } else if (request.get("args").isArray()) {
+            final JsonNode argsNode = request.get("args");
+            args = new String[argsNode.size()];
+            for (int i = 0; i < argsNode.size(); i++) {
+                args[i] = argsNode.get(i).asText();
+            }
+        } else {
+            throw new RuntimeException("Invalid args type");
+        }
+
+        final String[] command = new String[args.length + 1];
+        command[0] = commandArg;
+        System.arraycopy(args, 0, command, 1, args.length);
+        final Process p = new ProcessBuilder(command).start();
         p.waitFor(10, TimeUnit.SECONDS);
         final int exitCode = p.exitValue();
         return new ResponseEntity<>("OK: " + exitCode, HttpStatus.OK);
-    }
-
-    private static class ShellExecutionRequest {
-        public String command;
-        public String args;
-        public Options options;
-
-        static class Options {
-            public boolean shell;
-        }
     }
 
     @EventListener(ApplicationReadyEvent.class)


### PR DESCRIPTION
## Motivation

This endpoint for `/shell_execution` in Spring Boot is sometimes throwing exceptions because `args` can be a String or an array, and we supported only String. No test failing because these are skipped for other reasons. Fixed the endpoint, so we should have a proper XPASS when the time comes.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
