### PR TITLE
feat(debugger): Add PHP debugger endpoint & config

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -402,7 +402,9 @@ tests/:
     test_debugger_probe_snapshot.py:
       Test_Debugger_Probe_Snaphots: missing_feature
     test_debugger_probe_status.py:
-      Test_Debugger_Probe_Statuses: missing_feature
+      Test_Debugger_Probe_Statuses:
+        '*': missing_feature
+        'apache-mod-8.0': v1.7.3
     test_debugger_symdb.py:
       Test_Debugger_SymDb: missing_feature
     test_debugger_telemetry.py:

--- a/tests/debugger/probes/probe_status_metric.json
+++ b/tests/debugger/probes/probe_status_metric.json
@@ -38,27 +38,5 @@
       "sourceFile": null
     },
     "evaluateAt": "EXIT"
-  },
-  {
-    "language": "",
-    "type": "",
-    "id": "metricf2-line-45cf-9f39-59installed",
-    "version": 0,
-    "kind": "COUNT",
-    "metricName": "MetricCountInt",
-    "value": {
-      "dsl" : "",
-      "json": {
-        "ref": "id"
-      }
-    },
-    "where": {
-      "typeName": null,
-      "sourceFile": "ACTUAL_SOURCE_FILE",
-      "lines": [
-        "28"
-      ]
-    },
-    "evaluateAt": "EXIT"
   }
 ]

--- a/tests/debugger/probes/probe_status_metric_line.json
+++ b/tests/debugger/probes/probe_status_metric_line.json
@@ -1,0 +1,24 @@
+[
+  {
+    "language": "",
+    "type": "",
+    "id": "metricf2-line-45cf-9f39-59installed",
+    "version": 0,
+    "kind": "COUNT",
+    "metricName": "MetricCountInt",
+    "value": {
+      "dsl" : "",
+      "json": {
+        "ref": "id"
+      }
+    },
+    "where": {
+      "typeName": null,
+      "sourceFile": "ACTUAL_SOURCE_FILE",
+      "lines": [
+        "28"
+      ]
+    },
+    "evaluateAt": "EXIT"
+  }
+]

--- a/tests/debugger/probes/probe_status_spandecoration.json
+++ b/tests/debugger/probes/probe_status_spandecoration.json
@@ -7,6 +7,7 @@
         "targetSpan": "ACTIVE",
         "decorations": [
             {
+                "tags": [],
                 "when": {
                     "dsl" : "",
                     "json": {
@@ -37,6 +38,7 @@
         "targetSpan": "ACTIVE",
         "decorations": [
             {
+                "tags": [],
                 "when": {
                     "dsl" : "",
                     "json": {
@@ -56,39 +58,6 @@
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "SpanDecorationProbe",
             "sourceFile": null
-        },
-        "evaluateAt": "EXIT"
-    },
-    {
-        "language": "",
-        "type": "",
-        "id": "decorcf2-line-45cf-9f39-59installed",
-        "version": 0,
-        "targetSpan": "ACTIVE",
-        "decorations": [
-            {
-                "when": {
-                    "dsl" : "",
-                    "json": {
-                        "gt": [
-                            {
-                                "ref": "intLocal"
-                            },
-                            {
-                                "ref": "intArg"
-                            }
-                        ]
-                    }
-                }
-            }
-        ],
-        "where": {
-            "typeName": null,
-            "dsl" : "",
-            "sourceFile": "ACTUAL_SOURCE_FILE",
-            "lines": [
-                "44"
-            ]
         },
         "evaluateAt": "EXIT"
     }

--- a/tests/debugger/probes/probe_status_spandecoration_line.json
+++ b/tests/debugger/probes/probe_status_spandecoration_line.json
@@ -1,0 +1,36 @@
+[
+    {
+        "language": "",
+        "type": "",
+        "id": "decorcf2-line-45cf-9f39-59installed",
+        "version": 0,
+        "targetSpan": "ACTIVE",
+        "decorations": [
+            {
+                "tags": [],
+                "when": {
+                    "dsl" : "",
+                    "json": {
+                        "gt": [
+                            {
+                                "ref": "intLocal"
+                            },
+                            {
+                                "ref": "intArg"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "where": {
+            "typeName": null,
+            "dsl" : "",
+            "sourceFile": "ACTUAL_SOURCE_FILE",
+            "lines": [
+                "44"
+            ]
+        },
+        "evaluateAt": "EXIT"
+    }
+]

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -3,7 +3,6 @@
 # Copyright 2021 Datadog, Inc.
 
 import tests.debugger.utils as debugger
-
 from utils import scenarios, features, bug, missing_feature, context
 
 
@@ -66,6 +65,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
+    @missing_feature(context.library == "php", reason="Not yet implemented")
     def test_probe_status_log_line(self):
         self._assert()
 
@@ -90,6 +90,17 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
     def test_probe_status_metric(self):
         self._assert()
 
+    def setup_probe_status_metric_line(self):
+        self._setup("probe_status_metric_line")
+
+    @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
+    @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
+    @missing_feature(context.library == "ruby", reason="Not yet implemented")
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented")
+    @missing_feature(context.library == "php", reason="Not yet implemented")
+    def test_probe_status_metric_line(self):
+        self._assert()
+
     ############ span probe ############
     def setup_probe_status_span(self):
         self._setup("probe_status_span")
@@ -108,4 +119,15 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
     @missing_feature(context.library == "ruby", reason="Not yet implemented")
     @missing_feature(context.library == "nodejs", reason="Not yet implemented")
     def test_probe_status_spandecoration(self):
+        self._assert()
+
+    def setup_probe_status_spandecoration_line(self):
+        self._setup("probe_status_spandecoration_line")
+
+    @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
+    @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
+    @missing_feature(context.library == "ruby", reason="Not yet implemented")
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented")
+    @missing_feature(context.library == "php", reason="Not yet implemented")
+    def test_probe_status_spandecoration_line(self):
         self._assert()

--- a/utils/build/docker/php/common/debugger.php
+++ b/utils/build/docker/php/common/debugger.php
@@ -1,0 +1,198 @@
+<?php
+
+class DebuggerController {
+    private $intLocal = 0;
+    private $intMixLocal = 0;
+
+    public function LogProbe() {
+        return "Log probe";
+    }
+
+    public function MetricProbe($id) {
+        $id++;
+        return "Metric Probe " . $id;
+    }
+
+    public function SpanProbe() {
+        return "Span probe";
+    }
+
+    public function SpanDecorationProbe($arg, $intArg) {
+        $this->intLocal = $intArg * strlen($arg);
+        return "Span Decoration Probe " . $this->intLocal;
+    }
+
+    public function mixProbe($arg, $intArg) {
+        $this->intMixLocal = $intArg * strlen($arg);
+        return "Mixed result " . $this->intMixLocal;
+    }
+
+    public function pii() {
+        // Simulating Pii class behavior
+        $testValue = "test_value";
+        $customTestValue = "custom_test_value";
+        return "PII " . $testValue . ". CustomPII " . $customTestValue;
+    }
+
+    public function expression($inputValue) {
+        $localValue = strlen($inputValue);
+        return "Great success number " . $localValue;
+    }
+
+    public function ExpressionException() {
+        http_response_code(500);
+        return "Hello from exception";
+    }
+
+    public function ExpressionOperators($intValue, $floatValue, $strValue) {
+        return "Int value " . $intValue . ". Float value " . $floatValue . ". String value is " . $strValue . ".";
+    }
+
+    public function StringOperations($strValue, $emptyString = "", $nullString = null) {
+        return "strValue " . $strValue . ". emptyString " . $emptyString . ". " . $nullString . ".";
+    }
+
+    public function collectionOperations() {
+        // Simulating collection operations with different PHP collection types
+        $a0 = array();
+        $l0 = new SplFixedArray(0);
+        $h0 = array();
+        $a1 = array(1);
+        $l1 = new SplFixedArray(1);
+        $l1[0] = 1;
+        $h1 = array('key' => 1);
+        $a5 = array(1, 2, 3, 4, 5);
+        $l5 = new SplFixedArray(5);
+        for ($i = 0; $i < 5; $i++) {
+            $l5[$i] = $i + 1;
+        }
+        $h5 = array(
+            'k1' => 1,
+            'k2' => 2,
+            'k3' => 3,
+            'k4' => 4,
+            'k5' => 5
+        );
+
+        $a0_count = count($a0);
+        $l0_count = $l0->count();
+        $h0_count = count($h0);
+        $a1_count = count($a1);
+        $l1_count = $l1->count();
+        $h1_count = count($h1);
+        $a5_count = count($a5);
+        $l5_count = $l5->count();
+        $h5_count = count($h5);
+
+        return "{$a0_count},{$a1_count},{$a5_count},{$l0_count},{$l1_count},{$l5_count},{$h0_count},{$h1_count},{$h5_count}.";
+    }
+
+    public function nulls($intValue, $strValue, $boolValue) {
+        $pii = $boolValue ? new stdClass() : null;
+        return "Pii is null " . ($pii === null ? "true" : "false") . ". intValue is null " . ($intValue === null ? "true" : "false") . ". strValue is null " . ($strValue === null ? "true" : "false") . ".";
+    }
+
+    public function Budgets($loops) {
+        for ($i = 0; $i < $loops; $i++) {
+            // Empty loop to simulate the Python version
+        }
+        return "Budgets";
+    }
+}
+
+// Request handling
+$controller = new DebuggerController();
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$parts = explode('/', trim($path, '/'));
+
+// Remove the 'debugger' prefix if it exists
+if (count($parts) > 0 && $parts[0] === 'debugger') {
+    array_shift($parts);
+}
+
+$query = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
+parse_str($query, $queryParams);
+
+if (count($parts) === 1) {
+    switch ($parts[0]) {
+        case 'init':
+            echo "Debugger initialized";
+            break;
+        case 'log':
+            echo $controller->LogProbe();
+            break;
+        case 'span':
+            echo $controller->SpanProbe();
+            break;
+        case 'pii':
+            echo $controller->pii();
+            break;
+        case 'expression':
+            if (!isset($queryParams['inputValue'])) {
+                http_response_code(400);
+                break;
+            }
+            echo $controller->expression($queryParams['inputValue']);
+            break;
+        default:
+            http_response_code(404);
+            break;
+    }
+} elseif (count($parts) === 2) {
+    switch ($parts[0]) {
+        case 'metric':
+            echo $controller->MetricProbe(intval($parts[1]));
+            break;
+        case 'budgets':
+            echo $controller->Budgets(intval($parts[1]));
+            break;
+        case 'expression':
+            switch ($parts[1]) {
+                case 'exception':
+                    echo $controller->ExpressionException();
+                    break;
+                case 'operators':
+                    $intValue = isset($queryParams['intValue']) ? intval($queryParams['intValue']) : null;
+                    $floatValue = isset($queryParams['floatValue']) ? floatval($queryParams['floatValue']) : null;
+                    $strValue = isset($queryParams['strValue']) ? $queryParams['strValue'] : null;
+                    echo $controller->ExpressionOperators($intValue, $floatValue, $strValue);
+                    break;
+                case 'strings':
+                    $strValue = isset($queryParams['strValue']) ? $queryParams['strValue'] : null;
+                    $emptyString = isset($queryParams['emptyString']) ? $queryParams['emptyString'] : "";
+                    $nullString = isset($queryParams['nullString']) ? $queryParams['nullString'] : null;
+                    echo $controller->StringOperations($strValue, $emptyString, $nullString);
+                    break;
+                case 'collections':
+                    echo $controller->collectionOperations();
+                    break;
+                case 'null':
+                    $intValue = isset($queryParams['intValue']) ? intval($queryParams['intValue']) : null;
+                    $strValue = isset($queryParams['strValue']) ? $queryParams['strValue'] : null;
+                    $boolValue = isset($queryParams['boolValue']) ? filter_var($queryParams['boolValue'], FILTER_VALIDATE_BOOLEAN) : null;
+                    echo $controller->nulls($intValue, $strValue, $boolValue);
+                    break;
+                default:
+                    http_response_code(404);
+                    break;
+            }
+            break;
+        default:
+            http_response_code(404);
+            break;
+    }
+} elseif (count($parts) === 3) {
+    switch ($parts[0]) {
+        case 'span-decoration':
+            echo $controller->SpanDecorationProbe($parts[1], intval($parts[2]));
+            break;
+        case 'mix':
+            echo $controller->mixProbe($parts[1], intval($parts[2]));
+            break;
+        default:
+            http_response_code(404);
+            break;
+    }
+} else {
+    http_response_code(404);
+}

--- a/utils/build/docker/php/php-fpm/php-fpm.conf
+++ b/utils/build/docker/php/php-fpm/php-fpm.conf
@@ -28,6 +28,7 @@
         RewriteRule "^/signup$" "/signup/"
         RewriteRule "^/shell_execution$" "/shell_execution/"
         RewriteRule "^/rasp/(.*)" "/rasp/$1.php" [L]
+        RewriteRule "^/debugger$" "/debugger/"
         RewriteCond /var/www/html/%{REQUEST_URI} !-f
         RewriteRule "^/([^/]+)/(.*)" "/$1.php/$2" [L]
         ErrorDocument 404 /404.php
@@ -47,4 +48,3 @@
     </VirtualHost>
 </IfModule>
 </IfModule>
-


### PR DESCRIPTION
## Motivation

This pull request enables PHP for the `Test_Debugger_Probe_Statuses` scenario only. This is the minimal number of changes required to get PHP passing, and in future PRs we'll enable it for more scenarios including Exception Replay (@shurivich), telemetry, and the expression language.

## Changes

* [`manifests/php.yml`](diffhunk://#diff-164e30a9609b478cdace674ea20d1ae01e3872dc0d69e2da602f6acb450c4e85L389-R389): Updated the version for `Test_Debugger_Probe_Statuses` to `v1.7.3`.
* [`tests/debugger/test_debugger_probe_status.py`](diffhunk://#diff-67081901be029daaca4be54be8a1da76625549618ce0ebeeadaa82ecf079f984R93-R103): Added new test cases for `probe_status_metric_line` and `probe_status_spandecoration_line`, including the necessary setup methods and missing feature annotations. [[1]](diffhunk://#diff-67081901be029daaca4be54be8a1da76625549618ce0ebeeadaa82ecf079f984R93-R103) [[2]](diffhunk://#diff-67081901be029daaca4be54be8a1da76625549618ce0ebeeadaa82ecf079f984R123-R133)
* [`tests/debugger/utils.py`](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821L35-L43): Enhanced `extract_probe_ids` to handle both dictionaries and lists, added PHP-specific logic for setting probe fields, and ensured PHP tracer initiates logging with a request to `/debugger/init`. [[1]](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821L35-L43) [[2]](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821R131-R134) [[3]](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821R194-R197)
* [`utils/build/docker/php/common/debugger.php`](diffhunk://#diff-f2edf6e8bc69a97b40d99f57d3a703a98d736fdfb54a6a514aed82266cd90830R1-R198): Implemented a new PHP `DebuggerController` class with methods for various probe operations, and added request handling logic to route debugger-related requests.
* [`utils/build/docker/php/php-fpm/php-fpm.conf`](diffhunk://#diff-2385036f80059ba1670847bdfd58e9335d5756051cc38b1ce0659b00aa43c04aR31): Added a rewrite rule for `/debugger` to route requests appropriately.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
