### PR TITLE
[APPSEC-57504] Enable session tracking and fingerprinting

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -363,11 +363,11 @@ tests/:
     test_asm_standalone.py:
       Test_AppSecStandalone_NotEnabled: v2.13.0
       Test_AppSecStandalone_UpstreamPropagation: irrelevant
-      Test_AppSecStandalone_UpstreamPropagation_V2: v2.12.3-dev
+      Test_AppSecStandalone_UpstreamPropagation_V2: v2.13.0
       Test_IastStandalone_UpstreamPropagation: missing_feature
       Test_IastStandalone_UpstreamPropagation_V2: missing_feature
       Test_SCAStandalone_Telemetry: irrelevant
-      Test_SCAStandalone_Telemetry_V2: v2.12.3-dev
+      Test_SCAStandalone_Telemetry_V2: v2.13.0
       Test_UserEventsStandalone: missing_feature
     test_automated_login_events.py:
       Test_Login_Events: irrelevant
@@ -377,81 +377,81 @@ tests/:
       Test_V2_Login_Events_RC: irrelevant
       Test_V3_Auto_User_Instrum_Mode_Capability: missing_feature
       Test_V3_Login_Events:
-        "*": v2.12.3-dev
-        rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra14: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra20: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra21: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra22: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra30: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra31: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra32: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra40: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        "*": v2.13.0
+        rack: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra14: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra20: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra21: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra22: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra30: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra31: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra32: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra40: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        uds-sinatra: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
       Test_V3_Login_Events_Anon:
-        "*": v2.12.3-dev
-        rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra14: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra20: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra21: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra22: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra30: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra31: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra32: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra40: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        "*": v2.13.0
+        rack: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra14: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra20: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra21: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra22: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra30: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra31: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra32: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra40: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        uds-sinatra: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
       Test_V3_Login_Events_Blocking:
-        "*": v2.12.3-dev
-        rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra14: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra20: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra21: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra22: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra30: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra31: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra32: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra40: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        "*": v2.13.0
+        rack: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra14: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra20: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra21: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra22: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra30: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra31: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra32: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra40: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        uds-sinatra: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
       Test_V3_Login_Events_RC: irrelevant
     test_automated_user_and_session_tracking.py:
       Test_Automated_Session_Blocking:
         "*": v2.15.0-dev
-        rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra14: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra20: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra21: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra22: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra30: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra31: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra32: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra40: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        rack: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra14: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra20: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra21: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra22: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra30: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra31: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra32: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra40: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        uds-sinatra: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
       Test_Automated_User_Blocking:
-        "*": v2.12.3-dev
-        rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra14: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra20: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra21: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra22: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra30: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra31: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra32: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra40: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        "*": v2.13.0
+        rack: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra14: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra20: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra21: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra22: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra30: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra31: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra32: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra40: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        uds-sinatra: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
       Test_Automated_User_Tracking:
-        "*": v2.12.3-dev
-        rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra14: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra20: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra21: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra22: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra30: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra31: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra32: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra40: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        "*": v2.13.0
+        rack: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra14: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra20: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra21: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra22: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra30: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra31: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra32: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra40: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        uds-sinatra: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
     test_blocking_addresses.py:
-      Test_BlockingGraphqlResolvers: v2.3.1-dev
+      Test_BlockingGraphqlResolvers: v2.4.0
       Test_Blocking_client_ip: v1.0.0
       Test_Blocking_request_body: v1.0.0
       Test_Blocking_request_body_multipart: v1.0.0
@@ -500,30 +500,30 @@ tests/:
       Test_Fingerprinting_Header_Capability: missing_feature
       Test_Fingerprinting_Network_Capability: missing_feature
       Test_Fingerprinting_Session:
-        "*": v2.15.0-dev
-        rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra14: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra20: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra21: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra22: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra30: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra31: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra32: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra40: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        "*": missing_feature (WIP)
+        rack: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra14: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra20: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra21: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra22: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra30: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra31: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra32: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra40: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        uds-sinatra: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
       Test_Fingerprinting_Session_Capability: missing_feature
       Test_Fingerprinting_Session_Preprocessor:
         "*": v2.15.0-dev
-        rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra14: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra20: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra21: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra22: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra30: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra31: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra32: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        sinatra40: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
-        uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        rack: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra14: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra20: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra21: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra22: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra30: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra31: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra32: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        sinatra40: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+        uds-sinatra: missing_feature (no instrument of authentication frameworks that work with sinatra or rack)
     test_identify.py:
       Test_Basic: v1.0.0
     test_ip_blocking_full_denylist.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -414,7 +414,18 @@ tests/:
         uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
       Test_V3_Login_Events_RC: irrelevant
     test_automated_user_and_session_tracking.py:
