### PR TITLE
[python] update decorator with reason for skipping span event test

### DIFF
--- a/tests/test_span_events.py
+++ b/tests/test_span_events.py
@@ -33,7 +33,7 @@ class Test_SpanEvents_WithAgentSupport:
 
     @irrelevant(context.library in ["ruby"], reason="v0.5 is not the default format")
     @irrelevant(context.library in ["nodejs"], reason="v0.5 is not the default format")
-    @irrelevant(context.library > "python@3.3.0", reason="environment variable overrides v0.5")
+    @irrelevant(context.library > "python@3.3.0", reason="DD_TRACE_NATIVE_SPAN_EVENTS overrides v0.5")
     def test_v05_default_format(self):
         """For traces that default to the v0.5 format, send events as the span tag `events`
         given this format does not support native serialization.

--- a/tests/test_span_events.py
+++ b/tests/test_span_events.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, interfaces, irrelevant, weblog, scenarios, features, rfc, bug
+from utils import context, interfaces, irrelevant, weblog, scenarios, features, rfc
 
 
 @rfc("https://docs.google.com/document/d/1cVod_VI7Yruq8U9dfMRFJd7npDu-uBpste2IB04GyaQ")

--- a/tests/test_span_events.py
+++ b/tests/test_span_events.py
@@ -33,9 +33,7 @@ class Test_SpanEvents_WithAgentSupport:
 
     @irrelevant(context.library in ["ruby"], reason="v0.5 is not the default format")
     @irrelevant(context.library in ["nodejs"], reason="v0.5 is not the default format")
-    @bug(
-        context.library > "python@3.3.0" and context.weblog_variant in ("flask-poc", "uds-flask"), reason="APMAPI-1283"
-    )
+    @irrelevant(context.library > "python@3.3.0", reason="environment variable overrides v0.5")
     def test_v05_default_format(self):
         """For traces that default to the v0.5 format, send events as the span tag `events`
         given this format does not support native serialization.


### PR DESCRIPTION
## Motivation
There is a discrepancy in span events between what the RFC states and the current system test implementation for when `DD_TRACE_NATIVE_SPAN_EVENTS` is enabled for `v0.5`. The RFC states that setting `DD_TRACE_NATIVE_SPAN_EVENTS` should override the v0.5 protocol and switch to v0.4/v0.7; the system test expects that v0.5 is respected even when the environment variable is set.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
