### PR TITLE
Minor refactor to make telemetry data easier to use

### DIFF
--- a/tests/debugger/test_debugger_telemetry.py
+++ b/tests/debugger/test_debugger_telemetry.py
@@ -4,7 +4,7 @@
 
 import tests.debugger.utils as debugger
 from utils import scenarios, features, missing_feature, context, logger
-from utils.telemetry import load_telemetry_json, get_lang_configs
+from utils.telemetry import get_config_norm_rules, get_lang_configs
 
 ALLOWED_ORIGINS = {"env_var", "code", "dd_config", "remote_config", "app.config", "default", "unknown"}
 
@@ -18,7 +18,7 @@ class Test_Debugger_Telemetry(debugger.BaseDebuggerTest):
     ############ setup ############
     def _setup(self):
         # Load the telemetry intake general and language-specific configuration normalization rules.
-        self.config_norm_rules = load_telemetry_json("config_norm_rules")
+        self.config_norm_rules = get_config_norm_rules()
         self.lang_configs = get_lang_configs()
         self.lang_configs["java"] = self.lang_configs["jvm"]
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -5,7 +5,12 @@ import time
 from dateutil.parser import isoparse
 from utils import context, interfaces, missing_feature, bug, flaky, irrelevant, weblog, scenarios, features, rfc, logger
 from utils.interfaces._misc_validators import HeadersPresenceValidator, HeadersMatchValidator
-from utils.telemetry import get_lang_configs, load_telemetry_json
+from utils.telemetry import (
+    get_lang_configs,
+    get_config_norm_rules,
+    get_config_prefix_block_list,
+    get_config_aggregation_list,
+)
 
 INTAKE_TELEMETRY_PATH = "/api/v2/apmtelemetry"
 AGENT_TELEMETRY_PATH = "/telemetry/proxy/api/v2/apmtelemetry"
@@ -624,9 +629,9 @@ class Test_TelemetryV2:
         Runbook: https://github.com/DataDog/system-tests/blob/main/docs/edit/runbook.md#test_config_telemetry_completeness
         """
 
-        config_norm_rules = load_telemetry_json("config_norm_rules")
-        config_prefix_block_list = load_telemetry_json("config_prefix_block_list")
-        config_aggregation_list = load_telemetry_json("config_aggregation_list")
+        config_norm_rules = get_config_norm_rules()
+        config_prefix_block_list = get_config_prefix_block_list()
+        config_aggregation_list = get_config_aggregation_list()
 
         lang_configs = get_lang_configs()
 
@@ -733,7 +738,7 @@ class Test_ProductsDisabled:
     def test_debugger_products_disabled(self):
         """Assert that the debugger products are disabled by default including DI, and ER"""
         data_found = False
-        config_norm_rules = load_telemetry_json("config_norm_rules")
+        config_norm_rules = get_config_norm_rules()
         lang_configs = get_lang_configs()
         lang_configs["java"] = lang_configs["jvm"]
 

--- a/utils/telemetry/__init__.py
+++ b/utils/telemetry/__init__.py
@@ -1,3 +1,3 @@
-from ._utils import get_lang_configs, load_telemetry_json
+from ._utils import get_lang_configs, get_config_norm_rules, get_config_prefix_block_list, get_config_aggregation_list
 
-__all__ = ["get_lang_configs", "load_telemetry_json"]
+__all__ = ["get_config_aggregation_list", "get_config_norm_rules", "get_config_prefix_block_list", "get_lang_configs"]

--- a/utils/telemetry/_utils.py
+++ b/utils/telemetry/_utils.py
@@ -1,28 +1,56 @@
 import json
+from typing import Any
 
 from utils._context._scenarios import ScenarioGroup
 from utils._context.core import context
 
 
-def get_lang_configs():
-    # ensure that any scneario using this method got ScenarioGroup.TELEMETRY
-    assert (
-        ScenarioGroup.TELEMETRY in context.scenario.scenario_groups
-    ), f"Please add scenario group TELEMETRY to scenario {context.scenario.name}"
+class _TelemetrySingleton:
+    ALL_TELEMETRY_CONFIGS = None
 
+    @staticmethod
+    def get_all_telemetry_configs() -> dict[str, Any]:
+        # ensure that any scenario using this method got ScenarioGroup.TELEMETRY
+        assert (
+            ScenarioGroup.TELEMETRY in context.scenario.scenario_groups
+        ), f"Please add scenario group TELEMETRY to scenario {context.scenario.name}"
+
+        if _TelemetrySingleton.ALL_TELEMETRY_CONFIGS is None:
+            _TelemetrySingleton.ALL_TELEMETRY_CONFIGS = {
+                "config_norm_rules": _load_telemetry_json("config_norm_rules"),
+                "config_prefix_block_list": _load_telemetry_json("config_prefix_block_list"),
+                "config_aggregation_list": _load_telemetry_json("config_aggregation_list"),
+                "lang_configs": _load_get_lang_configs(),
+            }
+
+        return _TelemetrySingleton.ALL_TELEMETRY_CONFIGS
+
+
+def get_lang_configs():
+    return _TelemetrySingleton.get_all_telemetry_configs()["lang_configs"]
+
+
+def _load_get_lang_configs():
     lang_configs = {}
     for lang in ["dotnet", "go", "jvm", "nodejs", "php", "python", "ruby"]:
-        lang_configs[lang] = load_telemetry_json(lang + "_config_rules")
+        lang_configs[lang] = _load_telemetry_json(lang + "_config_rules")
 
     return lang_configs
 
 
-def load_telemetry_json(filename: str):
-    # ensure that any scneario using this method got ScenarioGroup.TELEMETRY
-    assert (
-        ScenarioGroup.TELEMETRY in context.scenario.scenario_groups
-    ), f"Please add scenario group TELEMETRY to scenario {context.scenario.name}"
+def get_config_norm_rules():
+    return _TelemetrySingleton.get_all_telemetry_configs()["config_norm_rules"]
 
+
+def get_config_prefix_block_list():
+    return _TelemetrySingleton.get_all_telemetry_configs()["config_prefix_block_list"]
+
+
+def get_config_aggregation_list():
+    return _TelemetrySingleton.get_all_telemetry_configs()["config_aggregation_list"]
+
+
+def _load_telemetry_json(filename: str):
     with open(f"utils/telemetry/intake/static/{filename}.json", encoding="utf-8") as fh:
         return _lowercase_obj(json.load(fh))
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Simplify the reading of telemetry data

## Changes

<!-- A brief description of the change being made with this pull request. -->
Turns telemetry data into a singleton so it's only read once with tight encapsulation 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
