### PR TITLE
Move logger inside utils (instead of utils.tools)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,7 @@ from pytest_jsonreport.plugin import JSONReport
 from manifests.parser.core import load as load_manifests
 from utils import context
 from utils._context._scenarios import scenarios, Scenario
-from utils.tools import logger
+from utils._logger import logger
 from utils.scripts.junit_report import junit_modifyreport
 from utils._context.library_version import LibraryVersion
 from utils._decorators import released, configure as configure_decorators

--- a/docs/edit/troubleshooting.md
+++ b/docs/edit/troubleshooting.md
@@ -3,7 +3,7 @@
 When a test fails, having the good information in the output makes all the difference. There is sweet spot between no info, and too much info, use your common sense!
 
 ```python
-from utils.tools import logger
+from utils import logger
 
 ...
 

--- a/tests/appsec/api_security/test_api_security_rc.py
+++ b/tests/appsec/api_security/test_api_security_rc.py
@@ -2,14 +2,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import (
-    interfaces,
-    rfc,
-    scenarios,
-    weblog,
-    features,
-)
-from utils.tools import logger
+from utils import interfaces, rfc, scenarios, weblog, features, logger
+
 from tests.appsec.api_security.utils import BaseAppsecApiSecurityRcTest
 
 

--- a/tests/appsec/api_security/test_apisec_sampling.py
+++ b/tests/appsec/api_security/test_apisec_sampling.py
@@ -6,9 +6,9 @@ from utils import (
     rfc,
     scenarios,
     weblog,
+    logger,
 )
 
-from utils.tools import logger
 import random
 import string
 import time

--- a/tests/appsec/api_security/test_schemas.py
+++ b/tests/appsec/api_security/test_schemas.py
@@ -2,16 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import (
-    context,
-    interfaces,
-    missing_feature,
-    rfc,
-    scenarios,
-    weblog,
-    features,
-)
-from utils.tools import logger
+from utils import context, interfaces, missing_feature, rfc, scenarios, weblog, features, logger
 
 
 def get_schema(request, address):

--- a/tests/appsec/iast/utils.py
+++ b/tests/appsec/iast/utils.py
@@ -1,6 +1,5 @@
 import json
-from utils import weblog, interfaces, context
-from utils.tools import logger
+from utils import weblog, interfaces, context, logger
 
 
 def _get_expectation(d):

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -4,8 +4,7 @@ from abc import ABC, abstractmethod
 from requests.structures import CaseInsensitiveDict
 
 from utils.telemetry_utils import TelemetryUtils
-from utils import context, weblog, interfaces, scenarios, features, rfc, bug, missing_feature, irrelevant
-from utils.tools import logger
+from utils import context, weblog, interfaces, scenarios, features, rfc, bug, missing_feature, irrelevant, logger
 
 
 class BaseAsmStandaloneUpstreamPropagation(ABC):

--- a/tests/appsec/test_rate_limiter.py
+++ b/tests/appsec/test_rate_limiter.py
@@ -5,8 +5,7 @@
 import datetime
 import time
 
-from utils import weblog, context, interfaces, rfc, bug, scenarios, features
-from utils.tools import logger
+from utils import weblog, context, interfaces, rfc, bug, scenarios, features, logger
 from utils.dd_constants import SamplingPriority
 
 

--- a/tests/appsec/waf/test_addresses.py
+++ b/tests/appsec/waf/test_addresses.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 import json
 import pytest
-from utils import weblog, bug, context, interfaces, irrelevant, missing_feature, rfc, scenarios, features
-from utils.tools import logger
+from utils import weblog, bug, context, interfaces, irrelevant, missing_feature, rfc, scenarios, features, logger
 
 
 @features.appsec_request_blocking

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -1,5 +1,4 @@
-from utils import bug, context, interfaces, features, rfc, scenarios, weblog
-from utils.tools import logger
+from utils import bug, context, interfaces, features, rfc, scenarios, weblog, logger
 
 TELEMETRY_REQUEST_TYPE_GENERATE_METRICS = "generate-metrics"
 TELEMETRY_REQUEST_TYPE_DISTRIBUTIONS = "distributions"

--- a/tests/auto_inject/test_auto_inject_chaos.py
+++ b/tests/auto_inject/test_auto_inject_chaos.py
@@ -1,6 +1,5 @@
 import requests
-from utils import scenarios, features, context, bug, irrelevant, missing_feature
-from utils.tools import logger
+from utils import scenarios, features, context, bug, irrelevant, missing_feature, logger
 from utils.onboarding.weblog_interface import warmup_weblog
 from utils.onboarding.wait_for_tcp_port import wait_for_port
 import tests.auto_inject.utils as base

--- a/tests/auto_inject/test_auto_inject_guardrail.py
+++ b/tests/auto_inject/test_auto_inject_guardrail.py
@@ -1,5 +1,4 @@
-from utils import scenarios, features, context
-from utils.tools import logger
+from utils import scenarios, features, context, logger
 from utils.onboarding.weblog_interface import make_get_request, warmup_weblog
 from utils.onboarding.wait_for_tcp_port import wait_for_port
 

--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -1,5 +1,4 @@
-from utils import scenarios, features, flaky, irrelevant, bug, context, missing_feature
-from utils.tools import logger
+from utils import scenarios, features, flaky, irrelevant, bug, context, missing_feature, logger
 from utils.onboarding.weblog_interface import warmup_weblog, get_child_pids, get_zombies, fork_and_crash
 import tests.auto_inject.utils as base
 

--- a/tests/auto_inject/test_blocklist_auto_inject.py
+++ b/tests/auto_inject/test_blocklist_auto_inject.py
@@ -1,8 +1,7 @@
 import uuid
 from scp import SCPClient
 
-from utils import scenarios, context, features, irrelevant, bug
-from utils.tools import logger
+from utils import scenarios, context, features, irrelevant, bug, logger
 from utils.onboarding.injection_log_parser import command_injection_skipped
 
 

--- a/tests/auto_inject/utils.py
+++ b/tests/auto_inject/utils.py
@@ -1,9 +1,8 @@
-from utils.tools import logger
 from utils.onboarding.weblog_interface import make_get_request, warmup_weblog, make_internal_get_request
 from utils.onboarding.backend_interface import wait_backend_trace_id
 from utils.onboarding.wait_for_tcp_port import wait_for_port
 from utils.virtual_machine.vm_logger import vm_logger
-from utils import context
+from utils import context, logger
 from threading import Timer
 
 

--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -5,8 +5,7 @@
 import tests.debugger.utils as debugger
 import os
 import re
-from utils import scenarios, features, bug, context, flaky, irrelevant
-from utils.tools import logger
+from utils import scenarios, features, bug, context, flaky, irrelevant, logger
 
 
 def get_env_bool(env_var_name, *, default=False) -> bool:

--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import tests.debugger.utils as debugger
-from utils import features, scenarios, missing_feature, context
-from utils.tools import logger
+from utils import features, scenarios, missing_feature, context, logger
 import json
 
 TIMEOUT = 5

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -9,8 +9,7 @@ import os.path
 from pathlib import Path
 import uuid
 
-from utils import interfaces, remote_config, weblog, context
-from utils.tools import logger
+from utils import interfaces, remote_config, weblog, context, logger
 from utils.dd_constants import RemoteConfigApplyState as ApplyState
 
 

--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -1,8 +1,6 @@
 from urllib.parse import urlparse
 
-from utils import scenarios, features, context, irrelevant, bug, interfaces
-from utils import weblog
-from utils.tools import logger
+from utils import scenarios, features, context, irrelevant, bug, interfaces, weblog, logger
 
 
 @scenarios.docker_ssi

--- a/tests/docker_ssi/test_docker_ssi_crash.py
+++ b/tests/docker_ssi/test_docker_ssi_crash.py
@@ -8,8 +8,7 @@ from utils import (
     context,
     interfaces,
 )
-from utils import weblog
-from utils.tools import logger
+from utils import weblog, logger
 
 
 @scenarios.docker_ssi

--- a/tests/fuzzer/main.py
+++ b/tests/fuzzer/main.py
@@ -6,7 +6,7 @@ import random
 import argparse
 
 from utils._context.containers import WeblogContainer, AgentContainer, create_network
-from utils.tools import get_logger
+from utils._logger import get_logger
 from utils import context, scenarios
 from tests.fuzzer.core import Fuzzer
 

--- a/tests/integrations/crossed_integrations/test_kafka.py
+++ b/tests/integrations/crossed_integrations/test_kafka.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import json
 
-from utils import interfaces, scenarios, weblog, missing_feature, features
+from utils import interfaces, scenarios, weblog, missing_feature, features, logger
 from utils.buddies import java_buddy
-from utils.tools import logger
 
 
 class _BaseKafka:

--- a/tests/integrations/crossed_integrations/test_kinesis.py
+++ b/tests/integrations/crossed_integrations/test_kinesis.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 import json
 
 from utils.buddies import python_buddy
-from utils import interfaces, scenarios, weblog, missing_feature, features, context
-from utils.tools import logger
+from utils import interfaces, scenarios, weblog, missing_feature, features, context, logger
 
 
 class _BaseKinesis:

--- a/tests/integrations/crossed_integrations/test_rabbitmq.py
+++ b/tests/integrations/crossed_integrations/test_rabbitmq.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import json
 
 from utils.buddies import java_buddy
-from utils import interfaces, scenarios, weblog, missing_feature, features
-from utils.tools import logger
+from utils import interfaces, scenarios, weblog, missing_feature, features, logger
 
 
 class _BaseRabbitMQ:

--- a/tests/integrations/crossed_integrations/test_sns_to_sqs.py
+++ b/tests/integrations/crossed_integrations/test_sns_to_sqs.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 import json
 
 from utils.buddies import python_buddy
-from utils import interfaces, scenarios, weblog, missing_feature, features, context
-from utils.tools import logger
+from utils import interfaces, scenarios, weblog, missing_feature, features, context, logger
 
 
 class _BaseSNS:

--- a/tests/integrations/crossed_integrations/test_sqs.py
+++ b/tests/integrations/crossed_integrations/test_sqs.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 import json
 
 from utils.buddies import python_buddy, java_buddy
-from utils import interfaces, scenarios, weblog, missing_feature, features, context, irrelevant
-from utils.tools import logger
+from utils import interfaces, scenarios, weblog, missing_feature, features, context, irrelevant, logger
 
 
 class _BaseSQS:

--- a/tests/integrations/test_db_integrations_sql.py
+++ b/tests/integrations/test_db_integrations_sql.py
@@ -2,8 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, bug, missing_feature, irrelevant, scenarios, features
-from utils.tools import logger
+from utils import context, bug, missing_feature, irrelevant, scenarios, features, logger
 
 from .utils import BaseDbIntegrationsTestClass
 

--- a/tests/integrations/test_dbm.py
+++ b/tests/integrations/test_dbm.py
@@ -6,8 +6,7 @@
 import json
 import re
 
-from utils import weblog, interfaces, context, scenarios, features, irrelevant, flaky, bug
-from utils.tools import logger
+from utils import weblog, interfaces, context, scenarios, features, irrelevant, flaky, bug, logger
 
 
 def remove_traceparent(s):

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -8,8 +8,7 @@ import os
 
 from tests.integrations.utils import compute_dsm_hash
 
-from utils import weblog, interfaces, scenarios, irrelevant, context, bug, features, missing_feature, flaky
-from utils.tools import logger
+from utils import weblog, interfaces, scenarios, irrelevant, context, bug, features, missing_feature, flaky, logger
 
 
 # Kafka specific

--- a/tests/integrations/test_inferred_proxy.py
+++ b/tests/integrations/test_inferred_proxy.py
@@ -1,8 +1,7 @@
 import json
 import time
 
-from utils import weblog, scenarios, features, interfaces
-from utils.tools import logger
+from utils import weblog, scenarios, features, interfaces, logger
 
 
 DISTRIBUTED_TRACE_ID = 1

--- a/tests/integrations/test_open_telemetry.py
+++ b/tests/integrations/test_open_telemetry.py
@@ -1,5 +1,4 @@
-from utils import context, bug, features, irrelevant, missing_feature, scenarios
-from utils.tools import logger
+from utils import context, bug, features, irrelevant, missing_feature, scenarios, logger
 from .utils import BaseDbIntegrationsTestClass
 
 

--- a/tests/integrations/utils.py
+++ b/tests/integrations/utils.py
@@ -8,8 +8,7 @@ from collections.abc import Callable
 import boto3
 import botocore.exceptions
 
-from utils import weblog, interfaces, scenarios
-from utils.tools import logger
+from utils import weblog, interfaces, scenarios, logger
 
 
 class BaseDbIntegrationsTestClass:

--- a/tests/k8s_lib_injection/test_k8s_init_image_validator.py
+++ b/tests/k8s_lib_injection/test_k8s_init_image_validator.py
@@ -1,6 +1,5 @@
 import requests
-from utils import scenarios, features, context, bug
-from utils.tools import logger
+from utils import scenarios, features, context, bug, logger
 from retry import retry
 
 

--- a/tests/k8s_lib_injection/test_k8s_lib_injection.py
+++ b/tests/k8s_lib_injection/test_k8s_lib_injection.py
@@ -1,6 +1,5 @@
-from utils import scenarios, features, context, bug
+from utils import scenarios, features, context, bug, logger
 from tests.k8s_lib_injection.utils import get_dev_agent_traces
-from utils.tools import logger
 from utils.onboarding.weblog_interface import make_get_request, warmup_weblog
 from utils.onboarding.backend_interface import wait_backend_trace_id
 from utils.onboarding.wait_for_tcp_port import wait_for_port

--- a/tests/k8s_lib_injection/test_k8s_lib_injection_djm.py
+++ b/tests/k8s_lib_injection/test_k8s_lib_injection_djm.py
@@ -1,6 +1,5 @@
 import json
-from utils import scenarios, features, context
-from utils.tools import logger
+from utils import scenarios, features, context, logger
 
 from tests.k8s_lib_injection.utils import get_dev_agent_traces
 

--- a/tests/k8s_lib_injection/utils.py
+++ b/tests/k8s_lib_injection/utils.py
@@ -1,7 +1,7 @@
 import time
 
 import requests
-from utils.tools import logger
+from utils import logger
 
 
 def get_dev_agent_traces(k8s_cluster_info, retry=10):

--- a/tests/otel_tracing_e2e/test_e2e.py
+++ b/tests/otel_tracing_e2e/test_e2e.py
@@ -2,8 +2,7 @@ import base64
 import os
 import time
 
-from utils import context, weblog, interfaces, scenarios, irrelevant, features
-from utils.tools import logger
+from utils import context, weblog, interfaces, scenarios, irrelevant, features, logger
 from utils.otel_validators.validator_trace import validate_all_traces
 from utils.otel_validators.validator_log import validate_log, validate_log_trace_correlation
 from utils.otel_validators.validator_metric import validate_metrics

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -24,9 +24,8 @@ from utils.parametric.spec.trace import Trace
 from utils.parametric.spec.trace import decode_v06_stats
 from utils.parametric._library_client import APMLibrary, APMLibraryClient
 
-from utils import context, scenarios
+from utils import context, scenarios, logger
 from utils.dd_constants import RemoteConfigApplyState, Capabilities
-from utils.tools import logger
 
 from utils._context._scenarios.parametric import APMLibraryTestServer
 

--- a/tests/parametric/test_crashtracking.py
+++ b/tests/parametric/test_crashtracking.py
@@ -4,8 +4,7 @@ import base64
 import json
 import pytest
 
-from utils import bug, context, features, scenarios
-from utils.tools import logger
+from utils import bug, context, features, scenarios, logger
 
 
 @scenarios.parametric

--- a/tests/parametric/test_headers_b3.py
+++ b/tests/parametric/test_headers_b3.py
@@ -5,8 +5,7 @@ import pytest
 from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
 from utils.parametric.spec.trace import span_has_no_parent
 from utils.parametric.spec.trace import find_only_span
-from utils import missing_feature, context, scenarios, features, irrelevant
-from utils.tools import logger
+from utils import missing_feature, context, scenarios, features, irrelevant, logger
 
 parametrize = pytest.mark.parametrize
 

--- a/tests/parametric/test_library_tracestats.py
+++ b/tests/parametric/test_library_tracestats.py
@@ -9,8 +9,7 @@ import pytest
 from utils.parametric.spec.trace import SPAN_MEASURED_KEY
 from utils.parametric.spec.trace import V06StatsAggr
 from utils.parametric.spec.trace import find_root_span
-from utils import missing_feature, context, scenarios, features
-from utils.tools import logger
+from utils import missing_feature, context, scenarios, features, logger
 
 parametrize = pytest.mark.parametrize
 

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -16,9 +16,8 @@ from utils import (
     weblog,
     features,
     remote_config,
+    logger,
 )
-
-from utils.tools import logger
 
 
 @rfc("https://docs.google.com/document/d/1bUVtEpXNTkIGvLxzkNYCxQzP2X9EK9HMBLHWXr_5KLM/edit#heading=h.vy1jegxy7cuc")

--- a/tests/serverless/span_pointers/aws/test_s3_span_pointers.py
+++ b/tests/serverless/span_pointers/aws/test_s3_span_pointers.py
@@ -1,7 +1,6 @@
 import json
 
-from utils import weblog, interfaces, rfc, features
-from utils.tools import logger
+from utils import weblog, interfaces, rfc, features, logger
 from tests.serverless.span_pointers.utils import (
     POINTER_DIRECTION_DOWNSTREAM,
     make_single_span_link_validator,

--- a/tests/serverless/span_pointers/utils.py
+++ b/tests/serverless/span_pointers/utils.py
@@ -1,7 +1,7 @@
 from hashlib import sha256
 from typing import NewType
 
-from utils.tools import logger
+from utils import logger
 
 
 PointerHash = NewType("PointerHash", str)

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -1,6 +1,5 @@
 import pytest
-from utils import interfaces, weblog, features, scenarios, missing_feature, context, bug
-from utils.tools import logger
+from utils import interfaces, weblog, features, scenarios, missing_feature, context, bug, logger
 
 """
 Test scenarios we want:

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -5,8 +5,7 @@
 import re
 import json
 import time
-from utils import weblog, interfaces, scenarios, features, rfc, irrelevant, context, bug, missing_feature
-from utils.tools import logger
+from utils import weblog, interfaces, scenarios, features, rfc, irrelevant, context, bug, missing_feature, logger
 
 # get the default log output
 stdout = interfaces.library_stdout if context.library != "dotnet" else interfaces.library_dotnet_managed

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -5,8 +5,7 @@
 """Misc checks around data integrity during components' lifetime"""
 
 import string
-from utils import weblog, interfaces, context, bug, rfc, irrelevant, missing_feature, features, scenarios, flaky
-from utils.tools import logger
+from utils import weblog, interfaces, context, bug, rfc, irrelevant, missing_feature, features, scenarios, flaky, logger
 from utils.dd_constants import SamplingPriority
 from utils.cgroup_info import get_container_id
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -3,9 +3,8 @@
 # Copyright 2022 Datadog, Inc.
 
 import json
-from utils import weblog, interfaces, scenarios, features, bug, context, missing_feature
+from utils import weblog, interfaces, scenarios, features, bug, context, missing_feature, logger
 from utils.parametric.spec.trace import SAMPLING_PRIORITY_KEY, ORIGIN
-from utils.tools import logger
 
 
 @scenarios.trace_propagation_style_w3c

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -8,8 +8,7 @@ from random import randint, seed
 from typing import Any
 from collections.abc import Generator
 
-from utils import weblog, interfaces, context, scenarios, features, missing_feature
-from utils.tools import logger
+from utils import weblog, interfaces, context, scenarios, features, missing_feature, logger
 from utils.dd_constants import SamplingPriority
 
 

--- a/tests/test_scrubbing.py
+++ b/tests/test_scrubbing.py
@@ -3,8 +3,7 @@
 # Copyright 2022 Datadog, Inc.
 
 import re
-from utils import bug, context, interfaces, rfc, weblog, missing_feature, features, scenarios
-from utils.tools import logger
+from utils import bug, context, interfaces, rfc, weblog, missing_feature, features, scenarios, logger
 
 
 def validate_no_leak(needle, whitelist_pattern=None):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -3,8 +3,7 @@ from collections import defaultdict
 from datetime import timedelta
 import time
 from dateutil.parser import isoparse
-from utils import context, interfaces, missing_feature, bug, flaky, irrelevant, weblog, scenarios, features, rfc
-from utils.tools import logger
+from utils import context, interfaces, missing_feature, bug, flaky, irrelevant, weblog, scenarios, features, rfc, logger
 from utils.interfaces._misc_validators import HeadersPresenceValidator, HeadersMatchValidator
 
 INTAKE_TELEMETRY_PATH = "/api/v2/apmtelemetry"

--- a/tests/test_the_test/test_decorators.py
+++ b/tests/test_the_test/test_decorators.py
@@ -3,10 +3,9 @@ import logging
 
 import pytest
 
-from utils import irrelevant, missing_feature, flaky, rfc, context
+from utils import irrelevant, missing_feature, flaky, rfc, context, logger
 from utils._decorators import released
 from utils._context.library_version import LibraryVersion
-from utils.tools import logger
 
 
 pytestmark = pytest.mark.scenario("TEST_THE_TEST")

--- a/tests/test_the_test/test_features.py
+++ b/tests/test_the_test/test_features.py
@@ -1,5 +1,4 @@
-from utils import scenarios, features
-from utils.tools import logger
+from utils import scenarios, features, logger
 
 from .utils import run_system_tests
 

--- a/tests/test_the_test/test_json_report.py
+++ b/tests/test_the_test/test_json_report.py
@@ -1,9 +1,8 @@
 import os
 import json
 import pytest
-from utils.tools import logger
 
-from utils import missing_feature, irrelevant, scenarios, rfc, features, bug, flaky
+from utils import missing_feature, irrelevant, scenarios, rfc, features, bug, flaky, logger
 
 pytestmark = pytest.mark.features(feature_id=666)
 

--- a/tests/test_the_test/test_scrubber.py
+++ b/tests/test_the_test/test_scrubber.py
@@ -4,8 +4,7 @@ import os
 from pathlib import Path
 import subprocess
 import pytest
-from utils import scenarios, missing_feature
-from utils.tools import logger
+from utils import scenarios, missing_feature, logger
 
 
 FILENAME = "tests/test_the_test/test_scrubber.py"

--- a/tests/test_the_test/utils.py
+++ b/tests/test_the_test/utils.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from utils.tools import logger
+from utils import logger
 
 
 def run_system_tests(scenario="MOCK_THE_TEST", test_path=None, *, verbose=False, forced_test=None, xfail_strict=False):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,6 +7,7 @@ from utils._weblog import weblog
 from utils._context.core import context
 from utils._context._scenarios import scenarios
 from utils._decorators import bug, irrelevant, missing_feature, rfc, flaky, incomplete_test_app
+from utils._logger import logger
 from utils import interfaces, _remote_config as remote_config
 from utils.interfaces._core import ValidationError
 from utils._features import features
@@ -20,6 +21,7 @@ __all__ = [
     "incomplete_test_app",
     "interfaces",
     "irrelevant",
+    "logger",
     "missing_feature",
     "remote_config",
     "rfc",

--- a/utils/_context/_scenarios/auto_injection.py
+++ b/utils/_context/_scenarios/auto_injection.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 import pytest
 from utils._context.library_version import LibraryVersion
-from utils.tools import logger
+from utils._logger import logger
 from utils.onboarding.debug_vm import extract_logs_to_file
 from utils.virtual_machine.utils import get_tested_apps_vms, generate_gitlab_pipeline
 from utils.virtual_machine.virtual_machines import _VirtualMachine, load_virtual_machines

--- a/utils/_context/_scenarios/core.py
+++ b/utils/_context/_scenarios/core.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import shutil
 
 import pytest
-from utils.tools import logger, get_log_formatter
+from utils._logger import logger, get_log_formatter
 
 
 class ScenarioGroup(Enum):

--- a/utils/_context/_scenarios/docker_ssi.py
+++ b/utils/_context/_scenarios/docker_ssi.py
@@ -20,7 +20,7 @@ from utils._context.containers import (
 )
 from utils.docker_ssi.docker_ssi_matrix_utils import resolve_runtime_version
 from utils.docker_ssi.docker_ssi_definitions import SupportedImages
-from utils.tools import logger
+from utils._logger import logger
 from utils.virtual_machine.vm_logger import vm_logger
 
 from .core import Scenario

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -32,7 +32,7 @@ from utils._context.containers import (
     _get_client as get_docker_client,
 )
 
-from utils.tools import logger
+from utils._logger import logger
 
 from .core import Scenario, ScenarioGroup
 

--- a/utils/_context/_scenarios/external_processing.py
+++ b/utils/_context/_scenarios/external_processing.py
@@ -4,7 +4,7 @@ from utils._context.containers import DummyServerContainer, ExternalProcessingCo
 from utils import interfaces
 from utils.interfaces._core import ProxyBasedInterfaceValidator
 
-from utils.tools import logger
+from utils._logger import logger
 
 from .endtoend import DockerScenario, ScenarioGroup
 

--- a/utils/_context/_scenarios/ipv6.py
+++ b/utils/_context/_scenarios/ipv6.py
@@ -1,4 +1,4 @@
-from utils.tools import logger
+from utils._logger import logger
 
 from .core import ScenarioGroup
 from .endtoend import EndToEndScenario

--- a/utils/_context/_scenarios/k8s_lib_injection.py
+++ b/utils/_context/_scenarios/k8s_lib_injection.py
@@ -18,7 +18,7 @@ from utils._context.containers import (
     _get_client as get_docker_client,
 )
 
-from utils.tools import logger
+from utils._logger import logger
 from .core import Scenario, ScenarioGroup
 
 

--- a/utils/_context/_scenarios/open_telemetry.py
+++ b/utils/_context/_scenarios/open_telemetry.py
@@ -5,7 +5,7 @@ import pytest
 from watchdog.observers.polling import PollingObserver
 from watchdog.events import FileSystemEventHandler, FileSystemEvent
 
-from utils.tools import logger
+from utils._logger import logger
 from utils import interfaces
 from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils._context.library_version import Version

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -19,7 +19,7 @@ from docker.models.containers import Container
 from docker.models.networks import Network
 
 from utils._context.library_version import LibraryVersion
-from utils.tools import logger
+from utils._logger import logger
 
 from .core import Scenario, ScenarioGroup
 

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -17,7 +17,7 @@ import requests
 
 from utils._context.library_version import LibraryVersion
 from utils.proxy.ports import ProxyPorts
-from utils.tools import logger
+from utils._logger import logger
 from utils import interfaces
 from utils.k8s_lib_injection.k8s_weblog import K8sWeblog
 from utils.interfaces._library.core import LibraryInterfaceValidator

--- a/utils/_logger.py
+++ b/utils/_logger.py
@@ -1,0 +1,51 @@
+import logging
+import sys
+
+from _pytest.terminal import TerminalReporter
+
+
+DEBUG_LEVEL_STDOUT = 100
+
+
+def get_log_formatter() -> logging.Formatter:
+    return logging.Formatter("%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s", "%H:%M:%S")
+
+
+class Logger(logging.Logger):
+    terminal: TerminalReporter
+
+    def stdout(self, message: str, *args, **kws) -> None:  # noqa: ANN002
+        if self.isEnabledFor(DEBUG_LEVEL_STDOUT):
+            # Yes, logger takes its '*args' as 'args'.
+            self._log(DEBUG_LEVEL_STDOUT, message, args, **kws)  # pylint: disable=protected-access
+
+            if hasattr(self, "terminal"):
+                self.terminal.write_line(message)
+                self.terminal.flush()
+            else:
+                # at this point, the logger may not yet be configured with the pytest terminal
+                # so directly print in stdout
+                print(message)  # noqa: T201
+
+
+logging.setLoggerClass(Logger)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+logging.addLevelName(DEBUG_LEVEL_STDOUT, "STDOUT")
+
+
+def get_logger(name: str = "tests", *, use_stdout: bool = False) -> Logger:
+    result: Logger = logging.getLogger(name)  # type: ignore[assignment]
+
+    if use_stdout:
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.setLevel(logging.DEBUG)
+        stdout_handler.setFormatter(get_log_formatter())
+        result.addHandler(stdout_handler)
+
+    result.setLevel(logging.DEBUG)
+
+    return result
+
+
+logger = get_logger()

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -16,7 +16,7 @@ import requests
 from utils._context.core import context
 from utils.dd_constants import RemoteConfigApplyState as ApplyState
 from utils.interfaces import library
-from utils.tools import logger
+from utils._logger import logger
 from utils._context.containers import ProxyContainer
 
 

--- a/utils/_weblog.py
+++ b/utils/_weblog.py
@@ -15,7 +15,7 @@ from requests.structures import CaseInsensitiveDict
 import grpc
 import google.protobuf.struct_pb2 as pb
 
-from utils.tools import logger
+from utils._logger import logger
 import utils.grpc.weblog_pb2_grpc as grpcapi
 
 # monkey patching header validation in requests module, as we want to be able to send anything to weblog

--- a/utils/interfaces/_agent.py
+++ b/utils/interfaces/_agent.py
@@ -7,7 +7,8 @@
 import threading
 import copy
 
-from utils.tools import logger, get_rid_from_span
+from utils.tools import get_rid_from_span
+from utils._logger import logger
 from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils.interfaces._misc_validators import HeadersPresenceValidator, HeadersMatchValidator
 

--- a/utils/interfaces/_backend.py
+++ b/utils/interfaces/_backend.py
@@ -11,7 +11,8 @@ import time
 import requests
 
 from utils.interfaces._core import ProxyBasedInterfaceValidator
-from utils.tools import logger, get_rid_from_span
+from utils.tools import get_rid_from_span
+from utils._logger import logger
 
 
 class _BackendInterfaceValidator(ProxyBasedInterfaceValidator):

--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import pytest
 
-from utils.tools import logger
+from utils._logger import logger
 from utils.interfaces._schemas_validators import SchemaValidator, SchemaError
 
 

--- a/utils/interfaces/_library/_utils.py
+++ b/utils/interfaces/_library/_utils.py
@@ -3,7 +3,8 @@
 # Copyright 2021 Datadog, Inc.
 
 from urllib.parse import urlparse
-from utils.tools import logger, get_rid_from_span
+from utils._logger import logger
+from utils.tools import get_rid_from_span
 
 
 def get_spans_related_to_rid(traces: list, rid: str):

--- a/utils/interfaces/_library/appsec.py
+++ b/utils/interfaces/_library/appsec.py
@@ -7,7 +7,7 @@
 from collections import Counter
 from collections.abc import Callable
 from utils.interfaces._library.appsec_data import rule_id_to_type
-from utils.tools import logger
+from utils._logger import logger
 
 
 class _WafAttack:

--- a/utils/interfaces/_library/core.py
+++ b/utils/interfaces/_library/core.py
@@ -8,7 +8,8 @@ import copy
 import json
 import threading
 
-from utils.tools import logger, get_rid_from_user_agent, get_rid_from_span
+from utils.tools import get_rid_from_user_agent, get_rid_from_span
+from utils._logger import logger
 from utils.dd_constants import RemoteConfigApplyState, Capabilities
 from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils.interfaces._library._utils import get_trace_request_path

--- a/utils/interfaces/_logs.py
+++ b/utils/interfaces/_logs.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import re
 
 from utils._context.core import context
-from utils.tools import logger
+from utils._logger import logger
 from utils.interfaces._core import InterfaceValidator
 
 

--- a/utils/interfaces/_open_telemetry.py
+++ b/utils/interfaces/_open_telemetry.py
@@ -6,7 +6,7 @@
 
 import threading
 
-from utils.tools import logger
+from utils._logger import logger
 from utils.interfaces._core import ProxyBasedInterfaceValidator
 
 

--- a/utils/interfaces/_test_agent.py
+++ b/utils/interfaces/_test_agent.py
@@ -2,7 +2,7 @@ import pathlib
 import threading
 import json
 from utils.interfaces._core import InterfaceValidator
-from utils.tools import logger
+from utils._logger import logger
 
 
 class _TestAgentInterfaceValidator(InterfaceValidator):

--- a/utils/k8s_lib_injection/k8s_cluster_provider.py
+++ b/utils/k8s_lib_injection/k8s_cluster_provider.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from utils.tools import logger
+from utils._logger import logger
 from utils.k8s_lib_injection.k8s_command_utils import execute_command
 from kubernetes import client, config
 

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -1,5 +1,5 @@
 import subprocess, datetime, os, time, signal, shlex
-from utils.tools import logger
+from utils._logger import logger
 from utils import context
 from retry import retry
 

--- a/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
+++ b/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
@@ -3,7 +3,7 @@ import time
 import yaml
 from pathlib import Path
 from kubernetes import client, watch
-from utils.tools import logger
+from utils._logger import logger
 from utils.k8s_lib_injection.k8s_command_utils import (
     helm_add_repo,
     helm_install_chart,

--- a/utils/k8s_lib_injection/k8s_weblog.py
+++ b/utils/k8s_lib_injection/k8s_weblog.py
@@ -1,5 +1,5 @@
 from kubernetes import client, watch
-from utils.tools import logger
+from utils._logger import logger
 from utils.k8s_lib_injection.k8s_logger import k8s_logger
 from retry import retry
 

--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime, timedelta, timezone
 import requests
 import random
-from utils.tools import logger
+from utils._logger import logger
 
 
 API_HOST = "https://dd.datadoghq.com"

--- a/utils/onboarding/debug_vm.py
+++ b/utils/onboarding/debug_vm.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 import paramiko
-from utils.tools import logger
+from utils._logger import logger
 
 
 def extract_logs_to_file(logs_data, log_folder):

--- a/utils/onboarding/injection_log_parser.py
+++ b/utils/onboarding/injection_log_parser.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from utils.tools import logger
+from utils._logger import logger
 
 
 def exclude_telemetry_logs_filter(line):

--- a/utils/onboarding/wait_for_tcp_port.py
+++ b/utils/onboarding/wait_for_tcp_port.py
@@ -19,7 +19,7 @@ SOFTWARE.
 
 import socket
 import time
-from utils.tools import logger
+from utils._logger import logger
 
 
 def wait_for_port(port: int, host: str = "localhost", timeout: float = 5.0):

--- a/utils/otel_validators/validator_trace.py
+++ b/utils/otel_validators/validator_trace.py
@@ -2,7 +2,7 @@
 
 import json
 import dictdiffer
-from utils.tools import logger
+from utils._logger import logger
 
 
 # Validates traces from Agent, Collector and Backend intake OTLP ingestion paths are consistent

--- a/utils/parametric/_library_client.py
+++ b/utils/parametric/_library_client.py
@@ -14,7 +14,7 @@ from opentelemetry.trace import SpanKind, StatusCode
 from utils import context
 
 from utils.parametric.spec.otel_trace import OtelSpanContext
-from utils.tools import logger
+from utils._logger import logger
 
 
 def _fail(message):

--- a/utils/properties_serialization.py
+++ b/utils/properties_serialization.py
@@ -7,7 +7,7 @@ from requests.structures import CaseInsensitiveDict
 
 from utils._weblog import HttpResponse, GrpcResponse, _Weblog
 from utils.interfaces._core import InterfaceValidator
-from utils.tools import logger
+from utils._logger import logger
 
 
 class _PropertiesEncoder(json.JSONEncoder):

--- a/utils/scripts/junit_report.py
+++ b/utils/scripts/junit_report.py
@@ -5,7 +5,7 @@
 import xml.etree.ElementTree as ET
 from operator import attrgetter
 
-from utils.tools import logger
+from utils._logger import logger
 
 
 def junit_modifyreport(json_report, junit_report_path, junit_properties) -> None:

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -3,11 +3,9 @@
 # Copyright 2021 Datadog, Inc.
 
 from enum import StrEnum
-import logging
 import os
 import re
-import sys
-from typing import Any
+from utils._logger import logger as _logger
 
 
 class ShColors(StrEnum):
@@ -24,66 +22,22 @@ class ShColors(StrEnum):
     UNDERLINE = "\033[4m"
 
 
-def get_log_formatter() -> logging.Formatter:
-    return logging.Formatter("%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s", "%H:%M:%S")
-
-
 def update_environ_with_local_env() -> None:
     # dynamically load .env file in environ if exists, it allow users to keep their conf via env vars
     try:
         with open(".env", encoding="utf-8") as f:
-            logger.debug("Found a .env file")
+            _logger.debug("Found a .env file")
             for raw_line in f:
                 line = raw_line.strip(" \t\n")
                 line = re.sub(r"(.*)#.$", r"\1", line)
                 line = re.sub(r"^(export +)(.*)$", r"\2", line)
                 if "=" in line:
                     items = line.split("=")
-                    logger.debug(f"adding {items[0]} in environ")
+                    _logger.debug(f"adding {items[0]} in environ")
                     os.environ[items[0]] = items[1]
 
     except FileNotFoundError:
         pass
-
-
-DEBUG_LEVEL_STDOUT = 100
-
-
-class Logger(logging.Logger):
-    terminal: Any
-
-    def stdout(self, message: str, *args, **kws) -> None:  # noqa: ANN002
-        if self.isEnabledFor(DEBUG_LEVEL_STDOUT):
-            # Yes, logger takes its '*args' as 'args'.
-            self._log(DEBUG_LEVEL_STDOUT, message, args, **kws)  # pylint: disable=protected-access
-
-            if hasattr(self, "terminal"):
-                self.terminal.write_line(message)
-                self.terminal.flush()
-            else:
-                # at this point, the logger may not yet be configured with the pytest terminal
-                # so directly print in stdout
-                print(message)  # noqa: T201
-
-
-logging.setLoggerClass(Logger)
-logging.getLogger("requests").setLevel(logging.WARNING)
-logging.getLogger("urllib3").setLevel(logging.WARNING)
-logging.addLevelName(DEBUG_LEVEL_STDOUT, "STDOUT")
-
-
-def get_logger(name: str = "tests", *, use_stdout: bool = False) -> Logger:
-    result: Logger = logging.getLogger(name)  # type: ignore[assignment]
-
-    if use_stdout:
-        stdout_handler = logging.StreamHandler(sys.stdout)
-        stdout_handler.setLevel(logging.DEBUG)
-        stdout_handler.setFormatter(get_log_formatter())
-        result.addHandler(stdout_handler)
-
-    result.setLevel(logging.DEBUG)
-
-    return result
 
 
 def o(message: str) -> str:
@@ -102,12 +56,9 @@ def e(message: str) -> str:
     return f"{ShColors.RED}{message}{ShColors.ENDC}"
 
 
-logger = get_logger()
-
-
 def get_rid_from_span(span: dict) -> str | None:
     if not isinstance(span, dict):
-        logger.error(f"Span should be an object, not {type(span)}")
+        _logger.error(f"Span should be an object, not {type(span)}")
         return None
 
     meta = span.get("meta", {})

--- a/utils/virtual_machine/aws_provider.py
+++ b/utils/virtual_machine/aws_provider.py
@@ -16,7 +16,7 @@ import pulumi_aws as aws
 from pulumi import Output
 import pulumi_command as command
 
-from utils.tools import logger
+from utils._logger import logger
 from utils import context
 from utils.virtual_machine.vm_logger import vm_logger
 

--- a/utils/virtual_machine/krunvm_provider.py
+++ b/utils/virtual_machine/krunvm_provider.py
@@ -8,7 +8,7 @@ import pexpect
 import shutil
 
 from utils.virtual_machine.virtual_machine_provider import VmProvider, Commander
-from utils.tools import logger
+from utils._logger import logger
 from utils import context
 from utils.virtual_machine.vm_logger import vm_logger
 

--- a/utils/virtual_machine/vagrant_provider.py
+++ b/utils/virtual_machine/vagrant_provider.py
@@ -5,7 +5,7 @@ import vagrant
 import paramiko
 from fabric.api import env
 from utils.virtual_machine.virtual_machine_provider import VmProvider, Commander
-from utils.tools import logger
+from utils._logger import logger
 from utils import context
 from scp import SCPClient
 from utils.virtual_machine.vm_logger import vm_logger

--- a/utils/virtual_machine/virtual_machine_provider.py
+++ b/utils/virtual_machine/virtual_machine_provider.py
@@ -1,6 +1,6 @@
 import os
 
-from utils.tools import logger
+from utils._logger import logger
 from utils.virtual_machine.vm_logger import vm_logger
 from utils import context
 

--- a/utils/virtual_machine/virtual_machine_provisioner.py
+++ b/utils/virtual_machine/virtual_machine_provisioner.py
@@ -1,7 +1,7 @@
 import os
 import yaml
 from yamlinclude import YamlIncludeConstructor
-from utils.tools import logger
+from utils._logger import logger
 from utils.virtual_machine.utils import nginx_parser
 
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
