### PR TITLE
[ruby] Temporary disable Test_Synthetics_APM_Datadog

### DIFF
--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -246,6 +246,7 @@ TRACECONTEXT_FLAGS_SET = 1 << 31
 
 @scenarios.default
 @features.datadog_headers_propagation
+@bug(context.library > "ruby@2.17.0", reason="APMRP-360")  # API security by default
 class Test_Synthetics_APM_Datadog:
     def setup_synthetics(self):
         self.r = weblog.get(


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
