### PR TITLE
parametric: config consistency add to expected values for logs_injection_enabled

### DIFF
--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -97,7 +97,7 @@ class Test_Defaults:
         configuration_by_name = test_agent.wait_for_telemetry_configurations()
         for apm_telemetry_name, value in [
             ("trace_sample_rate", (1.0, None, "1.0")),
-            ("logs_injection_enabled", ("false", False, "true", True)),
+            ("logs_injection_enabled", ("false", False, "true", True, None)),
             ("trace_header_tags", ""),
             ("trace_tags", ""),
             ("trace_enabled", ("true", True)),


### PR DESCRIPTION
## Motivation

There is on going effort to enable log injection by default for structured loggers. Soon all libraries should report the default value of logs_injection_enabled as:
 - unset/None,  log injection is enabled for structured loggers but not non-structured logs
 - True, log injection is always enabled

The value `False` will no longer be a supported default (this change will be made in a follow up PR).


Unblocks: https://github.com/DataDog/dd-trace-py/pull/13570

## Changes

- Updates the accepted values in a config consistency test.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
