### PR TITLE
Add Appsec SSI tests

### DIFF
--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -211,3 +211,29 @@ class TestSimpleInstallerAutoInjectManual(base.AutoInjectBaseTest):
         logger.info(
             f"Done test_install for : [{virtual_machine.name}][{virtual_machine.get_deployed_weblog().runtime_version}]"
         )
+
+
+@features.auto_instrumentation_appsec
+@scenarios.simple_auto_injection_appsec
+class TestSimpleInstallerAutoInjectManualAppsec(base.AutoInjectBaseTest):
+    def test_appsec(self):
+        logger.info(f"Launching test_appsec for : [{context.vm_name}]...")
+        self._test_install(context.virtual_machine, appsec=True)
+        logger.info(f"Done test_appsec for : [{context.vm_name}]")
+
+
+@features.host_auto_installation_script_appsec
+@scenarios.host_auto_injection_install_script_appsec
+class TestHostAutoInjectInstallScriptAppsec(base.AutoInjectBaseTest):
+    @missing_feature(context.vm_os_branch == "windows", reason="Not implemented on Windows")
+    def test_appsec(self):
+        logger.info(f"Launching test_appsec for : [{context.vm_name}]...")
+        self._test_install(context.virtual_machine, appsec=True)
+        logger.info(f"Done test_appsec for : [{context.vm_name}]")
+
+
+@features.container_auto_installation_script_appsec
+@scenarios.container_auto_injection_install_script_appsec
+class TestContainerAutoInjectInstallScriptAppsec(base.AutoInjectBaseTest):
+    def test_appsec(self):
+        self._test_install(context.virtual_machine, appsec=True)

--- a/tests/test_the_test/test_group_rules.py
+++ b/tests/test_the_test/test_group_rules.py
@@ -31,6 +31,7 @@ def test_tracer_release():
         scenarios.otel_tracing_e2e,
         # to be added once stability is proven
         scenarios.chaos_installer_auto_injection,
+        scenarios.container_auto_injection_install_script_appsec,
         scenarios.container_auto_injection_install_script_profiling,
         scenarios.container_auto_injection_install_script,
         scenarios.docker_ssi,
@@ -38,6 +39,7 @@ def test_tracer_release():
         scenarios.docker_ssi_servicenaming,
         scenarios.external_processing_blocking,  # need to declare a white list of library in get-workflow-parameters
         scenarios.external_processing,  # need to declare a white list of library in get-workflow-parameters
+        scenarios.host_auto_injection_install_script_appsec,
         scenarios.host_auto_injection_install_script_profiling,
         scenarios.host_auto_injection_install_script,
         scenarios.installer_auto_injection,
@@ -54,6 +56,7 @@ def test_tracer_release():
         scenarios.lib_injection_validation_unsupported_lang,
         scenarios.lib_injection_validation,
         scenarios.local_auto_injection_install_script,
+        scenarios.simple_auto_injection_appsec,
         scenarios.simple_auto_injection_profiling,
         scenarios.simple_installer_auto_injection,
         scenarios.multi_installer_auto_injection,

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -838,6 +838,35 @@ class _Scenarios:
         github_workflow="aws_ssi",
     )
 
