### PR TITLE
add a script that adds a label on tickets referenced in system-tests

### DIFF
--- a/utils/scripts/add-system-tests-label-on-known-tickets.py
+++ b/utils/scripts/add-system-tests-label-on-known-tickets.py
@@ -1,0 +1,74 @@
+from http import HTTPStatus
+import os
+import re
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+from utils.tools import update_environ_with_local_env
+
+
+update_environ_with_local_env()
+
+
+def crawl_and_search(
+    directories: tuple[str, ...], pattern: str, file_extensions: tuple[str, ...]
+) -> list[tuple[str, str]]:
+    regex = re.compile(pattern)
+
+    result = []
+    for directory in directories:
+        for root, _, files in os.walk(directory):
+            for filename in files:
+                if filename.endswith(file_extensions):
+                    filepath = os.path.join(root, filename)
+                    try:
+                        with open(filepath, "r", encoding="utf-8") as f:
+                            for line in f:
+                                match = regex.search(line)
+                                if match:
+                                    result.append((filepath, match.group(0)))
+                    except (UnicodeDecodeError, OSError) as e:
+                        print(f"Could not read file: {filepath} ({e})")
+
+    return result
+
+
+def add_label_on_jira_ticket(issue_key: str, label: str) -> None:
+    jira_domain: str = "datadoghq.atlassian.net"
+    url = f"https://{jira_domain}/rest/api/3/issue/{issue_key}"
+    html_url = f"https://{jira_domain}/browse/{issue_key}"
+
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+
+    payload = {"update": {"labels": [{"add": label}]}}
+
+    response = requests.put(
+        url,
+        json=payload,
+        headers=headers,
+        auth=HTTPBasicAuth(os.environ["JIRA_API_EMAIL"], os.environ["JIRA_API_TOKEN"]),
+        timeout=10,
+    )
+
+    if response.status_code == HTTPStatus.NO_CONTENT:
+        print(f"✅ Label '{label}' added to issue {html_url}")
+    else:
+        print(f"❌ Failed to add label on {html_url}: {response.status_code} - {response.text}")
+
+
+def main() -> None:
+    directories = ("manifests", "tests")
+    pattern = r"\b([A-Z]+-\d+)\b"
+    file_extensions = (".py", ".yml", ".yaml")
+
+    tickets = set()
+    for _, ticket in crawl_and_search(directories, pattern, file_extensions):
+        tickets.add(ticket)
+
+    for ticket in sorted(tickets):
+        add_label_on_jira_ticket(issue_key=ticket, label="system-tests")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/scripts/compute_impacted_scenario.py
+++ b/utils/scripts/compute_impacted_scenario.py
@@ -182,6 +182,7 @@ def main() -> None:
                     r"utils/scripts/replay_scenarios\.sh": None,
                     r"utils/scripts/get-nightly-logs\.py": None,
                     r"utils/scripts/get-workflow-summary\.py": None,
+                    r"utils/scripts/add-system-tests-label-on-known-tickets\.py": None,
                     r"utils/scripts/parametric/.*": scenarios.parametric,
                     r"utils/virtual_machine/.*": scenario_groups.onboarding,
                     r"utils/.*": scenario_groups.all,

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -32,7 +32,7 @@ def update_environ_with_local_env() -> None:
                 line = re.sub(r"(.*)#.$", r"\1", line)
                 line = re.sub(r"^(export +)(.*)$", r"\2", line)
                 if "=" in line:
-                    items = line.split("=")
+                    items = line.split("=", 1)
                     _logger.debug(f"adding {items[0]} in environ")
                     os.environ[items[0]] = items[1]
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
