### PR TITLE
[php][API Gateway] Add tracer version to the API Gateway test

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -429,7 +429,10 @@ tests/:
       Test_DsmSQS: missing_feature
       Test_Dsm_Manual_Checkpoint_Inter_Process: missing_feature
       Test_Dsm_Manual_Checkpoint_Intra_Process: missing_feature
-    test_inferred_proxy.py: missing_feature
+    test_inferred_proxy.py:
+      Test_AWS_API_Gateway_Inferred_Span_Creation: v1.8.0
+      Test_AWS_API_Gateway_Inferred_Span_Creation_With_Distributed_Context: v1.8.0
+      Test_AWS_API_Gateway_Inferred_Span_Creation_With_Error: v1.8.0
     test_otel_drop_in.py:
       Test_Otel_Drop_In: missing_feature
   otel/:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Since https://github.com/DataDog/dd-trace-php/pull/3116 has been merged with a release of 1.8.0, I'm updating the system tests.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [x] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
