### PR TITLE
[nodejs] deactivate tests for DEBUG-3487

### DIFF
--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -576,13 +576,12 @@ class EndToEndScenario(DockerScenario):
 
     def pytest_sessionfinish(self, session: pytest.Session, exitstatus: int):
         library_bugs = [
-            # deactivated to get a new occurence of the bug
-            # _SchemaBug(
-            #     endpoint="/debugger/v1/diagnostics",
-            #     data_path="$",
-            #     condition=context.library > "nodejs@5.36.0",
-            #     ticket="DEBUG-3487",
-            # ),
+            _SchemaBug(
+                endpoint="/debugger/v1/diagnostics",
+                data_path="$",
+                condition=self.library > "nodejs@5.36.0",
+                ticket="DEBUG-3487",
+            ),
             _SchemaBug(endpoint="/v0.4/traces", data_path="$", condition=self.library == "java", ticket="APMAPI-1161"),
             _SchemaBug(
                 endpoint="/telemetry/proxy/api/v2/apmtelemetry",
@@ -649,13 +648,12 @@ class EndToEndScenario(DockerScenario):
         self._test_schemas(session, interfaces.library, library_bugs)
 
         agent_bugs = [
-            # deactivated to get a new occurence of the bug
-            # _SchemaBug(
-            #     endpoint="/api/v2/debugger",
-            #     data_path="$",
-            #     condition=self.library > "nodejs@5.36.0",
-            #     ticket="DEBUG-3487",
-            # ),
+            _SchemaBug(
+                endpoint="/api/v2/debugger",
+                data_path="$",
+                condition=self.library > "nodejs@5.36.0",
+                ticket="DEBUG-3487",
+            ),
             _SchemaBug(
                 endpoint="/api/v2/apmtelemetry",
                 data_path="$.payload.configuration[]",


### PR DESCRIPTION
## Motivation

Follow up of #4072 and #4066 : we saw the failure again

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
