### PR TITLE
[golang] disable test_not_match_service_target

### DIFF
--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -506,6 +506,7 @@ class TestDynamicConfigV1_ServiceTargets:
     @bug(library="nodejs", reason="APMAPI-865")
     @irrelevant(library="java", reason="APMAPI-1003")
     @irrelevant(library="cpp", reason="APMAPI-1003")
+    @irrelevant(library="golang", reason="APMAPI-1003")
     def test_not_match_service_target(self, library_env, test_agent, test_library):
         """This is an old behavior, see APMAPI-1003
 


### PR DESCRIPTION
## Motivation

First part of the test switch needed to for [APMAPI-1005](https://datadoghq.atlassian.net/browse/APMAPI-1005)

We need to disable `test_not_match_service_target ` so the CI is green on [dd-trace-go/3261](https://github.com/DataDog/dd-trace-go/pull/3261) and then enable the new test `TestDynamicConfigV1_EmptyServiceTargets` after the merge.

## Changes

- Mark `test_not_match_service_target` as irrelevant 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-1005]: https://datadoghq.atlassian.net/browse/APMAPI-1005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