### PR TITLE
[python] enable metrics tests for ATO SDK V1

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -661,19 +661,19 @@ tests/:
         'django-poc': v3.7.0.dev (is v1.10.0 but weblog use new SDK now)'
         'django-py3.13': v3.7.0.dev (is v1.10.0 but weblog use new SDK now)
         'python3.12': v3.7.0.dev (is v1.10.0 but weblog use new SDK now)
-      Test_CustomEvent_Metrics: missing_feature
+      Test_CustomEvent_Metrics: v3.10.0.dev
       Test_UserLoginFailureEvent:
         '*': v2.10.0
         'django-poc': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)'
         'django-py3.13': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
         'python3.12': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
-      Test_UserLoginFailureEvent_Metrics: missing_feature
+      Test_UserLoginFailureEvent_Metrics: v3.10.0.dev
       Test_UserLoginSuccessEvent:
         '*': v2.10.0
         'django-poc': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)'
         'django-py3.13': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
         'python3.12': v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
-      Test_UserLoginSuccessEvent_Metrics: missing_feature
+      Test_UserLoginSuccessEvent_Metrics: v3.10.0.dev
     test_event_tracking_v2.py:
       Test_UserLoginFailureEventV2_HeaderCollection:
         '*': v3.7.0.dev

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -34,6 +34,8 @@ from iast import (
 import ddtrace
 from ddtrace import patch_all
 
+from ddtrace.appsec import trace_utils as ato_user_sdk_v1
+
 try:
     from ddtrace.appsec import track_user_sdk
 except ImportError:
@@ -847,16 +849,15 @@ _TRACK_USER = "system_tests_user"
 
 
 def track_user_login_success_event(request):
-    track_user_sdk.track_login_success(login=_TRACK_USER, user_id=_TRACK_USER, metadata=_TRACK_METADATA)
+    ato_user_sdk_v1.track_user_login_success_event(
+        None, login=_TRACK_USER, user_id=_TRACK_USER, metadata=_TRACK_METADATA
+    )
     return HttpResponse("OK")
 
 
 def track_user_login_failure_event(request):
-    track_user_sdk.track_login_failure(
-        login=_TRACK_USER,
-        exists=True,
-        user_id=_TRACK_USER,
-        metadata=_TRACK_METADATA,
+    ato_user_sdk_v1.track_user_login_failure_event(
+        None, login=_TRACK_USER, exists=True, user_id=_TRACK_USER, metadata=_TRACK_METADATA
     )
     return HttpResponse("OK")
 
@@ -946,7 +947,7 @@ _TRACK_CUSTOM_EVENT_NAME = "system_tests_event"
 
 
 def track_custom_event(request):
-    track_user_sdk.track_custom_event(event_name=_TRACK_CUSTOM_EVENT_NAME, metadata=_TRACK_METADATA)
+    ato_user_sdk_v1.track_custom_event(None, event_name=_TRACK_CUSTOM_EVENT_NAME, metadata=_TRACK_METADATA)
     return HttpResponse("OK")
 
 


### PR DESCRIPTION
## Motivation

After merging https://github.com/DataDog/dd-trace-py/pull/13727, python tracer will support telemetry metrics for ATO SDK V1

## Changes

- enable metric tests for ATO SDK V1
- fix Django weblog to use SDK V1 on endpoints that are testing for them. (they were upgraded to new SDK mistakenly)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
