### PR TITLE
Add new test for waf init failure telemetry tag

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -341,6 +341,7 @@ tests/:
     test_client_ip.py:
       Test_StandardTagsClientIp: v2.20.0
     test_customconf.py:
+      Test_CorruptedRules_Telemetry: missing_feature
       Test_NoLimitOnWafRules: v2.4.4
     test_event_tracking.py:
       Test_CustomEvent: v2.27.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -401,6 +401,7 @@ tests/:
     test_client_ip.py:
       Test_StandardTagsClientIp: v1.44.1
     test_customconf.py:
+      Test_CorruptedRules_Telemetry: missing_feature
       Test_NoLimitOnWafRules: v1.37.0
     test_event_tracking.py:
       Test_CustomEvent: v1.47.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1378,6 +1378,7 @@ tests/:
         akka-http: v1.22.0
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      Test_CorruptedRules_Telemetry: missing_feature
       Test_MissingRules:
         '*': v0.93.0
         akka-http: v1.22.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -687,6 +687,7 @@ tests/:
       Test_ConfigurationVariables: v2.7.0
     test_customconf.py:
       Test_ConfRuleSet: v2.0.0
+      Test_CorruptedRules_Telemetry: missing_feature
       Test_MissingRules: v2.0.0
       Test_NoLimitOnWafRules: v2.4.0
     test_event_tracking.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -329,6 +329,8 @@ tests/:
       Test_Suspicious_Request_Blocking: v1.6.2
     test_client_ip.py:
       Test_StandardTagsClientIp: v0.81.0
+    test_customconf.py:
+      Test_CorruptedRules_Telemetry: missing_feature
     test_fingerprinting.py:
       Test_Fingerprinting_Endpoint: v1.6.2
       Test_Fingerprinting_Endpoint_Capability: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -564,6 +564,7 @@ tests/:
         fastapi: v2.4.0
     test_customconf.py:
       Test_ConfRuleSet: v1.1.0-rc2
+      Test_CorruptedRules_Telemetry: missing_feature
       Test_NoLimitOnWafRules: v1.1.0-rc2
     test_event_tracking.py:
       Test_CustomEvent: v1.10.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -344,6 +344,7 @@ tests/:
     test_customconf.py:
       Test_ConfRuleSet: v1.0.0.beta2
       Test_CorruptedRules: v1.0.0.beta2
+      Test_CorruptedRules_Telemetry: missing_feature
       Test_MissingRules: v1.0.0.beta2
       Test_NoLimitOnWafRules: v1.0.0.beta2
     test_event_tracking.py:

--- a/tests/appsec/appsec_corrupted_rules.json
+++ b/tests/appsec/appsec_corrupted_rules.json
@@ -1,1 +1,3 @@
-corrupted::data
+{
+  "corrupted": "data"
+}

--- a/tests/appsec/test_customconf.py
+++ b/tests/appsec/test_customconf.py
@@ -2,6 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
+from tests.appsec.utils import find_series
 from utils import weblog, context, interfaces, scenarios, features
 
 
@@ -23,6 +24,27 @@ class Test_CorruptedRules:
             assert r.status_code == 200
             # Appsec does not catch any attack
             interfaces.library.assert_no_appsec_event(r)
+
+
+@scenarios.appsec_corrupted_rules
+@features.threats_configuration
+class Test_CorruptedRules_Telemetry:
+    """Report telemetry when rules file is corrupted"""
+
+    def setup_waf_init_and_config_errors_tags(self):
+        self.r_1 = weblog.get("/", headers={"User-Agent": "Arachni/v1"})
+        self.r_2 = weblog.get("/waf", params={"attack": "<script>"})
+
+    def test_waf_init_and_config_errors_tags(self):
+        waf_init_series = find_series("generate-metrics", "appsec", ["waf.init"])
+        waf_init_metric = [
+            d for d in waf_init_series if "event_rules_version:unknown" in d["tags"] and "success:false" in d["tags"]
+        ]
+        assert waf_init_metric, "waf.init missing 'success:false' or 'event_rules_version:unknown' tag"
+
+        waf_config_errors_series = find_series("generate-metrics", "appsec", ["waf.config_errors"])
+        waf_config_errors_metric = [d for d in waf_config_errors_series if "event_rules_version:unknown" in d["tags"]]
+        assert waf_config_errors_metric, "waf.config_errors missing 'event_rules_version:unknown' tag"
 
 
 @scenarios.appsec_missing_rules

