### PR TITLE
[Ruby] Update ruby manifest

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -306,16 +306,16 @@ tests/:
       test_ssrf.py:
         Test_Ssrf_BodyJson: v2.14.0
         Test_Ssrf_BodyUrlEncoded: v2.14.0
-        Test_Ssrf_BodyXml: irrelevant # xml body not natively supported
+        Test_Ssrf_BodyXml: irrelevant  # xml body not natively supported
         Test_Ssrf_Capability: v2.14.1-dev
         Test_Ssrf_Mandatory_SpanTags: v2.14.0
         Test_Ssrf_Optional_SpanTags: v2.14.0
-        Test_Ssrf_Rules_Version: missing_feature # requires Telemetry V2
+        Test_Ssrf_Rules_Version: missing_feature  # requires Telemetry V2
         Test_Ssrf_StackTrace: v2.14.0
         Test_Ssrf_Telemetry: v2.14.0
         Test_Ssrf_Telemetry_V2: missing_feature
         Test_Ssrf_UrlQuery: v2.14.0
-        Test_Ssrf_Waf_Version: missing_feature # requires Telemetry V2
+        Test_Ssrf_Waf_Version: missing_feature  # requires Telemetry V2
     waf/:
       test_addresses.py:
         Test_BodyJson: v1.8.0
@@ -326,7 +326,7 @@ tests/:
         Test_GraphQL: v2.3.0
         Test_GrpcServerMethod: missing_feature
         Test_Headers:
-          "*": v0.54.2 # assumed as the oldest supported version
+          "*": v0.54.2  # assumed as the oldest supported version
           sinatra14: missing_feature (endpoint not implemented)
           sinatra20: missing_feature (endpoint not implemented)
           sinatra21: missing_feature (endpoint not implemented)
@@ -754,8 +754,8 @@ tests/:
     test_dynamic_configuration.py:
       TestDynamicConfigSamplingRules: v2.0.0
       TestDynamicConfigTracingEnabled: missing_feature
-      TestDynamicConfigV1: bug (APMAPI-867) # theorical version is v1.13.0
-      TestDynamicConfigV1_EmptyServiceTargets: v2.8.0 # version unknown
+      TestDynamicConfigV1: bug (APMAPI-867)  # theorical version is v1.13.0
+      TestDynamicConfigV1_EmptyServiceTargets: v2.8.0  # version unknown
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_headers_baggage.py:
@@ -772,10 +772,10 @@ tests/:
       Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not supported)
       Test_Parametric_DDTrace_Baggage: missing_feature (baggage is not supported)
       Test_Parametric_DDTrace_Current_Span: incomplete_test_app (current span endpoint is not supported)
-      Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778) # set_name endpoint should set the resource name on a span (not the operation name)
+      Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778)  # set_name endpoint should set the resource name on a span (not the operation name)
       Test_Parametric_Otel_Baggage: missing_feature (otel baggage is not supported)
       Test_Parametric_Otel_Current_Span: incomplete_test_app (otel current span endpoint is not supported)
-    test_partial_flushing.py: # Not configurable in a standard way
+    test_partial_flushing.py:  # Not configurable in a standard way
       Test_Partial_Flushing: missing_feature
     test_process_discovery.py: missing_feature
     test_sampling_delegation.py:
@@ -793,7 +793,7 @@ tests/:
       Test_TelemetrySCAEnvVar: v2.1.0
       Test_TelemetrySSIConfigs: missing_feature
     test_trace_sampling.py:
-      Test_Trace_Sampling_Basic: v1.0.0 # TODO what is the earliest version?
+      Test_Trace_Sampling_Basic: v1.0.0  # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: v2.0.0
       Test_Trace_Sampling_Globs_Feb2024_Revision: v2.0.0
       Test_Trace_Sampling_Resource: v2.0.0
@@ -887,7 +887,7 @@ tests/:
     Test_HeaderTags: v1.13.0
     Test_HeaderTags_Colon_Leading: v1.13.0
     Test_HeaderTags_Colon_Trailing: v1.13.0
-    Test_HeaderTags_DynamicConfig: bug (APMAPI-867) # theorical version is v2.0.0
+    Test_HeaderTags_DynamicConfig: bug (APMAPI-867)  # theorical version is v2.0.0
     Test_HeaderTags_Long: v1.13.0
     Test_HeaderTags_Short: v1.13.0
     Test_HeaderTags_Whitespace_Header: v1.13.0
