### PR TITLE
[python] Skip circular import check for 3.2.1

### DIFF
--- a/tests/appsec/test_only_python.py
+++ b/tests/appsec/test_only_python.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, features, interfaces, irrelevant, scenarios
+from utils import context, features, interfaces, irrelevant, scenarios, flaky
 
 
 @scenarios.appsec_blocking
@@ -15,6 +15,7 @@ from utils import context, features, interfaces, irrelevant, scenarios
 class Test_ImportError:
     """Tests to verify that we don't have import errors due to tracer instrumentation."""
 
+    @flaky(context.library == "python@3.2.1" and "flask" in context.weblog_variant, reason="APMRP-360")
     def test_circular_import(self):
         """Test to verify that we don't have a circular import in the weblog."""
         assert context.library == "python"


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
