### PR TITLE
[nodejs] Add express4-typescript in weblog impacted by APMAPI-1252

### DIFF
--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -102,7 +102,8 @@ class Test_SamplingRates:
             weblog.get(p)
 
     @flaky(
-        context.library == "nodejs" and context.weblog_variant in ("express4", "express5", "uds-express4"),
+        context.library == "nodejs"
+        and context.weblog_variant in ("express4", "express5", "uds-express4", "express4-typescript"),
         reason="APMAPI-1252",
     )
     @missing_feature(library="cpp_httpd", reason="/sample_rate_route is not implemented")


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
