### PR TITLE
Rename Library version to ComponentVersion, and ComponentVersion.library to ComponentVersion.name

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,7 +20,7 @@ from utils import context
 from utils._context._scenarios import scenarios, Scenario
 from utils._logger import logger
 from utils.scripts.junit_report import junit_modifyreport
-from utils._context.library_version import LibraryVersion
+from utils._context.component_version import ComponentVersion
 from utils._decorators import released, configure as configure_decorators
 from utils.properties_serialization import SetupProperties
 
@@ -494,7 +494,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     if context.scenario.is_main_worker:
         with open(f"{context.scenario.host_log_folder}/known_versions.json", "w", encoding="utf-8") as f:
             json.dump(
-                {library: sorted(versions) for library, versions in LibraryVersion.known_versions.items()}, f, indent=2
+                {library: sorted(versions) for library, versions in ComponentVersion.known_versions.items()}, f, indent=2
             )
 
         data = session.config._json_report.report  # noqa: SLF001

--- a/conftest.py
+++ b/conftest.py
@@ -244,7 +244,7 @@ def _get_skip_reason_from_marker(marker: pytest.Mark) -> str | None:
 def pytest_pycollect_makemodule(module_path: Path, parent: pytest.Session) -> None | pytest.Module:
     # As now, declaration only works for tracers at module level
 
-    library = context.library.library
+    library = context.library.name
 
     manifests = load_manifests()
 
@@ -523,7 +523,7 @@ def export_feature_parity_dashboard(session: pytest.Session, data: dict) -> None
         "runDate": data["created"],
         "environment": session.config.option.report_environment or "local",
         "testSource": "systemtests",
