### PR TITLE
[Java] Allow sending debug telemetry related to Java not shipping with JPS or jvmstat

### DIFF
--- a/tests/test_library_logs.py
+++ b/tests/test_library_logs.py
@@ -51,6 +51,7 @@ class Test_NoExceptions:
             # APPSEC-56899:
             r".*WARN powerwaf_native - Failed to replace non-ephemeral target 'usr.id' with an ephemeral one.*",
             r".*WARN ddwaf_native - Failed to replace non-ephemeral target 'usr.id' with an ephemeral one.*",
+            r".*Failed to find the jdk.internal.jvmstat module.*",
         ]
         if context.weblog_variant == "spring-boot-openliberty":
             # XXX: openliberty logs are more noisy for some unexpected errors,


### PR DESCRIPTION
## Motivation

This is required for https://github.com/DataDog/dd-trace-java/pull/8718 to pass CI, which adds some additional telemetry intended to provide a more comprehensive picture of some of the modules un/available on the JVMs we instrument.

## Changes

Adds one additional allowed regex pattern for emitted logs.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
