### PR TITLE
[ruby] Add support for stable config

### DIFF
--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -382,7 +382,7 @@ SDK_DEFAULT_STABLE_CONFIG = {
     if context.library != "php"
     else "1",  # Profiling is enabled as "1" by default in PHP if loaded
     "dd_data_streams_enabled": "false",
-    "dd_logs_injection": "false",
+    "dd_logs_injection": "false" if context.library != "ruby" else "true", # Enabled by default in ruby
 }
 
 
@@ -424,18 +424,20 @@ class Test_Stable_Config_Default(StableConfigWriter):
                 {
                     **SDK_DEFAULT_STABLE_CONFIG,
                     "dd_data_streams_enabled": "true"
-                    if context.library != "php"
-                    else "false",  # PHP does not support data streams
+                    if context.library != "php" and context.library != "ruby"
+                    else "false",  # PHP and Ruby do not support data streams
                 },
             ),
             (
                 "logs_injection",
                 {
-                    "DD_LOGS_INJECTION": True,
+                    "DD_LOGS_INJECTION": True
+                    if context.library != "ruby"
+                    else False,  # Ruby defaults logs injection to true
                 },
                 {
                     **SDK_DEFAULT_STABLE_CONFIG,
-                    "dd_logs_injection": "true",
+                    "dd_logs_injection": "true" if context.library != "ruby" else "false",
                 },
             ),
         ],

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -382,7 +382,7 @@ SDK_DEFAULT_STABLE_CONFIG = {
     if context.library != "php"
     else "1",  # Profiling is enabled as "1" by default in PHP if loaded
     "dd_data_streams_enabled": "false",
-    "dd_logs_injection": "false" if context.library != "ruby" else "true", # Enabled by default in ruby
+    "dd_logs_injection": "false" if context.library != "ruby" else "true",  # Enabled by default in ruby
 }
 
 
@@ -424,16 +424,14 @@ class Test_Stable_Config_Default(StableConfigWriter):
                 {
                     **SDK_DEFAULT_STABLE_CONFIG,
                     "dd_data_streams_enabled": "true"
-                    if context.library != "php" and context.library != "ruby"
+                    if context.library not in ("php", "ruby")
                     else "false",  # PHP and Ruby do not support data streams
                 },
             ),
             (
                 "logs_injection",
                 {
-                    "DD_LOGS_INJECTION": True
-                    if context.library != "ruby"
-                    else False,  # Ruby defaults logs injection to true
+                    "DD_LOGS_INJECTION": context.library != "ruby",  # Ruby defaults logs injection to true
                 },
                 {
                     **SDK_DEFAULT_STABLE_CONFIG,

--- a/utils/build/docker/ruby/parametric/server.rb
+++ b/utils/build/docker/ruby/parametric/server.rb
@@ -649,19 +649,22 @@ class MyApp
   def handle_trace_config(_req, res)
     config = {}
 
-    Datadog.configure do |c|
-      config["dd_service"] = c.service || ""
-      config["dd_trace_sample_rate"] = c.tracing.sampling.default_rate.to_s
-      config["dd_trace_enabled"] = c.tracing.enabled.to_s
-      config["dd_runtime_metrics_enabled"] = c.runtime_metrics.enabled.to_s
-      config["dd_trace_propagation_style"] = c.tracing.propagation_style.join(",")
-      config["dd_trace_debug"] = c.diagnostics.debug.to_s
-      config["dd_env"] = c.env || ""
-      config["dd_version"] = c.version || ""
-      config["dd_tags"] = c.tags.nil? ? "" : c.tags.map { |k, v| "#{k}:#{v}" }.join(",")
-      config["dd_trace_rate_limit"] = c.tracing.sampling.rate_limit.to_s
-      config["dd_trace_agent_url"] = Datadog::Tracing::Diagnostics::EnvironmentCollector.collect_config![:agent_url] || ""
-    end
+    config["dd_service"] = Datadog.configuration.service || ""
+    config["dd_trace_sample_rate"] = Datadog.configuration.tracing.sampling.default_rate.to_s
+    config["dd_trace_enabled"] = Datadog.configuration.tracing.enabled.to_s
+    config["dd_runtime_metrics_enabled"] = Datadog.configuration.runtime_metrics.enabled.to_s
+    config["dd_trace_propagation_style"] = Datadog.configuration.tracing.propagation_style.join(",")
+    config["dd_trace_debug"] = Datadog.configuration.diagnostics.debug.to_s
+    config["dd_env"] = Datadog.configuration.env || ""
+    config["dd_version"] = Datadog.configuration.version || ""
+    config["dd_tags"] = Datadog.configuration.tags.nil? ? "" : Datadog.configuration.tags.map { |k, v| "#{k}:#{v}" }.join(",")
+    config["dd_trace_rate_limit"] = Datadog.configuration.tracing.sampling.rate_limit.to_s
+    config["dd_trace_agent_url"] = Datadog::Tracing::Diagnostics::EnvironmentCollector.collect_config![:agent_url] || ""
+    config["dd_profiling_enabled"] = Datadog.configuration.profiling.enabled.to_s
+    config["dd_logs_injection"] = Datadog.configuration.tracing.log_injection.to_s
+
+    config["dd_data_streams_enabled"] = false.to_s # Not implemented
+
     res.write(TraceConfigReturn.new(config).to_json)
   end
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Ruby don't have data streams, and have logs injection enabled by default, so we have to tweak the stable config tests a bit

## Changes

<!-- A brief description of the change being made with this pull request. -->
Add more config to the handle_trace_config endpoint (profiling, logs_injection)
Tweak the test for ruby (invert logs_injection tests, disable data stream tests)

Note: The test is not enabled yet, but you can run it locally by doing weird stuff documented [here](https://github.com/DataDog/system-tests/blob/main/utils/build/docker/ruby/parametric/README.md#locally-run-parametric-system-tests-with-an-unreleased-version-of-libdatadog)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
