### PR TITLE
[ruby] [APMAPI-1116] Enable Stable Config Phase 1

### DIFF
--- a/docs/execute/binaries.md
+++ b/docs/execute/binaries.md
@@ -158,7 +158,7 @@ echo “ddtrace @ git+https://github.com/DataDog/dd-trace-py.git@<name-of-your-b
 You have two ways to run system-tests with a custom Ruby Tracer version:
 
 1. Create `ruby-load-from-bundle-add` in `binaries` directory with the content that should be added to `Gemfile`. Content example:
-  * `gem 'datadog', git: 'https://github.com/Datadog/dd-trace-rb', branch: 'master', require: 'datadog/auto_instrument'`
+  * `gem 'datadog', git: 'https://github.com/Datadog/dd-trace-rb', branch: 'master', require: 'datadog/auto_instrument'`. To point to a specific branch, replace `branch: 'master'` with `branch: '<your-branch>'`. If you want to point to a specific commit, delete the `branch: 'master'` entry and replace it with `ref: '<commit-hash>'`.
 2. Clone the dd-trace-rb repo inside `binaries` and checkout the branch that you want to test against.
 
 You can also use `utils/scripts/watch.sh` script to sync your local `dd-trace-rb` repo into the `binaries` folder:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -748,7 +748,7 @@ tests/:
       Test_Config_TraceEnabled: v2.0.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v2.5.0
-      # Test_Stable_Config_Default: v2.15.1-dev
+      Test_Stable_Config_Default: v2.18.0
     test_crashtracking.py:
       Test_Crashtracking: v2.3.0
     test_dynamic_configuration.py:
@@ -788,7 +788,7 @@ tests/:
       Test_Consistent_Configs: missing_feature
       Test_Defaults: missing_feature
       Test_Environment: missing_feature
-      Test_Stable_Configuration_Origin: missing_feature
+      Test_Stable_Configuration_Origin: v2.18.0
       Test_TelemetryInstallSignature: missing_feature
       Test_TelemetrySCAEnvVar: v2.1.0
       Test_TelemetrySSIConfigs: missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -748,7 +748,7 @@ tests/:
       Test_Config_TraceEnabled: v2.0.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v2.5.0
-      Test_Stable_Config_Default: v2.15.1-dev
+      # Test_Stable_Config_Default: v2.15.1-dev
     test_crashtracking.py:
       Test_Crashtracking: v2.3.0
     test_dynamic_configuration.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -748,7 +748,7 @@ tests/:
       Test_Config_TraceEnabled: v2.0.0
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v2.5.0
-      Test_Stable_Config_Default: missing_feature
+      Test_Stable_Config_Default: v2.15.1-dev
     test_crashtracking.py:
       Test_Crashtracking: v2.3.0
     test_dynamic_configuration.py:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Stable config has been merged in dd-trace-rb

## Changes

<!-- A brief description of the change being made with this pull request. -->
Adds next dd-trace-rb release to manifest for stable config.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
