### PR TITLE
Update OTEL_TRACING_E2E with new span operation names

### DIFF
--- a/utils/otel_validators/validator_trace.py
+++ b/utils/otel_validators/validator_trace.py
@@ -60,14 +60,14 @@ def validate_trace_id(span: dict, *, use_128_bits_trace_id: bool) -> None:
 
 
 def validate_server_span(span: dict) -> None:
-    expected_tags = {"name": "WebController.basic", "resource": "GET /"}
+    expected_tags = {"name": "http.server.request", "resource": "GET /"}
     expected_meta = {"http.route": "/", "http.method": "GET"}
     assert expected_tags.items() <= span.items()
     assert expected_meta.items() <= span["meta"].items()
 
 
 def validate_message_span(span: dict) -> None:
-    expected_tags = {"name": "WebController.basic.publish", "resource": "publish"}
+    expected_tags = {"name": "rabbitmq.publish", "resource": "publish"}
     expected_meta = {"messaging.operation": "publish", "messaging.system": "rabbitmq"}
     assert expected_tags.items() <= span.items()
     assert expected_meta.items() <= span["meta"].items()


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/logs-backend/pull/93274 Added logic that updates the logic for translating DD operation name from OTLP spans. Update existing tests to expect new names.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
