### PR TITLE
[java] Allow deprecated methods to be used in the play app

### DIFF
--- a/utils/build/docker/java/play/pom.xml
+++ b/utils/build/docker/java/play/pom.xml
@@ -139,7 +139,7 @@
                 <artifactId>sbt-compiler-maven-plugin</artifactId>
                 <version>1.0.0</version>
                 <configuration>
-                    <scalacOptions>-feature -deprecation -Xfatal-warnings</scalacOptions>
+                    <scalacOptions>-feature -deprecation</scalacOptions>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Motivation

The deprecation of the login events SDK in Java is causing [failures](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/47398/workflows/b32268b0-b498-452b-a253-3c9f2eaf195d/jobs/1852305) when building the play app, this PR fixes that. 

## Changes

Allow deprecated methods in the play app.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
