### PR TITLE
[Java] Revert "[Java] Enable Baggage Tests (#4679)"

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2040,12 +2040,12 @@ tests/:
       Test_Mock: v0.0.99
       Test_NotReleased: missing_feature
   test_baggage.py:
-    Test_Baggage_Headers_Basic: v1.50.0
-    Test_Baggage_Headers_Malformed: v1.50.0
-    Test_Baggage_Headers_Malformed2: v1.50.0
-    Test_Baggage_Headers_Max_Bytes: v1.50.0
-    Test_Baggage_Headers_Max_Items: v1.50.0
-    Test_Only_Baggage_Header: v1.50.0
+    Test_Baggage_Headers_Basic: missing_feature (feature not completed yet)
+    Test_Baggage_Headers_Malformed: missing_feature (feature not completed yet)
+    Test_Baggage_Headers_Malformed2: missing_feature (feature not completed yet)
+    Test_Baggage_Headers_Max_Bytes: missing_feature (feature not completed yet)
+    Test_Baggage_Headers_Max_Items: missing_feature (feature not completed yet)
+    Test_Only_Baggage_Header: missing_feature (feature not completed yet)
   test_config_consistency.py:
     Test_Config_ClientIPHeaderEnabled_False: v1.43.0
     Test_Config_ClientIPHeader_Configured: v1.43.0


### PR DESCRIPTION
## Motivation

The baggage tests are currently failing on 1.50.0, so we should mark this feature as not completed yet

## Changes

This reverts commit a4a3c8502d3bd3103da56b66a7380f40be595626.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes (if something not related to your task is failing, you can ignore it)
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner. We're working on refining the `codeowners` file quickly.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] CI is green, or failing jobs are not related to this change (and you are 100% sure about this statement)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
