### PR TITLE
[NO-TICKET] Add forced_tests and branch inputs to parametric GHA workflow

### DIFF
--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -28,8 +28,8 @@ on:
         default: '[1]'
         required: false
         type: string
-      branch:
-        description: "Branch to run the tests on"
+      ref:
+        description: "system-tests ref to run the tests on (can be any valid branch, tag or SHA in system-tests repo)"
         default: 'main'
         required: false
         type: string
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.ref }}
       - name: Install runner
         uses: ./.github/actions/install_runner
       - name: Get binaries artifact

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -28,6 +28,16 @@ on:
         default: '[1]'
         required: false
         type: string
+      branch:
+        description: "Branch to run the tests on"
+        default: 'main'
+        required: false
+        type: string
+      forced_tests:
+        description: "Array of tests to force-execute, separated by commas"
+        default: '[]'
+        required: false
+        type: string
       _experimental_job_count:
         description: "DEPRECATED"
         default: 1
@@ -62,6 +72,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
+          ref: ${{ inputs.branch }}
       - name: Install runner
         uses: ./.github/actions/install_runner
       - name: Get binaries artifact
@@ -71,7 +82,9 @@ jobs:
           name: ${{ inputs.binaries_artifact }}
           path: binaries/
       - name: Run PARAMETRIC scenario
-        run: ./run.sh PARAMETRIC -L ${{ inputs.library }} --splits=${{ inputs.job_count }} --group=${{ matrix.job_instance }}
+        run: |
+          ./run.sh PARAMETRIC -L ${{ inputs.library }} --splits=${{ inputs.job_count }} --group=${{ matrix.job_instance }} \
+            ${{inputs.forced_tests != '[]' && format('-F {0}', join(fromJSON(inputs.forced_tests), ' -F ')) || ''}}
       - name: Compress logs
         id: compress_logs
         if: always()

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -33,9 +33,9 @@ on:
         default: 'main'
         required: false
         type: string
-      forced_tests:
+      force_execute_tests:
         description: "Array of tests to force-execute, separated by commas"
-        default: '[]'
+        default: ''
         required: false
         type: string
       _experimental_job_count:
@@ -84,7 +84,7 @@ jobs:
       - name: Run PARAMETRIC scenario
         run: |
           ./run.sh PARAMETRIC -L ${{ inputs.library }} --splits=${{ inputs.job_count }} --group=${{ matrix.job_instance }} \
-            ${{inputs.forced_tests != '[]' && format('-F {0}', join(fromJSON(inputs.forced_tests), ' -F ')) || ''}}
+            ${{inputs.force_execute_tests != '' && format('-F {0}', join(fromJSON(inputs.force_execute_tests), ' -F ')) || ''}}
       - name: Compress logs
         id: compress_logs
         if: always()


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
We'd like to force-execute parametric tests in dd-trace-rb CI, but we're directly using system-tests run-parametric.yml workflow

## Changes

<!-- A brief description of the change being made with this pull request. -->
This PR adds two new inputs to run-parametric.yml:
- branch: Tells GHA to checkout another branch than the main one
- forced_tests: An array of tests to force-execute

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
