### PR TITLE
Add healthcheck on proxy container

### DIFF
--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -341,6 +341,9 @@ class EndToEndScenario(DockerScenario):
         self.weblog_container.depends_on.append(self.agent_container)
         self.weblog_container.depends_on.extend(self._supporting_containers)
 
+        if use_proxy_for_weblog:
+            self.weblog_container.depends_on.append(self.proxy_container)
+
         self.weblog_container.environment["SYSTEMTESTS_SCENARIO"] = self.name
 
         self._required_containers.append(self.agent_container)

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -573,6 +573,10 @@ class ProxyContainer(TestedContainer):
 
         """
 
+        # Adjust healthcheck for IPv6 scenarios
+        host_target = "::1" if enable_ipv6 else "localhost"
+        socket_family = "socket.AF_INET6" if enable_ipv6 else "socket.AF_INET"
+
         super().__init__(
             image_name="datadog/system-tests:proxy-v1",
             name="proxy",
@@ -595,7 +599,7 @@ class ProxyContainer(TestedContainer):
             ports={f"{ProxyPorts.proxy_commands}/tcp": ("127.0.0.1", self.command_host_port)},
             command="python utils/proxy/core.py",
             healthcheck={
-                "test": f"python -c \"import socket; s=socket.socket(); s.settimeout(2); s.connect(('localhost', {ProxyPorts.weblog})); s.close()\"",  # noqa: E501
+                "test": f"python -c \"import socket; s=socket.socket({socket_family}); s.settimeout(2); s.connect(('{host_target}', {ProxyPorts.weblog})); s.close()\"",  # noqa: E501
                 "retries": 30,
             },
         )

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -594,6 +594,10 @@ class ProxyContainer(TestedContainer):
             },
             ports={f"{ProxyPorts.proxy_commands}/tcp": ("127.0.0.1", self.command_host_port)},
             command="python utils/proxy/core.py",
+            healthcheck={
+                "test": f"python -c \"import socket; s=socket.socket(); s.settimeout(2); s.connect(('localhost', {ProxyPorts.weblog})); s.close()\"",
+                "retries": 30,
+            },
         )
 
 

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -595,7 +595,7 @@ class ProxyContainer(TestedContainer):
             ports={f"{ProxyPorts.proxy_commands}/tcp": ("127.0.0.1", self.command_host_port)},
             command="python utils/proxy/core.py",
             healthcheck={
-                "test": f"python -c \"import socket; s=socket.socket(); s.settimeout(2); s.connect(('localhost', {ProxyPorts.weblog})); s.close()\"",
+                "test": f"python -c \"import socket; s=socket.socket(); s.settimeout(2); s.connect(('localhost', {ProxyPorts.weblog})); s.close()\"",  # noqa: E501
                 "retries": 30,
             },
         )


### PR DESCRIPTION
## Motivation

The lack of a healthcheck can cause a race condition on the weblog container startup, where the first few requests to the proxy fail.

This healthcheck ensures the proxy container is ready before the weblog one starts.

<!-- What inspired you to submit this pull request? -->

## Changes

* Add a simpke healthcheck on proxy container.
* Ensure the weblog container has the proxy among its dependencies.

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
