### PR TITLE
[golang] workaround: update load-binary.sh to set default TARGET_BRANCH to v1-maintenance

### DIFF
--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -217,7 +217,7 @@ elif [ "$TARGET" = "golang" ]; then
     rm -rf golang-load-from-go-get
     set -o pipefail
 
-    TARGET_BRANCH="${TARGET_BRANCH:-main}"
+    TARGET_BRANCH="${TARGET_BRANCH:-v1-maintenance}"
     echo "load last commit on $TARGET_BRANCH for DataDog/dd-trace-go"
     COMMIT_ID=$(curl -sS --fail "https://api.github.com/repos/DataDog/dd-trace-go/branches/$TARGET_BRANCH" | jq -r .commit.sha)
 


### PR DESCRIPTION
## Motivation

As `v2-dev` was merged in `dd-trace-go`, `system-tests`'s `main` branch is failing because it pulls the latest commit of `main` from `dd-trace-go`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
