### PR TITLE
aws ssi: skip node24 profiling support

### DIFF
--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -79,10 +79,10 @@ class TestContainerAutoInjectInstallScriptProfiling(base.AutoInjectBaseTest):
         context.weblog_variant == "test-app-python-alpine",
         reason="PROF-11296",
     )
-    @missing_feature(
-        context.weblog_variant == "test-app-nodejs-multicontainer",
-        reason="waiting for node24 support",
-    )
+    #@missing_feature(
+    #    context.weblog_variant == "test-app-nodejs-multicontainer",
+    #    reason="waiting for node24 support",
+    #)
     def test_profiling(self):
         self._test_install(context.virtual_machine, profile=True)
 

--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -79,6 +79,10 @@ class TestContainerAutoInjectInstallScriptProfiling(base.AutoInjectBaseTest):
         context.weblog_variant == "test-app-python-alpine",
         reason="PROF-11296",
     )
+    @missing_feature(
+        context.weblog_variant == "test-app-nodejs-multicontainer",
+        reason="waiting for node24 support",
+    )
     def test_profiling(self):
         self._test_install(context.virtual_machine, profile=True)
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Currently node24 is not support for profiling.
Skip the test until this problem is fixed

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
