### PR TITLE
tracing: Zach.montoya/otel otlp experiment

### DIFF
--- a/tests/otel/test_metrics.py
+++ b/tests/otel/test_metrics.py
@@ -3,43 +3,176 @@ import time
 
 from utils import context, weblog, interfaces, scenarios, irrelevant, features, logger
 
-def validate_example_counter_new(metric: dict, name: str, value: str) -> None:
-    assert metric["name"] == name
-    assert "sum" in metric # This asserts the metric type is a counter
-    assert len(metric["sum"]["dataPoints"]) == 1
-    assert metric["sum"]["dataPoints"][0]["asInt"] == value
-    assert metric["sum"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_DELTA"
-    assert metric["sum"]["isMonotonic"] == True
+def validate_resource_metrics(resource_metrics_list: list) -> None:
+    # Assert the following protobuf structure from https://github.com/open-telemetry/opentelemetry-proto/blob/v1.7.0/opentelemetry/proto/metrics/v1/metrics.proto:
+    # message ResourceMetrics {
+    #     optional opentelemetry.proto.resource.v1.Resource resource = 1;
+    #     repeated ScopeMetrics scope_metrics = 2;
+    #     optional string schema_url = 3;
+    # }
 
-def validate_example_histogram_new(metric: dict) -> None:
-    assert metric["name"] == "example.histogram"
+    assert all(len(resource_metrics) == 1 for resource_metrics in resource_metrics_list), "Metrics payloads from one configured application should have one set of resource metrics"
+    assert any("scopeMetrics" in resource_metrics[0] and len(resource_metrics[0]["scopeMetrics"]) > 0 for resource_metrics in resource_metrics_list), "Scope metrics should be present on some payloads"
+    assert all(resource_metrics[0]["resource"] is not None for resource_metrics in resource_metrics_list), "Resource metrics from an application with configured resources should have a resource field"
+    # Do not assert on schema_url, as it is not always present
+
+def validate_scope_metrics(scope_metrics_list: list) -> None:
+    # Assert the following protobuf structure from https://github.com/open-telemetry/opentelemetry-proto/blob/v1.7.0/opentelemetry/proto/metrics/v1/metrics.proto:
+    # message ScopeMetrics {
+    #     optional opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+    #     repeated Metric metrics = 2;
+    #     optional string schema_url = 3;
+    # }
+
+    assert all(len(scope_metrics) == 1 for scope_metrics in scope_metrics_list), "Metrics payloads from one configured application should have one set of scope metrics"
+    assert all(scope_metric[0]["scope"] is not None for scope_metric in scope_metrics_list), "Scope metrics should have a scope field"
+    # Do not assert on schema_url, as it is not always present
+    for scope_metrics in scope_metrics_list:
+        for metric in scope_metrics[0]["metrics"]:
+            validate_metric(metric) 
+
+def validate_metric(metric: dict) -> None:
+    # Assert the following protobuf structure from https://github.com/open-telemetry/opentelemetry-proto/blob/v1.7.0/opentelemetry/proto/metrics/v1/metrics.proto:
+    # message Metric {
+    #     optional string name = 1;
+    #     optional string description = 2;
+    #     optional string unit = 3;
+    #     oneof data {
+    #         Gauge gauge = 5;
+    #         Sum sum = 7;
+    #         Histogram histogram = 9;
+    #         ExponentialHistogram exponential_histogram = 10;
+    #         Summary summary = 11;
+    #     }
+    #     repeated opentelemetry.proto.common.v1.KeyValue metadata = 12;
+    # }
+
+    assert metric["name"] is not None, "Metrics are expected to have a name"
+    # assert metric["description"] is not None, "Metrics are expected to have a description"
+    # assert metric["unit"] is not None, "Metrics are expected to have a unit"
+    # assert metric["metadata"] is not None, "Metrics are expected to have metadata"
+
+    assert metric["name"] in metric_to_validator, f"Metric {metric['name']} is not expected"
+    func, name, value, aggregation_temporality = metric_to_validator[metric["name"]]
+    func(metric, name, value, aggregation_temporality)
+
+def validate_counter(metric: dict, name: str, value: str, aggregation_temporality: str) -> None:
+    # Assert the following protobuf structure from https://github.com/open-telemetry/opentelemetry-proto/blob/v1.7.0/opentelemetry/proto/metrics/v1/metrics.proto:
+    # message Sum {
+    #     repeated NumberDataPoint data_points = 1;
+    #     optional AggregationTemporality aggregation_temporality = 2;
+    #     optional bool is_monotonic = 3;
+    # }
+    # enum AggregationTemporality {
+    #     AGGREGATION_TEMPORALITY_UNSPECIFIED = 0;
+    #     AGGREGATION_TEMPORALITY_DELTA = 1;
+    #     AGGREGATION_TEMPORALITY_CUMULATIVE = 2;
+    # }
+
+    assert metric["name"] == name
+    assert "sum" in metric
+    assert len(metric["sum"]["dataPoints"]) == 1
+    assert metric["sum"]["aggregationTemporality"] == aggregation_temporality
+    assert metric["sum"]["isMonotonic"] == True
+    validate_number_data_point(metric["sum"]["dataPoints"][0], "asInt", value, "0")
+
+def validate_histogram(metric: dict, name: str, value: float, aggregation_temporality: str) -> None:
+    # Assert the following protobuf structure from https://github.com/open-telemetry/opentelemetry-proto/blob/v1.7.0/opentelemetry/proto/metrics/v1/metrics.proto:
+    # message Histogram {
+    #     repeated HistogramDataPoint data_points = 1;
+    #     optional AggregationTemporality aggregation_temporality = 2;
+    # }
+    # message HistogramDataPoint {
+    #     reserved 1;
+    #     repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
+    #     fixed64 start_time_unix_nano = 2;
+    #     fixed64 time_unix_nano = 3;
+    #     fixed64 count = 4;
+    #     optional double sum = 5;
+    #     repeated fixed64 bucket_counts = 6;
+    #     repeated double explicit_bounds = 7;
+    #     repeated Exemplar exemplars = 8;
+    #     uint32 flags = 10;
+    #     optional double min = 11;
+    #     optional double max = 12;
+    # }
+
+    assert metric["name"] == name
     assert "histogram" in metric # This asserts the metric type is a histogram
     assert len(metric["histogram"]["dataPoints"]) == 1
+    assert metric["histogram"]["aggregationTemporality"] == aggregation_temporality
+
+    assert metric["histogram"]["dataPoints"][0]["startTimeUnixNano"].isdecimal()
+    assert metric["histogram"]["dataPoints"][0]["timeUnixNano"].isdecimal()
     assert metric["histogram"]["dataPoints"][0]["count"] == "1"
-    assert metric["histogram"]["dataPoints"][0]["sum"] == 33.0
-    assert metric["histogram"]["dataPoints"][0]["min"] == 33.0
-    assert metric["histogram"]["dataPoints"][0]["max"] == 33.0
-    assert metric["histogram"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_DELTA"
+    assert metric["histogram"]["dataPoints"][0]["sum"] == value
+    assert metric["histogram"]["dataPoints"][0]["min"] == value
+    assert metric["histogram"]["dataPoints"][0]["max"] == value
 
-def validate_example_upDownCounter_new(metric: dict, name: str, value: str) -> None:
+def validate_upDownCounter(metric: dict, name: str, value: str, aggregation_temporality: str) -> None:
+    # Assert the following protobuf structure from https://github.com/open-telemetry/opentelemetry-proto/blob/v1.7.0/opentelemetry/proto/metrics/v1/metrics.proto:
+    # message Sum {
+    #     repeated NumberDataPoint data_points = 1;
+    #     optional AggregationTemporality aggregation_temporality = 2;
+    #     optional bool is_monotonic = 3;
+    # }
+    # enum AggregationTemporality {
+    #     AGGREGATION_TEMPORALITY_UNSPECIFIED = 0;
+    #     AGGREGATION_TEMPORALITY_DELTA = 1;
+    #     AGGREGATION_TEMPORALITY_CUMULATIVE = 2;
+    # }
+
     assert metric["name"] == name
-    assert "sum" in metric # This asserts the metric type is a counter
+    assert "sum" in metric
     assert len(metric["sum"]["dataPoints"]) == 1
-    assert metric["sum"]["dataPoints"][0]["asInt"] == value
-    assert metric["sum"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_CUMULATIVE"
+    assert metric["sum"]["aggregationTemporality"] == aggregation_temporality
+    validate_number_data_point(metric["sum"]["dataPoints"][0], "asInt", value)
 
-def validate_example_gauge_new(metric: dict) -> None:
-    assert metric["name"] == "example.gauge"
-    assert "gauge" in metric # This asserts the metric type is a gauge
+def validate_gauge(metric: dict, name: str, value: float, aggregation_temporality: str) -> None:
+    # Assert the following protobuf structure from https://github.com/open-telemetry/opentelemetry-proto/blob/v1.7.0/opentelemetry/proto/metrics/v1/metrics.proto:
+    # message Gauge {
+    #     repeated NumberDataPoint data_points = 1;
+    # }
+
+    assert metric["name"] == name
+    assert "gauge" in metric
     assert len(metric["gauge"]["dataPoints"]) == 1
-    assert metric["gauge"]["dataPoints"][0]["asDouble"] == 77.0
+    validate_number_data_point(metric["gauge"]["dataPoints"][0], "asDouble", value)
 
-def validate_example_async_gauge_new(metric: dict) -> None:
-    assert metric["name"] == "example.async.gauge"
-    assert "gauge" in metric # This asserts the metric type is a gauge
-    assert len(metric["gauge"]["dataPoints"]) == 1
-    assert metric["gauge"]["dataPoints"][0]["asDouble"] == 88.0
+def validate_number_data_point(data_point: dict, value_type: str, value: object, default_value: object = None) -> None:
+    # Assert the following protobuf structure from https://github.com/open-telemetry/opentelemetry-proto/blob/v1.7.0/opentelemetry/proto/metrics/v1/metrics.proto:
+    # message NumberDataPoint {
+    #     reserved 1;
+    #     repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
+    #     optional fixed64 start_time_unix_nano = 2;
+    #     optional fixed64 time_unix_nano = 3;
+    #     oneof value {
+    #         double as_double = 4;
+    #         sfixed64 as_int = 6;
+    #     }
+    #     repeated Exemplar exemplars = 5;
+    #     uint32 flags = 8;
+    # }
 
+    assert data_point["startTimeUnixNano"].isdecimal()
+    assert data_point["timeUnixNano"].isdecimal()
+    if default_value is not None:
+        assert data_point[value_type] == value or data_point[value_type] == default_value
+    else:
+        assert data_point[value_type] == value
+    # Do not assert attributes on every data point
+    # Do not assert exemplars on every data point
+    # Do not assert flags on every data point
+
+metric_to_validator = {
+    "example.counter": (validate_counter, "example.counter", "11", "AGGREGATION_TEMPORALITY_DELTA"),
+    "example.async.counter": (validate_counter, "example.async.counter", "22", "AGGREGATION_TEMPORALITY_DELTA"),
+    "example.histogram": (validate_histogram, "example.histogram", 33.0, "AGGREGATION_TEMPORALITY_DELTA"),
+    "example.upDownCounter": (validate_upDownCounter, "example.upDownCounter", "55", "AGGREGATION_TEMPORALITY_CUMULATIVE"),
+    "example.async.upDownCounter": (validate_upDownCounter, "example.async.upDownCounter", "66", "AGGREGATION_TEMPORALITY_CUMULATIVE"),
+    "example.gauge": (validate_gauge, "example.gauge", 77.0, ""),
+    "example.async.gauge": (validate_gauge, "example.async.gauge", 88.0, ""),
+}
 
 @scenarios.otel_metric_e2e
 @scenarios.apm_tracing_e2e_otel
@@ -64,42 +197,36 @@ class Test_OTelMetrics:
         rid = self.r.get_rid().lower()
         seen = set()
 
-        try:
-            metrics_agent = []
-            for _, metric in interfaces.open_telemetry.get_metrics(host="agent"):
-                if metric["name"].startswith("example"):
-                    # Asynchronous instruments report on each metric read, so we need to deduplicate
-                    # Also, the UpDownCounter instrument (in addition to the AsyncUpDownCounter instrument) is cumulative, so we need to deduplicate
-                    if metric["name"].startswith("example.async") or metric["name"] == "example.upDownCounter":
-                        if metric["name"] not in seen:
-                            metrics_agent.append(metric)
-                            seen.add(metric["name"])
-                    else:
-                        metrics_agent.append(metric)
+        all_resource_metrics = []
+        all_scope_metrics = []
+        filtered_individual_metrics = []
 
-        except ValueError as e:
-            logger.warning("Backend does not provide series")
-            logger.warning(e)
-            return
+        for _, resource_metrics in interfaces.open_telemetry.get_metrics(host="agent"):
+            all_resource_metrics.append(resource_metrics)
+            if "scopeMetrics" not in resource_metrics[0]:
+                continue
 
-        print(metrics_agent)
+            scope_metrics = resource_metrics[0]["scopeMetrics"]
+            all_scope_metrics.append(scope_metrics)
 
-        assert len(metrics_agent) == len(self.expected_metrics), "Agent metrics should match expected"
+            for scope_metric in scope_metrics:
+                for metric in scope_metric["metrics"]:
+                    if metric["name"].startswith("example"):
+                        # Asynchronous instruments report on each metric read, so we need to deduplicate
+                        # Also, the UpDownCounter instrument (in addition to the AsyncUpDownCounter instrument) is cumulative, so we need to deduplicate
+                        if metric["name"].startswith("example.async") or metric["name"] == "example.upDownCounter":
+                            if metric["name"] not in seen:
+                                filtered_individual_metrics.append(metric)
+                                seen.add(metric["name"])
+                        else:
+                            filtered_individual_metrics.append(metric)
 
-        for metric in metrics_agent:
-            if metric["name"] == "example.counter":
-                validate_example_counter_new(metric, "example.counter", "11")
-            elif metric["name"] == "example.async.counter":
-                validate_example_counter_new(metric, "example.async.counter", "22")
-            elif metric["name"] == "example.histogram":
-                validate_example_histogram_new(metric)
-            elif metric["name"] == "example.upDownCounter":
-                validate_example_upDownCounter_new(metric, "example.upDownCounter", "55")
-            elif metric["name"] == "example.async.upDownCounter":
-                validate_example_upDownCounter_new(metric, "example.async.upDownCounter", "66")
-            elif metric["name"] == "example.gauge":
-                validate_example_gauge_new(metric)
-            elif metric["name"] == "example.async.gauge":
-                validate_example_async_gauge_new(metric)
-            else:
-                assert False, f"Metric {metric["name"]} not expected"
+        # Assert resource metrics are present and valid
+        assert all(len(resource_metrics) == 1 for resource_metrics in all_resource_metrics), "Metrics payloads from one configured application should have one set of resource metrics, but in general this may be 0+"
+        assert all(resource_metrics[0]["resource"] is not None for resource_metrics in all_resource_metrics), "Resource metrics from an application with configured resources should have a resource field, but in general is optional"
+        validate_resource_metrics(all_resource_metrics)
+
+        # Assert scope metrics are present and valid
+        # Specific OTLP metric types not tested are: ExponentialHistogram (and by extension ExponentialHistogramDataPoint), Summary (and by extension SummaryDataPoint), Exemplar
+        assert len(filtered_individual_metrics) == len(self.expected_metrics), "Agent metrics should match expected"
+        validate_scope_metrics(all_scope_metrics)

--- a/tests/otel/test_metrics.py
+++ b/tests/otel/test_metrics.py
@@ -42,6 +42,7 @@ def validate_example_async_gauge_new(metric: dict) -> None:
 
 
 @scenarios.otel_metric_e2e
+@scenarios.apm_tracing_e2e_otel
 @irrelevant(context.library != "java_otel")
 @features.not_reported  # FPD does not support otel libs
 class Test_OTelMetrics:

--- a/tests/otel/test_metrics.py
+++ b/tests/otel/test_metrics.py
@@ -1,0 +1,104 @@
+import os
+import time
+
+from utils import context, weblog, interfaces, scenarios, irrelevant, features, logger
+
+def validate_example_counter_new(metric: dict, name: str, value: str) -> None:
+    assert metric["name"] == name
+    assert "sum" in metric # This asserts the metric type is a counter
+    assert len(metric["sum"]["dataPoints"]) == 1
+    assert metric["sum"]["dataPoints"][0]["asInt"] == value
+    assert metric["sum"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_DELTA"
+    assert metric["sum"]["isMonotonic"] == True
+
+def validate_example_histogram_new(metric: dict) -> None:
+    assert metric["name"] == "example.histogram"
+    assert "histogram" in metric # This asserts the metric type is a histogram
+    assert len(metric["histogram"]["dataPoints"]) == 1
+    assert metric["histogram"]["dataPoints"][0]["count"] == "1"
+    assert metric["histogram"]["dataPoints"][0]["sum"] == 33.0
+    assert metric["histogram"]["dataPoints"][0]["min"] == 33.0
+    assert metric["histogram"]["dataPoints"][0]["max"] == 33.0
+    assert metric["histogram"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_DELTA"
+
+def validate_example_upDownCounter_new(metric: dict, name: str, value: str) -> None:
+    assert metric["name"] == name
+    assert "sum" in metric # This asserts the metric type is a counter
+    assert len(metric["sum"]["dataPoints"]) == 1
+    assert metric["sum"]["dataPoints"][0]["asInt"] == value
+    assert metric["sum"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_CUMULATIVE"
+
+def validate_example_gauge_new(metric: dict) -> None:
+    assert metric["name"] == "example.gauge"
+    assert "gauge" in metric # This asserts the metric type is a gauge
+    assert len(metric["gauge"]["dataPoints"]) == 1
+    assert metric["gauge"]["dataPoints"][0]["asDouble"] == 77.0
+
+def validate_example_async_gauge_new(metric: dict) -> None:
+    assert metric["name"] == "example.async.gauge"
+    assert "gauge" in metric # This asserts the metric type is a gauge
+    assert len(metric["gauge"]["dataPoints"]) == 1
+    assert metric["gauge"]["dataPoints"][0]["asDouble"] == 88.0
+
+
+@scenarios.otel_metric_e2e
+@irrelevant(context.library != "java_otel")
+@features.not_reported  # FPD does not support otel libs
+class Test_OTelMetrics:
+    def setup_agent_otlp_upload(self):
+        self.start = int(time.time())
+        self.r = weblog.get(path="/basic/metric")
+        self.expected_metrics = [
+            "example.counter",
+            "example.async.counter",
+            "example.gauge",
+            "example.async.gauge",
+            "example.upDownCounter",
+            "example.async.upDownCounter",
+            "example.histogram",
+        ]
+
+    def test_agent_otlp_upload(self):
+        end = int(time.time())
+        rid = self.r.get_rid().lower()
+        seen = set()
+
+        try:
+            metrics_agent = []
+            for _, metric in interfaces.open_telemetry.get_metrics(host="agent"):
+                if metric["name"].startswith("example"):
+                    # Asynchronous instruments report on each metric read, so we need to deduplicate
+                    # Also, the UpDownCounter instrument (in addition to the AsyncUpDownCounter instrument) is cumulative, so we need to deduplicate
+                    if metric["name"].startswith("example.async") or metric["name"] == "example.upDownCounter":
+                        if metric["name"] not in seen:
+                            metrics_agent.append(metric)
+                            seen.add(metric["name"])
+                    else:
+                        metrics_agent.append(metric)
+
+        except ValueError as e:
+            logger.warning("Backend does not provide series")
+            logger.warning(e)
+            return
+
+        print(metrics_agent)
+
+        assert len(metrics_agent) == len(self.expected_metrics), "Agent metrics should match expected"
+
+        for metric in metrics_agent:
+            if metric["name"] == "example.counter":
+                validate_example_counter_new(metric, "example.counter", "11")
+            elif metric["name"] == "example.async.counter":
+                validate_example_counter_new(metric, "example.async.counter", "22")
+            elif metric["name"] == "example.histogram":
+                validate_example_histogram_new(metric)
+            elif metric["name"] == "example.upDownCounter":
+                validate_example_upDownCounter_new(metric, "example.upDownCounter", "55")
+            elif metric["name"] == "example.async.upDownCounter":
+                validate_example_upDownCounter_new(metric, "example.async.upDownCounter", "66")
+            elif metric["name"] == "example.gauge":
+                validate_example_gauge_new(metric)
+            elif metric["name"] == "example.async.gauge":
+                validate_example_async_gauge_new(metric)
+            else:
+                assert False, f"Metric {metric["name"]} not expected"

--- a/tests/otel/test_metrics.py
+++ b/tests/otel/test_metrics.py
@@ -34,15 +34,17 @@ def validate_scope_metrics(scope_metrics_list: list) -> None:
     # }
 
     assert all(
-        len(scope_metrics) == 1 for scope_metrics in scope_metrics_list
-    ), "Metrics payloads from one configured application should have one set of scope metrics"
+        len(scope_metrics) >= 1 for scope_metrics in scope_metrics_list
+    ), "Metrics payloads from one configured application should have one or more set of scope metrics"
     assert all(
-        scope_metric[0]["scope"] is not None for scope_metric in scope_metrics_list
+        scope_metrics[0]["scope"] is not None for scope_metrics in scope_metrics_list
     ), "Scope metrics should have a scope field"
     # Do not assert on schema_url, as it is not always present
     for scope_metrics in scope_metrics_list:
-        for metric in scope_metrics[0]["metrics"]:
-            validate_metric(metric)
+        # Assert values only for metrics we created, since we're asserting against specific fields
+        if "opentelemetry" not in scope_metrics[0]["scope"]["name"]:
+            for metric in scope_metrics[0]["metrics"]:
+                validate_metric(metric)
 
 
 def validate_metric(metric: dict) -> None:

--- a/tests/otel/test_metrics.py
+++ b/tests/otel/test_metrics.py
@@ -43,7 +43,7 @@ def validate_example_async_gauge_new(metric: dict) -> None:
 
 @scenarios.otel_metric_e2e
 @scenarios.apm_tracing_e2e_otel
-@irrelevant(context.library != "java_otel")
+@irrelevant(context.library not in ("java_otel", "dotnet"))
 @features.not_reported  # FPD does not support otel libs
 class Test_OTelMetrics:
     def setup_agent_otlp_upload(self):

--- a/tests/otel_tracing_e2e/test_e2e.py
+++ b/tests/otel_tracing_e2e/test_e2e.py
@@ -31,50 +31,42 @@ def validate_example_counter(counter_metric: dict) -> None:
     assert len(counter_series["pointlist"]) == 1
     assert counter_series["pointlist"][0][1] == 11.0
 
-def validate_example_counter_new(metric: dict) -> None:
-    assert metric["metric"] == "example.counter"
-    assert len(metric["points"]) == 1
-    assert metric["points"][0]["value"] == 11.0
-    assert metric["type"] == "COUNT"
-
-def validate_example_async_counter_new(metric: dict) -> None:
-    assert metric["metric"] == "example.async.counter"
-    assert len(metric["points"]) == 1
-
-    # The first reported metric should report a value of 22.0
-    # The later reported metrics may not have a value
-    assert metric["points"][0]["value"] == 22.0
-    assert metric["type"] == "COUNT"
+def validate_example_counter_new(metric: dict, name: str, value: str) -> None:
+    assert metric["name"] == name
+    assert "sum" in metric # This asserts the metric type is a counter
+    assert len(metric["sum"]["dataPoints"]) == 1
+    assert metric["sum"]["dataPoints"][0]["asInt"] == value
+    assert metric["sum"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_DELTA"
+    assert metric["sum"]["isMonotonic"] == True
 
 def validate_example_histogram_new(metric: dict) -> None:
-    assert metric["metric"].startswith("example.histogram")
-    assert len(metric["points"]) == 1
-    assert metric["points"][0]["value"] == 33.0 if metric["metric"] != "example.histogram.count" else 1.0
-    assert metric["type"] == "COUNT" if (metric["metric"] == "example.histogram.count" or metric["metric"] == "example.histogram.sum") else "GAUGE"
+    assert metric["name"] == "example.histogram"
+    assert "histogram" in metric # This asserts the metric type is a histogram
+    assert len(metric["histogram"]["dataPoints"]) == 1
+    assert metric["histogram"]["dataPoints"][0]["count"] == "1"
+    assert metric["histogram"]["dataPoints"][0]["sum"] == 33.0
+    assert metric["histogram"]["dataPoints"][0]["min"] == 33.0
+    assert metric["histogram"]["dataPoints"][0]["max"] == 33.0
+    assert metric["histogram"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_DELTA"
 
-def validate_example_upDownCounter_new(metric: dict) -> None:
-    assert metric["metric"] == "example.upDownCounter"
-    assert len(metric["points"]) == 1
-    assert metric["points"][0]["value"] == 55.0
-    assert metric["type"] == "GAUGE"
-
-def validate_example_async_upDownCounter_new(metric: dict) -> None:
-    assert metric["metric"] == "example.async.upDownCounter"
-    assert len(metric["points"]) == 1
-    assert metric["points"][0]["value"] == 66.0
-    assert metric["type"] == "GAUGE"
+def validate_example_upDownCounter_new(metric: dict, name: str, value: str) -> None:
+    assert metric["name"] == name
+    assert "sum" in metric # This asserts the metric type is a counter
+    assert len(metric["sum"]["dataPoints"]) == 1
+    assert metric["sum"]["dataPoints"][0]["asInt"] == value
+    assert metric["sum"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_CUMULATIVE"
 
 def validate_example_gauge_new(metric: dict) -> None:
-    assert metric["metric"] == "example.gauge"
-    assert len(metric["points"]) == 1
-    assert metric["points"][0]["value"] == 77.0
-    assert metric["type"] == "GAUGE"
+    assert metric["name"] == "example.gauge"
+    assert "gauge" in metric # This asserts the metric type is a gauge
+    assert len(metric["gauge"]["dataPoints"]) == 1
+    assert metric["gauge"]["dataPoints"][0]["asDouble"] == 77.0
 
 def validate_example_async_gauge_new(metric: dict) -> None:
-    assert metric["metric"] == "example.async.gauge"
-    assert len(metric["points"]) == 1
-    assert metric["points"][0]["value"] == 88.0
-    assert metric["type"] == "GAUGE"
+    assert metric["name"] == "example.async.gauge"
+    assert "gauge" in metric # This asserts the metric type is a gauge
+    assert len(metric["gauge"]["dataPoints"]) == 1
+    assert metric["gauge"]["dataPoints"][0]["asDouble"] == 88.0
 
 
 def validate_example_histogram(histogram_metric: dict, histogram_suffix: str) -> None:
@@ -228,26 +220,24 @@ class Test_OTelMetricE2E:
             "example.async.gauge",
             "example.upDownCounter",
             "example.async.upDownCounter",
-            "example.histogram.sum",
-            "example.histogram.count",
-            "example.histogram.min",
-            "example.histogram.max",
+            "example.histogram",
         ]
 
     def test_agent_otlp_upload(self):
         end = int(time.time())
         rid = self.r.get_rid().lower()
         seen = set()
+
         try:
             metrics_agent = []
-            for _, metric in interfaces.agent.get_metrics():
-                if metric["metric"].startswith("example"):
+            for _, metric in interfaces.open_telemetry.get_metrics(host="agent"):
+                if metric["name"].startswith("example"):
                     # Asynchronous instruments report on each metric read, so we need to deduplicate
                     # Also, the UpDownCounter instrument (in addition to the AsyncUpDownCounter instrument) is cumulative, so we need to deduplicate
-                    if metric["metric"].startswith("example.async") or metric["metric"] == "example.upDownCounter":
-                        if metric["metric"] not in seen:
+                    if metric["name"].startswith("example.async") or metric["name"] == "example.upDownCounter":
+                        if metric["name"] not in seen:
                             metrics_agent.append(metric)
-                            seen.add(metric["metric"])
+                            seen.add(metric["name"])
                     else:
                         metrics_agent.append(metric)
 
@@ -261,28 +251,22 @@ class Test_OTelMetricE2E:
         assert len(metrics_agent) == len(self.expected_metrics), "Agent metrics should match expected"
 
         for metric in metrics_agent:
-            if metric["metric"] == "example.counter":
-                validate_example_counter_new(metric)
-            elif metric["metric"] == "example.async.counter":
-                validate_example_async_counter_new(metric)
-            elif metric["metric"] == "example.histogram.sum":
+            if metric["name"] == "example.counter":
+                validate_example_counter_new(metric, "example.counter", "11")
+            elif metric["name"] == "example.async.counter":
+                validate_example_counter_new(metric, "example.async.counter", "22")
+            elif metric["name"] == "example.histogram":
                 validate_example_histogram_new(metric)
-            elif metric["metric"] == "example.histogram.count":
-                validate_example_histogram_new(metric)
-            elif metric["metric"] == "example.histogram.min":
-                validate_example_histogram_new(metric)
-            elif metric["metric"] == "example.histogram.max":
-                validate_example_histogram_new(metric)
-            elif metric["metric"] == "example.upDownCounter":
-                validate_example_upDownCounter_new(metric)
-            elif metric["metric"] == "example.async.upDownCounter":
-                validate_example_async_upDownCounter_new(metric)
-            elif metric["metric"] == "example.gauge":
+            elif metric["name"] == "example.upDownCounter":
+                validate_example_upDownCounter_new(metric, "example.upDownCounter", "55")
+            elif metric["name"] == "example.async.upDownCounter":
+                validate_example_upDownCounter_new(metric, "example.async.upDownCounter", "66")
+            elif metric["name"] == "example.gauge":
                 validate_example_gauge_new(metric)
-            elif metric["metric"] == "example.async.gauge":
+            elif metric["name"] == "example.async.gauge":
                 validate_example_async_gauge_new(metric)
             else:
-                assert False, f"Metric {metric['metric']} not expected"
+                assert False, f"Metric {metric["name"]} not expected"
 
 @scenarios.otel_log_e2e
 @irrelevant(context.library != "java_otel")

--- a/tests/otel_tracing_e2e/test_e2e.py
+++ b/tests/otel_tracing_e2e/test_e2e.py
@@ -31,44 +31,6 @@ def validate_example_counter(counter_metric: dict) -> None:
     assert len(counter_series["pointlist"]) == 1
     assert counter_series["pointlist"][0][1] == 11.0
 
-def validate_example_counter_new(metric: dict, name: str, value: str) -> None:
-    assert metric["name"] == name
-    assert "sum" in metric # This asserts the metric type is a counter
-    assert len(metric["sum"]["dataPoints"]) == 1
-    assert metric["sum"]["dataPoints"][0]["asInt"] == value
-    assert metric["sum"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_DELTA"
-    assert metric["sum"]["isMonotonic"] == True
-
-def validate_example_histogram_new(metric: dict) -> None:
-    assert metric["name"] == "example.histogram"
-    assert "histogram" in metric # This asserts the metric type is a histogram
-    assert len(metric["histogram"]["dataPoints"]) == 1
-    assert metric["histogram"]["dataPoints"][0]["count"] == "1"
-    assert metric["histogram"]["dataPoints"][0]["sum"] == 33.0
-    assert metric["histogram"]["dataPoints"][0]["min"] == 33.0
-    assert metric["histogram"]["dataPoints"][0]["max"] == 33.0
-    assert metric["histogram"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_DELTA"
-
-def validate_example_upDownCounter_new(metric: dict, name: str, value: str) -> None:
-    assert metric["name"] == name
-    assert "sum" in metric # This asserts the metric type is a counter
-    assert len(metric["sum"]["dataPoints"]) == 1
-    assert metric["sum"]["dataPoints"][0]["asInt"] == value
-    assert metric["sum"]["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_CUMULATIVE"
-
-def validate_example_gauge_new(metric: dict) -> None:
-    assert metric["name"] == "example.gauge"
-    assert "gauge" in metric # This asserts the metric type is a gauge
-    assert len(metric["gauge"]["dataPoints"]) == 1
-    assert metric["gauge"]["dataPoints"][0]["asDouble"] == 77.0
-
-def validate_example_async_gauge_new(metric: dict) -> None:
-    assert metric["name"] == "example.async.gauge"
-    assert "gauge" in metric # This asserts the metric type is a gauge
-    assert len(metric["gauge"]["dataPoints"]) == 1
-    assert metric["gauge"]["dataPoints"][0]["asDouble"] == 88.0
-
-
 def validate_example_histogram(histogram_metric: dict, histogram_suffix: str) -> None:
     assert len(histogram_metric["series"]) == 1
     histogram_series = histogram_metric["series"][0]
@@ -210,63 +172,6 @@ class Test_OTelMetricE2E:
         validate_metrics(metrics_agent, metrics_collector, "Agent", "Collector")
         validate_metrics(metrics_agent, metrics_intake, "Agent", "Intake")
 
-    def setup_agent_otlp_upload(self):
-        self.start = int(time.time())
-        self.r = weblog.get(path="/basic/metric")
-        self.expected_metrics = [
-            "example.counter",
-            "example.async.counter",
-            "example.gauge",
-            "example.async.gauge",
-            "example.upDownCounter",
-            "example.async.upDownCounter",
-            "example.histogram",
-        ]
-
-    def test_agent_otlp_upload(self):
-        end = int(time.time())
-        rid = self.r.get_rid().lower()
-        seen = set()
-
-        try:
-            metrics_agent = []
-            for _, metric in interfaces.open_telemetry.get_metrics(host="agent"):
-                if metric["name"].startswith("example"):
-                    # Asynchronous instruments report on each metric read, so we need to deduplicate
-                    # Also, the UpDownCounter instrument (in addition to the AsyncUpDownCounter instrument) is cumulative, so we need to deduplicate
-                    if metric["name"].startswith("example.async") or metric["name"] == "example.upDownCounter":
-                        if metric["name"] not in seen:
-                            metrics_agent.append(metric)
-                            seen.add(metric["name"])
-                    else:
-                        metrics_agent.append(metric)
-
-        except ValueError as e:
-            logger.warning("Backend does not provide series")
-            logger.warning(e)
-            return
-
-        print(metrics_agent)
-
-        assert len(metrics_agent) == len(self.expected_metrics), "Agent metrics should match expected"
-
-        for metric in metrics_agent:
-            if metric["name"] == "example.counter":
-                validate_example_counter_new(metric, "example.counter", "11")
-            elif metric["name"] == "example.async.counter":
-                validate_example_counter_new(metric, "example.async.counter", "22")
-            elif metric["name"] == "example.histogram":
-                validate_example_histogram_new(metric)
-            elif metric["name"] == "example.upDownCounter":
-                validate_example_upDownCounter_new(metric, "example.upDownCounter", "55")
-            elif metric["name"] == "example.async.upDownCounter":
-                validate_example_upDownCounter_new(metric, "example.async.upDownCounter", "66")
-            elif metric["name"] == "example.gauge":
-                validate_example_gauge_new(metric)
-            elif metric["name"] == "example.async.gauge":
-                validate_example_async_gauge_new(metric)
-            else:
-                assert False, f"Metric {metric["name"]} not expected"
 
 @scenarios.otel_log_e2e
 @irrelevant(context.library != "java_otel")

--- a/tests/otel_tracing_e2e/test_e2e.py
+++ b/tests/otel_tracing_e2e/test_e2e.py
@@ -31,6 +31,7 @@ def validate_example_counter(counter_metric: dict) -> None:
     assert len(counter_series["pointlist"]) == 1
     assert counter_series["pointlist"][0][1] == 11.0
 
+
 def validate_example_histogram(histogram_metric: dict, histogram_suffix: str) -> None:
     assert len(histogram_metric["series"]) == 1
     histogram_series = histogram_metric["series"][0]

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -526,6 +526,7 @@ class _Scenarios:
         weblog_env={"DD_TRACE_OTEL_ENABLED": "true"},
         backend_interface_timeout=5,
         require_api_key=True,
+        use_proxy_for_open_telemetry=True,
         doc="",
     )
     apm_tracing_e2e_single_span = EndToEndScenario(

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -253,8 +253,10 @@ class EndToEndScenario(DockerScenario):
         additional_trace_header_tags: tuple[str, ...] = (),
         library_interface_timeout: int | None = None,
         agent_interface_timeout: int = 5,
+        open_telemetry_interface_timeout: int = 5,
         use_proxy_for_weblog: bool = True,
         use_proxy_for_agent: bool = True,
+        use_proxy_for_open_telemetry: bool = True,
         rc_api_enabled: bool = False,
         meta_structs_disabled: bool = False,
         span_events: bool = True,
@@ -285,7 +287,7 @@ class EndToEndScenario(DockerScenario):
             github_workflow=github_workflow,
             scenario_groups=scenario_groups,
             enable_ipv6=enable_ipv6,
-            use_proxy=use_proxy_for_agent or use_proxy_for_weblog,
+            use_proxy=use_proxy_for_agent or use_proxy_for_weblog or use_proxy_for_open_telemetry,
             rc_api_enabled=rc_api_enabled,
             meta_structs_disabled=meta_structs_disabled,
             span_events=span_events,
@@ -302,6 +304,7 @@ class EndToEndScenario(DockerScenario):
 
         self._use_proxy_for_agent = use_proxy_for_agent
         self._use_proxy_for_weblog = use_proxy_for_weblog
+        self._use_proxy_for_open_telemetry = use_proxy_for_open_telemetry
 
         self._require_api_key = require_api_key
 
@@ -384,6 +387,7 @@ class EndToEndScenario(DockerScenario):
 
         self.agent_interface_timeout = agent_interface_timeout
         self.backend_interface_timeout = backend_interface_timeout
+        self.open_telemetry_interface_timeout = open_telemetry_interface_timeout
         self._library_interface_timeout = library_interface_timeout
 
     def configure(self, config: pytest.Config):
@@ -405,6 +409,7 @@ class EndToEndScenario(DockerScenario):
         interfaces.library_dotnet_managed.configure(self.host_log_folder, replay=self.replay)
         interfaces.library_stdout.configure(self.host_log_folder, replay=self.replay)
         interfaces.agent_stdout.configure(self.host_log_folder, replay=self.replay)
+        interfaces.open_telemetry.configure(self.host_log_folder, replay=self.replay)
 
         for container in self.buddies:
             container.interface.configure(self.host_log_folder, replay=self.replay)
@@ -447,7 +452,7 @@ class EndToEndScenario(DockerScenario):
 
     def _start_interfaces_watchdog(self):
         super().start_interfaces_watchdog(
-            [interfaces.library, interfaces.agent] + [container.interface for container in self.buddies]
+            [interfaces.library, interfaces.agent, interfaces.open_telemetry] + [container.interface for container in self.buddies]
         )
 
     def _set_weblog_domain(self):
@@ -503,6 +508,11 @@ class EndToEndScenario(DockerScenario):
                 raise ValueError("Datadog agent not ready")
             logger.debug("Agent ready")
 
+        if self._use_proxy_for_open_telemetry:
+            if not interfaces.open_telemetry.ready.wait(40):
+                raise ValueError("Open telemetry interface not ready")
+            logger.debug("Open telemetry ready")
+
     def post_setup(self, session: pytest.Session):
         # if no test are run, skip interface tomeouts
         is_empty_test_run = session.config.option.skip_empty_scenario and len(session.items) == 0
@@ -528,6 +538,9 @@ class EndToEndScenario(DockerScenario):
 
             interfaces.agent.load_data_from_logs()
             interfaces.agent.check_deserialization_errors()
+
+            interfaces.open_telemetry.load_data_from_logs()
+            interfaces.open_telemetry.check_deserialization_errors()
 
             interfaces.backend.load_data_from_logs()
 
@@ -567,6 +580,10 @@ class EndToEndScenario(DockerScenario):
             self._wait_interface(
                 interfaces.backend, 0 if force_interface_timout_to_zero else self.backend_interface_timeout
             )
+            self._wait_interface(
+                interfaces.open_telemetry, 0 if force_interface_timout_to_zero else self.open_telemetry_interface_timeout
+            )
+            interfaces.open_telemetry.check_deserialization_errors()
 
     def _wait_interface(self, interface: ProxyBasedInterfaceValidator, timeout: int):
         logger.terminal.write_sep("-", f"Wait for {interface} ({timeout}s)")

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -452,7 +452,8 @@ class EndToEndScenario(DockerScenario):
 
     def _start_interfaces_watchdog(self):
         super().start_interfaces_watchdog(
-            [interfaces.library, interfaces.agent, interfaces.open_telemetry] + [container.interface for container in self.buddies]
+            [interfaces.library, interfaces.agent, interfaces.open_telemetry]
+            + [container.interface for container in self.buddies]
         )
 
     def _set_weblog_domain(self):
@@ -581,7 +582,8 @@ class EndToEndScenario(DockerScenario):
                 interfaces.backend, 0 if force_interface_timout_to_zero else self.backend_interface_timeout
             )
             self._wait_interface(
-                interfaces.open_telemetry, 0 if force_interface_timout_to_zero else self.open_telemetry_interface_timeout
+                interfaces.open_telemetry,
+                0 if force_interface_timout_to_zero else self.open_telemetry_interface_timeout,
             )
             interfaces.open_telemetry.check_deserialization_errors()
 

--- a/utils/_context/_scenarios/open_telemetry.py
+++ b/utils/_context/_scenarios/open_telemetry.py
@@ -91,8 +91,13 @@ class OpenTelemetryScenario(DockerScenario):
             self.weblog_container.environment["OTEL_SYSTEST_INCLUDE_AGENT"] = "True"
             interfaces.agent.configure(self.host_log_folder, replay=self.replay)
 
+        # interfaces.agent.configure(self.host_log_folder, replay=self.replay)
+        interfaces.library.configure(self.host_log_folder, replay=self.replay)
         interfaces.backend.configure(self.host_log_folder, replay=self.replay)
+        interfaces.library_dotnet_managed.configure(self.host_log_folder, replay=self.replay)
+        interfaces.library_stdout.configure(self.host_log_folder, replay=self.replay)
         interfaces.open_telemetry.configure(self.host_log_folder, replay=self.replay)
+        interfaces.agent_stdout.configure(self.host_log_folder, replay=self.replay)
 
     def _start_interface_watchdog(self):
         class Event(FileSystemEventHandler):

--- a/utils/build/docker/dotnet/weblog/Endpoints/OtelDropInEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/OtelDropInEndpoint.cs
@@ -15,6 +15,9 @@ namespace weblog
         {
             routeBuilder.MapGet("/otel_drop_in_default_propagator_extract", async context =>
             {
+                OpenTelemetryInstrumentation.LongCounter.Add(1);
+                // _logger?.LogInformation("OtelStartSpanReturn: Called {CounterName}", Instrumentation.LongCounter.Name);
+
                 var parentContext = OpenTelemetryInstrumentation.Propagator.Extract(default, context.Request.Headers, (carrier, key) =>
                 {
                     return carrier.TryGetValue(key, out var value) && value.Count >= 1 ? new[] { value[0] } : null;
@@ -36,6 +39,9 @@ namespace weblog
 
             routeBuilder.MapGet("/otel_drop_in_default_propagator_inject", async context =>
             {
+                OpenTelemetryInstrumentation.LongCounter.Add(1);
+                // _logger?.LogInformation("OtelStartSpanReturn: Called {CounterName}", Instrumentation.LongCounter.Name);
+
                 var headersDict = new Dictionary<string,string>();
                 OpenTelemetryInstrumentation.Propagator.Inject(new PropagationContext(Activity.Current.Context, Baggage.Current), headersDict, (carrier, key, value) =>
                 {

--- a/utils/build/docker/dotnet/weblog/Endpoints/OtelDropInEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/OtelDropInEndpoint.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -49,6 +50,20 @@ namespace weblog
                 });
 
                 await context.Response.WriteAsync(JsonSerializer.Serialize(headersDict));
+            });
+
+            routeBuilder.MapGet("/basic/metric", async context =>
+            {
+                OpenTelemetryInstrumentation.LongCounter.Add(11L,
+                    new KeyValuePair<string, object?>("http.method", "GET"), new KeyValuePair<string, object?>("rid", "1234567890"));
+                OpenTelemetryInstrumentation.DoubleHistogram.Record(33L,
+                    new KeyValuePair<string, object?>("http.method", "GET"), new KeyValuePair<string, object?>("rid", "1234567890"));
+                OpenTelemetryInstrumentation.LongUpDownCounter.Add(55L,
+                    new KeyValuePair<string, object?>("http.method", "GET"), new KeyValuePair<string, object?>("rid", "1234567890"));
+                OpenTelemetryInstrumentation.DoubleGauge.Record(77L,
+                    new KeyValuePair<string, object?>("http.method", "GET"), new KeyValuePair<string, object?>("rid", "1234567890"));
+                Thread.Sleep(2000);
+                await context.Response.WriteAsync("Hello World!");
             });
         }
     }

--- a/utils/build/docker/dotnet/weblog/Endpoints/OtelDropInEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/OtelDropInEndpoint.cs
@@ -16,9 +16,6 @@ namespace weblog
         {
             routeBuilder.MapGet("/otel_drop_in_default_propagator_extract", async context =>
             {
-                OpenTelemetryInstrumentation.LongCounter.Add(1);
-                // _logger?.LogInformation("OtelStartSpanReturn: Called {CounterName}", Instrumentation.LongCounter.Name);
-
                 var parentContext = OpenTelemetryInstrumentation.Propagator.Extract(default, context.Request.Headers, (carrier, key) =>
                 {
                     return carrier.TryGetValue(key, out var value) && value.Count >= 1 ? new[] { value[0] } : null;
@@ -40,9 +37,6 @@ namespace weblog
 
             routeBuilder.MapGet("/otel_drop_in_default_propagator_inject", async context =>
             {
-                OpenTelemetryInstrumentation.LongCounter.Add(1);
-                // _logger?.LogInformation("OtelStartSpanReturn: Called {CounterName}", Instrumentation.LongCounter.Name);
-
                 var headersDict = new Dictionary<string,string>();
                 OpenTelemetryInstrumentation.Propagator.Inject(new PropagationContext(Activity.Current.Context, Baggage.Current), headersDict, (carrier, key, value) =>
                 {

--- a/utils/build/docker/dotnet/weblog/OpenTelemetryInstrumentation.cs
+++ b/utils/build/docker/dotnet/weblog/OpenTelemetryInstrumentation.cs
@@ -1,10 +1,17 @@
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using OpenTelemetry.Context.Propagation;
 
 namespace weblog
 {
     public static class OpenTelemetryInstrumentation
     {
+        internal const string ServiceName = "ApmTestApi";
+        internal const string MeterName = "ApmTestApi";
+
+        private static readonly Meter _meter = new Meter(MeterName);
+        public static Counter<long> LongCounter => _meter.CreateCounter<long>("parametric.count.long");
+
         public static TextMapPropagator Propagator { get; } = Propagators.DefaultTextMapPropagator;
     }
 }

--- a/utils/build/docker/dotnet/weblog/OpenTelemetryInstrumentation.cs
+++ b/utils/build/docker/dotnet/weblog/OpenTelemetryInstrumentation.cs
@@ -10,7 +10,13 @@ namespace weblog
         internal const string MeterName = "ApmTestApi";
 
         private static readonly Meter _meter = new Meter(MeterName);
-        public static Counter<long> LongCounter => _meter.CreateCounter<long>("parametric.count.long");
+        public static Counter<long> LongCounter => _meter.CreateCounter<long>("example.counter");
+        public static Histogram<double> DoubleHistogram => _meter.CreateHistogram<double>("example.histogram");
+        public static UpDownCounter<long> LongUpDownCounter = _meter.CreateUpDownCounter<long>("example.upDownCounter");
+        public static Gauge<double> DoubleGauge = _meter.CreateGauge<double>("example.gauge");
+        public static ObservableCounter<long> AsyncLongCounter = _meter.CreateObservableCounter<long>("example.async.counter", () => 22L);
+        public static ObservableUpDownCounter<long> AsyncLongUpDownCounter = _meter.CreateObservableUpDownCounter<long>("example.async.upDownCounter", () => 66L);
+        public static ObservableGauge<double> AsyncGauge = _meter.CreateObservableGauge<double>("example.async.gauge", () => 88L);
 
         public static TextMapPropagator Propagator { get; } = Propagators.DefaultTextMapPropagator;
     }

--- a/utils/build/docker/dotnet/weblog/Startup.cs
+++ b/utils/build/docker/dotnet/weblog/Startup.cs
@@ -8,6 +8,8 @@ using Serilog;
 using Serilog.Formatting.Compact;
 using weblog.IdentityStores;
 using weblog.ModelBinders;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Metrics;
 
 namespace weblog
 {
@@ -15,6 +17,13 @@ namespace weblog
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddOpenTelemetry()
+                .ConfigureResource(r => r.AddService(OpenTelemetryInstrumentation.ServiceName))
+                .WithMetrics(builder => builder
+                    .AddMeter(OpenTelemetryInstrumentation.MeterName)
+                    .AddConsoleExporter()
+                    .AddOtlpExporter());
+
             services.AddSerilog((services, lc) => lc
                 .Enrich.FromLogContext()
                 .WriteTo.Console(new CompactJsonFormatter()));

--- a/utils/build/docker/dotnet/weblog/Startup.cs
+++ b/utils/build/docker/dotnet/weblog/Startup.cs
@@ -22,7 +22,15 @@ namespace weblog
                 .WithMetrics(builder => builder
                     .AddMeter(OpenTelemetryInstrumentation.MeterName)
                     .AddConsoleExporter()
-                    .AddOtlpExporter());
+                    .AddOtlpExporter((exporterOptions, metricReaderOptions) =>
+                    {
+                        exporterOptions.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
+                        exporterOptions.Endpoint = new("http://proxy:8127/v1/metrics");
+                        exporterOptions.Headers = "dd-protocol=otlp,dd-otlp-path=agent";
+
+                        metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 1;
+                        metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
+                    }));
 
             services.AddSerilog((services, lc) => lc
                 .Enrich.FromLogContext()

--- a/utils/build/docker/dotnet/weblog/app.csproj
+++ b/utils/build/docker/dotnet/weblog/app.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <LangVersion>Latest</LangVersion>
@@ -46,6 +46,12 @@
         <PackageReference Include="MongoDB.Driver" Version="2.23.1"/>
 
         <PackageReference Include="Datadog.Trace" Version="*" />
-        <PackageReference Include="OpenTelemetry.Api" Version="1.10.0" />
+		<PackageReference Include="OpenTelemetry.Api" Version="1.10.0" />
+		
+		<!-- Added for POC of OTel Metrics baseline-->
+		<PackageReference Include="OpenTelemetry" Version="1.10.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     </ItemGroup>
 </Project>

--- a/utils/build/docker/dotnet/weblog/app.csproj
+++ b/utils/build/docker/dotnet/weblog/app.csproj
@@ -46,12 +46,12 @@
         <PackageReference Include="MongoDB.Driver" Version="2.23.1"/>
 
         <PackageReference Include="Datadog.Trace" Version="*" />
-		<PackageReference Include="OpenTelemetry.Api" Version="1.10.0" />
-		
-		<!-- Added for POC of OTel Metrics baseline-->
-		<PackageReference Include="OpenTelemetry" Version="1.10.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+        <PackageReference Include="OpenTelemetry.Api" Version="1.10.0" />
+
+        <!-- Added for POC of OTel Metrics baseline-->
+        <PackageReference Include="OpenTelemetry" Version="1.10.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     </ItemGroup>
 </Project>

--- a/utils/build/docker/java_otel/spring-boot-native.Dockerfile
+++ b/utils/build/docker/java_otel/spring-boot-native.Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY ./utils/build/docker/java_otel/spring-boot-native/pom.xml .
 COPY ./utils/build/docker/java_otel/spring-boot-native/src ./src
 
-ENV OTEL_VERSION="1.26.0"
+ENV OTEL_VERSION="1.38.0"
 # Compile application
 RUN mvn clean package
 

--- a/utils/interfaces/_open_telemetry.py
+++ b/utils/interfaces/_open_telemetry.py
@@ -50,6 +50,9 @@ class OpenTelemetryInterfaceValidator(ProxyBasedInterfaceValidator):
                 content = data["request"]["content"]["resourceMetrics"]
 
                 # Since there's only one source of data, we expect to only have one entry in the ResourceMetrics field
+                if "scopeMetrics" not in content[0]:
+                    continue
+
                 scope_metrics = content[0]["scopeMetrics"]
 
                 for scope_metric in scope_metrics:

--- a/utils/interfaces/_open_telemetry.py
+++ b/utils/interfaces/_open_telemetry.py
@@ -47,14 +47,4 @@ class OpenTelemetryInterfaceValidator(ProxyBasedInterfaceValidator):
                 if "resourceMetrics" not in data["request"]["content"]:
                     raise ValueError("resourceMetrics property is missing in metrics payload")
 
-                content = data["request"]["content"]["resourceMetrics"]
-
-                # Since there's only one source of data, we expect to only have one entry in the ResourceMetrics field
-                if "scopeMetrics" not in content[0]:
-                    continue
-
-                scope_metrics = content[0]["scopeMetrics"]
-
-                for scope_metric in scope_metrics:
-                    for metric in scope_metric["metrics"]:
-                        yield data, metric
+                yield data, data["request"]["content"]["resourceMetrics"]


### PR DESCRIPTION
## Motivation

We are looking to implement the OpenTelemetry Metrics API in our libraries, so this adds initial tests to ensure that the implementation generates metrics in the OTLP format. [APMAPI-1323]

## Changes
Test changes:
- Adds a new test `tests/otel/test_metrics.py::Test_OTelMetrics` to test that our various weblog applications that send OTLP metrics to the Datadog Agent's OTLP Ingest using OTLP/HTTP have the correct information. Asynchronous instruments report every time the configured MetricReader polls for results, and synchronous instruments are reported inside the `/basic/metric` weblog endpoint.
  - This new test is expected to be run under the following cases:
    - `scenario=OTEL_METRIC_E2E + library=java_otel`
    - `scenario=APM_TRACING_E2E_OTEL + library=dotnet`

Weblog changes:
- .NET: Adds the following asynchronous metrics using the OpenTelemetry Metrics API:
  - ObservableCounter (Asynchronous Counter)
  - ObservableUpDownCounter (Asynchronous UpDownCounter)
  - ObservableGauge (Asynchronous Gauge)
- .NET: Adds a `/basic/metric` endpoint to generate one of each of the following metrics using the OpenTelemetry Metrics API:
  - Counter
  - UpDownCounter
  - Histogram
  - Gauge
- .NET: (To be deleted) Imports the OpenTelemetry SDK and configures an OTLP metrics exporter. This will be removed before merging, as this behavior should be handled by the DD library
- Java OTel: Adds code to generate metrics with asynchronous instruments and the remaining synchronous instruments

Interface changes:
- OpenTelemetry: Adds a `get_metrics` function to return all of the OTLP metrics sent to the interface with a target host (e.g. 'agent')

Scenario changes:
- Provides some small fixes for the OpenTelemetry scenario by configuring additional interfaces
- Adds the `open_telemetry` interface to the general `EndToEndScenario` class so that any weblog application can emit OTLP data that will be properly captured by the proxy

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [X] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
