### PR TITLE
Add scenario for testing the python tracer in an emulated AWS Lambda context

### DIFF
--- a/.github/workflows/run-docker-mode.yml
+++ b/.github/workflows/run-docker-mode.yml
@@ -19,6 +19,8 @@ jobs:
             internal: system_tests/agent:latest
           - name: proxy
             internal: datadog/system-tests:proxy-v1
+          - name: lambda-proxy
+            internal: datadog/system-tests:lambda-proxy
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -41,6 +41,7 @@ def _assert_custom_event_tag_absence():
 @features.appsec_request_blocking
 @features.envoy_external_processing
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @scenarios.external_processing_blocking
 class Test_Blocking_client_ip:
     """Test if blocking is supported on http.client_ip address"""
@@ -66,6 +67,7 @@ class Test_Blocking_client_ip:
 
 
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @features.appsec_request_blocking
 class Test_Blocking_user_id:
     """Test if blocking is supported on usr.id address"""
@@ -84,6 +86,7 @@ class Test_Blocking_user_id:
 @features.appsec_request_blocking
 @features.envoy_external_processing
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @scenarios.external_processing_blocking
 class Test_Blocking_request_method:
     """Test if blocking is supported on server.request.method address"""
@@ -139,6 +142,7 @@ class Test_Blocking_request_method:
 @features.appsec_request_blocking
 @features.envoy_external_processing
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @scenarios.external_processing_blocking
 class Test_Blocking_request_uri:
     """Test if blocking is supported on server.request.uri.raw address"""
@@ -205,6 +209,7 @@ class Test_Blocking_request_uri:
 @features.appsec_request_blocking
 @features.envoy_external_processing
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @scenarios.external_processing_blocking
 class Test_Blocking_request_path_params:
     """Test if blocking is supported on server.request.path_params address"""
@@ -271,6 +276,7 @@ class Test_Blocking_request_path_params:
 @features.appsec_request_blocking
 @features.envoy_external_processing
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @scenarios.external_processing_blocking
 class Test_Blocking_request_query:
     """Test if blocking is supported on server.request.query address"""
@@ -329,6 +335,7 @@ class Test_Blocking_request_query:
 @features.appsec_request_blocking
 @features.envoy_external_processing
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @scenarios.external_processing_blocking
 class Test_Blocking_request_headers:
     """Test if blocking is supported on server.request.headers.no_cookies address"""
@@ -387,6 +394,7 @@ class Test_Blocking_request_headers:
 @features.appsec_request_blocking
 @features.envoy_external_processing
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @scenarios.external_processing_blocking
 class Test_Blocking_request_cookies:
     """Test if blocking is supported on server.request.cookies address"""
@@ -443,6 +451,7 @@ class Test_Blocking_request_cookies:
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @features.appsec_request_blocking
 class Test_Blocking_request_body:
     """Test if blocking is supported on server.request.body address for urlencoded body"""
@@ -511,6 +520,7 @@ class Test_Blocking_request_body:
 
 
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @features.appsec_request_blocking
 class Test_Blocking_request_body_multipart:
     """Test if blocking is supported on server.request.body address for multipart body"""
@@ -527,6 +537,7 @@ class Test_Blocking_request_body_multipart:
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @scenarios.external_processing_blocking
 @features.appsec_response_blocking
 @features.envoy_external_processing
@@ -596,6 +607,7 @@ class Test_Blocking_response_status:
 @features.appsec_response_blocking
 @features.envoy_external_processing
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @scenarios.external_processing_blocking
 class Test_Blocking_response_headers:
     """Test if blocking is supported on server.response.headers.no_cookies address"""
@@ -637,6 +649,7 @@ class Test_Blocking_response_headers:
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2667021177/Suspicious+requests+blocking")
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @features.appsec_request_blocking
 class Test_Suspicious_Request_Blocking:
     """Test if blocking on multiple addresses with multiple rules is supported"""

