### PR TITLE
Uses v2 of DataDog/ensure-ci-success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,10 +148,11 @@ jobs:
     - system_tests
     if: '!cancelled()'
     steps:
-    - uses: DataDog/ensure-ci-success@v0
+    - uses: DataDog/ensure-ci-success@v2
       with:
-        polling-interval-seconds: '30'
-        max-retries: '60'
+        initial-delay-seconds: '300'
+        polling-interval-seconds: '60'
+        max-retries: '120'
         ignored-name-patterns: |
           dd-gitlab/.*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
     steps:
     - uses: DataDog/ensure-ci-success@v2
       with:
-        initial-delay-seconds: '300'
+        # initial-delay-seconds: '300' Don't need this, as the job is executed after system tests
         polling-interval-seconds: '60'
         max-retries: '120'
         ignored-name-patterns: |


### PR DESCRIPTION
## Motivation

Guinea pig for DataDog/ensure-ci-success v2

## Changes

* Add a initial delay of 300s (5mn), no jobs is shorter than this
* set 120 retries * 60s interval -> 2 hours CI 😨  

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
