### PR TITLE
Exclude otel from system-tests CI

### DIFF
--- a/.github/workflows/compute-impacted-libraries.yml
+++ b/.github/workflows/compute-impacted-libraries.yml
@@ -38,13 +38,17 @@ jobs:
           libraries = "cpp|dotnet|golang|java|nodejs|php|python|ruby|java_otel|python_otel|nodejs_otel"
           result = set()
 
+          # do not include otel in system-tests CI by default, as the staging backend is not stable enough
+          # all_libraries = {"cpp", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby", "java_otel", "python_otel", "nodejs_otel"}
+          all_libraries = {"cpp", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby"}
+
           if github_context["ref"] == "refs/heads/main":
               print("Merge commit to main => run all libraries")
-              result |= {"cpp", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby", "java_otel", "python_otel", "nodejs_otel"}
+              result |= all_libraries
 
           elif github_context["event_name"] == "schedule":
               print("Scheduled job => run all libraries")
-              result |= {"cpp", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby", "java_otel", "python_otel", "nodejs_otel"}
+              result |= all_libraries
 
           else:
               pr_title = github_context["event"]["pull_request"]["title"].lower()
@@ -71,7 +75,7 @@ jobs:
 
                       if not manifest_match and not weblog_match and not injection_match:
                           print(f"{file} may impact any library => run all of them")
-                          result |= {"cpp", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby", "java_otel", "python_otel", "nodejs_otel"}
+                          result |= all_libraries
                           break
 
           populated_result = [


### PR DESCRIPTION
## Motivation

otel scenario relies on staging backend, but this backend is not stable enough to have usable results.
Turns out that those scenarios are ran manually, which leads to unecessary friction on system-tests CI, with failures with no actionnables.

=> Remove then from the CI until they are included in the CI owned by the team owning this product.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
