### PR TITLE
telemetry-intake: add missing config to configuration tests

### DIFF
--- a/utils/telemetry/intake/static/config_norm_rules.json
+++ b/utils/telemetry/intake/static/config_norm_rules.json
@@ -156,6 +156,7 @@
     "DD_INTERNAL_TELEMETRY_V2_ENABLED": "instrumentation_telemetry_v2_enabled",
     "DD_INTERNAL_WAIT_FOR_DEBUGGER_ATTACH": "internal_wait_for_debugger_attach_enabled",
     "DD_INTERNAL_WAIT_FOR_NATIVE_DEBUGGER_ATTACH": "internal_wait_for_native_debugger_attach_enabled",
+    "DD_LIVE_DEBUGGING_ENABLED": "live_debugging_enabled",
     "DD_LIB_INJECTED": "dd_lib_injected",
     "DD_LIB_INJECTION_ATTEMPTED": "dd_lib_injection_attempted",
     "DD_LOGS_DIRECT_SUBMISSION_BATCH_PERIOD_SECONDS": "logs_direct_submission_batch_period_seconds",


### PR DESCRIPTION
## Motivation

- Fix failing CI check in dd-trace-py: https://github.com/DataDog/dd-trace-py/actions/runs/14033557450/job/39286865502?pr=12820

## Changes

- Adds `DD_LIVE_DEBUGGING_ENABLED` to instrumentation telemetry config allow list.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
