### PR TITLE
[dotnet] Add system test for Kafka/.NET without cluster id

### DIFF
--- a/tests/integrations/test_dsm.py
+++ b/tests/integrations/test_dsm.py
@@ -106,8 +106,8 @@ class Test_DsmKafka:
     def test_dsm_kafka_without_cluster_id(self):
         assert self.r.text == "ok"
 
-        producer_hash = 14216899112169674443
-        consumer_hash = 4247242616665718048
+        producer_hash = 4463699290244539355
+        consumer_hash = 3735318893869752335
 
         edge_tags_in: tuple = ("direction:in", f"group:{DSM_CONSUMER_GROUP}", f"topic:{DSM_QUEUE}", "type:kafka")
         edge_tags_out: tuple = ("direction:out", f"topic:{DSM_QUEUE}", "type:kafka")


### PR DESCRIPTION
## Motivation

We want to fix system-tests for DSM/.NET as we are going to enable DSM by default.

The existing Kafka test also tests cluster id, which hasn't been implemented for .NET yet, but the core functionality works. Because of this, I made this a new Kafka test to make it clear that the test doesn't test the exact same feature set as the normal kafka test.

The plan is to implement extracting cluster ids for .NET afterwards, but the implementation is somewhat tricky (Node & Python implement this by making an API call on the first message to discover the cluster id). Then we can remove this test and use `test_dsm_kafka` for .NET.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
