### PR TITLE
Enable key-ordering for yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,4 +2,4 @@ extends: relaxed
 
 rules:
     line-length: disable
-    key-ordering: disable
+    key-ordering: enable

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -64,16 +64,6 @@ tests/:
       test_shi.py: irrelevant (ASM is not implemented in C++)
       test_sqli.py: irrelevant (ASM is not implemented in C++)
       test_ssrf.py: irrelevant (ASM is not implemented in C++)
-    waf/:
-      test_addresses.py: irrelevant (ASM is not implemented in C++)
-      test_blocking.py: irrelevant (ASM is not implemented in C++)
-      test_custom_rules.py: irrelevant (ASM is not implemented in C++)
-      test_exclusions.py: irrelevant (ASM is not implemented in C++)
-      test_miscs.py: irrelevant (ASM is not implemented in C++)
-      test_reports.py: irrelevant (ASM is not implemented in C++)
-      test_rules.py: irrelevant (ASM is not implemented in C++)
-      test_telemetry.py: irrelevant (ASM is not implemented in C++)
-      test_truncation.py: irrelevant (ASM is not implemented in C++)
     test_alpha.py: irrelevant (ASM is not implemented in C++)
     test_asm_standalone.py: irrelevant (ASM is not implemented in C++)
     test_automated_login_events.py: irrelevant (ASM is not implemented in C++)
@@ -98,6 +88,16 @@ tests/:
     test_traces.py: irrelevant (ASM is not implemented in C++)
     test_user_blocking_full_denylist.py: irrelevant (ASM is not implemented in C++)
     test_versions.py: irrelevant (ASM is not implemented in C++)
+    waf/:
+      test_addresses.py: irrelevant (ASM is not implemented in C++)
+      test_blocking.py: irrelevant (ASM is not implemented in C++)
+      test_custom_rules.py: irrelevant (ASM is not implemented in C++)
+      test_exclusions.py: irrelevant (ASM is not implemented in C++)
+      test_miscs.py: irrelevant (ASM is not implemented in C++)
+      test_reports.py: irrelevant (ASM is not implemented in C++)
+      test_rules.py: irrelevant (ASM is not implemented in C++)
+      test_telemetry.py: irrelevant (ASM is not implemented in C++)
+      test_truncation.py: irrelevant (ASM is not implemented in C++)
   debugger/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay: irrelevant

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -255,50 +255,6 @@ tests/:
         Test_Ssrf_Telemetry: v2.51.0
         Test_Ssrf_UrlQuery: v2.51.0
         Test_Ssrf_Waf_Version: v3.4.1
-    waf/:
-      test_addresses.py:
-        Test_BodyJson: v2.8.0
-        Test_BodyRaw: missing_feature
-        Test_BodyUrlEncoded: v2.7.0
-        Test_BodyXml: v2.8.0
-        Test_FullGrpc: missing_feature
-        Test_GraphQL: missing_feature
-        Test_GrpcServerMethod: missing_feature
-        Test_Headers: v1.28.6
-        Test_PathParams: v2.5.1
-        Test_ResponseStatus: v2.3.0
-        Test_UrlQuery: v1.28.6
-        Test_UrlQueryKey: v2.7.0
-        Test_UrlRaw: v1.28.6
-        Test_gRPC: missing_feature
-      test_blocking.py:
-        Test_Blocking: v2.27.0
-        Test_Blocking_strip_response_headers: missing_feature
-        Test_CustomBlockingResponse: v3.10.0
-      test_custom_rules.py:
-        Test_CustomRules: v2.30.0
-      test_exclusions.py:
-        Test_Exclusions: v2.26.0
-      test_miscs.py:
-        Test_404: v1.28.6
-        Test_CorrectOptionProcessing: v1.28.6
-        Test_MultipleAttacks: v2.1.0
-        Test_MultipleHighlight: v2.3.0
-      test_reports.py:
-        Test_Monitoring: v2.9.0
-      test_rules.py:
-        Test_CommandInjection: v1.28.6
-        Test_DiscoveryScan: v2.3.0
-        Test_JavaCodeInjection: v1.28.6
-        Test_JsInjection: v1.28.6
-        Test_NoSqli: v2.12.0
-        Test_RFI: v1.28.6
-        Test_SSRF: v1.28.6
-        Test_Scanners: v1.28.6
-      test_telemetry.py:
-        Test_TelemetryMetrics: missing_feature
-      test_truncation.py:
-        Test_Truncation: missing_feature
     test_alpha.py:
       Test_Basic: v1.28.6
     test_asm_standalone.py:
@@ -393,6 +349,50 @@ tests/:
       Test_RetainTraces: v1.29.0
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist: v2.30.0
+    waf/:
+      test_addresses.py:
+        Test_BodyJson: v2.8.0
+        Test_BodyRaw: missing_feature
+        Test_BodyUrlEncoded: v2.7.0
+        Test_BodyXml: v2.8.0
+        Test_FullGrpc: missing_feature
+        Test_GraphQL: missing_feature
+        Test_GrpcServerMethod: missing_feature
+        Test_Headers: v1.28.6
+        Test_PathParams: v2.5.1
+        Test_ResponseStatus: v2.3.0
+        Test_UrlQuery: v1.28.6
+        Test_UrlQueryKey: v2.7.0
+        Test_UrlRaw: v1.28.6
+        Test_gRPC: missing_feature
+      test_blocking.py:
+        Test_Blocking: v2.27.0
+        Test_Blocking_strip_response_headers: missing_feature
+        Test_CustomBlockingResponse: v3.10.0
+      test_custom_rules.py:
+        Test_CustomRules: v2.30.0
+      test_exclusions.py:
+        Test_Exclusions: v2.26.0
+      test_miscs.py:
+        Test_404: v1.28.6
+        Test_CorrectOptionProcessing: v1.28.6
+        Test_MultipleAttacks: v2.1.0
+        Test_MultipleHighlight: v2.3.0
+      test_reports.py:
+        Test_Monitoring: v2.9.0
+      test_rules.py:
+        Test_CommandInjection: v1.28.6
+        Test_DiscoveryScan: v2.3.0
+        Test_JavaCodeInjection: v1.28.6
+        Test_JsInjection: v1.28.6
+        Test_NoSqli: v2.12.0
+        Test_RFI: v1.28.6
+        Test_SSRF: v1.28.6
+        Test_Scanners: v1.28.6
+      test_telemetry.py:
+        Test_TelemetryMetrics: missing_feature
+      test_truncation.py:
+        Test_Truncation: missing_feature
   debugger/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay: v2.50.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -227,116 +227,6 @@ tests/:
         Test_Ssrf_Telemetry: missing_feature
         Test_Ssrf_UrlQuery: v1.65.1
         Test_Ssrf_Waf_Version: missing_feature
