### PR TITLE
new system tests for value obfuscation

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -350,6 +350,9 @@ tests/:
       Test_Suspicious_Request_Blocking: v3.2.0
     test_client_ip.py:
       Test_StandardTagsClientIp: v2.20.0
+    test_conf.py:
+      Test_ConfigurationVariables: missing_feature (unknown version)
+      Test_ConfigurationVariables_New_Obfuscation: missing_feature
     test_customconf.py:
       Test_CorruptedRules_Telemetry: missing_feature
       Test_NoLimitOnWafRules: v2.4.4

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -410,6 +410,9 @@ tests/:
       Test_Suspicious_Request_Blocking: missing_feature
     test_client_ip.py:
       Test_StandardTagsClientIp: v1.44.1
+    test_conf.py:
+      Test_ConfigurationVariables: missing_feature (unknown version)
+      Test_ConfigurationVariables_New_Obfuscation: missing_feature
     test_customconf.py:
       Test_CorruptedRules_Telemetry: missing_feature
       Test_NoLimitOnWafRules: v1.37.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1444,6 +1444,7 @@ tests/:
         '*': v0.100.0
         akka-http: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      Test_ConfigurationVariables_New_Obfuscation: missing_feature
     test_customconf.py:
       Test_ConfRuleSet:
         '*': v0.93.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -691,6 +691,7 @@ tests/:
       Test_StandardTagsClientIp: *ref_3_6_0
     test_conf.py:
       Test_ConfigurationVariables: v2.7.0
+      Test_ConfigurationVariables_New_Obfuscation: missing_feature
     test_customconf.py:
       Test_ConfRuleSet: v2.0.0
       Test_CorruptedRules_Telemetry: *ref_5_44_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -346,6 +346,9 @@ tests/:
       Test_Suspicious_Request_Blocking: v1.6.2
     test_client_ip.py:
       Test_StandardTagsClientIp: v0.81.0
+    test_conf.py:
+      Test_ConfigurationVariables: missing_feature (unknown version)
+      Test_ConfigurationVariables_New_Obfuscation: missing_feature
     test_customconf.py:
       Test_CorruptedRules_Telemetry: missing_feature
     test_event_tracking.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1,4 +1,4 @@
----
+git ---
 tests/:
   apm_tracing_e2e/:
     test_otel.py:
@@ -613,8 +613,9 @@ tests/:
       Test_StandardTagsClientIp: v1.5.0
     test_conf.py:
       Test_ConfigurationVariables:
-        '*': v1.1.2
+        '*': v1.5.0rc1.dev
         fastapi: v2.4.0
+      Test_ConfigurationVariables_New_Obfuscation: v3.9.0.dev
     test_customconf.py:
       Test_ConfRuleSet: v1.1.0-rc2
       Test_CorruptedRules_Telemetry: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1,3 +1,4 @@
+---
 tests/:
   apm_tracing_e2e/:
     test_otel.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1,4 +1,3 @@
-git ---
 tests/:
   apm_tracing_e2e/:
     test_otel.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -474,6 +474,9 @@ tests/:
       Test_Suspicious_Request_Blocking: v1.0.0
     test_client_ip.py:
       Test_StandardTagsClientIp: v1.8.0
+    test_conf.py:
+      Test_ConfigurationVariables: missing_feature (unknown version)
+      Test_ConfigurationVariables_New_Obfuscation: missing_feature
     test_customconf.py:
       Test_ConfRuleSet: v1.0.0.beta2
       Test_CorruptedRules: v1.0.0.beta2

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -104,8 +104,9 @@ class Test_ConfigurationVariables:
 @scenarios.appsec_blocking
 class Test_ConfigurationVariables_New_Obfuscation:
     """Check for new obfuscation features in libddwaf 1.25.0 and later
-       Requires libddwaf 1.25.0 or later and updated obfuscation regex for values
+    Requires libddwaf 1.25.0 or later and updated obfuscation regex for values
     """
+
     SECRET_WITH_HIDDEN_VALUE = "hide_value"
 
     def setup_partial_obfuscation_parameter_value(self):
@@ -123,4 +124,3 @@ class Test_ConfigurationVariables_New_Obfuscation:
         # previously, the value was obfuscated as "<Redacted>", now only the secret part is obfuscated
         interfaces.library.assert_waf_attack(self.r_op_value, value="/.git?password=<Redacted>")
         interfaces.library.validate_appsec(self.r_op_value, validate_appsec_span_tags, success_by_default=True)
-

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -97,3 +97,30 @@ class Test_ConfigurationVariables:
 
         interfaces.library.assert_waf_attack(self.r_op_value, pattern="<Redacted>")
         interfaces.library.validate_appsec(self.r_op_value, validate_appsec_span_tags, success_by_default=True)
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2355333252/Environment+Variables")
+@features.threats_configuration
+@scenarios.appsec_blocking
+class Test_ConfigurationVariables_New_Obfuscation:
+    """Check for new obfuscation features in libddwaf 1.25.0 and later
+       Requires libddwaf 1.25.0 or later and updated obfuscation regex for values
+    """
+    SECRET_WITH_HIDDEN_VALUE = "hide_value"
+
+    def setup_partial_obfuscation_parameter_value(self):
+        self.r_op_value = weblog.get(f"/.git?password={self.SECRET_WITH_HIDDEN_VALUE}")
+
+    @missing_feature(context.library <= "ruby@1.0.0")
+    def test_partial_obfuscation_parameter_value(self):
+        """Test DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP"""
+
+        def validate_appsec_span_tags(span, appsec_data):  # noqa: ARG001
+            assert not nested_lookup(
+                self.SECRET_WITH_HIDDEN_VALUE, appsec_data, look_in_keys=True
+            ), "The security events contain the secret value that should be obfuscated"
+
+        # previously, the value was obfuscated as "<Redacted>", now only the secret part is obfuscated
+        interfaces.library.assert_waf_attack(self.r_op_value, value="/.git?password=<Redacted>")
+        interfaces.library.validate_appsec(self.r_op_value, validate_appsec_span_tags, success_by_default=True)
+


### PR DESCRIPTION
## Motivation

libddwaf 1.25.0 has an improved obfuscation mechanism.

## Changes

- add a new test class to test for the improved feature
- update manifest. In particular add a missing file in several manifests!

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
