### PR TITLE
test(debugger): ensure code origins is disabled by default

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -737,7 +737,7 @@ class Test_ProductsDisabled:
         lang_configs = get_lang_configs()
         lang_configs["java"] = lang_configs["jvm"]
 
-        di_config, er_config = None, None
+        di_config, er_config, co_config = None, None, None
         for data in interfaces.library.get_telemetry_data():
             if get_request_type(data) not in ["app-started", "app-client-configuration-change"]:
                 continue
@@ -764,9 +764,13 @@ class Test_ProductsDisabled:
             if normalized_config.get("exception_replay_enabled") is not None:
                 er_config = str(normalized_config["exception_replay_enabled"]).lower()
 
+            if normalized_config.get("code_origin_for_spans_enabled") is not None:
+                co_config = str(normalized_config["code_origin_for_spans_enabled"]).lower()
+
         assert data_found, "No app-started event found in telemetry data"
         assert di_config == "false", "DI should be disabled by default"
         assert er_config == "false", "Exception Replay should be disabled by default"
+        assert co_config == "false", "Code Origin for Spans should be disabled by default"
 
 
 @features.dd_telemetry_dependency_collection_enabled_supported


### PR DESCRIPTION
## Motivation

This pull request updates the `test_debugger_products_disabled` test in `tests/test_telemetry.py` to include validation for a new configuration setting, `code_origin_for_spans_enabled`. The changes ensure that this new setting is properly tested alongside existing configurations.

## Changes

* [`tests/test_telemetry.py`](diffhunk://#diff-6ab9dd4d058d45bd9344fb44a8b55b5c358f9e2648bf50bbdedcbfe2dd50220cL740-R740): Added a new variable, `co_config`, to track the `code_origin_for_spans_enabled` setting. Updated the test logic to check if this setting is present in the telemetry data and assert that it is disabled by default. [[1]](diffhunk://#diff-6ab9dd4d058d45bd9344fb44a8b55b5c358f9e2648bf50bbdedcbfe2dd50220cL740-R740) [[2]](diffhunk://#diff-6ab9dd4d058d45bd9344fb44a8b55b5c358f9e2648bf50bbdedcbfe2dd50220cR767-R773)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
