### PR TITLE
Enable Test_ExtractBehavior_* tests for Java (v1.48.0)

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2124,10 +2124,18 @@ tests/:
       '*': v0.111.0
   test_ipv6.py: missing_feature (APMAPI-869)
   test_library_conf.py:
-    Test_ExtractBehavior_Default: v1.48.0
-    Test_ExtractBehavior_Ignore: bug (APMAPI-1443)
-    Test_ExtractBehavior_Restart: v1.48.0
-    Test_ExtractBehavior_Restart_With_Extract_First: v1.48.0
+    Test_ExtractBehavior_Default:
+      '*': incomplete_test_app (weblog endpoint not implemented)
+      spring-boot: v1.48.0
+    Test_ExtractBehavior_Ignore:
+      '*': incomplete_test_app (weblog endpoint not implemented)
+      spring-boot: bug (APMAPI-1443)
+    Test_ExtractBehavior_Restart:
+      '*': incomplete_test_app (weblog endpoint not implemented)
+      spring-boot: v1.48.0
+    Test_ExtractBehavior_Restart_With_Extract_First:
+      '*': incomplete_test_app (weblog endpoint not implemented)
+      spring-boot: v1.48.0
     Test_HeaderTags:
       '*': v1.35.0
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2124,10 +2124,10 @@ tests/:
       '*': v0.111.0
   test_ipv6.py: missing_feature (APMAPI-869)
   test_library_conf.py:
-    Test_ExtractBehavior_Default: incomplete_test_app (/make_distant_call endpoint is not correctly implemented)
-    Test_ExtractBehavior_Ignore: incomplete_test_app (/make_distant_call endpoint is not correctly implemented)
-    Test_ExtractBehavior_Restart: incomplete_test_app (/make_distant_call endpoint is not correctly implemented)
-    Test_ExtractBehavior_Restart_With_Extract_First: incomplete_test_app (/make_distant_call endpoint is not correctly implemented)
+    Test_ExtractBehavior_Default: v1.48.0
+    Test_ExtractBehavior_Ignore: bug (APMAPI-1443)
+    Test_ExtractBehavior_Restart: v1.48.0
+    Test_ExtractBehavior_Restart_With_Extract_First: v1.48.0
     Test_HeaderTags:
       '*': v1.35.0
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)


### PR DESCRIPTION
## Motivation

This unskips some XPASS tests for an APM trace context propagation feature, so that we can track any regressions if they occur.

## Changes

See PR title.

Note: There is one bug that exists when `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT=ignore` so the manifest has been updated with a corresponding JIRA card.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
