### PR TITLE
[python] telemetry_completeness: add config used by the python tracer

### DIFF
--- a/tests/telemetry_intake/static/config_norm_rules.json
+++ b/tests/telemetry_intake/static/config_norm_rules.json
@@ -79,6 +79,7 @@
     "DD_DOGSTATSD_PORT": "dogstatsd_port",
     "DD_DOGSTATSD_SOCKET": "dogstatsd_socket",
     "DD_DOGSTATSD_URL": "dogstatsd_url",
+    "DD_DOGSTATSD_HOST": "dogstatsd_host",
     "DD_DOTNET_TRACER_CONFIG_FILE": "trace_config_file",
     "DD_DYNAMIC_INSTRUMENTATION_DIAGNOSTICS_INTERVAL": "dynamic_instrumentation_diagnostics_interval",
     "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "dynamic_instrumentation_enabled",


### PR DESCRIPTION
## Motivation

Unblocks the following PR: https://github.com/DataDog/dd-trace-py/pull/12662

## Changes

Fix failing telemetry completeness test by add `DD_DOGSTATSD_HOST` to the telemetry configuration allowlist.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
