### PR TITLE
Enable updated DD_TAGS test cases for .NET tracing library

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -454,7 +454,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_Dogstatsd: missing_feature (does not support hostname)
       Test_Config_RateLimit: v3.4.1
-      Test_Config_Tags: missing_feature
+      Test_Config_Tags: v3.12.0
       Test_Config_TraceAgentURL: v3.4.1
       Test_Config_TraceEnabled: v3.3.0
       Test_Config_TraceLogDirectory: v3.3.0

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -306,7 +306,7 @@ tag_scenarios: dict = {
 @scenarios.parametric
 @features.trace_global_tags
 class Test_Config_Tags:
-    @parametrize("library_env", [{"DD_TAGS": key} for key in tag_scenarios])
+    @parametrize("library_env", [{"DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED": "all", "DD_TAGS": key} for key in tag_scenarios])
     def test_comma_space_tag_separation(self, library_env, test_agent, test_library):
         expected_local_tags = []
         if "DD_TAGS" in library_env:

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -306,7 +306,9 @@ tag_scenarios: dict = {
 @scenarios.parametric
 @features.trace_global_tags
 class Test_Config_Tags:
-    @parametrize("library_env", [{"DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED": "all", "DD_TAGS": key} for key in tag_scenarios])
+    @parametrize(
+        "library_env", [{"DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED": "all", "DD_TAGS": key} for key in tag_scenarios]
+    )
     def test_comma_space_tag_separation(self, library_env, test_agent, test_library):
         expected_local_tags = []
         if "DD_TAGS" in library_env:


### PR DESCRIPTION
## Motivation

As part of our tracing configuration consistency effort, we've established updated requirements for parsing `DD_TAGS` and the latest .NET Tracer now implements those behaviors.

## Changes

Runs the `tests/parametric/test_config_consistency.py::Test_Config_Tags` tests cases for .NET and adds the `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED=all` configuration to allow tracers to pass this when they opt-in to the potential breaking change.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
