### PR TITLE
[Java] Enable more CSS tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2078,8 +2078,6 @@ tests/:
   stats/:
     test_miscs.py:
       Test_Miscs: missing_feature
-    test_stats.py:
-      Test_Client_Stats: missing_feature
   test_the_test/:
     test_json_report.py:
       Test_Mock: v0.2.1

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -29,6 +29,11 @@ class Test_Client_Stats:
             weblog.get("/stats-unique?code=204")
 
     @bug(context.weblog_variant in ("django-poc", "python3.12"), library="python", reason="APMSP-1375")
+    @missing_feature(
+        context.weblog_variant in ("play", "ratpack", "spring-boot-3-native"),
+        library="java",
+        reason="not available in spring-boot-native. play and ratpack controllers also generate stats and the test will fail",
+    )
     def test_client_stats(self):
         stats_count = 0
         ok_hits = 0

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -72,6 +72,7 @@ class _Scenarios:
             "DD_TRACE_STATS_COMPUTATION_ENABLED": "1",
             "DD_TRACE_COMPUTE_STATS": "true",
             "DD_TRACE_FEATURES": "discovery",
+            "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
         },
         doc=(
             "End to end testing with DD_TRACE_COMPUTE_STATS=1. This feature compute stats at tracer level, and"

--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
@@ -178,6 +178,13 @@ object AppSecRoutes {
           }
         }
       } ~
