### PR TITLE
fix(er): mark ER telemetry for dotnet as flaky

### DIFF
--- a/tests/debugger/test_debugger_telemetry.py
+++ b/tests/debugger/test_debugger_telemetry.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import tests.debugger.utils as debugger
-from utils import scenarios, features, missing_feature, context, logger
+from utils import scenarios, features, missing_feature, context, logger, flaky
 from utils.telemetry import load_telemetry_json, get_lang_configs
 
 ALLOWED_ORIGINS = {"env_var", "code", "dd_config", "remote_config", "app.config", "default", "unknown"}
@@ -24,10 +24,6 @@ class Test_Debugger_Telemetry(debugger.BaseDebuggerTest):
 
         if not Test_Debugger_Telemetry.telemetry_data:
             telemetry_type = "app-started"
-
-            if self.get_tracer()["language"] == "dotnet":
-                telemetry_type = "app-client-configuration-change"
-
             Test_Debugger_Telemetry.telemetry_data = self.wait_for_telemetry(telemetry_type)
 
         self.telemetry = Test_Debugger_Telemetry.telemetry_data
@@ -79,6 +75,7 @@ class Test_Debugger_Telemetry(debugger.BaseDebuggerTest):
     def setup_telemetry_er(self):
         self._setup()
 
+    @flaky(context.library == "dotnet", reason="DEBUG-3322")
     @missing_feature(context.library == "nodejs", reason="feature not implemented", force_skip=True)
     @missing_feature(context.library == "php", reason="feature not implemented", force_skip=True)
     def test_telemetry_er(self):

--- a/tests/debugger/test_debugger_telemetry.py
+++ b/tests/debugger/test_debugger_telemetry.py
@@ -24,6 +24,10 @@ class Test_Debugger_Telemetry(debugger.BaseDebuggerTest):
 
         if not Test_Debugger_Telemetry.telemetry_data:
             telemetry_type = "app-started"
+
+            if self.get_tracer()["language"] == "dotnet":
+                telemetry_type = "app-client-configuration-change"
+
             Test_Debugger_Telemetry.telemetry_data = self.wait_for_telemetry(telemetry_type)
 
         self.telemetry = Test_Debugger_Telemetry.telemetry_data


### PR DESCRIPTION
## Motivation

Updates the `tests/debugger/test_debugger_telemetry.py` file removing redundant conditional logic, adding a `@flaky` decorator for the dotnet `exception_replay_enabled` telemetry until the order of initialization is updated as part of in-product enablement.

## Changes

* [`tests/debugger/test_debugger_telemetry.py`](diffhunk://#diff-c5ae7f71aecbbc23f76d9b4c50a11168c79b21efa14955cade1b8013a7461351L6-R6): Added the `flaky` utility to the imports for use in test annotations.
* [`tests/debugger/test_debugger_telemetry.py`](diffhunk://#diff-c5ae7f71aecbbc23f76d9b4c50a11168c79b21efa14955cade1b8013a7461351L27-L30): Removed redundant conditional logic in the `_setup` method, simplifying the determination of the telemetry type.
* [`tests/debugger/test_debugger_telemetry.py`](diffhunk://#diff-c5ae7f71aecbbc23f76d9b4c50a11168c79b21efa14955cade1b8013a7461351R78): Added a `@flaky` decorator to the `test_telemetry_er` method for handling intermittent failures in the `.NET` library (`DEBUG-3322`).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
