### PR TITLE
[Debugger] Enable tests for "evaluate_at" ENTRY/EXIT

### DIFF
--- a/tests/debugger/probes/expression_probe_base.json
+++ b/tests/debugger/probes/expression_probe_base.json
@@ -8,7 +8,6 @@
             "methodName": "",
             "": null
         },
-        "evaluateAt": "EXIT",
         "segments": []
     }
 ]

--- a/tests/debugger/probes/pii.json
+++ b/tests/debugger/probes/pii.json
@@ -9,7 +9,6 @@
             "methodName": "Pii",
             "sourceFile": null
         },
-        "evaluateAt": "EXIT",
         "captureSnapshot": true,
         "capture": {
             "maxFieldCount": 200

--- a/tests/debugger/probes/probe_log_method_budgets.json
+++ b/tests/debugger/probes/probe_log_method_budgets.json
@@ -13,7 +13,6 @@
       {
         "str": "log message received"
       }
-    ],
-    "evaluateAt": "EXIT"
+    ]
   }
 ]

--- a/tests/debugger/probes/probe_snapshot_log_line.json
+++ b/tests/debugger/probes/probe_snapshot_log_line.json
@@ -2,7 +2,7 @@
     {
         "language": "",
         "type": "",
-        "id": "log170aa-acda-4453-9111-1478a697line",
+        "id": "",
         "version": 0,
         "where": {
             "typeName": null,

--- a/tests/debugger/probes/probe_snapshot_log_line_budgets.json
+++ b/tests/debugger/probes/probe_snapshot_log_line_budgets.json
@@ -2,7 +2,7 @@
     {
         "language": "",
         "type": "",
-        "id": "log170aa-acda-4453-9111-1478a697line",
+        "id": "",
         "version": 0,
         "where": {
             "typeName": null,

--- a/tests/debugger/probes/probe_snapshot_log_method.json
+++ b/tests/debugger/probes/probe_snapshot_log_method.json
@@ -8,7 +8,6 @@
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "LogProbe",
             "sourceFile": null
-        },
-        "evaluateAt": "EXIT"
+        }
     }
 ]

--- a/tests/debugger/probes/probe_snapshot_log_method.json
+++ b/tests/debugger/probes/probe_snapshot_log_method.json
@@ -2,7 +2,7 @@
     {
         "language": "",
         "type": "",
-        "id": "log170aa-acda-4453-9111-1478a6method",
+        "id": "",
         "version": 0,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",

--- a/tests/debugger/probes/probe_snapshot_log_mixed.json
+++ b/tests/debugger/probes/probe_snapshot_log_mixed.json
@@ -9,8 +9,7 @@
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "MixProbe",
             "sourceFile": null
-        },
-        "evaluateAt": "EXIT"
+        }
     },
     {
         "language": "",

--- a/tests/debugger/probes/probe_snapshot_log_mixed.json
+++ b/tests/debugger/probes/probe_snapshot_log_mixed.json
@@ -2,7 +2,7 @@
     {
         "language": "",
         "type": "",
-        "id": "logfb5a-1974-4cdb-b1dd-77dba2method",
+        "id": "",
         "version": 0,
         "captureSnapshot": true,
         "where": {
@@ -14,7 +14,7 @@
     {
         "language": "",
         "type": "",
-        "id": "logfb5a-1974-4cdb-b1dd-77dba2f1line",
+        "id": "",
         "version": 0,
         "captureSnapshot": true,
         "where": {

--- a/tests/debugger/probes/probe_snapshot_span_decoration_line.json
+++ b/tests/debugger/probes/probe_snapshot_span_decoration_line.json
@@ -2,7 +2,7 @@
     {
         "language": "",
         "type": "",
-        "id": "decor0aa-acda-4453-9111-1478a697line",
+        "id": "",
         "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [

--- a/tests/debugger/probes/probe_snapshot_span_decoration_line.json
+++ b/tests/debugger/probes/probe_snapshot_span_decoration_line.json
@@ -44,7 +44,6 @@
             "lines": [
                 "44"
             ]
-        },
-        "evaluateAt": "EXIT"
+        }
     }
 ]

--- a/tests/debugger/probes/probe_snapshot_span_decoration_method.json
+++ b/tests/debugger/probes/probe_snapshot_span_decoration_method.json
@@ -2,7 +2,7 @@
     {
         "language": "",
         "type": "",
-        "id": "decor0aa-acda-4453-9111-1478a6method",
+        "id": "",
         "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [

--- a/tests/debugger/probes/probe_snapshot_span_decoration_method.json
+++ b/tests/debugger/probes/probe_snapshot_span_decoration_method.json
@@ -42,7 +42,6 @@
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "SpanDecorationProbe",
             "sourceFile": null
-        },
-        "evaluateAt": "EXIT"
+        }
     }
 ]

--- a/tests/debugger/probes/probe_snapshot_span_method.json
+++ b/tests/debugger/probes/probe_snapshot_span_method.json
@@ -8,7 +8,6 @@
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "SpanProbe",
             "sourceFile": null
-        },
-        "evaluateAt": "EXIT"
+        }
     }
 ]

