### PR TITLE
test(debugger): Ensure debugger features are disabled by default

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2071,7 +2071,7 @@ tests/:
       '*': v1.23.0
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     Test_ProductsDisabled:
-      '*': missing_feature
+      '*': v1.48.0
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     Test_Telemetry:
       '*': v0.108.1

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1075,7 +1075,7 @@ tests/:
     Test_MessageBatch: missing_feature
     Test_Metric_Generation_Disabled: missing_feature
     Test_Metric_Generation_Enabled: missing_feature
-    Test_ProductsDisabled: missing_feature
+    Test_ProductsDisabled: v3.4.0
     Test_Telemetry: v1.16.0
     Test_TelemetrySCAEnvVar: missing_feature
     Test_TelemetryV2: v1.17.3


### PR DESCRIPTION
## Motivation

During #incident-36407 we discovered that a tracer library had dynamic instrumentation enabled by default. This pull request lays the groundwork to ensure for all tracers that the defaults match our expectations.

## Changes

### Test Configuration Updates:
* [`manifests/python.yml`](diffhunk://#diff-6e0ee0ad398e4fe9a7f833e48406fd4ff99eff4ac88e92ec0e0b2e58eb6e3889L1078-R1078): Updated the `Test_ProductsDisabled` to use version `v2.8.0` instead of `missing_feature`.

### New Test Cases and Annotations:
* [`tests/test_telemetry.py`](diffhunk://#diff-6ab9dd4d058d45bd9344fb44a8b55b5c358f9e2648bf50bbdedcbfe2dd50220cR689): Added a `@missing_feature` decorator to the `test_app_started_product_disabled` method to indicate that the feature is not implemented for the Python library.
* [`tests/test_telemetry.py`](diffhunk://#diff-6ab9dd4d058d45bd9344fb44a8b55b5c358f9e2648bf50bbdedcbfe2dd50220cR729-R770): Introduced a new test method `test_debugger_products_disabled` with multiple `@missing_feature` decorators for different libraries (Ruby, Node.js, .NET) and an `@irrelevant` decorator for Go. This test checks that debugger products are disabled by default, including Dynamic Instrumentation (DI) and Exception Replay (ER).


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
