### PR TITLE
add support for passing scenario names in lowercase in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -305,7 +305,7 @@ function main() {
                 ;;
             -*)
                 # unknown flag probably to be passed to pytest
-                pytest_args+=("$1")
+                pytest_args+=("$1 $2")
                 shift
                 ;;
             *)


### PR DESCRIPTION
## Motivation

I NEED to be able to copy paste scenario names from the test decorators to the run command, and they're in lowercase, so run.sh also needs to support lowercase scenario names.

## Changes

This adds a condition that tests path sent as positional argument to the run.sh command starts with either `/` or `./tests/` or `tests/`. Otherwise case-insensitive alphanumeric strings will be considered scneario names, and anything else will be passed to pytest.

This allow run.sh to be used in these different ways:
```
./run.sh tests/...
./run.sh ./tests/...
./run.sh /asbolute/path/...

./run.sh SCENARIO_NAME tests/...
./run.sh SCENARIO_NAME ./tests/...
./run.sh SCENARIO_NAME /asbolute/path/...

# new syntax!
./run.sh scenario_name tests/...
./run.sh scenario_name ./tests/...
./run.sh scenario_name /asbolute/path/...
```
