### PR TITLE
Check stackId for IAST extended location tests

### DIFF
--- a/tests/appsec/iast/utils.py
+++ b/tests/appsec/iast/utils.py
@@ -304,6 +304,11 @@ def validate_extended_location_data(
     location = vuln["location"]
 
     stack_id = location.get("stackId")
+    # XXX: Backwards compatibility trick for tracers that got `stackId` outside location.
+    # The correct stackId location is tested else wher e.g. schema tests.
+    if not stack_id:
+        stack_id = vuln.get("stackId")
+
     if not stack_id:
         # If there is no stacktrace, just check for the presence of basic attributes.
         assert all(field in location for field in ["path", "line"])


### PR DESCRIPTION
## Motivation
Check stackId for IAST extended location tests:
* If there are two vulnerabilities, the code did not ensure we selected the correct stacktrace.
* If `stackId` was not correctly set, we could still be incorrectly matching a stacktrace.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
