### PR TITLE
[php] add http.route to tag_value

### DIFF
--- a/tests/appsec/api_security/test_api_security_rc.py
+++ b/tests/appsec/api_security/test_api_security_rc.py
@@ -8,10 +8,7 @@ from utils import (
     scenarios,
     weblog,
     features,
-    bug,
-    context,
 )
-from utils.tools import logger
 from tests.appsec.api_security.utils import BaseAppsecApiSecurityRcTest
 
 
@@ -19,20 +16,15 @@ def get_schema(request, address):
     """Get api security schema from spans"""
     for _, _, span in interfaces.library.get_spans(request):
         meta = span.get("meta", {})
-        key = "_dd.appsec.s." + address
-        payload = meta.get(key)
+        payload = meta.get("_dd.appsec.s." + address)
         if payload is not None:
             return payload
-        else:
-            logger.info(f"Schema not found in span meta for {key}")
-
     return None
 
 
 @rfc("https://docs.google.com/document/d/1Ig5lna4l57-tJLMnC76noGFJaIHvudfYXdZYKz6gXUo/edit#heading=h.88xvn2cvs9dt")
 @scenarios.appsec_api_security_rc
 @features.api_security_configuration
-@bug(context.library > "php@1.7.2", reason="APPSEC-57006")
 class Test_API_Security_RC_ASM_DD_processors(BaseAppsecApiSecurityRcTest):
     """Test API Security - Remote config ASM_DD - processors"""
 
@@ -53,7 +45,6 @@ class Test_API_Security_RC_ASM_DD_processors(BaseAppsecApiSecurityRcTest):
 @rfc("https://docs.google.com/document/d/1Ig5lna4l57-tJLMnC76noGFJaIHvudfYXdZYKz6gXUo/edit#heading=h.88xvn2cvs9dt")
 @scenarios.appsec_api_security_rc
 @features.api_security_configuration
-@bug(context.library > "php@1.7.2", reason="APPSEC-57006")
 class Test_API_Security_RC_ASM_DD_scanners(BaseAppsecApiSecurityRcTest):
     """Test API Security - Remote config ASM_DD - scanners"""
 

--- a/tests/appsec/api_security/test_api_security_rc.py
+++ b/tests/appsec/api_security/test_api_security_rc.py
@@ -9,6 +9,7 @@ from utils import (
     weblog,
     features,
 )
+from utils.tools import logger
 from tests.appsec.api_security.utils import BaseAppsecApiSecurityRcTest
 
 
@@ -16,9 +17,13 @@ def get_schema(request, address):
     """Get api security schema from spans"""
     for _, _, span in interfaces.library.get_spans(request):
         meta = span.get("meta", {})
-        payload = meta.get("_dd.appsec.s." + address)
+        key = "_dd.appsec.s." + address
+        payload = meta.get(key)
         if payload is not None:
             return payload
+        else:
+            logger.info(f"Schema not found in span meta for {key}")
+
     return None
 
 

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -11,13 +11,17 @@ from utils import (
     weblog,
     features,
 )
+from utils.tools import logger
 
 
 def get_schema(request, address):
     """Get api security schema from spans"""
     span = interfaces.library.get_root_span(request)
     meta = span.get("meta", {})
-    return meta.get("_dd.appsec.s." + address)
+    key = "_dd.appsec.s." + address
+    if key not in meta:
+        logger.info(f"Schema not found in span meta for {key}")
+    return meta.get(key)
 
 
 # can be used to match any value in a schema

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -10,19 +10,14 @@ from utils import (
     scenarios,
     weblog,
     features,
-    bug,
 )
-from utils.tools import logger
 
 
 def get_schema(request, address):
     """Get api security schema from spans"""
     span = interfaces.library.get_root_span(request)
     meta = span.get("meta", {})
