### PR TITLE
[Debugger] Ensure symdb has depth in scopes.

### DIFF
--- a/tests/debugger/test_debugger_symdb.py
+++ b/tests/debugger/test_debugger_symdb.py
@@ -36,21 +36,17 @@ class Test_Debugger_SymDb(debugger.BaseDebuggerTest):
         self._assert_debugger_controller_exists()
 
     def _assert_symbols_have_depth(self):
-        def has_nested_scopes(scope):
-            nested_scopes = scope.get("scopes", [])
-            if nested_scopes:
-                return True
-            return False
-
         has_depth = False
+
         for symbol in self.symbols:
             content = symbol.get("content", {})
             if isinstance(content, dict):
                 scopes = content.get("scopes", [])
                 for scope in scopes:
-                    if has_nested_scopes(scope):
+                    if scope.get("scopes", []):
                         has_depth = True
                         break
+
             if has_depth:
                 break
 


### PR DESCRIPTION
## Motivation
Test for https://datadoghq.atlassian.net/browse/DEBUG-3687 work item

## Changes
Ensure symdb has at least 1 depth in scopes.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
