### PR TITLE
Onboarding: disabled debian 12 again

### DIFF
--- a/utils/virtual_machine/virtual_machines.json
+++ b/utils/virtual_machine/virtual_machines.json
@@ -217,7 +217,7 @@
             "os_branch": "debian",
             "os_cpu": "amd64",
             "default_vm": true,
-            "disabled": false
+            "disabled": true
         },
         {
             "name": "Debian_12_arm64",
@@ -231,7 +231,7 @@
             "os_branch": "debian",
             "os_cpu": "arm64",
             "default_vm": false,
-            "disabled": false
+            "disabled": true
         },
         {
             "name": "Debian_11_amd64",
@@ -482,7 +482,7 @@
             "default_vm": false,
             "disabled": false
         },
-         {
+        {
             "name": "OracleLinux_9_2_amd64",
             "aws_config": {
                 "ami_id": "ami-01453ca80e53609e3",


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The debian 12 is failing on the agent qa account (not in the new account).
Let's disable the debian 12 again, until we migrate all the repositories to the new aws account

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
