### PR TITLE
Add telemetry AppSec configuration tests for remote config

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -424,6 +424,8 @@ tests/:
     test_service_activation_metric.py:
       TestServiceActivationEnvVarMetric: missing_feature
       TestServiceActivationRemoteConfigMetric: missing_feature
+    test_telemetry_appsec_configuration.py:
+      TestTelemetryAppSecRemoteConfigEnabled: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -495,6 +495,8 @@ tests/:
     test_service_activation_metric.py:
       TestServiceActivationEnvVarMetric: missing_feature
       TestServiceActivationRemoteConfigMetric: missing_feature
+    test_telemetry_appsec_configuration.py:
+      TestTelemetryAppSecRemoteConfigEnabled: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1699,6 +1699,8 @@ tests/:
     test_service_activation_metric.py:
       TestServiceActivationEnvVarMetric: missing_feature
       TestServiceActivationRemoteConfigMetric: missing_feature
+    test_telemetry_appsec_configuration.py:
+      TestTelemetryAppSecRemoteConfigEnabled: v1.51.0-SNAPSHOT
     test_shell_execution.py:
       Test_ShellExecution:
         '*': v1.2.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1028,6 +1028,8 @@ tests/:
     test_service_activation_metric.py:
       TestServiceActivationEnvVarMetric: *ref_5_55_0
       TestServiceActivationRemoteConfigMetric: *ref_5_55_0
+    test_telemetry_appsec_configuration.py:
+      TestTelemetryAppSecRemoteConfigEnabled: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: *ref_5_3_0
     test_suspicious_attacker_blocking.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -410,6 +410,8 @@ tests/:
     test_service_activation_metric.py:
       TestServiceActivationEnvVarMetric: missing_feature
       TestServiceActivationRemoteConfigMetric: missing_feature
+    test_telemetry_appsec_configuration.py:
+      TestTelemetryAppSecRemoteConfigEnabled: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: v0.95.0
     test_suspicious_attacker_blocking.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -753,6 +753,8 @@ tests/:
     test_service_activation_metric.py:
       TestServiceActivationEnvVarMetric: missing_feature
       TestServiceActivationRemoteConfigMetric: missing_feature
+    test_telemetry_appsec_configuration.py:
+      TestTelemetryAppSecRemoteConfigEnabled: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -578,6 +578,8 @@ tests/:
     test_service_activation_metric.py:
       TestServiceActivationEnvVarMetric: missing_feature
       TestServiceActivationRemoteConfigMetric: missing_feature
+    test_telemetry_appsec_configuration.py:
+      TestTelemetryAppSecRemoteConfigEnabled: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/tests/appsec/test_telemetry_appsec_configuration.py
+++ b/tests/appsec/test_telemetry_appsec_configuration.py
@@ -1,0 +1,94 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+from utils import scenarios, features, context, interfaces, missing_feature
+from utils import remote_config as rc
+
+
+CONFIG_ENABLED = {"asm": {"enabled": True}}
+CONFIG_DISABLED = {"asm": {"enabled": False}}
+
+
+def _send_config(config):
+    """Send remote configuration to enable/disable AppSec features"""
+    if config is not None:
+        rc.rc_state.set_config("datadog/2/ASM_FEATURES/asm_features_activation/config", config)
+    else:
+        rc.rc_state.reset()
+    return rc.rc_state.apply().state
+
+
+def validate_telemetry_configuration(telemetry_data, expected_config_name, expected_value, expected_origin=None):
+    """Validate that telemetry configuration contains the expected appsec.enabled value and origin"""
+    for data in telemetry_data:
+        if data["request"]["content"].get("request_type") == "app-client-configuration-change":
+            content = data["request"]["content"]
+            configurations = content["payload"]["configuration"]
+
+            for config in configurations:
+                if config.get("name") == expected_config_name:
+                    # Check if the configuration has the expected value
+                    # Handle both boolean and string values
+                    config_value = config.get("value")
+                    value_matches = config_value == expected_value or str(config_value).lower() == str(expected_value).lower()
+                    
+                    # Check origin if specified
+                    origin_matches = True
+                    if expected_origin is not None:
+                        config_origin = config.get("origin")
+                        origin_matches = config_origin == expected_origin
+                    
+                    if value_matches and origin_matches:
+                        return True
+
+    return False
+
+
+class BaseTelemetryAppSecConfiguration:
+    """Base class for testing telemetry configuration with AppSec enabled/disabled"""
+
+    expected_value: bool | None = None
+    expected_origin: str = ""
+
+    @missing_feature(context.library in ("php",), reason="Telemetry is not implemented yet.")
+    @missing_feature(context.library < "ruby@1.22.0", reason="Telemetry V2 is not implemented yet")
+    def test_telemetry_appsec_configuration(self):
+        """Test that telemetry configuration correctly reports appsec.enabled value"""
+        telemetry_data = list(interfaces.library.get_telemetry_data())
+
+        assert len(telemetry_data) > 0, "No telemetry data found"
+
+        expected_config_name = "appsec_enabled"
+
+        # Debug: Print all configurations to see what's actually there
+        for data in telemetry_data:
+            if data["request"]["content"].get("request_type") == "app-client-configuration-change":
+                content = data["request"]["content"]
+                configurations = content["payload"]["configuration"]
+                print(f"Found configurations: {[c.get('name') for c in configurations]}")
+                for config in configurations:
+                    if "appsec" in config.get("name", ""):
+                        print(f"AppSec config: {config}")
+
+        # Validate that the configuration is present with the expected value and origin
+        config_found = validate_telemetry_configuration(
+            telemetry_data, expected_config_name, self.expected_value, self.expected_origin
+        )
+
+        assert config_found, (
+            f"Telemetry configuration '{expected_config_name}' with value '{self.expected_value}' "
+            f"and origin '{self.expected_origin}' not found in app-client-configuration-change event"
+        )
+
+
+@scenarios.appsec_runtime_activation
+@features.telemetry_app_started_event
+@features.telemetry_configurations_collected
+class TestTelemetryAppSecRemoteConfigEnabled(BaseTelemetryAppSecConfiguration):
+    """Test that telemetry configuration correctly reports appsec.enabled=true when enabled via remote config"""
+
+    def setup_telemetry_appsec_configuration(self):
+        self.expected_value = True
+        self.expected_origin = "remote_config"
+        self.config_state = _send_config(CONFIG_ENABLED)


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