--- a/tests/appsec/test_conf.py
+++ b/tests/appsec/test_conf.py
@@ -102,6 +102,7 @@ class Test_ConfigurationVariables:
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2355333252/Environment+Variables")
 @features.threats_configuration
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 class Test_ConfigurationVariables_New_Obfuscation:
     """Check for new obfuscation features in libddwaf 1.25.0 and later
     Requires libddwaf 1.25.0 or later and updated obfuscation regex for values

--- a/tests/appsec/test_fingerprinting.py
+++ b/tests/appsec/test_fingerprinting.py
@@ -100,6 +100,7 @@ class Test_Fingerprinting_Session:
 @rfc("https://docs.google.com/document/d/1DivOa9XsCggmZVzMI57vyxH2_EBJ0-qqIkRHm_sEvSs/edit#heading=h.88xvn2cvs9dt")
 @features.fingerprinting
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 class Test_Fingerprinting_Endpoint_Preprocessor:
     endpoint_fingerprint_regex = r"http-[^-]*-[^-]*-[^-]*-[^-]*"
 
@@ -130,6 +131,7 @@ class Test_Fingerprinting_Endpoint_Preprocessor:
 @rfc("https://docs.google.com/document/d/1DivOa9XsCggmZVzMI57vyxH2_EBJ0-qqIkRHm_sEvSs/edit#heading=h.88xvn2cvs9dt")
 @features.fingerprinting
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 class Test_Fingerprinting_Header_And_Network_Preprocessor:
     network_fingerprint_regex = r"net-[^-]*-[^-]*"
     header_fingerprint_regex = r"hdr-[^-]*-[^-]*-[^-]*-[^-]*"
@@ -184,6 +186,7 @@ class Test_Fingerprinting_Header_And_Network_Preprocessor:
 @rfc("https://docs.google.com/document/d/1DivOa9XsCggmZVzMI57vyxH2_EBJ0-qqIkRHm_sEvSs/edit#heading=h.88xvn2cvs9dt")
 @features.fingerprinting
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 class Test_Fingerprinting_Session_Preprocessor:
     session_fingerprint_regex = r"ssn-[^-]*-[^-]*-[^-]*-[^-]*"
 

--- a/tests/appsec/test_only_python.py
+++ b/tests/appsec/test_only_python.py
@@ -6,6 +6,7 @@ from utils import context, features, interfaces, irrelevant, scenarios, flaky
 
 
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @scenarios.appsec_rasp
 @scenarios.appsec_runtime_activation
 @scenarios.appsec_standalone

--- a/tests/appsec/test_trace_tagging.py
+++ b/tests/appsec/test_trace_tagging.py
@@ -13,6 +13,7 @@ from utils.dd_constants import Capabilities, SamplingPriority
 
 @features.appsec_trace_tagging_rules
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 class Test_TraceTaggingRules:
     """Test different variants of trace-tagging rules"""
 

--- a/tests/appsec/waf/test_blocking.py
+++ b/tests/appsec/waf/test_blocking.py
@@ -52,6 +52,7 @@ JSON_CONTENT_TYPES = {
 
 
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @features.appsec_blocking_action
 class Test_Blocking:
     """Blocking response is obtained when triggering a blocking rule, test the default blocking response"""
@@ -205,6 +206,7 @@ class Test_Blocking:
 
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2705464728/Blocking#Stripping-response-headers")
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @features.appsec_blocking_action
 class Test_Blocking_strip_response_headers:
     def setup_strip_response_headers(self):
@@ -222,6 +224,7 @@ class Test_Blocking_strip_response_headers:
 
 @rfc("https://docs.google.com/document/d/1a_-isT9v_LiiGshzQZtzPzCK_CxMtMIil_2fOq9Z1RE/edit")
 @scenarios.appsec_blocking
+@scenarios.appsec_lambda_blocking
 @features.appsec_blocking_action
 class Test_CustomBlockingResponse:
     """Custom Blocking response"""

--- a/tests/test_the_test/test_group_rules.py
+++ b/tests/test_the_test/test_group_rules.py
@@ -61,6 +61,7 @@ def test_tracer_release():
         scenarios.simple_installer_auto_injection,
         scenarios.multi_installer_auto_injection,
         scenarios.demo_aws,
+        scenarios.appsec_lambda_request_blocking,
     ]
 
     for scenario in get_all_scenarios():

--- a/tests/test_the_test/test_group_rules.py
+++ b/tests/test_the_test/test_group_rules.py
@@ -61,7 +61,7 @@ def test_tracer_release():
         scenarios.simple_installer_auto_injection,
         scenarios.multi_installer_auto_injection,
         scenarios.demo_aws,
-        scenarios.appsec_lambda_request_blocking,
+        scenarios.appsec_lambda_blocking,
     ]
 
     for scenario in get_all_scenarios():

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -1,5 +1,6 @@
 import json
 
+from utils._context._scenarios.aws_lambda import LambdaScenario
 from utils._context.header_tag_vars import VALID_CONFIGS, INVALID_CONFIGS
 from utils.proxy.ports import ProxyPorts
 from utils.tools import update_environ_with_local_env
@@ -184,6 +185,15 @@ class _Scenarios:
         doc="Misc tests for appsec blocking",
         scenario_groups=[scenario_groups.appsec, scenario_groups.essentials],
     )
+
+    appsec_lambda_request_blocking = LambdaScenario(
+        "APPSEC_LAMBDA_REQUEST_BLOCKING",
+        doc="Appsec tests for AAP Request Blocking on AWS Lambda",
+        weblog_env={"DD_APPSEC_RULES": "/appsec_blocking_rule.json"},
+        weblog_volumes={"./tests/appsec/blocking_rule.json": {"bind": "/appsec_blocking_rule.json", "mode": "ro"}},
+        scenario_groups=[scenario_groups.appsec],
+    )
+
     # This GraphQL scenario can be used for any GraphQL testing, not just AppSec
     graphql_appsec = EndToEndScenario(
         "GRAPHQL_APPSEC",

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -186,11 +186,11 @@ class _Scenarios:
         scenario_groups=[scenario_groups.appsec, scenario_groups.essentials],
     )
 
-    appsec_lambda_request_blocking = LambdaScenario(
-        "APPSEC_LAMBDA_REQUEST_BLOCKING",
-        doc="Appsec tests for AAP Request Blocking on AWS Lambda",
+    appsec_lambda_blocking = LambdaScenario(
+        "APPSEC_LAMBDA_BLOCKING",
         weblog_env={"DD_APPSEC_RULES": "/appsec_blocking_rule.json"},
         weblog_volumes={"./tests/appsec/blocking_rule.json": {"bind": "/appsec_blocking_rule.json", "mode": "ro"}},
+        doc="Appsec tests for AAP Blocking on AWS Lambda",
         scenario_groups=[scenario_groups.appsec],
     )
 

--- a/utils/_context/_scenarios/aws_lambda.py
+++ b/utils/_context/_scenarios/aws_lambda.py
@@ -31,7 +31,7 @@ class LambdaScenario(DockerScenario):
         use_proxy_for_weblog: bool = True,
         use_proxy_for_agent: bool = True,
         require_api_key: bool = False,
-        weblog_env: dict[str, str] | None = None,
+        weblog_env: dict[str, str | None] | None = None,
         weblog_volumes: dict[str, dict[str, str]] | None = None,
     ):
         use_proxy = use_proxy_for_weblog or use_proxy_for_agent
@@ -135,7 +135,6 @@ class LambdaScenario(DockerScenario):
 
     def _set_components(self):
         self.components["libary"] = self.library.version
-        self.components["agent"] = self.extension.version
 
     def _wait_for_app_readiness(self):
         logger.debug("Wait for app readiness")
@@ -191,8 +190,4 @@ class LambdaScenario(DockerScenario):
 
     @property
     def library(self):
-        return self.lambda_proxy_container.library
-
-    @property
-    def extension(self):
-        return self.lambda_proxy_container.extension
+        return self.lambda_weblog.library

--- a/utils/_context/_scenarios/aws_lambda.py
+++ b/utils/_context/_scenarios/aws_lambda.py
@@ -1,0 +1,198 @@
+import os
+import pytest
+from utils import interfaces
+from utils._context._scenarios.core import ScenarioGroup
+from utils._context.containers import LambdaProxyContainer, LambdaWeblogContainer
+from utils._logger import logger
+from .endtoend import DockerScenario, ProxyBasedInterfaceValidator
+
+
+class LambdaScenario(DockerScenario):
+    """Scenario for end-to-end testing of AWS Lambda HTTP Instrumentation.
+
+    The `LambdaScenario` sets up an environment with the following components:
+    - A LambdaWeblog container that runs the application using AWS Lambda RIE (Runtime Interface Emulator).
+    - A LambdaProxy container that converts between http requests and lambda events to invoke the function.
+
+    In this scenario, there is no agent container, but the LambdaWeblog contains the `datadog-lambda-extension`
+    which is the agent in the context of Lambda.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        github_workflow: str = "endtoend",
+        doc: str,
+        scenario_groups: list[ScenarioGroup] | None = None,
+        agent_interface_timeout: int = 5,
+        backend_interface_timeout: int = 0,
+        library_interface_timeout: int | None = None,
+        use_proxy_for_weblog: bool = True,
+        use_proxy_for_agent: bool = True,
+        require_api_key: bool = False,
+        weblog_env: dict[str, str] | None = None,
+        weblog_volumes: dict[str, dict[str, str]] | None = None,
+    ):
+        use_proxy = use_proxy_for_weblog or use_proxy_for_agent
+        self._require_api_key = require_api_key
+
+        super().__init__(
+            name, github_workflow=github_workflow, doc=doc, use_proxy=use_proxy, scenario_groups=scenario_groups
+        )
+
+        self.lambda_weblog = LambdaWeblogContainer(
+            host_log_folder=self.host_log_folder,
+            environment=weblog_env or {},
+            volumes=weblog_volumes or {},
+        )
+
+        self.lambda_proxy_container = LambdaProxyContainer(
+            host_log_folder=self.host_log_folder,
+            lambda_weblog_host=self.lambda_weblog.name,
+            lambda_weblog_port=str(self.lambda_weblog.container_port),
+        )
+
+        self.lambda_proxy_container.depends_on.append(self.lambda_weblog)
+
+        if use_proxy:
+            self.lambda_weblog.depends_on.append(self.proxy_container)
+
+        if use_proxy_for_agent:
+            self.proxy_container.environment.update(
+                {
+                    "PROXY_TRACING_AGENT_TARGET_HOST": self.lambda_weblog.name,
+                    "PROXY_TRACING_AGENT_TARGET_PORT": "8126",
+                }
+            )
+
+        self._required_containers.extend((self.lambda_weblog, self.lambda_proxy_container))
+
+        self.agent_interface_timeout = agent_interface_timeout
+        self.backend_interface_timeout = backend_interface_timeout
+        self._library_interface_timeout = library_interface_timeout
+
+    def configure(self, config: pytest.Config):
+        super().configure(config)
+
+        if self._require_api_key and "DD_API_KEY" not in os.environ and not self.replay:
+            pytest.exit("DD_API_KEY is required for this scenario", 1)
+
+        if config.option.force_dd_trace_debug:
+            self.lambda_weblog.environment["DD_TRACE_DEBUG"] = "true"
+
+        if config.option.force_dd_iast_debug:
+            self.lambda_weblog.environment["_DD_IAST_DEBUG"] = "true"  # probably not used anymore ?
+            self.lambda_weblog.environment["DD_IAST_DEBUG_ENABLED"] = "true"
+
+        if config.option.force_dd_trace_debug:
+            self.lambda_weblog.environment["DD_TRACE_DEBUG"] = "true"
+
+        interfaces.agent.configure(self.host_log_folder, replay=self.replay)
+        interfaces.library.configure(self.host_log_folder, replay=self.replay)
+        interfaces.backend.configure(self.host_log_folder, replay=self.replay)
+        interfaces.library_dotnet_managed.configure(self.host_log_folder, replay=self.replay)
+        interfaces.library_stdout.configure(self.host_log_folder, replay=self.replay)
+        interfaces.agent_stdout.configure(self.host_log_folder, replay=self.replay)
+
+        library = self.lambda_weblog.image.labels["system-tests-library"]
+
+        if self._library_interface_timeout is None:
+            if library == "java":
+                self.library_interface_timeout = 25
+            elif library in ("golang",):
+                self.library_interface_timeout = 10
+            elif library in ("nodejs", "ruby"):
+                self.library_interface_timeout = 0
+            elif library in ("php",):
+                self.library_interface_timeout = 10
+            elif library in ("python",):
+                self.library_interface_timeout = 5
+            else:
+                self.library_interface_timeout = 40
+        else:
+            self.library_interface_timeout = self._library_interface_timeout
+
+    def _get_weblog_system_info(self):
+        try:
+            code, (stdout, stderr) = self.lambda_weblog.exec_run("uname -a", demux=True)
+            if code or stdout is None:
+                message = f"Failed to get weblog system info: [{code}] {stderr.decode()} {stdout.decode()}"
+            else:
+                message = stdout.decode()
+        except BaseException:
+            logger.exception("can't get weblog system info")
+        else:
+            logger.stdout(f"Weblog system: {message.strip()}")
+
+        if self.lambda_weblog.environment.get("DD_TRACE_DEBUG") == "true":
+            logger.stdout("\t/!\\ Debug logs are activated in weblog")
+
+        logger.stdout("")
+
+    def _start_interfaces_watchdog(self):
+        return super().start_interfaces_watchdog([interfaces.library, interfaces.agent])
+
+    def _set_components(self):
+        self.components["libary"] = self.library.version
+        self.components["agent"] = self.extension.version
+
+    def _wait_for_app_readiness(self):
+        logger.debug("Wait for app readiness")
+
+        if not interfaces.library.ready.wait(40):
+            raise ValueError("Library not ready")
+
+        logger.debug("Library ready")
+
+    def get_warmups(self):
+        warmups = super().get_warmups()
+
+        if not self.replay:
+            warmups.insert(1, self._start_interfaces_watchdog)
+            warmups.append(self._get_weblog_system_info)
+            warmups.append(self._wait_for_app_readiness)
+            warmups.append(self._set_components)
+
+        return warmups
+
+    def _wait_interface(self, interface: ProxyBasedInterfaceValidator, timeout: int):
+        logger.terminal.write_sep("-", f"Wait for {interface.name} interface ({timeout}s)")
+        logger.terminal.flush()
+
+        interface.wait(timeout)
+
+    def _wait_and_stop_containers(self, *, force_interface_timeout_to_zero: bool = False):
+        if self.replay:
+            logger.terminal.write_sep("-", "Load all data from logs")
+            logger.terminal.flush()
+
+            interfaces.library.load_data_from_logs()
+            interfaces.library.check_deserialization_errors()
+
+            interfaces.backend.load_data_from_logs()
+        else:
+            self._wait_interface(
+                interfaces.library, 0 if force_interface_timeout_to_zero else self.library_interface_timeout
+            )
+
+            self.lambda_weblog.stop()
+            interfaces.library.check_deserialization_errors()
+
+            self._wait_interface(interfaces.backend, 0)
+
+    def post_setup(self, session: pytest.Session):
+        is_empty_test_run = session.config.option.skip_empty_scenario and len(session.items) == 0
+
+        try:
+            self._wait_and_stop_containers(force_interface_timeout_to_zero=is_empty_test_run)
+        finally:
+            self.close_targets()
+
+    @property
+    def library(self):
+        return self.lambda_proxy_container.library
+
+    @property
+    def extension(self):
+        return self.lambda_proxy_container.extension

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -605,6 +605,63 @@ class ProxyContainer(TestedContainer):
         )
 
 
