### PR TITLE
Docker SSI base images from ecr (wildfly and websphere)

### DIFF
--- a/utils/docker_ssi/docker_ssi_images.json
+++ b/utils/docker_ssi/docker_ssi_images.json
@@ -67,12 +67,12 @@
     },
     {
       "name": "Websphere_amd64",
-      "image": "icr.io/appcafe/websphere-traditional",
+      "image": "235494822917.dkr.ecr.us-east-1.amazonaws.com/third-party/websphere-traditional:latest",
       "architecture": "linux/amd64"
     },
     {
       "name": "Wildfly_amd64",
-      "image": "quay.io/wildfly/wildfly:26.1.2.Final",
+      "image": "235494822917.dkr.ecr.us-east-1.amazonaws.com/third-party/wildfly:26.1.2.Final-amd64",
       "architecture": "linux/amd64"
     }
   ]


### PR DESCRIPTION
## Motivation

Wildfy and webspher base images moved to the ecr private registry, to avoid rate limits
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
