### PR TITLE
fix failing test for APPSEC-57552

### DIFF
--- a/tests/appsec/iast/sink/test_header_injection.py
+++ b/tests/appsec/iast/sink/test_header_injection.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import context, features, missing_feature, rfc, weblog, HttpResponse
+from utils import context, features, missing_feature, rfc, weblog, HttpResponse, bug
 from tests.appsec.iast.utils import (
     BaseSinkTest,
     validate_extended_location_data,
@@ -134,5 +134,6 @@ class TestHeaderInjection_ExtendedLocation:
     def setup_extended_location_data(self):
         self.r = weblog.post("/iast/header_injection/test_insecure", data={"test": "dummyvalue"})
 
+    @bug(context.library > "python@3.7.0", reason="APPSEC-57552")
     def test_extended_location_data(self):
         validate_extended_location_data(self.r, self.vulnerability_type)

--- a/tests/appsec/iast/utils.py
+++ b/tests/appsec/iast/utils.py
@@ -300,6 +300,9 @@ def validate_extended_location_data(
     if not is_expected_location_required:
         return
 
+    logger.debug(f"Vulnerabilities: {json.dumps(vulns, indent=2)}")
+    assert len(vulns) == 1, "Expected a single vulnerability with the matching criteria"
+
     vuln = vulns[0]
     location = vuln["location"]
 
@@ -341,12 +344,17 @@ def validate_extended_location_data(
 
         location_match = False
         for frame in stack_trace["frames"]:
-            if (
-                frame.get("file", "").endswith(location["path"])
-                and location["line"] == frame["line"]
-                and _norm(location.get("class")) == _norm(frame.get("class_name"))
-                and _norm(location.get("method")) == _norm(frame.get("function"))
-            ):
+            logger.debug(frame)
+            if not frame.get("file", "").endswith(location["path"]):
+                logger.debug("path does not match")
+            elif frame["line"] != location["line"]:
+                logger.debug("line does not match")
+            elif _norm(location.get("class")) != _norm(frame.get("class_name")):
+                logger.debug("class does not match")
+            elif _norm(location.get("method")) != _norm(frame.get("function")):
+                logger.debug("method does not match")
+            else:
+                logger.debug("location match")
                 location_match = True
                 break
 


### PR DESCRIPTION
## Motivation

Test was failing on python/dev 
Test was flaky, because it allows to have to reported vulns, and checked only the first one. As the order is not stable, the test randomly fails.

## Changes

skip test
allow only one reported vuln

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
