### PR TITLE
Enable exception replay telemetry test for python & dotnet

### DIFF
--- a/tests/debugger/test_debugger_telemetry.py
+++ b/tests/debugger/test_debugger_telemetry.py
@@ -79,8 +79,6 @@ class Test_Debugger_Telemetry(debugger.BaseDebuggerTest):
     def setup_telemetry_er(self):
         self._setup()
 
-    @missing_feature(context.library == "python", reason="DEBUG-3587", force_skip=True)
-    @missing_feature(context.library == "dotnet", reason="DEBUG-3587", force_skip=True)
     @missing_feature(context.library == "nodejs", reason="feature not implemented", force_skip=True)
     @missing_feature(context.library == "php", reason="feature not implemented", force_skip=True)
     def test_telemetry_er(self):


### PR DESCRIPTION
## Motivation

With DEBUG-3587, we can remove the `@missing_feature` decorators for python and dotnet for the exception replay telemetry debugger test.

## Changes

* In the `test_telemetry_er` method, removed `@missing_feature` decorators for the Python and .NET libraries for ER, indicating these tests are no longer being skipped for these libraries.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