+class LambdaProxyContainer(TestedContainer):
+    def __init__(
+        self,
+        *,
+        host_log_folder: str,
+        lambda_weblog_host: str,
+        lambda_weblog_port: str,
+    ) -> None:
+        from utils import weblog
+
+        self.host_port = weblog.port
+        self.container_port = "7777"
+
+        super().__init__(
+            image_name="datadog/system-tests:lambda-proxy",
+            name="lambda-proxy",
+            host_log_folder=host_log_folder,
+            environment={
+                "RIE_HOST": lambda_weblog_host,
+                "RIE_PORT": lambda_weblog_port,
+            },
+            ports={
+                f"{self.host_port}/tcp": self.container_port,
+            },
+            healthcheck={
+                "test": f"curl --fail --silent --show-error --max-time 2 localhost:{self.container_port}/healthcheck",
+                "retries": 60,
+            },
+        )
+
+    def post_start(self):
+        from utils import weblog
+
+        logger.debug(f"Docker host is {weblog.domain}")
+
+        with open(self.healthcheck_log_file, encoding="utf-8") as f:
+            data = json.load(f)
+            lib = data["library"]
+            extension = data["extension"]
+
+        self._library = ComponentVersion(lib["name"], lib["version"])
+        self._extension = ComponentVersion(extension["name"], extension["version"])
+
+        logger.stdout(f"Library: {self.library}")
+        logger.stdout(f"Agent: {self.extension}")
+
+    @property
+    def library(self) -> ComponentVersion:
+        assert self._library is not None, "Library version is not set"
+        return self._library
+
+    @property
+    def extension(self) -> ComponentVersion:
+        assert self._extension is not None, "Agent version is not set"
+        return self._extension
+
+
 class AgentContainer(TestedContainer):
     apm_receiver_port: int = 8127
     dogstatsd_port: int = 8125
