### PR TITLE
parametric: update stable config default value for log injection

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1005,7 +1005,7 @@ tests/:
       Test_Config_TraceEnabled: v2.12.2
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v2.12.2
-      Test_Stable_Config_Default: v3.2.0.dev
+      Test_Stable_Config_Default: v3.10.0  # default value of log injection changed in v3.10.0
     test_crashtracking.py:
       Test_Crashtracking: v2.11.2
     test_dynamic_configuration.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1005,7 +1005,7 @@ tests/:
       Test_Config_TraceEnabled: v2.12.2
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v2.12.2
-      Test_Stable_Config_Default: v3.10.0  # default value of log injection changed in v3.10.0
+      Test_Stable_Config_Default: v3.11.0  # default value of log injection changed in v3.10.0
     test_crashtracking.py:
       Test_Crashtracking: v2.11.2
     test_dynamic_configuration.py:

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -382,7 +382,9 @@ SDK_DEFAULT_STABLE_CONFIG = {
     if context.library != "php"
     else "1",  # Profiling is enabled as "1" by default in PHP if loaded
     "dd_data_streams_enabled": "false",
-    "dd_logs_injection": {"ruby": "true", "python": "none"}.get(context.library.name, "false"),  # Enabled by default in ruby, set to None in python
+    "dd_logs_injection": {"ruby": "true", "python": "none"}.get(
+        context.library.name, "false"
+    ),  # Enabled by default in ruby, set to None in python
 }
 
 

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -382,7 +382,7 @@ SDK_DEFAULT_STABLE_CONFIG = {
     if context.library != "php"
     else "1",  # Profiling is enabled as "1" by default in PHP if loaded
     "dd_data_streams_enabled": "false",
-    "dd_logs_injection": "false" if context.library != "ruby" else "true",  # Enabled by default in ruby
+    "dd_logs_injection": {"ruby": "true", "python": "none"}.get(context.library.name, "false"),  # Enabled by default in ruby, set to None in python
 }
 
 


### PR DESCRIPTION
## Motivation

Unblocks: https://github.com/DataDog/dd-trace-py/pull/13570

## Changes

- Allows the default value of log_injection_enabled to be `None`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
