### PR TITLE
[php] Download dev artifacts from s3

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -11,11 +11,11 @@ tests/:
         Test_API_Security_RC_ASM_DD_processors: v1.6.2
         Test_API_Security_RC_ASM_DD_scanners: v1.6.2
       test_apisec_sampling.py:
-        Test_API_Security_Sampling_Different_Endpoints: v1.8.0
-        Test_API_Security_Sampling_Different_Paths: v1.8.0
-        Test_API_Security_Sampling_Different_Status: v1.8.0
+        Test_API_Security_Sampling_Different_Endpoints: bug (APPSEC-58244)
+        Test_API_Security_Sampling_Different_Paths: bug (APPSEC-58244)
+        Test_API_Security_Sampling_Different_Status: bug (APPSEC-58244)
         Test_API_Security_Sampling_Rate: irrelevant (new sampling algorithm implemented)
-        Test_API_Security_Sampling_With_Delay: v1.8.0
+        Test_API_Security_Sampling_With_Delay: bug (APPSEC-58244)
       test_schemas.py:
         Test_Scanners: missing_feature
         Test_Schema_Request_Cookies: v0.94.0
@@ -395,6 +395,8 @@ tests/:
       Test_SecurityEvents_Appsec_Metastruct_Enabled: missing_feature
       Test_SecurityEvents_Iast_Metastruct_Disabled: irrelevant (no fallback will be implemented)
       Test_SecurityEvents_Iast_Metastruct_Enabled: missing_feature
+    test_rate_limiter.py:
+      Test_Main: bug (APPSEC-58244)
     test_remote_config_rule_changes.py:
       Test_AsmDdMultiConfiguration: missing_feature
       Test_BlockingActionChangesWithRemoteConfig: v1.6.2

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -206,16 +206,12 @@ elif [ "$TARGET" = "ruby" ]; then
 elif [ "$TARGET" = "php" ]; then
     rm -rf *.tar.gz
     if [ $VERSION = 'dev' ]; then
-        echo "Loading dev version"
-        curl --fail --location --silent --show-error --output datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//datadog-setup.php"
-        RELEASE_VERSION=$(grep "const RELEASE_VERSION" datadog-setup.php | sed "s/.*RELEASE_VERSION = '\([^']*\)'.*/\1/" | sed "s/+/%2B/g")
-        echo "RELEASE_VERSION: $RELEASE_VERSION"
-        echo "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz"
-        curl --fail --location --silent --show-error --output dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz"
+        curl --fail --location --silent --show-error --output ./temp/datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//datadog-setup.php"
+        RELEASE_VERSION=$(grep "const RELEASE_VERSION" ./temp/datadog-setup.php | sed "s/.*RELEASE_VERSION = '\([^']*\)'.*/\1/")
+        RELEASE_VERSION_ENCODED=$(grep "const RELEASE_VERSION" ./temp/datadog-setup.php | sed "s/.*RELEASE_VERSION = '\([^']*\)'.*/\1/" | sed "s/+/%2B/g")
+        curl --fail --location --silent --show-error --output ./temp/dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//dd-library-php-${RELEASE_VERSION_ENCODED}-x86_64-linux-gnu.tar.gz"
     elif [ $VERSION = 'prod' ]; then
-        curl --fail --location --silent --show-error --output datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds/datadog-setup.php"
-        RELEASE_VERSION=$(grep "const RELEASE_VERSION" datadog-setup.php | sed "s/.*RELEASE_VERSION = '\([^']*\)'.*/\1/" | sed "s/+/%2B/g")
-        curl --fail --location --silent --show-error --output dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds/dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz"
+        ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-php/dd-library-php:latest ./temp
     else
         echo "Don't know how to load version $VERSION for $TARGET"
     fi

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -206,13 +206,16 @@ elif [ "$TARGET" = "ruby" ]; then
 elif [ "$TARGET" = "php" ]; then
     rm -rf *.tar.gz
     if [ $VERSION = 'dev' ]; then
