### PR TITLE
aws ssi: added new errors to retry policy

### DIFF
--- a/utils/virtual_machine/aws_infra_exceptions.json
+++ b/utils/virtual_machine/aws_infra_exceptions.json
@@ -18,5 +18,8 @@
     "openssl_ssl_read_error": "OpenSSL SSL_read: error:0A000126:SSL routines::unexpected eof while reading",
     "docker_build_request_canceled": "net/http: request canceled while waiting for connection",
     "docker_build_error_microsoft": "failed to solve: mcr.microsoft.com/dotnet/sdk:7.0.100-preview.2",
-    "docker_build_error_reading_from_server": "Unavailable desc = error reading from server: EOF"
+    "docker_build_error_reading_from_server": "Unavailable desc = error reading from server: EOF",
+    "docker_build_error_reading_from_server_2": "listing workers for Build: failed to list workers: Unavailable: error reading from server: EOF",
+    "java_buildpack_build_error": "java.io.IOException: Downloading from https://github.com/bantonsson/gradle/releases/download/v7.5-patched/gradle-7.5.47-all.zip failed: timeout"
+    
 }


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Added new errors to aws ssi retry policy
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
