### PR TITLE
SSI tests: Enable k8s profiling for php 1.9.0

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -450,9 +450,9 @@ tests/:
       Test_Otel_Drop_In: missing_feature
   k8s_lib_injection/:
     test_k8s_lib_injection_profiling.py:
-      TestK8sLibInjectioProfilingClusterEnabled: v1.8.2
-      TestK8sLibInjectioProfilingClusterOverride: v1.8.2
-      TestK8sLibInjectioProfilingDisabledByDefault: v1.8.2
+      TestK8sLibInjectioProfilingClusterEnabled: v1.9.0
+      TestK8sLibInjectioProfilingClusterOverride: v1.9.0
+      TestK8sLibInjectioProfilingDisabledByDefault: v1.9.0
   otel/:
     test_context_propagation.py:
       Test_Otel_Context_Propagation_Default_Propagator_Api: incomplete_test_app (endpoint not implemented)

--- a/utils/scripts/ssi_wizards/k8s_ssi_wizard.sh
+++ b/utils/scripts/ssi_wizards/k8s_ssi_wizard.sh
@@ -186,7 +186,7 @@ welcome "K8s lib-injection Tests"
 ask_load_requirements
 ask_load_k8s_requirements
 ask_for_test_language
-load_workflow_data "lib-injection" "libinjection_scenario_defs"
+load_workflow_data "lib-injection,lib-injection-profiling" "libinjection_scenario_defs"
 select_scenario
 select_weblog
 select_weblog_img


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Enable K8s profiling scenarios for PHP 1.9.0

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
