### PR TITLE
[python] remove internal configs from parametric app

### DIFF
--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -10,6 +10,7 @@ import os
 from fastapi import FastAPI
 import opentelemetry.trace
 from pydantic import BaseModel
+from urllib.parse import urlparse
 
 import opentelemetry
 from opentelemetry.trace import set_tracer_provider
@@ -129,9 +130,9 @@ def trace_config() -> TraceConfigReturn:
             "dd_env": config.env,
             "dd_version": config.version,
             "dd_trace_rate_limit": str(config._trace_rate_limit),
-            "dd_trace_agent_url": config._trace_agent_url,
-            "dd_dogstatsd_host": config._stats_agent_hostname,
-            "dd_dogstatsd_port": config._stats_agent_port,
+            "dd_trace_agent_url": str(ddtrace.tracer._agent_url),
+            "dd_dogstatsd_host": urlparse(ddtrace.tracer._dogstatsd_url).hostname,
+            "dd_dogstatsd_port": urlparse(ddtrace.tracer._dogstatsd_url).port,
             "dd_logs_injection": str(config._logs_injection).lower(),
             "dd_profiling_enabled": str(profiling_config.enabled).lower(),
             "dd_data_streams_enabled": str(config._data_streams_enabled).lower(),


### PR DESCRIPTION
## Motivation

config._stats_agent_hostname and config._stats_agent_port are not used by the agent. They will be removed in a future ddtrace version. 

## Changes

- get statsd configs from the tracer instead of the global config object

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
