### PR TITLE
Add IAST schema validation

### DIFF
--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -11,6 +11,7 @@ tests/:
       sink/: irrelevant (ASM is not implemented in C++)
       source/: irrelevant (ASM is not implemented in C++)
       test_security_controls.py: irrelevant (ASM is not implemented in C++)
+      test_vulnerability_schema.py: irrelevant (ASM is not implemented in C++)
     rasp/: irrelevant (ASM is not implemented in C++)
     waf/: irrelevant (ASM is not implemented in C++)
     test_alpha.py: irrelevant (ASM is not implemented in C++)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -198,6 +198,8 @@ tests/:
           TestURI: missing_feature
       test_security_controls.py:
         TestSecurityControls: missing_feature
+      test_vulnerability_schema.py:
+        TestIastVulnerabilitySchema: missing_feature
     rasp/:
       test_cmdi.py: missing_feature
       test_lfi.py: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -727,6 +727,8 @@ tests/:
           play: missing_feature
           ratpack: missing_feature
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      test_vulnerability_schema.py:
+        TestIastVulnerabilitySchema: missing_feature
     rasp/:
       test_cmdi.py:
         Test_Cmdi_BodyJson:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -429,6 +429,8 @@ tests/:
         TestSecurityControls:
           '*': *ref_5_37_0
           nextjs: missing_feature
+      test_vulnerability_schema.py:
+        TestIastVulnerabilitySchema: missing_feature
     rasp/:
       test_cmdi.py:
         Test_Cmdi_BodyJson:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -183,6 +183,8 @@ tests/:
           TestURI: missing_feature
       test_security_controls.py:
         TestSecurityControls: missing_feature
+      test_vulnerability_schema.py:
+        TestIastVulnerabilitySchema: missing_feature
     rasp/:
       test_cmdi.py:
         Test_Cmdi_BodyJson: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -264,6 +264,8 @@ tests/:
           TestURI: missing_feature
       test_security_controls.py:
         TestSecurityControls: missing_feature
+      test_vulnerability_schema.py:
+        TestIastVulnerabilitySchema: missing_feature
     rasp/:
       test_cmdi.py:
         Test_Cmdi_BodyJson: v2.20.0.dev

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -184,6 +184,8 @@ tests/:
           TestURI: missing_feature
       test_security_controls.py:
         TestSecurityControls: missing_feature
+      test_vulnerability_schema.py:
+        TestIastVulnerabilitySchema: missing_feature
     rasp/:
       test_cmdi.py: missing_feature
       test_lfi.py: missing_feature

--- a/tests/appsec/iast/test_vulnerability_schema.py
+++ b/tests/appsec/iast/test_vulnerability_schema.py
@@ -1,0 +1,21 @@
+import jsonschema
+import json
+from pathlib import Path
+from utils import interfaces, features
+
+
+@features.iast_schema
+class TestIastVulnerabilitySchema:
+    def test_vulnerability_schema(self):
+        schema_path = Path(__file__).parent / "vulnerability_schema.json"
+        with open(schema_path, "r") as f:
+            schema = json.load(f)
+        validator = jsonschema.Draft7Validator(schema)
+        spans = [s for _, s in interfaces.library.get_root_spans()]
+        for span in spans:
+            meta = span.get("meta", {})
+            if "_dd.iast.json" not in meta:
+                continue
+            iast_data = meta["_dd.iast.json"]
+            validation_errors = list(validator.iter_errors(iast_data))
+            assert not validation_errors, f"Invalid IAST data for span: {iast_data}"

