### PR TITLE
update /trace/config logic to properly source dd_profiling_enabled

### DIFF
--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -562,32 +562,32 @@ class Test_Stable_Config_Default(StableConfigWriter):
         [
             (
                 "fleet>local",
-                {"DD_PROFILING_ENABLED": True},
-                {},
                 {"DD_PROFILING_ENABLED": False},
-                {"dd_profiling_enabled": "false"},  # expected
+                {},
+                {"DD_PROFILING_ENABLED": True},
+                {"dd_profiling_enabled": "true"},  # expected
             ),
             (
                 "fleet>env",
                 {},
-                {"DD_PROFILING_ENABLED": True},
                 {"DD_PROFILING_ENABLED": False},
-                {"dd_profiling_enabled": "false"},  # expected
+                {"DD_PROFILING_ENABLED": True},
+                {"dd_profiling_enabled": "true"},  # expected
             ),
             pytest.param(
                 "env>local",
-                {"DD_PROFILING_ENABLED": True},
                 {"DD_PROFILING_ENABLED": False},
+                {"DD_PROFILING_ENABLED": True},
                 {},
-                {"dd_profiling_enabled": "false"},  # expected
+                {"dd_profiling_enabled": "true"},  # expected
             ),
             (
                 "orthogonal_priorities",
-                {"DD_PROFILING_ENABLED": True, "DD_RUNTIME_METRICS_ENABLED": True},
+                {"DD_PROFILING_ENABLED": False, "DD_RUNTIME_METRICS_ENABLED": True},
                 {"DD_ENV": "abc"},
-                {"DD_PROFILING_ENABLED": False},
+                {"DD_PROFILING_ENABLED": True},
                 {
-                    "dd_profiling_enabled": "false",
+                    "dd_profiling_enabled": "true",
                     "dd_runtime_metrics_enabled": "true"
                     if context.library != "php"
                     else "false",  # PHP does not support runtime metrics

--- a/utils/build/docker/golang/parametric/datadog.go
+++ b/utils/build/docker/golang/parametric/datadog.go
@@ -291,6 +291,7 @@ func (l *CustomLogger) Log(logMessage string) {
 	// Check for profiler configuration
 	profilerRe := regexp.MustCompile(`.*Profiler configuration: (\{.*\})`)
 	profilerMatches := profilerRe.FindStringSubmatch(logMessage)
+	fmt.Println("MTOFF: profilerMatches: ", profilerMatches)
 	if len(profilerMatches) >= 2 {
 		l.profilerEnabled = true
 	}


### PR DESCRIPTION
## Motivation
Parametric app logic for reporting `dd_profiling_enabled` used to use the `enabled` field from  the `Profiler configuration` startup log.
However, https://github.com/DataDog/dd-trace-go/pull/3570 removed the `enabled` field from startup log. Therefore, we have to update the parametric app logic.

## Changes
Sources `dd_profiling_enabled` value from the presence of the `Profiler configuration` startup log (or lack thereof)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
