### PR TITLE
docker ssi: disable old ubuntu 16

### DIFF
--- a/utils/docker_ssi/docker_ssi_images.json
+++ b/utils/docker_ssi/docker_ssi_images.json
@@ -11,16 +11,6 @@
       "architecture": "linux/arm64"
     },
     {
-      "name": "Ubuntu_16_amd64",
-      "image": "public.ecr.aws/docker/library/ubuntu:16.04",
-      "architecture": "linux/amd64"
-    },
-    {
-      "name": "Ubuntu_16_arm64",
-      "image": "public.ecr.aws/docker/library/ubuntu:16.04",
-      "architecture": "linux/arm64"
-    },
-    {
       "name": "CentOS_7_amd64",
       "image": "public.ecr.aws/docker/library/centos:7",
       "architecture": "linux/amd64"

--- a/utils/scripts/ci_orchestrators/docker_ssi.json
+++ b/utils/scripts/ci_orchestrators/docker_ssi.json
@@ -74,18 +74,6 @@
                         ]
                     },
                     {
-                        "name": "Ubuntu_16_amd64",
-                        "allowed_runtime_versions": [
-                            "*"
-                        ]
-                    },
-                    {
-                        "name": "Ubuntu_16_arm64",
-                        "allowed_runtime_versions": [
-                            "*"
-                        ]
-                    },
-                    {
                         "name": "OracleLinux_9_3_arm64",
                         "allowed_runtime_versions": [
                             "*"


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
There are problems to access to the ubuntu 16 repositories. ubuntu 16 is not supported by ssi. we delete it

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
