### PR TITLE
[Ruby] Add SSRF endpoints to Rails Weblogs

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -99,9 +99,9 @@ tests/:
           TestSqlInjection_ExtendedLocation: missing_feature
           TestSqlInjection_StackTrace: missing_feature
         test_ssrf.py:
-          TestSSRF: missing_feature
-          TestSSRF_ExtendedLocation: missing_feature
-          TestSSRF_StackTrace: missing_feature
+          TestSSRF: v2.12.0.dev
+          TestSSRF_ExtendedLocation: v2.12.0.dev
+          TestSSRF_StackTrace: v2.12.0.dev
         test_stacktrace_leak.py:
           TestStackTraceLeak: missing_feature
         test_template_injection.py:

--- a/utils/build/docker/ruby/rails42/Gemfile
+++ b/utils/build/docker/ruby/rails42/Gemfile
@@ -21,6 +21,9 @@ gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 
+# For AppSec Server-Side-Request-Forgery tests
+gem "faraday"
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/utils/build/docker/ruby/rails42/app/controllers/rasp/ssrf_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/rasp/ssrf_controller.rb
@@ -1,0 +1,24 @@
+class RASP::SSRFController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def show
+    perform_http_request(params.fetch(:domain))
+
+    head :ok
+  end
+
+  def create
+    perform_http_request(params.fetch(:url))
+
+    head :ok
+  end
+
+  private
+
+  def perform_http_request(url)
+    url = URI.parse(url_param)
+    url = "https://#{url}" unless url.scheme
+
+    Faraday.get(url)
+  end
+end

--- a/utils/build/docker/ruby/rails42/config/initializers/inflections.rb
+++ b/utils/build/docker/ruby/rails42/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "RASP"
+  inflect.acronym "SSRF"
+end

--- a/utils/build/docker/ruby/rails42/config/routes.rb
+++ b/utils/build/docker/ruby/rails42/config/routes.rb
@@ -41,5 +41,9 @@ Rails.application.routes.draw do
   get '/rasp/sqli' => 'system_test#rasp_sqli'
   post '/rasp/sqli' => 'system_test#rasp_sqli'
 
+  namespace :rasp do
+    resource :ssrf, only: %i[show create]
+  end
+
   get '/sample_rate_route/:i' => 'system_test#sample_rate_route'
 end

--- a/utils/build/docker/ruby/rails50/Gemfile
+++ b/utils/build/docker/ruby/rails50/Gemfile
@@ -32,6 +32,9 @@ gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+# For AppSec Server-Side-Request-Forgery tests
+gem "faraday"
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/utils/build/docker/ruby/rails50/app/controllers/rasp/ssrf_controller.rb
+++ b/utils/build/docker/ruby/rails50/app/controllers/rasp/ssrf_controller.rb
@@ -1,0 +1,24 @@
+class RASP::SSRFController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def show
+    perform_http_request(params.fetch(:domain))
+
+    head :ok
+  end
+
+  def create
+    perform_http_request(params.fetch(:url))
+
+    head :ok
+  end
+
+  private
+
+  def perform_http_request(url)
+    url = URI.parse(url_param)
+    url = "https://#{url}" unless url.scheme
+
+    Faraday.get(url)
+  end
+end

--- a/utils/build/docker/ruby/rails50/config/initializers/inflections.rb
+++ b/utils/build/docker/ruby/rails50/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "RASP"
+  inflect.acronym "SSRF"
+end

--- a/utils/build/docker/ruby/rails50/config/routes.rb
+++ b/utils/build/docker/ruby/rails50/config/routes.rb
@@ -44,5 +44,9 @@ Rails.application.routes.draw do
   get '/rasp/sqli' => 'system_test#rasp_sqli'
   post '/rasp/sqli' => 'system_test#rasp_sqli'
 
+  namespace :rasp do
+    resource :ssrf, only: %i[show create]
+  end
+
   get '/sample_rate_route/:i' => 'system_test#sample_rate_route'
 end

