### PR TITLE
Add new waf requests mandatory tags

### DIFF
--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -216,7 +216,7 @@ class Test_TelemetryMetrics:
             "request_blocked",
         }
 
-        if context.library > "nodejs@5.43.0":
+        if context.library >= "java@1.47.0":
             mandatory_tag_prefixes.update({"block_failure", "rate_limited", "input_truncated"})
 
         return mandatory_tag_prefixes

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -99,12 +99,7 @@ class Test_TelemetryMetrics:
             "rate_limited",
             "input_truncated",
         }
-        mandatory_tag_prefixes = {
-            "waf_version",
-            "event_rules_version",
-            "rule_triggered",
-            "request_blocked",
-        }
+        mandatory_tag_prefixes = self._get_waf_requests_mandatory_tags()
         series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
         logger.debug(series)
         # Depending on the timing, there might be more than 3 series. For example, if a warmup
@@ -114,6 +109,10 @@ class Test_TelemetryMetrics:
         matched_not_blocked = 0
         matched_triggered = 0
         matched_blocked = 0
+        matched_input_truncated = 0
+        matched_rate_limited = 0
+        matched_block_failure = 0
+
         for s in series:
             assert s["_computed_namespace"] == "appsec"
             assert s["metric"] == expected_metric_name
@@ -139,10 +138,25 @@ class Test_TelemetryMetrics:
             else:
                 raise ValueError(f"Unexpected tags: {full_tags}")
 
+            if "input_truncated:false" in full_tags:
+                matched_input_truncated += 1
+            if "rate_limited:false" in full_tags:
+                matched_rate_limited += 1
+            if "block_failure:false" in full_tags:
+                matched_block_failure += 1
+
         # XXX: Warm up requests might generate more than one series.
         assert matched_not_blocked >= 1
         assert matched_triggered == 1
         assert matched_blocked == 1
+
+        # Assert only if the tags exist in mandatory_tag_prefixes
+        if "input_truncated" in mandatory_tag_prefixes:
+            assert matched_input_truncated >= 3
+        if "rate_limited" in mandatory_tag_prefixes:
+            assert matched_rate_limited >= 3
+        if "block_failure" in mandatory_tag_prefixes:
+            assert matched_block_failure >= 3
 
     setup_waf_requests_match_traced_requests = _setup
 
@@ -193,6 +207,19 @@ class Test_TelemetryMetrics:
 
         missing_tags = mandatory_prefixes - tag_prefixes
         assert not missing_tags
+
+    def _get_waf_requests_mandatory_tags(self):
+        mandatory_tag_prefixes = {
+            "waf_version",
+            "event_rules_version",
+            "rule_triggered",
+            "request_blocked",
+        }
+
+        if context.library > "nodejs@5.43.0":
+            mandatory_tag_prefixes.update({"block_failure", "rate_limited", "input_truncated"})
+
+        return mandatory_tag_prefixes
 
 
 def _validate_headers(headers, request_type):


### PR DESCRIPTION
## Motivation

Add new mandatory tags for waf requests telemetry metric

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
