### PR TITLE
[php] use ubuntu24.04 for PHP-FPM

### DIFF
--- a/utils/build/docker/php/php-fpm-7.0.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.0.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ARG PHP_VERSION=7.0
 
 ADD binaries* /binaries/

--- a/utils/build/docker/php/php-fpm-7.1.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.1.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ARG PHP_VERSION=7.1
 
 ADD binaries* /binaries/

--- a/utils/build/docker/php/php-fpm-7.2.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.2.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ARG PHP_VERSION=7.2
 
 ADD binaries* /binaries/

--- a/utils/build/docker/php/php-fpm-7.3.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.3.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ARG PHP_VERSION=7.3
 
 ADD binaries* /binaries/

--- a/utils/build/docker/php/php-fpm-7.4.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.4.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ARG PHP_VERSION=7.4
 
 ADD binaries* /binaries/

--- a/utils/build/docker/php/php-fpm-8.0.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.0.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ARG PHP_VERSION=8.0
 
 ADD binaries* /binaries/

--- a/utils/build/docker/php/php-fpm-8.1.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.1.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ARG PHP_VERSION=8.1
 
 ADD binaries* /binaries/

--- a/utils/build/docker/php/php-fpm-8.2.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.2.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ARG PHP_VERSION=8.2
 
 ADD binaries* /binaries/


### PR DESCRIPTION
## Motivation

ubuntu 20.04 is EOS may 2025, I strongly presume it causes atp-get failures


## Changes

Per title

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