@@ -898,11 +898,11 @@ tests/:
     Test_Profile: missing_feature (temporary fix, scenario not working on dd-trace-rb CI)
   test_protobuf.py: missing_feature
   test_sampling_rates.py:
-    Test_SampleRateFunction: v2.15.0 # real version unknown
-    Test_SamplingDecisionAdded: v2.12.1 # real version unknown
-    Test_SamplingDecisions: v2.15.0 # real version unknown
-    Test_SamplingDeterminism: v2.12.1 # real version unknown
-    Test_SamplingRates: v2.15.0 # real version unknown
+    Test_SampleRateFunction: v2.15.0  # real version unknown
+    Test_SamplingDecisionAdded: v2.12.1  # real version unknown
+    Test_SamplingDecisions: v2.15.0  # real version unknown
+    Test_SamplingDeterminism: v2.12.1  # real version unknown
+    Test_SamplingRates: v2.15.0  # real version unknown
   test_scrubbing.py:
     Test_UrlField: missing_feature (Needs weblog endpoint)
     Test_UrlQuery: v1.0.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -8,8 +8,8 @@ tests/:
   appsec/:
     api_security/:
       test_api_security_rc.py:
-        Test_API_Security_RC_ASM_DD_processors: missing_feature
-        Test_API_Security_RC_ASM_DD_scanners: missing_feature
+        Test_API_Security_RC_ASM_DD_processors: v2.17.1-dev
+        Test_API_Security_RC_ASM_DD_scanners: v2.17.1-dev
       test_apisec_sampling.py:
         Test_API_Security_Sampling_Different_Endpoints: v2.17.1-dev
         Test_API_Security_Sampling_Different_Paths:
@@ -306,16 +306,16 @@ tests/:
       test_ssrf.py:
         Test_Ssrf_BodyJson: v2.14.0
         Test_Ssrf_BodyUrlEncoded: v2.14.0
-        Test_Ssrf_BodyXml: irrelevant  # xml body not natively supported
+        Test_Ssrf_BodyXml: irrelevant # xml body not natively supported
         Test_Ssrf_Capability: v2.14.1-dev
         Test_Ssrf_Mandatory_SpanTags: v2.14.0
         Test_Ssrf_Optional_SpanTags: v2.14.0
-        Test_Ssrf_Rules_Version: missing_feature  # requires Telemetry V2
+        Test_Ssrf_Rules_Version: missing_feature # requires Telemetry V2
         Test_Ssrf_StackTrace: v2.14.0
         Test_Ssrf_Telemetry: v2.14.0
         Test_Ssrf_Telemetry_V2: missing_feature
         Test_Ssrf_UrlQuery: v2.14.0
-        Test_Ssrf_Waf_Version: missing_feature  # requires Telemetry V2
+        Test_Ssrf_Waf_Version: missing_feature # requires Telemetry V2
     waf/:
       test_addresses.py:
         Test_BodyJson: v1.8.0
@@ -326,7 +326,7 @@ tests/:
         Test_GraphQL: v2.3.0
         Test_GrpcServerMethod: missing_feature
         Test_Headers:
-          "*": v0.54.2  # assumed as the oldest supported version
+          "*": v0.54.2 # assumed as the oldest supported version
           sinatra14: missing_feature (endpoint not implemented)
           sinatra20: missing_feature (endpoint not implemented)
           sinatra21: missing_feature (endpoint not implemented)
@@ -754,8 +754,8 @@ tests/:
     test_dynamic_configuration.py:
       TestDynamicConfigSamplingRules: v2.0.0
       TestDynamicConfigTracingEnabled: missing_feature
-      TestDynamicConfigV1: bug (APMAPI-867)  # theorical version is v1.13.0
-      TestDynamicConfigV1_EmptyServiceTargets: v2.8.0  # version unknown
+      TestDynamicConfigV1: bug (APMAPI-867) # theorical version is v1.13.0
+      TestDynamicConfigV1_EmptyServiceTargets: v2.8.0 # version unknown
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_headers_baggage.py:
@@ -772,10 +772,10 @@ tests/:
       Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not supported)
       Test_Parametric_DDTrace_Baggage: missing_feature (baggage is not supported)
       Test_Parametric_DDTrace_Current_Span: incomplete_test_app (current span endpoint is not supported)
