### PR TITLE
[dotnet] reactivate tests on default scenario

### DIFF
--- a/tests/appsec/iast/sink/test_command_injection.py
+++ b/tests/appsec/iast/sink/test_command_injection.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, missing_feature, features, rfc, weblog, flaky
+from utils import context, missing_feature, features, rfc, weblog
 from tests.appsec.iast.utils import BaseSinkTest, validate_extended_location_data, validate_stack_traces
 
 
@@ -23,7 +23,6 @@ class TestCommandInjection(BaseSinkTest):
 
     @missing_feature(library="nodejs", reason="Endpoint not implemented")
     @missing_feature(library="java", reason="Endpoint not implemented")
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
     def test_secure(self):
         super().test_secure()
 

--- a/tests/appsec/iast/sink/test_email_html_injection.py
+++ b/tests/appsec/iast/sink/test_email_html_injection.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import missing_feature, features, weblog, rfc, flaky, context
+from utils import missing_feature, features, weblog, rfc
 from tests.appsec.iast.utils import BaseSinkTest, validate_extended_location_data, validate_stack_traces
 
 
@@ -20,10 +20,6 @@ class TestEmailHtmlInjection(BaseSinkTest):
     @missing_feature(library="dotnet", reason="Not implemented yet")
     def test_telemetry_metric_instrumented_sink(self):
         super().test_telemetry_metric_instrumented_sink()
