### PR TITLE
Fix appsec truncation object_depth test

### DIFF
--- a/tests/appsec/waf/test_truncation.py
+++ b/tests/appsec/waf/test_truncation.py
@@ -37,7 +37,15 @@ class Test_Truncation:
 
         assert int(metrics["_dd.appsec.truncated.string_length"]) == 5000
         assert int(metrics["_dd.appsec.truncated.container_size"]) == 300
-        assert int(metrics["_dd.appsec.truncated.container_depth"]) == 20
+
+        # Because finding the actual depth is non-trivial and the definition of depth could differ between libraries
+        # depending on if the addresses are counted or not, we are not asserting the exact value here.
+        # Max value of 28 is made of:
+        # * 25 "a" from create_nested_object()
+        # * 1 "deepObject" from setup_truncation()
+        # * 1 "server.request.body" address
+        # * 1 of leeway depending on how leafs of the tree are counted
+        assert 20 <= int(metrics["_dd.appsec.truncated.container_depth"]) <= 28
 
         waf_requests_series = find_series("generate-metrics", "appsec", ["waf.requests"])
         has_input_truncated = any("input_truncated:true" in series["tags"] for series in waf_requests_series)


### PR DESCRIPTION
## Motivation

Support for libraries that will actually try to check the actual depth of the object passed as parameter

## Changes

Broaden assert statement of the object depth span metric

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
