### PR TITLE
Fetch dd-trace-java artifacts from S3 instead of ghcr

### DIFF
--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -14,7 +14,7 @@
 # * cpp_httpd:  Github action artifact
 # * Golang:     github.com/DataDog/dd-trace-go/v2@main
 # * .NET:       ghcr.io/datadog/dd-trace-dotnet
-# * Java:       ghcr.io/datadog/dd-trace-java
+# * Java:       S3
 # * PHP:        ghcr.io/datadog/dd-trace-php
 # * Node.js:    Direct from github source
 # * C++:        Direct from github source
@@ -174,8 +174,10 @@ cd binaries/
 
 if [ "$TARGET" = "java" ]; then
     assert_version_is_dev
-    assert_target_branch_is_not_set
-    ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-java/dd-trace-java:latest_snapshot .
+
+    TARGET_BRANCH="${TARGET_BRANCH:-master}"
+
+    curl --fail --location --silent --show-error --output dd-java-agent.jar "https://s3.us-east-1.amazonaws.com/dd-trace-java-builds/${TARGET_BRANCH}/dd-java-agent.jar"
 
 elif [ "$TARGET" = "dotnet" ]; then
     assert_version_is_dev


### PR DESCRIPTION
## Motivation

Pushing images to GHCR will no longer work with PAT deprecation

## Changes

dd-trace-java snapshots are retrieved from s3 instead of GHCR
<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
