### PR TITLE
[Ruby] Enable endpoint, header, network fingerprinting

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -398,10 +398,10 @@ tests/:
       Test_UserLoginSuccessEventV2_Metrics: missing_feature
       Test_UserLoginSuccessEventV2_Tags: missing_feature
     test_fingerprinting.py:
-      Test_Fingerprinting_Endpoint: missing_feature
+      Test_Fingerprinting_Endpoint: v2.15.0
       Test_Fingerprinting_Endpoint_Capability: missing_feature
       Test_Fingerprinting_Endpoint_Preprocessor: missing_feature
-      Test_Fingerprinting_Header_And_Network: missing_feature
+      Test_Fingerprinting_Header_And_Network: v2.15.0
       Test_Fingerprinting_Header_And_Network_Preprocessor: missing_feature
       Test_Fingerprinting_Header_Capability: missing_feature
       Test_Fingerprinting_Network_Capability: missing_feature


### PR DESCRIPTION
## Motivation

We released fix which allows us to enable those checks

## Changes

Just turn on some fingerprinting and more coming