-
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
-    def test_secure(self):
-        return super().test_secure()
 
 
 @rfc(

--- a/tests/appsec/iast/sink/test_header_injection.py
+++ b/tests/appsec/iast/sink/test_header_injection.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, features, missing_feature, rfc, weblog, flaky
+from utils import context, features, missing_feature, rfc, weblog
 from tests.appsec.iast.utils import (
     BaseSinkTest,
     validate_extended_location_data,
@@ -72,10 +72,6 @@ class TestHeaderInjection(BaseSinkTest):
     @missing_feature(context.library < "java@1.22.0", reason="Metrics not implemented")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
-
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
-    def test_secure(self):
-        return super().test_secure()
 
 
 @rfc(

--- a/tests/appsec/iast/sink/test_insecure_auth_protocol.py
+++ b/tests/appsec/iast/sink/test_insecure_auth_protocol.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import missing_feature, features, rfc, weblog, context, flaky
+from utils import missing_feature, features, rfc, weblog
 from tests.appsec.iast.utils import BaseSinkTest, validate_extended_location_data, validate_stack_traces
 
 
@@ -27,10 +27,6 @@ class Test_InsecureAuthProtocol(BaseSinkTest):
     @missing_feature(library="java", reason="Not implemented yet")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
-
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
-    def test_secure(self):
-        super().test_secure()
 
 
 @rfc(

--- a/tests/appsec/iast/sink/test_insecure_cookie.py
+++ b/tests/appsec/iast/sink/test_insecure_cookie.py
@@ -31,7 +31,6 @@ class TestInsecureCookie(BaseSinkTest):
     def setup_empty_cookie(self):
         self.request_empty_cookie = weblog.get("/iast/insecure-cookie/test_empty_cookie", data={})
 
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
     def test_empty_cookie(self):
         self.assert_no_iast_event(self.request_empty_cookie)
 

--- a/tests/appsec/iast/sink/test_ldap_injection.py
+++ b/tests/appsec/iast/sink/test_ldap_injection.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, missing_feature, features, rfc, weblog, flaky
+from utils import context, missing_feature, features, rfc, weblog
 from tests.appsec.iast.utils import BaseSinkTest, validate_extended_location_data, validate_stack_traces
 
 
@@ -28,10 +28,6 @@ class TestLDAPInjection(BaseSinkTest):
     @missing_feature(context.library < "java@1.11.0", reason="Metrics not implemented")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
-
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
-    def test_secure(self):
-        return super().test_secure()
 
 
 @rfc(

--- a/tests/appsec/iast/sink/test_no_httponly_cookie.py
+++ b/tests/appsec/iast/sink/test_no_httponly_cookie.py
@@ -24,7 +24,6 @@ class TestNoHttponlyCookie(BaseSinkTest):
         "nodejs": {"express4": "iast/index.js", "express4-typescript": "iast.ts", "express5": "iast/index.js"}
     }
 
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
     @bug(context.library < "java@1.18.3", reason="APMRP-360")
     def test_secure(self):
         super().test_secure()
@@ -32,7 +31,6 @@ class TestNoHttponlyCookie(BaseSinkTest):
     def setup_empty_cookie(self):
         self.request_empty_cookie = weblog.get("/iast/no-httponly-cookie/test_empty_cookie", data={})
 
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
     def test_empty_cookie(self):
         self.assert_no_iast_event(self.request_empty_cookie)
 

--- a/tests/appsec/iast/sink/test_no_samesite_cookie.py
+++ b/tests/appsec/iast/sink/test_no_samesite_cookie.py
@@ -25,14 +25,12 @@ class TestNoSamesiteCookie(BaseSinkTest):
     }
 
     @bug(context.library < "java@1.18.3", reason="APMRP-360")
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
     def test_secure(self):
         super().test_secure()
 
     def setup_empty_cookie(self):
         self.request_empty_cookie = weblog.get("/iast/no-samesite-cookie/test_empty_cookie", data={})
 
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
     def test_empty_cookie(self):
         self.assert_no_iast_event(self.request_empty_cookie)
 

--- a/tests/appsec/iast/sink/test_reflection_injection.py
+++ b/tests/appsec/iast/sink/test_reflection_injection.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import missing_feature, features, rfc, weblog, flaky, context
+from utils import missing_feature, features, rfc, weblog
 from tests.appsec.iast.utils import BaseSinkTest, validate_extended_location_data, validate_stack_traces
 
 
@@ -23,10 +23,6 @@ class TestReflectionInjection(BaseSinkTest):
 
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
-
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
-    def test_secure(self):
-        super().test_secure()
 
 
 @rfc(

--- a/tests/appsec/iast/sink/test_sql_injection.py
+++ b/tests/appsec/iast/sink/test_sql_injection.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, missing_feature, features, bug, rfc, weblog, flaky
+from utils import context, missing_feature, features, bug, rfc, weblog
 from tests.appsec.iast.utils import BaseSinkTest, validate_extended_location_data, validate_stack_traces
 
 
@@ -38,7 +38,6 @@ class TestSqlInjection(BaseSinkTest):
         super().test_telemetry_metric_executed_sink()
 
     @missing_feature(context.weblog_variant == "jersey-grizzly2", reason="Endpoint responds 500")
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
     def test_secure(self):
         super().test_secure()
 

--- a/tests/appsec/iast/sink/test_ssrf.py
+++ b/tests/appsec/iast/sink/test_ssrf.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import bug, context, missing_feature, features, rfc, weblog, flaky
+from utils import bug, context, missing_feature, features, rfc, weblog
 from tests.appsec.iast.utils import BaseSinkTest, validate_extended_location_data, validate_stack_traces
 
 
@@ -27,7 +27,6 @@ class TestSSRF(BaseSinkTest):
 
     @missing_feature(library="nodejs", reason="Endpoint not implemented")
     @missing_feature(library="java", reason="Endpoint not implemented")
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
     def test_secure(self):
         super().test_secure()
 

--- a/tests/appsec/iast/sink/test_trust_boundary_violation.py
+++ b/tests/appsec/iast/sink/test_trust_boundary_violation.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, missing_feature, features, rfc, weblog, flaky
+from utils import context, missing_feature, features, rfc, weblog
 from tests.appsec.iast.utils import BaseSinkTest, validate_extended_location_data, validate_stack_traces
 
 
@@ -26,10 +26,6 @@ class Test_TrustBoundaryViolation(BaseSinkTest):
     @missing_feature(context.library < "java@1.22.0", reason="Metrics not implemented")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
-
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
-    def test_secure(self):
-        super().test_secure()
 
 
 @rfc(

--- a/tests/appsec/iast/sink/test_unvalidated_redirect.py
+++ b/tests/appsec/iast/sink/test_unvalidated_redirect.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, irrelevant, features, missing_feature, rfc, weblog, flaky
+from utils import context, irrelevant, features, missing_feature, rfc, weblog
 from tests.appsec.iast.utils import BaseSinkTestWithoutTelemetry, validate_extended_location_data, validate_stack_traces
 
 
@@ -66,7 +66,6 @@ class TestUnvalidatedHeader(BaseSinkTestWithoutTelemetry):
     @missing_feature(context.weblog_variant == "jersey-grizzly2", reason="Endpoint responds 405")
     @missing_feature(context.weblog_variant == "resteasy-netty3", reason="Endpoint responds 405")
     @missing_feature(context.weblog_variant == "vertx3", reason="Endpoint responds 403")
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
     def test_secure(self):
         return super().test_secure()
 

--- a/tests/appsec/iast/sink/test_weak_cipher.py
+++ b/tests/appsec/iast/sink/test_weak_cipher.py
@@ -21,7 +21,6 @@ class TestWeakCipher(BaseSinkTest):
     evidence_map = {"nodejs": "des-ede-cbc", "java": "Blowfish"}
 
     @flaky(context.library == "dotnet@3.3.1", reason="APMRP-360")
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
     def test_secure(self):
         super().test_secure()
 

--- a/tests/appsec/iast/sink/test_weak_hash.py
+++ b/tests/appsec/iast/sink/test_weak_hash.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import weblog, context, missing_feature, features, rfc, scenarios, flaky
+from utils import weblog, context, missing_feature, features, rfc, scenarios
 from tests.appsec.iast.utils import (
     BaseSinkTest,
     assert_iast_vulnerability,
@@ -60,10 +60,6 @@ class TestWeakHash(BaseSinkTest):
     @missing_feature(context.library < "dotnet@2.38.0", reason="Not implemented yet")
     def test_telemetry_metric_executed_sink(self):
         super().test_telemetry_metric_executed_sink()
-
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
-    def test_secure(self):
-        return super().test_secure()
 
 
 @rfc(

--- a/tests/appsec/iast/sink/test_xpath_injection.py
+++ b/tests/appsec/iast/sink/test_xpath_injection.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import features, weblog, rfc, context, flaky
+from utils import features, weblog, rfc
 from tests.appsec.iast.utils import BaseSinkTestWithoutTelemetry, validate_extended_location_data, validate_stack_traces
 
 
@@ -16,10 +16,6 @@ class TestXPathInjection(BaseSinkTestWithoutTelemetry):
     secure_endpoint = "/iast/xpathi/test_secure"
     data = {"expression": "expression"}
     location_map = {"java": "com.datadoghq.system_tests.iast.utils.XPathExamples"}
-
-    @flaky(context.library >= "dotnet@3.11.1", reason="APPSEC-56908")
-    def test_secure(self):
-        super().test_secure()
 
 
 @rfc(

--- a/tests/integrations/test_dbm.py
+++ b/tests/integrations/test_dbm.py
@@ -105,7 +105,7 @@ class Test_Dbm:
     setup_trace_payload_service = weblog_trace_payload
 
     @scenarios.default
-    @flaky(context.library >= "dotnet@2.54.0", reason="APMAPI-930")
+    # @flaky(context.library >= "dotnet@2.54.0", reason="APMAPI-930")
     def test_trace_payload_service(self):
         assert self.requests, "No requests to validate"
         self._assert_spans_are_untagged()


### PR DESCRIPTION
## Motivation

Follow up of #4291 

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