-    key = "_dd.appsec.s." + address
-    if key not in meta:
-        logger.info(f"Schema not found in span meta for {key}")
-    return meta.get(key)
+    return meta.get("_dd.appsec.s." + address)
 
 
 # can be used to match any value in a schema
@@ -54,7 +49,6 @@ def equal_value(t1, t2):
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@bug(context.library > "php@1.7.2", reason="APPSEC-57006")
 class Test_Schema_Request_Headers:
     """Test API Security - Request Headers Schema"""
 
@@ -75,7 +69,6 @@ class Test_Schema_Request_Headers:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@bug(context.library > "php@1.7.2", reason="APPSEC-57006")
 class Test_Schema_Request_Cookies:
     """Test API Security - Request Cookies Schema"""
 
@@ -99,7 +92,6 @@ class Test_Schema_Request_Cookies:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@bug(context.library > "php@1.7.2", reason="APPSEC-57006")
 class Test_Schema_Request_Query_Parameters:
     """Test API Security - Request Query Parameters Schema"""
 
@@ -141,7 +133,6 @@ class Test_Schema_Request_Path_Parameters:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@bug(context.library > "php@1.7.2", reason="APPSEC-57006")
 class Test_Schema_Request_Json_Body:
     """Test API Security - Request Body and list length"""
 
@@ -162,7 +153,6 @@ class Test_Schema_Request_Json_Body:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@bug(context.library > "php@1.7.2", reason="APPSEC-57006")
 class Test_Schema_Request_FormUrlEncoded_Body:
     """Test API Security - Request Body and list length"""
 
@@ -203,7 +193,6 @@ class Test_Schema_Request_FormUrlEncoded_Body:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@bug(context.library > "php@1.7.2", reason="APPSEC-57006")
 class Test_Schema_Response_Headers:
     """Test API Security - Response Header Schema"""
 
@@ -223,7 +212,6 @@ class Test_Schema_Response_Headers:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security
 @features.api_security_schemas
-@bug(context.library > "php@1.7.2", reason="APPSEC-57006")
 class Test_Schema_Response_Body:
     """Test API Security - Response Body Schema with urlencoded body"""
 
@@ -250,7 +238,6 @@ class Test_Schema_Response_Body:
 @rfc("https://docs.google.com/document/d/1OCHPBCAErOL2FhLl64YAHB8woDyq66y5t-JGolxdf1Q/edit#heading=h.bth088vsbjrz")
 @scenarios.appsec_api_security_no_response_body
 @features.api_security_schemas
-@bug(context.library > "php@1.7.2", reason="APPSEC-57006")
 class Test_Schema_Response_Body_env_var:
     """Test API Security - Response Body Schema with urlencoded body and env var disabling response body parsing
     Check that response headers are still parsed but not response body

--- a/utils/build/docker/php/common/php.ini
+++ b/utils/build/docker/php/common/php.ini
@@ -16,6 +16,7 @@ error_reporting=2147483647
 display_errors=0
 
 datadog.appsec.log_file=/var/log/system-tests/appsec.log
+;datadog.appsec.log_level=debug
 ; will be overridden
 datadog.appsec.helper_path=/usr/local/lib/libddappsec-helper.so
 datadog.appsec.helper_socket_path=/tmp/ddappsec.sock

--- a/utils/build/docker/php/common/tag_value.php
+++ b/utils/build/docker/php/common/tag_value.php
@@ -11,6 +11,10 @@ if (count($uri) < 4) {
 	error();
 }
 
+
+$rootSpan = \DDTrace\root_span();
+$rootSpan->meta["http.route"] = '/tag_value/{tag_value}/{status_code}';
+
 $value = $uri[2];
 $response_code= strtok($uri[3], '?'); //There can be url parameters. Lets remove them
 


### PR DESCRIPTION
## Motivation

Otherwise nothing is collected for the appsec api security.

If other php files are hit during these tests, then similar code needs to be added to them.

This suffices for the APPSEC_API_SECURITY and APPSEC_API_SECURITY_RC.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
