### PR TITLE
[python] fixing manifest version for new tests

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -491,19 +491,19 @@ tests/:
       Test_V3_Auto_User_Instrum_Mode_Capability: v2.11.0
       Test_V3_Login_Events:
         '*': v2.20.0.dev
-        'django-poc': v3.6.0.dev (is v2.20.0.dev but weblog use new SDK now)
-        'django-py3.13': v3.6.0.dev (is v2.20.0.dev but weblog use new SDK now)
-        'python3.12': v3.6.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        'django-poc': v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        'django-py3.13': v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        'python3.12': v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
       Test_V3_Login_Events_Anon:
         '*': v2.20.0.dev
-        'django-poc': v3.6.0.dev (is v2.20.0.dev but weblog use new SDK now)
-        'django-py3.13': v3.6.0.dev (is v2.20.0.dev but weblog use new SDK now)
-        'python3.12': v3.6.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        'django-poc': v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        'django-py3.13': v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        'python3.12': v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
       Test_V3_Login_Events_Blocking:
         '*': v2.20.0.dev
-        'django-poc': v3.6.0.dev (is v2.20.0.dev but weblog use new SDK now)
-        'django-py3.13': v3.6.0.dev (is v2.20.0.dev but weblog use new SDK now)
-        'python3.12': v3.6.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        'django-poc': v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        'django-py3.13': v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        'python3.12': v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
       Test_V3_Login_Events_RC: v2.11.0
     test_automated_user_and_session_tracking.py:
       Test_Automated_Session_Blocking:
@@ -513,14 +513,14 @@ tests/:
         python3.12: v3.3.0.dev
       Test_Automated_User_Blocking:
         '*': v3.0.0.rc
-        'django-poc': v3.6.0.dev (is v3.0.0.rc but weblog use new SDK now)
-        'django-py3.13': v3.6.0.dev (is v3.0.0.rc but weblog use new SDK now)
-        'python3.12': v3.6.0.dev (is v3.0.0.rc but weblog use new SDK now)
+        'django-poc': v3.7.0.dev (is v3.0.0.rc but weblog use new SDK now)
+        'django-py3.13': v3.7.0.dev (is v3.0.0.rc but weblog use new SDK now)
+        'python3.12': v3.7.0.dev (is v3.0.0.rc but weblog use new SDK now)
       Test_Automated_User_Tracking:
         '*': v3.1.0.dev
-        'django-poc': v3.6.0.dev (is v3.1.0.dev but weblog use new SDK now)
-        'django-py3.13': v3.6.0.dev (is v3.1.0.dev but weblog use new SDK now)
-        'python3.12': v3.6.0.dev (is v3.1.0.dev but weblog use new SDK now)
+        'django-poc': v3.7.0.dev (is v3.1.0.dev but weblog use new SDK now)
+        'django-py3.13': v3.7.0.dev (is v3.1.0.dev but weblog use new SDK now)
+        'python3.12': v3.7.0.dev (is v3.1.0.dev but weblog use new SDK now)
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
       Test_Blocking_client_ip:
@@ -597,39 +597,39 @@ tests/:
     test_event_tracking.py:
       Test_CustomEvent:
         '*': v1.10.0
-        'django-poc': v3.6.0.dev (is v1.10.0 but weblog use new SDK now)'
-        'django-py3.13': v3.6.0.dev (is v1.10.0 but weblog use new SDK now)
-        'python3.12': v3.6.0.dev (is v1.10.0 but weblog use new SDK now)
+        'django-poc': v3.7.0.dev (is v1.10.0 but weblog use new SDK now)'
+        'django-py3.13': v3.7.0.dev (is v1.10.0 but weblog use new SDK now)
+        'python3.12': v3.7.0.dev (is v1.10.0 but weblog use new SDK now)
       Test_CustomEvent_Metrics: missing_feature
       Test_UserLoginFailureEvent:
         '*': v2.10.0
-        'django-poc': v3.6.0.dev (is v2.10.0 but weblog use new SDK now)'
-        'django-py3.13': v3.6.0.dev (is v2.10.0 but weblog use new SDK now)
-        'python3.12': v3.6.0.dev (is v2.10.0 but weblog use new SDK now)
+        'django-poc': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)'
+        'django-py3.13': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
+        'python3.12': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
       Test_UserLoginFailureEvent_Metrics: missing_feature
       Test_UserLoginSuccessEvent:
         '*': v2.10.0
-        'django-poc': v3.6.0.dev (is v2.10.0 but weblog use new SDK now)'
-        'django-py3.13': v3.6.0.dev (is v2.10.0 but weblog use new SDK now)
-        'python3.12': v3.6.0.dev (is v2.10.0 but weblog use new SDK now)
+        'django-poc': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)'
+        'django-py3.13': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
+        'python3.12': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
       Test_UserLoginSuccessEvent_Metrics: missing_feature
     test_event_tracking_v2.py:
       Test_UserLoginFailureEventV2_HeaderCollection:
-        '*': v3.6.0.dev
+        '*': v3.7.0.dev
       Test_UserLoginFailureEventV2_Libddwaf:
-        '*': v3.6.0.dev
+        '*': v3.7.0.dev
       Test_UserLoginFailureEventV2_Metrics:
-        '*': v3.6.0.dev
+        '*': v3.7.0.dev
       Test_UserLoginFailureEventV2_Tags:
-        '*': v3.6.0.dev
+        '*': v3.7.0.dev
       Test_UserLoginSuccessEventV2_HeaderCollection:
-        '*': v3.6.0.dev
+        '*': v3.7.0.dev
       Test_UserLoginSuccessEventV2_Libddwaf:
-        '*': v3.6.0.dev
+        '*': v3.7.0.dev
       Test_UserLoginSuccessEventV2_Metrics:
-        '*': v3.6.0.dev
+        '*': v3.7.0.dev
       Test_UserLoginSuccessEventV2_Tags:
-        '*': v3.6.0.dev
+        '*': v3.7.0.dev
     test_fingerprinting.py:
       Test_Fingerprinting_Endpoint: v2.11.0
       Test_Fingerprinting_Endpoint_Capability: v2.11.0


### PR DESCRIPTION
## Motivation

When https://github.com/DataDog/system-tests/pull/4565 passed the CI, the dev branch was still 3.6.0.dev but the required changes were only merged in 3.7 released. This is making the CI fail for prod now.

Fixing this by upgrading the required versions for the new tests.


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
