### PR TITLE
Do not raise an internal error on deserialization error on 500 responses

### DIFF
--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -331,9 +331,15 @@ def deserialize(data, key, content, interface, export_content_files_to: str):
             data["path"], data[key], content, interface, key, export_content_files_to
         )
     except:
-        logger.exception(f"Error while deserializing {data['log_filename']}")
+        logger.exception(f"Error while deserializing {key} in {data['log_filename']}")
         data[key]["raw_content"] = str(content)
-        data[key]["traceback"] = str(traceback.format_exc())
+        if key == "response" and data[key]["status_code"] == 500:
+            # backend may respond 500, while giving application/x-protobuf as content-type
+            # deserialize_http_message() will fail, but it cannot be considered as an
+            # internal error, we only log it, and do not store anything in traceback
+            logger.exception(f"Error 500 in {data['log_filename']}")
+        else:
+            data[key]["traceback"] = str(traceback.format_exc())
 
 
 # if __name__ == "__main__":

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -331,14 +331,15 @@ def deserialize(data, key, content, interface, export_content_files_to: str):
             data["path"], data[key], content, interface, key, export_content_files_to
         )
     except:
-        logger.exception(f"Error while deserializing {key} in {data['log_filename']}")
-        data[key]["raw_content"] = str(content)
         if key == "response" and data[key]["status_code"] == 500:
             # backend may respond 500, while giving application/x-protobuf as content-type
             # deserialize_http_message() will fail, but it cannot be considered as an
             # internal error, we only log it, and do not store anything in traceback
-            logger.exception(f"Error 500 in {data['log_filename']}")
+            logger.exception(f"Error 500 in response in {data['log_filename']}, preventing deserialization")
+            data[key]["content"] = str(content)
         else:
+            logger.exception(f"Error while deserializing {key} in {data['log_filename']}")
+            data[key]["raw_content"] = str(content)
             data[key]["traceback"] = str(traceback.format_exc())
 
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