+      path("stats-unique") {
+        get {
+          parameter("code".as[Int].withDefault(200)) { code =>
+            complete(StatusCodes.custom(code, "whatever reason"))
+          }
+        }
+      } ~
       path("users") {
         get {
           parameter("user") { user =>

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
@@ -237,6 +237,12 @@ public class MyResource {
         return Response.status(code).build();
     }
 
+    @GET
+    @Path("/stats-unique")
+    public Response statsUnique(@QueryParam("code") @DefaultValue("200") Integer code) {
+        return Response.status(code).build();
+    }
+
     private static final Map<String, String> METADATA = createMetadata();
     private static final Map<String, String> createMetadata() {
         HashMap<String, String> h = new HashMap<>();

--- a/utils/build/docker/java/play/app/controllers/AppSecController.scala
+++ b/utils/build/docker/java/play/app/controllers/AppSecController.scala
@@ -189,6 +189,10 @@ class AppSecController @Inject()(cc: MessagesControllerComponents, ws: WSClient,
     Results.Status(code)
   }
 
+  def statsUnique(code: Option[Int]) = Action {
+    Results.Status(code.getOrElse(200))
+  }
+
   def users(user: String) = Action {
     var span = GlobalTracer.get().activeSpan()
     span match {

--- a/utils/build/docker/java/play/conf/routes
+++ b/utils/build/docker/java/play/conf/routes
@@ -13,6 +13,7 @@ GET  /waf/*segments            controllers.AppSecController.params(segments: Seq
 POST /waf                      controllers.AppSecController.wafPost
 GET  /make_distant_call        controllers.AppSecController.distantCall(url: String)
 GET  /status                   controllers.AppSecController.status(code: Int)
+GET  /stats-unique             controllers.AppSecController.status(code: Int)
 GET  /users                    controllers.AppSecController.users(user: String)
 GET  /identify                 controllers.AppSecController.identify
 GET  /user_login_success_event controllers.AppSecController.loginSuccess(event_user_id: Option[String])

--- a/utils/build/docker/java/play/conf/routes
+++ b/utils/build/docker/java/play/conf/routes
@@ -13,7 +13,7 @@ GET  /waf/*segments            controllers.AppSecController.params(segments: Seq
 POST /waf                      controllers.AppSecController.wafPost
 GET  /make_distant_call        controllers.AppSecController.distantCall(url: String)
 GET  /status                   controllers.AppSecController.status(code: Int)
-GET  /stats-unique             controllers.AppSecController.status(code: Int)
+GET  /stats-unique             controllers.AppSecController.statsUnique(code: Option[Int])
 GET  /users                    controllers.AppSecController.users(user: String)
 GET  /identify                 controllers.AppSecController.identify
 GET  /user_login_success_event controllers.AppSecController.loginSuccess(event_user_id: Option[String])

--- a/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
+++ b/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
@@ -247,7 +247,7 @@ public class Main {
                                 int code = Integer.parseInt(codeParam);
                                 ctx.getResponse().status(code).send();
                             })
-                            path("stats-unique", ctx -> {
+                            .path("stats-unique", ctx -> {
                                 String codeParam = ctx.getRequest().getQueryParams().get("code");
                                 int code = codeParam != null ? Integer.parseInt(codeParam): 200;
                                 ctx.getResponse().status(code).send();

--- a/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
+++ b/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
@@ -247,6 +247,11 @@ public class Main {
                                 int code = Integer.parseInt(codeParam);
                                 ctx.getResponse().status(code).send();
                             })
+                            path("stats-unique", ctx -> {
+                                String codeParam = ctx.getRequest().getQueryParams().get("code");
+                                int code = codeParam != null ? Integer.parseInt(codeParam): 200;
+                                ctx.getResponse().status(code).send();
+                            })
                             .get("users", ctx -> {
                                 final String user = ctx.getRequest().getQueryParams().get("user");
                                 final Span span = GlobalTracer.get().activeSpan();

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
@@ -273,7 +273,7 @@ public class MyResource {
 
     @GET
     @Path("/stats-unique")
-    public Response status(@QueryParam("code") @DefaultValue("200") Integer code) {
+    public Response statsUnique(@QueryParam("code") @DefaultValue("200") Integer code) {
         return Response.status(code).build();
     }
 

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
@@ -271,6 +271,12 @@ public class MyResource {
         return Response.status(code).build();
     }
 
+    @GET
+    @Path("/stats-unique")
+    public Response status(@QueryParam("code") @DefaultValue("200") Integer code) {
+        return Response.status(code).build();
+    }
+
     private static final Map<String, String> METADATA = createMetadata();
     private static final Map<String, String> createMetadata() {
         HashMap<String, String> h = new HashMap<>();

--- a/utils/build/docker/java/spring-boot-3-native/src/main/java/com/datadoghq/springbootnative/WebController.java
+++ b/utils/build/docker/java/spring-boot-3-native/src/main/java/com/datadoghq/springbootnative/WebController.java
@@ -84,7 +84,7 @@ public class WebController {
   }
 
   @RequestMapping("/stats-unique")
-  ResponseEntity<String> status(@RequestParam(defaultValue = "200") Integer code) {
+  ResponseEntity<String> statsUnique(@RequestParam(defaultValue = "200") Integer code) {
     return new ResponseEntity<>(HttpStatus.valueOf(code));
   }
 

--- a/utils/build/docker/java/spring-boot-3-native/src/main/java/com/datadoghq/springbootnative/WebController.java
+++ b/utils/build/docker/java/spring-boot-3-native/src/main/java/com/datadoghq/springbootnative/WebController.java
@@ -83,6 +83,11 @@ public class WebController {
     return new ResponseEntity<>(HttpStatus.valueOf(code));
   }
 
+  @RequestMapping("/stats-unique")
+  ResponseEntity<String> status(@RequestParam(defaultValue = "200") Integer code) {
+    return new ResponseEntity<>(HttpStatus.valueOf(code));
+  }
+
   @RequestMapping("/hello")
   public String hello() {
     return "Hello world";

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -302,6 +302,11 @@ public class App {
         return new ResponseEntity<>(HttpStatus.valueOf(code));
     }
 
+    @RequestMapping("/stats-unique")
+    ResponseEntity<String> status(@RequestParam(defaultValue = "200") Integer code) {
+        return new ResponseEntity<>(HttpStatus.valueOf(code));
+    }
+
     private static final Map<String, String> METADATA = createMetadata();
     private static final Map<String, String> createMetadata() {
         HashMap<String, String> h = new HashMap<>();

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -303,7 +303,7 @@ public class App {
     }
 
     @RequestMapping("/stats-unique")
-    ResponseEntity<String> status(@RequestParam(defaultValue = "200") Integer code) {
+    ResponseEntity<String> statsUnique(@RequestParam(defaultValue = "200") Integer code) {
         return new ResponseEntity<>(HttpStatus.valueOf(code));
     }
 

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
@@ -168,6 +168,12 @@ public class Main {
                     int code = Integer.parseInt(codeString);
                     ctx.response().setStatusCode(code).end();
                 });
+        router.get("/stats-unique")
+                .handler(ctx -> {
+                    String codeString = ctx.request().getParam("code");
+                    int code = codeString != null ? Integer.parseInt(codeString): 200;
+                    ctx.response().setStatusCode(code).end();
+                });
         router.get("/users")
                 .handler(ctx -> {
                     final String user = ctx.request().getParam("user");

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
@@ -170,6 +170,12 @@ public class Main {
                     int code = Integer.parseInt(codeString);
                     ctx.response().setStatusCode(code).end();
                 });
+        router.get("/stats-unique")
+                .handler(ctx -> {
+                    String codeString = ctx.request().getParam("code");
+                    int code = codeString != null ? Integer.parseInt(codeString): 200;
+                    ctx.response().setStatusCode(code).end();
+                });
         router.get("/users")
                 .handler(ctx -> {
                     final String user = ctx.request().getParam("user");


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Java already implement client stats computation

## Changes

<!-- A brief description of the change being made with this pull request. -->

Improve coverage for java CSS. Implement `/stats-unique` endpoint of various java weblogs

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
