### PR TITLE
[java] Fix flaky test on openliberty log check

### DIFF
--- a/tests/test_library_logs.py
+++ b/tests/test_library_logs.py
@@ -59,6 +59,10 @@ class Test_NoExceptions:
             allowed_patterns += [
                 r".*class java.util.LinkedHashMap.*",
                 r".*UnknownHostException: cassandra.*",
+                # XXX: This background warning occasionally gets printed in the
+                # middle of an unrelated error, breaing multi-line log parsing,
+                # and producing spurious failures.
+                ".*Using native clock.*",
                 # AIDM-588:
                 r".*Critical issue initializing instances: javax.management.JMRuntimeException.*",
                 r".*org.datadog.jmxfetch.App.*",


### PR DESCRIPTION
## Motivation

We've been getting this flaky test:
```
E       AssertionError: assert not ['2025-03-05 07:44:22.641  INFO 41 --- [     s5-admin-0] c.d.oss.driver.internal.core.time.Clock  : Using native clock...                                   com.ibm.ws.webcontainer.webapp.WebAppErrorReport: SRVE0295E: Error reported: 500\n']
```

This happens when this log line gets printed in the middle of an unrelated multi-line error, producing false positives in matches.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
