### PR TITLE
telemetry: fix flaky configuration tests

### DIFF
--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -87,7 +87,7 @@ def set_and_wait_rc(test_agent, config_overrides: dict[str, Any]) -> dict:
     _set_rc(test_agent, rc_config)
 
     # Wait for both the telemetry event and the RC apply status.
-    test_agent.wait_for_telemetry_configurations("app-client-configuration-change", clear=True)
+    test_agent.wait_for_telemetry_event("app-client-configuration-change", clear=True)
     return test_agent.wait_for_rc_apply_state("APM_TRACING", state=RemoteConfigApplyState.ACKNOWLEDGED, clear=True)
 
 

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -87,7 +87,7 @@ def set_and_wait_rc(test_agent, config_overrides: dict[str, Any]) -> dict:
     _set_rc(test_agent, rc_config)
 
     # Wait for both the telemetry event and the RC apply status.
-    test_agent.wait_for_telemetry_event("app-client-configuration-change", clear=True)
+    test_agent.wait_for_telemetry_configurations("app-client-configuration-change", clear=True)
     return test_agent.wait_for_rc_apply_state("APM_TRACING", state=RemoteConfigApplyState.ACKNOWLEDGED, clear=True)
 
 

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -78,8 +78,7 @@ class Test_Defaults:
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        event = test_agent.wait_for_telemetry_event("app-started", wait_loops=400)
-        configuration = event["payload"]["configuration"]
+        configuration = test_agent.wait_for_telemetry_configurations(wait_loops=400)
 
         configuration_by_name = {item["name"]: item for item in configuration}
         for apm_telemetry_name, value in [
@@ -152,8 +151,7 @@ class Test_Consistent_Configs:
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        event = test_agent.wait_for_telemetry_event("app-started", wait_loops=400)
-        configuration = event["payload"]["configuration"]
+        configuration = test_agent.wait_for_telemetry_configurations(wait_loops=400)
         configuration_by_name = {item["name"]: item for item in configuration}
 
         # # Check that the tags name match the expected value
@@ -189,8 +187,7 @@ class Test_Consistent_Configs:
     def test_library_settings_2(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        event = test_agent.wait_for_telemetry_event("app-started", wait_loops=400)
-        configuration = event["payload"]["configuration"]
+        configuration = test_agent.wait_for_telemetry_configurations(wait_loops=400)
         configuration_by_name = {item["name"]: item for item in configuration}
 
         assert configuration_by_name.get("DD_TRACE_LOG_DIRECTORY", {}).get("value") == "/some/temporary/directory"
@@ -230,8 +227,7 @@ class Test_Environment:
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        event = test_agent.wait_for_telemetry_event("app-started", wait_loops=400)
-        configuration = event["payload"]["configuration"]
+        configuration = test_agent.wait_for_telemetry_configurations(wait_loops=400)
 
         configuration_by_name = {item["name"]: item for item in configuration}
         for apm_telemetry_name, environment_value in [
@@ -496,8 +492,8 @@ class Test_Stable_Configuration_Origin(StableConfigWriter):
             )
             test_library.container_restart()
             test_library.dd_start_span("test")
-        event = test_agent.wait_for_telemetry_event("app-started", wait_loops=400)
-        configuration = {c["name"]: c for c in event["payload"]["configuration"]}
+        configuration_list = test_agent.wait_for_telemetry_configurations(wait_loops=400)
+        configuration = {c["name"]: c for c in configuration_list}
 
         for cfg_name, origin in expected_origin.items():
             apm_telemetry_name = _mapped_telemetry_name(context, cfg_name)

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -78,7 +78,7 @@ class Test_Defaults:
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        configuration = test_agent.wait_for_telemetry_configurations(wait_loops=400)
+        configuration = test_agent.wait_for_telemetry_configurations()
 
         configuration_by_name = {item["name"]: item for item in configuration}
         for apm_telemetry_name, value in [
@@ -151,7 +151,7 @@ class Test_Consistent_Configs:
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        configuration = test_agent.wait_for_telemetry_configurations(wait_loops=400)
+        configuration = test_agent.wait_for_telemetry_configurations()
         configuration_by_name = {item["name"]: item for item in configuration}
 
         # # Check that the tags name match the expected value
@@ -187,7 +187,7 @@ class Test_Consistent_Configs:
     def test_library_settings_2(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        configuration = test_agent.wait_for_telemetry_configurations(wait_loops=400)
+        configuration = test_agent.wait_for_telemetry_configurations()
         configuration_by_name = {item["name"]: item for item in configuration}
 
         assert configuration_by_name.get("DD_TRACE_LOG_DIRECTORY", {}).get("value") == "/some/temporary/directory"
@@ -227,7 +227,7 @@ class Test_Environment:
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        configuration = test_agent.wait_for_telemetry_configurations(wait_loops=400)
+        configuration = test_agent.wait_for_telemetry_configurations()
 
         configuration_by_name = {item["name"]: item for item in configuration}
         for apm_telemetry_name, environment_value in [
@@ -492,7 +492,7 @@ class Test_Stable_Configuration_Origin(StableConfigWriter):
             )
             test_library.container_restart()
             test_library.dd_start_span("test")
-        configuration_list = test_agent.wait_for_telemetry_configurations(wait_loops=400)
+        configuration_list = test_agent.wait_for_telemetry_configurations()
         configuration = {c["name"]: c for c in configuration_list}
 
         for cfg_name, origin in expected_origin.items():

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -78,9 +78,8 @@ class Test_Defaults:
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        configuration = test_agent.wait_for_telemetry_configurations()
 
-        configuration_by_name = {item["name"]: item for item in configuration}
+        configuration_by_name = test_agent.wait_for_telemetry_configurations()
         for apm_telemetry_name, value in [
             ("trace_sample_rate", (1.0, None, "1.0")),
             ("logs_injection_enabled", ("false", False, "true", True)),
@@ -151,9 +150,8 @@ class Test_Consistent_Configs:
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        configuration = test_agent.wait_for_telemetry_configurations()
-        configuration_by_name = {item["name"]: item for item in configuration}
 
+        configuration_by_name = test_agent.wait_for_telemetry_configurations()
         # # Check that the tags name match the expected value
         assert configuration_by_name.get("DD_ENV", {}).get("value") == "dev"
         assert configuration_by_name.get("DD_SERVICE", {}).get("value") == "service_test"
@@ -187,9 +185,8 @@ class Test_Consistent_Configs:
     def test_library_settings_2(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        configuration = test_agent.wait_for_telemetry_configurations()
-        configuration_by_name = {item["name"]: item for item in configuration}
 
+        configuration_by_name = test_agent.wait_for_telemetry_configurations()
         assert configuration_by_name.get("DD_TRACE_LOG_DIRECTORY", {}).get("value") == "/some/temporary/directory"
         assert configuration_by_name.get("DD_TRACE_HTTP_CLIENT_ERROR_STATUSES", {}).get("value") == "200-250"
         assert configuration_by_name.get("DD_TRACE_HTTP_SERVER_ERROR_STATUSES", {}).get("value") == "250-200"
@@ -227,9 +224,8 @@ class Test_Environment:
     def test_library_settings(self, library_env, test_agent, test_library):
         with test_library.dd_start_span("test"):
             pass
-        configuration = test_agent.wait_for_telemetry_configurations()
 
-        configuration_by_name = {item["name"]: item for item in configuration}
+        configuration_by_name = test_agent.wait_for_telemetry_configurations()
         for apm_telemetry_name, environment_value in [
             ("trace_sample_rate", ("0.3", 0.3)),
             ("logs_injection_enabled", ("true", True)),
@@ -492,9 +488,8 @@ class Test_Stable_Configuration_Origin(StableConfigWriter):
             )
             test_library.container_restart()
             test_library.dd_start_span("test")
-        configuration_list = test_agent.wait_for_telemetry_configurations()
-        configuration = {c["name"]: c for c in configuration_list}
 
+        configuration = test_agent.wait_for_telemetry_configurations()
         for cfg_name, origin in expected_origin.items():
             apm_telemetry_name = _mapped_telemetry_name(context, cfg_name)
             telemetry_item = configuration[apm_telemetry_name]


### PR DESCRIPTION
## Motivation

Currently many tests expect configurations to be sent in the `app-started` telemetry payload. This isn't always the case. Configurations can be queued after application start and be sent in the app-configurations-change event.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
