### PR TITLE
Update config_norm_rules.json for vertexai config

### DIFF
--- a/tests/telemetry_intake/static/config_norm_rules.json
+++ b/tests/telemetry_intake/static/config_norm_rules.json
@@ -1065,5 +1065,7 @@
     "universal_version": "universal_version_enabled",
     "url": "trace_agent_url",
     "version": "application_version",
+    "vertexai.spanCharLimit": "vertexai_span_char_limit",
+    "vertexai.spanPromptCompletionSampleRate": "vertexai_span_prompt_completion_sample_rate",
     "wcf_obfuscation_enabled": "trace_wcf_obfuscation_enabled"
 }


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
These changes are in sync with changes made to `dd-go` in https://github.com/DataDog/dd-go/pull/173755

Related PR for `dd-trace-js`: https://github.com/DataDog/dd-trace-js/pull/5369

## Changes

<!-- A brief description of the change being made with this pull request. -->

`config_norm_rules.json` for config telemetry test(s)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
