### PR TITLE
Span Events: Add .NET system tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -491,7 +491,7 @@ tests/:
       Test_Parametric_Otel_Baggage: incomplete_test_app (otel baggage endpoints are not implemented)
       Test_Parametric_Otel_Current_Span: incomplete_test_app (otel current span endpoint are not implemented)
     test_process_discovery.py: missing_feature
-    test_span_events.py: missing_feature
+    # test_span_events.py: missing_feature
     test_span_links.py: missing_feature
     test_telemetry.py:
       Test_Consistent_Configs: missing_feature
@@ -597,7 +597,6 @@ tests/:
     Test_UrlQuery: v2.13.0
   test_semantic_conventions.py:
     Test_MetricsStandardTags: v2.6.0
-  test_span_events.py: incomplete_test_app (Weblog `/add_event` not implemented)
   test_standard_tags.py:
     Test_StandardTagsClientIp: v2.26.0
     Test_StandardTagsMethod: v2.0.0

--- a/utils/build/docker/dotnet/weblog/Endpoints/AddEventEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/AddEventEndpoint.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Datadog.Trace;
+using System.Collections.Generic;
+
+namespace weblog
+{
+    public class AddEventEndpoint : ISystemTestEndpoint
+    {
+        public void Register(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder routeBuilder)
+        {
+            routeBuilder.MapGet("/add_event", async context =>
+            {
+                var span = Tracer.Instance.ActiveScope?.Span;
+                if (span != null)
+                {
+                    var attributes = new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>("string", "value"),
+                        new KeyValuePair<string, string>("int", "1")
+                    };
+                    var spanEvent = new SpanEvent("span.event", null, attributes);
+                    span.AddEvent(spanEvent);
+                }
+
+                await context.Response.WriteAsync("Event added");
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Changes

Depends on https://github.com/DataDog/dd-trace-dotnet/pull/6769

Add the .NET implementation to parametric tests and weblog for testing APM span events.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
