### PR TITLE
debugger(php): Wait for probe statuses for PHP

### DIFF
--- a/tests/debugger/test_debugger_expression_language.py
+++ b/tests/debugger/test_debugger_expression_language.py
@@ -17,9 +17,9 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
     def _setup(self, probes, request_path):
         self.set_probes(probes)
         self.send_rc_probes()
-        self.wait_for_all_probes_installed()
+        self.wait_for_all_probes(statuses=["INSTALLED"])
         self.send_weblog_request(request_path)
-        self.wait_for_all_probes_emitting()
+        self.wait_for_all_probes(statuses=["EMITTING"])
 
     ############ assert ############
     def _assert(self, expected_response: int):

--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -40,16 +40,16 @@ class Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation(debugger.BaseDe
         self.rc_states = []
 
         _send_config()
-        self.di_initial_disabled = not self.wait_for_all_probes_emitting(TIMEOUT)
+        self.di_initial_disabled = not self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
         _send_config(enabled=True)
-        self.di_explicit_enabled = self.wait_for_all_probes_emitting(TIMEOUT)
+        self.di_explicit_enabled = self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
         _send_config()
-        self.di_empty_config = self.wait_for_all_probes_emitting(TIMEOUT)
+        self.di_empty_config = self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
         _send_config(enabled=False)
-        self.di_explicit_disabled = not self.wait_for_all_probes_emitting(TIMEOUT)
+        self.di_explicit_disabled = not self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
     def test_inproduct_enablement_di(self):
         self.assert_rc_state_not_error()

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -124,9 +124,9 @@ class Test_Debugger_PII_Redaction(debugger.BaseDebuggerTest):
 
         self.set_probes(probes)
         self.send_rc_probes()
-        self.wait_for_all_probes_installed()
+        self.wait_for_all_probes(statuses=["INSTALLED"])
         self.send_weblog_request("/debugger/pii")
-        self.wait_for_all_probes_emitting()
+        self.wait_for_all_probes(statuses=["EMITTING"])
 
     ############ assert ############
     def _assert(self, redacted_keys, redacted_types, *, line_probe=False):

--- a/tests/debugger/test_debugger_probe_budgets.py
+++ b/tests/debugger/test_debugger_probe_budgets.py
@@ -38,7 +38,7 @@ class Test_Debugger_Probe_Budgets(debugger.BaseDebuggerTest):
 
         ### send requests
         self.send_rc_probes()
-        self.wait_for_all_probes_installed()
+        self.wait_for_all_probes(statuses=["INSTALLED"])
 
         start_time = time.time()
         self.send_weblog_request(request_path)
@@ -46,7 +46,7 @@ class Test_Debugger_Probe_Budgets(debugger.BaseDebuggerTest):
         # Store the total request time for later use in debugging tests where budgets are limited by time.
         self.total_request_time = end_time - start_time
 
-        self.wait_for_all_probes_emitting()
+        self.wait_for_all_probes(statuses=["EMITTING"])
 
     def _assert(self):
         self.collect()

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -39,7 +39,7 @@ class BaseDebuggerProbeSnaphotTest(debugger.BaseDebuggerTest):
 
         ### send requests
         self.send_rc_probes()
-        self.wait_for_all_probes_installed()
+        self.wait_for_all_probes(statuses=["INSTALLED"])
 
         start_time = time.time()
         self.send_weblog_request(request_path)
@@ -47,7 +47,7 @@ class BaseDebuggerProbeSnaphotTest(debugger.BaseDebuggerTest):
         # Store the total request time for later use in debugging tests where budgets are limited by time.
         self.total_request_time = end_time - start_time
 
-        self.wait_for_all_probes_emitting()
+        self.wait_for_all_probes(statuses=["EMITTING"])
 
     def _assert(self):
         self.collect()

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -36,6 +36,7 @@ class BaseDebuggerProbeStatusTest(debugger.BaseDebuggerTest):
 
         ### send requests
         self.send_rc_probes()
+        self.wait_for_all_probes(statuses=["INSTALLED", "RECEIVED"])
 
     def _assert(self):
         self.collect()


### PR DESCRIPTION
## Motivation

This pull request attempts to fix the [flakey PHP test](https://github.com/DataDog/system-tests-dashboard/actions/runs/14796928693/job/41553463399) by polling for statuses before asserts. It also refactors the probe status-checking functionality in the debugger test suite to improve flexibility and maintainability. The key change is the replacement of multiple specialized methods (`wait_for_all_probes_installed`, `wait_for_all_probes_emitting`) with a single generalized method (`wait_for_all_probes`) that accepts a list of statuses to wait for. This update simplifies the codebase and allows for more versatile status checks.

## Changes

  - Replaced `wait_for_all_probes_installed` and `wait_for_all_probes_emitting` with a single `wait_for_all_probes` method that accepts a `statuses` parameter. This allows for waiting on multiple statuses (e.g., `["INSTALLED", "EMITTING"]`) in a single call. (`tests/debugger/utils.py`, [[1]](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821L249-R259) [[2]](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821L272-R272) [[3]](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821L301-R297)
  - Modified `_setup` methods across various test files (`test_debugger_expression_language.py`, `test_debugger_pii.py`, `test_debugger_probe_budgets.py`, `test_debugger_probe_snapshot.py`) to use the new `wait_for_all_probes` method with appropriate statuses. (`[[1]](diffhunk://#diff-0539d5c323dff80a4f41945f9e8cef220330f0a29fe480e03d2105bfa4c6dc5eL20-R22)`, `[[2]](diffhunk://#diff-2cc81d31929c49f7bdc8fa6992d99f5d975abaea0843ee29909de7bf042d1728L127-R129)`, `[[3]](diffhunk://#diff-2dbb025e3913c31d55061570a493b7e754ab41ad60f082378e7fe6095f41896cL41-R49)`, `[[4]](diffhunk://#diff-838dccab9204ff2351b256cb32211afd0bd44a0cf4ff368044354f987b8dd462L42-R50)`)
  - Added support for waiting on multiple statuses (e.g., `["INSTALLED", "RECEIVED"]`) in specific tests, such as `test_debugger_probe_status.py`. (`[tests/debugger/test_debugger_probe_status.pyR39](diffhunk://#diff-67081901be029daaca4be54be8a1da76625549618ce0ebeeadaa82ecf079f984R39)`)
  - Eliminated the now-unnecessary `wait_for_all_probes_installed` and `wait_for_all_probes_emitting` methods, consolidating their functionality into `wait_for_all_probes`. (`tests/debugger/utils.py`, [tests/debugger/utils.pyL249-R259](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821L249-R259))
  - Updated logging messages to reflect the new generalized behavior, including listing all statuses being waited for. (`tests/debugger/utils.py`, [tests/debugger/utils.pyL272-R272](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821L272-R272))

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
