### PR TITLE
[golang] Change component tag for GCP Service Extension

### DIFF
--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -119,7 +119,6 @@ VARIANT_COMPONENT_MAP = {
     },
     "vertx3": {"netty.request": "netty", "vertx.route-handler": "vertx"},
     "vertx4": {"netty.request": "netty", "vertx.route-handler": "vertx"},
-    "envoyproxy-go-control-plane": "envoyproxy/go-control-plane",
 }
 
 

--- a/utils/_context/_scenarios/external_processing.py
+++ b/utils/_context/_scenarios/external_processing.py
@@ -111,7 +111,7 @@ class ExternalProcessingScenario(DockerScenario):
 
     @property
     def weblog_variant(self):
-        return "envoyproxy-go-control-plane"
+        return "gcp-service-extension"
 
     @property
     def library(self):


### PR DESCRIPTION
## Motivation

Identify more correctly which integration is used (Envoy or GCP SE).

**MERGE ONLY WHEN dd-trace-go `v2` is released!**
This change won't be reflected in the callout instance until the new v2 release of the go tracer is done. If it's merged now, the test checking the component name will fails as latest callout container image is on `v1.72.2`.

## Changes

The component tag when using the GCP Service Extension callout image is now `gcp-service-extension`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
