### PR TITLE
[ruby] Enable crashtracking test for Ruby

### DIFF
--- a/tests/parametric/test_crashtracking.py
+++ b/tests/parametric/test_crashtracking.py
@@ -10,7 +10,6 @@ from utils import bug, context, features, scenarios, logger
 @scenarios.parametric
 @features.crashtracking
 class Test_Crashtracking:
-    @bug(context.library >= "ruby@2.7.2-dev", reason="APMLP-335")
     @pytest.mark.parametrize("library_env", [{"DD_CRASHTRACKING_ENABLED": "true"}])
     def test_report_crash(self, test_agent, test_library):
         test_library.crash()


### PR DESCRIPTION
## Motivation

Validate that crashtracking is in good shape for Ruby!

## Changes

This PR enables the crashtracking test for Ruby. There isn't a lot of detail on https://datadoghq.atlassian.net/browse/APMLP-335 for why it was disabled, but I suspect https://github.com/DataDog/system-tests/pull/4804 was the reason.

Now that #4804 is fixed, we should be able to enable the test.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