-        curl --fail --location --silent --show-error --output datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds/datadog-setup.php"
-        RELEASE_VERSION=$(php -r "preg_match('/const RELEASE_VERSION = \'([^\']+)\'/', file_get_contents('binaries/datadog-setup.php'), \$matches); echo urlencode(\$matches[1]);")
+        echo "Loading dev version"
+        curl --fail --location --silent --show-error --output datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//datadog-setup.php"
+        RELEASE_VERSION=$(grep "const RELEASE_VERSION" datadog-setup.php | sed "s/.*RELEASE_VERSION = '\([^']*\)'.*/\1/" | sed "s/+/%2B/g")
+        echo "RELEASE_VERSION: $RELEASE_VERSION"
+        echo "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz"
         curl --fail --location --silent --show-error --output dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz"
     elif [ $VERSION = 'prod' ]; then
         curl --fail --location --silent --show-error --output datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds/datadog-setup.php"
-        RELEASE_VERSION=$(php -r "preg_match('/const RELEASE_VERSION = \'([^\']+)\'/', file_get_contents('binaries/datadog-setup.php'), \$matches); echo urlencode(\$matches[1]);")
-        curl --fail --location --silent --show-error --output dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz"
+        RELEASE_VERSION=$(grep "const RELEASE_VERSION" datadog-setup.php | sed "s/.*RELEASE_VERSION = '\([^']*\)'.*/\1/" | sed "s/+/%2B/g")
+        curl --fail --location --silent --show-error --output dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds/dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz"
     else
         echo "Don't know how to load version $VERSION for $TARGET"
     fi

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -206,9 +206,9 @@ elif [ "$TARGET" = "ruby" ]; then
 elif [ "$TARGET" = "php" ]; then
     rm -rf *.tar.gz
     if [ $VERSION = 'dev' ]; then
-        ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-php/dd-library-php:latest_snapshot ./temp
+        curl --fail --location --silent --show-error --output datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//datadog-setup.php"
     elif [ $VERSION = 'prod' ]; then
-        ../utils/scripts/docker_base_image.sh ghcr.io/datadog/dd-trace-php/dd-library-php:latest ./temp
+        curl --fail --location --silent --show-error --output datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//datadog-setup.php"
     else
         echo "Don't know how to load version $VERSION for $TARGET"
     fi

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -206,9 +206,13 @@ elif [ "$TARGET" = "ruby" ]; then
 elif [ "$TARGET" = "php" ]; then
     rm -rf *.tar.gz
     if [ $VERSION = 'dev' ]; then
-        curl --fail --location --silent --show-error --output datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//datadog-setup.php"
+        curl --fail --location --silent --show-error --output datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds/datadog-setup.php"
+        RELEASE_VERSION=$(php -r "preg_match('/const RELEASE_VERSION = \'([^\']+)\'/', file_get_contents('binaries/datadog-setup.php'), \$matches); echo urlencode(\$matches[1]);")
+        curl --fail --location --silent --show-error --output dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz"
     elif [ $VERSION = 'prod' ]; then
-        curl --fail --location --silent --show-error --output datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//datadog-setup.php"
+        curl --fail --location --silent --show-error --output datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds/datadog-setup.php"
+        RELEASE_VERSION=$(php -r "preg_match('/const RELEASE_VERSION = \'([^\']+)\'/', file_get_contents('binaries/datadog-setup.php'), \$matches); echo urlencode(\$matches[1]);")
+        curl --fail --location --silent --show-error --output dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//dd-library-php-${RELEASE_VERSION}-x86_64-linux-gnu.tar.gz"
     else
         echo "Don't know how to load version $VERSION for $TARGET"
     fi

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -205,6 +205,7 @@ elif [ "$TARGET" = "ruby" ]; then
 
 elif [ "$TARGET" = "php" ]; then
     rm -rf *.tar.gz
+    mkdir -p temp
     if [ $VERSION = 'dev' ]; then
         curl --fail --location --silent --show-error --output ./temp/datadog-setup.php "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds//datadog-setup.php"
         RELEASE_VERSION=$(grep "const RELEASE_VERSION" ./temp/datadog-setup.php | sed "s/.*RELEASE_VERSION = '\([^']*\)'.*/\1/")


### PR DESCRIPTION
## Motivation

Since `dd-trace-php` is now on gitlab, artifacts are not anymore available where they used to be. Now they are on a s3 bucket. This PR picks dev artifacts from s3

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
