### PR TITLE
AWS SSI: clean lestovers after new aws account

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,5 @@
 include:
- # - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/single-step-instrumentation-tests.yml
-  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include-wip/robertomonteromiguel/onboarding_tests_new_aws_account/single-step-instrumentation-tests.yml
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/one-pipeline/ca/553c9649e1dececdf1be41f90dd58366328a69aaa8b92c0743096933bd3b049c/single-step-instrumentation-tests.yml
 
 stages:
   - configure

--- a/.gitlab/ssi_gitlab-ci.yml
+++ b/.gitlab/ssi_gitlab-ci.yml
@@ -1,6 +1,5 @@
 include:
- # - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/single-step-instrumentation-tests.yml
-  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include-wip/robertomonteromiguel/onboarding_tests_new_aws_account/single-step-instrumentation-tests.yml
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/one-pipeline/ca/553c9649e1dececdf1be41f90dd58366328a69aaa8b92c0743096933bd3b049c/single-step-instrumentation-tests.yml
 
 stages:
   - SSI_TESTS

--- a/utils/scripts/ci_orchestrators/gitlab_exporter.py
+++ b/utils/scripts/ci_orchestrators/gitlab_exporter.py
@@ -93,47 +93,6 @@ def print_gitlab_pipeline(language, matrix_data, ci_environment) -> None:
     print_ssi_gitlab_pipeline(language, matrix_data, ci_environment)
 
 
-def should_use_new_aws_account() -> bool:
-    """Temporal patch to run the new AWS account system tests"""
-    all_projects = [
-        "system-tests",
-        "dd-trace-js",
-        "dd-trace-java",
-        "dd-trace-py",
-        "dd-trace-dotnet",
-        "dd-trace-php",
-        "dd-trace-rb",
-        "auto_inject",
-    ]
-
-    ci_commit_branch = os.getenv("CI_COMMIT_BRANCH", "")
-    ci_project_name = os.getenv("CI_PROJECT_NAME")
-    migrated_projects = [
-        "system-tests",
-        "dd-trace-js",
-        "dd-trace-java",
-        "dd-trace-py",
-        "auto_inject",
-        "dd-trace-dotnet",
-        "dd-trace-php",
-        "dd-trace-rb",
-    ]
-    # The projects that are under migration.
-    # It's going to apply the config of the new aws account only for a specific branch
-    partially_migrated_projects = [""]
-    print(f"Checking if project [{ci_project_name}] should run on the new AWS account")
-    if ci_project_name in all_projects:
-        if ci_project_name in migrated_projects:
-            if ci_project_name in partially_migrated_projects and "montero" not in ci_commit_branch:
-                print(f"Project [{ci_project_name}] is in migration process.")
-                print(f"This branch [{ci_commit_branch}] is going to use the OLD AWS account")
-                return False
-            print(f"Project [{ci_project_name}] is migrated, using NEW AWS account")
-            return True
-    print(f"Project [{ci_project_name}] is NOT migrated, using OLD AWS account")
-    return False
-
-
 def print_ssi_gitlab_pipeline(language, matrix_data, ci_environment) -> None:
     result_pipeline = {}  # type: dict
     result_pipeline["include"] = []
@@ -144,16 +103,11 @@ def print_ssi_gitlab_pipeline(language, matrix_data, ci_environment) -> None:
     with open(pipeline_file, encoding="utf-8") as f:
         pipeline_data = yaml.load(f, Loader=yaml.FullLoader)  # noqa: S506
 
-    if should_use_new_aws_account():
-        result_pipeline["include"] = [
-            {
-                "remote": "https://gitlab-templates.ddbuild.io/libdatadog/include-wip/robertomonteromiguel/onboarding_tests_new_aws_account/single-step-instrumentation-tests.yml"
-            }
-        ]
-    else:
-        result_pipeline["include"] = [
-            {"remote": "https://gitlab-templates.ddbuild.io/libdatadog/include/single-step-instrumentation-tests.yml"}
-        ]
+    result_pipeline["include"] = [
+        {
+            "remote": "https://gitlab-templates.ddbuild.io/libdatadog/one-pipeline/ca/553c9649e1dececdf1be41f90dd58366328a69aaa8b92c0743096933bd3b049c/single-step-instrumentation-tests.yml"
+        }
+    ]
 
     if (
         not matrix_data["aws_ssi_scenario_defs"]


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
After the migration to the new aws is completed, we can now clean the leftovers and old references to the "agent qa" account

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
