### PR TITLE
[NodeJS] Update `make_distant_call` to allow injecting of request headers

### DIFF
--- a/utils/build/docker/nodejs/express/app.js
+++ b/utils/build/docker/nodejs/express/app.js
@@ -141,21 +141,26 @@ app.get('/make_distant_call', (req, res) => {
 
     response.on('end', () => {
       res.json({
+        url,
         status_code: response.statusCode,
         request_headers: response.req._headers,
         response_headers: response.headers,
-        body: responseBody
+        response_body: responseBody
       })
     })
   })
 
   // Handle errors
-  request.on('error', (e) => {
-    console.error(`Problem with request: ${e.message}`)
-    res.status(500).json({ error: e.message })
+  request.on('error', (error) => {
+    console.log(error)
+    res.json({
+      url,
+      status_code: 500,
+      request_headers: null,
+      response_headers: null
+    })
   })
 
-  // End the request (send it out)
   request.end()
 })
 

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -1,6 +1,7 @@
 'use strict'
 
 import { Request, Response } from "express";
+import http from 'http';
 
 const tracer = require('dd-trace').init({ debug: true, flushInterval: 5000 });
 
@@ -103,28 +104,48 @@ app.get('/status', (req: Request, res: Response) => {
 });
 
 app.get("/make_distant_call", (req: Request, res: Response) => {
-  const url = req.query.url;
-  console.log(url);
+  const url = req.query.url
+  console.log(url)
 
-  axios.get(url)
-    .then((response: Response) => {
-      res.json({
-        url: url,
-        status_code: response.statusCode,
-        request_headers: null,
-        response_headers: null,
-      });
+  const parsedUrl = new URL(url as string)
+
+  const options = {
+    hostname: parsedUrl.hostname,
+    port: parsedUrl.port || 80, // Use default port if not provided
+    path: parsedUrl.pathname,
+    method: 'GET'
+  }
+
+  const request = http.request(options, (response: http.IncomingMessage) => {
+    let responseBody = ''
+    response.on('data', (chunk) => {
+      responseBody += chunk
     })
-    .catch((error: Error) => {
-      console.log(error);
+
+    response.on('end', () => {
       res.json({
-        url: url,
-        status_code: 500,
-        request_headers: null,
-        response_headers: null,
-      });
-    });
-});
+        url,
+        status_code: response.statusCode,
+        request_headers: (response as any).req._headers,
+        response_headers: response.headers,
+        response_body: responseBody
+      })
+    })
+  })
+
+  // Handle errors
+  request.on('error', (error: Error) => {
+    console.log(error)
+    res.json({
+      url,
+      status_code: 500,
+      request_headers: null,
+      response_headers: null
+    })
+  })
+
+  request.end()
+})
 
 app.get("/user_login_success_event", (req: Request, res: Response) => {
   const userId = req.query.event_user_id || "system_tests_user";

--- a/utils/build/docker/nodejs/nextjs/src/app/make_distant_call/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/make_distant_call/route.js
@@ -1,24 +1,46 @@
 import { NextResponse } from 'next/server'
-import axios from 'axios'
+import http from 'http'
 
 export async function GET (request) {
   const url = request.nextUrl.searchParams.get('url')
 
-  try {
-    const response = await axios.get(url)
+  const parsedUrl = new URL(url)
 
-    return NextResponse.json({
-      url,
-      status_code: response.statusCode,
-      request_headers: null,
-      response_headers: null
-    })
-  } catch (error) {
-    return NextResponse.json({
-      url,
-      status_code: 500,
-      request_headers: null,
-      response_headers: null
-    })
+  const options = {
+    hostname: parsedUrl.hostname,
+    port: parsedUrl.port || 80,
+    path: parsedUrl.pathname,
+    method: 'GET'
   }
+
+  return new Promise((resolve) => {
+    const request = http.request(options, (response) => {
+      let responseBody = ''
+      response.on('data', (chunk) => {
+        responseBody += chunk
+      })
+
+      response.on('end', () => {
+        resolve(NextResponse.json({
+          url,
+          status_code: response.statusCode,
+          request_headers: response.req._headers,
+          response_headers: response.headers,
+          response_body: responseBody
+        }))
+      })
+    })
+
+    request.on('error', (error) => {
+      console.log(error)
+      resolve(NextResponse.json({
+        url,
+        status_code: 500,
+        request_headers: null,
+        response_headers: null
+      }))
+    })
+
+    request.end()
+  })
 }


### PR DESCRIPTION
## Motivation
Previously, the `make_distant_call` endpoint in the weblog apps used `Axios` to fetch request headers that are being sent to the downstream request. This does not allow for injected headers from the tracer (such as through tracecontext or baggage propagation) to be added. This PR aims to do the same thing that #4069 does, but for the NodeJS weblog apps.

## Changes
Migrated from using `Axios` to `http` to get the request headers for the downstream request after the injection is done. 
## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
