### PR TITLE
Docker ssi: crashtracking dedicated scenario

### DIFF
--- a/.gitlab/ssi_gitlab-ci.yml
+++ b/.gitlab/ssi_gitlab-ci.yml
@@ -22,7 +22,7 @@ ssi_tests:
       # Force gitlab to keep the exit code as 3 if the job fails with exit code 3
       FF_USE_NEW_BASH_EVAL_STRATEGY: true
     after_script: |
-        SCENARIO_SUFIX=$(echo "DOCKER_SSI" | tr "[:upper:]" "[:lower:]")
+        SCENARIO_SUFIX=$(echo "$SCENARIO" | tr "[:upper:]" "[:lower:]")
         mkdir -p reports/
         if [ "$CI_PROJECT_NAME" = "system-tests" ]; then
             cp -R logs_"${SCENARIO_SUFIX}" reports/

--- a/tests/docker_ssi/test_docker_ssi_crash.py
+++ b/tests/docker_ssi/test_docker_ssi_crash.py
@@ -21,8 +21,11 @@ class TestDockerSSICrash:
 
     def setup_crash(self):
         if TestDockerSSICrash._r is None:
-            parsed_url = urlparse(scenarios.docker_ssi.weblog_url + "/crashme")
+            parsed_url = urlparse(scenarios.docker_ssi.weblog_url)
             logger.info(f"Setting up Docker SSI installation WEBLOG_URL {scenarios.docker_ssi.weblog_url}")
+            r_ready = weblog.request("GET", parsed_url.path, domain=parsed_url.hostname, port=parsed_url.port)
+            logger.info(f"Check Docker SSI installation https status: {r_ready.status_code}")
+            parsed_url = urlparse(scenarios.docker_ssi.weblog_url + "/crashme")
             TestDockerSSICrash._r = weblog.request(
                 "GET", parsed_url.path, domain=parsed_url.hostname, port=parsed_url.port
             )

--- a/tests/docker_ssi/test_docker_ssi_crash.py
+++ b/tests/docker_ssi/test_docker_ssi_crash.py
@@ -21,11 +21,11 @@ class TestDockerSSICrash:
 
     def setup_crash(self):
         if TestDockerSSICrash._r is None:
-            parsed_url = urlparse(scenarios.docker_ssi.weblog_url)
-            logger.info(f"Setting up Docker SSI installation WEBLOG_URL {scenarios.docker_ssi.weblog_url}")
+            parsed_url = urlparse(scenarios.docker_ssi_crashtracking.weblog_url)
+            logger.info(f"Setting up Docker SSI installation WEBLOG_URL {scenarios.docker_ssi_crashtracking.weblog_url}")
             r_ready = weblog.request("GET", parsed_url.path, domain=parsed_url.hostname, port=parsed_url.port)
             logger.info(f"Check Docker SSI installation https status: {r_ready.status_code}")
-            parsed_url = urlparse(scenarios.docker_ssi.weblog_url + "/crashme")
+            parsed_url = urlparse(scenarios.docker_ssi_crashtracking.weblog_url + "/crashme")
             TestDockerSSICrash._r = weblog.request(
                 "GET", parsed_url.path, domain=parsed_url.hostname, port=parsed_url.port
             )
@@ -43,12 +43,12 @@ class TestDockerSSICrash:
         logger.info(f"Testing Docker SSI crash tracking: {context.library.name}")
         assert (
             self.r.status_code is None
-        ), f"Response from request {scenarios.docker_ssi.weblog_url + '/crashme'} was supposed to fail: {self.r}"
+        ), f"Response from request {scenarios.docker_ssi_crashtracking.weblog_url + '/crashme'} was supposed to fail: {self.r}"
 
         # No traces should have been generated
         assert not interfaces.test_agent.get_traces(
             self.r
-        ), f"Traces found for request {scenarios.docker_ssi.weblog_url + '/crashme'}"
+        ), f"Traces found for request {scenarios.docker_ssi_crashtracking.weblog_url + '/crashme'}"
 
         # Crash report should have been generated
         crash_reports = interfaces.test_agent.get_crash_reports()

--- a/tests/docker_ssi/test_docker_ssi_crash.py
+++ b/tests/docker_ssi/test_docker_ssi_crash.py
@@ -22,7 +22,9 @@ class TestDockerSSICrash:
     def setup_crash(self):
         if TestDockerSSICrash._r is None:
             parsed_url = urlparse(scenarios.docker_ssi_crashtracking.weblog_url)
