### PR TITLE
Update 128 bit logging enabled tests and disable stable config tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1715,7 +1715,7 @@ tests/:
       Test_Config_TraceEnabled: v1.39.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v1.41.1
-      Test_Stable_Config_Default: v1.47.0-SNAPSHOT
+      Test_Stable_Config_Default: missing_feature (waiting on APMAPI-298 to be merged)
     test_crashtracking.py:
       Test_Crashtracking: v1.38.0
     test_dynamic_configuration.py:
@@ -1823,8 +1823,12 @@ tests/:
     Test_Config_IntegrationEnabled_True:
       '*': irrelevant (kafka endpoints are not implemented)
       spring-boot: v1.42.0
-    Test_Config_LogInjection_128Bit_TraceId_Default: missing_feature (disabled by default)
-    Test_Config_LogInjection_128Bit_TraceId_Disabled: incomplete_test_app (weblog endpoint not implemented)
+    Test_Config_LogInjection_128Bit_TraceId_Default: 
+      '*': incomplete_test_app (weblog endpoint not implemented)
+      'spring-boot-3-native': missing_feature
+    Test_Config_LogInjection_128Bit_TraceId_Disabled:
+      '*': incomplete_test_app (weblog endpoint not implemented)
+      'spring-boot-3-native': missing_feature
     Test_Config_LogInjection_Default:
       '*': incomplete_test_app (weblog endpoint not implemented)
       'spring-boot-3-native': missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1823,7 +1823,7 @@ tests/:
     Test_Config_IntegrationEnabled_True:
       '*': irrelevant (kafka endpoints are not implemented)
       spring-boot: v1.42.0
-    Test_Config_LogInjection_128Bit_TraceId_Default: 
+    Test_Config_LogInjection_128Bit_TraceId_Default:
       '*': incomplete_test_app (weblog endpoint not implemented)
       'spring-boot-3-native': missing_feature
     Test_Config_LogInjection_128Bit_TraceId_Disabled:

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -375,7 +375,7 @@ SDK_DEFAULT_STABLE_CONFIG = {
     "dd_runtime_metrics_enabled": "false" if context.library != "java" else "true",
     "dd_profiling_enabled": "false",
     "dd_data_streams_enabled": "false",
-    "dd_logs_injection": "false" if context.library != "java" else "true",
+    "dd_logs_injection": "false",
 }
 
 

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -584,7 +584,7 @@ class Test_Config_LogInjection_128Bit_TraceId_Disabled:
         # dd-trace-java stores injected trace information under the "mdc" key
         if context.library.library == "java":
             log_msg = log_msg.get("mdc")
-            
+
         trace_id = parse_log_trace_id(log_msg)
         assert re.match(r"^\d{1,20}$", str(trace_id)), f"Invalid 64-bit trace_id: {trace_id}"
 

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -558,6 +558,11 @@ class Test_Config_LogInjection_128Bit_TraceId_Default:
     def test_log_injection_128bit_traceid_default(self):
         assert self.r.status_code == 200
         log_msg = parse_log_injection_message(self.message)
+
+        # dd-trace-java stores injected trace information under the "mdc" key
+        if context.library.library == "java":
+            log_msg = log_msg.get("mdc")
+
         trace_id = parse_log_trace_id(log_msg)
         assert re.match(r"^[0-9a-f]{32}$", trace_id), f"Invalid 128-bit trace_id: {trace_id}"
 
@@ -575,6 +580,11 @@ class Test_Config_LogInjection_128Bit_TraceId_Disabled:
     def test_log_injection_128bit_traceid_disabled(self):
         assert self.r.status_code == 200
         log_msg = parse_log_injection_message(self.message)
+
+        # dd-trace-java stores injected trace information under the "mdc" key
+        if context.library.library == "java":
+            log_msg = log_msg.get("mdc")
+            
         trace_id = parse_log_trace_id(log_msg)
         assert re.match(r"^\d{1,20}$", str(trace_id)), f"Invalid 64-bit trace_id: {trace_id}"
 


### PR DESCRIPTION
## Motivation

Update 128bit logging enabled tests to consider the Java edge case. Update and disable stable config Java tests to allow CI to pass on the following dd-trace-java [PR](https://github.com/DataDog/dd-trace-java/pull/8489) that updates the default value of `DD_LOGS_INJECTION`. Stable Config tests will be enabled in a future PR following the merge of the above dd-trace-java PR.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