-      Test_Automated_Session_Blocking: missing_feature
+      Test_Automated_Session_Blocking:
+        "*": v2.15.0-dev
+        rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra14: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra20: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra21: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra22: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra30: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra31: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra32: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra40: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
       Test_Automated_User_Blocking:
         "*": v2.12.3-dev
         rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
@@ -483,14 +494,36 @@ tests/:
     test_fingerprinting.py:
       Test_Fingerprinting_Endpoint: v2.15.0
       Test_Fingerprinting_Endpoint_Capability: missing_feature
-      Test_Fingerprinting_Endpoint_Preprocessor: missing_feature
+      Test_Fingerprinting_Endpoint_Preprocessor: v2.15.0-dev
       Test_Fingerprinting_Header_And_Network: v2.15.0
-      Test_Fingerprinting_Header_And_Network_Preprocessor: missing_feature
+      Test_Fingerprinting_Header_And_Network_Preprocessor: v2.15.0-dev
       Test_Fingerprinting_Header_Capability: missing_feature
       Test_Fingerprinting_Network_Capability: missing_feature
-      Test_Fingerprinting_Session: missing_feature
+      Test_Fingerprinting_Session:
+        "*": v2.15.0-dev
+        rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra14: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra20: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra21: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra22: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra30: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra31: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra32: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra40: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
       Test_Fingerprinting_Session_Capability: missing_feature
-      Test_Fingerprinting_Session_Preprocessor: missing_feature
+      Test_Fingerprinting_Session_Preprocessor:
+        "*": v2.15.0-dev
+        rack: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra14: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra20: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra21: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra22: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra30: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra31: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra32: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        sinatra40: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
+        uds-sinatra: irrelevant (We do not instrument authentication frameworks that work with sinatra or rack)
     test_identify.py:
       Test_Basic: v1.0.0
     test_ip_blocking_full_denylist.py:

--- a/utils/build/docker/ruby/rails42/app/controllers/sessions_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    sign_out(:user)
+    sign_in(:user, User.find('social-security-id'))
+
+    # NOTE: Prevents Rack::Session to re-generate session id again as sign_in
+    #       generates a new session id
+    request.env['rack.session.options'][:renew] = false
+
+    render plain: session.id
+  end
+end

--- a/utils/build/docker/ruby/rails42/config/routes.rb
+++ b/utils/build/docker/ruby/rails42/config/routes.rb
@@ -32,6 +32,8 @@ Rails.application.routes.draw do
 
     post '/login' => 'login_events#create', format: false
     post '/signup' => 'signup_events#create', format: false
+
+    get 'session/new' => 'sessions#create'
   end
 
   get '/requestdownstream' => 'system_test#request_downstream'

--- a/utils/build/docker/ruby/rails50/app/controllers/sessions_controller.rb
+++ b/utils/build/docker/ruby/rails50/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    sign_out(:user)
+    sign_in(:user, User.find('social-security-id'))
+
+    # NOTE: Prevents Rack::Session to re-generate session id again as sign_in
+    #       generates a new session id
+    request.env['rack.session.options'][:renew] = false
+
+    render plain: session.id
+  end
+end

--- a/utils/build/docker/ruby/rails50/config/routes.rb
+++ b/utils/build/docker/ruby/rails50/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
 
     post '/login' => 'login_events#create', format: false
     post '/signup' => 'signup_events#create', format: false
+
+    get 'session/new' => 'sessions#create'
   end
 
   get '/requestdownstream' => 'system_test#request_downstream'

--- a/utils/build/docker/ruby/rails51/app/controllers/sessions_controller.rb
+++ b/utils/build/docker/ruby/rails51/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    sign_out(:user)
+    sign_in(:user, User.find('social-security-id'))
+
+    # NOTE: Prevents Rack::Session to re-generate session id again as sign_in
+    #       generates a new session id
+    request.env['rack.session.options'][:renew] = false
+
+    render plain: session.id
+  end
+end

--- a/utils/build/docker/ruby/rails51/config/routes.rb
+++ b/utils/build/docker/ruby/rails51/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
 
     post '/login' => 'login_events#create', format: false
     post '/signup' => 'signup_events#create', format: false
+
+    get 'session/new' => 'sessions#create'
   end
 
   get '/requestdownstream' => 'system_test#request_downstream'

--- a/utils/build/docker/ruby/rails52/app/controllers/sessions_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    sign_out(:user)
+    sign_in(:user, User.find('social-security-id'))
+
+    # NOTE: Prevents Rack::Session to re-generate session id again as sign_in
+    #       generates a new session id
+    request.env['rack.session.options'][:renew] = false
+
+    render plain: session.id
+  end
+end

--- a/utils/build/docker/ruby/rails52/config/routes.rb
+++ b/utils/build/docker/ruby/rails52/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
 
     post '/login' => 'login_events#create', format: false
     post '/signup' => 'signup_events#create', format: false
+
+    get 'session/new' => 'sessions#create'
   end
 
   get '/requestdownstream' => 'system_test#request_downstream'

