### PR TITLE
Skip empty test with `@irrelevant` decorator

### DIFF
--- a/tests/appsec/iast/source/test_parameter_value.py
+++ b/tests/appsec/iast/source/test_parameter_value.py
@@ -21,6 +21,7 @@ class TestParameterValue(BaseSourceTest):
     source_names = ["table"]
 
     # remove the base test, to handle the source_type spcial use case in node
+    @irrelevant()
     def test_source_reported(self): ...
 
     setup_source_post_reported = BaseSourceTest.setup_source_reported


### PR DESCRIPTION
## Motivation
<!-- What inspired you to submit this pull request? -->

New Easy win in a test that is testing nothing. 
## Changes
<!-- A brief description of the change being made with this pull request. -->

Mark the empty test as irrelevant.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
Failing tests seem are not related with the PR, this PR is only adding a `@irrelevant`

* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
