### PR TITLE
SSI tests: activate auto_inject new aws account

### DIFF
--- a/utils/scripts/ci_orchestrators/gitlab_exporter.py
+++ b/utils/scripts/ci_orchestrators/gitlab_exporter.py
@@ -120,7 +120,7 @@ def should_use_new_aws_account() -> bool:
     ]
     # The projects that are under migration.
     # It's going to apply the config of the new aws account only for a specific branch
-    partially_migrated_projects = ["auto_inject"]
+    partially_migrated_projects = [""]
     print(f"Checking if project [{ci_project_name}] should run on the new AWS account")
     if ci_project_name in all_projects:
         if ci_project_name in migrated_projects:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Activate the auto_inject repository to start using the new aws account

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
