### PR TITLE
Adding DD_TRACE_BAGGAGE_TAG_KEYS config

### DIFF
--- a/utils/telemetry/intake/static/config_norm_rules.json
+++ b/utils/telemetry/intake/static/config_norm_rules.json
@@ -215,6 +215,7 @@
     "DD_TRACE_AWS_ADD_SPAN_POINTERS": "trace_aws_add_span_pointers",
     "DD_TRACE_BAGGAGE_MAX_BYTES": "trace_baggage_max_bytes",
     "DD_TRACE_BAGGAGE_MAX_ITEMS": "trace_baggage_max_items",
+    "DD_TRACE_BAGGAGE_TAG_KEYS": "trace_baggage_tag_keys",
     "DD_TRACE_BATCH_INTERVAL": "trace_serialization_batch_interval",
     "DD_TRACE_BUFFER_SIZE": "trace_serialization_buffer_size",
     "DD_TRACE_BYPASS_HTTP_REQUEST_URL_CACHING_ENABLED": "trace_bypass_http_request_url_caching_enabled",


### PR DESCRIPTION
## Motivation
- Adding DD_TRACE_BAGGAGE_TAG_KEYS configuration to support auto adding baggage to span tags

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