+    simple_auto_injection_appsec = InstallerAutoInjectionScenario(
+        "SIMPLE_AUTO_INJECTION_APPSEC",
+        "Onboarding Single Step Instrumentation scenario with Appsec activated by the app env var",
+        app_env={"DD_APPSEC_ENABLED": "true"},
+        scenario_groups=[scenario_groups.all, scenario_groups.simple_onboarding_appsec],
+        github_workflow="aws_ssi",
+    )
+
+    host_auto_injection_install_script_appsec = InstallerAutoInjectionScenario(
+        "HOST_AUTO_INJECTION_INSTALL_SCRIPT_APPSEC",
+        doc=(
+            "Onboarding Host Single Step Instrumentation scenario using agent "
+            "auto install script with Appsec activated by the installation process"
+        ),
+        vm_provision="host-auto-inject-install-script",
+        agent_env={"DD_APPSEC_ENABLED": "true"},
+        scenario_groups=[scenario_groups.all],
+        github_workflow="aws_ssi",
+    )
+
+    container_auto_injection_install_script_appsec = InstallerAutoInjectionScenario(
+        "CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT_APPSEC",
+        "Onboarding Container Single Step Instrumentation Appsec scenario using agent auto install script",
+        vm_provision="container-auto-inject-install-script",
+        agent_env={"DD_APPSEC_ENABLED": "true"},
+        scenario_groups=[scenario_groups.all],
+        github_workflow="aws_ssi",
+    )
+
     demo_aws = InstallerAutoInjectionScenario(
         "DEMO_AWS",
         "Demo aws scenario",

--- a/utils/_context/_scenarios/core.py
+++ b/utils/_context/_scenarios/core.py
@@ -41,6 +41,7 @@ class _ScenarioGroups:
     onboarding = ScenarioGroup()
     simple_onboarding = ScenarioGroup()
     simple_onboarding_profiling = ScenarioGroup()
+    simple_onboarding_appsec = ScenarioGroup()
     docker_ssi = ScenarioGroup()
     essentials = ScenarioGroup()
     external_processing = ScenarioGroup()

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2690,5 +2690,32 @@ class _Features:
         pytest.mark.features(feature_id=474)(test_object)
         return test_object
 
+    @staticmethod
+    def auto_instrumentation_appsec(test_object):
+        """Appsec works when manually enabled with library injection in Host environments
+
+        https://feature-parity.us1.prod.dog/#/?feature=478
+        """
+        pytest.mark.features(feature_id=478)(test_object)
+        return test_object
+
+    @staticmethod
+    def host_auto_installation_script_appsec(test_object):
+        """Appsec works when enabled through the agent installer script in Host environments
+
+        https://feature-parity.us1.prod.dog/#/?feature=479
+        """
+        pytest.mark.features(feature_id=479)(test_object)
+        return test_object
+
+    @staticmethod
+    def container_auto_installation_script_appsec(test_object):
+        """Appsec works when enabled through the agent installer script in Container environments
+
+        https://feature-parity.us1.prod.dog/#/?feature=480
+        """
+        pytest.mark.features(feature_id=480)(test_object)
+        return test_object
+
 
 features = _Features()

--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -63,13 +63,14 @@ def _query_for_trace_id(trace_id, validator=None):
         logger.info("Backend trace is valid")
 
     root_id = trace_data["trace"]["root_id"]
-    start_time = trace_data["trace"]["spans"][root_id]["start"]
+    root_span = trace_data["trace"]["spans"][root_id]
+    start_time = root_span["start"]
     start_date = datetime.fromtimestamp(start_time)
     if (datetime.now() - start_date).days > 1:
         logger.info("Backend trace is too old")
         return None
 
-    return trace_data["trace"]["spans"][root_id]["meta"]["runtime-id"]
+    return root_span["meta"]["runtime-id"]
 
 
 def _make_request(

--- a/utils/scripts/ci_orchestrators/aws_ssi.json
+++ b/utils/scripts/ci_orchestrators/aws_ssi.json
@@ -44,7 +44,8 @@
         },
         {
             "scenarios": [
-                "CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING"
+                "CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING",
+                "CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT_APPSEC"
             ],
             "weblogs": [
                 {
@@ -99,7 +100,8 @@
         },
         {
             "scenarios": [
-                "HOST_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING"
+                "HOST_AUTO_INJECTION_INSTALL_SCRIPT_PROFILING",
+                "HOST_AUTO_INJECTION_INSTALL_SCRIPT_APPSEC"
             ],
             "weblogs": [
                 {
@@ -185,7 +187,8 @@
         },
         {
             "scenarios": [
-                "SIMPLE_AUTO_INJECTION_PROFILING"
+                "SIMPLE_AUTO_INJECTION_PROFILING",
+                "SIMPLE_AUTO_INJECTION_APPSEC"
             ],
             "weblogs": [
                 {

--- a/utils/scripts/ssi_wizards/aws_onboarding_wizard.sh
+++ b/utils/scripts/ssi_wizards/aws_onboarding_wizard.sh
@@ -296,7 +296,7 @@ if [[ -z "$ONBOARDING_KEEP_VMS" ]]; then
 fi
 
 ask_for_test_language
-load_workflow_data "all,onboarding,simple_onboarding,simple_onboarding_profiling" "aws_ssi_scenario_defs"
+load_workflow_data "all,onboarding,simple_onboarding,simple_onboarding_profiling,simple_onboarding_appsec" "aws_ssi_scenario_defs"
 select_scenario
 select_weblog
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Validate the auto activation of Appsec (AAP) using SSI in different environments.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Added new scenarios with corresponding new feature:
- `SIMPLE_AUTO_INJECTION_APPSEC` (feature [478](https://feature-parity.us1.prod.dog/#/?feature=478))
- `HOST_AUTO_INJECTION_INSTALL_SCRIPT_APPSEC` (feature [479](https://feature-parity.us1.prod.dog/#/?feature=479))
- `CONTAINER_AUTO_INJECTION_INSTALL_SCRIPT_APPSEC` (feature [480](https://feature-parity.us1.prod.dog/#/?feature=480))

The appsec test is verifying that the received span contain the metric `_dd.appsec.enabled` set to `1` and the `meta` tag `appsec.event` set to `true`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
