### PR TITLE
Improve performance of log checks

### DIFF
--- a/tests/test_scrubbing.py
+++ b/tests/test_scrubbing.py
@@ -119,6 +119,6 @@ class Test_EnvVar:
         interfaces.agent.validate(validate_no_leak("leaked-env-var"), success_by_default=True)
 
     def test_logs(self):
-        interfaces.library_stdout.assert_absence(".*leaked-env-var.*")
-        interfaces.library_dotnet_managed.assert_absence(".*leaked-env-var.*")
-        interfaces.agent_stdout.assert_absence(".*leaked-env-var.*")
+        interfaces.library_stdout.assert_absence("leaked-env-var")
+        interfaces.library_dotnet_managed.assert_absence("leaked-env-var")
+        interfaces.agent_stdout.assert_absence("leaked-env-var")


### PR DESCRIPTION
## Motivation

Do not use `.*` for `assert_absence`. The log assertions use `re.search` which already looks for a substring rather than a full match, so they are both functional equivalent. However, on a run with debug logs and ~60MB worth of logs, using `.*` will lead to a lot of backtracking and this test can take even minutes just for these 3 assertions.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
