### PR TITLE
Disable Client-Side-Stats on default tests

### DIFF
--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -261,7 +261,14 @@ class Test_Config_RateLimit:
 
     @parametrize(
         "library_env",
-        [{"DD_TRACE_RATE_LIMIT": "1", "DD_TRACE_SAMPLE_RATE": "1", "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":1}]'}],
+        [
+            {
+                "DD_TRACE_RATE_LIMIT": "1",
+                "DD_TRACE_SAMPLE_RATE": "1",
+                "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":1}]',
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
+            }
+        ],
     )
     def test_setting_trace_rate_limit(self, library_env, test_agent, test_library):
         # In PHP the rate limiter is continuously backfilled, i.e. if the rate limit is 2, and 0.2 seconds have passed, an allowance of 0.4 is backfilled.

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -29,6 +29,8 @@ DEFAULT_ENVVARS = {
     # Decrease the heartbeat/poll intervals to speed up the tests
     "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.2",
     "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.2",
+    # Disable CSS which is enabled by default on Go
+    "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
 }
 
 

--- a/tests/parametric/test_span_sampling.py
+++ b/tests/parametric/test_span_sampling.py
@@ -67,6 +67,7 @@ class Test_Span_Sampling:
                 "DD_SPAN_SAMPLING_RULES": json.dumps([{"service": "notmatching", "name": "notmatching"}]),
                 "DD_TRACE_SAMPLE_RATE": 0,
                 "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":0}]',
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             }
         ],
     )
@@ -113,6 +114,7 @@ class Test_Span_Sampling:
                 "DD_SPAN_SAMPLING_RULES": json.dumps([{"name": "no_match"}]),
                 "DD_TRACE_SAMPLE_RATE": 0,
                 "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":0}]',
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             }
         ],
     )
@@ -173,6 +175,7 @@ class Test_Span_Sampling:
                 ),
                 "DD_TRACE_SAMPLE_RATE": 0,
                 "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":0}]',
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             }
         ],
     )
@@ -206,6 +209,7 @@ class Test_Span_Sampling:
                 ),
                 "DD_TRACE_SAMPLE_RATE": 0,
                 "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":0}]',
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             }
         ],
     )
@@ -260,6 +264,7 @@ class Test_Span_Sampling:
                 ),
                 "DD_TRACE_SAMPLE_RATE": 0,
                 "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":0}]',
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             }
         ],
     )
@@ -431,6 +436,7 @@ class Test_Span_Sampling:
                 ),
                 "DD_TRACE_SAMPLE_RATE": 0,
                 "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":0}]',
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             }
         ],
     )
@@ -496,6 +502,7 @@ class Test_Span_Sampling:
                 ),
                 "DD_TRACE_SAMPLE_RATE": 0,
                 "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":0}]',
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             }
         ],
     )
@@ -541,6 +548,7 @@ class Test_Span_Sampling:
                 ),
                 "DD_TRACE_SAMPLE_RATE": 0,
                 "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":0}]',
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             }
         ],
     )

--- a/tests/parametric/test_trace_sampling.py
+++ b/tests/parametric/test_trace_sampling.py
@@ -61,6 +61,7 @@ class Test_Trace_Sampling_Basic:
                 "DD_TRACE_SAMPLING_RULES": json.dumps(
                     [{"service": "webserver", "name": "web.request", "sample_rate": 0}]
                 ),
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             }
         ],
     )
@@ -183,6 +184,7 @@ class Test_Trace_Sampling_Globs:
             {
                 "DD_TRACE_SAMPLE_RATE": 1,
                 "DD_TRACE_SAMPLING_RULES": json.dumps([{"service": "w?bs?rv?r", "name": "web.*", "sample_rate": 0}]),
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             }
         ],
     )
@@ -322,6 +324,7 @@ class Test_Trace_Sampling_Resource:
                         {"service": "webserver", "name": "web.request", "resource": "/bar", "sample_rate": 0},
                     ]
                 ),
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             }
         ],
     )
@@ -408,6 +411,7 @@ class Test_Trace_Sampling_Tags:
                         {"tags": {"tag1": "v?l1", "tag2": "val*"}, "sample_rate": 0},
                     ]
                 ),
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             },
         ],
     )
@@ -428,6 +432,7 @@ def tag_sampling_env(tag_glob_pattern):
         "DD_TRACE_SAMPLING_RULES": json.dumps(
             [{"tags": {"tag": tag_glob_pattern}, "sample_rate": 1.0}, {"sample_rate": 0}]
         ),
+        "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
     }
 
 

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -388,6 +388,7 @@ class _Scenarios:
             # added to test Test_ExtendedHeaderCollection
             "DD_APPSEC_COLLECT_ALL_HEADERS": "true",
             "DD_APPSEC_HEADER_COLLECTION_REDACTION_ENABLED": "false",
+            "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
         },
         doc="Appsec standalone mode (APM opt out)",
         scenario_groups=[scenario_groups.appsec],

--- a/utils/_context/_scenarios/default.py
+++ b/utils/_context/_scenarios/default.py
@@ -50,6 +50,7 @@ class DefaultScenario(EndToEndScenario):
                 "DD_DBM_PROPAGATION_MODE": "service",
                 "SOME_SECRET_ENV": "leaked-env-var",  # used for test that env var are not leaked
                 "DD_EXTERNAL_ENV": "it-false,cn-weblog,pu-75a2b6d5-3949-4afb-ad0d-92ff0674e759",
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
             },
             agent_env={"SOME_SECRET_ENV": "leaked-env-var"},
             include_postgres_db=True,


### PR DESCRIPTION
## Motivation

dd-trace-go is [about to enable Client-Side-Stats by default](https://github.com/DataDog/dd-trace-go/pull/3548). This feature causes all P0 traces to be dropped on the tracer side.

Many system-tests targeting all tracers rely on the fact that all traces are flushed to the agent, and to avoid breaking this pattern, the FF controlling CSS on Go is set to false.

A follow up PR(s) will enhance CSS coverage, which is currently rather low.

<!-- What inspired you to submit this pull request? -->

## Changes

Tests that rely on P0 traces being sent to the agent have `DD_TRACE_STATS_COMPUTATION` set to `false`, ensuring dd-trace-go doesn't drop P0 traces.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