-        "language": context.library.library,
+        "language": context.library.name,
         "variant": context.weblog_variant,
         "testedDependencies": [
             {"name": name, "version": str(version)} for name, version in context.scenario.components.items()

--- a/conftest.py
+++ b/conftest.py
@@ -494,7 +494,9 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     if context.scenario.is_main_worker:
         with open(f"{context.scenario.host_log_folder}/known_versions.json", "w", encoding="utf-8") as f:
             json.dump(
-                {library: sorted(versions) for library, versions in ComponentVersion.known_versions.items()}, f, indent=2
+                {library: sorted(versions) for library, versions in ComponentVersion.known_versions.items()},
+                f,
+                indent=2,
             )
 
         data = session.config._json_report.report  # noqa: SLF001

--- a/docs/scenarios/docker_ssi.md
+++ b/docs/scenarios/docker_ssi.md
@@ -376,7 +376,7 @@ class TestDockerSSIFeatures:
 
     @features.ssi_guardrails
     def test_install_supported_runtime(self):
-        logger.info(f"Testing Docker SSI installation on supported lang runtime: {context.scenario.library.library}")
+        logger.info(f"Testing Docker SSI installation on supported lang runtime: {context.scenario.library.name}")
         assert self.r.status_code == 200, f"Failed to get response from {context.scenario.weblog_url}"
 
         # If the language version is supported there are traces related with the request

--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -811,7 +811,7 @@ Returns a JSON dict, with those values :
 {
   "status": "ok",
   "library": {
-    "language": "<language>", // one of cpp, dotnet, golang, java, nodejs, php, python, ruby
+    "name": "<library's name>", // one of cpp, cpp_nginx, cpp_httpd, dotnet, golang, java, nodejs, php, python, ruby
     "version": "1.2.3" // version of the library
   }
 }

--- a/tests/appsec/iast/sink/test_hardcoded_passwords.py
+++ b/tests/appsec/iast/sink/test_hardcoded_passwords.py
@@ -39,7 +39,7 @@ class Test_HardcodedPasswords:
         assert vuln["location"]["path"] == self._get_expectation(self.location_map)
 
     def _get_expectation(self, d):
-        expected = d.get(context.library.library)
+        expected = d.get(context.library.name)
         if isinstance(expected, dict):
             expected = expected.get(context.weblog_variant)
         return expected
@@ -75,5 +75,5 @@ class Test_HardcodedPasswords_ExtendedLocation:
 
         assert all(field in location for field in ["path", "line"])
 
-        if context.library.library not in ("python", "nodejs"):
+        if context.library.name not in ("python", "nodejs"):
             assert all(field in location for field in ["class", "method"])

--- a/tests/appsec/iast/sink/test_hardcoded_secrets.py
+++ b/tests/appsec/iast/sink/test_hardcoded_secrets.py
@@ -12,7 +12,7 @@ from tests.appsec.iast.utils import get_hardcoded_vulnerabilities, validate_stac
 
 
 def get_expectation(d):
-    expected = d.get(context.library.library)
+    expected = d.get(context.library.name)
     if isinstance(expected, dict):
         expected = expected.get(context.weblog_variant)
     return expected
@@ -102,5 +102,5 @@ class Test_HardcodedSecrets_ExtendedLocation:
 
         assert all(field in location for field in ["path", "line"])
 
-        if context.library.library not in ("python", "nodejs"):
+        if context.library.name not in ("python", "nodejs"):
             assert all(field in location for field in ["class", "method"])

--- a/tests/appsec/iast/sink/test_unvalidated_redirect.py
+++ b/tests/appsec/iast/sink/test_unvalidated_redirect.py
@@ -7,7 +7,7 @@ from tests.appsec.iast.utils import BaseSinkTestWithoutTelemetry, validate_exten
 
 
 def _expected_location():
-    if context.library.library == "java":
+    if context.library.name == "java":
         if context.weblog_variant.startswith("spring-boot"):
             return "com.datadoghq.system_tests.springboot.AppSecIast"
         if context.weblog_variant == "resteasy-netty3":
@@ -18,7 +18,7 @@ def _expected_location():
             return "com.datadoghq.vertx3.iast.routes.IastSinkRouteProvider"
         if context.weblog_variant == "vertx4":
             return "com.datadoghq.vertx4.iast.routes.IastSinkRouteProvider"
-    if context.library.library == "nodejs":
+    if context.library.name == "nodejs":
         if context.weblog_variant in ("express4", "express5"):
             return "iast/index.js"
         if context.weblog_variant == "express4-typescript":

--- a/tests/appsec/iast/sink/test_unvalidated_redirect_forward.py
+++ b/tests/appsec/iast/sink/test_unvalidated_redirect_forward.py
@@ -7,7 +7,7 @@ from tests.appsec.iast.utils import BaseSinkTestWithoutTelemetry, validate_exten
 
 
 def _expected_location():
-    if context.library.library == "java":
+    if context.library.name == "java":
         if context.weblog_variant.startswith("spring-boot"):
             return "com.datadoghq.system_tests.springboot.AppSecIast"
         if context.weblog_variant == "vertx3":

--- a/tests/appsec/iast/sink/test_weak_hash.py
+++ b/tests/appsec/iast/sink/test_weak_hash.py
@@ -12,16 +12,16 @@ from tests.appsec.iast.utils import (
 
 
 def _expected_location() -> str | None:
-    if context.library.library == "java":
+    if context.library.name == "java":
         return "com.datadoghq.system_tests.iast.utils.CryptoExamples"
 
-    if context.library.library == "nodejs":
+    if context.library.name == "nodejs":
         if context.weblog_variant in ("express4", "express5"):
             return "iast/index.js"
         if context.weblog_variant == "express4-typescript":
             return "iast.ts"
 
-    if context.library.library == "python":
+    if context.library.name == "python":
         if context.library.version >= "1.12.0":
             return "iast.py"
         # old value: absolute path
@@ -33,7 +33,7 @@ def _expected_location() -> str | None:
 
 
 def _expected_evidence() -> str:
-    if context.library.library == "dotnet":
+    if context.library.name == "dotnet":
         return "MD5"
     else:
         return "md5"

--- a/tests/appsec/iast/source/test_header_name.py
+++ b/tests/appsec/iast/source/test_header_name.py
@@ -10,7 +10,7 @@ from tests.appsec.iast.utils import BaseSourceTest
 class TestHeaderName(BaseSourceTest):
     """Verify that request headers name are tainted"""
 
-    source_name = "User" if context.library.library == "python" else "user"
+    source_name = "User" if context.library.name == "python" else "user"
 
     endpoint = "/iast/source/headername/test"
     requests_kwargs = [{"method": "GET", "headers": {"user": "unused"}}]

--- a/tests/appsec/iast/source/test_header_value.py
+++ b/tests/appsec/iast/source/test_header_value.py
@@ -11,7 +11,7 @@ class TestHeaderValue(BaseSourceTest):
     """Verify that request headers are tainted"""
 
     source_name = (
-        "HTTP_TABLE" if context.library.library == "python" and context.weblog_variant == "django-poc" else "table"
+        "HTTP_TABLE" if context.library.name == "python" and context.weblog_variant == "django-poc" else "table"
     )
 
     endpoint = "/iast/source/header/test"

--- a/tests/appsec/iast/source/test_parameter_value.py
+++ b/tests/appsec/iast/source/test_parameter_value.py
@@ -16,8 +16,8 @@ class TestParameterValue(BaseSourceTest):
         {"method": "POST", "data": {"table": "user"}},
     ]
     # In test case in node, the value is redacted
-    source_value = None if context.library.library == "nodejs" else "user"
-    source_type = "http.request.body" if context.library.library in ("nodejs", "dotnet") else "http.request.parameter"
+    source_value = None if context.library.name == "nodejs" else "user"
+    source_type = "http.request.body" if context.library.name in ("nodejs", "dotnet") else "http.request.parameter"
     source_names = ["table"]
 
     # remove the base test, to handle the source_type spcial use case in node

--- a/tests/appsec/iast/utils.py
+++ b/tests/appsec/iast/utils.py
@@ -8,7 +8,7 @@ def _get_expectation(d: str | dict | None) -> str | None:
         return d
 
     if isinstance(d, dict):
-        expected = d.get(context.library.library)
+        expected = d.get(context.library.name)
         if isinstance(expected, dict):
             expected = expected.get(context.weblog_variant)
         return expected
@@ -336,7 +336,7 @@ def validate_extended_location_data(
     else:
         assert all(field in location for field in ["path", "line"])
 
-        if context.library.library not in ("python", "nodejs"):
+        if context.library.name not in ("python", "nodejs"):
             assert all(field in location for field in ["class", "method"])
 
 

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -725,7 +725,7 @@ class BaseSCAStandaloneTelemetry:
     def test_app_dependencies_loaded(self):
         self.assert_standalone_is_enabled(self.r)
 
-        seen_loaded_dependencies = TelemetryUtils.get_loaded_dependency(context.library.library)
+        seen_loaded_dependencies = TelemetryUtils.get_loaded_dependency(context.library.name)
 
         for data in interfaces.library.get_telemetry_data():
             content = data["request"]["content"]

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -225,7 +225,7 @@ class Test_TelemetryMetrics:
 def _validate_headers(headers, request_type):
     """https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/how-to-use.md"""
 
-    expected_language = context.library.library
+    expected_language = context.library.name
     if expected_language == "java":
         expected_language = "jvm"
 

--- a/tests/auto_inject/test_auto_inject_chaos.py
+++ b/tests/auto_inject/test_auto_inject_chaos.py
@@ -18,7 +18,7 @@ class BaseAutoInjectChaos(base.AutoInjectBaseTest):
         weblog_url = f"http://{vm_ip}:{vm_port}/"
         # Weblog start command. If it's a ruby tracer, we must to rebuild the app before restart it
         weblog_start_command = "sudo systemctl start test-app.service"
-        if context.scenario.library.library in ["ruby", "python", "dotnet"]:
+        if context.scenario.library.name in ["ruby", "python", "dotnet"]:
             weblog_start_command = virtual_machine._vm_provision.weblog_installation.remote_command
 
         # Ok the installation is done, now we can do some chaos
@@ -56,7 +56,7 @@ class BaseAutoInjectChaos(base.AutoInjectBaseTest):
         apm_inject_restore = "sudo datadog-installer apm instrument"
 
         # Env for installation command
-        prefix_env = f"DD_LANG={context.scenario.library.library}"
+        prefix_env = f"DD_LANG={context.scenario.library.name}"
         for key, value in virtual_machine._vm_provision.env.items():
             prefix_env += f" DD_{key}={value}"
 

--- a/tests/auto_inject/test_blocklist_auto_inject.py
+++ b/tests/auto_inject/test_blocklist_auto_inject.py
@@ -105,7 +105,7 @@ class TestAutoInjectBlockListInstallManualHost(_AutoInjectBlockListBaseTest):
         """Check that we are blocking command with args. These args are defined in the buildIn args ignore list for each language."""
         virtual_machine = context.scenario.virtual_machine
         logger.info(f"[{virtual_machine.get_ip()}] Executing test_builtIn_block_args")
-        language = context.scenario.library.library
+        language = context.scenario.library.name
         if language in self.builtin_args_commands_block:
             ssh_client = virtual_machine.get_ssh_connection()
             for command in self.builtin_args_commands_block[language]:
@@ -129,7 +129,7 @@ class TestAutoInjectBlockListInstallManualHost(_AutoInjectBlockListBaseTest):
         """Check that we are instrumenting the command with args that it should be instrumented. The args are not included on the buildIn args list"""
         virtual_machine = context.scenario.virtual_machine
         logger.info(f"[{virtual_machine.get_ip()}] Executing test_builtIn_instrument_args")
-        language = context.scenario.library.library
+        language = context.scenario.library.name
         if language in self.builtin_args_commands_injected:
             ssh_client = virtual_machine.get_ssh_connection()
             for command in self.builtin_args_commands_injected[language]:

--- a/tests/auto_inject/utils.py
+++ b/tests/auto_inject/utils.py
@@ -153,10 +153,10 @@ class AutoInjectBaseTest:
         vm_logger(context.scenario.name, virtual_machine.name).info(
             f"{header} \n {header}  \n  Launching the uninstall for VM: {virtual_machine.name}  \n {header} \n {header}"
         )
-        if context.weblog_variant == f"test-app-{context.scenario.library.library}":  # Host
+        if context.weblog_variant == f"test-app-{context.scenario.library.name}":  # Host
             stop_weblog_command = "sudo systemctl kill -s SIGKILL test-app.service"
             start_weblog_command = "sudo systemctl start test-app.service"
-            if context.scenario.library.library in ["ruby", "python", "dotnet"]:
+            if context.scenario.library.name in ["ruby", "python", "dotnet"]:
                 start_weblog_command = virtual_machine._vm_provision.weblog_installation.remote_command
         else:  # Container
             stop_weblog_command = "sudo -E docker-compose -f docker-compose.yml down"

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -527,7 +527,7 @@ class BaseDebuggerTest:
     def get_tracer(self) -> dict[str, str]:
         if not BaseDebuggerTest.tracer:
             BaseDebuggerTest.tracer = {
-                "language": context.library.library,
+                "language": context.library.name,
                 "tracer_version": str(context.library.version),
             }
 

--- a/tests/docker_ssi/test_docker_ssi_crash.py
+++ b/tests/docker_ssi/test_docker_ssi_crash.py
@@ -37,7 +37,7 @@ class TestDockerSSICrash:
     @bug(context.library >= "python@3.2", reason="INPLAT-448")
     def test_crash(self):
         """Validate that a crash report is generated when the application crashes"""
-        logger.info(f"Testing Docker SSI crash tracking: {context.library.library}")
+        logger.info(f"Testing Docker SSI crash tracking: {context.library.name}")
         assert (
             self.r.status_code is None
         ), f"Response from request {scenarios.docker_ssi.weblog_url + '/crashme'} was supposed to fail: {self.r}"

--- a/tests/integrations/crossed_integrations/test_kinesis.py
+++ b/tests/integrations/crossed_integrations/test_kinesis.py
@@ -74,7 +74,7 @@ class _BaseKinesis:
         """
         message = (
             "[crossed_integrations/test_kinesis.py][Kinesis] Hello from Kinesis "
-            f"[{context.library.library} weblog->{self.buddy_interface.name}] test produce at {self.unique_id}"
+            f"[{context.library.name} weblog->{self.buddy_interface.name}] test produce at {self.unique_id}"
         )
 
         self.production_response = weblog.get(
@@ -133,7 +133,7 @@ class _BaseKinesis:
         """
         message = (
             "[crossed_integrations/test_kinesis.py][Kinesis] Hello from Kinesis "
-            f"[{self.buddy_interface.name}->{context.library.library} weblog] test consume at {self.unique_id}"
+            f"[{self.buddy_interface.name}->{context.library.name} weblog] test consume at {self.unique_id}"
         )
 
         self.production_response = self.buddy.get(

--- a/tests/integrations/crossed_integrations/test_sns_to_sqs.py
+++ b/tests/integrations/crossed_integrations/test_sns_to_sqs.py
@@ -101,7 +101,7 @@ class _BaseSNS:
         """
         message = (
             "[crossed_integrations/test_sns_to_sqs.py][SNS] Hello from SNS "
-            f"[{context.library.library} weblog->{self.buddy_interface.name}] test produce at {self.unique_id}"
+            f"[{context.library.name} weblog->{self.buddy_interface.name}] test produce at {self.unique_id}"
         )
 
         self.production_response = weblog.get(
@@ -161,7 +161,7 @@ class _BaseSNS:
         """
         message = (
             "[crossed_integrations/test_sns_to_sqs.py][SNS] Hello from SNS "
-            f"[{self.buddy_interface.name}->{context.library.library} weblog] test consume at {self.unique_id}"
+            f"[{self.buddy_interface.name}->{context.library.name} weblog] test consume at {self.unique_id}"
         )
 
         self.production_response = self.buddy.get(

--- a/tests/integrations/crossed_integrations/test_sqs.py
+++ b/tests/integrations/crossed_integrations/test_sqs.py
@@ -86,7 +86,7 @@ class _BaseSQS:
         """
         message = (
             "[crossed_integrations/sqs.py][SQS] Hello from SQS "
-            f"[{context.library.library} weblog->{self.buddy_interface.name}] test produce: {self.unique_id}"
+            f"[{context.library.name} weblog->{self.buddy_interface.name}] test produce: {self.unique_id}"
         )
 
         self.production_response = weblog.get(
@@ -149,7 +149,7 @@ class _BaseSQS:
         """
         message = (
             "[crossed_integrations/test_sqs.py][SQS] Hello from SQS "
-            f"[{self.buddy_interface.name}->{context.library.library} weblog] test consume: {self.unique_id}"
+            f"[{self.buddy_interface.name}->{context.library.name} weblog] test consume: {self.unique_id}"
         )
 
         self.production_response = self.buddy.get(

--- a/tests/integrations/test_db_integrations_sql.py
+++ b/tests/integrations/test_db_integrations_sql.py
@@ -305,7 +305,7 @@ class Test_MsSql(_BaseDatadogDbIntegrationTestClass):
             elif db_operation == "procedure":
                 # Insert and procedure:These operations also receive two parameters, but are obfuscated as only one.
                 # Node.js: The proccedure has a input parameter, but we are calling through method `execute`` and we can't see the parameters in the traces
-                expected_obfuscation_count = 0 if context.library.library == "nodejs" else 2
+                expected_obfuscation_count = 0 if context.library.name == "nodejs" else 2
             else:
                 expected_obfuscation_count = 2
 

--- a/tests/integrations/test_dbm.py
+++ b/tests/integrations/test_dbm.py
@@ -21,7 +21,7 @@ class Test_Dbm:
 
     # Helper Methods
     def weblog_trace_payload(self):
-        self.library_name = context.library.library
+        self.library_name = context.library.name
         self.scenario_name = context.scenario.name
         self.requests = []
 

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -46,7 +46,7 @@ WEBLOG_VARIANT_SANITIZED = context.weblog_variant.replace(".", "_").replace(" ",
 
 
 def get_message(test, system):
-    return f"[test_dsm.py::{test}] [{system.upper()}] Hello from {context.library.library} DSM test: {scenarios.integrations_aws.unique_id}"
+    return f"[test_dsm.py::{test}] [{system.upper()}] Hello from {context.library.name} DSM test: {scenarios.integrations_aws.unique_id}"
 
 
 @features.datastreams_monitoring_support_for_kafka
@@ -94,12 +94,12 @@ class Test_DsmKafka:
             },
         }
 
-        producer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["producer"]
-        consumer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["consumer"]
-        edge_tags_out = language_hashes.get(context.library.library, language_hashes.get("default")).get(
+        producer_hash = language_hashes.get(context.library.name, language_hashes.get("default"))["producer"]
+        consumer_hash = language_hashes.get(context.library.name, language_hashes.get("default"))["consumer"]
+        edge_tags_out = language_hashes.get(context.library.name, language_hashes.get("default")).get(
             "edge_tags_out", language_hashes.get("default")["edge_tags_out"]
         )
-        edge_tags_in = language_hashes.get(context.library.library, language_hashes.get("default")).get(
+        edge_tags_in = language_hashes.get(context.library.name, language_hashes.get("default")).get(
             "edge_tags_in", language_hashes.get("default")["edge_tags_in"]
         )
 
@@ -157,8 +157,8 @@ class Test_DsmRabbitmq:
             },
         }
 
-        producer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["producer"]
-        consumer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["consumer"]
+        producer_hash = language_hashes.get(context.library.name, language_hashes.get("default"))["producer"]
+        consumer_hash = language_hashes.get(context.library.name, language_hashes.get("default"))["consumer"]
         edge_tags_in = language_hashes.get("default")["edge_tags_in"]
         edge_tags_out = language_hashes.get("default")["edge_tags_out"]
 
@@ -277,10 +277,10 @@ class Test_DsmSQS:
 
         # we can't add the time hash to node since we can't replicate the hashing algo in python and compute a hash,
         # which changes for each run with the time stamp added
-        if context.library.library != "nodejs":
-            self.queue = f"{DSM_QUEUE}_{context.library.library}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}"
+        if context.library.name != "nodejs":
+            self.queue = f"{DSM_QUEUE}_{context.library.name}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}"
         else:
-            self.queue = f"{DSM_QUEUE}_{context.library.library}"
+            self.queue = f"{DSM_QUEUE}_{context.library.name}"
 
         self.r = weblog.get(
             f"/dsm?integration=sqs&timeout=60&queue={self.queue}&message={message}", timeout=DSM_REQUEST_TIMEOUT
@@ -302,10 +302,10 @@ class Test_DsmSQS:
             },
         }
 
-        tags_in = hash_inputs.get(context.library.library, hash_inputs["default"])["tags_in"]
-        tags_out = hash_inputs.get(context.library.library, hash_inputs["default"])["tags_out"]
+        tags_in = hash_inputs.get(context.library.name, hash_inputs["default"])["tags_in"]
+        tags_out = hash_inputs.get(context.library.name, hash_inputs["default"])["tags_out"]
 
-        if context.library.library != "nodejs":
+        if context.library.name != "nodejs":
             producer_hash = compute_dsm_hash(0, tags_out)
             consumer_hash = compute_dsm_hash(producer_hash, tags_in)
         else:
@@ -326,12 +326,12 @@ class Test_DsmSNS:
 
         # we can't add the time hash to node since we can't replicate the hashing algo in python and compute a hash,
         # which changes for each run with the time stamp added
-        if context.library.library != "nodejs":
-            self.topic = f"{DSM_TOPIC}_{context.library.library}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}_raw"
-            self.queue = f"{DSM_QUEUE_SNS}_{context.library.library}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}_raw"
+        if context.library.name != "nodejs":
+            self.topic = f"{DSM_TOPIC}_{context.library.name}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}_raw"
+            self.queue = f"{DSM_QUEUE_SNS}_{context.library.name}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}_raw"
         else:
-            self.topic = f"{DSM_TOPIC}_{context.library.library}_raw"
-            self.queue = f"{DSM_QUEUE_SNS}_{context.library.library}_raw"
+            self.topic = f"{DSM_TOPIC}_{context.library.name}_raw"
+            self.queue = f"{DSM_QUEUE_SNS}_{context.library.name}_raw"
 
         self.r = weblog.get(
             f"/dsm?integration=sns&timeout=60&queue={self.queue}&topic={self.topic}&message={message}",
@@ -341,7 +341,7 @@ class Test_DsmSNS:
     def test_dsm_sns(self):
         assert self.r.text == "ok"
 
-        topic = self.topic if context.library.library == "java" else f"arn:aws:sns:us-east-1:{AWS_ACCT}:{self.topic}"
+        topic = self.topic if context.library.name == "java" else f"arn:aws:sns:us-east-1:{AWS_ACCT}:{self.topic}"
 
         hash_inputs = {
             "default": {
@@ -356,10 +356,10 @@ class Test_DsmSNS:
             },
         }
 
-        tags_in = hash_inputs.get(context.library.library, hash_inputs["default"])["tags_in"]
-        tags_out = hash_inputs.get(context.library.library, hash_inputs["default"])["tags_out"]
+        tags_in = hash_inputs.get(context.library.name, hash_inputs["default"])["tags_in"]
+        tags_out = hash_inputs.get(context.library.name, hash_inputs["default"])["tags_out"]
 
-        if context.library.library != "nodejs":
+        if context.library.name != "nodejs":
             producer_hash = compute_dsm_hash(0, tags_out)
             consumer_hash = compute_dsm_hash(producer_hash, tags_in)
         else:
@@ -380,10 +380,10 @@ class Test_DsmKinesis:
 
         # we can't add the time hash to node since we can't replicate the hashing algo in python and compute a hash,
         # which changes for each run with the time stamp added
-        if context.library.library != "nodejs":
-            self.stream = f"{DSM_STREAM}_{context.library.library}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}"
+        if context.library.name != "nodejs":
+            self.stream = f"{DSM_STREAM}_{context.library.name}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}"
         else:
-            self.stream = f"{DSM_STREAM}_{context.library.library}"
+            self.stream = f"{DSM_STREAM}_{context.library.name}"
 
         self.r = weblog.get(
             f"/dsm?integration=kinesis&timeout=60&stream={self.stream}&message={message}",
@@ -408,10 +408,10 @@ class Test_DsmKinesis:
                 "tags_in": ("direction:in", f"topic:{self.stream}", "type:kinesis"),
             },
         }
-        tags_in = hash_inputs.get(context.library.library, hash_inputs["default"])["tags_in"]
-        tags_out = hash_inputs.get(context.library.library, hash_inputs["default"])["tags_out"]
+        tags_in = hash_inputs.get(context.library.name, hash_inputs["default"])["tags_in"]
+        tags_out = hash_inputs.get(context.library.name, hash_inputs["default"])["tags_out"]
 
-        if context.library.library != "nodejs":
+        if context.library.name != "nodejs":
             producer_hash = compute_dsm_hash(0, tags_out)
             consumer_hash = compute_dsm_hash(producer_hash, tags_in)
         else:
@@ -441,7 +441,7 @@ class Test_DsmContext_Injection_Base64:
             "nodejs": {"producer": 18431567370843181989},
             "default": {"producer": 6031446427375485596},
         }
-        producer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["producer"]
+        producer_hash = language_hashes.get(context.library.name, language_hashes.get("default"))["producer"]
         edge_tags = ("direction:out", "topic:dsm-injection-topic", "type:kafka")
 
         # get json carrier object
@@ -458,7 +458,7 @@ class Test_DsmContext_Injection_Base64:
 
         # nodejs uses big endian, others use little endian
         _format = "<Q"
-        if context.library.library == "nodejs":
+        if context.library.name == "nodejs":
             _format = ">Q"
         # decoded_pathway = struct.unpack(_format, encoded_pathway[:8])[0]
 
@@ -494,8 +494,8 @@ class Test_DsmContext_Extraction_Base64:
             "default": {"producer": 6031446427375485596, "consumer": 12795903374559614717},
         }
         edge_tags = ("direction:in", "topic:dsm-injection-topic", "type:kafka")
-        producer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["producer"]
-        consumer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["consumer"]
+        producer_hash = language_hashes.get(context.library.name, language_hashes.get("default"))["producer"]
+        consumer_hash = language_hashes.get(context.library.name, language_hashes.get("default"))["consumer"]
 
         DsmHelper.assert_checkpoint_presence(hash_=consumer_hash, parent_hash=producer_hash, tags=edge_tags)
 
@@ -558,13 +558,13 @@ class Test_Dsm_Manual_Checkpoint_Intra_Process:
             },
         }
 
