### PR TITLE
Gitlab: temporary disable check_pipeline_status

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -140,21 +140,21 @@ ruby_ssi_pipeline:
         job: compute_pipeline
     strategy: depend
 
-check_pipeline_status:
-  stage: pipeline-status
-  image: registry.ddbuild.io/images/ci_docker_base
-  tags: ["runner:docker"]
-  script:
-    - echo "Checking if any job failed..."
-    - |
-      FAILED_JOBS=$(curl --header "PRIVATE-TOKEN: $CI_JOB_TOKEN" \
-      "$CI_API_V4_URL/projects/$CI_PROJECT_ID/pipelines/$CI_PIPELINE_ID/jobs?scope=failed" | jq '. | length')
-    - if [ "$FAILED_JOBS" -gt 0 ]; then
-        echo "❌ A job failed, failing the pipeline!";
-        echo "Failing Jobs [$FAILED_JOBS]";
-        exit 1;
-      fi
-  when: always
+# check_pipeline_status:
+#   stage: pipeline-status
+#   image: registry.ddbuild.io/images/ci_docker_base
+#   tags: ["runner:docker"]
+#   script:
+#     - echo "Checking if any job failed..."
+#     - |
+#       FAILED_JOBS=$(curl --header "PRIVATE-TOKEN: $CI_JOB_TOKEN" \
+#       "$CI_API_V4_URL/projects/$CI_PROJECT_ID/pipelines/$CI_PIPELINE_ID/jobs?scope=failed" | jq '. | length')
+#     - if [ "$FAILED_JOBS" -gt 0 ]; then
+#         echo "❌ A job failed, failing the pipeline!";
+#         echo "Failing Jobs [$FAILED_JOBS]";
+#         exit 1;
+#       fi
+#   when: always
 
 check_merge_labels:
   #Build docker images if it's needed. Check if the PR has the labels associated with the image build.


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
