### PR TITLE
[python] Skip test for APMAPI-1283

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1055,10 +1055,10 @@ tests/:
     Test_MetaDatadogTags: v3.2.0
   test_span_events.py:
     Test_SpanEvents_WithAgentSupport:
-      "*": irrelevant (endpoint not implemented)
+      "*": missing_feature (endpoint not implemented)
       flask-poc: v3.0.0
     Test_SpanEvents_WithoutAgentSupport:
-      "*": irrelevant (endpoint not implemented)
+      "*": missing_feature (endpoint not implemented)
       flask-poc: v3.0.0
   test_standard_tags.py:
     Test_StandardTagsClientIp: v2.7.0

--- a/tests/test_span_events.py
+++ b/tests/test_span_events.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, interfaces, irrelevant, weblog, scenarios, features, rfc
+from utils import context, interfaces, irrelevant, weblog, scenarios, features, rfc, bug
 
 
 @rfc("https://docs.google.com/document/d/1cVod_VI7Yruq8U9dfMRFJd7npDu-uBpste2IB04GyaQ")
@@ -33,6 +33,9 @@ class Test_SpanEvents_WithAgentSupport:
 
     @irrelevant(context.library in ["ruby"], reason="v0.5 is not the default format")
     @irrelevant(context.library in ["nodejs"], reason="v0.5 is not the default format")
+    @bug(
+        context.library > "python@3.3.0" and context.weblog_variant in ("flask-poc", "uds-flask"), reason="APMAPI-1283"
+    )
     def test_v05_default_format(self):
         """For traces that default to the v0.5 format, send events as the span tag `events`
         given this format does not support native serialization.


### PR DESCRIPTION
## Motivation

https://datadoghq.atlassian.net/browse/APMAPI-1283

## Changes

* mark failing test as bug
* also changed two declarations in manifest (when an endpoint is missing in weblog, we must use `missing_feature`)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
