### PR TITLE
[ruby] Add doc for running parametric tests with an unreleased version of libdatadog

### DIFF
--- a/utils/build/docker/ruby/parametric/README.md
+++ b/utils/build/docker/ruby/parametric/README.md
@@ -48,10 +48,10 @@ This is a bit of a hack that is intended to help you validate WIP changes in dd-
     mv compiled_libdatadog_folder /path/to/dd-trace-rb/tmp
     ```
 
-2. Add `ENV["LIBDATADOG_VENDOR_OVERRIDE"] ||= Pathname.new("#{__dir__}/../tmp/compiled_libdatadog_folder/").expand_path.to_s`to dd-trace-rb's `ext/libdatadog_extconf_helpers.rb
+2. Add `ENV["LIBDATADOG_VENDOR_OVERRIDE"] ||= Pathname.new("#{__dir__}/../tmp/compiled_libdatadog_folder/").expand_path.to_s`to dd-trace-rb's `ext/libdatadog_extconf_helpers.rb`
 
 3. Add compile step in parametric tests Dockerfile template located in `utils/_context/_scenarios/parametric.py::ruby_library_factory`
-    - Change the FROM line to `ghcr.io/datadog/images-rb/engines/ruby:3.2` (or any Ruby version that you're used during the `libdatadog` compile step)
+    - Change the FROM line to `ghcr.io/datadog/images-rb/engines/ruby:3.2` (or any Ruby version that you've used during the `libdatadog` compile step)
     - After `COPY {ruby_reldir}/../install_ddtrace.sh binaries* /binaries/` line, add:
     ```
     WORKDIR /binaries/dd-trace-rb

--- a/utils/build/docker/ruby/parametric/README.md
+++ b/utils/build/docker/ruby/parametric/README.md
@@ -35,3 +35,33 @@ DEBUG=1 bundle exec ruby server.rb
 You'll be presented with a Ruby REPL, with the gRPC server running in the same process.
 
 A `client` object will be available for you to make gRPC requests to the server.
+
+# Locally run Parametric system-tests with an unreleased version of libdatadog
+
+This is a bit of a hack that is intended to help you validate WIP changes in dd-trace-rb while waiting for libdatadog release.
+
+1. Clone and compile `libdatadog`, and move it to dd-trace-rb folder
+    ```
+    export DD_RUBY_PLATFORM=`ruby -e 'puts Gem::Platform.local.to_s'`
+    mkdir -p compiled_libdatadog_folder/$DD_RUBY_PLATFORM
+    ./build-profiling-ffi.sh compiled_libdatadog_folder/$DD_RUBY_PLATFORM
+    mv compiled_libdatadog_folder /path/to/dd-trace-rb/tmp
+    ```
+
+2. Add `ENV["LIBDATADOG_VENDOR_OVERRIDE"] ||= Pathname.new("#{__dir__}/../tmp/compiled_libdatadog_folder/").expand_path.to_s`to dd-trace-rb's `ext/libdatadog_extconf_helpers.rb
+
+3. Add compile step in parametric tests Dockerfile template located in `utils/_context/_scenarios/parametric.py::ruby_library_factory`
+    - Change the FROM line to `ghcr.io/datadog/images-rb/engines/ruby:3.2` (or any Ruby version that you're used during the `libdatadog` compile step)
+    - After `COPY {ruby_reldir}/../install_ddtrace.sh binaries* /binaries/` line, add:
+    ```
+    WORKDIR /binaries/dd-trace-rb
+    RUN bundle install
+    # Replace with your Ruby version and platform
+    RUN bundle exec rake clean compile:libdatadog_api.3.2_aarch64-linux
+    # Or if you want to compile profiling too
+    # RUN bundle exec rake clean compile
+    WORKDIR /app
+    ```
+
+4. In `utils/build/docker/install_ddtrace.sh`, replace the last `bundle install` by `bundle install --force --gemfile=Gemfile`
+    - For whatever reason, this `bundle install` will reuse dd-trace-rb's one instead of the app one if you don't specify the Gemfile.


### PR DESCRIPTION
## Motivation

I had to test my changes on dd-trace-rb with an unreleased version of libdatadog. But to validate my changes before moving to something else, I had to test them using system-tests. Running (parametric) system-tests with an unreleased version of was painful to figure out, so I'm documenting it for future usage, or to look for improvements in the process.

## Changes

<!-- A brief description of the change being made with this pull request. -->
Update docs.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
