### PR TITLE
Docker SSI: Migrate to docker_in_docker gitlab runners

### DIFF
--- a/utils/scripts/ci_orchestrators/gitlab_exporter.py
+++ b/utils/scripts/ci_orchestrators/gitlab_exporter.py
@@ -204,7 +204,7 @@ def print_docker_ssi_gitlab_pipeline(language, docker_ssi_matrix, ci_environment
                 result_pipeline[vm_job]["stage"] = scenario
                 result_pipeline[vm_job]["extends"] = ".base_docker_ssi_job"
                 result_pipeline[vm_job]["tags"] = [
-                    f"docker-in-docker:{'amd64' if architecture == 'linux/amd64' else 'arm64'}"
+                    f"{'docker-in-docker:amd64' if architecture == 'linux/amd64' else 'runner:docker-arm'}"
                 ]
                 # Job variables
                 result_pipeline[vm_job]["variables"] = {}

--- a/utils/scripts/ci_orchestrators/gitlab_exporter.py
+++ b/utils/scripts/ci_orchestrators/gitlab_exporter.py
@@ -204,7 +204,7 @@ def print_docker_ssi_gitlab_pipeline(language, docker_ssi_matrix, ci_environment
                 result_pipeline[vm_job]["stage"] = scenario
                 result_pipeline[vm_job]["extends"] = ".base_docker_ssi_job"
                 result_pipeline[vm_job]["tags"] = [
-                    f"runner:{'docker' if architecture == 'linux/amd64' else 'docker-arm'}"
+                    f"docker-in-docker:{'amd64' if architecture == 'linux/amd64' else 'arm64'}"
                 ]
                 # Job variables
                 result_pipeline[vm_job]["variables"] = {}


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Docker runners are deprecated on gitlab. Migrate to docker_in_docker runner
Apply only to docker ssi

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