--- a/tests/appsec/iast/vulnerability_schema.json
+++ b/tests/appsec/iast/vulnerability_schema.json
@@ -1,0 +1,247 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "IAST vulnerability events 1.0.0",
+    "title": "iast",
+    "type": "object",
+    "properties": {
+        "sources": {
+            "description": "List of sources where the input data for the vulnerabilities originated (request parameters, headers ...).",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "origin": {
+                        "description": "Origin of the source (where the source comes from).",
+                        "type": "string",
+                        "enum": [
+                            "http.request.parameter",
+                            "http.request.parameter.name",
+                            "http.request.header",
+                            "http.request.header.name",
+                            "http.request.path",
+                            "http.request.body",
+                            "http.request.query",
+                            "http.request.path.parameter",
+                            "http.request.matrix.parameter",
+                            "http.request.cookie.name",
+                            "http.request.cookie.value",
+                            "http.request.uri",
+                            "grpc.request.body",
+                            "http.request.multipart.parameter",
+                            "kafka.message.key",
+                            "kafka.message.value",
+                            "graphql.resolver.argument",
+                            "sql.row.value"
+                        ]
+                    },
+                    "name": {
+                        "description": "Name of the source. For example, the name of the request parameter.",
+                        "type": "string"
+                    },
+                    "value": {
+                        "value": "Value of the source. For example, the value of the request parameter",
+                        "type": "string"
+                    },
+                    "redacted": {
+                        "value": "If the value of the source has been redacted",
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "origin",
+                    "name"
+                ],
+                "oneOf": [
+                    { "required": ["value"] },
+                    { "required": ["redacted"] }
+                ]
+            }
+        },
+        "vulnerabilities": {
+            "description": "List of vulnerabilities found in the current execution context.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "$ref": "#/definitions/VulnerabilityType"
+                    },
+                    "hash": {
+                        "description": "Unique identifier for a particular vulnerability, used to deduplicate them",
+                        "type": "integer"
+                    },
+                    "evidence": {
+                        "description": "The evidence of the vulnerability describing why there is a vulnerability",
+                        "oneOf": [
+                            { "$ref": "#/definitions/StringEvidence" },
+                            { "$ref": "#/definitions/TaintedEvidence" }
+                        ]
+                    },
+                    "location": {
+                        "description": "The location of the vulnerability in the source code",
+                        "type": "object",
+                        "properties": {
+                            "spanId": {
+                                "description": "The ID of the active span when the vulnerability was triggered, for later use in correlation APIs",
+                                "type": "integer"
+                            },
+                            "path": {
+                                "description": "The name of the file containing the vulnerability.",
+                                "type": "string"
+                            },
+                            "class": {
+                                "description": "The name of the class containing the vulnerability.",
+                                "type": "string"
+                            },
+                            "line": {
+                                "description": "The zero based line number in the source code file where the vulnerability is located",
+                                "type": "integer",
+                                "minimum": 0
+                            },
+                            "method": {
+                                "description": "Name or descriptor of the method where this location points to.",
+                                "type": "string"
+                            },
+                            "stackId": {
+                                "description": "Id of the stack in the vulnerability category under the _dd.stack tag in metastruct, ",
+                                "type": "string"
+                            }                            
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "spanId"
+                        ]
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "type",
+                    "hash"
+                ]
+            }
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "vulnerabilities"
+    ],
+    "definitions": {
+        "VulnerabilityType":{
+            "description": "Type of the vulnerability",
+            "type": "string",
+            "enum": [
+                "ADMIN_CONSOLE_ACTIVE",
+                "CODE_INJECTION",
+                "COMMAND_INJECTION",
+                "DEFAULT_HTML_ESCAPE_INVALID",
+                "DIRECTORY_LISTING_LEAK",
+                "EMAIL_HTML_INJECTION",   
+                "HARDCODED_KEY", 
+                "HARDCODED_PASSWORD",
+                "HARDCODED_SECRET",
+                "HEADER_INJECTION",
+                "HSTS_HEADER_MISSING",
+                "INSECURE_AUTH_PROTOCOL",
+                "INSECURE_COOKIE",
+                "INSECURE_JSP_LAYOUT",
+                "LDAP_INJECTION",
+                "NOSQL_MONGODB_INJECTION",
+                "NO_HTTPONLY_COOKIE",
+                "NO_SAMESITE_COOKIE",
+                "PATH_TRAVERSAL",
+                "REFLECTION_INJECTION",
+                "SESSION_REWRITING",
+                "SESSION_TIMEOUT",
+                "SQL_INJECTION",
+                "SSRF",
+                "STACKTRACE_LEAK",
+                "TEMPLATE_INJECTION",
+                "TRUST_BOUNDARY_VIOLATION",
+                "UNTRUSTED_DESERIALIZATION",
+                "UNVALIDATED_REDIRECT",
+                "VERB_TAMPERING",
+                "WEAK_CIPHER",
+                "WEAK_HASH",
+                "WEAK_RANDOMNESS",
+                "XCONTENTTYPE_HEADER_MISSING",
+                "XPATH_INJECTION",
+                "XSS"
+            ]
+        },
+        "StringEvidence": {
+            "$ref": "#/definitions/StringValue",
+            "description": "Value that triggered the vulnerability. For example, crypto algorithm for insecure cipher"
+        },
+        "TaintedEvidence": {
+            "type": "object",
+            "description": "Value that triggered the vulnerability including the string value and tainted ranges",
+            "properties": {
+                "valueParts": {
+                    "description": "Each of the parts of the tainted value that triggered the vulnerability",
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            { "$ref": "#/definitions/TaintedValue" },
+                            { "$ref": "#/definitions/StringValue" }
+                        ]
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "valueParts"
+            ]
+        },
+        "StringValue": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "description": "String value part of the evidence",
+                    "type": "string"
+                },
+                "redacted": {
+                    "value": "If the current value of the evidence has been redacted",
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false,
+            "oneOf": [
+                { "required": ["value"] },
+                { "required": ["redacted"] }
+            ]
+        },
+        "TaintedValue": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "description": "The string value that is tainted",
+                    "type": "string"
+                },
+                "source": {
+                    "description": "The index of the source in the sources array",
+                    "type": "integer"
+                },
+                "redacted": {
+                    "value": "If the current value of the evidence has been redacted",
+                    "type": "boolean"
+                },
+                "secure_marks": {
+                    "description": "Secure marks for evidence part",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VulnerabilityType"
+                    }
+                }
+            },
+            "required": [
+                "source"
+            ],
+            "additionalProperties": false,
+            "oneOf": [
+                { "required": ["value"] },
+                { "required": ["redacted"] }
+            ]
+        }
+    }
+}

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2582,5 +2582,14 @@ class _Features:
         pytest.mark.features(feature_id=387)(test_object)
         return test_object
 
+    @staticmethod
+    def iast_schema(test_object):
+        """Enforces standardized behaviors for configurations across the tracing libraries.
+
+        https://feature-parity.us1.prod.dog/#/?feature=394
+        """
+        pytest.mark.features(feature_id=394)(test_object)
+        return test_object
+
 
 features = _Features()


### PR DESCRIPTION
## Motivation

We used to host the IAST vulnerability schema in a separate internal repository. Implementations have often deviated. So moving the schema to system-tests as source of truth, and check that all IAST payloads conform to it.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
