### PR TITLE
Adapt distributed headers propagation to the new API security default

### DIFF
--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -70,6 +70,7 @@ tests/:
     Test_Span_Links_Flags_From_Conflicting_Contexts: missing_feature (implementation specs have not been determined)
     Test_Span_Links_From_Conflicting_Contexts: missing_feature (baggage should be implemented and conflicting trace contexts should generate span link)
     Test_Span_Links_Omit_Tracestate_From_Conflicting_Contexts: missing_feature (implementation specs have not been determined)
+    Test_Synthetics_APM_Datadog: missing_feature (A non-root span carry user agent informations)
   test_graphql.py: missing_feature
   test_identify.py: irrelevant
   test_ipv6.py: missing_feature (APMAPI-869)

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -100,7 +100,7 @@ class _Scenarios:
     trace_propagation_style_default = EndToEndScenario(
         "TRACE_PROPAGATION_STYLE_DEFAULT",
         weblog_env={
-            # This scenario is empty since it's testing the default propagation styles
+            "DD_API_SECURITY_ENABLED": "false",
         },
         doc="Test Default propagation",
     )

--- a/utils/_context/_scenarios/default.py
+++ b/utils/_context/_scenarios/default.py
@@ -51,6 +51,11 @@ class DefaultScenario(EndToEndScenario):
                 "SOME_SECRET_ENV": "leaked-env-var",  # used for test that env var are not leaked
                 "DD_EXTERNAL_ENV": "it-false,cn-weblog,pu-75a2b6d5-3949-4afb-ad0d-92ff0674e759",
                 "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
+                # api security will be activated by default (done on ruby)
+                # those setting allow the feature to be deterministic
+                "DD_API_SECURITY_REQUEST_SAMPLE_RATE": "1.0",
+                "DD_API_SECURITY_SAMPLE_DELAY": "0.0",
+                "DD_API_SECURITY_MAX_CONCURRENT_REQUESTS": "50",
             },
             agent_env={"SOME_SECRET_ENV": "leaked-env-var"},
             include_postgres_db=True,

--- a/utils/dd_constants.py
+++ b/utils/dd_constants.py
@@ -84,5 +84,7 @@ class Capabilities(IntEnum):
 
 
 class SamplingPriority(IntEnum):
+    USER_REJECT = -1
+    AUTO_REJECT = 0
     AUTO_KEEP = 1
     USER_KEEP = 2


### PR DESCRIPTION
* API_SECURITY is now enabled by default.
    * -> add settings on DEFAULT scenario to make it deterministic
* API security overwrite sampling priority when it reports schema, is sampling priority > AUTO_REJECT
    * use sampling priority = AUTO_REJECT in the default scenario to check the good propagation
    * add a test on a scenario with API_SECURITY disabled and with sampling priority = 1


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
