### PR TITLE
Updating Live Debugger Exception Lines `spring-webmvc-3.1`

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1709,8 +1709,8 @@ tests/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay:
         '*': missing_feature
-        spring-boot: v1.33.0
-        uds-spring-boot: v1.33.0
+        spring-boot: missing_feature (Temporarily disabling until Java PR is updated)
+        uds-spring-boot: missing_feature (Temporarily disabling until Java PR is updated)
     test_debugger_expression_language.py:
       Test_Debugger_Expression_Language:
         '*': missing_feature

--- a/tests/debugger/approvals/exception_replay_inner_java_snapshots_expected.json
+++ b/tests/debugger/approvals/exception_replay_inner_java_snapshots_expected.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -53,7 +53,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"

--- a/tests/debugger/approvals/exception_replay_multiframe_java_snapshots_expected.json
+++ b/tests/debugger/approvals/exception_replay_multiframe_java_snapshots_expected.json
@@ -36,7 +36,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -69,7 +69,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -114,7 +114,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -151,7 +151,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -196,7 +196,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -237,7 +237,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -282,7 +282,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -311,7 +311,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"

--- a/tests/debugger/approvals/exception_replay_recursion_20_java_snapshots_expected.json
+++ b/tests/debugger/approvals/exception_replay_recursion_20_java_snapshots_expected.json
@@ -112,7 +112,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -141,7 +141,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -266,7 +266,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -379,7 +379,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -504,7 +504,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -613,7 +613,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -738,7 +738,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -811,7 +811,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -936,7 +936,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -1005,7 +1005,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -1130,7 +1130,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -1195,7 +1195,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -1320,7 +1320,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -1381,7 +1381,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -1506,7 +1506,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -1563,7 +1563,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -1688,7 +1688,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -1741,7 +1741,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -1866,7 +1866,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -1915,7 +1915,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -2040,7 +2040,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -2085,7 +2085,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -2210,7 +2210,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -2251,7 +2251,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -2376,7 +2376,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -2413,7 +2413,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -2538,7 +2538,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -2643,7 +2643,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -2768,7 +2768,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -2801,7 +2801,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -2926,7 +2926,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -3027,7 +3027,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -3152,7 +3152,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -3249,7 +3249,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -3374,7 +3374,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -3467,7 +3467,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -3592,7 +3592,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -3681,7 +3681,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -3806,7 +3806,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -3891,7 +3891,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -4016,7 +4016,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -4097,7 +4097,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -4222,7 +4222,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -4299,7 +4299,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"

--- a/tests/debugger/approvals/exception_replay_recursion_3_java_snapshots_expected.json
+++ b/tests/debugger/approvals/exception_replay_recursion_3_java_snapshots_expected.json
@@ -44,7 +44,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -73,7 +73,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -130,7 +130,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -175,7 +175,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -232,7 +232,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -273,7 +273,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -330,7 +330,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -367,7 +367,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -424,7 +424,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -457,7 +457,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"

--- a/tests/debugger/approvals/exception_replay_recursion_5_java_snapshots_expected.json
+++ b/tests/debugger/approvals/exception_replay_recursion_5_java_snapshots_expected.json
@@ -52,7 +52,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -81,7 +81,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -146,7 +146,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -199,7 +199,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -264,7 +264,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -313,7 +313,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -378,7 +378,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -423,7 +423,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -488,7 +488,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -529,7 +529,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -594,7 +594,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -631,7 +631,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -696,7 +696,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -729,7 +729,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"

--- a/tests/debugger/approvals/exception_replay_rockpaperscissors_java_snapshots_expected.json
+++ b/tests/debugger/approvals/exception_replay_rockpaperscissors_java_snapshots_expected.json
@@ -28,7 +28,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -57,7 +57,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -94,7 +94,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -123,7 +123,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"
@@ -160,7 +160,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -189,7 +189,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"

--- a/tests/debugger/approvals/exception_replay_simple_java_snapshots_expected.json
+++ b/tests/debugger/approvals/exception_replay_simple_java_snapshots_expected.json
@@ -24,7 +24,7 @@
             },
             {
               "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-              "lineNumber": 50
+              "lineNumber": 55
             },
             {
               "<runtime>": "<scrubbed>"
@@ -53,7 +53,7 @@
       },
       {
         "function": "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter.doFilterInternal",
-        "lineNumber": 50
+        "lineNumber": 55
       },
       {
         "<runtime>": "<scrubbed>"


### PR DESCRIPTION
## Motivation

Changes made to `spring-webmvc-3.1` in this [PR](https://github.com/DataDog/dd-trace-java/pull/8820) has now changed the lines where Live Debugger tests expect the errors to be thrown. This PR updates the lines that the tests expect the lines to be at.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
