### PR TITLE
DEBUG-3573 enable Ruby debugger telemetry tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -622,7 +622,9 @@ tests/:
     test_debugger_telemetry.py:
       Test_Debugger_Telemetry:
         "*": irrelevant
-        rails70: missing_feature (feature not implemented)
+        rails70: v2.15.1-dev
+        rails80: v2.15.1-dev
+        uds-rails: v2.15.1-dev
   integrations/:
     crossed_integrations/:
       test_kafka.py:

--- a/tests/debugger/test_debugger_telemetry.py
+++ b/tests/debugger/test_debugger_telemetry.py
@@ -71,7 +71,6 @@ class Test_Debugger_Telemetry(debugger.BaseDebuggerTest):
     def setup_telemetry_di(self):
         self._setup()
 
-    @missing_feature(context.library == "ruby", reason="DEBUG-3573", force_skip=True)
     def test_telemetry_di(self):
         self._assert(required_telemetry=["dynamic_instrumentation_enabled"])
 
@@ -82,6 +81,7 @@ class Test_Debugger_Telemetry(debugger.BaseDebuggerTest):
     @flaky(context.library == "dotnet", reason="DEBUG-3322")
     @missing_feature(context.library == "nodejs", reason="feature not implemented", force_skip=True)
     @missing_feature(context.library == "php", reason="feature not implemented", force_skip=True)
+    @missing_feature(context.library == "ruby", reason="feature not implemented", force_skip=True)
     def test_telemetry_er(self):
         self._assert(required_telemetry=["exception_replay_enabled"])
 
@@ -91,6 +91,7 @@ class Test_Debugger_Telemetry(debugger.BaseDebuggerTest):
 
     @missing_feature(context.library == "nodejs", reason="feature not implemented", force_skip=True)
     @missing_feature(context.library == "php", reason="feature not implemented", force_skip=True)
+    @missing_feature(context.library == "ruby", reason="feature not implemented", force_skip=True)
     def test_telemetry_symdb(self):
         self._assert(required_telemetry=["symbol_database_upload_enabled"])
 
@@ -101,5 +102,6 @@ class Test_Debugger_Telemetry(debugger.BaseDebuggerTest):
     @missing_feature(context.library == "python", reason="DEBUG-3550", force_skip=True)
     @missing_feature(context.library == "dotnet", reason="feature not implemented", force_skip=True)
     @missing_feature(context.library == "php", reason="feature not implemented", force_skip=True)
+    @missing_feature(context.library == "ruby", reason="feature not implemented", force_skip=True)
     def test_telemetry_co(self):
         self._assert(required_telemetry=["code_origin_for_spans_enabled"])


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
