### PR TITLE
[golang] fix: update install_orchestrion.sh to remove the -u flag from go get commands for better compatibility

### DIFF
--- a/utils/build/docker/golang/install_orchestrion.sh
+++ b/utils/build/docker/golang/install_orchestrion.sh
@@ -8,11 +8,11 @@ if [ -e "/binaries/orchestrion" ]; then
     go -C /binaries/orchestrion build -o "$(go env GOPATH)/bin/orchestrion" .
 elif [ -e "/binaries/orchestrion-load-from-go-get" ]; then
     echo "Install from go get -d $(cat /binaries/orchestrion-load-from-go-get)"
-    go get -u "$(cat /binaries/orchestrion-load-from-go-get)"
+    go get "$(cat /binaries/orchestrion-load-from-go-get)"
     go install "$(cat /binaries/orchestrion-load-from-go-get)"
 else
     echo "Installing production orchestrion"
-    go get -u github.com/DataDog/orchestrion@latest
+    go get github.com/DataDog/orchestrion@latest
     go install github.com/DataDog/orchestrion@latest
 fi
 


### PR DESCRIPTION
## Motivation

Avoid turning `system-tests` in smoke tests by not using `go get -u`.

## Changes

Remove `-u` flag from `install_orchestrion.sh`'s calls to `go get`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