--- a/utils/build/docker/ruby/rails60/app/controllers/sessions_controller.rb
+++ b/utils/build/docker/ruby/rails60/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    sign_out(:user)
+    sign_in(:user, User.find('social-security-id'))
+
+    # NOTE: Prevents Rack::Session to re-generate session id again as sign_in
+    #       generates a new session id
+    request.env['rack.session.options'][:renew] = false
+
+    render plain: session.id
+  end
+end

--- a/utils/build/docker/ruby/rails60/config/routes.rb
+++ b/utils/build/docker/ruby/rails60/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
 
     post '/login' => 'login_events#create', format: false
     post '/signup' => 'signup_events#create', format: false
+
+    get 'session/new' => 'sessions#create'
   end
 
   get '/requestdownstream' => 'system_test#request_downstream'

--- a/utils/build/docker/ruby/rails61/app/controllers/sessions_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    sign_out(:user)
+    sign_in(:user, User.find('social-security-id'))
+
+    # NOTE: Prevents Rack::Session to re-generate session id again as sign_in
+    #       generates a new session id
+    request.env['rack.session.options'][:renew] = false
+
+    render plain: session.id
+  end
+end

--- a/utils/build/docker/ruby/rails61/config/routes.rb
+++ b/utils/build/docker/ruby/rails61/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
 
     post '/login' => 'login_events#create', format: false
     post '/signup' => 'signup_events#create', format: false
+
+    get 'session/new' => 'sessions#create'
   end
 
   get '/requestdownstream' => 'system_test#request_downstream'

--- a/utils/build/docker/ruby/rails70/app/controllers/sessions_controller.rb
+++ b/utils/build/docker/ruby/rails70/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    sign_out(:user)
+    sign_in(:user, User.find('social-security-id'))
+
+    # NOTE: Prevents Rack::Session to re-generate session id again as sign_in
+    #       generates a new session id
+    request.env['rack.session.options'][:renew] = false
+
+    render plain: session.id
+  end
+end

--- a/utils/build/docker/ruby/rails70/config/routes.rb
+++ b/utils/build/docker/ruby/rails70/config/routes.rb
@@ -46,6 +46,8 @@ Rails.application.routes.draw do
     get '/login' => 'login_events#create', format: false
     post '/login' => 'login_events#create', format: false
     post '/signup' => 'signup_events#create', format: false
+
+    get 'session/new' => 'sessions#create'
   end
 
   get '/requestdownstream' => 'system_test#request_downstream'

--- a/utils/build/docker/ruby/rails71/app/controllers/sessions_controller.rb
+++ b/utils/build/docker/ruby/rails71/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    sign_out(:user)
+    sign_in(:user, User.find('social-security-id'))
+
+    # NOTE: Prevents Rack::Session to re-generate session id again as sign_in
+    #       generates a new session id
+    request.env['rack.session.options'][:renew] = false
+
+    render plain: session.id
+  end
+end

--- a/utils/build/docker/ruby/rails71/config/routes.rb
+++ b/utils/build/docker/ruby/rails71/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
 
     post '/login' => 'login_events#create', format: false
     post '/signup' => 'signup_events#create', format: false
+
+    get 'session/new' => 'sessions#create'
   end
 
   get '/requestdownstream' => 'system_test#request_downstream'

--- a/utils/build/docker/ruby/rails72/app/controllers/sessions_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    sign_out(:user)
+    sign_in(:user, User.find('social-security-id'))
+
+    # NOTE: Prevents Rack::Session to re-generate session id again as sign_in
+    #       generates a new session id
+    request.env['rack.session.options'][:renew] = false
+
+    render plain: session.id
+  end
+end

--- a/utils/build/docker/ruby/rails72/config/routes.rb
+++ b/utils/build/docker/ruby/rails72/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
 
     post '/login' => 'login_events#create', format: false
     post '/signup' => 'signup_events#create', format: false
+
+    get 'session/new' => 'sessions#create'
   end
 
   get '/requestdownstream' => 'system_test#request_downstream'

--- a/utils/build/docker/ruby/rails80/app/controllers/sessions_controller.rb
+++ b/utils/build/docker/ruby/rails80/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    sign_out(:user)
+    sign_in(:user, User.find('social-security-id'))
+
+    # NOTE: Prevents Rack::Session to re-generate session id again as sign_in
+    #       generates a new session id
+    request.env['rack.session.options'][:renew] = false
+
+    render plain: session.id
+  end
+end

--- a/utils/build/docker/ruby/rails80/config/routes.rb
+++ b/utils/build/docker/ruby/rails80/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
 
     post '/login' => 'login_events#create', format: false
     post '/signup' => 'signup_events#create', format: false
+
+    get 'session/new' => 'sessions#create'
   end
 
   get '/requestdownstream' => 'system_test#request_downstream'


### PR DESCRIPTION
## Motivation

This is the last bits for rails session tracking and general fingerprinting

## Changes

An important change is that since runtime activation is not working in Ruby I have to change it to Remote Config and AppSec enabled.