### PR TITLE
fix(sampling): update sample rate env var in parametric test

### DIFF
--- a/tests/parametric/test_sampling_delegation.py
+++ b/tests/parametric/test_sampling_delegation.py
@@ -30,6 +30,7 @@ class Test_Decisionless_Extraction:
                 #
                 # [1]: https://docs.google.com/document/d/1zeO6LGnvxk5XweObHAwJbK3SfK23z7jQzp7ozWJTa2A/edit#heading=h.2nfwolfi3o1j
                 "DD_TRACE_SAMPLE_RATE": "1.0",
+                "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":1.0}]',
             }
         ],
     )


### PR DESCRIPTION
## Motivation

One of the parametric test is using an env var that is not used anymore by the python client. `DD_TRACE_SAMPLE_RATE` has been dropped and replaced by `DD_TRACE_SAMPLING_RULES`

The test is currently passing due to an hardcoded sampling decision `USER_KEEP` in the http header extractor that is being reworked [dd-trace-py#12950](https://github.com/DataDog/dd-trace-py/pull/12950)


## Changes

* add DD_TRACE_SAMPLING_RULES env var to Test_Decisionless_Extraction

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
