### PR TITLE
Config Consistency: Enable XPassing tests

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -611,7 +611,7 @@ tests/:
       Test_Config_TraceAgentURL: v1.70.0
       Test_Config_TraceEnabled: v1.67.0
       Test_Config_TraceLogDirectory: v1.70.0
-      Test_Config_UnifiedServiceTagging: bug (APMAPI-746)
+      Test_Config_UnifiedServiceTagging: v1.72.0
       Test_Stable_Config_Default: missing_feature
     test_crashtracking.py: missing_feature
     test_dynamic_configuration.py:
@@ -681,14 +681,9 @@ tests/:
     Test_Config_ClientTagQueryString_Configured: v1.72.0-dev
     Test_Config_ClientTagQueryString_Empty: v1.72.0-dev
     Test_Config_HttpClientErrorStatuses_Default: v1.69.0
-    Test_Config_HttpClientErrorStatuses_FeatureFlagCustom:
-      '*': v1.69.0
-      net-http-orchestrion: v1.72.0-dev
+    Test_Config_HttpClientErrorStatuses_FeatureFlagCustom: v1.72.0-dev
     Test_Config_HttpServerErrorStatuses_Default: v1.67.0
-    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom:
-      "*": v1.69.0
-      echo: missing_feature
-      uds-echo: missing_feature
+    Test_Config_HttpServerErrorStatuses_FeatureFlagCustom: v1.69.0
     Test_Config_IntegrationEnabled_False: irrelevant (not applicable to Go because of how they do auto instrumentation)
     Test_Config_IntegrationEnabled_True: irrelevant (not applicable to Go because of how they do auto instrumentation)
     Test_Config_LogInjection_128Bit_TraceId_Default: missing_feature (disabled by default)
@@ -724,7 +719,7 @@ tests/:
     Test_HeaderTags: v1.53.0
     Test_HeaderTags_Colon_Leading: v1.53.0
     Test_HeaderTags_Colon_Trailing: v1.70.0
-    Test_HeaderTags_DynamicConfig: missing_feature
+    Test_HeaderTags_DynamicConfig: v1.70.0
     Test_HeaderTags_Long: v1.53.0
     Test_HeaderTags_Short: v1.53.0
     Test_HeaderTags_Whitespace_Header: v1.53.0

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -282,7 +282,6 @@ class Test_Config_ClientTagQueryString_Configured:
     def setup_query_string_redaction(self):
         self.r = weblog.get("/make_distant_call", params={"url": "http://weblog:7777/?hi=monkey"})
 
-    @bug(context.library >= "golang@1.72.0", reason="APMAPI-1196")
     def test_query_string_redaction(self):
         trace = [span for _, _, span in interfaces.library.get_spans(self.r, full_trace=True)]
         expected_tags = {"http.url": "http://weblog:7777/"}


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
