### PR TITLE
fix(java): Enable debug PII excluded test for v1.49

### DIFF
--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -247,7 +247,6 @@ class Test_Debugger_PII_Redaction_Excluded_Identifiers(BaseDebuggerPIIRedactionT
     def setup_pii_redaction_excluded_identifiers(self):
         self._setup(line_probe=True)
 
-    @bug(context.library == "java", reason="DEBUG-3745")
     @bug(context.library == "ruby", reason="DEBUG-3747")
     @bug(context.library == "python", reason="DEBUG-3746")
     def test_pii_redaction_excluded_identifiers(self):


### PR DESCRIPTION
## Motivation

This pull request includes a minor update to the `tests/debugger/test_debugger_pii.py` file. The change removes a `@bug` decorator for the Java library (`DEBUG-3745`) in the `test_pii_redaction_excluded_identifiers` method, because the related issue has been resolved.

## Changes

- Remove `@bug` decorator for Java library (`DEBUG-3745`) in the `test_pii_redaction_excluded_identifiers` method

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
