### PR TITLE
[PHP][APMAPI-1270] Validating Telemetry Headers Test

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -662,7 +662,6 @@ class Test_TelemetryV2:
     @missing_feature(library="cpp_httpd")
     @missing_feature(context.library < "ruby@1.22.0", reason="dd-client-library-version missing")
     @bug(context.library == "python" and context.library.version.prerelease is not None, reason="APMAPI-927")
-    @bug(context.library > "php@1.7.3", reason="APMAPI-1270")
     def test_telemetry_v2_required_headers(self):
         """Assert library add the relevant headers to telemetry v2 payloads"""
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

To try solving an incoming failure after my [Baggage PR](https://github.com/DataDog/dd-trace-php/pull/3102) got merged into master.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Removing `bug` clause to try checking the outcome of the tests running on this PR since locally I am currently able to run both tests and pass them, so hopefully if it fails here we get more data as of why:
![image](https://github.com/user-attachments/assets/5aa26fac-29d8-4182-b918-dd31786b863c)


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
