### PR TITLE
[nodejs] Set the max context operations in 10

### DIFF
--- a/utils/build/docker/nodejs/express4-typescript.Dockerfile
+++ b/utils/build/docker/nodejs/express4-typescript.Dockerfile
@@ -22,7 +22,7 @@ ENV PGPORT=5433
 
 ENV DD_DATA_STREAMS_ENABLED=true
 
-ENV DD_IAST_MAX_CONTEXT_OPERATIONS=5
+ENV DD_IAST_MAX_CONTEXT_OPERATIONS=10
 
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh

--- a/utils/build/docker/nodejs/express4.Dockerfile
+++ b/utils/build/docker/nodejs/express4.Dockerfile
@@ -27,7 +27,7 @@ ENV PGPORT=5433
 
 ENV DD_DATA_STREAMS_ENABLED=true
 
-ENV DD_IAST_MAX_CONTEXT_OPERATIONS=5
+ENV DD_IAST_MAX_CONTEXT_OPERATIONS=10
 
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh

--- a/utils/build/docker/nodejs/express5.Dockerfile
+++ b/utils/build/docker/nodejs/express5.Dockerfile
@@ -26,7 +26,7 @@ ENV PGPORT=5433
 
 ENV DD_DATA_STREAMS_ENABLED=true
 
-ENV DD_IAST_MAX_CONTEXT_OPERATIONS=5
+ENV DD_IAST_MAX_CONTEXT_OPERATIONS=10
 
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh

--- a/utils/build/docker/nodejs/uds-express4.Dockerfile
+++ b/utils/build/docker/nodejs/uds-express4.Dockerfile
@@ -30,7 +30,7 @@ ENV UDS_WEBLOG=1
 
 ENV DD_DATA_STREAMS_ENABLED=true
 
-ENV DD_IAST_MAX_CONTEXT_OPERATIONS=5
+ENV DD_IAST_MAX_CONTEXT_OPERATIONS=10
 
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh


### PR DESCRIPTION
## Motivation
<!-- What inspired you to submit this pull request? -->
New vulnerabilities sampling algorithm works in a different way when the max vulnerabilities per request is reached, and to be able to detect the same vulnerability twice needs to have free budget in the first request.
That is why some ST are failing in the new algorithm PR: https://github.com/DataDog/dd-trace-js/pull/5697

## Changes

<!-- A brief description of the change being made with this pull request. -->
Update the env var where the max vulnerabilities per request are defined

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
