### PR TITLE
[nodejs] Disable IAST deduplication cookie name filter tests for future tracers versions

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -38,6 +38,7 @@ refs:
   - &ref_5_22_0 '>=5.22.0 || ^4.46.0'
   - &ref_5_23_0 '>=5.23.0 || ^4.47.0'
   - &ref_5_24_0 '>=5.24.0 || ^4.48.0'
+  - &ref_5_24_0_5_49_0 '5.24.0 - 5.49.0 || ^4.48.0'
   - &ref_5_25_0 '>=5.25.0 || ^4.49.0'
   - &ref_5_26_0 '>=5.26.0 || ^4.50.0'
   - &ref_5_27_0 '>=5.27.0 || ^4.51.0'
@@ -189,7 +190,7 @@ tests/:
             '*': *ref_4_1_0
             nextjs: missing_feature
           TestInsecureCookieNameFilter:
-            '*': *ref_5_24_0
+            '*': *ref_5_24_0_5_49_0
             nextjs: missing_feature
           TestInsecureCookie_ExtendedLocation:
             '*': *ref_5_37_0
@@ -212,7 +213,7 @@ tests/:
             '*': *ref_4_3_0
             nextjs: missing_feature
           TestNoHttponlyCookieNameFilter:
-            '*': *ref_5_24_0
+            '*': *ref_5_24_0_5_49_0
             nextjs: missing_feature
           TestNoHttponlyCookie_ExtendedLocation:
             '*': *ref_5_37_0
@@ -225,7 +226,7 @@ tests/:
             '*': *ref_4_3_0
             nextjs: missing_feature
           TestNoSamesiteCookieNameFilter:
-            '*': *ref_5_24_0
+            '*': *ref_5_24_0_5_49_0
             nextjs: missing_feature
           TestNoSamesiteCookie_ExtendedLocation:
             '*': *ref_5_37_0

--- a/tests/appsec/iast/utils.py
+++ b/tests/appsec/iast/utils.py
@@ -1,5 +1,5 @@
 import json
-from utils import weblog, interfaces, context, logger
+from utils import weblog, interfaces, context, logger, irrelevant
 from utils._weblog import HttpResponse
 
 
@@ -576,6 +576,10 @@ class BaseTestCookieNameFilter:
         self.req2 = weblog.post(self.endpoint, data={"cookieName": cookie_name_2, "cookieValue": "value2"})
         self.req3 = weblog.post(self.endpoint, data={"cookieName": cookie_name_3, "cookieValue": "value3"})
 
+    @irrelevant(
+        context.library >= "nodejs@5.50.0",
+        reason="cookie name filtering is not present anymore after the change on cookie vuln hash calculation.",
+    )
     def test_cookie_name_filter(self) -> None:
         assert_iast_vulnerability(
             request=self.req1,


### PR DESCRIPTION
## Motivation

Since cookie name is not used anymore as hash key, cookie vulnerability hashes are computed in the same way that the others. So cookie name filtering has been deprecated from `v5.50.0`.

## Changes

Set the correct version in Node.js manifest for cookie name filter tests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
