### PR TITLE
retry npm install when it fails

### DIFF
--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -402,7 +402,7 @@ COPY {nodejs_reldir}/*.js /usr/app/
 COPY {nodejs_reldir}/*.sh /usr/app/
 COPY {nodejs_reldir}/npm/* /usr/app/
 
-RUN npm install
+RUN npm install || npm install
 
 COPY {nodejs_reldir}/../install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh

--- a/utils/build/docker/nodejs/express4-typescript.Dockerfile
+++ b/utils/build/docker/nodejs/express4-typescript.Dockerfile
@@ -31,7 +31,7 @@ CMD ./app.sh
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
 
-RUN npm install
+RUN npm install || npm install
 RUN /binaries/install_ddtrace.sh
 RUN npm run build
 ENV DD_TRACE_HEADER_TAGS=user-agent

--- a/utils/build/docker/nodejs/express4.Dockerfile
+++ b/utils/build/docker/nodejs/express4.Dockerfile
@@ -13,8 +13,9 @@ WORKDIR /usr/app
 
 ENV NODE_ENV=production
 
-RUN npm install
-RUN npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
+RUN npm install || npm install
+RUN npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0" \
+  || npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
 
 EXPOSE 7777
 

--- a/utils/build/docker/nodejs/express5.Dockerfile
+++ b/utils/build/docker/nodejs/express5.Dockerfile
@@ -13,8 +13,8 @@ WORKDIR /usr/app
 
 ENV NODE_ENV=production
 
-RUN npm install
-RUN npm install "express@5.0.1"
+RUN npm install || npm install
+RUN npm install "express@5.0.1" || npm install "express@5.0.1"
 
 EXPOSE 7777
 

--- a/utils/build/docker/nodejs/install_ddtrace.sh
+++ b/utils/build/docker/nodejs/install_ddtrace.sh
@@ -20,5 +20,5 @@ else
         echo "install from NPM"
     fi
 
-    npm install $target
+    npm install $target || npm install $target
 fi

--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -11,7 +11,7 @@ COPY utils/build/docker/nodejs/nextjs /usr/app
 
 WORKDIR /usr/app
 
-RUN npm install
+RUN npm install || npm install
 
 EXPOSE 7777
 

--- a/utils/build/docker/nodejs/uds-express4.Dockerfile
+++ b/utils/build/docker/nodejs/uds-express4.Dockerfile
@@ -13,8 +13,9 @@ WORKDIR /usr/app
 
 ENV NODE_ENV=production
 
-RUN npm install
-RUN npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
+RUN npm install || npm install
+RUN npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0" \
+  || npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
 
 EXPOSE 7777
 

--- a/utils/build/docker/nodejs_otel/express4-otel.Dockerfile
+++ b/utils/build/docker/nodejs_otel/express4-otel.Dockerfile
@@ -15,8 +15,9 @@ WORKDIR /usr/app
 
 ENV NODE_ENV=production
 
-RUN npm install
-RUN npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
+RUN npm install || npm install
+RUN npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0" \
+  || npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
 
 EXPOSE 7777
 
@@ -29,11 +30,12 @@ ENV PGPORT=5433
 #ENV OTEL_BSP_MAX_QUEUE_SIZE=10000
 ENV OTEL_BSP_EXPORT_TIMEOUT=1000
 ENV OTEL_BSP_SCHEDULE_DELAY=200
-RUN npm install --save @opentelemetry/api
-RUN npm install --save @opentelemetry/auto-instrumentations-node
-RUN npm install @opentelemetry/instrumentation-mysql2
-RUN npm install @opentelemetry/otlp-exporter-base
-RUN npm install --save opentelemetry-instrumentation-mssql
+RUN npm install --save @opentelemetry/api || npm install --save @opentelemetry/api
+RUN npm install --save @opentelemetry/auto-instrumentations-node \
+  || npm install --save @opentelemetry/auto-instrumentations-node
+RUN npm install @opentelemetry/instrumentation-mysql2 || npm install @opentelemetry/instrumentation-mysql2
+RUN npm install @opentelemetry/otlp-exporter-base || npm install @opentelemetry/otlp-exporter-base
+RUN npm install --save opentelemetry-instrumentation-mssql || npm install --save opentelemetry-instrumentation-mssql
 
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

This is a common cause of flakiness, often with a random 500 error from npm or from an ECONNRESET. Rerunning it reduces the flakiness pretty much to 0 (or as close as we can realistically expect without rerunning many times).

## Changes

<!-- A brief description of the change being made with this pull request. -->

Retry `npm install` when it fails.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