--- a/tests/appsec/utils.py
+++ b/tests/appsec/utils.py
@@ -3,6 +3,20 @@ from utils import remote_config
 from utils.dd_constants import RemoteConfigApplyState
 
 
+def find_series(request_type, namespace, metrics):
+    series = []
+    for data in interfaces.library.get_telemetry_data():
+        content = data["request"]["content"]
+        if content.get("request_type") != request_type:
+            continue
+        fallback_namespace = content["payload"].get("namespace")
+        for serie in content["payload"]["series"]:
+            computed_namespace = serie.get("namespace", fallback_namespace)
+            if computed_namespace == namespace and serie["metric"] in metrics:
+                series.append(serie)
+    return series
+
+
 class BaseFullDenyListTest:
     states = None
 

--- a/tests/appsec/waf/test_truncation.py
+++ b/tests/appsec/waf/test_truncation.py
@@ -1,4 +1,5 @@
 import json
+from tests.appsec.utils import find_series
 from utils import weblog, rfc, features, interfaces
 
 
@@ -12,19 +13,6 @@ def create_nested_object(n, obj):
 @features.appsec_truncation_action
 class Test_Truncation:
     """Test WAF truncation"""
-
-    def _find_series(self, request_type, namespace, metrics):
-        series = []
-        for data in interfaces.library.get_telemetry_data():
-            content = data["request"]["content"]
-            if content.get("request_type") != request_type:
-                continue
-            fallback_namespace = content["payload"].get("namespace")
-            for serie in content["payload"]["series"]:
-                computed_namespace = serie.get("namespace", fallback_namespace)
-                if computed_namespace == namespace and serie["metric"] in metrics:
-                    series.append(serie)
-        return series
 
     def setup_truncation(self):
         # Create complex data
@@ -51,7 +39,7 @@ class Test_Truncation:
         assert int(metrics["_dd.appsec.truncated.container_size"]) == 300
         assert int(metrics["_dd.appsec.truncated.container_depth"]) == 20
 
-        waf_requests_series = self._find_series("generate-metrics", "appsec", ["waf.requests"])
+        waf_requests_series = find_series("generate-metrics", "appsec", ["waf.requests"])
         has_input_truncated = any("input_truncated:true" in series["tags"] for series in waf_requests_series)
         assert has_input_truncated, "Expected at least one serie to have input_truncated:true tag"
 
@@ -61,7 +49,7 @@ class Test_Truncation:
         )
         assert all_have_input_truncated_tag, "Expected all series to have input_truncated tag"
 
-        count_series = self._find_series("generate-metrics", "appsec", ["waf.input_truncated"])
+        count_series = find_series("generate-metrics", "appsec", ["waf.input_truncated"])
         input_truncated = count_series[0] if count_series else None
 
         assert input_truncated is not None, "No telemetry data received for metric appsec.waf.input_truncated"
@@ -69,7 +57,7 @@ class Test_Truncation:
         assert input_truncated["type"] == "count"
         assert "truncation_reason:7" in input_truncated["tags"]
 
-        distribution_series = self._find_series("distributions", "appsec", ["waf.truncated_value_size"])
+        distribution_series = find_series("distributions", "appsec", ["waf.truncated_value_size"])
 
         assert (
             len(distribution_series) == 3

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -144,7 +144,7 @@ class _Scenarios:
     )
     appsec_corrupted_rules = EndToEndScenario(
         "APPSEC_CORRUPTED_RULES",
-        weblog_env={"DD_APPSEC_RULES": "/appsec_corrupted_rules.yml"},
+        weblog_env={"DD_APPSEC_RULES": "/appsec_corrupted_rules.json"},
         weblog_volumes={
             "./tests/appsec/appsec_corrupted_rules.json": {"bind": "/appsec_corrupted_rules.json", "mode": "ro"}
         },


### PR DESCRIPTION
## Motivation

Adding checks for `waf.init` and `waf.config_errors` during WAF initialization failure for the new telemetry [RFC](https://docs.google.com/document/d/1D4hkC0jwwUyeo0hEQgyKP54kM1LZU98GL8MaP60tQrA/edit?pli=1&tab=t.0)

## Changes

- [x] Create new test `Test_CorruptedRules_Telemetry`
- [x] Add checks for `waf.init` and `waf.config_errors`
- [x] Move `find_series` to utils

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
