### PR TITLE
Generate user event on standalone mode

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -312,6 +312,7 @@ tests/:
       Test_IastStandalone_UpstreamPropagation_V2: v3.12.0
       Test_SCAStandalone_Telemetry: missing_feature
       Test_SCAStandalone_Telemetry_V2: missing_feature
+      Test_UserEventsStandalone: missing_feature
     test_automated_login_events.py:
       Test_Login_Events: irrelevant (was v2.53.0 but will be replaced by V2)
       Test_Login_Events_Extended: irrelevant (was v2.53.0 but will be replaced by V2)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -351,6 +351,7 @@ tests/:
       Test_IastStandalone_UpstreamPropagation_V2: missing_feature
       Test_SCAStandalone_Telemetry: missing_feature
       Test_SCAStandalone_Telemetry_V2: missing_feature
+      Test_UserEventsStandalone: missing_feature
     test_automated_login_events.py:
       Test_Login_Events: missing_feature
       Test_Login_Events_Extended: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1194,6 +1194,7 @@ tests/:
       Test_SCAStandalone_Telemetry_V2:
         '*': v1.47.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      Test_UserEventsStandalone: missing_feature
     test_automated_login_events.py:
       Test_Login_Events: irrelevant (was v1.36.0 but will be replaced by V2)
       Test_Login_Events_Extended: irrelevant (was v1.36.0 but will be replaced by V2)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -621,6 +621,7 @@ tests/:
       Test_IastStandalone_UpstreamPropagation_V2: *ref_5_40_0
       Test_SCAStandalone_Telemetry: irrelevant (due to v2)
       Test_SCAStandalone_Telemetry_V2: *ref_5_40_0
+      Test_UserEventsStandalone: missing_feature
     test_automated_login_events.py:
       Test_Login_Events: irrelevant
       Test_Login_Events_Extended: irrelevant

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -309,6 +309,7 @@ tests/:
       Test_IastStandalone_UpstreamPropagation_V2: missing_feature
       Test_SCAStandalone_Telemetry: missing_feature
       Test_SCAStandalone_Telemetry_V2: missing_feature
+      Test_UserEventsStandalone: v1.8.0
     test_automated_login_events.py:
       Test_Login_Events: irrelevant (was v0.89.0 but will be replaced by V2)
       Test_Login_Events_Extended: irrelevant (was v0.89.0 but will be replaced by V2)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -484,6 +484,7 @@ tests/:
         uds-flask: bug (APPSEC-57145)
       Test_SCAStandalone_Telemetry: irrelevant (was v2.19.0.dev but will be replaced by V2)
       Test_SCAStandalone_Telemetry_V2: v3.2.0.dev
+      Test_UserEventsStandalone: missing_feature
     test_automated_login_events.py:
       Test_Login_Events: irrelevant (was v2.10.0 but will be replaced by V2)
       Test_Login_Events_Extended: irrelevant (was v2.10.0 but will be replaced by V2)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -286,6 +286,7 @@ tests/:
       Test_IastStandalone_UpstreamPropagation_V2: missing_feature
       Test_SCAStandalone_Telemetry: irrelevant
       Test_SCAStandalone_Telemetry_V2: v2.12.3-dev
+      Test_UserEventsStandalone: missing_feature
     test_automated_login_events.py:
       Test_Login_Events: irrelevant
       Test_Login_Events_Extended: irrelevant

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -6,6 +6,39 @@ from requests.structures import CaseInsensitiveDict
 from utils.telemetry_utils import TelemetryUtils
 from utils import context, weblog, interfaces, scenarios, features, rfc, bug, missing_feature, irrelevant, logger
 
+USER = "test"
+NEW_USER = "testnew"
+INVALID_USER = "invalidUser"
+UUID_USER = "testuuid"
+PASSWORD = "1234"
+
+
+# Return a boolean indicating if the test passed
+def assert_tags(first_trace, span, obj, expected_tags) -> bool:
+    def _assert_tags_value(span, obj, expected_tags):
+        struct = span if obj is None else span[obj]
+        for tag, value in expected_tags.items():
+            if value is None:
+                assert tag not in struct
+            elif tag == "_sampling_priority_v1":  # special case, it's a lambda to check for a condition
+                assert value(struct[tag])
+            else:
+                assert struct[tag] == value
+
+    # Case 1: The tags are set on the first span of every trace chunk
+    try:
+        _assert_tags_value(first_trace, obj, expected_tags)
+        return True
+    except (KeyError, AssertionError):
+        pass  # should try the second case
+
+    # Case 2: The tags are set on the local root span
+    try:
+        _assert_tags_value(span, obj, expected_tags)
+        return True
+    except (KeyError, AssertionError):
+        return False
+
 
 class BaseAsmStandaloneUpstreamPropagation(ABC):
     """APM correctly propagates AppSec events in distributing tracing."""
@@ -32,33 +65,6 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
 
     # Tested product
     tested_product: str | None = None