--- a/tests/debugger/probes/probe_snapshot_span_method.json
+++ b/tests/debugger/probes/probe_snapshot_span_method.json
@@ -2,7 +2,7 @@
     {
         "language": "",
         "type": "",
-        "id": "span70aa-acda-4453-9111-1478a6method",
+        "id": "",
         "version": 0,
         "where": {
             "typeName": "ACTUAL_TYPE_NAME",

--- a/tests/debugger/probes/probe_status_log_line.json
+++ b/tests/debugger/probes/probe_status_log_line.json
@@ -2,7 +2,7 @@
   {
     "language": "",
     "type": "",
-    "id": "loga0cf2-line-45cf-9f39-59installed",
+    "id": "",
     "version": 0,
     "where": {
       "typeName": null,

--- a/tests/debugger/probes/probe_status_log_method.json
+++ b/tests/debugger/probes/probe_status_log_method.json
@@ -8,8 +8,7 @@
         "typeName": "NotReallyExists",
         "methodName": "SomeMethod",
         "sourceFile": null
-      },
-      "evaluateAt": "EXIT"
+      }
     },
     {
       "language": "",
@@ -20,7 +19,6 @@
         "typeName": "ACTUAL_TYPE_NAME",
         "methodName": "LogProbe",
         "sourceFile": null
-      },
-      "evaluateAt": "EXIT"
+      }
     }
   ]

--- a/tests/debugger/probes/probe_status_log_method.json
+++ b/tests/debugger/probes/probe_status_log_method.json
@@ -2,7 +2,7 @@
     {
       "language": "",
       "type": "",
-      "id": "loga0cf2-meth-45cf-9f39-591received",
+      "id": "",
       "version": 0,
       "where": {
         "typeName": "NotReallyExists",
@@ -13,7 +13,7 @@
     {
       "language": "",
       "type": "",
-      "id": "loga0cf2-meth-45cf-9f39-59installed",
+      "id": "",
       "version": 0,
       "where": {
         "typeName": "ACTUAL_TYPE_NAME",

--- a/tests/debugger/probes/probe_status_metric.json
+++ b/tests/debugger/probes/probe_status_metric.json
@@ -16,8 +16,7 @@
       "typeName": "NotReallyExists",
       "methodName": "SomeMethod",
       "sourceFile": null
-    },
-    "evaluateAt": "EXIT"
+    }
   },
   {
     "language": "",
@@ -36,7 +35,6 @@
       "typeName": "ACTUAL_TYPE_NAME",
       "methodName": "MetricProbe",
       "sourceFile": null
-    },
-    "evaluateAt": "EXIT"
+    }
   }
 ]

--- a/tests/debugger/probes/probe_status_metric.json
+++ b/tests/debugger/probes/probe_status_metric.json
@@ -2,7 +2,7 @@
   {
     "language": "",
     "type": "",
-    "id": "metricf2-meth-45cf-9f39-591received",
+    "id": "",
     "version": 0,
     "metricName": "MetricCountInt",
     "kind": "COUNT",
@@ -21,7 +21,7 @@
   {
     "language": "",
     "type": "",
-    "id": "metricf2-meth-45cf-9f39-59installed",
+    "id": "",
     "version": 0,
     "metricName": "MetricCountInt",
     "kind": "COUNT",

--- a/tests/debugger/probes/probe_status_metric_line.json
+++ b/tests/debugger/probes/probe_status_metric_line.json
@@ -2,7 +2,7 @@
   {
     "language": "",
     "type": "",
-    "id": "metricf2-line-45cf-9f39-59installed",
+    "id": "",
     "version": 0,
     "kind": "COUNT",
     "metricName": "MetricCountInt",

--- a/tests/debugger/probes/probe_status_metric_line.json
+++ b/tests/debugger/probes/probe_status_metric_line.json
@@ -18,7 +18,6 @@
       "lines": [
         "28"
       ]
-    },
-    "evaluateAt": "EXIT"
+    }
   }
 ]

--- a/tests/debugger/probes/probe_status_span.json
+++ b/tests/debugger/probes/probe_status_span.json
@@ -8,8 +8,7 @@
       "typeName": "NotReallyExists",
       "methodName": "SomeMethod",
       "sourceFile": null
-    },
-    "evaluateAt": "EXIT"
+    }
   },
   {
     "language": "",
@@ -20,7 +19,6 @@
       "typeName": "ACTUAL_TYPE_NAME",
       "methodName": "SpanProbe",
       "sourceFile": null
-    },
-    "evaluateAt": "EXIT"
+    }
   }
 ]

--- a/tests/debugger/probes/probe_status_span.json
+++ b/tests/debugger/probes/probe_status_span.json
@@ -2,7 +2,7 @@
   {
     "language": "",
     "type": "",
-    "id": "span0cf2-meth-45cf-9f39-591received",
+    "id": "",
     "version": 0,
     "where": {
       "typeName": "NotReallyExists",
@@ -13,7 +13,7 @@
   {
     "language": "",
     "type": "",
-    "id": "span0cf2-meth-45cf-9f39-59installed",
+    "id": "",
     "version": 0,
     "where": {
       "typeName": "ACTUAL_TYPE_NAME",

--- a/tests/debugger/probes/probe_status_spandecoration.json
+++ b/tests/debugger/probes/probe_status_spandecoration.json
@@ -27,8 +27,7 @@
             "typeName": "NotReallyExists",
             "methodName": "SomeMethod",
             "sourceFile": null
-        },
-        "evaluateAt": "EXIT"
+        }
     },
     {
         "language": "",
@@ -58,7 +57,6 @@
             "typeName": "ACTUAL_TYPE_NAME",
             "methodName": "SpanDecorationProbe",
             "sourceFile": null
-        },
-        "evaluateAt": "EXIT"
+        }
     }
 ]

