### PR TITLE
[Node.js] Enable Debugger Expression Language tests for Node.js

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -804,7 +804,10 @@ tests/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay: missing_feature (feature not implented)
     test_debugger_expression_language.py:
-      Test_Debugger_Expression_Language: missing_feature (feature not implented)
+      Test_Debugger_Expression_Language:
+        '*': irrelevant
+        express4: v5.48.0
+        uds-express4: v5.48.0
     test_debugger_inproduct_enablement.py:
       Test_Debugger_InProduct_Enablement_Code_Origin: missing_feature
       Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation: missing_feature

--- a/tests/debugger/test_debugger_expression_language.py
+++ b/tests/debugger/test_debugger_expression_language.py
@@ -115,6 +115,7 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
         self.message_map = message_map
         self._setup(probes, "/debugger/expression?inputValue=asd")
 
+    @missing_feature(library="nodejs", reason="Not yet implemented")
     def test_expression_language_contextual_variables(self):
         self._assert(expected_response=200)
 
@@ -130,6 +131,7 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
         self.message_map = message_map
         self._setup(probes, "/debugger/expression/exception")
 
+    @missing_feature(library="nodejs", reason="Not yet implemented")
     def test_expression_language_access_exception(self):
         self._assert(expected_response=500)
 
@@ -196,7 +198,7 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
     def test_expression_language_comparison_operators(self):
         self._assert(expected_response=200)
 
