### PR TITLE
[Java] Graal native image update - debug flags

### DIFF
--- a/utils/build/docker/java/spring-boot-3-native/pom.xml
+++ b/utils/build/docker/java/spring-boot-3-native/pom.xml
@@ -97,9 +97,11 @@
                 <version>0.10.3</version>
                 <configuration>
                     <quickBuild>true</quickBuild>
+                    <debug>true</debug>
                     <buildArgs>
-                        <arg>-g</arg>
-                        <arg>-H:-DeleteLocalSymbols</arg>
+                        <buildArg>-H:+SourceLevelDebug</buildArg>
+                        <buildArg>-H:-DeleteLocalSymbols</buildArg>
+                        <buildArg>-H:+PreserveFramePointer</buildArg>
                     </buildArgs>
                 </configuration>
             </plugin>

--- a/utils/build/docker/java/spring-boot-3-native/pom.xml
+++ b/utils/build/docker/java/spring-boot-3-native/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -28,7 +28,7 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-         <dependency>
+        <dependency>
             <groupId>com.datadoghq</groupId>
             <artifactId>dd-trace-api</artifactId>
             <version>LATEST</version>
@@ -43,7 +43,7 @@
             <artifactId>opentracing-util</artifactId>
             <version>LATEST</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
@@ -82,10 +82,9 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.14</version> 
+            <version>1.4.14</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -97,7 +96,11 @@
                 <artifactId>native-maven-plugin</artifactId>
                 <version>0.10.3</version>
                 <configuration>
-                     <quickBuild>true</quickBuild>
+                    <quickBuild>true</quickBuild>
+                    <buildArgs>
+                        <arg>-g</arg>
+                        <arg>-H:-DeleteLocalSymbols</arg>
+                    </buildArgs>
                 </configuration>
             </plugin>
         </plugins>
@@ -112,13 +115,13 @@
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
                         <configuration>
-                          <buildArgs combine.children="append">
-                            <buildArg>--enable-monitoring=jfr</buildArg>
-                            <buildArg>-J-Ddd.profiling.enabled=true</buildArg>
-                            <buildArg>-J-javaagent:${agent.path}</buildArg>
-                          </buildArgs>
+                            <buildArgs combine.children="append">
+                                <buildArg>--enable-monitoring=jfr</buildArg>
+                                <buildArg>-J-Ddd.profiling.enabled=true</buildArg>
+                                <buildArg>-J-javaagent:${agent.path}</buildArg>
+                            </buildArgs>
                         </configuration>
-                      </plugin>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -131,11 +134,11 @@
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
                         <configuration>
-                          <buildArgs combine.children="append">
-                            <buildArg>-J-javaagent:${agent.path}</buildArg>
-                          </buildArgs>
+                            <buildArgs combine.children="append">
+                                <buildArg>-J-javaagent:${agent.path}</buildArg>
+                            </buildArgs>
                         </configuration>
-                      </plugin>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
In relenv, we want to compare the accuracy of native profilers to the in process java profiler.

## Changes

<!-- A brief description of the change being made with this pull request. -->
Add debug flags to ensure we can unwind and symbolicate the application using otel / ddprof profilers.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [X] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [X] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
