### PR TITLE
[java] Enable identify easy wins

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1863,8 +1863,12 @@ tests/:
   test_graphql.py: missing_feature
   test_identify.py:
     Test_Basic: missing_feature
-    Test_Propagate: missing_feature
-    Test_Propagate_Legacy: missing_feature
+    Test_Propagate:
+      '*': v0.111.0
+      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+    Test_Propagate_Legacy:
+      '*': v0.111.0
+      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
   test_ipv6.py: missing_feature (APMAPI-869)
   test_library_conf.py:
     Test_ExtractBehavior_Default: incomplete_test_app (/make_distant_call endpoint is not correctly implemented)

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -65,6 +65,7 @@ class Test_Propagate_Legacy:
         self.r_outgoing = weblog.get("/identify-propagate")
 
     @missing_feature(library="nodejs", reason="only supports incoming tags for now")
+    @missing_feature(library="java", reason="only supports incoming tags for now")
     def test_identify_tags_outgoing(self):
         tagTable = {"_dd.p.usr.id": "dXNyLmlk"}
         interfaces.library.validate_spans(self.r_outgoing, validate_identify_tags(tagTable))
@@ -90,6 +91,7 @@ class Test_Propagate:
         self.r_outgoing = weblog.get("/identify-propagate")
 
     @missing_feature(library="nodejs", reason="only supports incoming tags for now")
+    @missing_feature(library="java", reason="only supports incoming tags for now")
     def test_identify_tags_outgoing(self):
         tagTable = {"usr.id": "usr.id", "_dd.p.usr.id": "dXNyLmlk"}
         interfaces.library.validate_spans(self.r_outgoing, validate_identify_tags(tagTable))


### PR DESCRIPTION
## Motivation

[APPSEC-54879](https://datadoghq.atlassian.net/browse/APPSEC-54879)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-54879]: https://datadoghq.atlassian.net/browse/APPSEC-54879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