### PR TITLE
Settings for API security

### DIFF
--- a/utils/_context/_scenarios/default.py
+++ b/utils/_context/_scenarios/default.py
@@ -51,6 +51,11 @@ class DefaultScenario(EndToEndScenario):
                 "SOME_SECRET_ENV": "leaked-env-var",  # used for test that env var are not leaked
                 "DD_EXTERNAL_ENV": "it-false,cn-weblog,pu-75a2b6d5-3949-4afb-ad0d-92ff0674e759",
                 "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
+                # api security will be activated by default (done on ruby)
+                # those setting allow the feature to be deterministic
+                "DD_API_SECURITY_REQUEST_SAMPLE_RATE": "1.0",
+                "DD_API_SECURITY_SAMPLE_DELAY": "0.0",
+                "DD_API_SECURITY_MAX_CONCURRENT_REQUESTS": "50",
             },
             agent_env={"SOME_SECRET_ENV": "leaked-env-var"},
             include_postgres_db=True,


### PR DESCRIPTION
## Motivation

API_SECURITY is now enabled by default.
-> add settings on DEFAULT scenario to make it deterministic

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
