### PR TITLE
[Java] Increase max number of IAST vulnerabilities per request

### DIFF
--- a/utils/build/docker/java/akka-http.Dockerfile
+++ b/utils/build/docker/java/akka-http.Dockerfile
@@ -27,5 +27,6 @@ RUN chmod +x /app/app.sh
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 CMD [ "/app/app.sh" ]

--- a/utils/build/docker/java/play.Dockerfile
+++ b/utils/build/docker/java/play.Dockerfile
@@ -26,5 +26,6 @@ RUN chmod +x /app/app.sh
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 CMD [ "/app/app.sh" ]

--- a/utils/build/docker/java/ratpack.Dockerfile
+++ b/utils/build/docker/java/ratpack.Dockerfile
@@ -26,5 +26,6 @@ RUN chmod +x /app/app.sh
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 CMD [ "/app/app.sh" ]

--- a/utils/build/docker/java/resteasy-netty3.Dockerfile
+++ b/utils/build/docker/java/resteasy-netty3.Dockerfile
@@ -27,5 +27,6 @@ RUN chmod +x /app/app.sh
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 CMD [ "/app/app.sh" ]

--- a/utils/build/docker/java/spring-boot-3-native.Dockerfile
+++ b/utils/build/docker/java/spring-boot-3-native.Dockerfile
@@ -28,6 +28,7 @@ COPY --from=build /app/without-profiling/myproject ./without-profiling/
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 COPY ./utils/build/docker/java/app-native-profiling.sh app.sh
 RUN chmod +x app.sh

--- a/utils/build/docker/java/spring-boot-jetty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-jetty.Dockerfile
@@ -28,5 +28,6 @@ RUN chmod +x /app/app.sh
 ENV APP_EXTRA_ARGS="--server.port=7777"
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 CMD [ "/app/app.sh" ]

--- a/utils/build/docker/java/spring-boot-openliberty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-openliberty.Dockerfile
@@ -24,6 +24,7 @@ COPY --from=build /dd-tracer/dd-java-agent.jar .
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 # FIXME: Fails on APPSEC_BLOCKING, see APPSEC-51405
 # ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 ENV JVM_ARGS='-javaagent:/app/dd-java-agent.jar'
 

--- a/utils/build/docker/java/spring-boot-payara.Dockerfile
+++ b/utils/build/docker/java/spring-boot-payara.Dockerfile
@@ -38,5 +38,6 @@ ENV APP_EXTRA_ARGS="--port 7777"
 ENV HZ_PHONE_HOME_ENABLED=false
 # https://blog.payara.fish/faster-payara-micro-startup-times-with-openj9
 ENV payaramicro_noCluster=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 CMD [ "/app/app.sh" ]

--- a/utils/build/docker/java/spring-boot-undertow.Dockerfile
+++ b/utils/build/docker/java/spring-boot-undertow.Dockerfile
@@ -28,5 +28,6 @@ RUN chmod +x /app/app.sh
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
 ENV APP_EXTRA_ARGS="--server.port=7777"
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 CMD [ "/app/app.sh" ]

--- a/utils/build/docker/java/spring-boot-wildfly.Dockerfile
+++ b/utils/build/docker/java/spring-boot-wildfly.Dockerfile
@@ -29,5 +29,6 @@ ENV DD_APP_CUSTOMLOGMANAGER=true
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
 ENV APP_EXTRA_ARGS="-Djboss.http.port=7777 -b=0.0.0.0"
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 CMD [ "/app/app.sh" ]

--- a/utils/build/docker/java/spring-boot.Dockerfile
+++ b/utils/build/docker/java/spring-boot.Dockerfile
@@ -32,5 +32,6 @@ ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
 ENV APP_EXTRA_ARGS="--server.port=7777"
 ENV DD_DATA_STREAMS_ENABLED=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 CMD [ "/app/app.sh" ]

--- a/utils/build/docker/java/uds-spring-boot.Dockerfile
+++ b/utils/build/docker/java/uds-spring-boot.Dockerfile
@@ -24,6 +24,7 @@ COPY --from=build /dd-tracer/dd-java-agent.jar .
 
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh
 ENV DD_APM_RECEIVER_SOCKET=/var/run/datadog/apm.socket

--- a/utils/build/docker/java/vertx3.Dockerfile
+++ b/utils/build/docker/java/vertx3.Dockerfile
@@ -28,5 +28,6 @@ RUN chmod +x /app/app.sh
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 # FIXME: Fails on DEFAULT scenario, see APPSEC-51406
 # ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 CMD [ "/app/app.sh" ]

--- a/utils/build/docker/java/vertx4.Dockerfile
+++ b/utils/build/docker/java/vertx4.Dockerfile
@@ -28,5 +28,6 @@ RUN chmod +x /app/app.sh
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 # FIXME: Fails on DEFAULT scenario, see APPSEC-51407
 # ENV DD_TRACE_INTERNAL_EXIT_ON_FAILURE=true
+ENV DD_IAST_VULNERABILITIES_PER_REQUEST=10
 
 CMD [ "/app/app.sh" ]


### PR DESCRIPTION
## Motivation

The new IAST detection algorithm defined in [RFC-1029](https://docs.google.com/document/d/1CfGFm2Ouz5vxOhibNyLCZjGzLbDI3F0fO9irKWqxhVI/edit?tab=t.0#heading=h.vmqy3j71slqi) causes some existing IAST-related tests to fail, as the default limit of 2 vulnerabilities per request is no longer sufficient under the new implementation.

## Changes

Increase number of vulnerabilities detected by request to 10

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
