### PR TITLE
[ruby] Fix gem build when using older weblogs

### DIFF
--- a/utils/build/docker/ruby/install_ddtrace.sh
+++ b/utils/build/docker/ruby/install_ddtrace.sh
@@ -21,7 +21,12 @@ if [ -e "/binaries/dd-trace-rb" ]; then
     export GEM_NAME=$(find /binaries/dd-trace-rb -name *.gemspec | ruby -ne 'puts Gem::Specification.load($_.chomp).name')
     export GEM_VERSION=$(find /binaries/dd-trace-rb -name *.gemspec | ruby -ne 'puts Gem::Specification.load($_.chomp).version')
 
-    gem -C /binaries/dd-trace-rb build
+    # if gem -v is >= 4.0 (including 5.0, 12.0...), use gem -C PATH build, else use gem build -C PATH
+    if gem -v | ruby -ne 'exit(Gem::Version.new($_.chomp) >= Gem::Version.new("4.0") ? 0 : 1)'; then
+        gem -C /binaries/dd-trace-rb build
+    else
+        gem build -C /binaries/dd-trace-rb
+    fi
     gem install /binaries/dd-trace-rb/$GEM_NAME-*.gem
 
     echo -e "gem '$GEM_NAME', '$GEM_VERSION', require: '$GEM_NAME/auto_instrument'" >> Gemfile


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Using gem -C PATH build on older versions of RubyGems does not work. but using gem build -C PATH will fail in the future.

## Changes

<!-- A brief description of the change being made with this pull request. -->
Checks if RubyGems version is lower than 4 or not, and uses the right command accordingly

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
