### PR TITLE
[php]  Enable scaner tests for PHP

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -17,7 +17,16 @@ tests/:
         Test_API_Security_Sampling_Rate: irrelevant (new sampling algorithm implemented)
         Test_API_Security_Sampling_With_Delay: bug (APPSEC-58244)
       test_schemas.py:
-        Test_Scanners: v1.11.0-dev
+        Test_Scanners:
+          '*': v1.11.0-dev
+          apache-mod-7.0: missing_feature (Needs configuring apache to use auth_digest)
+          apache-mod-7.0-zts: missing_feature (Needs configuring apache to use auth_digest)
+          apache-mod-7.1: missing_feature (Needs configuring apache to use auth_digest)
+          apache-mod-7.1-zts: missing_feature (Needs configuring apache to use auth_digest)
+          apache-mod-7.2: missing_feature (Needs configuring apache to use auth_digest)
+          apache-mod-7.2-zts: missing_feature (Needs configuring apache to use auth_digest)
+          apache-mod-7.3: missing_feature (Needs configuring apache to use auth_digest)
+          apache-mod-7.3-zts: missing_feature (Needs configuring apache to use auth_digest)
         Test_Schema_Request_Cookies: v0.94.0
         Test_Schema_Request_FormUrlEncoded_Body: v0.94.0
         Test_Schema_Request_Headers: v0.94.0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -17,7 +17,7 @@ tests/:
         Test_API_Security_Sampling_Rate: irrelevant (new sampling algorithm implemented)
         Test_API_Security_Sampling_With_Delay: bug (APPSEC-58244)
       test_schemas.py:
-        Test_Scanners: missing_feature
+        Test_Scanners: v1.11.0-dev
         Test_Schema_Request_Cookies: v0.94.0
         Test_Schema_Request_FormUrlEncoded_Body: v0.94.0
         Test_Schema_Request_Headers: v0.94.0
@@ -27,7 +27,7 @@ tests/:
         Test_Schema_Response_Body: v0.99.1
         Test_Schema_Response_Body_env_var: v1.6.2
         Test_Schema_Response_Headers: v0.94.0
-        Test_Schema_Response_on_Block: missing_feature
+        Test_Schema_Response_on_Block: v1.11.0-dev
     iast/:
       sink/:
         test_code_injection.py:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
