### PR TITLE
Update IAST vulnerability schema

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -727,8 +727,6 @@ tests/:
           play: missing_feature
           ratpack: missing_feature
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      test_vulnerability_schema.py:
-        TestIastVulnerabilitySchema: missing_feature
     rasp/:
       test_cmdi.py:
         Test_Cmdi_BodyJson:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -429,8 +429,6 @@ tests/:
         TestSecurityControls:
           '*': *ref_5_37_0
           nextjs: missing_feature
-      test_vulnerability_schema.py:
-        TestIastVulnerabilitySchema: missing_feature
     rasp/:
       test_cmdi.py:
         Test_Cmdi_BodyJson:

--- a/tests/appsec/iast/vulnerability_schema.json
+++ b/tests/appsec/iast/vulnerability_schema.json
@@ -39,22 +39,25 @@
                         "type": "string"
                     },
                     "value": {
-                        "value": "Value of the source. For example, the value of the request parameter",
+                        "description": "Value of the source. For example, the value of the request parameter",
+                        "type": "string"
+                    },
+                    "pattern": {
+                        "description": "Pattern characterizing the redacted value",
                         "type": "string"
                     },
                     "redacted": {
-                        "value": "If the value of the source has been redacted",
-                        "type": "boolean"
+                        "description": "If the value of the source has been redacted",
+                        "const": true
+                    },
+                    "truncated": {
+                        "description": "Side at which truncation happened (if any)",
+                        "const": "right"
                     }
                 },
                 "additionalProperties": false,
                 "required": [
-                    "origin",
-                    "name"
-                ],
-                "oneOf": [
-                    { "required": ["value"] },
-                    { "required": ["redacted"] }
+                    "origin"
                 ]
             }
         },
@@ -75,7 +78,8 @@
                         "description": "The evidence of the vulnerability describing why there is a vulnerability",
                         "oneOf": [
                             { "$ref": "#/definitions/StringEvidence" },
-                            { "$ref": "#/definitions/TaintedEvidence" }
+                            { "$ref": "#/definitions/TaintedEvidence" },
+                            { "$ref": "#/definitions/EmptyEvidence" }
                         ]
                     },
                     "location": {
@@ -84,7 +88,10 @@
                         "properties": {
                             "spanId": {
                                 "description": "The ID of the active span when the vulnerability was triggered, for later use in correlation APIs",
-                                "type": "integer"
+                                "oneOf": [
+                                    { "type": "integer" },
+                                    { "type": "string" }
+                                ]
                             },
                             "path": {
                                 "description": "The name of the file containing the vulnerability.",
@@ -95,9 +102,9 @@
                                 "type": "string"
                             },
                             "line": {
-                                "description": "The zero based line number in the source code file where the vulnerability is located",
+                                "description": "The zero based line number in the source code file where the vulnerability is located (-1 may be used as missing line)",
                                 "type": "integer",
-                                "minimum": 0
+                                "minimum": -1
                             },
                             "method": {
                                 "description": "Name or descriptor of the method where this location points to.",
@@ -169,6 +176,12 @@
                 "XSS"
             ]
         },
+        "EmptyEvidence": {
+            "type": "object",
+            "description": "Empty evidence",
+            "properties": {},
+            "additionalProperties": false
+        },
         "StringEvidence": {
             "$ref": "#/definitions/StringValue",
             "description": "Value that triggered the vulnerability. For example, crypto algorithm for insecure cipher"
@@ -194,24 +207,56 @@
             ]
         },
         "StringValue": {
+            "oneOf": [
+                { "$ref": "#/definitions/UnredactedStringValue" },
+                { "$ref": "#/definitions/RedactedStringValue" }
+            ]
+        },
+        "UnredactedStringValue": {
             "type": "object",
             "properties": {
                 "value": {
                     "description": "String value part of the evidence",
                     "type": "string"
                 },
-                "redacted": {
-                    "value": "If the current value of the evidence has been redacted",
-                    "type": "boolean"
+                "truncated": {
+                    "description": "Side at which truncation happened (if any)",
+                    "const": "right"
                 }
             },
             "additionalProperties": false,
             "oneOf": [
-                { "required": ["value"] },
-                { "required": ["redacted"] }
+                { "required": ["value"] }
+            ]
+        },
+        "RedactedStringValue": {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "description": "Pattern characterizing the redacted value",
+                    "type": "string"
+                },
+                "redacted": {
+                    "description": "If the current value of the evidence has been redacted",
+                    "const": true
+                },
+                "truncated": {
+                    "description": "Side at which truncation happened (if any)",
+                    "const": "right"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "redacted"
             ]
         },
         "TaintedValue": {
+            "oneOf": [
+                { "$ref": "#/definitions/UnredactedTaintedValue" },
+                { "$ref": "#/definitions/RedactedTaintedValue" }
+            ]
+        },
+        "UnredactedTaintedValue": {
             "type": "object",
             "properties": {
                 "value": {
@@ -222,9 +267,38 @@
                     "description": "The index of the source in the sources array",
                     "type": "integer"
                 },
+                "secure_marks": {
+                    "description": "Secure marks for evidence part",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VulnerabilityType"
+                    }
+                },
+                "truncated": {
+                    "description": "Side at which truncation happened (if any)",
+                    "const": "right"
+                }
+            },
+            "required": [
+                "value",
+                "source"
+            ],
+            "additionalProperties": false
+        },
+        "RedactedTaintedValue": {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "description": "Pattern characterizing the redacted value",
+                    "type": "string"
+                },
                 "redacted": {
-                    "value": "If the current value of the evidence has been redacted",
-                    "type": "boolean"
+                    "description": "If the current value of the evidence has been redacted",
+                    "const": true
+                },
+                "source": {
+                    "description": "The index of the source in the sources array",
+                    "type": "integer"
                 },
                 "secure_marks": {
                     "description": "Secure marks for evidence part",
@@ -232,15 +306,16 @@
                     "items": {
                         "$ref": "#/definitions/VulnerabilityType"
                     }
+                },
+                "truncated": {
+                    "description": "Side at which truncation happened (if any)",
+                    "const": "right"
                 }
             },
-            "required": [
-                "source"
-            ],
             "additionalProperties": false,
-            "oneOf": [
-                { "required": ["value"] },
-                { "required": ["redacted"] }
+            "required": [
+                "redacted",
+                "source"
             ]
         }
     }


### PR DESCRIPTION
## Motivation

Update schema with a few changes from RFCs and other discussions:

* A source may lack `value` (e.g. a bytestream for HTTP body, which is not captured) or `name` (cannot determine which part of the body is being used). So the only required field for source is `origin`. This is the case in Java when tainting an InputStream representing a body.
* Evidence may be empty. This is the case in Node.js with weak randomness.
* The field `redacted` can be `true` or absent, but not `false`. It is omitted in that case.
* Added validation for `truncated` field.
* When evidence is redacted, there is no `value` field, but there is a `pattern` field instead.
* In location, `line` may be `-1` (representing an unknown line). This is the case in Java, for example, in native code.
* In location, `spanId` may be represented as an integer (presumably a 64bit id), or a string (64bit or 128bit id). The original spec was always the former. Node.js uses the later. Backend is currently not using this field.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
