### PR TITLE
Add test for `TRACE_EXTRACT_BEHAVIOR_FIRST` Span Id overrides

### DIFF
--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -512,6 +512,62 @@ class Test_ExtractBehavior_Restart:
         assert "_dd.p.tid=1111111111111111" not in data["request_headers"]["x-datadog-tags"]
         assert "key1=value1" in data["request_headers"]["baggage"]
 
+    def setup_multiple_tracecontexts_with_overrides(self):
+        self.r = weblog.get(
+            "/make_distant_call",
+            params={"url": "http://weblog:7777/"},
+            headers={
+                "x-datadog-trace-id": "1",
+                "x-datadog-parent-id": "1",
+                "x-datadog-sampling-priority": "2",
+                "x-datadog-tags": "_dd.p.tid=1111111111111111,_dd.p.dm=-4",
+                "traceparent": "00-11111111111111110000000000000001-1234567890123456-01",
+                "baggage": "key1=value1",
+            },
+        )
+
+    @missing_feature(
+        library="cpp",
+        reason="baggage is not implemented, also remove DD_TRACE_PROPAGATION_STYLE_EXTRACT workaround in containers.py",
+    )
+    def test_multiple_tracecontexts_with_overrides(self):
+        interfaces.library.assert_trace_exists(self.r)
+        spans = interfaces.agent.get_spans_list(self.r)
+        assert len(spans) == 1, "Agent received the incorrect amount of spans"
+
+        # Test the extracted span context
+        span = spans[0]
+        assert (
+            span.get("traceID") != "1"  # Lower 64-bits of traceparent
+        )
+        assert (
+            span.get("traceID") != "8687463697196027922"  # Lower 64-bits of traceparent
+        )
+        assert span.get("parentID") is None
+        assert "tracestate" not in span
+
+        # Test the extracted span links: One span link for the incoming (Datadog trace context).
+        # In the case that span links are generated for conflicting trace contexts, those span links
+        # are not included in the new trace context
+        span_links = retrieve_span_links(span)
+        assert len(span_links) == 1
+
+        # Assert the Datadog (restarted) span link
+        link = span_links[0]
+        assert int(link["traceID"]) == 1
+        assert int(link["spanID"]) == 1311768467284833366
+        assert int(link["traceIDHigh"]) == 1229782938247303441
+        assert link["attributes"] == {"reason": "propagation_behavior_extract", "context_headers": "datadog"}
+
+        # Test the next outbound span context
+        assert self.r.status_code == 200
+        data = json.loads(self.r.text)
+        assert data is not None
+
+        assert data["request_headers"]["x-datadog-trace-id"] != "1"
+        assert "_dd.p.tid=1111111111111111" not in data["request_headers"]["x-datadog-tags"]
+        assert "key1=value1" in data["request_headers"]["baggage"]
+
 
 @scenarios.tracing_config_nondefault_2
 @features.context_propagation_extract_behavior


### PR DESCRIPTION
## Motivation

Adding a test case for spanId overrides when `TRACE_EXTRACT_BEHAVIOR_FIRST=restart` and traceIds of DD and W3C headers match.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
