### PR TITLE
parametric: update reporting for 128bit traceid cpp tests [cpp]

### DIFF
--- a/tests/parametric/test_128_bit_traceids.py
+++ b/tests/parametric/test_128_bit_traceids.py
@@ -185,7 +185,7 @@ class Test_128_Bit_Traceids:
         assert "_dd.p.tid=" + dd_p_tid in headers["x-datadog-tags"]
         validate_dd_p_tid(dd_p_tid)
 
-    @missing_feature(context.library == "cpp", reason="propagation style not supported")
+    @irrelevant(context.library == "cpp", reason="propagation style not supported")
     @missing_feature(context.library == "ruby", reason="not implemented")
     @irrelevant(context.library > "python@2.20.0", reason="3.x set `b3` instead of `B3 single header`")
     @pytest.mark.parametrize(
@@ -209,7 +209,7 @@ class Test_128_Bit_Traceids:
         assert dd_p_tid == "640cfd8d00000000"
         check_128_bit_trace_id(fields[0], trace_id, dd_p_tid)
 
-    @missing_feature(context.library == "cpp", reason="propagation style not supported")
+    @irrelevant(context.library == "cpp", reason="propagation style not supported")
     @missing_feature(context.library == "ruby", reason="not implemented")
     @irrelevant(context.library > "python@2.20.0", reason="3.x set `b3` instead of `B3 single header`")
     @pytest.mark.parametrize(
@@ -229,7 +229,7 @@ class Test_128_Bit_Traceids:
         assert dd_p_tid is None
         check_64_bit_trace_id(fields[0], trace_id, dd_p_tid)
 
-    @missing_feature(context.library == "cpp", reason="propagation style not supported")
+    @irrelevant(context.library == "cpp", reason="propagation style not supported")
     @missing_feature(
         context.library == "ruby", reason="Issue: Ruby doesn't support case-insensitive distributed headers"
     )
@@ -249,7 +249,7 @@ class Test_128_Bit_Traceids:
 
         check_64_bit_trace_id(fields[0], span.get("trace_id"), span["meta"].get("_dd.p.tid"))
 
-    @missing_feature(context.library == "cpp", reason="propagation style not supported")
+    @irrelevant(context.library == "cpp", reason="propagation style not supported")
     @missing_feature(context.library == "ruby", reason="not implemented")
     @irrelevant(context.library > "python@2.20.0", reason="3.x set `b3` instead of `B3 single header`")
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation

- Ensures the FPD reports that the cpp tracer has the expected value for the 128bit trace id generation.

## Changes

- Update test annotations from missing_feature to `irrelevant`. We don't need to test 128bit trace id support for b3 headers if b3 headers are not supported.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
