### PR TITLE
Remove tests on telemetry keys

### DIFF
--- a/docs/edit/runbook.md
+++ b/docs/edit/runbook.md
@@ -1,3 +1,7 @@
+DEPRECATED
+
+----
+
 ⚠️ Did this test just fail, and you want to fix it? ⚠️
 
 Here's what you need to do!

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -618,6 +618,9 @@ class Test_TelemetryV2:
         library="dotnet",
         reason="Re-enable when this automatically updates the dd-go files.",
     )
+    @irrelevant(
+        condition=True, reason="This test causes to many friction. It has been replaced by alerts on slack channels"
+    )
     def test_config_telemetry_completeness(self):
         """Assert that config telemetry is handled properly by telemetry intake
 


### PR DESCRIPTION
## Motivation

This test causes too many friction. Adding a new key requires to 

1. A PR on dd-go
2. A PR on system-tests
3. A PR in the final repo


And there is no easy way to entirely remove step 2.

So we'll try another approach, based on alerts in slack channels.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
