### PR TITLE
[Debugger] Enable tests for java and python in-product enablement

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1695,9 +1695,33 @@ tests/:
         spring-boot-wildfly: v1.38.0
         uds-spring-boot: v1.33.0
     test_debugger_inproduct_enablement.py:
-      Test_Debugger_InProduct_Enablement_Code_Origin: v1.48.0
-      Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation: v1.48.0
-      Test_Debugger_InProduct_Enablement_Exception_Replay: v1.48.0
+      Test_Debugger_InProduct_Enablement_Code_Origin:
+        '*': missing_feature
+        spring-boot: v1.48.0
+        spring-boot-jetty: v1.48.0
+        spring-boot-openliberty: v1.48.0
+        spring-boot-payara: v1.48.0
+        spring-boot-undertow: v1.48.0
+        spring-boot-wildfly: v1.48.0
+        uds-spring-boot: v1.48.0
+      Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation:
+        '*': missing_feature
+        spring-boot: v1.48.0
+        spring-boot-jetty: v1.48.0
+        spring-boot-openliberty: v1.48.0
+        spring-boot-payara: v1.48.0
+        spring-boot-undertow: v1.48.0
+        spring-boot-wildfly: v1.48.0
+        uds-spring-boot: v1.48.0
+      Test_Debugger_InProduct_Enablement_Exception_Replay:
+        '*': missing_feature
+        spring-boot: v1.48.0
+        spring-boot-jetty: v1.48.0
+        spring-boot-openliberty: v1.48.0
+        spring-boot-payara: v1.48.0
+        spring-boot-undertow: v1.48.0
+        spring-boot-wildfly: v1.48.0
+        uds-spring-boot: v1.48.0
     test_debugger_pii.py:
       Test_Debugger_PII_Redaction:
         '*': missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1695,9 +1695,9 @@ tests/:
         spring-boot-wildfly: v1.38.0
         uds-spring-boot: v1.33.0
     test_debugger_inproduct_enablement.py:
-      Test_Debugger_InProduct_Enablement_Code_Origin: missing_feature
-      Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation: missing_feature
-      Test_Debugger_InProduct_Enablement_Exception_Replay: missing_feature
+      Test_Debugger_InProduct_Enablement_Code_Origin: v1.48.0
+      Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation: v1.48.0
+      Test_Debugger_InProduct_Enablement_Exception_Replay: v1.48.0
     test_debugger_pii.py:
       Test_Debugger_PII_Redaction:
         '*': missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -670,9 +670,21 @@ tests/:
         uds-flask: v2.11.0
         uwsgi-poc: v2.11.0
     test_debugger_inproduct_enablement.py:
-      Test_Debugger_InProduct_Enablement_Code_Origin: v3.5.0
-      Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation: v3.5.0
-      Test_Debugger_InProduct_Enablement_Exception_Replay: v3.5.0
+      Test_Debugger_InProduct_Enablement_Code_Origin:
+        '*': missing_feature
+        flask-poc: v3.5.0
+        uds-flask: v3.5.0
+        uwsgi-poc: v3.5.0
+      Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation:
+        '*': missing_feature
+        flask-poc: v3.5.0
+        uds-flask: v3.5.0
+        uwsgi-poc: v3.5.0
+      Test_Debugger_InProduct_Enablement_Exception_Replay:
+        '*': missing_feature
+        flask-poc: v3.5.0
+        uds-flask: v3.5.0
+        uwsgi-poc: v3.5.0
     test_debugger_pii.py:
       Test_Debugger_PII_Redaction:
         '*': missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -670,9 +670,9 @@ tests/:
         uds-flask: v2.11.0
         uwsgi-poc: v2.11.0
     test_debugger_inproduct_enablement.py:
-      Test_Debugger_InProduct_Enablement_Code_Origin: missing_feature
-      Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation: missing_feature
-      Test_Debugger_InProduct_Enablement_Exception_Replay: missing_feature
+      Test_Debugger_InProduct_Enablement_Code_Origin: v3.5.0
+      Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation: v3.5.0
+      Test_Debugger_InProduct_Enablement_Exception_Replay: v3.5.0
     test_debugger_pii.py:
       Test_Debugger_PII_Redaction:
         '*': missing_feature

--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -11,6 +11,7 @@ TIMEOUT = 5
 
 @features.debugger_inproduct_enablement
 @scenarios.debugger_inproduct_enablement
+@missing_feature(context.library == "python", force_skip=True)
 class Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation(debugger.BaseDebuggerTest):
     ############ dynamic instrumentation ############
     _probe_template = """

--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -5,6 +5,7 @@
 import tests.debugger.utils as debugger
 from utils import features, scenarios, missing_feature, context, logger
 import json
+
 TIMEOUT = 5
 
 

--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -5,19 +5,16 @@
 import tests.debugger.utils as debugger
 from utils import features, scenarios, missing_feature, context, logger
 import json
-
 TIMEOUT = 5
 
 
 @features.debugger_inproduct_enablement
 @scenarios.debugger_inproduct_enablement
-@missing_feature(context.library == "java", force_skip=True)
 class Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation(debugger.BaseDebuggerTest):
     ############ dynamic instrumentation ############
     _probe_template = """
     {
         "version": 0,
-        "type": "LOG_PROBE",
         "where": {
             "typeName": null,
             "sourceFile": "ACTUAL_SOURCE_FILE",
@@ -33,7 +30,6 @@ class Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation(debugger.BaseDe
             self.set_probes([probe])
 
             self.send_rc_apm_tracing(dynamic_instrumentation_enabled=enabled)
-
             self.send_rc_probes()
             self.send_weblog_request("/debugger/log")
 
@@ -65,7 +61,7 @@ class Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation(debugger.BaseDe
 
 @features.debugger_inproduct_enablement
 @scenarios.debugger_inproduct_enablement
-@missing_feature(context.library == "java", force_skip=True)
+@missing_feature(context.library == "python", force_skip=True)
 class Test_Debugger_InProduct_Enablement_Exception_Replay(debugger.BaseDebuggerTest):
     ############ exception replay ############
     _max_retries = 2
@@ -102,7 +98,7 @@ class Test_Debugger_InProduct_Enablement_Exception_Replay(debugger.BaseDebuggerT
 
         _send_config()
         self.er_empty_config = _wait_for_exception_snapshot_received(
-            "/exceptionreplay/?depth=1", "recursion exception depth 1"
+            "/exceptionreplay/recursion?depth=1", "recursion exception depth 1"
         )
 
         _send_config(enabled=False)
@@ -123,6 +119,7 @@ class Test_Debugger_InProduct_Enablement_Exception_Replay(debugger.BaseDebuggerT
 @features.debugger_inproduct_enablement
 @scenarios.debugger_inproduct_enablement
 @missing_feature(context.library == "java", force_skip=True)
+@missing_feature(context.library == "python", force_skip=True)
 class Test_Debugger_InProduct_Enablement_Code_Origin(debugger.BaseDebuggerTest):
     ########### code origin ############
     def setup_inproduct_enablement_code_origin(self):


### PR DESCRIPTION
## Motivation
Enable tests for java and pythin in-product enablement

## Changes

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
