### PR TITLE
Remove testing of RC request_sample_rate for API Security

### DIFF
--- a/tests/appsec/api_security/utils.py
+++ b/tests/appsec/api_security/utils.py
@@ -121,7 +121,7 @@ class BaseAppsecApiSecurityRcTest:
             )
             rc_state.set_config(
                 "datadog/2/ASM_FEATURES/ASM_FEATURES-base/config",
-                {"asm": {"enabled": True}, "api_security": {"request_sample_rate": 1.0}},
+                {"asm": {"enabled": True}},
             )
 
             BaseAppsecApiSecurityRcTest.states = rc_state.apply()

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -272,7 +272,12 @@ class _Scenarios:
 
     appsec_api_security_rc = EndToEndScenario(
         "APPSEC_API_SECURITY_RC",
-        weblog_env={"DD_EXPERIMENTAL_API_SECURITY_ENABLED": "true", "DD_API_SECURITY_SAMPLE_DELAY": "0.0"},
+        weblog_env={
+            "DD_EXPERIMENTAL_API_SECURITY_ENABLED": "true",
+            "DD_API_SECURITY_ENABLED": "true",
+            "DD_API_SECURITY_REQUEST_SAMPLE_RATE": "1.0",
+            "DD_API_SECURITY_SAMPLE_DELAY": "0.0",
+        },
         rc_api_enabled=True,
         doc="""
             Scenario to test API Security Remote config


### PR DESCRIPTION
## Motivation
Remove testing sampling rate via RC. This mechanism was never in production. Making it compatible with both old and new API Security algorithms, but without RC.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
