### PR TITLE
[NodeJS] Enable baggage otel support drop in test

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -929,7 +929,7 @@ tests/:
     test_otel_env_vars.py:
       Test_Otel_Env_Vars: v5.11.0  #implemented in v5.11.0, v4.35.0, &v3.56.0
     test_otel_span_with_baggage.py:
-      Test_Otel_Span_With_Baggage: &ref_5_32_0
+      Test_Otel_Span_With_Baggage: *ref_5_32_0
     test_parametric_endpoints.py:
       Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not implemented)
       Test_Parametric_DDSpan_Start: bug (APMAPI-778)  # The resource name of the child span is overidden by the parent span.

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -929,7 +929,7 @@ tests/:
     test_otel_env_vars.py:
       Test_Otel_Env_Vars: v5.11.0  #implemented in v5.11.0, v4.35.0, &v3.56.0
     test_otel_span_with_baggage.py:
-      Test_Otel_Span_With_Baggage: missing_feature
+      Test_Otel_Span_With_Baggage: &ref_5_32_0
     test_parametric_endpoints.py:
       Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not implemented)
       Test_Parametric_DDSpan_Start: bug (APMAPI-778)  # The resource name of the child span is overidden by the parent span.

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -8,7 +8,7 @@ tracer.use('dns', false)
 const SpanContext = require('dd-trace/packages/dd-trace/src/opentracing/span_context')
 const OtelSpanContext = require('dd-trace/packages/dd-trace/src/opentelemetry/span_context')
 
-const { trace, ROOT_CONTEXT, SpanKind } = require('@opentelemetry/api')
+const { trace, ROOT_CONTEXT, SpanKind, propagation } = require('@opentelemetry/api')
 const { millisToHrTime } = require('@opentelemetry/core')
 
 const { TracerProvider } = tracer
@@ -261,6 +261,8 @@ app.post('/trace/otel/end_span', (req, res) => {
   res.json({});
 });
 
+
+
 app.post('/trace/otel/flush', async (req, res) => {
   tracerProvider.forceFlush().then(function() {
     otelSpans.clear()
@@ -361,6 +363,15 @@ app.post("/trace/otel/record_exception", (req, res) => {
   span.recordException(new Error(message))
   res.json({})
 })
+
+app.post("/trace/otel/otel_set_baggage", (req, res) => {
+  const bag = propagation
+        .createBaggage()
+        .setEntry(req.body.key, { value: req.body.value });
+  const context = propagation.setBaggage(ROOT_CONTEXT, bag)
+  const value = propagation.getBaggage(context).getEntry(req.body.key)
+  res.json({ value });
+});
 
 const port = process.env.APM_TEST_CLIENT_SERVER_PORT;
 app.listen(port, () => {

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -261,8 +261,6 @@ app.post('/trace/otel/end_span', (req, res) => {
   res.json({});
 });
 
-
-
 app.post('/trace/otel/flush', async (req, res) => {
   tracerProvider.forceFlush().then(function() {
     otelSpans.clear()

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -369,7 +369,7 @@ app.post("/trace/otel/otel_set_baggage", (req, res) => {
         .createBaggage()
         .setEntry(req.body.key, { value: req.body.value });
   const context = propagation.setBaggage(ROOT_CONTEXT, bag)
-  const value = propagation.getBaggage(context).getEntry(req.body.key)
+  const value = propagation.getBaggage(context).getEntry(req.body.key).value
   res.json({ value });
 });
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes
added endpoint to enable otel baggage test

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