-            logger.info(f"Setting up Docker SSI installation WEBLOG_URL {scenarios.docker_ssi_crashtracking.weblog_url}")
+            logger.info(
+                f"Setting up Docker SSI installation WEBLOG_URL {scenarios.docker_ssi_crashtracking.weblog_url}"
+            )
             r_ready = weblog.request("GET", parsed_url.path, domain=parsed_url.hostname, port=parsed_url.port)
             logger.info(f"Check Docker SSI installation https status: {r_ready.status_code}")
             parsed_url = urlparse(scenarios.docker_ssi_crashtracking.weblog_url + "/crashme")

--- a/tests/docker_ssi/test_docker_ssi_crash.py
+++ b/tests/docker_ssi/test_docker_ssi_crash.py
@@ -11,7 +11,7 @@ from utils import (
 from utils import weblog, logger
 
 
-@scenarios.docker_ssi
+@scenarios.docker_ssi_crashtracking
 class TestDockerSSICrash:
     """Test the ssi in a simulated host injection environment (docker container + test agent)
     We test scenarios when the application crashes and sends a crash report.

--- a/tests/test_the_test/test_group_rules.py
+++ b/tests/test_the_test/test_group_rules.py
@@ -34,6 +34,7 @@ def test_tracer_release():
         scenarios.container_auto_injection_install_script_profiling,
         scenarios.container_auto_injection_install_script,
         scenarios.docker_ssi,
+        scenarios.docker_ssi_crashtracking,
         scenarios.external_processing_blocking,  # need to declare a white list of library in get-workflow-parameters
         scenarios.external_processing,  # need to declare a white list of library in get-workflow-parameters
         scenarios.host_auto_injection_install_script_profiling,

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -884,12 +884,12 @@ class _Scenarios:
     docker_ssi = DockerSSIScenario(
         "DOCKER_SSI",
         doc="Validates the installer and the ssi on a docker environment",
-        scenario_groups=[scenario_groups.docker_ssi],
+        scenario_groups=[scenario_groups.all, scenario_groups.docker_ssi],
     )
     docker_ssi_crashtracking = DockerSSIScenario(
         "DOCKER_SSI_CRASHTRACKING",
         doc="Validates the crashtracking for ssi on a docker environment",
-        scenario_groups=[scenario_groups.docker_ssi],
+        scenario_groups=[scenario_groups.all, scenario_groups.docker_ssi],
     )
     appsec_rasp = EndToEndScenario(
         "APPSEC_RASP",

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -886,7 +886,11 @@ class _Scenarios:
         doc="Validates the installer and the ssi on a docker environment",
         scenario_groups=[scenario_groups.all, scenario_groups.docker_ssi],
     )
-
+    docker_ssi_crashtracking = DockerSSIScenario(
+        "DOCKER_SSI_CRASHTRACKING",
+        doc="Validates the crashtracking for ssi on a docker environment",
+        scenario_groups=[scenario_groups.all, scenario_groups.docker_ssi],
+    )
     appsec_rasp = EndToEndScenario(
         "APPSEC_RASP",
         weblog_env={"DD_APPSEC_RASP_ENABLED": "true", "DD_APPSEC_RULES": "/appsec_rasp_ruleset.json"},

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -884,12 +884,12 @@ class _Scenarios:
     docker_ssi = DockerSSIScenario(
         "DOCKER_SSI",
         doc="Validates the installer and the ssi on a docker environment",
-        scenario_groups=[scenario_groups.all, scenario_groups.docker_ssi],
+        scenario_groups=[scenario_groups.docker_ssi],
     )
     docker_ssi_crashtracking = DockerSSIScenario(
         "DOCKER_SSI_CRASHTRACKING",
         doc="Validates the crashtracking for ssi on a docker environment",
-        scenario_groups=[scenario_groups.all, scenario_groups.docker_ssi],
+        scenario_groups=[scenario_groups.docker_ssi],
     )
     appsec_rasp = EndToEndScenario(
         "APPSEC_RASP",

--- a/utils/scripts/ci_orchestrators/docker_ssi.json
+++ b/utils/scripts/ci_orchestrators/docker_ssi.json
@@ -2,7 +2,7 @@
     "scenario_matrix": [
         {
             "scenarios": [
-                "DOCKER_SSI"
+                "DOCKER_SSI","DOCKER_SSI_CRASHTRACKING"
             ],
             "weblogs": [
                 {

--- a/utils/scripts/ci_orchestrators/gitlab_exporter.py
+++ b/utils/scripts/ci_orchestrators/gitlab_exporter.py
@@ -171,7 +171,7 @@ def print_ssi_gitlab_pipeline(language, matrix_data, ci_environment) -> None:
             result_pipeline[".base_job_onboarding_system_tests"]["script"].insert(
                 0, "git clone https://git@github.com/DataDog/system-tests.git system-tests"
             )
-    print_aws_gitlab_pipeline(language, matrix_data["aws_ssi_scenario_defs"], ci_environment, result_pipeline)
+        print_aws_gitlab_pipeline(language, matrix_data["aws_ssi_scenario_defs"], ci_environment, result_pipeline)
     if matrix_data["dockerssi_scenario_defs"]:
         # Copy the base job for the docker ssi system tests
         result_pipeline[".base_docker_ssi_job"] = pipeline_data[".base_docker_ssi_job"]
@@ -186,7 +186,7 @@ def print_ssi_gitlab_pipeline(language, matrix_data, ci_environment) -> None:
             result_pipeline[".k8s_lib_injection_base"]["script"].insert(
                 0, "git clone https://git@github.com/DataDog/system-tests.git system-tests"
             )
-    print_k8s_gitlab_pipeline(language, matrix_data["libinjection_scenario_defs"], ci_environment, result_pipeline)
+        print_k8s_gitlab_pipeline(language, matrix_data["libinjection_scenario_defs"], ci_environment, result_pipeline)
 
     pipeline_yml = yaml.dump(result_pipeline, sort_keys=False, default_flow_style=False)
     output_file = f"{language}_ssi_gitlab_pipeline.yml"

--- a/utils/scripts/ci_orchestrators/gitlab_exporter.py
+++ b/utils/scripts/ci_orchestrators/gitlab_exporter.py
@@ -171,7 +171,7 @@ def print_ssi_gitlab_pipeline(language, matrix_data, ci_environment) -> None:
             result_pipeline[".base_job_onboarding_system_tests"]["script"].insert(
                 0, "git clone https://git@github.com/DataDog/system-tests.git system-tests"
             )
-    # TODO print_aws_gitlab_pipeline(language, matrix_data["aws_ssi_scenario_defs"], ci_environment, result_pipeline)
+    print_aws_gitlab_pipeline(language, matrix_data["aws_ssi_scenario_defs"], ci_environment, result_pipeline)
     if matrix_data["dockerssi_scenario_defs"]:
         # Copy the base job for the docker ssi system tests
         result_pipeline[".base_docker_ssi_job"] = pipeline_data[".base_docker_ssi_job"]
@@ -186,7 +186,7 @@ def print_ssi_gitlab_pipeline(language, matrix_data, ci_environment) -> None:
             result_pipeline[".k8s_lib_injection_base"]["script"].insert(
                 0, "git clone https://git@github.com/DataDog/system-tests.git system-tests"
             )
-    # TODO print_k8s_gitlab_pipeline(language, matrix_data["libinjection_scenario_defs"], ci_environment, result_pipeline)
+    print_k8s_gitlab_pipeline(language, matrix_data["libinjection_scenario_defs"], ci_environment, result_pipeline)
 
     pipeline_yml = yaml.dump(result_pipeline, sort_keys=False, default_flow_style=False)
     output_file = f"{language}_ssi_gitlab_pipeline.yml"

--- a/utils/scripts/ci_orchestrators/gitlab_exporter.py
+++ b/utils/scripts/ci_orchestrators/gitlab_exporter.py
@@ -171,7 +171,7 @@ def print_ssi_gitlab_pipeline(language, matrix_data, ci_environment) -> None:
             result_pipeline[".base_job_onboarding_system_tests"]["script"].insert(
                 0, "git clone https://git@github.com/DataDog/system-tests.git system-tests"
             )
-        print_aws_gitlab_pipeline(language, matrix_data["aws_ssi_scenario_defs"], ci_environment, result_pipeline)
+    # TODO print_aws_gitlab_pipeline(language, matrix_data["aws_ssi_scenario_defs"], ci_environment, result_pipeline)
     if matrix_data["dockerssi_scenario_defs"]:
         # Copy the base job for the docker ssi system tests
         result_pipeline[".base_docker_ssi_job"] = pipeline_data[".base_docker_ssi_job"]
@@ -186,7 +186,7 @@ def print_ssi_gitlab_pipeline(language, matrix_data, ci_environment) -> None:
             result_pipeline[".k8s_lib_injection_base"]["script"].insert(
                 0, "git clone https://git@github.com/DataDog/system-tests.git system-tests"
             )
-        print_k8s_gitlab_pipeline(language, matrix_data["libinjection_scenario_defs"], ci_environment, result_pipeline)
+    # TODO print_k8s_gitlab_pipeline(language, matrix_data["libinjection_scenario_defs"], ci_environment, result_pipeline)
 
     pipeline_yml = yaml.dump(result_pipeline, sort_keys=False, default_flow_style=False)
     output_file = f"{language}_ssi_gitlab_pipeline.yml"


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Crashtracking tests kill the app container. Better to have a dedicated scenario

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
