### PR TITLE
[python]: enable forwarder tests

### DIFF
--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -69,8 +69,6 @@ class TestDockerSSIFeatures:
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
     @irrelevant(context.library >= "python@3.0.0.dev" and context.installed_language_runtime < "3.8.0")
     @irrelevant(context.library < "python@3.0.0.dev" and context.installed_language_runtime < "3.7.0")
-    @bug(context.library == "python@2.19.1", reason="INPLAT-448")
-    @bug(context.library >= "python@3.0.0dev", reason="INPLAT-448")
     def test_telemetry(self):
         # There is telemetry data about the auto instrumentation injector. We only validate there is data
         telemetry_autoinject_data = interfaces.test_agent.get_telemetry_for_autoinject()
@@ -157,9 +155,8 @@ class TestDockerSSIFeatures:
         self._setup_all()
 
     @features.ssi_injection_metadata
-    @missing_feature(
-        context.library in ("python", "nodejs", "dotnet", "java", "php", "ruby"), reason="Not implemented yet"
-    )
+    @missing_feature(context.library in ("dotnet", "java", "php", "ruby"), reason="Not implemented yet")
+    @missing_feature(context.library < "python@3.9.5.dev", reason="Not implemented")
     def test_injection_metadata(self):
         logger.info("Testing injection result variables")
         events = interfaces.test_agent.get_injection_metadata_for_autoinject()


### PR DESCRIPTION

## Motivation

<!-- What inspired you to submit this pull request? -->

Python has been failing the forwarder tests for some time. The injection metadata tests added by @sydney-tung also rely on this feature to be working. I've fixed the Python tracer integration with telemetry forwarding here: https://github.com/DataDog/dd-trace-py/pull/13926. This change enables both tests so they can be run on the Python pipeline.

## Changes

<!-- A brief description of the change being made with this pull request. -->

- [chore: enable forwarder tests](https://github.com/DataDog/system-tests/pull/4910/commits/c9ef059bfccfb8a5e82cdee1c17375e6d0c75615) 
    - This commit enables the telemetry forwarding tests that have been disabled.
- [fix: resolve an issue with the injection metadata test](https://github.com/DataDog/system-tests/pull/4910/commits/6b1780a294a765388ea2e5d85503cd7645dc0d43) 
    - This commit accounts for the two events we expect, one from the injector and one from the tracer so that we can enable these tests for Python.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
