### PR TITLE
Tests for appsec service activation origin metric

### DIFF
--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -37,6 +37,7 @@ tests/:
     test_reports.py: irrelevant (ASM is not implemented in C++)
     test_request_blocking.py: irrelevant (ASM is not implemented in C++)
     test_runtime_activation.py: irrelevant (ASM is not implemented in C++)
+    test_service_activation_metric.py: irrelevant (ASM is not implemented in C++)
     test_shell_execution.py: irrelevant (ASM is not implemented in C++)
     test_suspicious_attacker_blocking.py: irrelevant (ASM is not implemented in C++)
     test_traces.py: irrelevant (ASM is not implemented in C++)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -413,6 +413,9 @@ tests/:
     test_runtime_activation.py:
       Test_RuntimeActivation: v2.16.0
       Test_RuntimeDeactivation: v2.16.0
+    test_service_activation_metric.py:
+      TestServiceActivationEnvVarMetric: missing_feature
+      TestServiceActivationRemoteConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -484,6 +484,9 @@ tests/:
     test_runtime_activation.py:
       Test_RuntimeActivation: v1.69.0
       Test_RuntimeDeactivation: v1.69.0
+    test_service_activation_metric.py:
+      TestServiceActivationEnvVarMetric: missing_feature
+      TestServiceActivationRemoteConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1648,6 +1648,9 @@ tests/:
         akka-http: v1.22.0
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+    test_service_activation_metric.py:
+      TestServiceActivationEnvVarMetric: missing_feature
+      TestServiceActivationRemoteConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution:
         '*': v1.2.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -793,6 +793,9 @@ tests/:
     test_runtime_activation.py:
       Test_RuntimeActivation: *ref_3_9_0
       Test_RuntimeDeactivation: *ref_3_9_0
+    test_service_activation_metric.py:
+      TestServiceActivationEnvVarMetric: missing_feature
+      TestServiceActivationRemoteConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: *ref_5_3_0
     test_suspicious_attacker_blocking.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -399,6 +399,9 @@ tests/:
     test_runtime_activation.py:
       Test_RuntimeActivation: v1.6.2
       Test_RuntimeDeactivation: v1.6.2
+    test_service_activation_metric.py:
+      TestServiceActivationEnvVarMetric: missing_feature
+      TestServiceActivationRemoteConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: v0.95.0
     test_suspicious_attacker_blocking.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -726,6 +726,9 @@ tests/:
     test_runtime_activation.py:
       Test_RuntimeActivation: v2.10.1
       Test_RuntimeDeactivation: v2.10.1
+    test_service_activation_metric.py:
+      TestServiceActivationEnvVarMetric: missing_feature
+      TestServiceActivationRemoteConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -558,6 +558,9 @@ tests/:
     test_runtime_activation.py:
       Test_RuntimeActivation: missing_feature
       Test_RuntimeDeactivation: missing_feature
+    test_service_activation_metric.py:
+      TestServiceActivationEnvVarMetric: missing_feature
+      TestServiceActivationRemoteConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/tests/appsec/test_service_activation_metric.py
+++ b/tests/appsec/test_service_activation_metric.py
@@ -1,0 +1,50 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+from utils import scenarios
+from utils import features
+from utils import remote_config as rc
+from tests.appsec.utils import find_series
+
+CONFIG_ENABLED = {"asm": {"enabled": True}}
+
+
+def _send_config(config):
+    if config is not None:
+        rc.rc_state.set_config("datadog/2/ASM_FEATURES/asm_features_activation/config", config)
+    else:
+        rc.rc_state.reset()
+    return rc.rc_state.apply().state
+
+
+def validate_metric_tag(origin, metric):
+    return metric.get("type") == "gauge" and f"origin:{origin}" in metric.get("tags", ())
+
+
+class BaseServiceActivationMetric:
+    origin = ""
+
+    def test_service_activation_metric(self):
+        series = find_series("generate-metrics", "appsec", ["enabled"])
+
+        assert series
+        assert any(validate_metric_tag(self.origin, s) for s in series), [s.get("tags") for s in series]
+
+
+@scenarios.appsec_runtime_activation
+@features.appsec_service_activation_origin_metric
+class TestServiceActivationRemoteConfigMetric(BaseServiceActivationMetric):
+    """Test that the service activation remote config metric is sent"""
+
+    def setup_service_activation_metric(self):
+        self.origin = "remote_config"
+        self.config_state = _send_config(CONFIG_ENABLED)
+
+
+@features.appsec_service_activation_origin_metric
+class TestServiceActivationEnvVarMetric(BaseServiceActivationMetric):
+    """Test that the service activation env var metric is sent"""
+
+    def setup_service_activation_metric(self):
+        self.origin = "env_var"

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -920,6 +920,15 @@ class _Features:
         return test_object
 
     @staticmethod
+    def appsec_service_activation_origin_metric(test_object):
+        """Appsec service activation origin metric
+
+        https://feature-parity.us1.prod.dog/#/?feature=471
+        """
+        pytest.mark.features(feature_id=471)(test_object)
+        return test_object
+
+    @staticmethod
     def serialize_waf_rules_without_limiting_their_sizes(test_object):
         """Serialize WAF rules without limiting their sizes
 


### PR DESCRIPTION
## Motivation
<!-- What inspired you to submit this pull request? -->
Add tests for new feature

## Changes
<!-- A brief description of the change being made with this pull request. -->
New tests, checking the origin in configurations by env variable and remote config.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
