### PR TITLE
[ruby] skip failing tests for APPSEC-58061

### DIFF
--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -2001,6 +2001,7 @@ class Test_V3_Login_Events_Blocking:
 
         self.r_login_blocked = weblog.post("/login?auth=local", data=login_data(context, USER, PASSWORD))
 
+    @bug(context.library >= "ruby@2.17.1-dev", reason="APPSEC-58061")
     def test_login_event_blocking_auto_login(self):
         assert self.r_login.status_code == 200
 
@@ -2032,6 +2033,7 @@ class Test_V3_Login_Events_Blocking:
             for trigger in SDK_TRIGGERS
         ]
 
+    @bug(context.library >= "ruby@2.17.1-dev", reason="APPSEC-58061")
     def test_login_event_blocking_sdk(self):
         for request in self.r_login:
             assert request.status_code == 200

--- a/tests/appsec/test_automated_user_and_session_tracking.py
+++ b/tests/appsec/test_automated_user_and_session_tracking.py
@@ -4,6 +4,7 @@
 
 
 from typing import Any
+from utils import bug
 from utils import context
 from utils import features
 from utils import interfaces
@@ -156,6 +157,7 @@ class Test_Automated_User_Blocking:
         context.library == "python" and context.weblog_variant not in ["django-poc", "python3.12", "django-py3.13"],
         reason="no possible auto-instrumentation for python except on Django",
     )
+    @bug(context.library >= "ruby@2.17.1-dev", reason="APPSEC-58061")
     def test_user_blocking_auto(self):
         assert self.r_login.status_code == 200
 

--- a/tests/appsec/waf/test_reports.py
+++ b/tests/appsec/waf/test_reports.py
@@ -51,6 +51,7 @@ class Test_Monitoring:
         self.r_once = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
 
     @irrelevant(context.library >= "golang@v2.1.0-dev", reason="replaced by test_waf_monitoring_once_rfc1025")
+    @bug(context.library >= "ruby@2.17.1-dev", reason="APPSEC-58061")
     def test_waf_monitoring_once(self):
         """Some WAF monitoring span tags and metrics are expected to be sent at
         least once in a request span at some point. The metrics asserted by this
@@ -189,6 +190,7 @@ class Test_Monitoring:
 
     @scenarios.appsec_rules_monitoring_with_errors
     @bug(library="golang", reason="LANGPLAT-584")
+    @bug(context.library >= "ruby@2.17.1-dev", reason="APPSEC-58061")
     @missing_feature(
         context.library < "nodejs@5.57.0" and context.weblog_variant == "fastify",
         reason="Query string not supported yet",


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
