### PR TITLE
K8s lib injection: Use gitlab docker_in_docker runners

### DIFF
--- a/.gitlab/ssi_gitlab-ci.yml
+++ b/.gitlab/ssi_gitlab-ci.yml
@@ -112,7 +112,7 @@ ssi_tests:
 
 .k8s_lib_injection_base:
   image: registry.ddbuild.io/ci/libdatadog-build/system-tests:57161036
-  tags: [ "runner:docker" ]
+  tags: ["docker-in-docker:amd64"]
   needs: []
   stage: K8S_LIB_INJECTION
   allow_failure: false


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Use new docker_in_docker runner on k8s lib injection

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