-
-    # Return a boolean indicating if the test passed
-    @staticmethod
-    def _assert_tags(first_trace, span, obj, expected_tags) -> bool:
-        def _assert_tags_value(span, obj, expected_tags):
-            struct = span if obj is None else span[obj]
-            for tag, value in expected_tags.items():
-                if value is None:
-                    assert tag not in struct
-                elif tag == "_sampling_priority_v1":  # special case, it's a lambda to check for a condition
-                    assert value(struct[tag])
-                else:
-                    assert struct[tag] == value
-
-        # Case 1: The tags are set on the first span of every trace chunk
-        try:
-            _assert_tags_value(first_trace, obj, expected_tags)
-            return True
-        except (KeyError, AssertionError):
-            pass  # should try the second case
-
-        # Case 2: The tags are set on the local root span
-        try:
-            _assert_tags_value(span, obj, expected_tags)
-            return True
-        except (KeyError, AssertionError):
-            return False
 
     @staticmethod
     def assert_product_is_enabled(response, product) -> None:
@@ -122,8 +128,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x < 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -166,8 +172,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x < 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -210,8 +216,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x < 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -254,8 +260,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x < 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -297,8 +303,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -340,8 +346,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0
             assert span["trace_id"] == 1212121212121212121
@@ -384,8 +390,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x in [0, 2]}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -427,8 +433,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x in [1, 2]}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -470,8 +476,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -511,8 +517,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -552,8 +558,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -593,8 +599,8 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
-            assert self._assert_tags(trace[0], span, "meta", tested_meta)
-            assert self._assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+            assert assert_tags(trace[0], span, "metrics", tested_metrics)
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -846,3 +852,83 @@ class Test_SCAStandalone_Telemetry_V2(BaseSCAStandaloneTelemetry):
 
     def propagated_tag_value(self):
         return "02"
+
+
+@rfc("https://docs.google.com/document/d/18JZdOS5fmnYomRn6OGer0ViS1I6zzT6xl5HMtjDtFn4/edit")
+@features.appsec_standalone
+@scenarios.appsec_standalone
+class Test_UserEventsStandalone:
+    """IAST correctly propagates user events in distributing tracing with DD_APM_TRACING_ENABLED=false."""
+
+    def _get_test_headers(self, trace_id):
+        return {
+            "x-datadog-trace-id": str(trace_id),
+            "x-datadog-parent-id": str(34343434),
+            "x-datadog-origin": "rum",
+            "x-datadog-sampling-priority": "-1",
+            "x-datadog-tags": "_dd.p.other=1",
+        }
+
+    def _login_data(self, context, user, password):
+        """In Rails the parameters are group by scope. In the case of the test the scope is user.
+        The syntax to group parameters in a POST request is scope[parameter]
+        """
+        username_key = "user[username]" if "rails" in context.weblog_variant else "username"
+        password_key = "user[password]" if "rails" in context.weblog_variant else "password"
+        return {username_key: user, password_key: password}
+
+    def _get_standalone_span_meta(self, trace_id):
+        tested_meta = {
+            "_dd.p.ts": "02",
+        }
+        for data, trace, span in interfaces.library.get_spans(request=self.r):
+            assert assert_tags(trace[0], span, "meta", tested_meta)
+
+            assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
+            assert span["trace_id"] == trace_id
+            assert trace[0]["trace_id"] == trace_id
+
+            # Some tracers use true while others use yes
+            assert any(
+                ["Datadog-Client-Computed-Stats", trueish] in data["request"]["headers"] for trueish in ["yes", "true"]
+            )
+            return span["meta"]
+
+        return None
+
+    def _call_endpoint(self, endpoint, user, trace_id):
+        self.r = weblog.post(
+            endpoint,
+            headers=self._get_test_headers(trace_id),
+            data=self._login_data(context, user, PASSWORD),
+        )
+
+    def setup_user_login_success_event_generates_asm_event(self):
+        trace_id = 1212121212121212111
+        self._call_endpoint("/login?auth=local", USER, trace_id)
+
+    def test_user_login_success_event_generates_asm_event(self):
+        trace_id = 1212121212121212111
+        meta = self._get_standalone_span_meta(trace_id)
+        assert meta is not None
+        assert meta["_dd.appsec.usr.login"] == USER
+
+    def setup_user_login_failure_event_generates_asm_event(self):
+        trace_id = 1212121212121212122
+        self._call_endpoint("/login?auth=local", INVALID_USER, trace_id)
+
+    def test_user_login_failure_event_generates_asm_event(self):
+        trace_id = 1212121212121212122
+        meta = self._get_standalone_span_meta(trace_id)
+        assert meta is not None
+        assert meta["appsec.events.users.login.failure.usr.exists"] == "false"
+
+    def setup_user_signup_event_generates_asm_event(self):
+        trace_id = 1212121212121212133
+        self._call_endpoint("/signup", NEW_USER, trace_id)
+
+    def test_user_signup_event_generates_asm_event(self):
+        trace_id = 1212121212121212133
+        meta = self._get_standalone_span_meta(trace_id)
+        assert meta is not None
+        assert meta["appsec.events.users.signup.usr.login"] == NEW_USER


### PR DESCRIPTION
## Motivation

Test that user events propagate asm events with `_dd.p.ts`

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
