### PR TITLE
[JAVA] Fix xpass for spring-boot-3-native in Test_ConfRuleSet

### DIFF
--- a/tests/appsec/test_customconf.py
+++ b/tests/appsec/test_customconf.py
@@ -57,6 +57,9 @@ class Test_ConfRuleSet:
         interfaces.library.assert_waf_attack(self.r_2, pattern="dedicated-value-for-testing-purpose")
 
     def test_log(self):
+        """Check if it's implemented for the weblog variant"""
+        if context.library == "java":
+            stdout.assert_presence("AppSec is FULLY_ENABLED with powerwaf")
         """Check there is no error reported in logs"""
         stdout.assert_absence("AppSec could not read the rule file")
         stdout.assert_absence("failed to parse rule")


### PR DESCRIPTION
## Motivation

`tests/appsec/test_customconf.py::Test_ConfRuleSet::test_log` is XPASSED for spring-boot-3-native but GraalVM has tracing support only

## Changes

Check that APPSEC is enabled before other checks

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
