### PR TITLE
[golang] fix(process-discovery): Go tracer reports `go` instead of `golang`

### DIFF
--- a/tests/parametric/test_process_discovery.py
+++ b/tests/parametric/test_process_discovery.py
@@ -4,7 +4,8 @@ import pytest
 import json
 import msgpack
 from jsonschema import validate as validation_jsonschema
-from utils import features, scenarios
+from utils import features, scenarios, context
+from utils._context.component_version import Version
 
 
 def find_dd_memfds(test_library, pid: int) -> list[str]:
@@ -61,11 +62,12 @@ class Test_ProcessDiscovery:
             assert tracer_metadata["schema_version"] == 1
             assert tracer_metadata["runtime_id"]
             # assert tracer_metadata["hostname"]
-            # TODO(@dmehala): how to get the version?
-            # assert tracer_metadata["tracer_version"] ==
+
             lang = "go" if test_library.lang == "golang" else test_library.lang
             assert tracer_metadata["tracer_language"] == lang
-
             assert tracer_metadata["service_name"] == library_env["DD_SERVICE"]
             assert tracer_metadata["service_version"] == library_env["DD_VERSION"]
             assert tracer_metadata["service_env"] == library_env["DD_ENV"]
+
+            version = Version(tracer_metadata["tracer_version"])
+            assert context.library.version == version

--- a/tests/parametric/test_process_discovery.py
+++ b/tests/parametric/test_process_discovery.py
@@ -63,7 +63,9 @@ class Test_ProcessDiscovery:
             # assert tracer_metadata["hostname"]
             # TODO(@dmehala): how to get the version?
             # assert tracer_metadata["tracer_version"] ==
-            assert tracer_metadata["tracer_language"] == test_library.lang
+            lang = "go" if test_library.lang == "golang" else test_library.lang
+            assert tracer_metadata["tracer_language"] == lang
+
             assert tracer_metadata["service_name"] == library_env["DD_SERVICE"]
             assert tracer_metadata["service_version"] == library_env["DD_VERSION"]
             assert tracer_metadata["service_env"] == library_env["DD_ENV"]


### PR DESCRIPTION
## Motivation
`test_library.lang` evaluates to `golang` for Go, which does not align with the language reported by the Go tracer. This fix resolves the issue by matching against `go` instead of `golang`.

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
