### PR TITLE
[Java] Enable Round 2 Config Consistency system-tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1712,7 +1712,7 @@ tests/:
     test_config_consistency.py:
       Test_Config_Dogstatsd: missing_feature (default hostname is inconsistent)
       Test_Config_RateLimit: v1.41.1
-      Test_Config_Tags: missing_feature
+      Test_Config_Tags: v1.48.0
       Test_Config_TraceAgentURL: v1.41.1
       Test_Config_TraceEnabled: v1.39.0
       Test_Config_TraceLogDirectory: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1827,16 +1827,16 @@ tests/:
       spring-boot: v1.42.0
     Test_Config_LogInjection_128Bit_TraceId_Disabled:
       '*': incomplete_test_app (weblog endpoint not implemented)
-      'spring-boot-3-native': missing_feature
+      'spring-boot-3-native': v1.48.0
     Test_Config_LogInjection_128Bit_TraceId_Enabled:
       '*': incomplete_test_app (weblog endpoint not implemented)
-      'spring-boot-3-native': missing_feature
+      'spring-boot-3-native': v1.48.0
     Test_Config_LogInjection_Default:
       '*': incomplete_test_app (weblog endpoint not implemented)
-      'spring-boot-3-native': missing_feature
+      'spring-boot-3-native': v1.48.0
     Test_Config_LogInjection_Enabled:
       '*': incomplete_test_app (weblog endpoint not implemented)
-      'spring-boot-3-native': missing_feature
+      'spring-boot-3-native': v1.48.0
     Test_Config_ObfuscationQueryStringRegexp_Configured: v1.39.0
     Test_Config_ObfuscationQueryStringRegexp_Default: v1.39.0
     Test_Config_ObfuscationQueryStringRegexp_Empty: v1.39.0

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -524,8 +524,10 @@ class Test_Config_LogInjection_Enabled:
             assert field in msg, f"Missing field: {field}"
 
 
+# Using TRACING_CONFIG_NONDEFAULT_2 for dd-trace-java since the default value is under the DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED
+# TODO: Change scenarios back to DEFAULT once all libraries change it to true
 @rfc("https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit#heading=h.8v16cioi7qxp")
-@scenarios.default
+@scenarios.tracing_config_nondefault_2
 @features.log_injection
 class Test_Config_LogInjection_Default:
     """Verify log injection is disabled by default"""

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -571,6 +571,7 @@ class _Scenarios:
             "DD_TRACE_CLIENT_IP_ENABLED": "true",
             "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "datadog,tracecontext,b3multi,baggage",
             "DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT": "ignore",
+            "DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED": "DD_LOGS_INJECTION",
         },
         include_kafka=True,
         include_postgres_db=True,

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -571,7 +571,7 @@ class _Scenarios:
             "DD_TRACE_CLIENT_IP_ENABLED": "true",
             "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "datadog,tracecontext,b3multi,baggage",
             "DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT": "ignore",
-            "DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED": "DD_LOGS_INJECTION",
+            "DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED": "DD_LOGS_INJECTION",  # Test false default value in dd-trace-java
         },
         include_kafka=True,
         include_postgres_db=True,


### PR DESCRIPTION
## Motivation

All changes for Round 2 of Config Consistency have been merged. This PR aims to enable all of the previously disabled tests.

## Changes

[APMAPI-1043](https://datadoghq.atlassian.net/browse/APMAPI-1043)
## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-1043]: https://datadoghq.atlassian.net/browse/APMAPI-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