### PR TITLE
[python] signup events on django

### DIFF
--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -1505,7 +1505,15 @@ class Test_V3_Login_Events:
         self.r_success = weblog.post("/signup", data=login_data(context, NEW_USER, PASSWORD))
 
     @missing_feature(context.library == "nodejs", reason="Signup events not implemented")
-    @missing_feature(context.library == "python", reason="Signup events not implemented")
+    @irrelevant(
+        context.library == "python" and context.weblog_variant not in ["django-poc", "python3.12", "django-py3.13"],
+        reason="No signup in framework",
+    )
+    @missing_feature(
+        context.library < "python@3.2.0.dev"
+        and context.weblog_variant in ["django-poc", "python3.12", "django-py3.13"],
+        reason="Signup events not implemented yet",
+    )
     def test_signup_local(self):
         assert self.r_success.status_code == 200
         for _, trace, span in interfaces.library.get_spans(request=self.r_success):
@@ -1818,7 +1826,15 @@ class Test_V3_Login_Events_Anon:
         self.r_success = weblog.post("/signup", data=login_data(context, NEW_USER, PASSWORD))
 
     @missing_feature(context.library == "nodejs", reason="Signup events not implemented")
-    @missing_feature(context.library == "python", reason="Signup events not implemented")
+    @irrelevant(
+        context.library == "python" and context.weblog_variant not in ["django-poc", "python3.12", "django-py3.13"],
+        reason="No signup in framework",
+    )
+    @missing_feature(
+        context.library < "python@3.2.0.dev"
+        and context.weblog_variant in ["django-poc", "python3.12", "django-py3.13"],
+        reason="Signup events not implemented yet",
+    )
     def test_signup_local(self):
         assert self.r_success.status_code == 200
         for _, trace, span in interfaces.library.get_spans(request=self.r_success):

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -786,6 +786,21 @@ def login(request):
     return HttpResponse("login failure", status=401)
 
 
+@csrf_exempt
+def signup_user(request):
+    from app.models import CustomUser
+
+    try:
+        username = request.POST.get("username")
+        password = request.POST.get("password")
+        email = request.POST.get("email")
+        user = CustomUser.objects.create_user(username=username, email=email, password=password, id="new-user")
+        user.save()
+        return HttpResponse("OK")
+    except Exception as e:
+        return HttpResponse(f"signup failure {e!r}", status=400)
+
+
 MAGIC_SESSION_KEY = "random_session_id"
 
 
@@ -1019,6 +1034,7 @@ urlpatterns = [
     path("login", login),
     path("session/new", session_new),
     path("session/user", session_user),
+    path("signup", signup_user),
     path("custom_event", track_custom_event),
     path("read_file", read_file),
     path("mock_s3/put_object", s3_put_object),


### PR DESCRIPTION
Enable signup tests for auto instrumentation on Django

Add corresponding endpoint for django weblogs.

APPSEC-56662

To be merged after https://github.com/DataDog/dd-trace-py/pull/12547

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
