### PR TITLE
Fix(PHP): Enable probe statuses again

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -407,7 +407,9 @@ tests/:
     test_debugger_probe_snapshot.py:
       Test_Debugger_Probe_Snaphots: missing_feature
     test_debugger_probe_status.py:
-      Test_Debugger_Probe_Statuses: missing_feature
+      Test_Debugger_Probe_Statuses:
+        '*': missing_feature
+        'apache-mod-8.0': v1.8.3
     test_debugger_symdb.py:
       Test_Debugger_SymDb: missing_feature
     test_debugger_telemetry.py:

--- a/utils/build/docker/php/common/php.ini
+++ b/utils/build/docker/php/common/php.ini
@@ -35,3 +35,4 @@ datadog.experimental_api_security_enabled=1
 datadog.api_security_request_sample_rate=1
 
 datadog.trace.log_file=/var/log/system-tests/tracer.log
+datadog.trace.log_level=trace

--- a/utils/build/docker/php/common/php.ini
+++ b/utils/build/docker/php/common/php.ini
@@ -35,4 +35,3 @@ datadog.experimental_api_security_enabled=1
 datadog.api_security_request_sample_rate=1
 
 datadog.trace.log_file=/var/log/system-tests/tracer.log
-datadog.trace.log_level=trace


### PR DESCRIPTION
## Motivation

This scenario was disabled because it was suspected as the root cause making the nightly build to fail, but it continued to fail after it was disabled

Charles has fixed this with https://github.com/DataDog/system-tests/pull/4516

Reverts https://github.com/DataDog/system-tests/pull/4511

## Changes

<!-- A brief description of the change being made with this pull request. -->
* [`tests/manifests/php.yml`](diffhunk://#diff-164e30a9609b478cdace674ea20d1ae01e3872dc0d69e2da602f6acb450c4e85L403-R405): Modified the `Test_Debugger_Probe_Snaphots` entry to `Test_Debugger_Probe_Statuses` and added specific versioning for `apache-mod-8.0`.
## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
