### PR TITLE
Introduce a way to add extra argument to library cmd on parametric scenario

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -195,6 +195,16 @@
             "python": "${workspaceFolder}/venv/bin/python"
         },
         {
+            "name": "Run PARAMETRIC scenario",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["-S", "PARAMETRIC", "-L", "java"],
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python"
+        },
+        {
             "name": "Python: Current File",
             "type": "debugpy",
             "request": "launch",

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -393,9 +393,6 @@ def node_library_factory() -> APMLibraryTestServer:
 FROM node:18.10-slim
 RUN apt-get update && apt-get -y install bash curl git jq
 WORKDIR /usr/app
-COPY {nodejs_reldir}/../app.sh /usr/app/
-RUN printf 'node server.js' >> app.sh
-RUN chmod +x app.sh
 COPY {nodejs_reldir}/package.json /usr/app/
 COPY {nodejs_reldir}/package-lock.json /usr/app/
 COPY {nodejs_reldir}/*.js /usr/app/
@@ -580,7 +577,7 @@ ADD {php_reldir}/server.php .
         container_cmd=[
             "bash",
             "-c",
-            "php server.php || sleep 2s",
+            "php server.php ${SYSTEM_TESTS_EXTRA_COMMAND_ARGUMENTS:-} || sleep 2s",
         ],  # In case of crash, give time to the sidecar to upload the crash report
         container_build_dir=php_absolute_appdir,
         container_build_context=_get_base_directory(),

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -364,7 +364,7 @@ RUN /binaries/install_ddtrace.sh
 RUN mkdir /parametric-tracer-logs
 ENV DD_PATCH_MODULES="fastapi:false,startlette:false"
 """,
-        container_cmd="ddtrace-run python3.11 -m apm_test_client".split(" "),
+        container_cmd=["ddtrace-run", "python3.11", "-m", "apm_test_client"],
         container_build_dir=python_absolute_appdir,
         container_build_context=_get_base_directory(),
         volumes={os.path.join(python_absolute_appdir, "apm_test_client"): "/app/apm_test_client"},
@@ -517,9 +517,8 @@ COPY --from=build-version-tool /app/out /app
 COPY --from=build-app /app/out /app
 
 RUN mkdir /parametric-tracer-logs
-CMD ["./ApmTestApi"]
 """,
-        container_cmd=[],
+        container_cmd=["./ApmTestApi"],
         container_build_dir=dotnet_absolute_appdir,
         container_build_context=_get_base_directory(),
     )

--- a/utils/build/docker/java/parametric/run.sh
+++ b/utils/build/docker/java/parametric/run.sh
@@ -33,6 +33,7 @@ DISABLE_INTEGRATIONS=(-Ddd.integration.servlet-request-body.enabled=false \
 OPTIMIZATION_OPTIONS=(-XX:TieredStopAtLevel=1)
 
 # Start client application
+# shellcheck disable=SC2086
 java -Xmx128M -javaagent:"${DD_JAVA_AGENT}" \
   $ENABLE_OTEL_TRACING_API \
   "${ENABLE_CRASH_TRACKING[@]}" \

--- a/utils/build/docker/java/parametric/run.sh
+++ b/utils/build/docker/java/parametric/run.sh
@@ -39,4 +39,5 @@ java -Xmx128M -javaagent:"${DD_JAVA_AGENT}" \
   "${DISABLED_FEATURES[@]}" \
   "${DISABLE_INTEGRATIONS[@]}" \
   "${OPTIMIZATION_OPTIONS[@]}" \
+  ${SYSTEM_TESTS_EXTRA_COMMAND_ARGUMENTS:-} \
   -jar target/dd-trace-java-client-1.0.0.jar

--- a/utils/build/docker/nodejs/parametric/app.sh
+++ b/utils/build/docker/nodejs/parametric/app.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "${UDS_WEBLOG:-}" = "1" ]; then
+    ./set-uds-transport.sh
+fi
+
+set -e
+
+if [ -e /volumes/dd-trace-js ]; then
+    cd /volumes/dd-trace-js
+    npm link
+    cd /usr/app
+    npm link dd-trace
+fi
+
+# shellcheck disable=SC2086
+node server.js ${SYSTEM_TESTS_EXTRA_COMMAND_ARGUMENTS:-}


### PR DESCRIPTION
## Motivation

Allow to add arbitary argument to library container command in parametric scenario

## Changes

Add `library_extra_command_arguments` parameter. 

## Usage : 

```python
import pytest
from utils import scenarios


class Test_stuff:
    @scenarios.parametric
    @pytest.mark.parametrize(
        "library_extra_command_arguments",
        [
            ["--arg1"]
            ["--arg2=12"]
        ],
    )
    def test_stuff(self, test_agent, test_library):
        pass
```

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
