### PR TITLE
[nodejs] Mark test_waf_monitoring_once as irrelevant

### DIFF
--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -191,10 +191,7 @@ class Test_Monitoring:
 
     @scenarios.appsec_rules_monitoring_with_errors
     @bug(library="golang", reason="LANGPLAT-584")
-    @missing_feature(
-        context.library < "nodejs@5.57.0" and context.weblog_variant == "fastify",
-        reason="Query string not supported yet",
-    )
+    @irrelevant(context.library >= "nodejs@5.56.0", reason="expected tags were deprecated by rfc1025")
     @irrelevant(library="ruby", reason="replaced by test_waf_monitoring_once_rfc1025")
     def test_waf_monitoring_errors(self):
         """Some WAF monitoring span tags and metrics are expected to be sent at

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -51,7 +51,7 @@ class Test_Monitoring:
         self.r_once = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
     @irrelevant(context.library >= "golang@v2.1.0-dev", reason="replaced by test_waf_monitoring_once_rfc1025")
-    @irrelevant(context.library >= "nodejs@5.56.0", reason="replaced by test_waf_monitoring_once_rfc1025")
+    @irrelevant(context.library >= "nodejs@5.58.0", reason="replaced by test_waf_monitoring_once_rfc1025")
     @irrelevant(library="ruby", reason="replaced by test_waf_monitoring_once_rfc1025")
     def test_waf_monitoring_once(self):
         """Some WAF monitoring span tags and metrics are expected to be sent at
@@ -191,7 +191,7 @@ class Test_Monitoring:
 
     @scenarios.appsec_rules_monitoring_with_errors
     @bug(library="golang", reason="LANGPLAT-584")
-    @irrelevant(context.library >= "nodejs@5.56.0", reason="expected tags were deprecated by rfc1025")
+    @irrelevant(context.library >= "nodejs@5.58.0", reason="expected tags were deprecated by rfc1025")
     @irrelevant(library="ruby", reason="replaced by test_waf_monitoring_once_rfc1025")
     def test_waf_monitoring_errors(self):
         """Some WAF monitoring span tags and metrics are expected to be sent at

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -4,7 +4,7 @@
 import re
 import json
 
-from utils import weblog, context, interfaces, irrelevant, scenarios, features, missing_feature, bug
+from utils import weblog, context, interfaces, irrelevant, scenarios, features, bug
 
 
 @features.support_in_app_waf_metrics_report

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -51,6 +51,7 @@ class Test_Monitoring:
         self.r_once = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
     @irrelevant(context.library >= "golang@v2.1.0-dev", reason="replaced by test_waf_monitoring_once_rfc1025")
+    @irrelevant(context.library >= "nodejs@5.56.0", reason="replaced by test_waf_monitoring_once_rfc1025")
     @irrelevant(library="ruby", reason="replaced by test_waf_monitoring_once_rfc1025")
     def test_waf_monitoring_once(self):
         """Some WAF monitoring span tags and metrics are expected to be sent at


### PR DESCRIPTION
## Motivation

RFC-1025 makes the WAF rules metrics obsolete; and libraries implemeting it should no longer produce them.

## Changes

Mark `test_waf_monitoring_once` as irrelevant

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
