### PR TITLE
check waf request input truncated tag

### DIFF
--- a/tests/appsec/waf/test_truncation.py
+++ b/tests/appsec/waf/test_truncation.py
@@ -56,7 +56,7 @@ class Test_Truncation:
         assert has_input_truncated, "Expected at least one serie to have input_truncated:true tag"
 
         all_have_input_truncated_tag = all(
-            "input_truncated:true" in series["tags"] or "input_truncated:false" in series["tags"] 
+            "input_truncated:true" in series["tags"] or "input_truncated:false" in series["tags"]
             for series in waf_requests_series
         )
         assert all_have_input_truncated_tag, "Expected all series to have input_truncated tag"

--- a/tests/appsec/waf/test_truncation.py
+++ b/tests/appsec/waf/test_truncation.py
@@ -53,8 +53,13 @@ class Test_Truncation:
 
         waf_requests_series = self._find_series("generate-metrics", "appsec", ["waf.requests"])
         has_input_truncated = any("input_truncated:true" in series["tags"] for series in waf_requests_series)
-
         assert has_input_truncated, "Expected at least one serie to have input_truncated:true tag"
+
+        all_have_input_truncated_tag = all(
+            "input_truncated:true" in series["tags"] or "input_truncated:false" in series["tags"] 
+            for series in waf_requests_series
+        )
+        assert all_have_input_truncated_tag, "Expected all series to have input_truncated tag"
 
         count_series = self._find_series("generate-metrics", "appsec", ["waf.input_truncated"])
         input_truncated = count_series[0] if count_series else None

--- a/tests/appsec/waf/test_truncation.py
+++ b/tests/appsec/waf/test_truncation.py
@@ -51,6 +51,11 @@ class Test_Truncation:
         assert int(metrics["_dd.appsec.truncated.container_size"]) == 300
         assert int(metrics["_dd.appsec.truncated.container_depth"]) == 20
 
+        waf_requests_series = self._find_series("generate-metrics", "appsec", ["waf.requests"])
+        has_input_truncated = any("input_truncated:true" in series["tags"] for series in waf_requests_series)
+
+        assert has_input_truncated, "Expected at least one serie to have input_truncated:true tag"
+
         count_series = self._find_series("generate-metrics", "appsec", ["waf.input_truncated"])
         input_truncated = count_series[0] if count_series else None
 


### PR DESCRIPTION
## Motivation

Check if the `waf.requests` telemetry metric includes `input_truncated:true` when a truncation occurs, in addition to the previous checks


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
