### PR TITLE
[nodejs] Skip IAST header injection test

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -141,32 +141,7 @@ tests/:
             '*': *ref_5_37_0
             nextjs: missing_feature
           Test_HardcodedSecrets_StackTrace: missing_feature
-        test_header_injection.py:
-          TestHeaderInjection:
-            '*': *ref_4_21_0
-            nextjs: missing_feature
-          TestHeaderInjectionExclusionAccessControlAllow:
-            '*': *ref_5_26_0
-            express5: *ref_5_29_0  # test uses querystring
-            nextjs: missing_feature
-          TestHeaderInjectionExclusionContentEncoding:
-            '*': *ref_5_26_0
-            express5: *ref_5_29_0  # test uses querystring
-            nextjs: missing_feature
-          TestHeaderInjectionExclusionPragma:
-            '*': *ref_5_26_0
-            express5: *ref_5_29_0  # test uses querystring
-            nextjs: missing_feature
-          TestHeaderInjectionExclusionTransferEncoding:
-            '*': *ref_5_26_0
-            express5: *ref_5_29_0  # test uses querystring
-            nextjs: missing_feature
-          TestHeaderInjection_ExtendedLocation:
-            '*': *ref_5_37_0
-            nextjs: missing_feature
-          TestHeaderInjection_StackTrace:
-            '*': *ref_5_39_0
-            nextjs: missing_feature
+        test_header_injection.py: irrelevant (Header Injection detection was removed)
         test_hsts_missing_header.py:
           Test_HstsMissingHeader:
             '*': *ref_4_8_0


### PR DESCRIPTION
## Motivation

Header Injection vulnerability detections has been disabled in Node.js tracer

## Changes

Mark header injection related test as irrelevant

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
