### PR TITLE
[ruby] Change install_ddtrace script for dev versions

### DIFF
--- a/utils/build/docker/ruby/install_ddtrace.sh
+++ b/utils/build/docker/ruby/install_ddtrace.sh
@@ -8,14 +8,14 @@ sed -i -e '/gem .datadog./d' Gemfile
 
 cat Gemfile
 
-if [ -e "/binaries/dd-trace-rb" ]; then
+if [ -e "/binaries/dd-trace-rb-null" ]; then
     #
     # Build the gem from the local directory
     # And use it in weblog gemfile
     # This way, it will go through compilation steps of the native lib
     # and will be closer an actual installation.
     #
-    echo "Build gem from /binaries/dd-trace-rb"
+    echo "Build and install gem from /binaries/dd-trace-rb"
 
     # Read the gem name and version from the gemspec file
     export GEM_NAME=$(find /binaries/dd-trace-rb -name *.gemspec | ruby -ne 'puts Gem::Specification.load($_.chomp).name')

--- a/utils/build/docker/ruby/install_ddtrace.sh
+++ b/utils/build/docker/ruby/install_ddtrace.sh
@@ -17,13 +17,14 @@ if [ -e "/binaries/dd-trace-rb" ]; then
     #
     echo "Build gem from /binaries/dd-trace-rb"
 
-    # Read the gem name from the gemspec file
+    # Read the gem name and version from the gemspec file
     export GEM_NAME=$(find /binaries/dd-trace-rb -name *.gemspec | ruby -ne 'puts Gem::Specification.load($_.chomp).name')
+    export GEM_VERSION=$(find /binaries/dd-trace-rb -name *.gemspec | ruby -ne 'puts Gem::Specification.load($_.chomp).version')
 
     gem -C /binaries/dd-trace-rb build
     gem install /binaries/dd-trace-rb/$GEM_NAME-*.gem
 
-    echo -e "gem '$GEM_NAME', require: '$GEM_NAME/auto_instrument'" >> Gemfile
+    echo -e "gem '$GEM_NAME', '$GEM_VERSION', require: '$GEM_NAME/auto_instrument'" >> Gemfile
 elif [ $(ls /binaries/ruby-load-from-bundle-add | wc -l) = 0 ]; then
     #
     # Install the gem from https://rubygems.org/

--- a/utils/build/docker/ruby/install_ddtrace.sh
+++ b/utils/build/docker/ruby/install_ddtrace.sh
@@ -10,15 +10,20 @@ cat Gemfile
 
 if [ -e "/binaries/dd-trace-rb" ]; then
     #
-    # Install the gem from this local directory
-    # Being triggered by upstream: https://github.com/DataDog/dd-trace-rb
+    # Build the gem from the local directory
+    # And use it in weblog gemfile
+    # This way, it will go through compilation steps of the native lib
+    # and will be closer an actual installation.
     #
-    echo "Install from folder /binaries/dd-trace-rb"
+    echo "Build gem from /binaries/dd-trace-rb"
 
     # Read the gem name from the gemspec file
     export GEM_NAME=$(find /binaries/dd-trace-rb -name *.gemspec | ruby -ne 'puts Gem::Specification.load($_.chomp).name')
 
-    echo "gem '$GEM_NAME', require: '$GEM_NAME/auto_instrument', path: '/binaries/dd-trace-rb'" >> Gemfile
+    gem -C /binaries/dd-trace-rb build
+    gem install /binaries/dd-trace-rb/$GEM_NAME-*.gem
+
+    echo -e "gem '$GEM_NAME', require: '$GEM_NAME/auto_instrument'" >> Gemfile
 elif [ $(ls /binaries/ruby-load-from-bundle-add | wc -l) = 0 ]; then
     #
     # Install the gem from https://rubygems.org/


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Native extensions are not compiled when using dd-trace-rb unpacked gem (dev branch)

## Changes

<!-- A brief description of the change being made with this pull request. -->
This changes install_ddtrace.sh script for Ruby dev, by building a .gem file and using the packed gem instead.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