-      Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778)  # set_name endpoint should set the resource name on a span (not the operation name)
+      Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778) # set_name endpoint should set the resource name on a span (not the operation name)
       Test_Parametric_Otel_Baggage: missing_feature (otel baggage is not supported)
       Test_Parametric_Otel_Current_Span: incomplete_test_app (otel current span endpoint is not supported)
-    test_partial_flushing.py:  # Not configurable in a standard way
+    test_partial_flushing.py: # Not configurable in a standard way
       Test_Partial_Flushing: missing_feature
     test_process_discovery.py: missing_feature
     test_sampling_delegation.py:
@@ -793,7 +793,7 @@ tests/:
       Test_TelemetrySCAEnvVar: v2.1.0
       Test_TelemetrySSIConfigs: missing_feature
     test_trace_sampling.py:
-      Test_Trace_Sampling_Basic: v1.0.0  # TODO what is the earliest version?
+      Test_Trace_Sampling_Basic: v1.0.0 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: v2.0.0
       Test_Trace_Sampling_Globs_Feb2024_Revision: v2.0.0
       Test_Trace_Sampling_Resource: v2.0.0
@@ -887,7 +887,7 @@ tests/:
     Test_HeaderTags: v1.13.0
     Test_HeaderTags_Colon_Leading: v1.13.0
     Test_HeaderTags_Colon_Trailing: v1.13.0
-    Test_HeaderTags_DynamicConfig: bug (APMAPI-867)  # theorical version is v2.0.0
+    Test_HeaderTags_DynamicConfig: bug (APMAPI-867) # theorical version is v2.0.0
     Test_HeaderTags_Long: v1.13.0
     Test_HeaderTags_Short: v1.13.0
     Test_HeaderTags_Whitespace_Header: v1.13.0
@@ -898,11 +898,11 @@ tests/:
     Test_Profile: missing_feature (temporary fix, scenario not working on dd-trace-rb CI)
   test_protobuf.py: missing_feature
   test_sampling_rates.py:
-    Test_SampleRateFunction: v2.15.0  # real version unknown
-    Test_SamplingDecisionAdded: v2.12.1  # real version unknown
-    Test_SamplingDecisions: v2.15.0  # real version unknown
-    Test_SamplingDeterminism: v2.12.1  # real version unknown
-    Test_SamplingRates: v2.15.0  # real version unknown
+    Test_SampleRateFunction: v2.15.0 # real version unknown
+    Test_SamplingDecisionAdded: v2.12.1 # real version unknown
+    Test_SamplingDecisions: v2.15.0 # real version unknown
+    Test_SamplingDeterminism: v2.12.1 # real version unknown
+    Test_SamplingRates: v2.15.0 # real version unknown
   test_scrubbing.py:
     Test_UrlField: missing_feature (Needs weblog endpoint)
     Test_UrlQuery: v1.0.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -565,9 +565,9 @@ tests/:
       Test_SecurityEvents_Iast_Metastruct_Disabled: irrelevant (no fallback will be implemented)
       Test_SecurityEvents_Iast_Metastruct_Enabled: missing_feature
     test_remote_config_rule_changes.py:
-      Test_AsmDdMultiConfiguration: missing_feature
-      Test_BlockingActionChangesWithRemoteConfig: missing_feature
-      Test_UpdateRuleFileWithRemoteConfig: missing_feature
+      Test_AsmDdMultiConfiguration: v2.17.1-dev
+      Test_BlockingActionChangesWithRemoteConfig: v2.17.1-dev
+      Test_UpdateRuleFileWithRemoteConfig: v2.17.1-dev
     test_reports.py:
       Test_ExtraTagsFromRule: v1.15.0
     test_request_blocking.py:
@@ -845,19 +845,19 @@ tests/:
       "*": irrelevant (endpoint not implemented)
       rails70: v2.0.0
     Test_Config_IntegrationEnabled_True:
-      '*': irrelevant (endpoint not implemented)
+      "*": irrelevant (endpoint not implemented)
       rails70: v2.13.0-dev
     Test_Config_LogInjection_128Bit_TraceId_Disabled:
-      '*': irrelevant (endpoint not implemented)
+      "*": irrelevant (endpoint not implemented)
       rails70: v2.13.0-dev
     Test_Config_LogInjection_128Bit_TraceId_Enabled:
-      '*': irrelevant (endpoint not implemented)
+      "*": irrelevant (endpoint not implemented)
       rails70: v2.13.0-dev
     Test_Config_LogInjection_Default:
