### PR TITLE
Verify correct extraction of http.referrer_hostname

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -645,6 +645,7 @@ tests/:
   test_standard_tags.py:
     Test_StandardTagsClientIp: v2.26.0
     Test_StandardTagsMethod: v2.0.0
+    Test_StandardTagsReferrerHostname: missing_feature
     Test_StandardTagsRoute: v2.13.0
     Test_StandardTagsStatusCode: v2.0.0
     Test_StandardTagsUrl: v2.13.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -795,6 +795,7 @@ tests/:
   test_standard_tags.py:
     Test_StandardTagsClientIp: v1.46.0
     Test_StandardTagsMethod: v1.39.0
+    Test_StandardTagsReferrerHostname: missing_feature
     Test_StandardTagsRoute: v1.39.0
     Test_StandardTagsStatusCode: v1.39.0
     Test_StandardTagsUrl: v1.40.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2156,6 +2156,7 @@ tests/:
       play: v1.22.0
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     Test_StandardTagsMethod: v0.102.0
+    Test_StandardTagsReferrerHostname: missing_feature
     Test_StandardTagsRoute:
       '*': v0.102.0
       akka-http: bug (AIDM-594)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1180,6 +1180,7 @@ tests/:
       '*': *ref_3_6_0
       nextjs: missing_feature  # nextjs makes some internal requests, so we have more than 1 rootspans
     Test_StandardTagsMethod: v2.11.0
+    Test_StandardTagsReferrerHostname: missing_feature
     Test_StandardTagsRoute:
       '*': v2.11.0
       nextjs: missing_feature  # http.route not added in nextjs

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -642,6 +642,7 @@ tests/:
   test_span_events.py: incomplete_test_app (Weblog `/add_event` not implemented)
   test_standard_tags.py:
     Test_StandardTagsMethod: v0.75.0
+    Test_StandardTagsReferrerHostname: v1.9.0
     Test_StandardTagsRoute: missing_feature
     Test_StandardTagsStatusCode: v0.75.0
     Test_StandardTagsUrl: v0.76.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1190,6 +1190,7 @@ tests/:
   test_standard_tags.py:
     Test_StandardTagsClientIp: v2.7.0
     Test_StandardTagsMethod: v1.2.1
+    Test_StandardTagsReferrerHostname: v3.4.0
     Test_StandardTagsRoute:
       '*': v1.6.0
     Test_StandardTagsStatusCode: v1.4.0-rc1

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -887,6 +887,7 @@ tests/:
   test_standard_tags.py:
     Test_StandardTagsClientIp: v1.10.1
     Test_StandardTagsMethod: v1.8.0
+    Test_StandardTagsReferrerHostname: missing_feature
     Test_StandardTagsRoute:
       "*": missing_feature
       rack: irrelevant (rack can not access route pattern)

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2618,5 +2618,14 @@ class _Features:
         pytest.mark.features(feature_id=391)(test_object)
         return test_object
 
+    @staticmethod
+    def referrer_hostname(test_object):
+        """Enforces standardized behaviors for configurations across the tracing libraries.
+
+        https://feature-parity.us1.prod.dog/#/?feature=396
+        """
+        pytest.mark.features(feature_id=396)(test_object)
+        return test_object
+
 
 features = _Features()


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

A new feature has currently been released both in [Python](https://github.com/DataDog/dd-trace-py/pull/12778) and [PHP](https://github.com/DataDog/dd-trace-php/pull/3196). It parses referrer hostname from http header when it exists and adds it to span tags as `http.referrer_hostname`.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Add tests for this feature.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
