### PR TITLE
[python] Use agent_config in parametric config endpoint

### DIFF
--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -29,6 +29,7 @@ from opentelemetry.baggage import get_baggage
 import ddtrace
 from ddtrace import config
 from ddtrace.settings.profiling import config as profiling_config
+from ddtrace.internal.agent import config as agent_config
 from ddtrace.contrib.trace_utils import set_http_meta
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
@@ -130,9 +131,9 @@ def trace_config() -> TraceConfigReturn:
             "dd_env": config.env,
             "dd_version": config.version,
             "dd_trace_rate_limit": str(config._trace_rate_limit),
-            "dd_trace_agent_url": str(ddtrace.tracer._agent_url),
-            "dd_dogstatsd_host": urlparse(ddtrace.tracer._dogstatsd_url).hostname,
-            "dd_dogstatsd_port": urlparse(ddtrace.tracer._dogstatsd_url).port,
+            "dd_trace_agent_url": agent_config.trace_agent_url,
+            "dd_dogstatsd_host": urlparse(agent_config.dogstatsd_url).hostname,
+            "dd_dogstatsd_port": urlparse(agent_config.dogstatsd_url).port,
             "dd_logs_injection": str(config._logs_injection).lower(),
             "dd_profiling_enabled": str(profiling_config.enabled).lower(),
             "dd_data_streams_enabled": str(config._data_streams_enabled).lower(),

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -68,6 +68,24 @@ Implement the API specified below to enable your library to run all of the share
 opentelemetry.trace.set_tracer_provider(TracerProvider())
 
 
+try:
+    # ddtrace.internal.agent.config is only available in ddtrace>=3.3.0
+    from ddtrace.internal.agent import config as agent_config
+
+    def trace_agent_url():
+        return agent_config.trace_agent_url
+
+    def dogstatsd_url():
+        return agent_config.dogstatsd_url
+except ImportError:
+    # TODO: Remove this block once we stop running parametric tests for ddtrace<3.3.0
+    def trace_agent_url():
+        return ddtrace.tracer._agent_url
+
+    def dogstatsd_url():
+        return ddtrace.tracer._dogstatsd_url
+
+
 class StartSpanArgs(BaseModel):
     name: str
     parent_id: Optional[int]
@@ -131,9 +149,9 @@ def trace_config() -> TraceConfigReturn:
             "dd_env": config.env,
             "dd_version": config.version,
             "dd_trace_rate_limit": str(config._trace_rate_limit),
-            "dd_trace_agent_url": agent_config.trace_agent_url,
-            "dd_dogstatsd_host": urlparse(agent_config.dogstatsd_url).hostname,
-            "dd_dogstatsd_port": urlparse(agent_config.dogstatsd_url).port,
+            "dd_trace_agent_url": trace_agent_url(),
+            "dd_dogstatsd_host": urlparse(dogstatsd_url()).hostname,
+            "dd_dogstatsd_port": urlparse(dogstatsd_url()).port,
             "dd_logs_injection": str(config._logs_injection).lower(),
             "dd_profiling_enabled": str(profiling_config.enabled).lower(),
             "dd_data_streams_enabled": str(config._data_streams_enabled).lower(),


### PR DESCRIPTION
## Motivation

Unblocks this refactor: https://github.com/DataDog/dd-trace-py/pull/12749. 

Agent configurations will no longer be stored on the Tracer. The global config object will be the source of truth. 

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
