### PR TITLE
chore: update config_norm for error tracking env variables

### DIFF
--- a/utils/telemetry/intake/static/config_norm_rules.json
+++ b/utils/telemetry/intake/static/config_norm_rules.json
@@ -98,6 +98,8 @@
     "DD_ERROR_TRACKING_REPORT_HANDLED_ERRORS_ENABLED": "error_tracking_report_handled_errors_enabled",
     "DD_ERROR_TRACKING_REPORT_HANDLED_ERRORS_ENABLED_MODULES": "error_tracking_report_handled_errors_enabled_modules",
     "DD_ERROR_TRACKING_REPORT_HANDLED_ERRORS_LOGGER": "error_tracking_report_handled_errors_logger",
+    "DD_ERROR_TRACKING_HANDLED_ERRORS": "error_tracking_handled_errors",
+    "DD_ERROR_TRACKING_HANDLED_ERRORS_MODULES": "error_tracking_handled_errors_modules",
     "DD_EXCEPTION_DEBUGGING_CAPTURE_FULL_CALLSTACK_ENABLED": "dd_exception_debugging_capture_full_callstack_enabled",
     "DD_EXCEPTION_DEBUGGING_ENABLED": "exception_replay_enabled",
     "DD_EXCEPTION_DEBUGGING_MAX_EXCEPTION_ANALYSIS_LIMIT": "dd_exception_debugging_max_exception_analysis_limit",


### PR DESCRIPTION
## Motivation

Resolve errors from this job: https://github.com/DataDog/dd-trace-py/actions/runs/14535339749/job/40782814596?pr=13214

## Changes

Update error tracking env variables in telemetry intake config norms.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
