### PR TITLE
fix(tests/parametric): update test_dogstatsd_custom_hostname to use 127.0.0.1 hostname

### DIFF
--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -363,11 +363,11 @@ class Test_Config_Dogstatsd:
             resp = t.config()
         assert resp["dd_dogstatsd_host"] == "192.168.10.1"
 
-    @parametrize("library_env", [{"DD_DOGSTATSD_HOST": "randomname"}])
+    @parametrize("library_env", [{"DD_DOGSTATSD_HOST": "127.0.0.1"}])
     def test_dogstatsd_custom_hostname(self, library_env, test_agent, test_library):
         with test_library as t:
             resp = t.config()
-        assert resp["dd_dogstatsd_host"] == "randomname"
+        assert resp["dd_dogstatsd_host"] == "127.0.0.1"
 
     @parametrize("library_env", [{"DD_DOGSTATSD_PORT": "8150"}])
     def test_dogstatsd_custom_port(self, library_env, test_agent, test_library):


### PR DESCRIPTION
## Motivation

Avoid using a non-existent host, as this fails under `dd-trace-go` v2 (and therefore, in `v1 transitional` wrapper/shim).

## Changes

Replace `randomname` with `127.0.0.1` to ensure it works in all versions, including Go `v1` and any other tracer.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