--- a/utils/build/docker/ruby/rails51/Gemfile
+++ b/utils/build/docker/ruby/rails51/Gemfile
@@ -30,6 +30,9 @@ gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+# For AppSec Server-Side-Request-Forgery tests
+gem "faraday"
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/utils/build/docker/ruby/rails51/app/controllers/rasp/ssrf_controller.rb
+++ b/utils/build/docker/ruby/rails51/app/controllers/rasp/ssrf_controller.rb
@@ -1,0 +1,24 @@
+class RASP::SSRFController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def show
+    perform_http_request(params.fetch(:domain))
+
+    head :ok
+  end
+
+  def create
+    perform_http_request(params.fetch(:url))
+
+    head :ok
+  end
+
+  private
+
+  def perform_http_request(url)
+    url = URI.parse(url_param)
+    url = "https://#{url}" unless url.scheme
+
+    Faraday.get(url)
+  end
+end

--- a/utils/build/docker/ruby/rails51/config/initializers/inflections.rb
+++ b/utils/build/docker/ruby/rails51/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "RASP"
+  inflect.acronym "SSRF"
+end

--- a/utils/build/docker/ruby/rails51/config/routes.rb
+++ b/utils/build/docker/ruby/rails51/config/routes.rb
@@ -44,5 +44,9 @@ Rails.application.routes.draw do
   get '/rasp/sqli' => 'system_test#rasp_sqli'
   post '/rasp/sqli' => 'system_test#rasp_sqli'
 
+  namespace :rasp do
+    resource :ssrf, only: %i[show create]
+  end
+
   get '/sample_rate_route/:i' => 'system_test#sample_rate_route'
 end

--- a/utils/build/docker/ruby/rails52/Gemfile
+++ b/utils/build/docker/ruby/rails52/Gemfile
@@ -27,6 +27,9 @@ gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+# For AppSec Server-Side-Request-Forgery tests
+gem "faraday"
+
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 

--- a/utils/build/docker/ruby/rails52/app/controllers/rasp/ssrf_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/rasp/ssrf_controller.rb
@@ -1,0 +1,24 @@
+class RASP::SSRFController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def show
+    perform_http_request(params.fetch(:domain))
+
+    head :ok
+  end
+
+  def create
+    perform_http_request(params.fetch(:url))
+
+    head :ok
+  end
+
+  private
+
+  def perform_http_request(url)
+    url = URI.parse(url_param)
+    url = "https://#{url}" unless url.scheme
+
+    Faraday.get(url)
+  end
+end

--- a/utils/build/docker/ruby/rails52/config/initializers/inflections.rb
+++ b/utils/build/docker/ruby/rails52/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "RASP"
+  inflect.acronym "SSRF"
+end

--- a/utils/build/docker/ruby/rails52/config/routes.rb
+++ b/utils/build/docker/ruby/rails52/config/routes.rb
@@ -44,5 +44,9 @@ Rails.application.routes.draw do
   get '/rasp/sqli' => 'system_test#rasp_sqli'
   post '/rasp/sqli' => 'system_test#rasp_sqli'
 
+  namespace :rasp do
+    resource :ssrf, only: %i[show create]
+  end
+
   get '/sample_rate_route/:i' => 'system_test#sample_rate_route'
 end

--- a/utils/build/docker/ruby/rails60/Gemfile
+++ b/utils/build/docker/ruby/rails60/Gemfile
@@ -22,6 +22,9 @@ gem 'jbuilder', '~> 2.7'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+# For AppSec Server-Side-Request-Forgery tests
+gem "faraday"
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/utils/build/docker/ruby/rails60/app/controllers/rasp/ssrf_controller.rb
+++ b/utils/build/docker/ruby/rails60/app/controllers/rasp/ssrf_controller.rb
@@ -1,0 +1,24 @@
+class RASP::SSRFController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def show
+    perform_http_request(params.fetch(:domain))
+
+    head :ok
+  end
+
+  def create
+    perform_http_request(params.fetch(:url))
+
+    head :ok
+  end
+
+  private
+
+  def perform_http_request(url)
+    url = URI.parse(url_param)
+    url = "https://#{url}" unless url.scheme
+
+    Faraday.get(url)
+  end
+end

