### PR TITLE
[Debugger] Add tests for exception replay `no_capture_reason` 

### DIFF
--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -373,6 +373,33 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
         assert found_top, "Top layer snapshot not found"
         assert found_lowest, "Lowest layer snapshot not found"
 
+    def _validate_no_capture_reason(self, exception_key: str, expected_reason: str):
+        """Validate no_capture_reason field from collected spans."""
+        spans_with_no_capture_reason = self.probe_spans.get(exception_key, [])
+        assert (
+            spans_with_no_capture_reason
+        ), f"No spans with _dd.debug.error.no_capture_reason found for {exception_key}"
+
+        found_expected_reason = False
+        actual_reasons = []
+
+        for span in spans_with_no_capture_reason:
+            meta = span.get("meta", {})
+            actual_reason = meta["_dd.debug.error.no_capture_reason"]
+            actual_reasons.append(actual_reason)
+
+            logger.debug(f"Found _dd.debug.error.no_capture_reason: {actual_reason}")
+
+            if actual_reason == expected_reason:
+                found_expected_reason = True
+                logger.debug(f"Expected reason '{expected_reason}' matches actual reason '{actual_reason}'")
+            else:
+                logger.warning(f"Expected reason '{expected_reason}' but got '{actual_reason}'")
+
+        assert (
+            found_expected_reason
+        ), f"Expected no_capture_reason '{expected_reason}' not found. Actual reasons: {actual_reasons}"
+
     ########### test ############
     ########### Simple ############
     def setup_exception_replay_simple(self):
@@ -481,3 +508,40 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
     @bug(context.library < "java@1.46.0", reason="DEBUG-3285")
     def test_exception_replay_async(self):
         self._assert("exception_replay_async", ["async exception"])
+
+    ############ No capture reason ############
+    no_capture_reason_span_found = False
+
+    def _setup_no_capture_exception(self, exception_key: str):
+        self.send_weblog_request(f"/exceptionreplay/{exception_key}")
+        self.wait_for_no_capture_reason_span(exception_key, _timeout_next)
+
+    def _test_no_capture_exception(self, exception_key: str, expected_reason: str):
+        self.collect()
+        self.assert_all_weblog_responses_ok(expected_code=500)
+        self._validate_no_capture_reason(exception_key, expected_reason)
+
+    ############ dotnet OutOfMemoryException Test ############
+    def setup_exception_replay_outofmemory(self):
+        self._setup_no_capture_exception("outofmemory")
+
+    @irrelevant(context.library != "dotnet", reason="Test specific for.NET")
+    def test_exception_replay_outofmemory(self):
+        self._test_no_capture_exception("outofmemory", "NonSupportedExceptionType")
+
+    ############ .NET StackOverflowException Test ############
+    def setup_exception_replay_stackoverflow(self):
+        self._setup_no_capture_exception("stackoverflow")
+
+    @irrelevant(context.library != "dotnet", reason="Test specific for.NET")
+    @bug(context.library == "dotnet", reason="DEBUG-3999")
+    def test_exception_replay_stackoverflow(self):
+        self._test_no_capture_exception("stackoverflow", "NonSupportedExceptionType")
+
+    ############ .NET First Hit Exception Test ############
+    def setup_exception_replay_firsthit(self):
+        self._setup_no_capture_exception("firsthit")
+
+    @irrelevant(context.library != "dotnet", reason="Test specific for.NET")
+    def test_exception_replay_firsthit(self):
+        self._test_no_capture_exception("firsthit", "FirstOccurrence")

--- a/utils/build/docker/dotnet/weblog/Controllers/ExceptionReplayController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/ExceptionReplayController.cs
@@ -117,5 +117,35 @@ namespace weblog
         {
             return await AsyncThrow();
         }
+
+        [HttpGet("outofmemory")]
+        [Consumes("application/json", "application/xml")]
+        public IActionResult ExceptionReplayOutOfMemory()
+        {
+            throw new System.OutOfMemoryException("outofmemory");
+        }
+
+        [HttpGet("stackoverflow")]
+        [Consumes("application/json", "application/xml")]
+        public IActionResult ExceptionReplayStackOverflow()
+        {
+            throw new System.StackOverflowException("stackoverflow");
+        }
+
+        private static bool _firstHitExceptionThrown = false;
+
+        [HttpGet("firsthit")]
+        [Consumes("application/json", "application/xml")]
+        public IActionResult ExceptionReplayFirstHit()
+        {
+            if (!_firstHitExceptionThrown)
+            {
+                _firstHitExceptionThrown = true;
+                throw new System.InvalidOperationException("firsthit");
+            }
+
+            return Content("Exception was already thrown on first hit, no exception on subsequent calls");
+        }
+
     }
 }


### PR DESCRIPTION
## Motivation
Add tests for exception replay `no_capture_reason`, when exception is not processed for known reasons

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
