### PR TITLE
Lenient location matching for missing fields in IAST location

### DIFF
--- a/tests/appsec/iast/utils.py
+++ b/tests/appsec/iast/utils.py
@@ -336,13 +336,16 @@ def validate_extended_location_data(
         assert "frames" in stack_trace
 
         # Verify frame matches location
+        def _norm(s: str | None) -> str | None:
+            return s if s else None
+
         location_match = False
         for frame in stack_trace["frames"]:
             if (
                 frame.get("file", "").endswith(location["path"])
                 and location["line"] == frame["line"]
-                and location.get("class", "") == frame.get("class_name", "")
-                and location.get("method", "") == frame.get("function", "")
+                and _norm(location.get("class")) == _norm(frame.get("class_name"))
+                and _norm(location.get("method")) == _norm(frame.get("function"))
             ):
                 location_match = True
                 break


### PR DESCRIPTION
## Motivation

Python currently signals absent fields in location with empty strings rather than absent fields. Make matching in IAST location tests a bit more lenient.

This will be fixed in Python anyway: https://github.com/DataDog/dd-trace-py/pull/13333
but it's not necessary that the code to match location in stackframe is strict to this level.

Required for https://github.com/DataDog/dd-trace-py/pull/13272 to pass system-tests.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
