### PR TITLE
[NodeJs] disable parametric tests for nodejs baggage

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1009,7 +1009,7 @@ tests/:
       TestDynamicConfigV1_ServiceTargets: *ref_5_4_0
       TestDynamicConfigV2: *ref_4_23_0
     test_headers_baggage.py:
-      Test_Headers_Baggage: *ref_5_29_0
+      Test_Headers_Baggage: irrelevant (uses weblog tests)
       Test_Headers_Baggage_Span_Tags: *ref_5_54_0
     test_otel_api_interoperability.py: missing_feature
     test_otel_env_vars.py:

--- a/tests/parametric/test_headers_baggage.py
+++ b/tests/parametric/test_headers_baggage.py
@@ -73,7 +73,6 @@ class Test_Headers_Baggage:
         assert headers["baggage"] == "foo=bar"
 
     @only_baggage_enabled()
-    @missing_feature(context.library == "nodejs", reason="pausing on this feature to avoid app crashes")
     def test_headers_baggage_only_D002(self, test_library):
         """Ensure that only baggage headers are injected when baggage is the only enabled propagation style."""
         with test_library:
@@ -124,9 +123,6 @@ class Test_Headers_Baggage:
         assert "serverNode=DF%2028" in baggage_items
         assert "%22%2C%3B%5C%28%29%2F%3A%3C%3D%3E%3F%40%5B%5D%7B%7D=%22%2C%3B%5C" in baggage_items
 
-    @missing_feature(
-        context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage"
-    )
     def test_baggage_extract_header_D005(self, test_library):
         """Testing baggage header extraction and decoding"""
 
@@ -176,9 +172,6 @@ class Test_Headers_Baggage:
             headers = test_library.dd_inject_headers(span.span_id)
         assert not any("baggage" in item for item in headers)
 
-    @missing_feature(
-        context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage"
-    )
     def test_baggage_get_D008(self, test_library):
         """Testing baggage API get_baggage"""
         with test_library.dd_extract_headers_and_make_child_span(
@@ -191,9 +184,6 @@ class Test_Headers_Baggage:
             assert span.get_baggage("userId") == "Amélie"
             assert span.get_baggage("serverNode") == "DF 28"
 
-    @missing_feature(
-        context.library == "nodejs", reason="`dd_extract_headers_and_make_child_span` does not work with only baggage"
-    )
     def test_baggage_get_all_D009(self, test_library):
         """Testing baggage API get_all_baggage"""
         with test_library.dd_extract_headers_and_make_child_span(
@@ -233,10 +223,6 @@ class Test_Headers_Baggage:
             headers = test_library.dd_make_child_span_and_get_headers([["baggage", "foo=valid"]])
             assert "baggage" in headers
 
-    @missing_feature(
-        context.library == "nodejs",
-        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage",
-    )
     def test_baggage_malformed_headers_D012(self, test_library):
         """Ensure that malformed baggage headers are handled properly. Unable to use get_baggage functions because it does not return anything"""
         Test_Headers_Baggage._assert_valid_baggage(self, test_library)
@@ -248,10 +234,6 @@ class Test_Headers_Baggage:
 
             assert "baggage" not in headers
 
-    @missing_feature(
-        context.library == "nodejs",
-        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage",
-    )
     def test_baggage_malformed_headers_D013(self, test_library):
         """Ensure that malformed baggage headers are handled properly. Unable to use get_baggage functions because it does not return anything"""
         Test_Headers_Baggage._assert_valid_baggage(self, test_library)
@@ -261,10 +243,6 @@ class Test_Headers_Baggage:
 
             assert "baggage" not in headers
 
-    @missing_feature(
-        context.library == "nodejs",
-        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage",
-    )
     def test_baggage_malformed_headers_D014(self, test_library):
         Test_Headers_Baggage._assert_valid_baggage(self, test_library)
 
@@ -273,10 +251,6 @@ class Test_Headers_Baggage:
 
             assert "baggage" not in headers
 
-    @missing_feature(
-        context.library == "nodejs",
-        reason="`dd_make_child_span_and_get_headers` calls `dd_extract_headers_and_make_child_span`, which does not work with only baggage",
-    )
     def test_baggage_malformed_headers_D015(self, test_library):
         Test_Headers_Baggage._assert_valid_baggage(self, test_library)
 

--- a/tests/parametric/test_headers_baggage.py
+++ b/tests/parametric/test_headers_baggage.py
@@ -1,6 +1,6 @@
 from utils._decorators import irrelevant
 from utils.parametric.spec.trace import find_only_span
-from utils import features, scenarios, context, missing_feature
+from utils import features, scenarios, context
 
 import pytest
 


### PR DESCRIPTION
## Motivation
We are switching to the [weblog tests](https://github.com/DataDog/system-tests/blob/main/tests/test_baggage.py) for nodejs baggage after this [PR](https://github.com/DataDog/dd-trace-js/pull/5815) is released

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
