### PR TITLE
K8s Lib Injection: Using minikube on CI

### DIFF
--- a/.gitlab/ssi_gitlab-ci.yml
+++ b/.gitlab/ssi_gitlab-ci.yml
@@ -112,7 +112,7 @@ ssi_tests:
             - reports/
 
 .k8s_lib_injection_base:
-  image: registry.ddbuild.io/ci/libdatadog-build/system-tests:57161036
+  image: registry.ddbuild.io/ci/libdatadog-build/system-tests-minikube:61396538
   tags: [ "runner:docker" ]
   needs: []
   stage: K8S_LIB_INJECTION
@@ -128,7 +128,7 @@ ssi_tests:
     - source venv/bin/activate
     - python --version
     - pip freeze
-    - ./run.sh ${K8S_SCENARIO} --k8s-library ${TEST_LIBRARY} --k8s-weblog ${K8S_WEBLOG} --k8s-weblog-img ${K8S_WEBLOG_IMG} --k8s-lib-init-img ${K8S_LIB_INIT_IMG} --k8s-injector-img ${K8S_INJECTOR_IMG} --k8s-cluster-img ${K8S_CLUSTER_IMG} --report-run-url $CI_JOB_URL --report-environment ${REPORT_ENVIRONMENT}
+    - ./run.sh ${K8S_SCENARIO} --k8s-library ${TEST_LIBRARY} --k8s-weblog ${K8S_WEBLOG} --k8s-weblog-img ${K8S_WEBLOG_IMG} --k8s-lib-init-img ${K8S_LIB_INIT_IMG} --k8s-injector-img ${K8S_INJECTOR_IMG} --k8s-cluster-img ${K8S_CLUSTER_IMG} --k8s-provider minikube --report-run-url $CI_JOB_URL --report-environment ${REPORT_ENVIRONMENT}
   after_script: |
     kind delete clusters --all || true
     mkdir -p reports


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Using the new gitlab runner to run the k8s tests on minikube

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
