### PR TITLE
[PHP] Enable schema path params tests on PHP

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -22,7 +22,7 @@ tests/:
         Test_Schema_Request_FormUrlEncoded_Body: v0.94.0
         Test_Schema_Request_Headers: v0.94.0
         Test_Schema_Request_Json_Body: v0.98.1
-        Test_Schema_Request_Path_Parameters: missing_feature
+        Test_Schema_Request_Path_Parameters: v1.10.0
         Test_Schema_Request_Query_Parameters: v0.94.0
         Test_Schema_Response_Body: v0.99.1
         Test_Schema_Response_Body_env_var: v1.6.2

--- a/utils/build/docker/php/common/tag_value.php
+++ b/utils/build/docker/php/common/tag_value.php
@@ -22,6 +22,12 @@ if (!is_numeric($response_code)) {
 	error();
 }
 
+//This is done automatically on framework integrations
+\datadog\appsec\push_addresses(["server.request.path_params" => [
+	'tag_value' => $value,
+	'status_code' => $response_code,
+]]);
+
 \datadog\appsec\track_custom_event('system_tests_appsec_event',
 [
     'value' => $value


### PR DESCRIPTION
## Motivation

Enable PHP schemas path params tests

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
