### PR TITLE
Enable Test_ExtractBehavior_* tests for .NET (v3.10.0+) and Python (v2.20.0+)

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -627,10 +627,10 @@ tests/:
     Test_Propagate_Legacy: v2.26.0
   test_ipv6.py: missing_feature (APMAPI-869)
   test_library_conf.py:
-    Test_ExtractBehavior_Default: missing_feature (conflicting trace contexts should generate span link)
-    Test_ExtractBehavior_Ignore: missing_feature (extract behavior not implemented)
-    Test_ExtractBehavior_Restart: missing_feature (extract behavior not implemented)
-    Test_ExtractBehavior_Restart_With_Extract_First: missing_feature (extract behavior not implemented)
+    Test_ExtractBehavior_Default: v3.10.0
+    Test_ExtractBehavior_Ignore: v3.10.0
+    Test_ExtractBehavior_Restart: v3.10.0
+    Test_ExtractBehavior_Restart_With_Extract_First: v3.10.0
     Test_HeaderTags: v2.27.0
     Test_HeaderTags_Colon_Leading: v2.1.0
     Test_HeaderTags_Colon_Trailing: v3.0.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1190,10 +1190,10 @@ tests/:
     Test_Propagate: v1.9.0
     Test_Propagate_Legacy: v1.5.0-rc1
   test_library_conf.py:
-    Test_ExtractBehavior_Default: missing_feature (trace context with only baggage should still be propagated)
-    Test_ExtractBehavior_Ignore: missing_feature (extract behavior not implemented)
-    Test_ExtractBehavior_Restart: missing_feature (extract behavior not implemented)
-    Test_ExtractBehavior_Restart_With_Extract_First: missing_feature (extract behavior not implemented)
+    Test_ExtractBehavior_Default: v2.20.0
+    Test_ExtractBehavior_Ignore: v2.20.0
+    Test_ExtractBehavior_Restart: v2.20.0
+    Test_ExtractBehavior_Restart_With_Extract_First: v2.20.0
     Test_HeaderTags: v0.53
     Test_HeaderTags_Colon_Leading: v1.2.1  # actual version unknown
     Test_HeaderTags_Colon_Trailing: v2.8.0


### PR DESCRIPTION
## Motivation

This unskips some XPASS tests for an APM trace context propagation feature, so that we can track any regressions if they occur.

## Changes

See PR title.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
* [x] A scenario is added (or removed)?
    * [x] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
