### PR TITLE
[Java] Weblog endpoint prompt rules

### DIFF
--- a/utils/build/docker/java/.cursor/README.md
+++ b/utils/build/docker/java/.cursor/README.md
@@ -1,0 +1,258 @@
+# Java Weblog Development with Cursor IDE
+
+This directory contains tools and configurations for Java weblog development in **system-tests** using **Cursor IDE**.
+
+## 📋 Table of Contents
+
+- [Description](#description)
+- [Core Workflow](#core-workflow)
+- [Prerequisites](#prerequisites)
+- [Manual Setup](#manual-setup)
+- [Using the Prompt](#using-the-prompt)
+- [Supported Frameworks](#supported-frameworks)
+- [Development Workflow](#development-workflow)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
+
+## 🎯 Description
+
+The `java-endpoint-prompt.mdc` file is a **specialized prompt** for Cursor IDE that contains:
+
+- **Implementation guidelines** for Java endpoints in system-tests weblogs
+- **Framework-specific patterns** for each framework (Spring Boot, Vert.x, Jersey, etc.)
+- **Critical rules** for preserving existing code
+- **Best practices** for development and testing
+
+## 🚀 Core Workflow
+
+The **fundamental way to work** with this prompt is to **create endpoints from test files**. Here's how it works:
+
+### 📝 Test-Driven Endpoint Creation
+
+1. **Start with a test file** (e.g., `tests/appsec/iast/test_sqli.py`)
+2. **Feed the test to Cursor** with the prompt
+3. **Cursor analyzes the test** and extracts the required endpoints
+4. **Cursor generates the implementation** following the framework patterns
+
+### 💡 Example Usage
+
+```markdown
+@java-endpoint-prompt.mdc
+
+Analyze this test file and create the missing endpoints for Spring Boot:
+
+[paste test file content or reference the test file]
+
+Framework: spring-boot
+Test file: tests/appsec/iast/test_sqli.py
+```
+
+**Cursor will:**
+- 🔍 **Extract endpoint requirements** from the test (paths, methods, parameters)
+- 🏗️ **Generate the Java implementation** using the correct framework patterns
+- ⚡ **Follow preservation rules** to avoid breaking existing code
+- 🎯 **Create only what's needed** based on the test specifications
+
+## ⚙️ Prerequisites
+
+Before using this prompt, make sure you have:
+
+1. **Cursor IDE** installed and configured
+2. **Java 11+** installed on your system
+3. **System-tests** cloned locally
+4. **Basic knowledge** of the supported Java frameworks
+
+## 🔧 Manual Setup
+
+### Step 1: Add to Cursor Context
+
+1. **Open Cursor IDE** in your system-tests workspace
+2. **Access Cursor settings**:
+   - Press `Cmd/Ctrl + ,` to open settings
+   - Or use `Cmd/Ctrl + Shift + P` → "Cursor: Open Settings"
+
+3. **Add the file to context**:
+   ```
+   Option A: Drag the java-endpoint-prompt.mdc file to Cursor chat
+   Option B: Reference the file using @java-endpoint-prompt.mdc
+   Option C: Include the full path: @utils/build/docker/java/.cursor/rules/java-endpoint-prompt.mdc
+   ```
+
+### Step 2: Verify Configuration
+
+In Cursor chat, ask:
+```
+Can you see the java-endpoint-prompt.mdc rules?
+```
+
+If the response includes information about Java frameworks and implementation rules, the configuration is correct!
+
+## 💡 Using the Prompt
+
+### Useful Cursor Commands
+
+Once you have the prompt loaded, you can use commands like:
+
+```markdown
+# Create endpoints from test file (RECOMMENDED APPROACH)
+@java-endpoint-prompt.mdc Analyze this test file and create the missing endpoints for Spring Boot:
+[paste test content or reference test file]
+
+# Create a specific endpoint
+@java-endpoint-prompt.mdc Create a POST /iast/sqli/test endpoint for Spring Boot
+
+# Analyze existing endpoint
+@java-endpoint-prompt.mdc Analyze the /rasp/lfi endpoint in vertx4
+
+# Fix build issues
+@java-endpoint-prompt.mdc Help me fix this compilation error in Jersey
+```
+
+### Request Structure
+
+For best results, structure your requests like this:
+
+```markdown
+@java-endpoint-prompt.mdc
+
+Framework: [spring-boot/vertx3/vertx4/jersey-grizzly2/etc.]
+Test file: [path/to/test_file.py] (RECOMMENDED)
+Action: [analyze-test/create/modify/debug]
+
+Detailed description of what you need...
+```
+
+### 🎯 Test-First Approach (Recommended)
+
+The most effective way to use this prompt:
+
+```markdown
+@java-endpoint-prompt.mdc
+
+Framework: spring-boot
+Test file: tests/appsec/iast/test_sql_injection.py
+
+Please analyze this test file and create all the missing endpoints that are needed for the test to pass.
+```
+
+## 🛠️ Supported Frameworks
+
+The prompt includes specific configurations for:
+
+| Framework | Directory | Characteristics |
+|-----------|-----------|-----------------|
+| **Spring Boot** | `spring-boot/` | Annotations, Controllers, RequestMapping |
+| **Vert.x 3** | `vertx3/` | Route Providers, Consumer<Router> |
+| **Vert.x 4** | `vertx4/` | Route Providers, Consumer<Router> |
+| **Jersey** | `jersey-grizzly2/` | JAX-RS, Resource Classes |
+| **Play** | `play/` | Scala Controllers, Actions |
+| **Ratpack** | `ratpack/` | Handler Classes, Chain |
+| **Akka-HTTP** | `akka-http/` | Scala DSL, Route Objects |
+| **RESTEasy** | `resteasy-netty3/` | JAX-RS, Resource Classes |
+
+## 🔄 Development Workflow
+
+### 1. Test-Driven Endpoint Development
+
+```bash
+# 1. Analyze test file to understand requirements
+@java-endpoint-prompt.mdc Analyze this test file and extract endpoint requirements:
+[paste or reference test file]
+
+# 2. Find existing implementations in other languages (optional)
+@java-endpoint-prompt.mdc Search for similar endpoints in other languages
+
+# 3. Generate endpoints based on test analysis
+@java-endpoint-prompt.mdc Create the missing endpoints for [framework] based on the test analysis
+
+# 4. Build and validate
+./utils/build/build.sh --library java --weblog-variant spring-boot
+
+# 5. Run the test
+./run.sh tests/path/to/test_file.py
+```
+
+### 2. Debugging
+
+```bash
+# For compilation errors
+@java-endpoint-prompt.mdc Analyze this build error: [error]
+
+# For test failures
+@java-endpoint-prompt.mdc This test fails with 404, what should I check?
+```
+
+## 🚨 Troubleshooting
+
+### Cursor doesn't see the file
+
+**Problem**: Cursor doesn't recognize the prompt
+**Solution**:
+1. Verify you're in the correct directory
+2. Use the full path: `@utils/build/docker/java/.cursor/rules/java-endpoint-prompt.mdc`
+3. Restart Cursor IDE
+
+### Generic responses
+
+**Problem**: Cursor gives generic responses without following the rules
+**Solution**:
+1. Make sure to reference the file with `@java-endpoint-prompt.mdc`
+2. Specify the framework in your request
+3. Include specific endpoint context
+4. **Use the test-first approach** for better results
+
+### Build errors
+
+**Problem**: Generated code doesn't compile
+**Solution**:
+1. Verify that existing imports haven't been removed
+2. Check that class fields are preserved
+3. Consult the troubleshooting section in the prompt
+
+### Test analysis issues
+
+**Problem**: Cursor doesn't extract endpoints correctly from tests
+**Solution**:
+1. Make sure to reference both the prompt and the test file clearly
+2. Specify the target framework
+3. Provide the complete test file content or path
+4. Ask for step-by-step analysis if needed
+
+## 🤝 Contributing
+
+### Improving the Prompt
+
+If you find patterns or rules that should be added:
+
+1. **Edit** `java-endpoint-prompt.mdc`
+2. **Test** the changes with various frameworks
+3. **Document** the changes in this README
+4. **Share** in #apm-shared-testing
+
+### Reporting Issues
+
+If you find bugs or inconsistencies:
+
+1. **Describe** the specific problem
+2. **Include** the framework and affected endpoint
+3. **Provide** error logs
+4. **Report** in #apm-shared-testing
+
+## 📚 Additional Resources
+
+- [Weblog Documentation](../../../docs/weblog/)
+- [System-Tests Scenarios](../../../docs/scenarios/)
+- [Development Guide](../../../docs/edit/)
+- [Slack: #apm-shared-testing](https://datadoghq.slack.com/channels/apm-shared-testing)
+
+---
+
+## 🎉 Congratulations!
+
+Thanks for using **system-tests**! This prompt will help you develop Java endpoints efficiently and consistently. Remember that system-tests is very easy to use and brings great confidence to the software you test.
+
+**Have questions?** Ask in the Slack channel **#apm-shared-testing**!
+
+---
+
+**📋 DOCUMENTATION USED**: @java-endpoint-prompt.mdc, @docs/weblog/, @docs/scenarios/ 

--- a/utils/build/docker/java/.cursor/rules/java-endpoint-prompt.mdc
+++ b/utils/build/docker/java/.cursor/rules/java-endpoint-prompt.mdc
@@ -1,0 +1,202 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# Java Endpoint Generation Guidelines
+
+## Repository Structure
+
+```
+system-tests/
+|-- docs/                   # Documentation files. Folder to provide good and accurate answers. Follow the links.
+|   |-- weblog/             # Weblog service documentation
+|-- utils/                  # Util files
+|   |-- build/              # Build utilities
+|   |   |-- docker/         # Here you can find the Docker applications (weblogs) for the tests
+|   |   |   |-- java/       # Weblog implementation for java
+|   |   |   |   |-- akka-http/          # Weblog implementation for akka-http
+|   |   |   |   |-- jersey-grizzly2/    # Weblog implementation for jersey-grizzly2
+|   |   |   |   |-- play/               # Weblog implementation for play
+|   |   |   |   |-- ratpack/            # Weblog implementation for ratpack
+|   |   |   |   |-- resteasy-netty3/    # Weblog implementation for resteasy-netty3
+|   |   |   |   |-- spring-boot/        # Weblog implementation for spring-boot 
+|   |   |   |   |-- vertx3/             # Weblog implementation for vertx3
+|   |   |   |   |-- vertx4/             # Weblog implementation for vertx4
+|-- build.sh                # Script to build test environment
+|-- run.sh                  # Script to run tests and scenarios
+```
+
+## Code Style
+- All code, comments, and documentation must be written in English.
+- Never write redundant or superfluous comments in code.
+- If the next line is obvious, really, do not add a comment.
+- If a code block is self-documenting for a Senior Engineer, DO NOT ADD A COMMENT.
+
+## Critical Implementation Rules
+
+### 1. Dependency Preservation
+- **NEVER remove existing imports, fields, or methods** unless explicitly asked to do only the requested endpoints
+- When adding new functionality, only add what's necessary - don't modify existing working code
+- Pay special attention to:
+  - Import statements (especially framework-specific imports)
+  - Class fields (like `emailExamples`, `sqlExamples`, etc.)
+  - Constructor initialization
+  - Existing endpoint methods
+
+### 2. Validation Before Changes
+- **ALWAYS search for existing endpoints** with similar paths before creating new ones
+- Use `grep_search` to find existing implementations in other languages (Node.js, Python, etc.)
+- Check if the test file already has endpoint definitions to understand requirements
+- Look for existing controller classes that handle the same base path (e.g., `/iast/`)
+
+## Endpoint Implementation Process
+
+### Step 1: Analysis
+1. Read the test file to understand:
+   - Required HTTP methods (GET, POST, OPTIONS)
+   - Expected parameters
+   - Number of vulnerabilities needed
+   - Expected response format
+
+2. Search for existing implementations:
+   ```bash
+   # Find existing implementations in other languages
+   grep -r "endpoint-path" utils/build/docker/
+   ```
+
+3. Identify the correct controller class:
+   - For `/iast/*` paths → Usually `AppSecIast.java`
+   - For `/appsec/*` paths → Usually `AppSec.java`
+   - Look for classes with `@RequestMapping` annotations
+
+### Step 2: Implementation
+1. Add endpoints to the appropriate controller class
+2. Follow existing patterns in the same class
+3. Use proper Spring Boot annotations:
+   - `@GetMapping`, `@PostMapping` for HTTP methods
+   - `@PathVariable` for URL parameters
+   - `@RequestParam` for query parameters
+   - `ServletRequest` for form parameters
+
+### Step 3: Build and Test
+1. **Build the weblog**:
+   ```bash
+   ./utils/build/build.sh --library java --weblog-variant [framework]
+   ```
+   
+2. **Run the test to validate**:
+   ```bash
+   ./run.sh tests/path/to/test_file.py
+   ```
+
+3. **Check build errors carefully** - they often indicate missing dependencies
+
+
+## Framework-Specific Notes
+
+### Spring Boot
+- Controller classes are in `src/main/java/com/datadoghq/system_tests/springboot/`
+- Use `@RestController` and `@RequestMapping` at class level
+- Common imports needed: `ServletRequest`, `HttpServletRequest`, `@PathVariable`
+- Example classes: `AppSecIast.java`, `AppSec.java`, `Rasp.java`
+
+### Vert.x 3
+- Route providers are in `src/main/java/com/datadoghq/vertx3/` organized by feature (e.g., `iast/routes/`, `rasp/`)
+- Implement `Consumer<Router>` interface with `accept(Router router)` method
+- Use `router.get()`, `router.post()` for HTTP methods with `.handler()` for implementation
+- Path parameters use `:paramName` syntax (e.g., `/endpoint/:key`)
+- Access request with `ctx.request()` and get parameters with `request.getParam("paramName")`
+- Response with `ctx.response().end("message")` or `ctx.response().putHeader().end()`
+- Common imports needed: `HttpServerRequest`, `Router`, `Json` for JSON responses
+- Route providers implement specific functionality (security, performance, etc.)
+- Constructor receives dependencies via dependency injection
+- Route registration done in Main.java by adding provider to router
+
+### Vert.x 4
+- Route providers are in `src/main/java/com/datadoghq/vertx4/` organized by feature (e.g., `iast/routes/`, `rasp/`)
+- Implement `Consumer<Router>` interface with `accept(Router router)` method
+- Use `router.get()`, `router.post()` for HTTP methods with `.handler()` for implementation
+- Path parameters use `:paramName` syntax (e.g., `/endpoint/:key`)
+- Access request with `ctx.request()` and get parameters with `request.getParam("paramName")`
+- Response with `ctx.response().end("message")` or `ctx.response().putHeader().end()`
+- Common imports needed: `HttpServerRequest`, `Router`, `Json` for JSON responses
+- Route providers implement specific functionality (security, performance, etc.)
+- Constructor receives dependencies via dependency injection
+- Route registration done in Main.java by adding provider to router
+
+### Jersey (JAX-RS) with Grizzly2
+- Resource classes are in `src/main/java/com/datadoghq/jersey/`
+- Use JAX-RS annotations: `@Path`, `@GET`, `@POST`, `@PathParam`, `@FormParam`
+- Class-level `@Path("/base")` and method-level `@Path("/endpoint/{param}")` 
+- Parameters: `@PathParam("id")` for URL params, `@FormParam("param")` for form data
+- Response with `String` return or `Response.builder()` for complex responses
+- Common imports needed: `jakarta.ws.rs.*`, `Response`, `MediaType`
+- Use `@Produces(MediaType.TEXT_PLAIN)` or `MediaType.APPLICATION_JSON`
+- Constructor receives dependencies via static references or injection
+- Automatic registration via JAX-RS scanning
+
+### Play Framework (Scala)
+- Controllers are in `app/controllers/` using Scala
+- Extend `AbstractController` and use dependency injection with `@Inject`
+- Define actions with `def endpointName = Action { request =>` or `Action.async`
+- URL parameters via method parameters, form data via `request.body`
+- Response with `Results.Ok("message")`, `Json.toJson()` for JSON responses
+- Path parameters defined in routes file: `GET /endpoint/:id controllers.Controller.method(id: String)`
+- Common imports needed: `play.api.mvc._`, `play.api.libs.json.Json`
+- Request parsing: `AnyContentAsFormUrlEncoded`, `AnyContentAsJson`, etc.
+- Async support with `Future` and `Action.async`
+
+### Ratpack
+- Handler classes are in `src/main/java/com/datadoghq/ratpack/`
+- Implement setup method that receives `Chain` parameter
+- Use `chain.path("endpoint", ctx -> ctx.getResponse().send("message"))`
+- Path parameters via `chain.path("endpoint/:id", ctx -> ...)` 
+- Access request with `ctx.getRequest()` and query params with `getQueryParams().get("param")`
+- Response with `ctx.getResponse().send("message")`
+- Common imports needed: `ratpack.handling.Chain`, `ratpack.handling.Context`
+- Chain-based routing with method chaining
+- Registration done in Main.java by adding handler to server spec
+
+### Akka-HTTP (Scala)
+- Route objects are in `src/main/scala/com/datadoghq/akka_http/`
+- Define routes with DSL: `pathPrefix("base") { get { path("endpoint") { complete("response") } } }`
+- Path parameters with `path(Segment)` or `pathPrefix(Segment)`
+- Form parameters with `paramOrFormField("param")` or `formField("param")`
+- Response with `complete("message")` or `complete(StatusCodes.OK, data)`
+- Common imports needed: `akka.http.scaladsl.server.Directives._`, `akka.http.scaladsl.server.Route`
+- Nested routing with `pathPrefix` and `~` for route composition
+- JSON marshalling with custom marshallers
+- Route registration done in Main.scala by combining routes
+
+### RESTEasy with Netty3
+- Resource classes are in `src/main/java/com/datadoghq/resteasy/`
+- Use JAX-RS annotations: `@Path`, `@GET`, `@POST`, `@PathParam`, `@FormParam`
+- Similar pattern to Jersey but with RESTEasy-specific features
+- Class-level `@Path("/base")` and method-level `@Path("/endpoint/{param}")`
+- Parameters: `@PathParam("id")` for URL params, `@FormParam("param")` for form data
+- Response with `String` return or `Response.builder()` for complex responses
+- Common imports needed: `jakarta.ws.rs.*`, `Response`, `MediaType`
+- Constructor receives dependencies via static references
+- Registration done via RESTEasy application scanning
+
+## Troubleshooting
+
+### Build Failures
+1. **Missing imports**: Check if you removed necessary imports
+2. **Missing fields**: Verify all class fields are preserved
+3. **Constructor issues**: Ensure all field initializations remain
+
+### Test Failures
+1. **404 errors**: Check endpoint path matches test expectations
+2. **500 errors**: Usually dependency injection or method signature issues
+3. **xfailed tests**: Normal for new endpoints, indicates test ran successfully
+
+## Quality Checklist
+Before submitting:
+- [ ] All existing imports and fields preserved
+- [ ] Build passes without errors
+- [ ] Test runs (even if xfailed)
+- [ ] Code follows existing patterns in the same controller
+- [ ] No unnecessary comments added
+- [ ] Only implemented what was explicitly requested


### PR DESCRIPTION
## Motivation

In Java, we need to support at least seven different implementations of the same endpoint to cover all the weblog variants we support.

This means that whenever a new test is created that affects Java, we need to implement all the endpoints that the test needs for each of these variants.

These rules are intended to streamline and automate the creation of those endpoints.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
