### PR TITLE
Replace the built info in version if and only if it's a SHA

### DIFF
--- a/tests/test_the_test/test_version.py
+++ b/tests/test_the_test/test_version.py
@@ -97,7 +97,7 @@ def test_version_serialization():
     assert v.version == "1.0.14+1.0.beta1"
 
     v = ComponentVersion("php", "1.0.0-nightly")
-    assert v.version == "1.0.0"
+    assert v.version == "1.0.0-nightly"
 
     v = ComponentVersion("nodejs", "3.0.0-pre0")
     assert v.version == "3.0.0-pre0"
@@ -165,23 +165,37 @@ def test_library_version():
     assert v == "python@0.53.0.dev70+g494e6dc0"
 
     v = ComponentVersion("java", "0.94.1~dde6877139")
-    assert v == "java@0.94.1"
+    assert v == "java@0.94.1+dde6877139"
     assert v >= "java@0.94.1"
     assert v < "java@0.94.2"
 
     v = ComponentVersion("java", "0.94.0-SNAPSHOT~57664cfbe5")
-    assert v == "java@0.94.0"
-    assert v >= "java@0.94.0"
+    assert v == "java@0.94.0-SNAPSHOT+57664cfbe5"
+    assert v < "java@0.94.0"
     assert v < "java@0.94.1"
 
     assert ComponentVersion("agent", "7.39.0-devel") == "agent@7.39.0-devel"
 
-    v2 = ComponentVersion("php", "1.9.0-7ab1806dec09cbf6e7079ac59453b79fc5e9c91f")
+
+def test_php_version():
+    v1 = ComponentVersion("php", "1.8.9")
+    v2 = ComponentVersion("php", "1.9.0-prerelease")
     v3 = ComponentVersion("php", "1.9.0")
-    v4 = ComponentVersion("php", "1.8.9")
-    v5 = ComponentVersion("php", "1.9.0+7ab1806dec09cbf6e7079ac59453b79fc5e9c91f")
+    v4 = ComponentVersion("php", "1.9.0+7ab1806dec09cbf6e7079ac59453b79fc5e9c91f")
 
     assert v3 == "php@v1.9.0"
-    assert v3 <= v2
+
+    assert v1 < v2
+    assert v1 < v3
+    assert v2 < v3
+    assert v3 <= v4
+
+    # PHP may use a `-` to separate the version from the build
+    # system-tests then replace the `-` with a `+`
+    v5 = ComponentVersion("php", "1.9.0-7ab1806dec09cbf6e7079ac59453b79fc5e9c91f")  # hacked
+    assert str(v5.version) == "1.9.0+7ab1806dec09cbf6e7079ac59453b79fc5e9c91f"
     assert v3 <= v5
-    assert v4 < v2
+
+    # but legit pre-release names are kept untouched
+    assert str(ComponentVersion("php", "1.9.0-prerelease").version) == "1.9.0-prerelease"
+    assert str(ComponentVersion("php", "1.9.0-dev").version) == "1.9.0-dev"

--- a/utils/_context/component_version.py
+++ b/utils/_context/component_version.py
@@ -93,15 +93,15 @@ class ComponentVersion:
                     version = re.sub(r"\* *libddwaf *\((.*)\)", r"\1", version)
 
             elif name == "java":
-                version = version.split("~")[0]
-                version = version.replace("-SNAPSHOT", "")
+                version = version.replace("~", "+")  # Java uses a ~ to separate the version from the build
 
             elif name == "dotnet":
                 version = re.sub(r"(datadog-dotnet-apm-)?(.*?)(\.tar\.gz)?", r"\2", version)
 
             elif name == "php":
-                version = version.replace("-nightly", "")
-                version = version.replace("-", "+")
+                # if the pre-release part looks like a commit sha [0-9abcdef]{32,100}
+                # the we can hack to move it to the built part:
+                version = re.sub(r"-([0-9a-f]{32,100})$", r"+\1", version)
 
             self.version = Version(version)
 


### PR DESCRIPTION
## Motivation

Follow up of #4533

## Changes

The version from PHP may be like `1.9.0-7ab1806dec09cbf6e7079ac59453b79fc5e9c91f`

The `-` tells that `7ab1806dec09cbf6e7079ac59453b79fc5e9c91f` is a prerelease info, where it's a commit sha, and should be placed in built info in the version scheme.

#4533 always replaced the `-` by a `+` to fix that, though, it can cause trouble for real pre-release info.

-> change the `-` into a `+` only if the info "looks like" a commit sha.

I also deleted two hacks that removed the pre-release info in php and java

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