-    waf/:
-      test_addresses.py:
-        Test_BodyJson: v1.37.0
-        Test_BodyRaw: missing_feature
-        Test_BodyUrlEncoded: v1.37.0
-        Test_BodyXml: v1.37.0
-        Test_Cookies:
-          '*': v1.34.0
-          chi: v1.36.0
-          echo: v1.36.0
-          gin: v1.37.0
-        Test_FullGrpc: missing_feature
-        Test_GraphQL: missing_feature
-        Test_GrpcServerMethod: v1.62.0
-        Test_Headers:
-          '*': v1.34.0
-          chi: v1.36.0
-          echo: v1.36.0
-          gin: v1.37.0
-        Test_PathParams:
-          '*': v1.36.0
-          gin: v1.37.0
-          net-http: irrelevant (net-http doesn't handle path params)
-          net-http-orchestrion: irrelevant (net-http doesn't handle path params)
-        Test_ResponseStatus:
-          '*': v1.36.0
-          gin: v1.37.0
-        Test_UrlQuery:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_UrlQueryKey: v1.38.1
-        Test_UrlRaw:
-          '*': v1.34.0
-          chi: v1.36.0
-          echo: v1.36.0
-          gin: v1.37.0
-        Test_gRPC: v1.36.0
-      test_blocking.py:
-        Test_Blocking: v1.50.0-rc.1
-        Test_Blocking_strip_response_headers: missing_feature
-        Test_CustomBlockingResponse:
-          '*': v1.63.0
-      test_custom_rules.py:
-        Test_CustomRules: v1.51.0
-      test_exclusions.py:
-        Test_Exclusions: v1.53.0
-      test_miscs.py:
-        Test_404:
-          '*': v1.34.0
-          chi: v1.36.0
-          echo: v1.36.0
-          gin: v1.37.0
-        Test_CorrectOptionProcessing:
-          '*': v1.34.0
-          chi: v1.36.0
-          echo: v1.36.0
-          gin: v1.37.0
-        Test_MultipleAttacks:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_MultipleHighlight:
-          '*': v1.36.0
-          gin: v1.37.0
-      test_reports.py:
-        Test_Monitoring: v1.38.0
-      test_rules.py:
-        Test_CommandInjection:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_DiscoveryScan:
-          '*': v1.36.0
-          gin: v1.37.0
-        Test_HttpProtocol:
-          '*': v1.36.1
-          gin: v1.37.0
-        Test_JavaCodeInjection:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_JsInjection:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_LFI:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_NoSqli:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_PhpCodeInjection:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_RFI:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_SQLI:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_SSRF:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_Scanners:
-          '*': v1.35.0
-          gin: v1.37.0
-        Test_XSS:
-          '*': v1.35.0
-          echo: v1.36.0
-          gin: v1.37.0
-      test_telemetry.py:
-        Test_TelemetryMetrics: missing_feature
-      test_truncation.py:
-        Test_Truncation: missing_feature
     test_alpha.py:
       Test_Basic:
         '*': v1.34.0
@@ -476,6 +366,116 @@ tests/:
       Test_Events:
         '*': v1.36.0
         gin: v1.37.0
+    waf/:
+      test_addresses.py:
+        Test_BodyJson: v1.37.0
+        Test_BodyRaw: missing_feature
+        Test_BodyUrlEncoded: v1.37.0
+        Test_BodyXml: v1.37.0
+        Test_Cookies:
+          '*': v1.34.0
+          chi: v1.36.0
+          echo: v1.36.0
+          gin: v1.37.0
+        Test_FullGrpc: missing_feature
+        Test_GraphQL: missing_feature
+        Test_GrpcServerMethod: v1.62.0
+        Test_Headers:
+          '*': v1.34.0
+          chi: v1.36.0
+          echo: v1.36.0
+          gin: v1.37.0
+        Test_PathParams:
+          '*': v1.36.0
+          gin: v1.37.0
+          net-http: irrelevant (net-http doesn't handle path params)
+          net-http-orchestrion: irrelevant (net-http doesn't handle path params)
+        Test_ResponseStatus:
+          '*': v1.36.0
+          gin: v1.37.0
+        Test_UrlQuery:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_UrlQueryKey: v1.38.1
+        Test_UrlRaw:
+          '*': v1.34.0
+          chi: v1.36.0
+          echo: v1.36.0
+          gin: v1.37.0
+        Test_gRPC: v1.36.0
+      test_blocking.py:
+        Test_Blocking: v1.50.0-rc.1
+        Test_Blocking_strip_response_headers: missing_feature
+        Test_CustomBlockingResponse:
+          '*': v1.63.0
+      test_custom_rules.py:
+        Test_CustomRules: v1.51.0
+      test_exclusions.py:
+        Test_Exclusions: v1.53.0
+      test_miscs.py:
+        Test_404:
+          '*': v1.34.0
+          chi: v1.36.0
+          echo: v1.36.0
+          gin: v1.37.0
+        Test_CorrectOptionProcessing:
+          '*': v1.34.0
+          chi: v1.36.0
+          echo: v1.36.0
+          gin: v1.37.0
+        Test_MultipleAttacks:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_MultipleHighlight:
+          '*': v1.36.0
+          gin: v1.37.0
+      test_reports.py:
+        Test_Monitoring: v1.38.0
+      test_rules.py:
+        Test_CommandInjection:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_DiscoveryScan:
+          '*': v1.36.0
+          gin: v1.37.0
+        Test_HttpProtocol:
+          '*': v1.36.1
+          gin: v1.37.0
+        Test_JavaCodeInjection:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_JsInjection:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_LFI:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_NoSqli:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_PhpCodeInjection:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_RFI:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_SQLI:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_SSRF:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_Scanners:
+          '*': v1.35.0
+          gin: v1.37.0
+        Test_XSS:
+          '*': v1.35.0
+          echo: v1.36.0
+          gin: v1.37.0
+      test_telemetry.py:
+        Test_TelemetryMetrics: missing_feature
+      test_truncation.py:
+        Test_Truncation: missing_feature
   debugger/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay: missing_feature (feature not implented)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -919,191 +919,6 @@ tests/:
         Test_Ssrf_Waf_Version:
           '*': v1.40.0
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-    waf/:
-      test_addresses.py:
-        Test_BodyJson:
-          '*': v0.95.1
-          akka-http: v1.22.0
-          play: v1.22.0
-          ratpack: v0.99.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          vertx3: v0.99.0
-          vertx4: v1.47.0
-        Test_BodyRaw:
-          '*': missing_feature
-          akka-http: v1.22.0
-          play: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_BodyUrlEncoded:
-          '*': v0.95.1
-          akka-http: v1.22.0
-          play: v1.22.0
-          ratpack: v0.99.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-undertow: v0.98.0
-          vertx3: v0.99.0
-        Test_BodyXml:
-          '*': v0.95.1
-          akka-http: missing_feature (no built-in XML unmarshalling to instrument)
-          play: v1.23.0
-          ratpack: v0.99.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          vertx3: missing_feature
-          vertx4: bug (APPSEC-54983)
-        Test_Cookies:
-          akka-http: v1.22.0
-          play: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_FullGrpc: missing_feature
-        Test_GraphQL: missing_feature
-        Test_GrpcServerMethod: missing_feature
-        Test_Headers:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_PathParams:
-          '*': v0.95.1
-          akka-http: missing_feature (unclear how to implement; matching doesn't happen in one go)
-          jersey-grizzly2: v1.15.0
-          play: v1.22.0
-          ratpack: v0.99.0
-          resteasy-netty3: v1.15.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          vertx3: v0.99.0
-        Test_ResponseStatus:
-          '*': v0.88.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_UrlQuery:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_UrlQueryKey:
-          '*': v0.100.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_UrlRaw:
-          '*': v0.87.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_gRPC:
-          '*': v0.96.0
-          akka-http: irrelevant
-          jersey-grizzly2: irrelevant
-          play: irrelevant
-          ratpack: irrelevant
-          resteasy-netty3: irrelevant
-          spring-boot: v0.109.0  # APPSEC-5426
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          vertx3: irrelevant
-          vertx4: irrelevant
-      test_blocking.py:
-        Test_Blocking:
-          '*': v0.112.0
-          akka-http: v1.22.0
-          jersey-grizzly2: v1.7.0
-          play: v1.22.0
-          ratpack: v1.7.0
-          resteasy-netty3: v1.7.0
-          spring-boot-3-native: missing_feature
-          spring-boot-openliberty: v1.3.0
-          vertx3: v1.7.0
-        Test_Blocking_strip_response_headers:
-          '*': missing_feature
-          akka-http: v1.22.0
-          play: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_CustomBlockingResponse:
-          '*': v1.11.0
-          akka-http: v1.22.0
-          play: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      test_custom_rules.py:
-        Test_CustomRules: missing_feature
-      test_exclusions.py:
-        Test_Exclusions:
-          '*': v1.6.0
-          akka-http: v1.22.0
-          play: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      test_miscs.py:
-        Test_404:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_CorrectOptionProcessing:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_MultipleAttacks:
-          '*': v0.92.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_MultipleHighlight:
-          '*': v0.95.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      test_reports.py:
-        Test_Monitoring:
-          '*': v0.100.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      test_rules.py:
-        Test_CommandInjection:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_DiscoveryScan:
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: bug (APPSEC-52334)
-        Test_HttpProtocol:
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_JavaCodeInjection:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_JsInjection:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_LFI:
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_NoSqli:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_PhpCodeInjection:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_RFI:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_SQLI:
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_SSRF:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_Scanners:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-        Test_XSS:
-          '*': v0.87.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      test_telemetry.py:
-        Test_TelemetryMetrics:
-          '*': v1.12.0
-          akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      test_truncation.py:
-        Test_Truncation: missing_feature
     test_alpha.py:
       Test_Basic:
         '*': v0.87.0
@@ -1558,6 +1373,191 @@ tests/:
         vertx3: v1.7.0
     test_versions.py:
       Test_Events: v0.90.0
+    waf/:
+      test_addresses.py:
+        Test_BodyJson:
+          '*': v0.95.1
+          akka-http: v1.22.0
+          play: v1.22.0
+          ratpack: v0.99.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: v0.99.0
+          vertx4: v1.47.0
+        Test_BodyRaw:
+          '*': missing_feature
+          akka-http: v1.22.0
+          play: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_BodyUrlEncoded:
+          '*': v0.95.1
+          akka-http: v1.22.0
+          play: v1.22.0
+          ratpack: v0.99.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-undertow: v0.98.0
+          vertx3: v0.99.0
+        Test_BodyXml:
+          '*': v0.95.1
+          akka-http: missing_feature (no built-in XML unmarshalling to instrument)
+          play: v1.23.0
+          ratpack: v0.99.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: missing_feature
+          vertx4: bug (APPSEC-54983)
+        Test_Cookies:
+          akka-http: v1.22.0
+          play: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_FullGrpc: missing_feature
+        Test_GraphQL: missing_feature
+        Test_GrpcServerMethod: missing_feature
+        Test_Headers:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_PathParams:
+          '*': v0.95.1
+          akka-http: missing_feature (unclear how to implement; matching doesn't happen in one go)
+          jersey-grizzly2: v1.15.0
+          play: v1.22.0
+          ratpack: v0.99.0
+          resteasy-netty3: v1.15.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: v0.99.0
+        Test_ResponseStatus:
+          '*': v0.88.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_UrlQuery:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_UrlQueryKey:
+          '*': v0.100.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_UrlRaw:
+          '*': v0.87.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_gRPC:
+          '*': v0.96.0
+          akka-http: irrelevant
+          jersey-grizzly2: irrelevant
+          play: irrelevant
+          ratpack: irrelevant
+          resteasy-netty3: irrelevant
+          spring-boot: v0.109.0  # APPSEC-5426
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          vertx3: irrelevant
+          vertx4: irrelevant
+      test_blocking.py:
+        Test_Blocking:
+          '*': v0.112.0
+          akka-http: v1.22.0
+          jersey-grizzly2: v1.7.0
+          play: v1.22.0
+          ratpack: v1.7.0
+          resteasy-netty3: v1.7.0
+          spring-boot-3-native: missing_feature
+          spring-boot-openliberty: v1.3.0
+          vertx3: v1.7.0
+        Test_Blocking_strip_response_headers:
+          '*': missing_feature
+          akka-http: v1.22.0
+          play: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_CustomBlockingResponse:
+          '*': v1.11.0
+          akka-http: v1.22.0
+          play: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      test_custom_rules.py:
+        Test_CustomRules: missing_feature
+      test_exclusions.py:
+        Test_Exclusions:
+          '*': v1.6.0
+          akka-http: v1.22.0
+          play: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      test_miscs.py:
+        Test_404:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_CorrectOptionProcessing:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_MultipleAttacks:
+          '*': v0.92.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_MultipleHighlight:
+          '*': v0.95.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      test_reports.py:
+        Test_Monitoring:
+          '*': v0.100.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      test_rules.py:
+        Test_CommandInjection:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_DiscoveryScan:
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-payara: bug (APPSEC-52334)
+        Test_HttpProtocol:
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_JavaCodeInjection:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_JsInjection:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_LFI:
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_NoSqli:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_PhpCodeInjection:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_RFI:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_SQLI:
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_SSRF:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_Scanners:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        Test_XSS:
+          '*': v0.87.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      test_telemetry.py:
+        Test_TelemetryMetrics:
+          '*': v1.12.0
+          akka-http: v1.22.0
+          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      test_truncation.py:
+        Test_Truncation: missing_feature
   debugger/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay:
@@ -1791,10 +1791,6 @@ tests/:
       Test_Miscs: missing_feature
     test_stats.py:
       Test_Client_Stats: missing_feature
-  test_the_test/:
-    test_json_report.py:
-      Test_Mock: v0.0.99
-      Test_NotReleased: missing_feature
   test_config_consistency.py:
     Test_Config_ClientIPHeaderEnabled_False: v1.43.0
     Test_Config_ClientIPHeader_Configured: v1.43.0
@@ -1940,3 +1936,7 @@ tests/:
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     Test_TelemetrySCAEnvVar: missing_feature
     Test_TelemetryV2: v1.23.0
+  test_the_test/:
+    test_json_report.py:
+      Test_Mock: v0.0.99
+      Test_NotReleased: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -541,72 +541,6 @@ tests/:
           express5: *ref_5_29_0
           nextjs: missing_feature
         Test_Ssrf_Waf_Version: *ref_5_25_0
-    waf/:
-      test_addresses.py:
-        Test_BodyJson:
-          '*': v2.2.0
-          nextjs: *ref_4_17_0
-        Test_BodyRaw: missing_feature
-        Test_BodyUrlEncoded:
-          '*': v2.2.0
-          nextjs: *ref_5_3_0
-        Test_BodyXml:
-          '*': v2.2.0
-          nextjs: irrelevant  # Body xml is not converted to JSON in nextjs
-        Test_Cookies: v2.0.0
-        Test_FullGrpc: missing_feature
-        Test_GraphQL:
-          '*': *ref_4_22_0
-          express5: missing_feature  # graphql not yet compatible with express5
-          nextjs: irrelevant  # nextjs is not related with graphql
-        Test_GrpcServerMethod: missing_feature
-        Test_Headers: v2.0.0
-        Test_PathParams:
-          '*': v2.0.0
-          express5: *ref_5_29_0
-          nextjs: missing_feature
-        Test_ResponseStatus: v2.0.0
-        Test_UrlQuery:
-          '*': v2.0.0
-          nextjs: *ref_4_17_0
-        Test_UrlQueryKey:
-          '*': v2.6.0
-          nextjs: *ref_4_17_0
-        Test_UrlRaw: v2.0.0
-        Test_gRPC: missing_feature
-      test_blocking.py:
-        Test_Blocking: *ref_3_19_0
-        Test_Blocking_strip_response_headers: *ref_5_17_0
-        Test_CustomBlockingResponse: *ref_5_15_0
-      test_custom_rules.py:
-        Test_CustomRules: *ref_4_1_0
-      test_exclusions.py:
-        Test_Exclusions: *ref_3_19_0
-      test_miscs.py:
-        Test_404: v2.0.0
-        Test_CorrectOptionProcessing: *ref_3_19_0  # probably sooner, but bugged
-        Test_MultipleAttacks: v2.0.0
-        Test_MultipleHighlight: v2.0.0
-      test_reports.py:
-        Test_Monitoring: v2.8.0
-      test_rules.py:
-        Test_CommandInjection: v2.0.0
-        Test_DiscoveryScan: v2.0.0
-        Test_HttpProtocol: v2.0.0
-        Test_JavaCodeInjection: v2.0.0
-        Test_JsInjection: v2.0.0
-        Test_LFI: v2.0.0
-        Test_NoSqli: v2.0.0
-        Test_PhpCodeInjection: v2.0.0
-        Test_RFI: v2.0.0
-        Test_SQLI: v2.0.0
-        Test_SSRF: v2.0.0
-        Test_Scanners: v2.0.0
-        Test_XSS: v2.0.0
-      test_telemetry.py:
-        Test_TelemetryMetrics: *ref_4_17_0
-      test_truncation.py:
-        Test_Truncation: missing_feature
     test_alpha.py:
       Test_Basic: v2.0.0
     test_asm_standalone.py:
@@ -756,6 +690,72 @@ tests/:
         nextjs: missing_feature (block method not implemented for nextjs yet)
     test_versions.py:
       Test_Events: v2.0.0
+    waf/:
+      test_addresses.py:
+        Test_BodyJson:
+          '*': v2.2.0
+          nextjs: *ref_4_17_0
+        Test_BodyRaw: missing_feature
+        Test_BodyUrlEncoded:
+          '*': v2.2.0
+          nextjs: *ref_5_3_0
+        Test_BodyXml:
+          '*': v2.2.0
+          nextjs: irrelevant  # Body xml is not converted to JSON in nextjs
+        Test_Cookies: v2.0.0
+        Test_FullGrpc: missing_feature
+        Test_GraphQL:
+          '*': *ref_4_22_0
+          express5: missing_feature  # graphql not yet compatible with express5
+          nextjs: irrelevant  # nextjs is not related with graphql
+        Test_GrpcServerMethod: missing_feature
+        Test_Headers: v2.0.0
+        Test_PathParams:
+          '*': v2.0.0
+          express5: *ref_5_29_0
+          nextjs: missing_feature
+        Test_ResponseStatus: v2.0.0
+        Test_UrlQuery:
+          '*': v2.0.0
+          nextjs: *ref_4_17_0
+        Test_UrlQueryKey:
+          '*': v2.6.0
+          nextjs: *ref_4_17_0
+        Test_UrlRaw: v2.0.0
+        Test_gRPC: missing_feature
+      test_blocking.py:
+        Test_Blocking: *ref_3_19_0
+        Test_Blocking_strip_response_headers: *ref_5_17_0
+        Test_CustomBlockingResponse: *ref_5_15_0
+      test_custom_rules.py:
+        Test_CustomRules: *ref_4_1_0
+      test_exclusions.py:
+        Test_Exclusions: *ref_3_19_0
+      test_miscs.py:
+        Test_404: v2.0.0
+        Test_CorrectOptionProcessing: *ref_3_19_0  # probably sooner, but bugged
+        Test_MultipleAttacks: v2.0.0
+        Test_MultipleHighlight: v2.0.0
+      test_reports.py:
+        Test_Monitoring: v2.8.0
+      test_rules.py:
+        Test_CommandInjection: v2.0.0
+        Test_DiscoveryScan: v2.0.0
+        Test_HttpProtocol: v2.0.0
+        Test_JavaCodeInjection: v2.0.0
+        Test_JsInjection: v2.0.0
+        Test_LFI: v2.0.0
+        Test_NoSqli: v2.0.0
+        Test_PhpCodeInjection: v2.0.0
+        Test_RFI: v2.0.0
+        Test_SQLI: v2.0.0
+        Test_SSRF: v2.0.0
+        Test_Scanners: v2.0.0
+        Test_XSS: v2.0.0
+      test_telemetry.py:
+        Test_TelemetryMetrics: *ref_4_17_0
+      test_truncation.py:
+        Test_Truncation: missing_feature
   debugger/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay: missing_feature (feature not implented)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -249,54 +249,6 @@ tests/:
         Test_Ssrf_Telemetry: v1.7.0
         Test_Ssrf_UrlQuery: v1.7.0
         Test_Ssrf_Waf_Version: v1.7.0
-    waf/:
-      test_addresses.py:
-        Test_BodyJson: v0.98.1  # TODO what is the earliest version?
-        Test_BodyRaw: v0.68.3
-        Test_BodyUrlEncoded: v0.68.3
-        Test_BodyXml: v0.98.0
-        Test_Cookies: v0.68.3
-        Test_FullGrpc: missing_feature
-        Test_GraphQL: missing_feature
-        Test_GrpcServerMethod: missing_feature
-        Test_Headers: v0.68.3
-        Test_PathParams: v0.71.0
-        Test_UrlQuery: v0.68.3
-        Test_UrlQueryKey: v0.74.0
-        Test_UrlRaw: v0.68.3  # probably sooner, but was flaky
-        Test_gRPC: missing_feature
-      test_blocking.py:
-        Test_Blocking: v0.86.0
-        Test_Blocking_strip_response_headers: missing_feature
-        Test_CustomBlockingResponse: v0.86.0
-      test_custom_rules.py:
-        Test_CustomRules: v0.87.2
-      test_exclusions.py:
-        Test_Exclusions: v0.86.0
-      test_miscs.py:
-        Test_404: v0.1.0
-        Test_CorrectOptionProcessing: v0.1.0
-        Test_MultipleAttacks: v0.1.0
-        Test_MultipleHighlight: v0.2.0
-      test_reports.py:
-        Test_Monitoring: v0.73.0
-      test_rules.py:
-        Test_CommandInjection: v0.68.3
-        Test_HttpProtocol: v0.68.3
-        Test_JavaCodeInjection: v0.68.3
-        Test_JsInjection: v0.68.3
-        Test_LFI: v0.68.3
-        Test_NoSqli: v0.68.3
-        Test_PhpCodeInjection: v0.68.3
-        Test_RFI: v0.68.3
-        Test_SQLI: v0.68.3
-        Test_SSRF: v0.68.3
-        Test_Scanners: v0.68.3
-        Test_XSS: v0.68.3
-      test_telemetry.py:
-        Test_TelemetryMetrics: missing_feature
-      test_truncation.py:
-        Test_Truncation: missing_feature
     test_asm_standalone.py:
       Test_AppSecStandalone_NotEnabled: v1.6.2
       Test_AppSecStandalone_UpstreamPropagation: v1.6.0
@@ -366,6 +318,54 @@ tests/:
       Test_ExternalWafRequestsIdentification: v1.0.0
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist: v0.86.3
+    waf/:
+      test_addresses.py:
+        Test_BodyJson: v0.98.1  # TODO what is the earliest version?
+        Test_BodyRaw: v0.68.3
+        Test_BodyUrlEncoded: v0.68.3
+        Test_BodyXml: v0.98.0
+        Test_Cookies: v0.68.3
+        Test_FullGrpc: missing_feature
+        Test_GraphQL: missing_feature
+        Test_GrpcServerMethod: missing_feature
+        Test_Headers: v0.68.3
+        Test_PathParams: v0.71.0
+        Test_UrlQuery: v0.68.3
+        Test_UrlQueryKey: v0.74.0
+        Test_UrlRaw: v0.68.3  # probably sooner, but was flaky
+        Test_gRPC: missing_feature
+      test_blocking.py:
+        Test_Blocking: v0.86.0
+        Test_Blocking_strip_response_headers: missing_feature
+        Test_CustomBlockingResponse: v0.86.0
+      test_custom_rules.py:
+        Test_CustomRules: v0.87.2
+      test_exclusions.py:
+        Test_Exclusions: v0.86.0
+      test_miscs.py:
+        Test_404: v0.1.0
+        Test_CorrectOptionProcessing: v0.1.0
+        Test_MultipleAttacks: v0.1.0
+        Test_MultipleHighlight: v0.2.0
+      test_reports.py:
+        Test_Monitoring: v0.73.0
+      test_rules.py:
+        Test_CommandInjection: v0.68.3
+        Test_HttpProtocol: v0.68.3
+        Test_JavaCodeInjection: v0.68.3
+        Test_JsInjection: v0.68.3
+        Test_LFI: v0.68.3
+        Test_NoSqli: v0.68.3
+        Test_PhpCodeInjection: v0.68.3
+        Test_RFI: v0.68.3
+        Test_SQLI: v0.68.3
+        Test_SSRF: v0.68.3
+        Test_Scanners: v0.68.3
+        Test_XSS: v0.68.3
+      test_telemetry.py:
+        Test_TelemetryMetrics: missing_feature
+      test_truncation.py:
+        Test_Truncation: missing_feature
   debugger/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay: irrelevant

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -330,138 +330,6 @@ tests/:
         Test_Ssrf_Telemetry: v2.10.0
         Test_Ssrf_UrlQuery: v2.10.0
         Test_Ssrf_Waf_Version: v2.15.0
-    waf/:
-      test_addresses.py:
-        Test_BodyJson:
-          '*': v1.4.0-rc1
-          fastapi: v2.4.0
-        Test_BodyRaw:
-          '*': missing_feature
-          django-poc: v1.5.2
-          fastapi: v2.4.0
-          python3.12: v1.5.2
-        Test_BodyUrlEncoded:
-          '*': v1.4.0-rc1
-          fastapi: v2.4.0
-        Test_BodyXml:
-          '*': v1.5.0-rc1
-          fastapi: v2.4.0
-        Test_Cookies:
-          django-poc: v1.1.0-rc2
-          fastapi: v2.4.0
-          flask-poc: v1.4.0-rc1
-          python3.12: v1.1.0-rc2
-          uds-flask: v1.4.0-rc1
-          uwsgi-poc: v1.16.1
-        Test_FullGrpc: missing_feature
-        Test_GraphQL: missing_feature
-        Test_GrpcServerMethod: missing_feature
-        Test_Headers: v1.6
-        Test_PathParams:
-          django-poc: v1.1.0-rc2
-          fastapi: v2.4.0
-          flask-poc: v1.4.0-rc1
-          python3.12: v1.1.0-rc2
-          uds-flask: v1.4.0-rc1
-          uwsgi-poc: v1.5.2
-        Test_ResponseStatus:
-          '*': v0.58.5
-          fastapi: v2.4.0
-        Test_UrlQuery:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_UrlQueryKey:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_UrlRaw:
-          '*': v0.58.5
-          fastapi: v2.4.0
-        Test_gRPC: missing_feature
-      test_blocking.py:
-        Test_Blocking:
-          '*': v1.16.1
-          django-poc: v1.10
-          fastapi: v2.4.0
-          flask-poc: v1.10
-        Test_Blocking_strip_response_headers: v2.10.0
-        Test_CustomBlockingResponse:
-          '*': v1.20.0
-          fastapi: v2.4.0
-      test_custom_rules.py:
-        Test_CustomRules:
-          '*': v1.16.1
-          django-poc: v1.12
-          fastapi: v2.4.0
-          flask-poc: v1.12
-      test_exclusions.py:
-        Test_Exclusions:
-          '*': v1.16.1
-          django-poc: v1.12
-          fastapi: v2.4.0
-          flask-poc: v1.12
-      test_miscs.py:
-        Test_404: v1.1.0-rc2
-        Test_CorrectOptionProcessing:
-          '*': v1.1.0
-          fastapi: v2.4.0
-        Test_MultipleAttacks:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_MultipleHighlight:
-          '*': v1.2.1
-          fastapi: v2.4.0
-      test_reports.py:
-        Test_Monitoring:
-          '*': v1.5.0-rc1
-          fastapi: v2.4.0
-      test_rules.py:
-        Test_CommandInjection:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_DiscoveryScan:
-          '*': v0.58.5
-          fastapi: v2.4.0
-        Test_HttpProtocol:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_JavaCodeInjection:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_JsInjection:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_LFI:
-          '*': v2.4.0
-          flask-poc: v1.5.2
-          uds-flask: v1.5.2
-          uwsgi-poc: v2.9.0
-        Test_NoSqli:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_PhpCodeInjection:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_RFI:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_SQLI:
-          '*': v1.3.0
-          fastapi: v2.4.0
-        Test_SSRF:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_Scanners:
-          '*': v1.2.1
-          fastapi: v2.4.0
-        Test_XSS:
-          '*': v1.3.0
-          fastapi: v2.4.0
-      test_telemetry.py:
-        Test_TelemetryMetrics:
-          '*': v1.14.0
-          fastapi: v2.4.0
-      test_truncation.py:
-        Test_Truncation: v3.3.0.dev
     test_alpha.py:
       Test_Basic:
         '*': v1.1.0-rc2
@@ -625,6 +493,138 @@ tests/:
       Test_UserBlocking_FullDenylist: v2.11.0
     test_versions.py:
       Test_Events: v0.58.5
+    waf/:
+      test_addresses.py:
+        Test_BodyJson:
+          '*': v1.4.0-rc1
+          fastapi: v2.4.0
+        Test_BodyRaw:
+          '*': missing_feature
+          django-poc: v1.5.2
+          fastapi: v2.4.0
+          python3.12: v1.5.2
+        Test_BodyUrlEncoded:
+          '*': v1.4.0-rc1
+          fastapi: v2.4.0
+        Test_BodyXml:
+          '*': v1.5.0-rc1
+          fastapi: v2.4.0
+        Test_Cookies:
+          django-poc: v1.1.0-rc2
+          fastapi: v2.4.0
+          flask-poc: v1.4.0-rc1
+          python3.12: v1.1.0-rc2
+          uds-flask: v1.4.0-rc1
+          uwsgi-poc: v1.16.1
+        Test_FullGrpc: missing_feature
+        Test_GraphQL: missing_feature
+        Test_GrpcServerMethod: missing_feature
+        Test_Headers: v1.6
+        Test_PathParams:
+          django-poc: v1.1.0-rc2
+          fastapi: v2.4.0
+          flask-poc: v1.4.0-rc1
+          python3.12: v1.1.0-rc2
+          uds-flask: v1.4.0-rc1
+          uwsgi-poc: v1.5.2
+        Test_ResponseStatus:
+          '*': v0.58.5
+          fastapi: v2.4.0
+        Test_UrlQuery:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_UrlQueryKey:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_UrlRaw:
+          '*': v0.58.5
+          fastapi: v2.4.0
+        Test_gRPC: missing_feature
+      test_blocking.py:
+        Test_Blocking:
+          '*': v1.16.1
+          django-poc: v1.10
+          fastapi: v2.4.0
+          flask-poc: v1.10
+        Test_Blocking_strip_response_headers: v2.10.0
+        Test_CustomBlockingResponse:
+          '*': v1.20.0
+          fastapi: v2.4.0
+      test_custom_rules.py:
+        Test_CustomRules:
+          '*': v1.16.1
+          django-poc: v1.12
+          fastapi: v2.4.0
+          flask-poc: v1.12
+      test_exclusions.py:
+        Test_Exclusions:
+          '*': v1.16.1
+          django-poc: v1.12
+          fastapi: v2.4.0
+          flask-poc: v1.12
+      test_miscs.py:
+        Test_404: v1.1.0-rc2
+        Test_CorrectOptionProcessing:
+          '*': v1.1.0
+          fastapi: v2.4.0
+        Test_MultipleAttacks:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_MultipleHighlight:
+          '*': v1.2.1
+          fastapi: v2.4.0
+      test_reports.py:
+        Test_Monitoring:
+          '*': v1.5.0-rc1
+          fastapi: v2.4.0
+      test_rules.py:
+        Test_CommandInjection:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_DiscoveryScan:
+          '*': v0.58.5
+          fastapi: v2.4.0
+        Test_HttpProtocol:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_JavaCodeInjection:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_JsInjection:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_LFI:
+          '*': v2.4.0
+          flask-poc: v1.5.2
+          uds-flask: v1.5.2
+          uwsgi-poc: v2.9.0
+        Test_NoSqli:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_PhpCodeInjection:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_RFI:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_SQLI:
+          '*': v1.3.0
+          fastapi: v2.4.0
+        Test_SSRF:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_Scanners:
+          '*': v1.2.1
+          fastapi: v2.4.0
+        Test_XSS:
+          '*': v1.3.0
+          fastapi: v2.4.0
+      test_telemetry.py:
+        Test_TelemetryMetrics:
+          '*': v1.14.0
+          fastapi: v2.4.0
+      test_truncation.py:
+        Test_Truncation: v3.3.0.dev
   debugger/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -222,62 +222,6 @@ tests/:
           "*": missing_feature
           rails42: bug (APPSEC-56765)  # ActiveRecord instrumentation with Rails < 5 and Ruby < 2.7 not working due to kwargs
       test_ssrf.py: missing_feature
-    waf/:
-      test_addresses.py:
-        Test_BodyJson: v1.8.0
-        Test_BodyRaw: v1.1.0
-        Test_BodyUrlEncoded: v1.8.0
-        Test_BodyXml: irrelevant (unsupported by framework)
-        Test_FullGrpc: missing_feature
-        Test_GraphQL: v2.3.0
-        Test_GrpcServerMethod: missing_feature
-        Test_Headers:
-          '*': v0.54.2  # assumed as the oldest supported version
-          sinatra14: missing_feature (endpoint not implemented)
-          sinatra20: missing_feature (endpoint not implemented)
-          sinatra21: missing_feature (endpoint not implemented)
-          sinatra22: missing_feature (endpoint not implemented)
-          sinatra30: missing_feature (endpoint not implemented)
-          sinatra31: missing_feature (endpoint not implemented)
-          sinatra32: missing_feature (endpoint not implemented)
-          sinatra40: missing_feature (endpoint not implemented)
-          uds-sinatra: missing_feature (endpoint not implemented)
-        Test_PathParams:
-          '*': v1.8.0
-          rack: irrelevant
-        Test_ResponseStatus: v1.10.0
-        Test_UrlQuery: v0.54.2
-        Test_UrlQueryKey: v1.0.0
-        Test_gRPC: missing_feature
-      test_blocking.py:
-        Test_Blocking: v1.11.0
-        Test_Blocking_strip_response_headers: v1.13.0
-        Test_CustomBlockingResponse: v1.15.0
-      test_custom_rules.py:
-        Test_CustomRules: v1.12.0
-      test_exclusions.py:
-        Test_Exclusions:
-          '*': v1.11.0
-          sinatra14: missing_feature (endpoint not implemented)
-          sinatra20: missing_feature (endpoint not implemented)
-          sinatra21: missing_feature (endpoint not implemented)
-          sinatra22: missing_feature (endpoint not implemented)
-          sinatra30: missing_feature (endpoint not implemented)
-          sinatra31: missing_feature (endpoint not implemented)
-          sinatra32: missing_feature (endpoint not implemented)
-          sinatra40: missing_feature (endpoint not implemented)
-          uds-sinatra: missing_feature (endpoint not implemented)
-      test_miscs.py:
-        Test_MultipleAttacks: v0.54.2
-        Test_MultipleHighlight: v1.0.0.beta1
-      test_reports.py:
-        Test_Monitoring: v1.8.0
-      test_rules.py:
-        Test_NoSqli: v1.8.0
-      test_telemetry.py:
-        Test_TelemetryMetrics: missing_feature
-      test_truncation.py:
-        Test_Truncation: missing_feature
     test_asm_standalone.py:
       Test_AppSecStandalone_UpstreamPropagation: v2.4.1-dev
       Test_AppSecStandalone_UpstreamPropagation_V2: missing_feature
@@ -395,6 +339,62 @@ tests/:
       Test_UserBlocking_FullDenylist: v2.9.0
     test_versions.py:
       Test_Events: v0.54.2
+    waf/:
+      test_addresses.py:
+        Test_BodyJson: v1.8.0
+        Test_BodyRaw: v1.1.0
+        Test_BodyUrlEncoded: v1.8.0
+        Test_BodyXml: irrelevant (unsupported by framework)
+        Test_FullGrpc: missing_feature
+        Test_GraphQL: v2.3.0
+        Test_GrpcServerMethod: missing_feature
+        Test_Headers:
+          '*': v0.54.2  # assumed as the oldest supported version
+          sinatra14: missing_feature (endpoint not implemented)
+          sinatra20: missing_feature (endpoint not implemented)
+          sinatra21: missing_feature (endpoint not implemented)
+          sinatra22: missing_feature (endpoint not implemented)
+          sinatra30: missing_feature (endpoint not implemented)
+          sinatra31: missing_feature (endpoint not implemented)
+          sinatra32: missing_feature (endpoint not implemented)
+          sinatra40: missing_feature (endpoint not implemented)
+          uds-sinatra: missing_feature (endpoint not implemented)
+        Test_PathParams:
+          '*': v1.8.0
+          rack: irrelevant
+        Test_ResponseStatus: v1.10.0
+        Test_UrlQuery: v0.54.2
+        Test_UrlQueryKey: v1.0.0
+        Test_gRPC: missing_feature
+      test_blocking.py:
+        Test_Blocking: v1.11.0
+        Test_Blocking_strip_response_headers: v1.13.0
+        Test_CustomBlockingResponse: v1.15.0
+      test_custom_rules.py:
+        Test_CustomRules: v1.12.0
+      test_exclusions.py:
+        Test_Exclusions:
+          '*': v1.11.0
+          sinatra14: missing_feature (endpoint not implemented)
+          sinatra20: missing_feature (endpoint not implemented)
+          sinatra21: missing_feature (endpoint not implemented)
+          sinatra22: missing_feature (endpoint not implemented)
+          sinatra30: missing_feature (endpoint not implemented)
+          sinatra31: missing_feature (endpoint not implemented)
+          sinatra32: missing_feature (endpoint not implemented)
+          sinatra40: missing_feature (endpoint not implemented)
+          uds-sinatra: missing_feature (endpoint not implemented)
+      test_miscs.py:
+        Test_MultipleAttacks: v0.54.2
+        Test_MultipleHighlight: v1.0.0.beta1
+      test_reports.py:
+        Test_Monitoring: v1.8.0
+      test_rules.py:
+        Test_NoSqli: v1.8.0
+      test_telemetry.py:
+        Test_TelemetryMetrics: missing_feature
+      test_truncation.py:
+        Test_Truncation: missing_feature
   debugger/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay: missing_feature (feature not implemented)


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Turn a manual check done by reviewers into an automated CI (and local script) check

## Changes

<!-- A brief description of the change being made with this pull request. -->
Enables `key-ordering` for `yamllint` and fixes the issues that showed up as a result
No values were changed as a result

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
