### PR TITLE
Change request blocking scenario for ATO

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -245,6 +245,9 @@ jobs:
     - name: Run APPSEC_REQUEST_BLOCKING scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"APPSEC_REQUEST_BLOCKING"')
       run: ./run.sh APPSEC_REQUEST_BLOCKING
+    - name: Run APPSEC_AND_RC_ENABLED scenario
+      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"APPSEC_AND_RC_ENABLED"')
+      run: ./run.sh APPSEC_AND_RC_ENABLED
     - name: Run APPSEC_RUNTIME_ACTIVATION scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"APPSEC_RUNTIME_ACTIVATION"')
       run: ./run.sh APPSEC_RUNTIME_ACTIVATION

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -1968,25 +1968,25 @@ BLOCK_USER_LOGIN = (
 
 @rfc("https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw")
 @features.user_monitoring
-@scenarios.appsec_runtime_activation
+@scenarios.appsec_and_rc_enabled
 class Test_V3_Login_Events_Blocking:
     def setup_login_event_blocking_auto_id(self):
         rc.rc_state.reset().apply()
 
-        self.config_state_1 = rc.rc_state.set_config(*CONFIG_ENABLED).apply()
         self.r_login = weblog.post("/login?auth=local", data=login_data(context, USER, PASSWORD))
 
-        self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER_RULE).apply()
-        self.config_state_3 = rc.rc_state.set_config(*BLOCK_USER_ID).apply()
+        self.config_state_1 = rc.rc_state.set_config(*BLOCK_USER_RULE).apply()
+        self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER_ID).apply()
+
         self.r_login_blocked = weblog.post("/login?auth=local", data=login_data(context, USER, PASSWORD))
 
     @irrelevant(context.library == "java", reason="Blocking by user ID not available in java")
     def test_login_event_blocking_auto_id(self):
-        assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
         assert self.r_login.status_code == 200
 
+        assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
         assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
-        assert self.config_state_3[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+
         if context.library not in libs_without_user_id:
             interfaces.library.assert_waf_attack(self.r_login_blocked, rule="block-user-id")
             assert self.r_login_blocked.status_code == 403
@@ -1994,26 +1994,25 @@ class Test_V3_Login_Events_Blocking:
     def setup_login_event_blocking_auto_login(self):
         rc.rc_state.reset().apply()
 
-        self.config_state_1 = rc.rc_state.set_config(*CONFIG_ENABLED).apply()
         self.r_login = weblog.post("/login?auth=local", data=login_data(context, USER, PASSWORD))
 
-        self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER_RULE).apply()
-        self.config_state_3 = rc.rc_state.set_config(*BLOCK_USER_LOGIN).apply()
+        self.config_state_1 = rc.rc_state.set_config(*BLOCK_USER_RULE).apply()
+        self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER_LOGIN).apply()
+
         self.r_login_blocked = weblog.post("/login?auth=local", data=login_data(context, USER, PASSWORD))
 
     def test_login_event_blocking_auto_login(self):
-        assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
         assert self.r_login.status_code == 200
 
+        assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
         assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
-        assert self.config_state_3[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+
         interfaces.library.assert_waf_attack(self.r_login_blocked, rule="block-user-login")
         assert self.r_login_blocked.status_code == 403
 
     def setup_login_event_blocking_sdk(self):
         rc.rc_state.reset().apply()
 
-        self.config_state_1 = rc.rc_state.set_config(*CONFIG_ENABLED).apply()
         self.r_login = [
             weblog.post(
                 f"/login?auth=local&sdk_trigger={trigger}&sdk_event=success&sdk_user=sdkUser",
@@ -2022,8 +2021,9 @@ class Test_V3_Login_Events_Blocking:
             for trigger in SDK_TRIGGERS
         ]
 
-        self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER_RULE).apply()
-        self.config_state_3 = rc.rc_state.set_config(*BLOCK_USER_ID).apply()
+        self.config_state_1 = rc.rc_state.set_config(*BLOCK_USER_RULE).apply()
+        self.config_state_2 = rc.rc_state.set_config(*BLOCK_USER_ID).apply()
+
         self.r_login_blocked = [
             weblog.post(
                 f"/login?auth=local&sdk_trigger={trigger}&sdk_event=success&sdk_user=sdkUser",
@@ -2033,12 +2033,12 @@ class Test_V3_Login_Events_Blocking:
         ]
 
     def test_login_event_blocking_sdk(self):
-        assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
         for request in self.r_login:
             assert request.status_code == 200
 
+        assert self.config_state_1[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
         assert self.config_state_2[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
-        assert self.config_state_3[rc.RC_STATE] == rc.ApplyState.ACKNOWLEDGED
+
         for request in self.r_login_blocked:
             interfaces.library.assert_waf_attack(request, rule="block-user-id")
             assert request.status_code == 403

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -249,6 +249,21 @@ class _Scenarios:
         scenario_groups=[ScenarioGroup.APPSEC],
     )
 
+    appsec_and_rc_enabled = EndToEndScenario(
+        "APPSEC_AND_RC_ENABLED",
+        rc_api_enabled=True,
+        appsec_enabled=True,
+        iast_enabled=False,
+        weblog_env={"DD_APPSEC_WAF_TIMEOUT": "10000000", "DD_APPSEC_TRACE_RATE_LIMIT": "10000"},  # 10 seconds
+        doc="""
+            A scenario with AppSec and Remote Config enabled. In addition WAF and
+            tracer are configured to have bigger threshold.
+            This scenario should be used in most of the cases if you need
+            Remote Config and AppSec working for all libraries.
+        """,
+        scenario_groups=[ScenarioGroup.APPSEC],
+    )
+
     appsec_runtime_activation = EndToEndScenario(
         "APPSEC_RUNTIME_ACTIVATION",
         rc_api_enabled=True,


### PR DESCRIPTION
## Motivation

In the current setup in the request blocking for automated user events we use runtime activation scenario which requires 1-click activation. First of all, it's a mix of two tests - 1-click activation and request blocking. Second - in Ruby we don't support yet 1-click activation.

## Changes

Change runtime activation scenario to request blocking

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
