### PR TITLE
Remove unused fake secret from Rails weblog apps

### DIFF
--- a/utils/build/docker/ruby/rails42/config/initializers/devise.rb
+++ b/utils/build/docker/ruby/rails42/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '2aa7763a03b8aeefb5507ab110519240bbd9c017f8c15c8e5d652871ebdc194735d7acda52f0a3eef7a46fb2f16bc4a0eeacd1542a3f63ad6d56e38a15484fa8'
+  # config.secret_key = SecureRandom.hex(64)
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/utils/build/docker/ruby/rails50/config/initializers/devise.rb
+++ b/utils/build/docker/ruby/rails50/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '2aa7763a03b8aeefb5507ab110519240bbd9c017f8c15c8e5d652871ebdc194735d7acda52f0a3eef7a46fb2f16bc4a0eeacd1542a3f63ad6d56e38a15484fa8'
+  # config.secret_key = SecureRandom.hex(64)
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/utils/build/docker/ruby/rails51/config/initializers/devise.rb
+++ b/utils/build/docker/ruby/rails51/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '2aa7763a03b8aeefb5507ab110519240bbd9c017f8c15c8e5d652871ebdc194735d7acda52f0a3eef7a46fb2f16bc4a0eeacd1542a3f63ad6d56e38a15484fa8'
+  # config.secret_key = SecureRandom.hex(64)
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/utils/build/docker/ruby/rails52/config/initializers/devise.rb
+++ b/utils/build/docker/ruby/rails52/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '2aa7763a03b8aeefb5507ab110519240bbd9c017f8c15c8e5d652871ebdc194735d7acda52f0a3eef7a46fb2f16bc4a0eeacd1542a3f63ad6d56e38a15484fa8'
+  # config.secret_key = SecureRandom.hex(64)
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/utils/build/docker/ruby/rails60/config/initializers/devise.rb
+++ b/utils/build/docker/ruby/rails60/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '2aa7763a03b8aeefb5507ab110519240bbd9c017f8c15c8e5d652871ebdc194735d7acda52f0a3eef7a46fb2f16bc4a0eeacd1542a3f63ad6d56e38a15484fa8'
+  # config.secret_key = SecureRandom.hex(64)
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/utils/build/docker/ruby/rails61/config/initializers/devise.rb
+++ b/utils/build/docker/ruby/rails61/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '2aa7763a03b8aeefb5507ab110519240bbd9c017f8c15c8e5d652871ebdc194735d7acda52f0a3eef7a46fb2f16bc4a0eeacd1542a3f63ad6d56e38a15484fa8'
+  # config.secret_key = SecureRandom.hex(64)
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/utils/build/docker/ruby/rails70/config/initializers/devise.rb
+++ b/utils/build/docker/ruby/rails70/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '2aa7763a03b8aeefb5507ab110519240bbd9c017f8c15c8e5d652871ebdc194735d7acda52f0a3eef7a46fb2f16bc4a0eeacd1542a3f63ad6d56e38a15484fa8'
+  # config.secret_key = SecureRandom.hex(64)
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/utils/build/docker/ruby/rails71/config/initializers/devise.rb
+++ b/utils/build/docker/ruby/rails71/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '2aa7763a03b8aeefb5507ab110519240bbd9c017f8c15c8e5d652871ebdc194735d7acda52f0a3eef7a46fb2f16bc4a0eeacd1542a3f63ad6d56e38a15484fa8'
+  # config.secret_key = SecureRandom.hex(64)
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/utils/build/docker/ruby/rails72/config/initializers/devise.rb
+++ b/utils/build/docker/ruby/rails72/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '2aa7763a03b8aeefb5507ab110519240bbd9c017f8c15c8e5d652871ebdc194735d7acda52f0a3eef7a46fb2f16bc4a0eeacd1542a3f63ad6d56e38a15484fa8'
+  # config.secret_key = SecureRandom.hex(64)
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/utils/build/docker/ruby/rails80/config/initializers/devise.rb
+++ b/utils/build/docker/ruby/rails80/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '2aa7763a03b8aeefb5507ab110519240bbd9c017f8c15c8e5d652871ebdc194735d7acda52f0a3eef7a46fb2f16bc4a0eeacd1542a3f63ad6d56e38a15484fa8'
+  # config.secret_key = SecureRandom.hex(64)
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.


### PR DESCRIPTION
## Changes

This key could trip security scanning tools to think it's a real secret key.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