-        producer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["producer"]
-        consumer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["consumer"]
-        parent_producer_hash = language_hashes.get(context.library.library, {}).get("parent", 0)
-        edge_tags_out = language_hashes.get(context.library.library, language_hashes.get("default")).get(
+        producer_hash = language_hashes.get(context.library.name, language_hashes.get("default"))["producer"]
+        consumer_hash = language_hashes.get(context.library.name, language_hashes.get("default"))["consumer"]
+        parent_producer_hash = language_hashes.get(context.library.name, {}).get("parent", 0)
+        edge_tags_out = language_hashes.get(context.library.name, language_hashes.get("default")).get(
             "edge_tags_out", language_hashes.get("default")["edge_tags_out"]
         )
-        edge_tags_in = language_hashes.get(context.library.library, language_hashes.get("default")).get(
+        edge_tags_in = language_hashes.get(context.library.name, language_hashes.get("default")).get(
             "edge_tags_in", language_hashes.get("default")["edge_tags_in"]
         )
 
@@ -631,13 +631,13 @@ class Test_Dsm_Manual_Checkpoint_Inter_Process:
             },
         }
 
-        producer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["producer"]
-        consumer_hash = language_hashes.get(context.library.library, language_hashes.get("default"))["consumer"]
-        parent_producer_hash = language_hashes.get(context.library.library, {}).get("parent", 0)
-        edge_tags_out = language_hashes.get(context.library.library, language_hashes.get("default")).get(
+        producer_hash = language_hashes.get(context.library.name, language_hashes.get("default"))["producer"]
+        consumer_hash = language_hashes.get(context.library.name, language_hashes.get("default"))["consumer"]
+        parent_producer_hash = language_hashes.get(context.library.name, {}).get("parent", 0)
+        edge_tags_out = language_hashes.get(context.library.name, language_hashes.get("default")).get(
             "edge_tags_out", language_hashes.get("default")["edge_tags_out"]
         )
-        edge_tags_in = language_hashes.get(context.library.library, language_hashes.get("default")).get(
+        edge_tags_in = language_hashes.get(context.library.name, language_hashes.get("default")).get(
             "edge_tags_in", language_hashes.get("default")["edge_tags_in"]
         )
 

--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -278,7 +278,9 @@ class Test_DsmSQS:
         # we can't add the time hash to node since we can't replicate the hashing algo in python and compute a hash,
         # which changes for each run with the time stamp added
         if context.library.name != "nodejs":
-            self.queue = f"{DSM_QUEUE}_{context.library.name}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}"
+            self.queue = (
+                f"{DSM_QUEUE}_{context.library.name}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}"
+            )
         else:
             self.queue = f"{DSM_QUEUE}_{context.library.name}"
 
@@ -381,7 +383,9 @@ class Test_DsmKinesis:
         # we can't add the time hash to node since we can't replicate the hashing algo in python and compute a hash,
         # which changes for each run with the time stamp added
         if context.library.name != "nodejs":
-            self.stream = f"{DSM_STREAM}_{context.library.name}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}"
+            self.stream = (
+                f"{DSM_STREAM}_{context.library.name}_{WEBLOG_VARIANT_SANITIZED}_{scenarios.integrations_aws.unique_id}"
+            )
         else:
             self.stream = f"{DSM_STREAM}_{context.library.name}"
 

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -220,9 +220,9 @@ class TestDynamicConfigTracingEnabled:
     @bug(context.library == "java", reason="APMAPI-1225")
     def test_default_capability_completeness(self, library_env, test_agent, test_library):
         """Ensure the RC request contains the expected default capabilities per language, no more and no less."""
-        if context.library is not None and context.library.library is not None:
+        if context.library is not None and context.library.name is not None:
             seen_capabilities = test_agent.wait_for_rc_capabilities()
-            expected_capabilities = DEFAULT_SUPPORTED_CAPABILITIES_BY_LANG[context.library.library]
+            expected_capabilities = DEFAULT_SUPPORTED_CAPABILITIES_BY_LANG[context.library.name]
 
             seen_but_not_expected_capabilities = seen_capabilities.difference(expected_capabilities)
             expected_but_not_seen_capabilities = expected_capabilities.difference(seen_capabilities)

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -53,7 +53,7 @@ telemetry_name_mapping = {
 
 def _mapped_telemetry_name(context, apm_telemetry_name):
     if apm_telemetry_name in telemetry_name_mapping:
-        mapped_name = telemetry_name_mapping[apm_telemetry_name].get(context.library.library)
+        mapped_name = telemetry_name_mapping[apm_telemetry_name].get(context.library.name)
         if mapped_name is not None:
             return mapped_name
     return apm_telemetry_name

--- a/tests/perfs/test_performances.py
+++ b/tests/perfs/test_performances.py
@@ -32,7 +32,7 @@ class Test_Performances:
         self.finished = False
 
         self.appsec = "with_appsec" if environ.get("DD_APPSEC_ENABLED") == "true" else "without_appsec"
-        self.lang = scenarios.performances.library.library
+        self.lang = scenarios.performances.library.name
 
         threads = [threading.Thread(target=self.watch_docker_target)] + [
             threading.Thread(target=self.fetch) for _ in range(MAX_CONCURRENT_REQUEST)

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -517,9 +517,9 @@ class Test_Config_LogInjection_Enabled:
         assert sid is not None, "Expected a span ID, but got None"
 
         required_fields = ["service", "version", "env"]
-        if context.library.library in ("java", "python"):
+        if context.library.name in ("java", "python"):
             required_fields = ["dd.service", "dd.version", "dd.env"]
-        elif context.library.library == "dotnet":
+        elif context.library.name == "dotnet":
             required_fields = ["dd_service", "dd_version", "dd_env"]
 
         for field in required_fields:
@@ -608,7 +608,7 @@ class Test_Config_RuntimeMetrics_Enabled:
 
         for metric in runtime_metrics:
             tags = {tag.split(":")[0]: tag.split(":")[1] for tag in metric["tags"]}
-            language_tag_key, language_tag_value = runtime_metrics_lang_map[context.library.library]
+            language_tag_key, language_tag_value = runtime_metrics_lang_map[context.library.name]
             if language_tag_key is not None:
                 assert tags.get(language_tag_key) == language_tag_value
 
@@ -706,12 +706,12 @@ def parse_log_injection_message(log_message):
             except json.JSONDecodeError:
                 continue
             # Locate log with the custom message, which should have the trace ID and span ID
-            if message.get(log_injection_fields[context.library.library]["message"]) != log_message:
+            if message.get(log_injection_fields[context.library.name]["message"]) != log_message:
                 continue
             if message.get("dd"):
                 return message.get("dd")
             # dd-trace-java stores injected trace information under the "mdc" key
-            if context.library.library == "java":
+            if context.library.name == "java":
                 message = message.get("mdc")
             return message
     return None

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -262,7 +262,7 @@ class Test_Meta:
 
             assert "language" in span["meta"], "Span must have a language tag set."
 
-            library = context.library.library
+            library = context.library.name
             expected_language = RUNTIME_LANGUAGE_MAP.get(library, library)
 
             actual_language = span["meta"]["language"]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -412,8 +412,8 @@ class Test_Telemetry:
             "ruby": {},
         }
 
-        seen_loaded_dependencies = test_loaded_dependencies[context.library.library]
-        seen_defined_dependencies = test_defined_dependencies[context.library.library]
+        seen_loaded_dependencies = test_loaded_dependencies[context.library.name]
+        seen_defined_dependencies = test_defined_dependencies[context.library.name]
 
         for data in interfaces.library.get_telemetry_data():
             content = data["request"]["content"]
@@ -480,7 +480,7 @@ class Test_Telemetry:
             "ruby": {"DD_AGENT_TRANSPORT": "TCP"},
             "golang": {"lambda_mode": False},
         }
-        configuration_map = test_configuration[context.library.library]
+        configuration_map = test_configuration[context.library.name]
 
         def validator(data):
             if get_request_type(data) == "app-started":
@@ -489,7 +489,7 @@ class Test_Telemetry:
                 configurations_present = []
                 for cnf in configurations:
                     configuration_name = cnf["name"]
-                    if context.library.library == "java":
+                    if context.library.name == "java":
                         # support for older versions of Java Tracer
                         configuration_name = configuration_name.replace(".", "_")
                     if configuration_name in configuration_map:

--- a/tests/test_the_test/test_decorators.py
+++ b/tests/test_the_test/test_decorators.py
@@ -5,7 +5,7 @@ import pytest
 
 from utils import irrelevant, missing_feature, flaky, rfc, logger, scenarios
 from utils._decorators import released
-from utils._context.library_version import LibraryVersion
+from utils._context.component_version import ComponentVersion
 
 
 pytestmark = pytest.mark.scenario("TEST_THE_TEST")
@@ -83,7 +83,7 @@ def test_version_range():
             pass
 
         original_library = scenarios.test_the_test.library  # not very clean, TODO: add a fixture for that purpose
-        scenarios.test_the_test.library = LibraryVersion("java", tested_version)
+        scenarios.test_the_test.library = ComponentVersion("java", tested_version)
         decorated_class = released(java=declaration)(LocalClass)
         scenarios.test_the_test.library = original_library
 

--- a/tests/test_the_test/test_version.py
+++ b/tests/test_the_test/test_version.py
@@ -1,7 +1,7 @@
 import pytest
 import semantic_version as semver
 from utils._decorators import CustomSpec
-from utils._context.library_version import LibraryVersion, Version
+from utils._context.component_version import ComponentVersion, Version
 
 
 pytestmark = pytest.mark.scenario("TEST_THE_TEST")
@@ -37,38 +37,38 @@ def test_version_comparizon():
 
 
 def test_ruby_version():
-    v = LibraryVersion("ruby", "0.53.0.appsec.180045")
+    v = ComponentVersion("ruby", "0.53.0.appsec.180045")
     assert str(v.version) == "0.53.1-appsec+180045"
 
-    v = LibraryVersion("ruby", "1.0.0.beta1 de82857")
+    v = ComponentVersion("ruby", "1.0.0.beta1 de82857")
     assert v.version == Version("1.0.1-beta1+de82857")
 
-    v = LibraryVersion("ruby", "2.3.0 7dbcc40")
+    v = ComponentVersion("ruby", "2.3.0 7dbcc40")
     assert str(v.version) == "2.3.1-z+7dbcc40"
 
-    assert LibraryVersion("ruby", "1.0.0.beta1") == "ruby@1.0.1-z+beta1"
-    assert LibraryVersion("ruby", "1.0.0.beta1 de82857") == "ruby@1.0.1-beta1+de82857"
+    assert ComponentVersion("ruby", "1.0.0.beta1") == "ruby@1.0.1-z+beta1"
+    assert ComponentVersion("ruby", "1.0.0.beta1 de82857") == "ruby@1.0.1-beta1+de82857"
 
     # very particular use case, because we hack the path for dev versions
-    assert LibraryVersion("ruby", "1.0.0.beta1 de82857") < "ruby@1.0.1"
-    assert LibraryVersion("ruby", "1.0.0.rc1") < "ruby@1.0.1"
+    assert ComponentVersion("ruby", "1.0.0.beta1 de82857") < "ruby@1.0.1"
+    assert ComponentVersion("ruby", "1.0.0.rc1") < "ruby@1.0.1"
 
-    assert LibraryVersion("ruby", "2.3.0 7dbcc40") >= "ruby@2.3.1-dev"
+    assert ComponentVersion("ruby", "2.3.0 7dbcc40") >= "ruby@2.3.1-dev"
 
 
 def test_library_version_comparizon():
-    assert LibraryVersion("x", "1.31.1") < "x@1.34.1"
-    assert LibraryVersion("x", "v1.34.1") > "x@1.31.1"
-    assert LibraryVersion("x", "1.31.1") < LibraryVersion("x", "v1.34.1")
+    assert ComponentVersion("x", "1.31.1") < "x@1.34.1"
+    assert ComponentVersion("x", "v1.34.1") > "x@1.31.1"
+    assert ComponentVersion("x", "1.31.1") < ComponentVersion("x", "v1.34.1")
 
-    assert LibraryVersion("python", "1.1.0rc2.dev15+gc41d325d") >= "python@1.1.0rc2.dev"
-    assert LibraryVersion("python", "1.1.0") > "python@1.1.0rc2.dev"
+    assert ComponentVersion("python", "1.1.0rc2.dev15+gc41d325d") >= "python@1.1.0rc2.dev"
+    assert ComponentVersion("python", "1.1.0") > "python@1.1.0rc2.dev"
 
-    assert LibraryVersion("python", "2.1.0-dev") < "python@2.1.0.dev83+gac1037728"
-    assert LibraryVersion("python", "2.1.0-dev") < "python@2.1.0"
+    assert ComponentVersion("python", "2.1.0-dev") < "python@2.1.0.dev83+gac1037728"
+    assert ComponentVersion("python", "2.1.0-dev") < "python@2.1.0"
 
-    assert LibraryVersion("nodejs", "6.0.0-pre") > "nodejs@5.0.0"
-    assert LibraryVersion("nodejs", "5.0.0") <= "nodejs@6.0.0-pre"
+    assert ComponentVersion("nodejs", "6.0.0-pre") > "nodejs@5.0.0"
+    assert ComponentVersion("nodejs", "5.0.0") <= "nodejs@6.0.0-pre"
 
 
 def test_spec():
@@ -90,32 +90,32 @@ def test_spec():
 
 
 def test_version_serialization():
-    assert LibraryVersion("cpp", "v1.3.1") == "cpp@1.3.1"
+    assert ComponentVersion("cpp", "v1.3.1") == "cpp@1.3.1"
 
-    v = LibraryVersion("libddwaf", "* libddwaf (1.0.14.1.0.beta1)")
+    v = ComponentVersion("libddwaf", "* libddwaf (1.0.14.1.0.beta1)")
     assert v.version == Version("1.0.14.1.0.beta1")
     assert v.version == "1.0.14+1.0.beta1"
 
-    v = LibraryVersion("php", "1.0.0-nightly")
+    v = ComponentVersion("php", "1.0.0-nightly")
     assert v.version == "1.0.0"
 
-    v = LibraryVersion("nodejs", "3.0.0-pre0")
+    v = ComponentVersion("nodejs", "3.0.0-pre0")
     assert v.version == "3.0.0-pre0"
 
-    v = LibraryVersion("agent", "7.43.1-beta-cache-hit-ratio")
+    v = ComponentVersion("agent", "7.43.1-beta-cache-hit-ratio")
     assert v.version == "7.43.1-beta-cache-hit-ratio"
 
-    v = LibraryVersion("agent", "7.50.0-dbm-oracle-0.1")
+    v = ComponentVersion("agent", "7.50.0-dbm-oracle-0.1")
     assert str(v.version) == "7.50.0-dbm-oracle-0.1"
 
 
 def test_agent_version():
-    v = LibraryVersion("agent", "7.54.0-installer-0.0.7+git.106.b0943ad")
+    v = ComponentVersion("agent", "7.54.0-installer-0.0.7+git.106.b0943ad")
     assert v == "agent@7.54.0-installer-0.0.7+git.106.b0943ad"
 
 
 def test_in_operator():
-    v = LibraryVersion("p", "1.0")
+    v = ComponentVersion("p", "1.0")
 
     assert v in ("p@1.0", "p@1.1")
     assert v not in ("p@1.1", "p@1.2")
@@ -123,11 +123,11 @@ def test_in_operator():
 
 
 def test_library_version():
-    v = LibraryVersion("p")
+    v = ComponentVersion("p")
     assert v == "p"
     assert v != "u"
 
-    v = LibraryVersion("p", "1.0")
+    v = ComponentVersion("p", "1.0")
 
     assert v == "p@1.0"
     assert v == "p"
@@ -156,22 +156,22 @@ def test_library_version():
     assert (v >= "u@1.0") is False
     assert (v <= "u@1.0") is False
 
-    v = LibraryVersion("p")
+    v = ComponentVersion("p")
 
     assert (v == "u@1.0") is False
     assert (v >= "u@1.0") is False
 
-    v = LibraryVersion("python", "0.53.0.dev70+g494e6dc0")
+    v = ComponentVersion("python", "0.53.0.dev70+g494e6dc0")
     assert v == "python@0.53.0.dev70+g494e6dc0"
 
-    v = LibraryVersion("java", "0.94.1~dde6877139")
+    v = ComponentVersion("java", "0.94.1~dde6877139")
     assert v == "java@0.94.1"
     assert v >= "java@0.94.1"
     assert v < "java@0.94.2"
 
-    v = LibraryVersion("java", "0.94.0-SNAPSHOT~57664cfbe5")
+    v = ComponentVersion("java", "0.94.0-SNAPSHOT~57664cfbe5")
     assert v == "java@0.94.0"
     assert v >= "java@0.94.0"
     assert v < "java@0.94.1"
 
-    assert LibraryVersion("agent", "7.39.0-devel") == "agent@7.39.0-devel"
+    assert ComponentVersion("agent", "7.39.0-devel") == "agent@7.39.0-devel"

--- a/utils/_context/_scenarios/auto_injection.py
+++ b/utils/_context/_scenarios/auto_injection.py
@@ -3,7 +3,7 @@ import json
 import os
 from pathlib import Path
 import pytest
-from utils._context.library_version import LibraryVersion
+from utils._context.component_version import ComponentVersion
 from utils._logger import logger
 from utils.onboarding.debug_vm import extract_logs_to_file
 from utils.virtual_machine.utils import get_tested_apps_vms, generate_gitlab_pipeline
@@ -60,7 +60,7 @@ class _VirtualMachineScenario(Scenario):
 
         if config.option.vm_provider:
             self.vm_provider_id = config.option.vm_provider
-        self._library = LibraryVersion(config.option.vm_library, "0.0")
+        self._library = ComponentVersion(config.option.vm_library, "0.0")
         self._datadog_apm_inject_version = "v0.00.00"
         self._os_configurations = {}
         self._env = config.option.vm_env
@@ -181,7 +181,7 @@ class _VirtualMachineScenario(Scenario):
             if key.startswith("datadog-apm-inject") and self.components[key]:
                 self._datadog_apm_inject_version = f"v{self.components[key]}"
             if key.startswith("datadog-apm-library-") and self.components[key]:
-                self._library = LibraryVersion(self._library.name, self.components[key])
+                self._library = ComponentVersion(self._library.name, self.components[key])
                 # We store without the lang sufix
                 self.components["datadog-apm-library"] = self.components[key]
                 del self.components[key]

--- a/utils/_context/_scenarios/auto_injection.py
+++ b/utils/_context/_scenarios/auto_injection.py
@@ -83,7 +83,7 @@ class _VirtualMachineScenario(Scenario):
             "utils/virtual_machine/virtual_machines.json",
             "utils/scripts/ci_orchestrators/aws_ssi.json",
             [self.name],
-            self._library.library,
+            self._library.name,
         )[self.name][self._weblog]
         logger.info(f" Supported names: {supported_vm_names} ")
         supported_vms = [vm for vm in all_vms if vm.name in supported_vm_names]
@@ -99,7 +99,7 @@ class _VirtualMachineScenario(Scenario):
             for vm in supported_vms:
                 vm.add_provision(
                     provisioner.get_provision(
-                        self._library.library,
+                        self._library.name,
                         self._env,
                         self._weblog,
                         self.vm_provision_name,
@@ -129,7 +129,7 @@ class _VirtualMachineScenario(Scenario):
             self.vm_provider.configure(self.virtual_machine)
             self.virtual_machine.add_provision(
                 provisioner.get_provision(
-                    self._library.library,
+                    self._library.name,
                     self._env,
                     self._weblog,
                     self.vm_provision_name,
@@ -150,7 +150,7 @@ class _VirtualMachineScenario(Scenario):
         assert self._weblog is not None, "Weblog is not set (use --vm-weblog)"
 
         base_folder = "utils/build/virtual_machine"
-        weblog_provision_file = f"{base_folder}/weblogs/{self._library.library}/provision_{self._weblog}.yml"
+        weblog_provision_file = f"{base_folder}/weblogs/{self._library.name}/provision_{self._weblog}.yml"
         assert Path(weblog_provision_file).is_file(), f"Weblog Provision file not found: {weblog_provision_file}"
 
         provision_file = f"{base_folder}/provisions/{self.vm_provision_name}/provision.yml"
@@ -181,7 +181,7 @@ class _VirtualMachineScenario(Scenario):
             if key.startswith("datadog-apm-inject") and self.components[key]:
                 self._datadog_apm_inject_version = f"v{self.components[key]}"
             if key.startswith("datadog-apm-library-") and self.components[key]:
-                self._library = LibraryVersion(self._library.library, self.components[key])
+                self._library = LibraryVersion(self._library.name, self.components[key])
                 # We store without the lang sufix
                 self.components["datadog-apm-library"] = self.components[key]
                 del self.components[key]

--- a/utils/_context/_scenarios/docker_ssi.py
+++ b/utils/_context/_scenarios/docker_ssi.py
@@ -10,7 +10,7 @@ from docker.models.networks import Network
 import pytest
 
 from utils import interfaces
-from utils._context.library_version import LibraryVersion, Version
+from utils._context.component_version import ComponentVersion, Version
 from utils._context.containers import (
     create_network,
     DockerSSIContainer,
@@ -67,7 +67,7 @@ class DockerSSIScenario(Scenario):
         )
         self._push_base_images = config.option.ssi_push_base_images
         self._force_build = config.option.ssi_force_build
-        self._libray_version = LibraryVersion(self._library, "v9.99.99")
+        self._libray_version = ComponentVersion(self._library, "v9.99.99")
         self._datadog_apm_inject_version = "v9.99.99"
         # The runtime that is installed on the base image (because we installed automatically or because the weblog contains the runtime preinstalled).
         # the language is the language used by the tested datadog library
@@ -186,7 +186,7 @@ class DockerSSIScenario(Scenario):
                 self._datadog_apm_inject_version = f"v{json_tested_components[key].lstrip(' ')}"
             if key.startswith("datadog-apm-library-") and self.components[key]:
                 library_version_number = json_tested_components[key].lstrip(" ")
-                self._libray_version = LibraryVersion(self._library, library_version_number)
+                self._libray_version = ComponentVersion(self._library, library_version_number)
                 # We store without the lang sufix
                 self.components["datadog-apm-library"] = self.components[key]
                 del self.components[key]

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -744,7 +744,7 @@ class EndToEndScenario(DockerScenario):
         result = super().get_junit_properties()
 
         result["dd_tags[systest.suite.context.agent]"] = self.agent_version
-        result["dd_tags[systest.suite.context.library.name]"] = self.library.library
+        result["dd_tags[systest.suite.context.library.name]"] = self.library.name
         result["dd_tags[systest.suite.context.library.version]"] = self.library.version
         result["dd_tags[systest.suite.context.weblog_variant]"] = self.weblog_variant
         result["dd_tags[systest.suite.context.sampling_rate]"] = self.weblog_container.tracer_sampling_rate

--- a/utils/_context/_scenarios/k8s_lib_injection.py
+++ b/utils/_context/_scenarios/k8s_lib_injection.py
@@ -107,7 +107,7 @@ class K8sScenario(Scenario):
         # Weblog handler (the lib init and injector imgs are set in weblog/pod as annotations)
         self.test_weblog = K8sWeblog(
             self.k8s_weblog_img,
-            self.library.library,
+            self.library.name,
             self.k8s_lib_init_img,
             self.k8s_injector_img,
             self.host_log_folder,
@@ -217,7 +217,7 @@ class K8sManualInstrumentationScenario(Scenario):
         # Weblog handler
         self.test_weblog = K8sWeblog(
             self.k8s_weblog_img,
-            self.library.library,
+            self.library.name,
             self.k8s_lib_init_img,
             None,
             self.host_log_folder,
@@ -291,7 +291,7 @@ class K8sSparkScenario(K8sScenario):
 
         self.test_weblog = K8sWeblog(
             self.k8s_weblog_img,
-            self.library.library,
+            self.library.name,
             self.k8s_lib_init_img,
             self.k8s_injector_img,
             self.host_log_folder,

--- a/utils/_context/_scenarios/k8s_lib_injection.py
+++ b/utils/_context/_scenarios/k8s_lib_injection.py
@@ -3,7 +3,7 @@ import os
 from docker.models.networks import Network
 import pytest
 
-from utils._context.library_version import LibraryVersion, Version
+from utils._context.component_version import ComponentVersion, Version
 
 from utils.k8s_lib_injection.k8s_datadog_kubernetes import K8sDatadog
 from utils.k8s_lib_injection.k8s_weblog import K8sWeblog
@@ -57,7 +57,7 @@ class K8sScenario(Scenario):
         self.k8s_provider_name = config.option.k8s_provider if config.option.k8s_provider else "kind"
 
         # Get Lib init version
-        self._library = LibraryVersion(
+        self._library = ComponentVersion(
             config.option.k8s_library, extract_library_version(config.option.k8s_lib_init_img)
         )
         self.k8s_lib_init_img = config.option.k8s_lib_init_img
@@ -197,7 +197,7 @@ class K8sManualInstrumentationScenario(Scenario):
         self.k8s_provider_name = config.option.k8s_provider if config.option.k8s_provider else "kind"
 
         # Get Lib init version
-        self._library = LibraryVersion(
+        self._library = ComponentVersion(
             config.option.k8s_library, extract_library_version(config.option.k8s_lib_init_img)
         )
         self.k8s_lib_init_img = config.option.k8s_lib_init_img
@@ -335,7 +335,7 @@ class WeblogInjectionScenario(Scenario):
 
     def configure(self, config: pytest.Config):  # noqa: ARG002
         assert "TEST_LIBRARY" in os.environ, "TEST_LIBRARY must be set: java,python,nodejs,dotnet,ruby"
-        self._library = LibraryVersion(os.getenv("TEST_LIBRARY"), "0.0")
+        self._library = ComponentVersion(os.getenv("TEST_LIBRARY"), "0.0")
 
         assert "LIB_INIT_IMAGE" in os.environ, "LIB_INIT_IMAGE must be set"
         self._lib_init_image = os.getenv("LIB_INIT_IMAGE")

--- a/utils/_context/_scenarios/open_telemetry.py
+++ b/utils/_context/_scenarios/open_telemetry.py
@@ -8,7 +8,7 @@ from watchdog.events import FileSystemEventHandler, FileSystemEvent
 from utils._logger import logger
 from utils import interfaces
 from utils.interfaces._core import ProxyBasedInterfaceValidator
-from utils._context.library_version import Version
+from utils._context.component_version import Version
 
 from utils._context.containers import (
     AgentContainer,

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -207,7 +207,7 @@ class ParametricScenario(Scenario):
 
     @property
     def weblog_variant(self):
-        return f"parametric-{self.library.library}"
+        return f"parametric-{self.library.name}"
 
     def _build_apm_test_server_image(self) -> None:
         logger.stdout("Build tested container...")

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -18,7 +18,7 @@ from docker.errors import DockerException
 from docker.models.containers import Container
 from docker.models.networks import Network
 
-from utils._context.library_version import LibraryVersion
+from utils._context.component_version import ComponentVersion
 from utils._logger import logger
 
 from .core import Scenario, ScenarioGroup
@@ -173,7 +173,7 @@ class ParametricScenario(Scenario):
                 command=["cat", "SYSTEM_TESTS_LIBRARY_VERSION"],
             )
 
-        self._library = LibraryVersion(library, output.decode("utf-8"))
+        self._library = ComponentVersion(library, output.decode("utf-8"))
         logger.debug(f"Library version is {self._library}")
 
     def get_warmups(self):

--- a/utils/_context/_scenarios/test_the_test.py
+++ b/utils/_context/_scenarios/test_the_test.py
@@ -1,9 +1,9 @@
-from utils._context.library_version import LibraryVersion
+from utils._context.component_version import ComponentVersion
 from .core import Scenario
 
 
 class TestTheTestScenario(Scenario):
-    library = LibraryVersion("java", "0.66.0")
+    library = ComponentVersion("java", "0.66.0")
 
     def __init__(self, name: str, doc: str) -> None:
         super().__init__(name, doc=doc, github_workflow="testthetest")

--- a/utils/_context/component_version.py
+++ b/utils/_context/component_version.py
@@ -49,14 +49,14 @@ class Version(version_module.Version):
         return super().__ge__(_build(other))
 
 
-class LibraryVersion:  # TODO : rename into ComponentVersion
+class ComponentVersion:
     known_versions: dict = defaultdict(set)
     version: Version
     # name: str
 
     def add_known_version(self, version: Version | None, library: str | None = None):
         library = self.name if library is None else library
-        LibraryVersion.known_versions[library].add(str(version))
+        ComponentVersion.known_versions[library].add(str(version))
 
     def __init__(self, name: str, version: str = "0.0.0"):
         if "@" in name:
@@ -144,11 +144,11 @@ class LibraryVersion:  # TODO : rename into ComponentVersion
         return f"{self.name}@{self.version}" if self.version else self.name
 
     def __eq__(self, other: object):
-        if isinstance(other, LibraryVersion):
+        if isinstance(other, ComponentVersion):
             return self.name == other.name and self.version == other.version
 
         if not isinstance(other, str):
-            raise TypeError(f"Can't compare LibraryVersion to type {type(other)}")
+            raise TypeError(f"Can't compare ComponentVersion to type {type(other)}")
 
         if "@" in other:
             library, version = other.split("@", 1)
@@ -166,11 +166,11 @@ class LibraryVersion:  # TODO : rename into ComponentVersion
         return self.name == library
 
     def _extract_members(self, other: object) -> tuple[str | None, Version | None]:
-        if isinstance(other, LibraryVersion):
+        if isinstance(other, ComponentVersion):
             return other.name, other.version
 
         if not isinstance(other, str):
-            raise TypeError(f"Can't compare LibraryVersion to type {type(other)}")
+            raise TypeError(f"Can't compare ComponentVersion to type {type(other)}")
 
         if "@" not in other:
             raise ValueError("Can't compare version numbers without a version")
@@ -222,5 +222,5 @@ def _build(version: object) -> Version:
 
 
 if __name__ == "__main__":
-    v = LibraryVersion("ruby", "  * ddtrace (0.53.0.appsec.180045)")
+    v = ComponentVersion("ruby", "  * ddtrace (0.53.0.appsec.180045)")
     assert str(v.version) == "0.53.1-appsec+180045"

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1216,7 +1216,7 @@ class WeblogInjectionInitContainer(TestedContainer):
 
     def set_environment_for_library(self, library: LibraryVersion):
         lib_inject_props = {}
-        for lang_env_vars in K8sWeblog.manual_injection_props["js" if library.library == "nodejs" else library.library]:
+        for lang_env_vars in K8sWeblog.manual_injection_props["js" if library.name == "nodejs" else library.name]:
             lib_inject_props[lang_env_vars["name"]] = lang_env_vars["value"]
         lib_inject_props["DD_AGENT_HOST"] = "ddapm-test-agent"
         lib_inject_props["DD_TRACE_DEBUG"] = "true"

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -884,7 +884,7 @@ class WeblogContainer(TestedContainer):
             data = json.load(f)
             lib = data["library"]
 
-        self._library = LibraryVersion(lib["language"], lib["version"])
+        self._library = LibraryVersion(lib["name"], lib["version"])
 
         logger.stdout(f"Library: {self.library}")
 
@@ -1322,7 +1322,7 @@ class ExternalProcessingContainer(TestedContainer):
             data = json.load(f)
             lib = data["library"]
 
-        self.library = LibraryVersion(lib["language"], lib["version"])
+        self.library = LibraryVersion(lib["name"], lib["version"])
 
         logger.stdout(f"Library: {self.library}")
         logger.stdout(f"Image: {self.image.name}")

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -15,7 +15,7 @@ from docker.models.networks import Network
 import pytest
 import requests
 
-from utils._context.library_version import LibraryVersion
+from utils._context.component_version import ComponentVersion
 from utils.proxy.ports import ProxyPorts
 from utils._logger import logger
 from utils import interfaces
@@ -581,7 +581,7 @@ class AgentContainer(TestedContainer):
         with open(self.healthcheck_log_file, encoding="utf-8") as f:
             data = json.load(f)
 
-        self.agent_version = LibraryVersion("agent", data["version"]).version
+        self.agent_version = ComponentVersion("agent", data["version"]).version
 
         logger.stdout(f"Agent: {self.agent_version}")
         logger.stdout(f"Backend: {self.dd_site}")
@@ -773,7 +773,7 @@ class WeblogContainer(TestedContainer):
         self.additional_trace_header_tags = additional_trace_header_tags
 
         self.weblog_variant = ""
-        self._library: LibraryVersion | None = None
+        self._library: ComponentVersion | None = None
 
     @property
     def trace_agent_port(self):
@@ -884,7 +884,7 @@ class WeblogContainer(TestedContainer):
             data = json.load(f)
             lib = data["library"]
 
-        self._library = LibraryVersion(lib["name"], lib["version"])
+        self._library = ComponentVersion(lib["name"], lib["version"])
 
         logger.stdout(f"Library: {self.library}")
 
@@ -899,7 +899,7 @@ class WeblogContainer(TestedContainer):
         self.stdout_interface.init_patterns(self.library)
 
     @property
-    def library(self) -> LibraryVersion:
+    def library(self) -> ComponentVersion:
         assert self._library is not None, "Library version is not set"
         return self._library
 
@@ -1214,7 +1214,7 @@ class WeblogInjectionInitContainer(TestedContainer):
             volumes={_VOLUME_INJECTOR_NAME: {"bind": "/datadog-lib", "mode": "rw"}},
         )
 
-    def set_environment_for_library(self, library: LibraryVersion):
+    def set_environment_for_library(self, library: ComponentVersion):
         lib_inject_props = {}
         for lang_env_vars in K8sWeblog.manual_injection_props["js" if library.name == "nodejs" else library.name]:
             lib_inject_props[lang_env_vars["name"]] = lang_env_vars["value"]
@@ -1277,7 +1277,7 @@ class EnvoyContainer(TestedContainer):
 
 
 class ExternalProcessingContainer(TestedContainer):
-    library: LibraryVersion
+    library: ComponentVersion
 
     def __init__(
         self,
@@ -1322,7 +1322,7 @@ class ExternalProcessingContainer(TestedContainer):
             data = json.load(f)
             lib = data["library"]
 
-        self.library = LibraryVersion(lib["name"], lib["version"])
+        self.library = ComponentVersion(lib["name"], lib["version"])
 
         logger.stdout(f"Library: {self.library}")
         logger.stdout(f"Image: {self.image.name}")

--- a/utils/_context/core.py
+++ b/utils/_context/core.py
@@ -7,7 +7,7 @@
 import json
 from typing import Any
 
-from utils._context.library_version import LibraryVersion
+from utils._context.component_version import ComponentVersion
 # from utils._context._scenarios.core import Scenario  # TODO : lot of revamp to come
 
 
@@ -46,7 +46,7 @@ class _Context:
         return self._get_scenario_property("uds_socket", None)
 
     @property
-    def library(self) -> LibraryVersion:
+    def library(self) -> ComponentVersion:
         result = self._get_scenario_property("library", None)
         assert result is not None
         return result

--- a/utils/_context/library_version.py
+++ b/utils/_context/library_version.py
@@ -49,24 +49,25 @@ class Version(version_module.Version):
         return super().__ge__(_build(other))
 
 
-class LibraryVersion:
+class LibraryVersion:  # TODO : rename into ComponentVersion
     known_versions: dict = defaultdict(set)
     version: Version
+    # name: str
 
     def add_known_version(self, version: Version | None, library: str | None = None):
-        library = self.library if library is None else library
+        library = self.name if library is None else library
         LibraryVersion.known_versions[library].add(str(version))
 
-    def __init__(self, library: str, version: str = "0.0.0"):
-        if "@" in library:
-            raise ValueError("Library can't contains '@'")
+    def __init__(self, name: str, version: str = "0.0.0"):
+        if "@" in name:
+            raise ValueError("Library's name can't contains '@'")
 
-        self.library = library
+        self.name = name
 
         if version:
             version = version.strip()
 
-            if library == "ruby":
+            if name == "ruby":
                 # ruby version pattern can be like
 
                 # 2.0.0.rc1 b908262
@@ -87,23 +88,23 @@ class LibraryVersion:
                 elif re.match(rf"{base}[\. ]{prerelease}", version):
                     version = re.sub(rf"({base})[\. ]({prerelease})", r"\1-\2", version)
 
-            elif library == "libddwaf":
+            elif name == "libddwaf":
                 if version.startswith("* libddwaf"):
                     version = re.sub(r"\* *libddwaf *\((.*)\)", r"\1", version)
 
-            elif library == "java":
+            elif name == "java":
                 version = version.split("~")[0]
                 version = version.replace("-SNAPSHOT", "")
 
-            elif library == "dotnet":
+            elif name == "dotnet":
                 version = re.sub(r"(datadog-dotnet-apm-)?(.*?)(\.tar\.gz)?", r"\2", version)
 
-            elif library == "php":
+            elif name == "php":
                 version = version.replace("-nightly", "")
 
             self.version = Version(version)
 
-            if library == "ruby":
+            if name == "ruby":
                 if len(self.version.build) != 0 or len(self.version.prerelease) != 0:
                     # we are not in a released version
 
@@ -134,17 +135,17 @@ class LibraryVersion:
             self.version = Version("0.0.0")
 
     def __repr__(self):
-        return f'{self.__class__.__name__}("{self.library}", "{self.version}")'
+        return f'{self.__class__.__name__}("{self.name}", "{self.version}")'
 
     def __str__(self):
-        if not self.library:
+        if not self.name:
             return str(None)
 
-        return f"{self.library}@{self.version}" if self.version else self.library
+        return f"{self.name}@{self.version}" if self.version else self.name
 
     def __eq__(self, other: object):
         if isinstance(other, LibraryVersion):
-            return self.library == other.library and self.version == other.version
+            return self.name == other.name and self.version == other.version
 
         if not isinstance(other, str):
             raise TypeError(f"Can't compare LibraryVersion to type {type(other)}")
@@ -153,20 +154,20 @@ class LibraryVersion:
             library, version = other.split("@", 1)
             self.add_known_version(library=library, version=Version(version))
 
-            if self.library != library:
+            if self.name != library:
                 return False
 
             if self.version is None:
                 raise ValueError("Weblog does not provide an library version number")
 
-            return self.library == library and self.version == Version(version)
+            return self.name == library and self.version == Version(version)
 
         library = other
-        return self.library == library
+        return self.name == library
 
     def _extract_members(self, other: object) -> tuple[str | None, Version | None]:
         if isinstance(other, LibraryVersion):
-            return other.library, other.version
+            return other.name, other.version
 
         if not isinstance(other, str):
             raise TypeError(f"Can't compare LibraryVersion to type {type(other)}")
@@ -177,7 +178,7 @@ class LibraryVersion:
         library, version_str = other.split("@", 1)
         version = Version(version_str)
 
-        if self.version is None and self.library == library:
+        if self.version is None and self.name == library:
             # the second comparizon is here because if it's not the good library,
             # the result will be always false, and nothing will be compared
             # on version. This use case ccan happens if a version is not provided
@@ -189,23 +190,23 @@ class LibraryVersion:
 
     def __lt__(self, other: object):
         library, version = self._extract_members(other)
-        return self.library == library and self.version and self.version < version
+        return self.name == library and self.version and self.version < version
 
     def __le__(self, other: object):
         library, version = self._extract_members(other)
-        return self.library == library and self.version and self.version <= version
+        return self.name == library and self.version and self.version <= version
 
     def __gt__(self, other: object):
         library, version = self._extract_members(other)
-        return self.library == library and self.version and self.version > version
+        return self.name == library and self.version and self.version > version
 
     def __ge__(self, other: object):
         library, version = self._extract_members(other)
-        return self.library == library and self.version and self.version >= version
+        return self.name == library and self.version and self.version >= version
 
     def serialize(self):
         return {
-            "library": self.library,
+            "library": self.name,
             "version": str(self.version),
         }
 

--- a/utils/_decorators.py
+++ b/utils/_decorators.py
@@ -10,7 +10,7 @@ import pytest
 import semantic_version as semver
 
 from utils._context.core import context
-from utils._context.library_version import Version
+from utils._context.component_version import Version
 
 
 _jira_ticket_pattern = re.compile(r"([A-Z]{3,}-\d+)(, [A-Z]{3,}-\d+)*")

--- a/utils/build/docker/cpp_httpd/install_ddtrace.sh
+++ b/utils/build/docker/cpp_httpd/install_ddtrace.sh
@@ -24,7 +24,7 @@ else
   rm "$TARBALL"
 fi
 
-echo '{"status": "ok", "library": {"language": "cpp_httpd", "version": "'"$HTTPD_DATADOG_VERSION"'"}}' > /app/healthcheck.json
+echo '{"status": "ok", "library": {"name": "cpp_httpd", "version": "'"$HTTPD_DATADOG_VERSION"'"}}' > /app/healthcheck.json
 echo "$HTTPD_DATADOG_VERSION" > SYSTEM_TESTS_LIBRARY_VERSION
 cat /app/healthcheck.json
 

--- a/utils/build/docker/cpp_nginx/install_ddtrace.sh
+++ b/utils/build/docker/cpp_nginx/install_ddtrace.sh
@@ -53,6 +53,6 @@ else
   rm "$TARBALL"
 fi
 
-echo '{"status": "ok", "library": {"language": "cpp_nginx", "version": "'$NGINX_DATADOG_VERSION'"}}' > /builds/healthcheck.json
+echo '{"status": "ok", "library": {"name": "cpp_nginx", "version": "'$NGINX_DATADOG_VERSION'"}}' > /builds/healthcheck.json
 cat /builds/healthcheck.json
 

--- a/utils/build/docker/golang/app/internal/common/common.go
+++ b/utils/build/docker/golang/app/internal/common/common.go
@@ -14,7 +14,7 @@ import (
 )
 
 type DatadogInformations struct {
-	Language string `json:"language"`
+	Name string `json:"name"`
 	Version  string `json:"version"`
 }
 
@@ -86,7 +86,7 @@ func GetDatadogInformations() (DatadogInformations, error) {
 	}
 
 	return DatadogInformations{
-		Language: "golang",
+		Name: "golang",
 		Version:  string(tracerVersion),
 	}, nil
 }

--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/HealthcheckRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/HealthcheckRoutes.scala
@@ -17,7 +17,7 @@ object HealthcheckRoutes {
       }
 
       val library = JsObject(
-        "language" -> JsString("java"),
+        "name" -> JsString("java"),
         "version" -> JsString(version)
       )
 

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
@@ -72,7 +72,7 @@ public class MyResource {
         }
 
         Map<String, String> library = new HashMap<>();
-        library.put("language", "java");
+        library.put("name", "java");
         library.put("version", version);
 
         Map<String, Object> response = new HashMap<>();

--- a/utils/build/docker/java/play/app/controllers/AppSecController.scala
+++ b/utils/build/docker/java/play/app/controllers/AppSecController.scala
@@ -48,7 +48,7 @@ class AppSecController @Inject()(cc: MessagesControllerComponents, ws: WSClient,
     val response = Json.obj(
       "status" -> "ok",
       "library" -> Json.obj(
-        "language" -> "java",
+        "name" -> "java",
         "version" -> version
       )
     )

--- a/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
+++ b/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
@@ -116,7 +116,7 @@ public class Main {
 
                                 Map<String, Object> response = new HashMap<>();
                                 Map<String, String> library = new HashMap<>();
-                                library.put("language", "java");
+                                library.put("name", "java");
                                 library.put("version", version);
                                 response.put("status", "ok");
                                 response.put("library", library);

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
@@ -74,7 +74,7 @@ public class MyResource {
         }
 
         Map<String, String> library = new HashMap<>();
-        library.put("language", "java");
+        library.put("name", "java");
         library.put("version", version);
 
         Map<String, Object> response = new HashMap<>();

--- a/utils/build/docker/java/spring-boot-3-native/src/main/java/com/datadoghq/springbootnative/WebController.java
+++ b/utils/build/docker/java/spring-boot-3-native/src/main/java/com/datadoghq/springbootnative/WebController.java
@@ -59,7 +59,7 @@ public class WebController {
       }
 
       Map<String, String> library = new HashMap<>();
-      library.put("language", "java");
+      library.put("name", "java");
       library.put("version", version);
 
       Map<String, Object> response = new HashMap<>();

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -167,7 +167,7 @@ public class App {
         }
 
         Map<String, String> library = new HashMap<>();
-        library.put("language", "java");
+        library.put("name", "java");
         library.put("version", version);
 
         Map<String, Object> response = new HashMap<>();

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
@@ -357,7 +357,7 @@ public class Main {
 
         Map<String, Object> response = new HashMap<>();
         Map<String, String> library = new HashMap<>();
-        library.put("language", "java");
+        library.put("name", "java");
         library.put("version", version);
         response.put("status", "ok");
         response.put("library", library);

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
@@ -352,7 +352,7 @@ public class Main {
 
         Map<String, Object> response = new HashMap<>();
         Map<String, String> library = new HashMap<>();
-        library.put("language", "java");
+        library.put("name", "java");
         library.put("version", version);
         response.put("status", "ok");
         response.put("library", library);

--- a/utils/build/docker/java_otel/spring-boot-native/src/main/java/com/datadoghq/springbootnative/WebController.java
+++ b/utils/build/docker/java_otel/spring-boot-native/src/main/java/com/datadoghq/springbootnative/WebController.java
@@ -56,7 +56,7 @@ public class WebController {
       }
 
       Map<String, String> library = new HashMap<>();
-      library.put("language", "java_otel");
+      library.put("name", "java_otel");
       library.put("version", version.strip());
 
       Map<String, Object> response = new HashMap<>();

--- a/utils/build/docker/java_otel/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java_otel/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -144,7 +144,7 @@ public class App {
         }
 
         Map<String, String> library = new HashMap<>();
-        library.put("language", "java_otel");
+        library.put("name", "java_otel");
         library.put("version", version.strip());
 
         Map<String, Object> response = new HashMap<>();

--- a/utils/build/docker/php/common/healthcheck.php
+++ b/utils/build/docker/php/common/healthcheck.php
@@ -2,4 +2,4 @@
 
 header('content-type: application/json');
 $version=phpversion("ddtrace");
-echo '{"status": "ok", "library": {"language": "php", "version": "' . $version . '"}}';
+echo '{"status": "ok", "library": {"name": "php", "version": "' . $version . '"}}';

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -87,7 +87,7 @@ def healthcheck(request):
     result = {
         "status": "ok",
         "library": {
-            "language": "python",
+            "name": "python",
             "version": ddtrace.__version__,
         },
     }

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -105,7 +105,7 @@ async def healthcheck():
     return {
         "status": "ok",
         "library": {
-            "language": "python",
+            "name": "python",
             "version": ddtrace.__version__,
         },
     }

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -268,7 +268,7 @@ def healthcheck():
     return {
         "status": "ok",
         "library": {
-            "language": "python",
+            "name": "python",
             "version": ddtrace.__version__,
         },
     }

--- a/utils/build/docker/python_otel/flask-poc-otel/app.py
+++ b/utils/build/docker/python_otel/flask-poc-otel/app.py
@@ -28,7 +28,7 @@ def healthcheck():
     return {
         "status": "ok",
         "library": {
-            "language": "python_otel",
+            "name": "python_otel",
             "version": otel_version,
         },
     }

--- a/utils/interfaces/_logs.py
+++ b/utils/interfaces/_logs.py
@@ -12,7 +12,7 @@ import re
 
 from utils._logger import logger
 from utils.interfaces._core import InterfaceValidator
-from utils._context.library_version import LibraryVersion
+from utils._context.component_version import ComponentVersion
 
 
 class _LogsInterfaceValidator(InterfaceValidator):
@@ -130,7 +130,7 @@ class _LibraryStdout(_StdoutLogsInterfaceValidator):
         super().__init__("weblog")
         self.library = None
 
-    def init_patterns(self, library: LibraryVersion):
+    def init_patterns(self, library: ComponentVersion):
         self.library = library
         p = "(?P<{}>{})".format
 

--- a/utils/telemetry_utils.py
+++ b/utils/telemetry_utils.py
@@ -1,4 +1,4 @@
-from utils._context.library_version import LibraryVersion
+from utils._context.component_version import ComponentVersion
 
 
 class TelemetryUtils:
@@ -15,7 +15,7 @@ class TelemetryUtils:
         return TelemetryUtils.test_loaded_dependencies[library]
 
     @staticmethod
-    def get_dd_appsec_sca_enabled_str(library: LibraryVersion) -> str:
+    def get_dd_appsec_sca_enabled_str(library: ComponentVersion) -> str:
         result = "DD_APPSEC_SCA_ENABLED"
         if library == "java":
             result = "appsec_sca_enabled"


### PR DESCRIPTION
## Motivation

Clear code

## Changes

### Object's  name

`LibraryVersion` is an object that ship : 

* a component name
* and its version

Though, it's not necessarily a library (aka a dd-trace repo). It can also be an agent, or anything else that have a version.

Having it named `LibraryVersion` is misleading, `ComponentVersion` is more generic.

### Property  name

`ComponentVersion.library` was a string shipping the component's name. For the same reason, it's not  necessarily a library, and it's a name. So change to `name`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
