### PR TITLE
Onboarding: PHP profiling markers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,8 +135,7 @@ python_ssi_pipeline:
 
 php_ssi_pipeline:
   stage: php
-  #needs: ["compute_pipeline", "python_ssi_pipeline"]
-  needs: ["compute_pipeline"]
+  needs: ["compute_pipeline", "python_ssi_pipeline"]
   allow_failure: true
   variables:
     PARENT_PIPELINE_SOURCE: $CI_PIPELINE_SOURCE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,7 +135,8 @@ python_ssi_pipeline:
 
 php_ssi_pipeline:
   stage: php
-  needs: ["compute_pipeline", "python_ssi_pipeline"]
+  #needs: ["compute_pipeline", "python_ssi_pipeline"]
+  needs: ["compute_pipeline"]
   allow_failure: true
   variables:
     PARENT_PIPELINE_SOURCE: $CI_PIPELINE_SOURCE

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -388,6 +388,11 @@ tests/:
       Test_ExternalWafRequestsIdentification: v1.0.0
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist: v0.86.3
+  auto_inject/:
+    test_auto_inject_install.py:
+      TestContainerAutoInjectInstallScriptProfiling: v1.9.0
+      TestHostAutoInjectInstallScriptProfiling: v1.9.0
+      TestSimpleInstallerAutoInjectManualProfiling: v1.9.0
   debugger/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay: missing_feature


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Skip onboarding profiling tests for PHP and version < 1.9.0

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
