### PR TITLE
User events standalone for Node.js

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -616,7 +616,9 @@ tests/:
       Test_IastStandalone_UpstreamPropagation_V2: *ref_5_40_0
       Test_SCAStandalone_Telemetry: irrelevant (due to v2)
       Test_SCAStandalone_Telemetry_V2: *ref_5_40_0
-      Test_UserEventsStandalone: missing_feature
+      Test_UserEventsStandalone:
+        '*': *ref_5_40_0
+        nextjs: missing_feature
     test_automated_login_events.py:
       Test_Login_Events: irrelevant
       Test_Login_Events_Extended: irrelevant

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -1081,7 +1081,7 @@ class Test_UserEventsStandalone:
         trace_id = 1212121212121212122
         meta = self._get_standalone_span_meta(trace_id)
         assert meta is not None
-        assert meta["appsec.events.users.login.failure.usr.exists"] == "false"
+        assert meta["_dd.appsec.usr.login"] == INVALID_USER
 
     def setup_user_signup_event_generates_asm_event(self):
         trace_id = 1212121212121212133
@@ -1091,6 +1091,7 @@ class Test_UserEventsStandalone:
         context.library == "python" and context.weblog_variant not in ["django-poc", "python3.12", "django-py3.13"],
         reason="no signup events in Python except for django",
     )
+    @missing_feature(context.library == "nodejs", reason="no signup events in passport")
     def test_user_signup_event_generates_asm_event(self):
         trace_id = 1212121212121212133
         meta = self._get_standalone_span_meta(trace_id)


### PR DESCRIPTION
## Motivation

Node.js do not send `appsec.events.users.login.failure.usr.exists` meta so instead of asserting this tag check that  `_dd.appsec.usr.login` is an `INVALID_USER`

## Changes

- `test_user_signup_event_generates_asm_event` is irrelevant for Node.js
- Change `test_user_login_failure_event_generates_asm_event` 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
