### PR TITLE
[Java] Spring-boot Increase Default Max Http Header Size

### DIFF
--- a/utils/build/docker/java/spring-boot/src/main/resources/application.properties
+++ b/utils/build/docker/java/spring-boot/src/main/resources/application.properties
@@ -6,3 +6,4 @@ spring.sql.init.mode=always
 spring.ldap.embedded.ldif=classpath:test-server.ldif
 spring.ldap.embedded.base-dn=dc=example
 spring.ldap.embedded.port=8389
+server.max-http-header-size=65536


### PR DESCRIPTION
## Motivation

Springboot defaults the max http header sizes of all combined headers to be 8192 bytes. Since we by default support a maximum size of 8192 bytes for baggage headers alone, we need to increase this limit in the weblog app to receive baggage headers in the tracer.

## Changes

Update Springboot weblog app `max-http-header-size`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