--- a/utils/build/docker/ruby/rails60/config/initializers/inflections.rb
+++ b/utils/build/docker/ruby/rails60/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "RASP"
+  inflect.acronym "SSRF"
+end

--- a/utils/build/docker/ruby/rails60/config/routes.rb
+++ b/utils/build/docker/ruby/rails60/config/routes.rb
@@ -44,5 +44,9 @@ Rails.application.routes.draw do
   get '/rasp/sqli' => 'system_test#rasp_sqli'
   post '/rasp/sqli' => 'system_test#rasp_sqli'
 
+  namespace :rasp do
+    resource :ssrf, only: %i[show create]
+  end
+
   get '/sample_rate_route/:i' => 'system_test#sample_rate_route'
 end

--- a/utils/build/docker/ruby/rails61/Gemfile
+++ b/utils/build/docker/ruby/rails61/Gemfile
@@ -22,6 +22,9 @@ gem 'jbuilder', '~> 2.7'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+# For AppSec Server-Side-Request-Forgery tests
+gem "faraday"
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/utils/build/docker/ruby/rails61/app/controllers/rasp/ssrf_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/rasp/ssrf_controller.rb
@@ -1,0 +1,24 @@
+class RASP::SSRFController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def show
+    perform_http_request(params.fetch(:domain))
+
+    head :ok
+  end
+
+  def create
+    perform_http_request(params.fetch(:url))
+
+    head :ok
+  end
+
+  private
+
+  def perform_http_request(url)
+    url = URI.parse(url_param)
+    url = "https://#{url}" unless url.scheme
+
+    Faraday.get(url)
+  end
+end

--- a/utils/build/docker/ruby/rails61/config/initializers/inflections.rb
+++ b/utils/build/docker/ruby/rails61/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "RASP"
+  inflect.acronym "SSRF"
+end

--- a/utils/build/docker/ruby/rails61/config/routes.rb
+++ b/utils/build/docker/ruby/rails61/config/routes.rb
@@ -44,5 +44,9 @@ Rails.application.routes.draw do
   get '/rasp/sqli' => 'system_test#rasp_sqli'
   post '/rasp/sqli' => 'system_test#rasp_sqli'
 
+  namespace :rasp do
+    resource :ssrf, only: %i[show create]
+  end
+
   get '/sample_rate_route/:i' => 'system_test#sample_rate_route'
 end

--- a/utils/build/docker/ruby/rails71/Gemfile
+++ b/utils/build/docker/ruby/rails71/Gemfile
@@ -30,6 +30,9 @@ gem "jbuilder"
 # Talk with Kafka for propagation tests
 gem "rdkafka"
 
+# For AppSec Server-Side-Request-Forgery tests
+gem "faraday"
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/utils/build/docker/ruby/rails71/app/controllers/rasp/ssrf_controller.rb
+++ b/utils/build/docker/ruby/rails71/app/controllers/rasp/ssrf_controller.rb
@@ -1,0 +1,24 @@
+class RASP::SSRFController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def show
+    perform_http_request(params.fetch(:domain))
+
+    head :ok
+  end
+
+  def create
+    perform_http_request(params.fetch(:url))
+
+    head :ok
+  end
+
+  private
+
+  def perform_http_request(url)
+    url = URI.parse(url_param)
+    url = "https://#{url}" unless url.scheme
+
+    Faraday.get(url)
+  end
+end

--- a/utils/build/docker/ruby/rails71/config/initializers/inflections.rb
+++ b/utils/build/docker/ruby/rails71/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "RASP"
+  inflect.acronym "SSRF"
+end

--- a/utils/build/docker/ruby/rails71/config/routes.rb
+++ b/utils/build/docker/ruby/rails71/config/routes.rb
@@ -51,5 +51,9 @@ Rails.application.routes.draw do
   get '/rasp/sqli' => 'system_test#rasp_sqli'
   post '/rasp/sqli' => 'system_test#rasp_sqli'
 
+  namespace :rasp do
+    resource :ssrf, only: %i[show create]
+  end
+
   get '/sample_rate_route/:i' => 'system_test#sample_rate_route'
 end

