### PR TITLE
[ruby] Update puma gem to > 5.0 in all weblogs

### DIFF
--- a/utils/build/docker/ruby/rails50/Gemfile
+++ b/utils/build/docker/ruby/rails50/Gemfile
@@ -11,7 +11,7 @@ gem 'rails', '~> 5.0.7', '>= 5.0.7.2'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '< 1.4.0'
 # Use Puma as the app server
-gem 'puma', '~> 3.0'
+gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/utils/build/docker/ruby/rails50/Gemfile.lock
+++ b/utils/build/docker/ruby/rails50/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.1.4)
+    base64 (0.3.0)
     bcrypt (3.1.20)
     bindex (0.8.1)
     builder (3.2.4)
@@ -64,8 +65,14 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dogstatsd-ruby (5.6.6)
     erubis (2.7.0)
     execjs (2.8.1)
+    faraday (2.8.1)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -127,7 +134,8 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    puma (3.12.6)
+    puma (5.6.9)
+      nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-test (0.6.3)
@@ -162,6 +170,7 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby2_keywords (0.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -218,12 +227,14 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   ddtrace (~> 1.0.0.a)
   devise
+  dogstatsd-ruby
+  faraday
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
   mini_racer (~> 0.4.0)
   pry
-  puma (~> 3.0)
+  puma (~> 5.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   sass-rails (~> 5.0)
   spring

--- a/utils/build/docker/ruby/rails51/Gemfile
+++ b/utils/build/docker/ruby/rails51/Gemfile
@@ -11,7 +11,7 @@ gem 'rails', '~> 5.1.7'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use Puma as the app server
-gem 'puma', '~> 3.7'
+gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/utils/build/docker/ruby/rails51/Gemfile.lock
+++ b/utils/build/docker/ruby/rails51/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (8.0.0)
+    base64 (0.3.0)
     bcrypt (3.1.20)
     bindex (0.8.1)
     builder (3.2.4)
@@ -76,8 +77,14 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dogstatsd-ruby (5.6.6)
     erubi (1.10.0)
     execjs (2.8.1)
+    faraday (2.8.1)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -127,7 +134,8 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
-    puma (3.12.6)
+    puma (5.6.9)
+      nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -164,6 +172,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
+    ruby2_keywords (0.0.5)
     ruby_dep (1.5.0)
     rubyzip (2.3.2)
     sass (3.7.4)
@@ -229,12 +238,14 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   ddtrace (~> 1.0.0.a)
   devise
+  dogstatsd-ruby
+  faraday
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   mini_racer (~> 0.6.2)
   nokogiri
   pry
-  puma (~> 3.7)
+  puma (~> 5.0)
   rails (~> 5.1.7)
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/utils/build/docker/ruby/rails52/Gemfile
+++ b/utils/build/docker/ruby/rails52/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 5.2.6'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use Puma as the app server
-gem 'puma', '~> 3.11'
+gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/utils/build/docker/ruby/rails52/Gemfile.lock
+++ b/utils/build/docker/ruby/rails52/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    base64 (0.3.0)
     bcrypt (3.1.20)
     bindex (0.8.1)
     bootsnap (1.10.2)
@@ -87,8 +88,14 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dogstatsd-ruby (5.6.6)
     erubi (1.10.0)
     execjs (2.8.1)
+    faraday (2.8.1)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -140,7 +147,8 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
-    puma (3.12.6)
+    puma (5.6.9)
+      nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -178,6 +186,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.5)
+    ruby2_keywords (0.0.5)
     ruby_dep (1.5.0)
     rubyzip (2.3.2)
     sass (3.7.4)
@@ -245,12 +254,14 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   ddtrace (~> 1.0.0.a)
   devise
+  dogstatsd-ruby
+  faraday
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   mini_racer (~> 0.6.2)
   nokogiri
   pry
-  puma (~> 3.11)
+  puma (~> 5.0)
   rails (~> 5.2.6)
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/utils/build/docker/ruby/rails60/Gemfile
+++ b/utils/build/docker/ruby/rails60/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 6.0.4', '>= 6.0.4.4'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
-gem 'puma', '~> 4.1'
+gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker

--- a/utils/build/docker/ruby/rails60/Gemfile.lock
+++ b/utils/build/docker/ruby/rails60/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    base64 (0.3.0)
     bcrypt (3.1.20)
     bindex (0.8.1)
     bootsnap (1.10.2)
@@ -88,7 +89,13 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dogstatsd-ruby (5.6.6)
     erubi (1.10.0)
+    faraday (2.8.1)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -139,7 +146,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
-    puma (4.3.10)
+    puma (5.6.9)
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
@@ -182,6 +189,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.5)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -252,10 +260,12 @@ DEPENDENCIES
   capybara (>= 2.15)
   ddtrace (~> 1.0.0.a)
   devise
+  dogstatsd-ruby
+  faraday
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pry
-  puma (~> 4.1)
+  puma (~> 5.0)
   rails (~> 6.0.4, >= 6.0.4.4)
   sass-rails (>= 6)
   selenium-webdriver


### PR DESCRIPTION
## Motivation

This PR aligns an external dependency webserver to be the same for all Rails weblog variants. Starting 5.x puma is able to hold fail sticky session which puma < 5.0 is unable to do.

If we want to test different puma variants it should be done either in dd-trace-rb repo or in weblog-variant which explicitly have that version in the name.

Otherwise it makes all the tests unpredictable because puma is not direct dependency of the Rails variant and behaves differently.

## Changes

`puma ~> 5.0`