@@ -1006,6 +1063,86 @@ class WeblogContainer(TestedContainer):
     @property
     def telemetry_heartbeat_interval(self):
         return 2
+
+
+class LambdaWeblogContainer(WeblogContainer):
+    def __init__(
+        self,
+        host_log_folder: str,
+        *,
+        environment: dict[str, str | None] | None = None,
+        tracer_sampling_rate: float | None = None,
+        appsec_enabled: bool = True,
+        iast_enabled: bool = True,
+        runtime_metrics_enabled: bool = False,
+        additional_trace_header_tags: tuple[str, ...] = (),
+        use_proxy: bool = True,
+        volumes: dict | None = None,
+    ):
+        # overwrite values with those set in the scenario
+        environment = (environment or {}) | {
+            "DD_HOSTNAME": "test",
+            "DD_SITE": os.environ.get("DD_SITE", "datad0g.com"),
+            "DD_API_KEY": os.environ.get("DD_API_KEY", _FAKE_DD_API_KEY),
+        }
+
+        volumes = volumes or {}
+
+        if use_proxy:
+            environment["DD_PROXY_HTTPS"] = f"http://proxy:{ProxyPorts.agent}"
+            environment["DD_PROXY_HTTP"] = f"http://proxy:{ProxyPorts.agent}"
+            environment["DD_APM_NON_LOCAL_TRAFFIC"] = (
+                "true"  # Required for the extension to receive traces from outside the container
+            )
+            volumes.update(
+                {
+                    "./utils/build/docker/agent/ca-certificates.crt": {
+                        "bind": "/etc/ssl/certs/ca-certificates.crt",
+                        "mode": "ro",
+                    },
+                    "./utils/build/docker/agent/datadog.yaml": {
+                        "bind": "/etc/datadog-agent/datadog.yaml",
+                        "mode": "ro",
+                    },
+                },
+            )
+
+        self.tracer_sampling_rate = tracer_sampling_rate
+        self.additional_trace_header_tags = additional_trace_header_tags
+
+        super().__init__(
+            host_log_folder,
+            environment=environment,
+            tracer_sampling_rate=tracer_sampling_rate,
+            appsec_enabled=appsec_enabled,
+            iast_enabled=iast_enabled,
+            runtime_metrics_enabled=runtime_metrics_enabled,
+            additional_trace_header_tags=additional_trace_header_tags,
+            use_proxy=use_proxy,
+            volumes=volumes,
+        )
+
+        # Remove healthchecks, as they are performed in the LambdaProxyContainer
+        self.healthcheck = None
+        # Remove port bindings, as only the LambdaProxyContainer needs to expose a server
+        self.ports = {}
+        # Set the container port to the one used by the one of the Lambda RIE
+        self.container_port = 8080
+
+    def post_start(self):
+        from utils import weblog
+
+        logger.debug(f"Docker host is {weblog.domain}")
+
+        if self.appsec_rules_file:
+            logger.stdout("Using a custom appsec rules file")
+
+        if self.uds_mode:
+            logger.stdout(f"UDS socket: {self.uds_socket}")
+
+        logger.stdout(f"Weblog variant: {self.weblog_variant}")
+
+        self.stdout_interface.init_patterns(self.library)
 
 
 class PostgresContainer(SqlDbTestedContainer):

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -215,6 +215,10 @@ build() {
 
                 DOCKERFILE=utils/build/docker/${TEST_LIBRARY}/${WEBLOG_VARIANT}.Dockerfile
 
+                if [[ $WEBLOG_VARIANT == lambda-python* ]]; then
+                    ./utils/build/docker/python/build_lambda_layer.sh
+                fi
+
                 docker buildx build \
                     --build-arg BUILDKIT_INLINE_CACHE=1 \
                     --load \

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -247,6 +247,15 @@ build() {
                     docker save system_tests/weblog | gzip > $BINARIES_FILENAME
                 fi
             fi
+        elif [[ $IMAGE_NAME == lambda-proxy ]]; then
+            docker buildx build \
+                --build-arg BUILDKIT_INLINE_CACHE=1 \
+                --load \
+                --progress=plain \
+                -f utils/build/docker/lambda-proxy.Dockerfile \
+                -t datadog/system-tests:lambda-proxy \
+                $EXTRA_DOCKER_ARGS \
+                .
         else
             echo "Don't know how to build $IMAGE_NAME"
             exit 1

--- a/utils/build/docker/lambda-proxy.Dockerfile
+++ b/utils/build/docker/lambda-proxy.Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.13-alpine
+
+WORKDIR /app
+
+RUN apk add --no-cache curl
+
+COPY ./utils/build/docker/lambda_proxy/pyproject.toml ./
+RUN pip install --no-cache-dir .
+
+COPY utils/build/docker/lambda_proxy/main.py ./
+
+ENTRYPOINT ["gunicorn", "--bind=0.0.0.0:7777", "--workers=1", "main:app"]

--- a/utils/build/docker/lambda_proxy/README.md
+++ b/utils/build/docker/lambda_proxy/README.md
@@ -1,0 +1,1 @@
+# Lambda Proxy

--- a/utils/build/docker/lambda_proxy/main.py
+++ b/utils/build/docker/lambda_proxy/main.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from samcli.local.apigw.event_constructor import construct_v1_event
+from samcli.local.apigw.local_apigw_service import LocalApigwService
+
+# Create super simple catch-all flask app
+from flask import Flask, request
+from requests import post
+
+PORT = 7777
+
+RIE_HOST = os.environ.get("RIE_HOST", "lambda-weblog")
+RIE_PORT = os.environ.get("RIE_PORT", "8080")
+FUNCTION_NAME = os.environ.get("FUNCTION_NAME", "function")
+RIE_URL = f"http://{RIE_HOST}:{RIE_PORT}/2015-03-31/functions/{FUNCTION_NAME}/invocations"
+
+app = Flask(__name__)
+
+
+@app.route("/")
+@app.route("/<path:path>")
+def main(path):
+    converted_event = construct_v1_event(request, PORT, binary_types=[], stage_name="Prod")
+
+    response = post(
+        RIE_URL,
+        json=converted_event,
+        headers={"Content-Type": "application/json"},
+    )
+
+    (status_code, headers, body) = LocalApigwService._parse_v1_payload_format_lambda_output(
+        response.content.decode("utf-8"), binary_types=[], flask_request=request, event_type="Api"
+    )
+
+    return app.response_class(response=body, status=status_code, headers=headers)

--- a/utils/build/docker/lambda_proxy/main.py
+++ b/utils/build/docker/lambda_proxy/main.py
@@ -19,7 +19,7 @@ app = Flask(__name__)
 
 @app.route("/")
 @app.route("/<path:path>")
-def main(path):
+def main(path=""):
     converted_event = construct_v1_event(request, PORT, binary_types=[], stage_name="Prod")
 
     response = post(

--- a/utils/build/docker/lambda_proxy/pyproject.toml
+++ b/utils/build/docker/lambda_proxy/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "lambda-proxy"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = ["aws-sam-cli<=1.141.0", "flask>=3.1.1", "gunicorn>=23.0.0"]

--- a/utils/build/docker/python/aws_lambda/function/handler.py
+++ b/utils/build/docker/python/aws_lambda/function/handler.py
@@ -1,0 +1,46 @@
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.utilities.typing.lambda_context import LambdaContext
+from aws_lambda_powertools.event_handler import Response
+
+import logging
+import os
+
+import ddtrace
+
+logger = logging.getLogger(__name__)
+
+
+app = APIGatewayRestResolver()
+
+
+@app.get("/healthcheck")
+def healthcheck():
+    return Response(
+        status_code=200,
+        content_type="application/json",
+        body={
+            "status": "ok",
+            "library": {
+                "name": "ddtrace",
+                "version": ddtrace.__version__,
+            },
+            "extension": {
+                "name": "datadog-lambda-extension",
+                "version": os.environ.get("EXTENSION_VERSION", "unknown"),
+            },
+        },
+    )
+
+
+def lambda_handler(event, context: LambdaContext):
+    """
+    Lambda function handler for AWS Lambda Powertools API Gateway integration.
+
+    Args:
+        event (dict): The event data passed to the Lambda function.
+        context (LambdaContext): The context object provided by AWS Lambda.
+
+    Returns:
+        dict: The response from the API Gateway resolver.
+    """
+    return app.resolve(event, context)

--- a/utils/build/docker/python/aws_lambda/requirements.txt
+++ b/utils/build/docker/python/aws_lambda/requirements.txt
@@ -1,0 +1,1 @@
+aws-lambda-powertools

--- a/utils/build/docker/python/build_lambda_layer.sh
+++ b/utils/build/docker/python/build_lambda_layer.sh
@@ -29,12 +29,20 @@ fi
 if [[ $SKIP_BUILD -eq 0 ]]; then
     if [ -e "dd-trace-py" ]; then
         echo "Install from local folder /binaries/dd-trace-py"
-        sed -i '' 's|^ddtrace =.*$|ddtrace = { path = "./dd-trace-py" }|' datadog-lambda-python/pyproject.toml
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' 's|^ddtrace =.*$|ddtrace = { path = "./dd-trace-py" }|' datadog-lambda-python/pyproject.toml
+        else
+            sed -i 's|^ddtrace =.*$|ddtrace = { path = "./dd-trace-py" }|' datadog-lambda-python/pyproject.toml
+        fi
         cp -r dd-trace-py datadog-lambda-python/dd-trace-py
     elif [ "$(find . -maxdepth 1 -name "*.whl" | wc -l)" = "1" ]; then
         path=$(readlink -f "$(find . -maxdepth 1 -name "*.whl")")
         echo "Install ddtrace from ${path}"
-        sed -i '' "s|^ddtrace =.*$|ddtrace = { path = \"file://${path}\" }|" datadog-lambda-python/pyproject.toml
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s|^ddtrace =.*$|ddtrace = { path = \"file://${path}\" }|" datadog-lambda-python/pyproject.toml
+        else
+            sed -i "s|^ddtrace =.*$|ddtrace = { path = \"file://${path}\" }|" datadog-lambda-python/pyproject.toml
+        fi
         cp -r ./*.whl datadog-lambda-python/
     elif [ "$(find . -maxdepth 1 -name "python-load-from-pip" | wc -l)" = "1" ]; then
         echo "Install ddtrace from $(cat python-load-from-pip)"
@@ -44,11 +52,19 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
             # Format with revision: ddtrace @ git+https://...@revision
             git_url="${BASH_REMATCH[1]}"
             git_rev="${BASH_REMATCH[2]}"
-            sed -i '' "s|^ddtrace =.*$|ddtrace = { git = \"${git_url}\", rev = \"${git_rev}\" }|" datadog-lambda-python/pyproject.toml
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                sed -i '' "s|^ddtrace =.*$|ddtrace = { git = \"${git_url}\", rev = \"${git_rev}\" }|" datadog-lambda-python/pyproject.toml
+            else
+                sed -i "s|^ddtrace =.*$|ddtrace = { git = \"${git_url}\", rev = \"${git_rev}\" }|" datadog-lambda-python/pyproject.toml
+            fi
         elif [[ $pip_spec =~ ddtrace\ @\ git\+(.*)$ ]]; then
             # Format without revision: ddtrace @ git+https://... (defaults to main)
             git_url="${BASH_REMATCH[1]}"
-            sed -i '' "s|^ddtrace =.*$|ddtrace = { git = \"${git_url}\" }|" datadog-lambda-python/pyproject.toml
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                sed -i '' "s|^ddtrace =.*$|ddtrace = { git = \"${git_url}\" }|" datadog-lambda-python/pyproject.toml
+            else
+                sed -i "s|^ddtrace =.*$|ddtrace = { git = \"${git_url}\" }|" datadog-lambda-python/pyproject.toml
+            fi
         else
             echo "ERROR: Unable to parse git URL from python-load-from-pip format: $pip_spec"
             exit 1

--- a/utils/build/docker/python/build_lambda_layer.sh
+++ b/utils/build/docker/python/build_lambda_layer.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ARCH=${ARCH:-$(uname -m)}
+PYTHON_VERSION=${PYTHON_VERSION:-3.13}
+
+cd binaries
+
+SKIP_BUILD=0
+CLONED_REPO=0
+
+if [ -e "datadog-lambda-python" ]; then
+    echo "datadog-lambda-python already exists, skipping clone."
+elif [ "$(find . -maxdepth 1 -name "*.zip" | wc -l)" = "1" ]; then
+    echo "Using provided datadog-lambda-python layer."
+    SKIP_BUILD=1
+else
+    echo "Cloning datadog-lambda-python repository..."
+    git clone --depth 1 https://github.com/DataDog/datadog-lambda-python.git
+    CLONED_REPO=1
+fi
+
+# Patch the ddtrace dependency in datadog-lambda-python based on the same rules as install_ddtrace.sh
+if [[ $SKIP_BUILD -eq 0 ]]; then
+    if [ -e "dd-trace-py" ]; then
+        echo "Install from local folder /binaries/dd-trace-py"
+        sed -i '' 's|^ddtrace =.*$|ddtrace = { path = "./dd-trace-py" }|' datadog-lambda-python/pyproject.toml
+        cp -r dd-trace-py datadog-lambda-python/dd-trace-py
+    elif [ "$(find . -maxdepth 1 -name "*.whl" | wc -l)" = "1" ]; then
+        path=$(readlink -f "$(find . -maxdepth 1 -name "*.whl")")
+        echo "Install ddtrace from ${path}"
+        sed -i '' "s|^ddtrace =.*$|ddtrace = { path = \"file://${path}\" }|" datadog-lambda-python/pyproject.toml
+        cp -r ./*.whl datadog-lambda-python/
+    elif [ "$(find . -maxdepth 1 -name "python-load-from-pip" | wc -l)" = "1" ]; then
+        echo "Install ddtrace from $(cat python-load-from-pip)"
+
+        pip_spec=$(cat python-load-from-pip)
+        if [[ $pip_spec =~ ddtrace\ @\ git\+(.*)@(.*)$ ]]; then
+            # Format with revision: ddtrace @ git+https://...@revision
+            git_url="${BASH_REMATCH[1]}"
+            git_rev="${BASH_REMATCH[2]}"
+            sed -i '' "s|^ddtrace =.*$|ddtrace = { git = \"${git_url}\", rev = \"${git_rev}\" }|" datadog-lambda-python/pyproject.toml
+        elif [[ $pip_spec =~ ddtrace\ @\ git\+(.*)$ ]]; then
+            # Format without revision: ddtrace @ git+https://... (defaults to main)
+            git_url="${BASH_REMATCH[1]}"
+            sed -i '' "s|^ddtrace =.*$|ddtrace = { git = \"${git_url}\" }|" datadog-lambda-python/pyproject.toml
+        else
+            echo "ERROR: Unable to parse git URL from python-load-from-pip format: $pip_spec"
+            exit 1
+        fi
+    elif [ "$(find . -maxdepth 1 -name "*.whl" | wc -l)" = "0" ]; then
+        echo "Install ddtrace from pypi"
+        # Keep the default ddtrace dependency in pyproject.toml
+    else
+        echo "ERROR: Found several wheel files in binaries/, abort."
+        exit 1
+    fi
+    # Build the datadog-lambda-python package
+    cd datadog-lambda-python
+    ARCH=$ARCH PYTHON_VERSION=$PYTHON_VERSION ./scripts/build_layers.sh
+
+    mv .layers/*.zip ../
+    cd ..
+
+    # Clean up the datadog-lambda-python directory
+    if [ "$CLONED_REPO" -eq 1 ]; then
+        echo "Removing datadog-lambda-python directory..."
+        rm -rf datadog-lambda-python
+    else
+        # Restore the original pyproject.toml if it was not cloned
+        cd datadog-lambda-python
+        git checkout -- pyproject.toml
+        rm -rf dd-trace-py ./*.whl
+        cd ..
+    fi
+fi
+
+cd ..

--- a/utils/build/docker/python/build_lambda_layer.sh
+++ b/utils/build/docker/python/build_lambda_layer.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 ARCH=${ARCH:-$(uname -m)}
 PYTHON_VERSION=${PYTHON_VERSION:-3.13}
 
+if [ "$ARCH" = "x86_64" ]; then
+    ARCH="amd64"
+fi
+
 cd binaries
 
 SKIP_BUILD=0

--- a/utils/build/docker/python/lambda-python-apigw-rest.Dockerfile
+++ b/utils/build/docker/python/lambda-python-apigw-rest.Dockerfile
@@ -1,17 +1,12 @@
-ARG EXTENSION_VERSION=82
 ARG PYTHON_VERSION=3.13
-FROM public.ecr.aws/datadog/lambda-extension:${EXTENSION_VERSION} AS datadog-extension
 
 FROM public.ecr.aws/lambda/python:${PYTHON_VERSION}
-ARG EXTENSION_VERSION
-ENV EXTENSION_VERSION=${EXTENSION_VERSION}
 
-# Install the unzip utility
 RUN dnf install -y unzip
 
 # Add the Datadog Extension
 RUN mkdir -p /opt/extensions
-COPY --from=datadog-extension /opt/. /opt/
+COPY --from=public.ecr.aws/datadog/lambda-extension:latest /opt/. /opt/
 
 # Add the Datadog Lambda Python Layer
 COPY binaries/*.zip /binaries/

--- a/utils/build/docker/python/lambda-python-apigw-rest.Dockerfile
+++ b/utils/build/docker/python/lambda-python-apigw-rest.Dockerfile
@@ -1,0 +1,28 @@
+ARG EXTENSION_VERSION=82
+ARG PYTHON_VERSION=3.13
+FROM public.ecr.aws/datadog/lambda-extension:${EXTENSION_VERSION} AS datadog-extension
+
+FROM public.ecr.aws/lambda/python:${PYTHON_VERSION}
+ARG EXTENSION_VERSION
+ENV EXTENSION_VERSION=${EXTENSION_VERSION}
+
+# Install the unzip utility
+RUN dnf install -y unzip
+
+# Add the Datadog Extension
+RUN mkdir -p /opt/extensions
+COPY --from=datadog-extension /opt/. /opt/
+
+# Add the Datadog Lambda Python Layer
+COPY binaries/*.zip /binaries/
+RUN unzip /binaries/*.zip -d /opt
+
+# Setup the aws_lambda handler
+COPY utils/build/docker/python/aws_lambda/requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
+RUN pip install -r ${LAMBDA_TASK_ROOT}/requirements.txt
+
+COPY utils/build/docker/python/aws_lambda/function/handler.py ${LAMBDA_TASK_ROOT}
+
+ENV DD_LAMBDA_HANDLER=handler.lambda_handler
+
+CMD ["datadog_lambda.handler.handler"]

--- a/utils/proxy/core.py
+++ b/utils/proxy/core.py
@@ -48,6 +48,9 @@ class _RequestLogger:
         self.rc_api_enabled = os.environ.get("SYSTEM_TESTS_RC_API_ENABLED") == "True"
         self.span_meta_structs_disabled = os.environ.get("SYSTEM_TESTS_AGENT_SPAN_META_STRUCTS_DISABLED") == "True"
 
+        self.tracing_agent_target_host = os.environ.get("PROXY_TRACING_AGENT_TARGET_HOST", "agent")
+        self.tracing_agent_target_port = int(os.environ.get("PROXY_TRACING_AGENT_TARGET_PORT", "8127"))
+
         span_events = os.environ.get("SYSTEM_TESTS_AGENT_SPAN_EVENTS")
         self.span_events = span_events != "False"
 
@@ -122,7 +125,10 @@ class _RequestLogger:
             ProxyPorts.golang_buddy,
             ProxyPorts.weblog,
         ):
-            flow.request.host, flow.request.port = "agent", 8127
+            flow.request.host, flow.request.port = (
+                self.tracing_agent_target_host,
+                self.tracing_agent_target_port,
+            )
             flow.request.scheme = "http"
             logger.info(f"    => reverse proxy to {flow.request.pretty_url}")
 


### PR DESCRIPTION
## Motivation

In the context of my internship, I am implementing Appsec for AWS Lambda through the python tracer to replace the current implementation which relies on the extension (the agent in the context of lambda).

The goal of this pull request is to be able to do end-to-end testing of the python tracer in the context of AWS Lambda.
To avoid relying on provisioning resources in AWS, I am attempting to emulate the AWS Lambda behaviour using a system-test Docker scenario.

A typical AWS Serverless deployment works with an AWS Managed Load Balancer such as APIGateway, ALB, or the Lambda Function Url service, the load balancer converts the incoming HTTP request to a json representation called an `Event` that is passed to the AWS Lambda runtime to execute the function.

```mermaid
graph LR
    A[Incoming HTTP Request] -->|HTTP| B[AWS Managed Load Balancer]
    B -->|event: request as JSON| C[AWS Lambda]
```

AWS Provides the [AWS Lambda Runtime Interface Emulator](https://github.com/aws/aws-lambda-runtime-interface-emulator) to simulate the Lambda runtime inside a Docker container and a cli to emulate a local APIGateway ([AWS SAM cli](https://github.com/aws/aws-sam-cli)).

Leveraging these two tools, we can envision a **DockerScenario** with the following architecture:

```mermaid
graph LR
    A[Incoming HTTP Request] -->|HTTP| B[LambdaProxy]
    B -->|event: request as JSON| C[LambdaWeblog]
```

With the following components:
- **LambdaWeblog**: A weblog app written as a lambda function, running with the AWS Lambda RIE
- **LambdaProxy**: A small flask app, to convert http request to lambda events, invoke the function with this event and return the result as an http response. This one relies on primitives of [AWS SAM cli](https://github.com/aws/aws-sam-cli), a tool to emulate an API Gateway locally


A specificity of this scenario is that the extension runs inside the **LambdaWeblog** because it needs access to the Lambda Runtime API, this requires the proxy to be able to send traces back to the weblog instead of sending them to a dedicated agent.

As a first step, this PR contains a single scenario to test Appsec Blocking capabilities for the APIGateway Rest API event type. The goal would be to eventually (in following PRs) emulate all other types of http events that a Lambda can receive: APIGateway HTTP API, Application Load Balancer, Lambda Function Url.

The tests can run but don't pass just yet.

## Changes

Additions:
- A weblog for AWS Lambda python APIGateway Rest API with only a few routes for now
- Add a helper container `LambdaProxy` to relay system-test http request to invoke the Lambda Runtime Interface
- A new Scenario type `LambdaScenario` to orchestrate the two containers and configure the Proxy

Modifications:
- Make the Proxy configurable so that it can send traces to the lambda extension instead of the dedicated agent container.
- Add a new scenario of the new type `LambdaScenario`: `appsec_lambda_blocking` and add to it all tests of the scenario `appsec_blocking` => maybe there is a better way to run multiple scenarios per feature without adding decorations for all tests.

Note: For now nothing is added to the CI.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