--- a/tests/debugger/probes/probe_status_spandecoration.json
+++ b/tests/debugger/probes/probe_status_spandecoration.json
@@ -2,14 +2,14 @@
     {
         "language": "",
         "type": "",
-        "id": "decorcf2-meth-45cf-9f39-591received",
+        "id": "",
         "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {
                 "tags": [],
                 "when": {
-                    "dsl" : "",
+                    "dsl": "",
                     "json": {
                         "gt": [
                             {
@@ -32,7 +32,7 @@
     {
         "language": "",
         "type": "",
-        "id": "decorcf2-meth-45cf-9f39-59installed",
+        "id": "",
         "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [

--- a/tests/debugger/probes/probe_status_spandecoration_line.json
+++ b/tests/debugger/probes/probe_status_spandecoration_line.json
@@ -2,14 +2,14 @@
     {
         "language": "",
         "type": "",
-        "id": "decorcf2-line-45cf-9f39-59installed",
+        "id": "",
         "version": 0,
         "targetSpan": "ACTIVE",
         "decorations": [
             {
                 "tags": [],
                 "when": {
-                    "dsl" : "",
+                    "dsl": "",
                     "json": {
                         "gt": [
                             {

--- a/tests/debugger/probes/probe_status_spandecoration_line.json
+++ b/tests/debugger/probes/probe_status_spandecoration_line.json
@@ -30,7 +30,6 @@
             "lines": [
                 "44"
             ]
-        },
-        "evaluateAt": "EXIT"
+        }
     }
 ]

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -14,7 +14,9 @@ from utils import scenarios, features, missing_feature, context, rfc, logger
 @missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
 class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     ############ setup ############
-    def _setup(self, probes_name: str, request_path: str, lines=None, evaluate_at: EvaluationPoint = EvaluationPoint.EXIT):
+    def _setup(
+        self, probes_name: str, request_path: str, lines=None, evaluate_at: EvaluationPoint = EvaluationPoint.EXIT
+    ):
         self.initialize_weblog_remote_config()
 
         ### prepare probes
@@ -104,7 +106,9 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
 
     ### span decoration probe ###
     def setup_span_decoration_method_exit_snapshot(self):
-        self._setup("probe_snapshot_span_decoration_method", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.EXIT)
+        self._setup(
+            "probe_snapshot_span_decoration_method", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.EXIT
+        )
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
@@ -113,7 +117,11 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
         self._validate_spans()
 
     def setup_span_decoration_method_entry_snapshot(self):
-        self._setup("probe_snapshot_span_decoration_method", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup(
+            "probe_snapshot_span_decoration_method",
+            "/debugger/span-decoration/asd/1",
+            evaluate_at=EvaluationPoint.ENTRY,
+        )
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
@@ -139,7 +147,9 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
 
     ### span decoration probe ###
     def setup_span_decoration_line_exit_snapshot(self):
-        self._setup("probe_snapshot_span_decoration_line", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.EXIT)
+        self._setup(
+            "probe_snapshot_span_decoration_line", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.EXIT
+        )
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
@@ -148,7 +158,9 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
         self._validate_spans()
 
     def setup_span_decoration_line_entry_snapshot(self):
-        self._setup("probe_snapshot_span_decoration_line", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup(
+            "probe_snapshot_span_decoration_line", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.ENTRY
+        )
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
@@ -184,18 +196,14 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
         self.send_weblog_request("/healthcheck")
 
     @features.debugger_code_origins
-    @missing_feature(
-        context.library == "dotnet", reason="Entry spans code origins not yet implemented", force_skip=True
-    )
+    @missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
     @missing_feature(
         context.library == "java" and context.weblog_variant != "spring-boot",
-        reason="Entry spans code origins only implemented for spring-mvc",
+        reason="Implemented for spring-mvc",
         force_skip=True,
     )
-    @missing_feature(
-        context.library == "nodejs", reason="Entry spans code origins not yet implemented for express", force_skip=True
-    )
-    @missing_feature(context.library == "ruby", reason="Entry spans code origins not yet implemented", force_skip=True)
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented for express", force_skip=True)
+    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     def test_code_origin_entry_present(self):
         self.collect()
 
@@ -214,22 +222,35 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
 
         assert code_origins_entry_found
 
-    def setup_log_line_budgets_snapshot(self):
+    def setup_log_line_exit_budgets(self):
         self._setup(
             "probe_snapshot_log_line_budgets",
             "/debugger/budgets/150",
             lines=self.method_and_language_to_line_number("Budgets", self.get_tracer()["language"]),
-            evaluate_at=EvaluationPoint.EXIT
+            evaluate_at=EvaluationPoint.EXIT,
         )
 
     @features.debugger_probe_budgets
-    @missing_feature(
-        context.library == "nodejs", reason="Probe snapshot budgets are not yet implemented", force_skip=True
-    )
-    @missing_feature(
-        context.library == "ruby", reason="Probe snapshot budgets are not yet implemented", force_skip=True
-    )
-    def test_log_line_budgets_snapshot(self):
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+    def test_log_line_exit_budgets(self):
+        self._assert_budgets()
+
+    def setup_log_line_entry_budgets(self):
+        self._setup(
+            "probe_snapshot_log_line_budgets",
+            "/debugger/budgets/150",
+            lines=self.method_and_language_to_line_number("Budgets", self.get_tracer()["language"]),
+            evaluate_at=EvaluationPoint.ENTRY,
+        )
+
+    @features.debugger_probe_budgets
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+    def test_log_line_entry_budgets(self):
+        self._assert_budgets()
+
+    def _assert_budgets(self):
         self._assert()
         self._validate_snapshots()
 

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -15,12 +15,22 @@ from utils import scenarios, features, missing_feature, context, rfc, logger
 class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     ############ setup ############
     def _setup(
-        self, probes_name: str, request_path: str, lines=None, evaluate_at: EvaluationPoint = EvaluationPoint.EXIT
+        self,
+        probes_name: str,
+        request_path: str,
+        probe_type: str,
+        evaluate_at: EvaluationPoint,
+        lines=None,
     ):
         self.initialize_weblog_remote_config()
 
         ### prepare probes
         probes = debugger.read_probes(probes_name)
+
+        # Update probe IDs using the generate_probe_id function with the provided probe_type
+        for probe in probes:
+            probe["id"] = debugger.generate_probe_id(probe_type)
+
         if lines is not None:
             for probe in probes:
                 if "methodName" in probe["where"]:
@@ -70,7 +80,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     ########### method ############
     ### log probe ###
     def setup_log_method_exit_snapshot(self):
-        self._setup("probe_snapshot_log_method", "/debugger/log", evaluate_at=EvaluationPoint.EXIT)
+        self._setup("probe_snapshot_log_method", "/debugger/log", "log", evaluate_at=EvaluationPoint.EXIT)
 
     @missing_feature(context.library == "nodejs", reason="Not yet implemented")
     def test_log_method_exit_snapshot(self):
@@ -78,7 +88,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
         self._validate_snapshots()
 
     def setup_log_method_entry_snapshot(self):
-        self._setup("probe_snapshot_log_method", "/debugger/log", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup("probe_snapshot_log_method", "/debugger/log", "log", evaluate_at=EvaluationPoint.ENTRY)
 
     @missing_feature(context.library == "nodejs", reason="Not yet implemented")
     def test_log_method_entry_snapshot(self):
@@ -87,7 +97,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
 
     ### span probe ###
     def setup_span_method_exit_snapshot(self):
-        self._setup("probe_snapshot_span_method", "/debugger/span", evaluate_at=EvaluationPoint.EXIT)
+        self._setup("probe_snapshot_span_method", "/debugger/span", "span", evaluate_at=EvaluationPoint.EXIT)
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
@@ -96,7 +106,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
         self._validate_spans()
 
     def setup_span_method_entry_snapshot(self):
-        self._setup("probe_snapshot_span_method", "/debugger/span", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup("probe_snapshot_span_method", "/debugger/span", "span", evaluate_at=EvaluationPoint.ENTRY)
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
@@ -107,7 +117,10 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     ### span decoration probe ###
     def setup_span_decoration_method_exit_snapshot(self):
         self._setup(
-            "probe_snapshot_span_decoration_method", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.EXIT
+            "probe_snapshot_span_decoration_method",
+            "/debugger/span-decoration/asd/1",
+            "decor",
+            evaluate_at=EvaluationPoint.EXIT,
         )
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
@@ -120,6 +133,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
         self._setup(
             "probe_snapshot_span_decoration_method",
             "/debugger/span-decoration/asd/1",
+            "decor",
             evaluate_at=EvaluationPoint.ENTRY,
         )
 
@@ -132,14 +146,14 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     ########### line ############
     ### log probe ###
     def setup_log_line_exit_snapshot(self):
-        self._setup("probe_snapshot_log_line", "/debugger/log", evaluate_at=EvaluationPoint.EXIT)
+        self._setup("probe_snapshot_log_line", "/debugger/log", "log", evaluate_at=EvaluationPoint.EXIT)
 
     def test_log_line_exit_snapshot(self):
         self._assert()
         self._validate_snapshots()
 
     def setup_log_line_entry_snapshot(self):
-        self._setup("probe_snapshot_log_line", "/debugger/log", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup("probe_snapshot_log_line", "/debugger/log", "log", evaluate_at=EvaluationPoint.ENTRY)
 
     def test_log_line_entry_snapshot(self):
         self._assert()
@@ -148,7 +162,10 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     ### span decoration probe ###
     def setup_span_decoration_line_exit_snapshot(self):
         self._setup(
-            "probe_snapshot_span_decoration_line", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.EXIT
+            "probe_snapshot_span_decoration_line",
+            "/debugger/span-decoration/asd/1",
+            "decor",
+            evaluate_at=EvaluationPoint.EXIT,
         )
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
@@ -159,7 +176,10 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
 
     def setup_span_decoration_line_entry_snapshot(self):
         self._setup(
-            "probe_snapshot_span_decoration_line", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.ENTRY
+            "probe_snapshot_span_decoration_line",
+            "/debugger/span-decoration/asd/1",
+            "decor",
+            evaluate_at=EvaluationPoint.ENTRY,
         )
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
@@ -171,7 +191,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     ########### mix ############
     ### mix log probe ###
     def setup_mix_exit_snapshot(self):
-        self._setup("probe_snapshot_log_mixed", "/debugger/mix/asd/1", evaluate_at=EvaluationPoint.EXIT)
+        self._setup("probe_snapshot_log_mixed", "/debugger/mix/asd/1", "log", evaluate_at=EvaluationPoint.EXIT)
 
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
     def test_mix_exit_snapshot(self):
@@ -179,7 +199,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
         self._validate_snapshots()
 
     def setup_mix_entry_snapshot(self):
-        self._setup("probe_snapshot_log_mixed", "/debugger/mix/asd/1", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup("probe_snapshot_log_mixed", "/debugger/mix/asd/1", "log", evaluate_at=EvaluationPoint.ENTRY)
 
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
     def test_mix_entry_snapshot(self):
@@ -228,6 +248,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
             "/debugger/budgets/150",
             lines=self.method_and_language_to_line_number("Budgets", self.get_tracer()["language"]),
             evaluate_at=EvaluationPoint.EXIT,
+            probe_type="log",
         )
 
     @features.debugger_probe_budgets

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -4,6 +4,7 @@
 
 import time
 import tests.debugger.utils as debugger
+from debugger import EvaluationPoint
 
 from utils import scenarios, features, missing_feature, context, rfc, logger
 
@@ -13,7 +14,7 @@ from utils import scenarios, features, missing_feature, context, rfc, logger
 @missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
 class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     ############ setup ############
-    def _setup(self, probes_name: str, request_path: str, lines=None):
+    def _setup(self, probes_name: str, request_path: str, lines=None, evaluate_at: EvaluationPoint = EvaluationPoint.EXIT):
         self.initialize_weblog_remote_config()
 
         ### prepare probes
@@ -26,7 +27,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
                 probe["where"]["sourceFile"] = "ACTUAL_SOURCE_FILE"
                 probe["where"]["typeName"] = None
 
-        self.set_probes(probes)
+        self.set_probes(probes, evaluate_at=evaluate_at)
 
         ### send requests
         self.send_rc_probes()
@@ -66,60 +67,110 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
 
     ########### method ############
     ### log probe ###
-    def setup_log_method_probe_snaphots(self):
+    def setup_log_method_exit_snapshot(self):
         self._setup("probe_snapshot_log_method", "/debugger/log")
 
     @missing_feature(context.library == "nodejs", reason="Not yet implemented")
-    def test_log_method_probe_snaphots(self):
+    def test_log_method_exit_snapshot(self):
+        self._assert()
+        self._validate_snapshots()
+
+    def setup_log_method_entry_snapshot(self):
+        self._setup("probe_snapshot_log_method", "/debugger/log", evaluate_at=EvaluationPoint.ENTRY)
+
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented")
+    def test_log_method_entry_snapshot(self):
         self._assert()
         self._validate_snapshots()
 
     ### span probe ###
-    def setup_span_method_probe_snaphots(self):
+    def setup_span_method_exit_snapshot(self):
         self._setup("probe_snapshot_span_method", "/debugger/span")
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
-    def test_span_method_probe_snaphots(self):
+    def test_span_method_exit_snapshot(self):
+        self._assert()
+        self._validate_spans()
+
+    def setup_span_method_entry_snapshot(self):
+        self._setup("probe_snapshot_span_method", "/debugger/span", evaluate_at=EvaluationPoint.ENTRY)
+
+    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    def test_span_method_entry_snapshot(self):
         self._assert()
         self._validate_spans()
 
     ### span decoration probe ###
-    def setup_span_decoration_method_probe_snaphots(self):
+    def setup_span_decoration_method_exit_snapshot(self):
         self._setup("probe_snapshot_span_decoration_method", "/debugger/span-decoration/asd/1")
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
-    def test_span_decoration_method_probe_snaphots(self):
+    def test_span_decoration_method_exit_snapshot(self):
+        self._assert()
+        self._validate_spans()
+
+    def setup_span_decoration_method_entry_snapshot(self):
+        self._setup("probe_snapshot_span_decoration_method", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.ENTRY)
+
+    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    def test_span_decoration_method_entry_snapshot(self):
         self._assert()
         self._validate_spans()
 
     ########### line ############
     ### log probe ###
-    def setup_log_line_probe_snaphots(self):
+    def setup_log_line_exit_snapshot(self):
         self._setup("probe_snapshot_log_line", "/debugger/log")
 
-    def test_log_line_probe_snaphots(self):
+    def test_log_line_exit_snapshot(self):
+        self._assert()
+        self._validate_snapshots()
+
+    def setup_log_line_entry_snapshot(self):
+        self._setup("probe_snapshot_log_line", "/debugger/log", evaluate_at=EvaluationPoint.ENTRY)
+
+    def test_log_line_entry_snapshot(self):
         self._assert()
         self._validate_snapshots()
 
     ### span decoration probe ###
-    def setup_span_decoration_line_probe_snaphots(self):
+    def setup_span_decoration_line_exit_snapshot(self):
         self._setup("probe_snapshot_span_decoration_line", "/debugger/span-decoration/asd/1")
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
-    def test_span_decoration_line_probe_snaphots(self):
+    def test_span_decoration_line_exit_snapshot(self):
+        self._assert()
+        self._validate_spans()
+
+    def setup_span_decoration_line_entry_snapshot(self):
+        self._setup("probe_snapshot_span_decoration_line", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.ENTRY)
+
+    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    def test_span_decoration_line_entry_snapshot(self):
         self._assert()
         self._validate_spans()
 
     ########### mix ############
     ### mix log probe ###
-    def setup_mix_probe(self):
+    def setup_mix_exit_snapshot(self):
         self._setup("probe_snapshot_log_mixed", "/debugger/mix/asd/1")
 
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
-    def test_mix_probe(self):
+    def test_mix_exit_snapshot(self):
+        self._assert()
+        self._validate_snapshots()
+
+    def setup_mix_entry_snapshot(self):
+        self._setup("probe_snapshot_log_mixed", "/debugger/mix/asd/1", evaluate_at=EvaluationPoint.ENTRY)
+
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    def test_mix_entry_snapshot(self):
         self._assert()
         self._validate_snapshots()
 
@@ -163,7 +214,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
 
         assert code_origins_entry_found
 
-    def setup_log_line_probe_snaphots_budgets(self):
+    def setup_log_line_budgets_snapshot(self):
         self._setup(
             "probe_snapshot_log_line_budgets",
             "/debugger/budgets/150",
@@ -177,7 +228,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     @missing_feature(
         context.library == "ruby", reason="Probe snapshot budgets are not yet implemented", force_skip=True
     )
-    def test_log_line_probe_snaphots_budgets(self):
+    def test_log_line_budgets_snapshot(self):
         self._assert()
         self._validate_snapshots()
 

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -234,23 +234,6 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     def test_log_line_exit_budgets(self):
-        self._assert_budgets()
-
-    def setup_log_line_entry_budgets(self):
-        self._setup(
-            "probe_snapshot_log_line_budgets",
-            "/debugger/budgets/150",
-            lines=self.method_and_language_to_line_number("Budgets", self.get_tracer()["language"]),
-            evaluate_at=EvaluationPoint.ENTRY,
-        )
-
-    @features.debugger_probe_budgets
-    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
-    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
-    def test_log_line_entry_budgets(self):
-        self._assert_budgets()
-
-    def _assert_budgets(self):
         self._assert()
         self._validate_snapshots()
 

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -4,7 +4,7 @@
 
 import time
 import tests.debugger.utils as debugger
-from debugger import EvaluationPoint
+from tests.debugger.utils import EvaluationPoint
 
 from utils import scenarios, features, missing_feature, context, rfc, logger
 
@@ -68,7 +68,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     ########### method ############
     ### log probe ###
     def setup_log_method_exit_snapshot(self):
-        self._setup("probe_snapshot_log_method", "/debugger/log")
+        self._setup("probe_snapshot_log_method", "/debugger/log", evaluate_at=EvaluationPoint.EXIT)
 
     @missing_feature(context.library == "nodejs", reason="Not yet implemented")
     def test_log_method_exit_snapshot(self):
@@ -85,7 +85,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
 
     ### span probe ###
     def setup_span_method_exit_snapshot(self):
-        self._setup("probe_snapshot_span_method", "/debugger/span")
+        self._setup("probe_snapshot_span_method", "/debugger/span", evaluate_at=EvaluationPoint.EXIT)
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
@@ -104,7 +104,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
 
     ### span decoration probe ###
     def setup_span_decoration_method_exit_snapshot(self):
-        self._setup("probe_snapshot_span_decoration_method", "/debugger/span-decoration/asd/1")
+        self._setup("probe_snapshot_span_decoration_method", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.EXIT)
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
@@ -124,7 +124,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     ########### line ############
     ### log probe ###
     def setup_log_line_exit_snapshot(self):
-        self._setup("probe_snapshot_log_line", "/debugger/log")
+        self._setup("probe_snapshot_log_line", "/debugger/log", evaluate_at=EvaluationPoint.EXIT)
 
     def test_log_line_exit_snapshot(self):
         self._assert()
@@ -139,7 +139,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
 
     ### span decoration probe ###
     def setup_span_decoration_line_exit_snapshot(self):
-        self._setup("probe_snapshot_span_decoration_line", "/debugger/span-decoration/asd/1")
+        self._setup("probe_snapshot_span_decoration_line", "/debugger/span-decoration/asd/1", evaluate_at=EvaluationPoint.EXIT)
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
@@ -159,7 +159,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
     ########### mix ############
     ### mix log probe ###
     def setup_mix_exit_snapshot(self):
-        self._setup("probe_snapshot_log_mixed", "/debugger/mix/asd/1")
+        self._setup("probe_snapshot_log_mixed", "/debugger/mix/asd/1", evaluate_at=EvaluationPoint.EXIT)
 
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
     def test_mix_exit_snapshot(self):
@@ -219,6 +219,7 @@ class Test_Debugger_Probe_Snaphots(debugger.BaseDebuggerTest):
             "probe_snapshot_log_line_budgets",
             "/debugger/budgets/150",
             lines=self.method_and_language_to_line_number("Budgets", self.get_tracer()["language"]),
+            evaluate_at=EvaluationPoint.EXIT
         )
 
     @features.debugger_probe_budgets

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -13,11 +13,19 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
     expected_diagnostics: dict = {}
 
     ############ setup ############
-    def _setup(self, probes_name: str, evaluate_at: EvaluationPoint = EvaluationPoint.EXIT):
+    def _setup(self, probes_name: str, probe_type: str, evaluate_at: EvaluationPoint):
         self.initialize_weblog_remote_config()
 
         ### prepare probes
         probes = debugger.read_probes(probes_name)
+
+        for probe in probes:
+            if probe["where"]["typeName"] == "NotReallyExists":
+                suffix = "received"
+            else:
+                suffix = "installed"
+            probe["id"] = debugger.generate_probe_id(probe_type, suffix)
+
         self.set_probes(probes, evaluate_at=evaluate_at)
 
         ### set expected
@@ -62,7 +70,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
 
     ############ log line probe ############
     def setup_log_line_exit_status(self):
-        self._setup("probe_status_log_line", evaluate_at=EvaluationPoint.EXIT)
+        self._setup("probe_status_log_line", probe_type="log", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
@@ -71,7 +79,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
         self._assert()
 
     def setup_log_line_entry_status(self):
-        self._setup("probe_status_log_line", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup("probe_status_log_line", probe_type="log", evaluate_at=EvaluationPoint.ENTRY)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
@@ -81,7 +89,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
 
     ############ log method probe ############
     def setup_log_method_exit_status(self):
-        self._setup("probe_status_log_method", evaluate_at=EvaluationPoint.EXIT)
+        self._setup("probe_status_log_method", probe_type="log", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
@@ -90,7 +98,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
         self._assert()
 
     def setup_log_method_entry_status(self):
-        self._setup("probe_status_log_method", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup("probe_status_log_method", probe_type="log", evaluate_at=EvaluationPoint.ENTRY)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
@@ -100,7 +108,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
 
     ############ metric probe ############
     def setup_metric_exit_status(self):
-        self._setup("probe_status_metric", evaluate_at=EvaluationPoint.EXIT)
+        self._setup("probe_status_metric", probe_type="metric", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
@@ -110,7 +118,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
         self._assert()
 
     def setup_metric_entry_status(self):
-        self._setup("probe_status_metric", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup("probe_status_metric", probe_type="metric", evaluate_at=EvaluationPoint.ENTRY)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
@@ -120,7 +128,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
         self._assert()
 
     def setup_metric_line_exit_status(self):
-        self._setup("probe_status_metric_line", evaluate_at=EvaluationPoint.EXIT)
+        self._setup("probe_status_metric_line", probe_type="metric", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
@@ -131,7 +139,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
         self._assert()
 
     def setup_metric_line_entry_status(self):
-        self._setup("probe_status_metric_line", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup("probe_status_metric_line", probe_type="metric", evaluate_at=EvaluationPoint.ENTRY)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
@@ -143,7 +151,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
 
     ############ span probe ############
     def setup_span_method_exit_status(self):
-        self._setup("probe_status_span", evaluate_at=EvaluationPoint.EXIT)
+        self._setup("probe_status_span", probe_type="span", evaluate_at=EvaluationPoint.EXIT)
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
@@ -151,7 +159,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
         self._assert()
 
     def setup_span_method_entry_status(self):
-        self._setup("probe_status_span", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup("probe_status_span", probe_type="span", evaluate_at=EvaluationPoint.ENTRY)
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
@@ -160,7 +168,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
 
     ############ span decoration probe ############
     def setup_span_decoration_method_exit_status(self):
-        self._setup("probe_status_spandecoration", evaluate_at=EvaluationPoint.EXIT)
+        self._setup("probe_status_spandecoration", probe_type="decor", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
@@ -170,7 +178,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
         self._assert()
 
     def setup_span_decoration_method_entry_status(self):
-        self._setup("probe_status_spandecoration", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup("probe_status_spandecoration", probe_type="decor", evaluate_at=EvaluationPoint.ENTRY)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
@@ -180,7 +188,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
         self._assert()
 
     def setup_span_decoration_line_exit_status(self):
-        self._setup("probe_status_spandecoration_line", evaluate_at=EvaluationPoint.EXIT)
+        self._setup("probe_status_spandecoration_line", probe_type="decor", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
@@ -191,7 +199,7 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
         self._assert()
 
     def setup_span_decoration_line_entry_status(self):
-        self._setup("probe_status_spandecoration_line", evaluate_at=EvaluationPoint.ENTRY)
+        self._setup("probe_status_spandecoration_line", probe_type="decor", evaluate_at=EvaluationPoint.ENTRY)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -3,6 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import tests.debugger.utils as debugger
+from tests.debugger.utils import EvaluationPoint
 from utils import scenarios, features, bug, missing_feature, context
 
 
@@ -12,12 +13,12 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
     expected_diagnostics: dict = {}
 
     ############ setup ############
-    def _setup(self, probes_name: str):
+    def _setup(self, probes_name: str, evaluate_at: EvaluationPoint = EvaluationPoint.EXIT):
         self.initialize_weblog_remote_config()
 
         ### prepare probes
         probes = debugger.read_probes(probes_name)
-        self.set_probes(probes)
+        self.set_probes(probes, evaluate_at=evaluate_at)
 
         ### set expected
         self.expected_diagnostics = {}
@@ -60,74 +61,142 @@ class Test_Debugger_Probe_Statuses(debugger.BaseDebuggerTest):
         assert not errors, "Probe status errors:\n" + "\n".join(errors)
 
     ############ log line probe ############
-    def setup_probe_status_log_line(self):
-        self._setup("probe_status_log_line")
+    def setup_log_line_exit_status(self):
+        self._setup("probe_status_log_line", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
     @missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
-    def test_probe_status_log_line(self):
+    def test_log_line_exit_status(self):
+        self._assert()
+
+    def setup_log_line_entry_status(self):
+        self._setup("probe_status_log_line", evaluate_at=EvaluationPoint.ENTRY)
+
+    @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
+    @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
+    @missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+    def test_log_line_entry_status(self):
         self._assert()
 
     ############ log method probe ############
-    def setup_probe_status_log_method(self):
-        self._setup("probe_status_log_method")
+    def setup_log_method_exit_status(self):
+        self._setup("probe_status_log_method", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
-    def test_probe_status_log_method(self):
+    def test_log_method_exit_status(self):
+        self._assert()
+
+    def setup_log_method_entry_status(self):
+        self._setup("probe_status_log_method", evaluate_at=EvaluationPoint.ENTRY)
+
+    @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
+    @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    def test_log_method_entry_status(self):
         self._assert()
 
     ############ metric probe ############
-    def setup_probe_status_metric(self):
-        self._setup("probe_status_metric")
+    def setup_metric_exit_status(self):
+        self._setup("probe_status_metric", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
-    def test_probe_status_metric(self):
+    def test_metric_exit_status(self):
         self._assert()
 
-    def setup_probe_status_metric_line(self):
-        self._setup("probe_status_metric_line")
+    def setup_metric_entry_status(self):
+        self._setup("probe_status_metric", evaluate_at=EvaluationPoint.ENTRY)
+
+    @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
+    @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
+    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    def test_metric_entry_status(self):
+        self._assert()
+
+    def setup_metric_line_exit_status(self):
+        self._setup("probe_status_metric_line", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
-    def test_probe_status_metric_line(self):
+    def test_metric_line_exit_status(self):
+        self._assert()
+
+    def setup_metric_line_entry_status(self):
+        self._setup("probe_status_metric_line", evaluate_at=EvaluationPoint.ENTRY)
+
+    @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
+    @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
+    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+    def test_metric_line_entry_status(self):
         self._assert()
 
     ############ span probe ############
-    def setup_probe_status_span(self):
-        self._setup("probe_status_span")
+    def setup_span_method_exit_status(self):
+        self._setup("probe_status_span", evaluate_at=EvaluationPoint.EXIT)
 
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
-    def test_probe_status_span(self):
+    def test_span_method_exit_status(self):
+        self._assert()
+
+    def setup_span_method_entry_status(self):
+        self._setup("probe_status_span", evaluate_at=EvaluationPoint.ENTRY)
+
+    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    def test_span_method_entry_status(self):
         self._assert()
 
     ############ span decoration probe ############
-    def setup_probe_status_spandecoration(self):
-        self._setup("probe_status_spandecoration")
+    def setup_span_decoration_method_exit_status(self):
+        self._setup("probe_status_spandecoration", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
-    def test_probe_status_spandecoration(self):
+    def test_span_decoration_method_exit_status(self):
         self._assert()
 
-    def setup_probe_status_spandecoration_line(self):
-        self._setup("probe_status_spandecoration_line")
+    def setup_span_decoration_method_entry_status(self):
+        self._setup("probe_status_spandecoration", evaluate_at=EvaluationPoint.ENTRY)
+
+    @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
+    @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
+    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    def test_span_decoration_method_entry_status(self):
+        self._assert()
+
+    def setup_span_decoration_line_exit_status(self):
+        self._setup("probe_status_spandecoration_line", evaluate_at=EvaluationPoint.EXIT)
 
     @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
     @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
     @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
     @missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
-    def test_probe_status_spandecoration_line(self):
+    def test_span_decoration_line_exit_status(self):
+        self._assert()
+
+    def setup_span_decoration_line_entry_status(self):
+        self._setup("probe_status_spandecoration_line", evaluate_at=EvaluationPoint.ENTRY)
+
+    @bug(context.library == "python@2.16.0", reason="DEBUG-3127")
+    @bug(context.library == "python@2.16.1", reason="DEBUG-3127")
+    @missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+    @missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+    def test_span_decoration_line_entry_status(self):
         self._assert()

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -8,10 +8,15 @@ import os
 import os.path
 from pathlib import Path
 import uuid
+from enum import Enum
 
 from utils import interfaces, remote_config, weblog, context, logger
 from utils.dd_constants import RemoteConfigApplyState as ApplyState
 
+
+class EvaluationPoint(Enum):
+    ENTRY = "ENTRY"
+    EXIT = "EXIT"
 
 _CONFIG_PATH = "/v0.7/config"
 _DEBUGGER_PATH = "/api/v2/debugger"
@@ -109,7 +114,7 @@ class BaseDebuggerTest:
         return definitions.get(method, {}).get(language, [])
 
     ###### set #####
-    def set_probes(self, probes: list[dict]) -> None:
+    def set_probes(self, probes: list[dict], evaluate_at: EvaluationPoint = EvaluationPoint.EXIT) -> None:
         def _enrich_probes(probes: list[dict]):
             def __get_probe_type(probe_id: str):
                 if probe_id.startswith("log"):
@@ -127,6 +132,7 @@ class BaseDebuggerTest:
 
             for probe in probes:
                 probe["language"] = language
+                probe["evaluateAt"] = evaluate_at.value
 
                 # PHP validates that the segments field is present.
                 if "segments" not in probe:

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -18,6 +18,7 @@ class EvaluationPoint(Enum):
     ENTRY = "ENTRY"
     EXIT = "EXIT"
 
+
 _CONFIG_PATH = "/v0.7/config"
 _DEBUGGER_PATH = "/api/v2/debugger"
 _LOGS_PATH = "/api/v2/logs"

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -34,8 +34,13 @@ def read_probes(test_name: str) -> list:
         return json.load(f)
 
 
-def generate_probe_id(probe_type: str) -> str:
-    return probe_type + str(uuid.uuid4())[len(probe_type) :]
+def generate_probe_id(probe_type: str, suffix: str = "") -> str:
+    uuid_str = str(uuid.uuid4())
+    if suffix:
+        # Replace the last len(suffix) characters of the UUID with the suffix
+        uuid_str = uuid_str[: -len(suffix)] + suffix
+
+    return probe_type + uuid_str[len(probe_type) :]
 
 
 def extract_probe_ids(probes: dict | list) -> list:

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -622,6 +622,12 @@ class EndToEndScenario(DockerScenario):
                 ticket="APMRP-360",
             ),
             _SchemaBug(
+                endpoint="/debugger/v1/input",
+                data_path="$[].debugger.snapshot.probe.location.method",
+                condition=self.library == "dotnet",
+                ticket="DEBUG-3734",
+            ),
+            _SchemaBug(
                 endpoint="/symdb/v1/input",
                 data_path=None,
                 condition=self.library == "dotnet" and self.name == "DEBUGGER_SYMDB",

--- a/utils/build/docker/dotnet/weblog/Controllers/DebuggerController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/DebuggerController.cs
@@ -35,7 +35,7 @@ namespace weblog
             return Content("Span probe");
         }
 
-        private int intLocal = 0;
+        private int intLocal = 1000;
         [HttpGet("span-decoration/{arg}/{intArg}")]
         [Consumes("application/json", "application/xml")]
         public IActionResult SpanDecorationProbe(string arg, int intArg)

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/DebuggerController.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/DebuggerController.java
@@ -37,7 +37,7 @@ public class DebuggerController {
 
 // Dummy line
 // Dummy line
-    private int intLocal = 0;
+    private int intLocal = 1000;
     @GetMapping("/span-decoration/{arg}/{intArg}")
     public String spanDecorationProbe(@PathVariable String arg, @PathVariable int intArg) {
         intLocal = intArg * arg.length();

--- a/utils/build/docker/python/flask/debugger_controller.py
+++ b/utils/build/docker/python/flask/debugger_controller.py
@@ -11,7 +11,7 @@ from debugger.collection_factory import CollectionFactory
 # dummy line
 debugger_blueprint = Blueprint("debugger", __name__, url_prefix="/debugger")
 
-intLocal = 0
+intLocal = 1000
 intMixLocal = 0
 
 


### PR DESCRIPTION
## Motivation
Enable tests for "evaluate_at" ENTRY/EXIT

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
