### PR TITLE
[Java] Re-enabling Baggage Tests with Supported Weblog Instrumentations

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2040,12 +2040,12 @@ tests/:
       Test_Mock: v0.0.99
       Test_NotReleased: missing_feature
   test_baggage.py:
-    Test_Baggage_Headers_Basic: missing_feature (feature not completed yet)
-    Test_Baggage_Headers_Malformed: missing_feature (feature not completed yet)
-    Test_Baggage_Headers_Malformed2: missing_feature (feature not completed yet)
-    Test_Baggage_Headers_Max_Bytes: missing_feature (feature not completed yet)
-    Test_Baggage_Headers_Max_Items: missing_feature (feature not completed yet)
-    Test_Only_Baggage_Header: missing_feature (feature not completed yet)
+    Test_Baggage_Headers_Basic: v1.50.0
+    Test_Baggage_Headers_Malformed: v1.50.0
+    Test_Baggage_Headers_Malformed2: v1.50.0
+    Test_Baggage_Headers_Max_Bytes: v1.50.0
+    Test_Baggage_Headers_Max_Items: v1.50.0
+    Test_Only_Baggage_Header: v1.50.0
   test_config_consistency.py:
     Test_Config_ClientIPHeaderEnabled_False: v1.43.0
     Test_Config_ClientIPHeader_Configured: v1.43.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2040,12 +2040,24 @@ tests/:
       Test_Mock: v0.0.99
       Test_NotReleased: missing_feature
   test_baggage.py:
-    Test_Baggage_Headers_Basic: v1.50.0
-    Test_Baggage_Headers_Malformed: v1.50.0
-    Test_Baggage_Headers_Malformed2: v1.50.0
-    Test_Baggage_Headers_Max_Bytes: v1.50.0
-    Test_Baggage_Headers_Max_Items: v1.50.0
-    Test_Only_Baggage_Header: v1.50.0
+    Test_Baggage_Headers_Basic:
+      '*': incomplete_test_app (endpoint does not support fetching headers injected to downstream call)
+      spring-boot: v1.50.0
+    Test_Baggage_Headers_Malformed:
+      '*': incomplete_test_app (endpoint does not support fetching headers injected to downstream call)
+      spring-boot: v1.50.0
+    Test_Baggage_Headers_Malformed2:
+      '*': incomplete_test_app (endpoint does not support fetching headers injected to downstream call)
+      spring-boot: v1.50.0
+    Test_Baggage_Headers_Max_Bytes:
+      '*': incomplete_test_app (endpoint does not support fetching headers injected to downstream call)
+      spring-boot: v1.50.0
+    Test_Baggage_Headers_Max_Items:
+      '*': incomplete_test_app (endpoint does not support fetching headers injected to downstream call)
+      spring-boot: v1.50.0
+    Test_Only_Baggage_Header:
+      '*': incomplete_test_app (endpoint does not support fetching headers injected to downstream call)
+      spring-boot: v1.50.0
   test_config_consistency.py:
     Test_Config_ClientIPHeaderEnabled_False: v1.43.0
     Test_Config_ClientIPHeader_Configured: v1.43.0


### PR DESCRIPTION
## Motivation

Fixing issues with enabling all weblog instrumentations from #4679. Reverts #4819 with updates.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
