### PR TITLE
[golang] AAP: Enable trace tagging rules support

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -413,7 +413,7 @@ tests/:
       Test_StandardTagsClientIp: v1.44.1
     test_conf.py:
       Test_ConfigurationVariables: missing_feature (unknown version)
-      Test_ConfigurationVariables_New_Obfuscation: missing_feature
+      Test_ConfigurationVariables_New_Obfuscation: v2.1.0-dev
     test_customconf.py:
       Test_CorruptedRules_Telemetry: missing_feature
       Test_NoLimitOnWafRules: v1.37.0
@@ -494,8 +494,8 @@ tests/:
     test_suspicious_attacker_blocking.py:
       Test_Suspicious_Attacker_Blocking: v1.69.0
     test_trace_tagging.py:
-      Test_TraceTaggingRules: missing_feature
-      Test_TraceTaggingRulesRcCapability: missing_feature
+      Test_TraceTaggingRules: v2.1.0-dev
+      Test_TraceTaggingRulesRcCapability: v2.1.0-dev
     test_traces.py:
       Test_AppSecEventSpanTags:
         '*': v1.36.0


### PR DESCRIPTION
## Motivation

Enables new system tests for AAP Trace Tagging support.
Also fixes one XPASS test.

Depends-on: https://github.com/DataDog/dd-trace-go/pull/3619

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
