### PR TITLE
[Java] Add jvmstat telemetry logging override (follow-up)

### DIFF
--- a/tests/test_library_logs.py
+++ b/tests/test_library_logs.py
@@ -85,6 +85,7 @@ class Test_NoExceptions:
             re.escape("Skipped authentication, auth={}"),
             # APPSEC-56726:
             re.escape("Attempt to replace context value for {}"),
+            re.escape(".*Failed to find the jdk.internal.jvmstat module.*"),
         ]
         if context.weblog_variant == "spring-boot-openliberty":
             # AIDM-588:


### PR DESCRIPTION
## Motivation

This is a follow-up to https://github.com/DataDog/system-tests/pull/4547

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