-      '*': irrelevant (endpoint not implemented)
+      "*": irrelevant (endpoint not implemented)
       rails70: irrelevant (dd-trace-rb enables log injection by default, we are planning to revist this behavior in the future. This will likely be the new default)
     Test_Config_LogInjection_Enabled:
-      '*': irrelevant (endpoint not implemented)
+      "*": irrelevant (endpoint not implemented)
       rails70: v2.13.0-dev
     Test_Config_ObfuscationQueryStringRegexp_Configured: missing_feature
     Test_Config_ObfuscationQueryStringRegexp_Default: bug (APMAPI-1013)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -566,8 +566,8 @@ tests/:
       Test_SecurityEvents_Iast_Metastruct_Enabled: missing_feature
     test_remote_config_rule_changes.py:
       Test_AsmDdMultiConfiguration: missing_feature
-      Test_BlockingActionChangesWithRemoteConfig: v2.17.1-dev
-      Test_UpdateRuleFileWithRemoteConfig: v2.17.1-dev
+      Test_BlockingActionChangesWithRemoteConfig: missing_feature (the test relies on remote AppSec activation)
+      Test_UpdateRuleFileWithRemoteConfig: missing_feature (the test relies on remote AppSec activation)
     test_reports.py:
       Test_ExtraTagsFromRule: v1.15.0
     test_request_blocking.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -565,7 +565,7 @@ tests/:
       Test_SecurityEvents_Iast_Metastruct_Disabled: irrelevant (no fallback will be implemented)
       Test_SecurityEvents_Iast_Metastruct_Enabled: missing_feature
     test_remote_config_rule_changes.py:
-      Test_AsmDdMultiConfiguration: v2.17.1-dev
+      Test_AsmDdMultiConfiguration: missing_feature
       Test_BlockingActionChangesWithRemoteConfig: v2.17.1-dev
       Test_UpdateRuleFileWithRemoteConfig: v2.17.1-dev
     test_reports.py:

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -51,7 +51,7 @@ class Test_Monitoring:
         self.r_once = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
     @irrelevant(context.library >= "golang@v2.1.0-dev", reason="replaced by test_waf_monitoring_once_rfc1025")
-    @irrelevant(context.library >= "ruby@v2.17.1-dev", reason="replaced by test_waf_monitoring_once_rfc1025")
+    @irrelevant(library="ruby", reason="replaced by test_waf_monitoring_once_rfc1025")
     def test_waf_monitoring_once(self):
         """Some WAF monitoring span tags and metrics are expected to be sent at
         least once in a request span at some point. The metrics asserted by this
@@ -194,7 +194,7 @@ class Test_Monitoring:
         context.library < "nodejs@5.57.0" and context.weblog_variant == "fastify",
         reason="Query string not supported yet",
     )
-    @irrelevant(context.library >= "ruby@v2.17.1-dev", reason="replaced by test_waf_monitoring_once_rfc1025")
+    @irrelevant(library="ruby", reason="replaced by test_waf_monitoring_once_rfc1025")
     def test_waf_monitoring_errors(self):
         """Some WAF monitoring span tags and metrics are expected to be sent at
         least once in a request span at some point

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -194,6 +194,7 @@ class Test_Monitoring:
         context.library < "nodejs@5.57.0" and context.weblog_variant == "fastify",
         reason="Query string not supported yet",
     )
+    @irrelevant(context.library >= "ruby@v2.17.1-dev", reason="replaced by test_waf_monitoring_once_rfc1025")
     def test_waf_monitoring_errors(self):
         """Some WAF monitoring span tags and metrics are expected to be sent at
         least once in a request span at some point

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -51,6 +51,7 @@ class Test_Monitoring:
         self.r_once = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
     @irrelevant(context.library >= "golang@v2.1.0-dev", reason="replaced by test_waf_monitoring_once_rfc1025")
+    @irrelevant(context.library >= "ruby@v2.17.1-dev", reason="replaced by test_waf_monitoring_once_rfc1025")
     def test_waf_monitoring_once(self):
         """Some WAF monitoring span tags and metrics are expected to be sent at
         least once in a request span at some point. The metrics asserted by this


### PR DESCRIPTION
## Motivation

PR for error reporting per config in Ruby tracer: https://github.com/DataDog/dd-trace-rb/pull/4757

## Changes

This PR enables Remote Config rule changes tests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
