### PR TITLE
[ruby] Exclude Rack contrib from API Security paths tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -14,10 +14,10 @@ tests/:
         Test_API_Security_Sampling_Different_Endpoints: v2.17.1-dev
         Test_API_Security_Sampling_Different_Paths:
           "*": v2.17.1-dev
-          rack: irrelevant
+          rack: irrelevant (rack does not have path parameters support)
         Test_API_Security_Sampling_Different_Status:
           "*": v2.17.1-dev
-          rack: irrelevant
+          rack: irrelevant (rack does not have path parameters support)
         Test_API_Security_Sampling_Rate: irrelevant
         Test_API_Security_Sampling_With_Delay: v2.17.1-dev
       test_schemas.py:
@@ -28,7 +28,7 @@ tests/:
         Test_Schema_Request_Json_Body: v1.15.0
         Test_Schema_Request_Path_Parameters:
           "*": v1.15.0
-          rack: missing_feature (rack does not have path parameters support)
+          rack: irrelevant (rack does not have path parameters support)
         Test_Schema_Request_Query_Parameters: v1.15.0
         Test_Schema_Response_Body: missing_feature
         Test_Schema_Response_Body_env_var: missing_feature


### PR DESCRIPTION
## Motivation

Rack doesn't support path parameters from router (no such functionality), so I mark it as irrelevant because it's impossible to implement for us.

## Changes

Convert some Rack missing features into irrelevant with additional comment