-    ############ intance of ############
+    ############ instance of ############
     def setup_expression_language_instance_of(self):
         language, method = self.get_tracer()["language"], "ExpressionOperators"
         message_map, probes = self._create_expression_probes(
@@ -225,12 +227,12 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
                 ],
                 [
                     "intValue instanceof float",
-                    False,
+                    self.get_tracer()["language"] == "nodejs",
                     Dsl("instanceof", [Dsl("ref", "intValue"), self._get_type("float")]),
                 ],
                 [
                     "floatValue instanceof int",
-                    False,
+                    self.get_tracer()["language"] == "nodejs",
                     Dsl("instanceof", [Dsl("ref", "floatValue"), self._get_type("int")]),
                 ],
                 [
@@ -305,7 +307,7 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
                 ["strValue substring 0 5", "veryl", Dsl("substring", [Dsl("ref", "strValue"), 0, 5])],
                 ["strValue substring 5 10", "ongst", Dsl("substring", [Dsl("ref", "strValue"), 5, 10])],
                 ["strValue substring 0 0", "", Dsl("substring", [Dsl("ref", "strValue"), 0, 0])],
-                ["emptyStr substring 0 0", "", Dsl("substring", [Dsl("ref", "emptyStr"), 0, 0])],
+                ["emptyString substring 0 0", "", Dsl("substring", [Dsl("ref", "emptyString"), 0, 0])],
                 ##### startsWith
                 ["strValue startsWith very", True, Dsl("startsWith", [Dsl("ref", "strValue"), "very"])],
                 ["strValue startsWith foo", False, Dsl("startsWith", [Dsl("ref", "strValue"), "foo"])],
@@ -355,6 +357,7 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
                 ["List1 len", 1, Dsl("len", Dsl("ref", "l1"))],
                 ["List5 len", 5, Dsl("len", Dsl("ref", "l5"))],
                 ##### index
+                # TODO: It's not a good test to check that index x contains the value x. Instead it should test that index x contains y
                 ["Array5 index 4", 4, Dsl("index", [Dsl("ref", "a5"), 4])],
                 ["List5 index 4", 4, Dsl("index", [Dsl("ref", "l5"), 4])],
                 ##### any
@@ -414,6 +417,13 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
 
     def setup_expression_language_hash_operations(self):
         language, method = self.get_tracer()["language"], "CollectionOperations"
+        if self.get_tracer()["language"] == "dotnet":
+            get_hash_value = Dsl("getmember", [Dsl("ref", "@it"), "Value"])
+        elif self.get_tracer()["language"] == "nodejs":
+            get_hash_value = Dsl("ref", "@value")
+        else:
+            get_hash_value = Dsl("getmember", [Dsl("ref", "@it"), "value"])
+
         message_map, probes = self._create_expression_probes(
             method_name=method,
             expressions=[
@@ -427,124 +437,28 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
                 ##### index
                 ["Hash5 index 4", 4, Dsl("index", [Dsl("ref", "h5"), 4])],
                 ##### any
-                [
-                    "Hash0 any gt 1",
-                    False,
-                    Dsl(
-                        "any",
-                        [
-                            Dsl("ref", "h0"),
-                            Dsl("gt", [Dsl("getmember", [Dsl("ref", "@it"), self._get_hash_value_property_name()]), 1]),
-                        ],
-                    ),
-                ],
-                [
-                    "Hash1 any gt 1",
-                    False,
-                    Dsl(
-                        "any",
-                        [
-                            Dsl("ref", "h1"),
-                            Dsl("gt", [Dsl("getmember", [Dsl("ref", "@it"), self._get_hash_value_property_name()]), 1]),
-                        ],
-                    ),
-                ],
-                [
-                    "Hash5 any gt 1",
-                    True,
-                    Dsl(
-                        "any",
-                        [
-                            Dsl("ref", "h5"),
-                            Dsl("gt", [Dsl("getmember", [Dsl("ref", "@it"), self._get_hash_value_property_name()]), 1]),
-                        ],
-                    ),
-                ],
+                ["Hash0 any gt 1", False, Dsl("any", [Dsl("ref", "h0"), Dsl("gt", [get_hash_value, 1])])],
+                ["Hash1 any gt 1", False, Dsl("any", [Dsl("ref", "h1"), Dsl("gt", [get_hash_value, 1])])],
+                ["Hash5 any gt 1", True, Dsl("any", [Dsl("ref", "h5"), Dsl("gt", [get_hash_value, 1])])],
                 ##### all
-                [
-                    "Hash0 all ge 0",
-                    True,
-                    Dsl(
-                        "all",
-                        [
-                            Dsl("ref", "h0"),
-                            Dsl("ge", [Dsl("getmember", [Dsl("ref", "@it"), self._get_hash_value_property_name()]), 0]),
-                        ],
-                    ),
-                ],
-                [
-                    "Hash1 all ge 0",
-                    True,
-                    Dsl(
-                        "all",
-                        [
-                            Dsl("ref", "h1"),
-                            Dsl("ge", [Dsl("getmember", [Dsl("ref", "@it"), self._get_hash_value_property_name()]), 0]),
-                        ],
-                    ),
-                ],
-                [
-                    "Hash5 all ge 1",
-                    False,
-                    Dsl(
-                        "all",
-                        [
-                            Dsl("ref", "h5"),
-                            Dsl("ge", [Dsl("getmember", [Dsl("ref", "@it"), self._get_hash_value_property_name()]), 1]),
-                        ],
-                    ),
-                ],
+                ["Hash0 all ge 0", True, Dsl("all", [Dsl("ref", "h0"), Dsl("ge", [get_hash_value, 0])])],
+                ["Hash1 all ge 0", True, Dsl("all", [Dsl("ref", "h1"), Dsl("ge", [get_hash_value, 0])])],
+                ["Hash5 all ge 1", False, Dsl("all", [Dsl("ref", "h5"), Dsl("ge", [get_hash_value, 1])])],
                 ##### filter
                 [
                     "Hash0 len filter lt 2",
                     0,
-                    Dsl(
-                        "len",
-                        Dsl(
-                            "filter",
-                            [
-                                Dsl("ref", "h0"),
-                                Dsl(
-                                    "lt",
-                                    [Dsl("getmember", [Dsl("ref", "@it"), self._get_hash_value_property_name()]), 2],
-                                ),
-                            ],
-                        ),
-                    ),
+                    Dsl("len", Dsl("filter", [Dsl("ref", "h0"), Dsl("lt", [get_hash_value, 2])])),
                 ],
                 [
                     "Hash1 len filter lt 2",
                     1,
-                    Dsl(
-                        "len",
-                        Dsl(
-                            "filter",
-                            [
-                                Dsl("ref", "h1"),
-                                Dsl(
-                                    "lt",
-                                    [Dsl("getmember", [Dsl("ref", "@it"), self._get_hash_value_property_name()]), 2],
-                                ),
-                            ],
-                        ),
-                    ),
+                    Dsl("len", Dsl("filter", [Dsl("ref", "h1"), Dsl("lt", [get_hash_value, 2])])),
                 ],
                 [
                     "Hash5 len filter lt 2",
                     2,
-                    Dsl(
-                        "len",
-                        Dsl(
-                            "filter",
-                            [
-                                Dsl("ref", "h5"),
-                                Dsl(
-                                    "lt",
-                                    [Dsl("getmember", [Dsl("ref", "@it"), self._get_hash_value_property_name()]), 2],
-                                ),
-                            ],
-                        ),
-                    ),
+                    Dsl("len", Dsl("filter", [Dsl("ref", "h5"), Dsl("lt", [get_hash_value, 2])])),
                 ],
             ],
             lines=self.method_and_language_to_line_number(method, language),
@@ -561,13 +475,20 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
     ############ nulls ############
     def setup_expression_language_nulls_true(self):
         language, method = self.get_tracer()["language"], "Nulls"
+        expressions = [["pii eq null", True, Dsl("eq", [Dsl("ref", "pii"), None])]]
+
+        # In Node.js, numbers and strings cannot be null as they are not objects
+        if language != "nodejs":
+            expressions.extend(
+                [
+                    ["intValue eq null", True, Dsl("eq", [Dsl("ref", "intValue"), None])],
+                    ["strValue eq null", True, Dsl("eq", [Dsl("ref", "strValue"), None])],
+                ]
+            )
+
         message_map, probes = self._create_expression_probes(
             method_name=method,
-            expressions=[
-                ["intValue eq null", True, Dsl("eq", [Dsl("ref", "intValue"), None])],
-                ["strValue eq null", True, Dsl("eq", [Dsl("ref", "strValue"), None])],
-                ["pii eq null", True, Dsl("eq", [Dsl("ref", "pii"), None])],
-            ],
+            expressions=expressions,
             lines=self.method_and_language_to_line_number(method, language),
         )
 
@@ -638,21 +559,28 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
                 instance_type = "debugger.pii.PiiBase"
             else:
                 instance_type = value_type
+        elif self.get_tracer()["language"] == "nodejs":
+            if value_type in ("int", "float"):
+                instance_type = "number"
+            elif value_type == "string":
+                instance_type = "string"
+            elif value_type == "pii":
+                instance_type = "Pii"
+            elif value_type == "pii":
+                instance_type = "PiiBase"
+            else:
+                instance_type = value_type
         else:
             instance_type = value_type
 
         return instance_type
 
-    def _get_hash_value_property_name(self):
-        if self.get_tracer()["language"] == "dotnet":
-            return "Value"
-        else:
-            return "value"
-
     def _create_expression_probes(self, method_name, expressions, lines=()):
         probes = []
         expected_message_map = {}
-        prob_types = ["method"]
+        prob_types = []
+        if self.get_tracer()["language"] != "nodejs":  # Method probes are not supported in Node.js
+            prob_types.append("method")
         if len(lines) > 0:
             prob_types.append("line")
 

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -97,13 +97,13 @@ class BaseDebuggerTest:
         """method_and_language_to_line_number returns the respective line number given the method and language"""
         definitions: dict[str, dict[str, list[int]]] = {
             "Budgets": {"java": [138], "dotnet": [136], "python": [142]},
-            "Expression": {"java": [71], "dotnet": [74], "python": [72]},
+            "Expression": {"java": [71], "dotnet": [74], "python": [72], "nodejs": [82]},
             # The `@exception` variable is not available in the context of line probes.
             "ExpressionException": {},
-            "ExpressionOperators": {"java": [82], "dotnet": [90], "python": [87]},
-            "StringOperations": {"java": [87], "dotnet": [97], "python": [96]},
-            "CollectionOperations": {"java": [114], "dotnet": [114], "python": [123]},
-            "Nulls": {"java": [130], "dotnet": [127], "python": [136]},
+            "ExpressionOperators": {"java": [82], "dotnet": [90], "python": [87], "nodejs": [90]},
+            "StringOperations": {"java": [87], "dotnet": [97], "python": [96], "nodejs": [96]},
+            "CollectionOperations": {"java": [114], "dotnet": [114], "python": [123], "nodejs": [120]},
+            "Nulls": {"java": [130], "dotnet": [127], "python": [136], "nodejs": [126]},
         }
 
         return definitions.get(method, {}).get(language, [])

--- a/utils/build/docker/nodejs/express/debugger/index.js
+++ b/utils/build/docker/nodejs/express/debugger/index.js
@@ -1,10 +1,10 @@
 'use strict'
+/* eslint-disable no-unused-vars, camelcase */
 
 const Pii = require('./pii')
 
 module.exports = {
   initRoutes (app) {
-    // Padding
     // Padding
     // Padding
     // Padding
@@ -60,8 +60,70 @@ module.exports = {
     // Padding
 
     app.get('/debugger/pii', (req, res) => {
-      const pii = new Pii() // eslint-disable-line no-unused-vars
+      const pii = new Pii()
       res.send('Hello World') // This needs to be line 64
+    })
+
+    app.get('/debugger/expression', (req, res) => {
+      const { inputValue } = req.query
+      const localValue = 3
+      const testStruct = {
+        IntValue: 1,
+        DoubleValue: 1.1,
+        StringValue: 'one',
+        BoolValue: true,
+        Collection: ['one', 'two', 'three'],
+        Dictionary: {
+          one: 1,
+          two: 2,
+          three: 3
+        }
+      }
+      res.send('Expression probe') // This needs to be line 82
+    })
+
+    app.get('/debugger/expression/operators', (req, res) => {
+      const intValue = Number(req.query.intValue)
+      const floatValue = Number(req.query.floatValue)
+      const strValue = req.query.strValue
+      const pii = new Pii()
+      res.send('Expression probe') // This needs to be line 90
+    })
+
+    app.get('/debugger/expression/strings', (req, res) => {
+      const { strValue } = req.query
+      const emptyString = ''
+      res.send('Expression probe') // This needs to be line 96
+    })
+
+    app.get('/debugger/expression/collections', (req, res) => {
+      const a0 = []
+      const l0 = []
+      const h0 = {}
+      const a1 = [1]
+      const l1 = [1]
+      const h1 = { 0: 0 }
+      const a5 = [0, 1, 2, 3, 4]
+      const l5 = [0, 1, 2, 3, 4]
+      const h5 = { 0: 0, 1: 1, 2: 2, 3: 3, 4: 4 }
+
+      const a0_count = a0.length
+      const l0_count = l0.length
+      const h0_count = Object.keys(h0).length
+      const a1_count = a1.length
+      const l1_count = l1.length
+      const h1_count = Object.keys(h1).length
+      const a5_count = a5.length
+      const l5_count = l5.length
+      const h5_count = Object.keys(h5).length
+
+      res.send('Expression probe') // This needs to be line 120
+    })
+
+    app.get('/debugger/expression/null', (req, res) => {
+      const { intValue, strValue, boolValue } = req.query
+      const pii = boolValue ? new Pii() : null
+      res.send('Expression probe') // This needs to be line 126
     })
   }
 }


### PR DESCRIPTION
## Motivation

Support for this feature was just merged to `master` in the Node.js tracer and now we need to enable the corresponding system tests.

## Changes

1. Add new test related endpoints to the Express 4 test app
2. Enable the tests in `tests/debugger/test_debugger_expression_language.py` to run for Node.js
3. Modify the tests in `tests/debugger/test_debugger_expression_language.py` slightly, so they fit some small quirks with Node.js

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
