### PR TITLE
[APM] Do not consider None priority as sampled

### DIFF
--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -5,7 +5,7 @@
 """Misc checks around data integrity during components' lifetime"""
 
 import string
-from utils import weblog, interfaces, context, bug, rfc, irrelevant, missing_feature, features, scenarios, flaky, logger
+from utils import weblog, interfaces, context, bug, rfc, irrelevant, missing_feature, features, scenarios, logger
 from utils.dd_constants import SamplingPriority
 from utils.cgroup_info import get_container_id
 

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -230,7 +230,6 @@ class Test_Agent:
             header_value_pattern="application/json",
         )
 
-    @flaky(condition=True, reason="APMSP-1811")
     def test_agent_do_not_drop_traces(self):
         """Agent does not drop traces"""
 
@@ -245,7 +244,7 @@ class Test_Agent:
         for data, span in interfaces.library.get_root_spans():
             metrics = span["metrics"]
             sampling_priority = metrics.get("_sampling_priority_v1")
-            if sampling_priority in (None, SamplingPriority.AUTO_KEEP, SamplingPriority.USER_KEEP):
+            if sampling_priority in (SamplingPriority.AUTO_KEEP, SamplingPriority.USER_KEEP):
                 trace_ids_reported_by_tracer.add(span["trace_id"])
                 if span["trace_id"] not in trace_ids_reported_by_agent:
                     logger.error(f"Trace {span['trace_id']} has not been reported ({data['log_filename']})")

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -244,10 +244,11 @@ class Test_Agent:
             # sampling priority tag will be returned. This isthe same logic found on the trace-agent.
             span_with_sampling_data = None
             for span in trace:
-                if span["metrics"].get("_sampling_priority_v1", None) is not None:
+                if span.get("metrics", {}).get("_sampling_priority_v1", None) is not None:
                     if span.get("parent_id") in (0, None):
                         return span
-                    span_with_sampling_data = span
+                    elif span_with_sampling_data is None:
+                        span_with_sampling_data = span
 
             return span_with_sampling_data
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

This is a fix for https://datadoghq.atlassian.net/browse/APMSP-1811

This tests was marked as flaky, and noticed that the sampling priority was somewhat flawed. Only sampling priorities > 0 will be considered as _sampled_, and lack of a sampling priority (`None`) will be treated as a P0, which is the same behavior the Agent has.

## Changes

<!-- A brief description of the change being made with this pull request. -->


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
