### PR TITLE
[python] pass APISecurityStandalone

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -499,7 +499,7 @@ tests/:
         '*': v1.1.0-rc2
         fastapi: v2.4.0
     test_asm_standalone.py:
-      Test_APISecurityStandalone: missing_feature
+      Test_APISecurityStandalone: v3.9.0.dev
       Test_AppSecStandalone_NotEnabled: v2.12.3
       Test_AppSecStandalone_UpstreamPropagation: irrelevant (was v2.12.3 for all, v2.17.1 for uwsgi-poc but will be replaced by V2)
       Test_AppSecStandalone_UpstreamPropagation_V2: v3.2.0.dev

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -119,6 +119,13 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
             },
         )
 
+    @bug(
+        condition=(
+            context.scenario.name == scenarios.appsec_standalone_api_security.name
+            and context.weblog_variant in ("django-poc", "django-py3.13", "python3.12")
+        ),
+        reason="APPSEC-57830",
+    )
     def test_no_appsec_upstream__no_asm_event__is_kept_with_priority_1__from_minus_1(self):
         self.assert_product_is_enabled(self.check_r, self.tested_product)
         spans_checked = 0


### PR DESCRIPTION
Depends on: https://github.com/DataDog/dd-trace-py/pull/13505

## Motivation

API Security sampling in AAP standalone mode should be working for python except for a bug for the Django weblog.

## Changes

Mark Test_APISecurityStandalone as passing as of v3.9.0.dev, except for one of the django system tests

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
