### PR TITLE
[php] Fix php component version

### DIFF
--- a/tests/test_the_test/test_version.py
+++ b/tests/test_the_test/test_version.py
@@ -175,3 +175,13 @@ def test_library_version():
     assert v < "java@0.94.1"
 
     assert ComponentVersion("agent", "7.39.0-devel") == "agent@7.39.0-devel"
+
+    v2 = ComponentVersion("php", "1.9.0-7ab1806dec09cbf6e7079ac59453b79fc5e9c91f")
+    v3 = ComponentVersion("php", "1.9.0")
+    v4 = ComponentVersion("php", "1.8.9")
+    v5 = ComponentVersion("php", "1.9.0+7ab1806dec09cbf6e7079ac59453b79fc5e9c91f")
+
+    assert v3 == "php@v1.9.0"
+    assert v3 <= v2
+    assert v3 <= v5
+    assert v4 < v2

--- a/utils/_context/component_version.py
+++ b/utils/_context/component_version.py
@@ -101,6 +101,7 @@ class ComponentVersion:
 
             elif name == "php":
                 version = version.replace("-nightly", "")
+                version = version.replace("-", "+")
 
             self.version = Version(version)
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The versioning for php doesn't work well for k8s and aws tests

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
