### PR TITLE
[python] enable session blocking tests for Django

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -486,7 +486,11 @@ tests/:
       Test_V3_Login_Events_Blocking: v2.20.0.dev
       Test_V3_Login_Events_RC: v2.11.0
     test_automated_user_and_session_tracking.py:
-      Test_Automated_Session_Blocking: missing_feature
+      Test_Automated_Session_Blocking:
+        '*': missing_feature (no auto instrumentation for session on non Django weblogs)
+        django-poc: v3.3.0.dev
+        django-py3.13: v3.3.0.dev
+        python3.12: v3.3.0.dev
       Test_Automated_User_Blocking: v3.0.0.rc
       Test_Automated_User_Tracking: v3.1.0.dev
     test_blocking_addresses.py:

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -786,9 +786,9 @@ MAGIC_SESSION_KEY = "random_session_id"
 
 
 def session_new(request):
-    response = HttpResponse("OK")
-    response.set_cookie("session_id", MAGIC_SESSION_KEY)
-    return response
+    request.session.save()
+    session_id = request.session.session_key
+    return HttpResponse(session_id)
 
 
 def session_user(request):


### PR DESCRIPTION
After the merge of https://github.com/DataDog/dd-trace-py/pull/12760
- update relevant endpoint of Django
- enable relevant test for all Django weblogs

APPSEC-57027

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