--- a/utils/build/docker/ruby/rails72/Gemfile
+++ b/utils/build/docker/ruby/rails72/Gemfile
@@ -30,6 +30,9 @@ gem "jbuilder"
 # Talk with Kafka for propagation tests
 gem "rdkafka"
 
+# For AppSec Server-Side-Request-Forgery tests
+gem "faraday"
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/utils/build/docker/ruby/rails72/app/controllers/rasp/ssrf_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/rasp/ssrf_controller.rb
@@ -1,0 +1,24 @@
+class RASP::SSRFController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def show
+    perform_http_request(params.fetch(:domain))
+
+    head :ok
+  end
+
+  def create
+    perform_http_request(params.fetch(:url))
+
+    head :ok
+  end
+
+  private
+
+  def perform_http_request(url)
+    url = URI.parse(url_param)
+    url = "https://#{url}" unless url.scheme
+
+    Faraday.get(url)
+  end
+end

--- a/utils/build/docker/ruby/rails72/config/initializers/inflections.rb
+++ b/utils/build/docker/ruby/rails72/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "RASP"
+  inflect.acronym "SSRF"
+end

--- a/utils/build/docker/ruby/rails72/config/routes.rb
+++ b/utils/build/docker/ruby/rails72/config/routes.rb
@@ -51,5 +51,9 @@ Rails.application.routes.draw do
   get '/rasp/sqli' => 'system_test#rasp_sqli'
   post '/rasp/sqli' => 'system_test#rasp_sqli'
 
+  namespace :rasp do
+    resource :ssrf, only: %i[show create]
+  end
+
   get '/sample_rate_route/:i' => 'system_test#sample_rate_route'
 end

--- a/utils/build/docker/ruby/rails80/Gemfile
+++ b/utils/build/docker/ruby/rails80/Gemfile
@@ -30,6 +30,9 @@ gem "jbuilder"
 # Talk with Kafka for propagation tests
 gem "rdkafka"
 
+# For AppSec Server-Side-Request-Forgery tests
+gem "faraday"
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/utils/build/docker/ruby/rails80/Gemfile.lock
+++ b/utils/build/docker/ruby/rails80/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dogstatsd-ruby (5.6.6)
     drb (2.2.1)
     erubi (1.13.1)
     ffi (1.17.1)
@@ -335,6 +336,7 @@ DEPENDENCIES
   datadog (~> 2.7.0)
   debug
   devise
+  dogstatsd-ruby
   importmap-rails
   jbuilder
   pry

--- a/utils/build/docker/ruby/rails80/app/controllers/rasp/ssrf_controller.rb
+++ b/utils/build/docker/ruby/rails80/app/controllers/rasp/ssrf_controller.rb
@@ -1,0 +1,24 @@
+class RASP::SSRFController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def show
+    perform_http_request(params.fetch(:domain))
+
+    head :ok
+  end
+
+  def create
+    perform_http_request(params.fetch(:url))
+
+    head :ok
+  end
+
+  private
+
+  def perform_http_request(url)
+    url = URI.parse(url_param)
+    url = "https://#{url}" unless url.scheme
+
+    Faraday.get(url)
+  end
+end

--- a/utils/build/docker/ruby/rails80/config/initializers/inflections.rb
+++ b/utils/build/docker/ruby/rails80/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "RASP"
+  inflect.acronym "SSRF"
+end

--- a/utils/build/docker/ruby/rails80/config/routes.rb
+++ b/utils/build/docker/ruby/rails80/config/routes.rb
@@ -56,5 +56,9 @@ Rails.application.routes.draw do
   get '/rasp/sqli' => 'system_test#rasp_sqli'
   post '/rasp/sqli' => 'system_test#rasp_sqli'
 
+  namespace :rasp do
+    resource :ssrf, only: %i[show create]
+  end
+
   get '/sample_rate_route/:i' => 'system_test#sample_rate_route'
 end


### PR DESCRIPTION
## Motivation

We want to enable SSRF tests for Ruby. For this we need to add endpoints to all weblog variants.

## Changes

This PR:
  - enables tests for SSRF for Ruby
  - adds weblog endpoints for SSRF tests

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
