### PR TITLE
Cleanly dispose of RabbitMQ connections

### DIFF
--- a/utils/build/docker/dotnet/weblog/Endpoints/DsmEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/DsmEndpoint.cs
@@ -104,72 +104,80 @@ namespace weblog
     class RabbitMQProducer {
         public static void DoWork(string queue, string exchange, string routing_key)
         {
-            var helper = new RabbitMQHelper();
-            helper.ExchangeDeclare(exchange, ExchangeType.Direct);
-            helper.CreateQueue(queue);
-            helper.QueueBind(queue, exchange, routing_key);
+            using (var helper = new RabbitMQHelper())
+            {
+                helper.ExchangeDeclare(exchange, ExchangeType.Direct);
+                helper.CreateQueue(queue);
+                helper.QueueBind(queue, exchange, routing_key);
 
-            helper.ExchangePublish(exchange, routing_key, "hello world");
-            Console.WriteLine("[rabbitmq] Produced message");
+                helper.ExchangePublish(exchange, routing_key, "hello world");
+                Console.WriteLine("[rabbitmq] Produced message");
+            }
         }
     }
 
     class RabbitMQConsumer {
         public static void DoWork(string queue, string exchange, string routing_key)
         {
-            var helper = new RabbitMQHelper();
-            helper.ExchangeDeclare(exchange, ExchangeType.Direct);
-            helper.CreateQueue(queue);
-            helper.QueueBind(queue, exchange, routing_key);
-
-            helper.AddListener(queue, message =>
+            using (var helper = new RabbitMQHelper())
             {
-                Console.WriteLine("[rabbitmq] Consumed message");
-            });
+                helper.ExchangeDeclare(exchange, ExchangeType.Direct);
+                helper.CreateQueue(queue);
+                helper.QueueBind(queue, exchange, routing_key);
+
+                helper.AddListener(queue, message =>
+                {
+                    Console.WriteLine("[rabbitmq] Consumed message");
+                });
+            }
         }
     }
 
     class RabbitMQProducerFanoutExchange {
         public static void DoWork()
         {
-            var helper = new RabbitMQHelper();
-            helper.ExchangeDeclare("systemTestFanoutExchange", ExchangeType.Fanout);
-            helper.CreateQueue("systemTestRabbitmqFanoutQueue1");
-            helper.CreateQueue("systemTestRabbitmqFanoutQueue2");
-            helper.CreateQueue("systemTestRabbitmqFanoutQueue3");
-            helper.QueueBind("systemTestRabbitmqFanoutQueue1", "systemTestFanoutExchange", "");
-            helper.QueueBind("systemTestRabbitmqFanoutQueue2", "systemTestFanoutExchange", "");
-            helper.QueueBind("systemTestRabbitmqFanoutQueue3", "systemTestFanoutExchange", "");
+            using (var helper = new RabbitMQHelper())
+            {
+                helper.ExchangeDeclare("systemTestFanoutExchange", ExchangeType.Fanout);
+                helper.CreateQueue("systemTestRabbitmqFanoutQueue1");
+                helper.CreateQueue("systemTestRabbitmqFanoutQueue2");
+                helper.CreateQueue("systemTestRabbitmqFanoutQueue3");
+                helper.QueueBind("systemTestRabbitmqFanoutQueue1", "systemTestFanoutExchange", "");
+                helper.QueueBind("systemTestRabbitmqFanoutQueue2", "systemTestFanoutExchange", "");
+                helper.QueueBind("systemTestRabbitmqFanoutQueue3", "systemTestFanoutExchange", "");
 
-            helper.ExchangePublish("systemTestFanoutExchange", "", "hello world, fanout exchange!");
-            Console.WriteLine("[rabbitmq_fanout] Produced message");
+                helper.ExchangePublish("systemTestFanoutExchange", "", "hello world, fanout exchange!");
+                Console.WriteLine("[rabbitmq_fanout] Produced message");
+            }
         }
     }
 
     class RabbitMQConsumerFanoutExchange {
         public static void DoWork()
         {
-            var helper = new RabbitMQHelper();
-            helper.ExchangeDeclare("systemTestFanoutExchange", ExchangeType.Fanout);
-            helper.CreateQueue("systemTestRabbitmqFanoutQueue1");
-            helper.CreateQueue("systemTestRabbitmqFanoutQueue2");
-            helper.CreateQueue("systemTestRabbitmqFanoutQueue3");
-            helper.QueueBind("systemTestRabbitmqFanoutQueue1", "systemTestFanoutExchange", "");
-            helper.QueueBind("systemTestRabbitmqFanoutQueue2", "systemTestFanoutExchange", "");
-            helper.QueueBind("systemTestRabbitmqFanoutQueue3", "systemTestFanoutExchange", "");
+            using (var helper = new RabbitMQHelper())
+            {
+                helper.ExchangeDeclare("systemTestFanoutExchange", ExchangeType.Fanout);
+                helper.CreateQueue("systemTestRabbitmqFanoutQueue1");
+                helper.CreateQueue("systemTestRabbitmqFanoutQueue2");
+                helper.CreateQueue("systemTestRabbitmqFanoutQueue3");
+                helper.QueueBind("systemTestRabbitmqFanoutQueue1", "systemTestFanoutExchange", "");
+                helper.QueueBind("systemTestRabbitmqFanoutQueue2", "systemTestFanoutExchange", "");
+                helper.QueueBind("systemTestRabbitmqFanoutQueue3", "systemTestFanoutExchange", "");
 
-            helper.AddListener("systemTestRabbitmqFanoutQueue1", message =>
-            {
-                Console.WriteLine("[rabbitmq_fanout] Consumed message: " + message);
-            });
-            helper.AddListener("systemTestRabbitmqFanoutQueue2", message =>
-            {
-                Console.WriteLine("[rabbitmq_fanout] Consumed message: " + message);
-            });
-            helper.AddListener("systemTestRabbitmqFanoutQueue3", message =>
-            {
-                Console.WriteLine("[rabbitmq_fanout] Consumed message: " + message);
-            });
+                helper.AddListener("systemTestRabbitmqFanoutQueue1", message =>
+                {
+                    Console.WriteLine("[rabbitmq_fanout] Consumed message: " + message);
+                });
+                helper.AddListener("systemTestRabbitmqFanoutQueue2", message =>
+                {
+                    Console.WriteLine("[rabbitmq_fanout] Consumed message: " + message);
+                });
+                helper.AddListener("systemTestRabbitmqFanoutQueue3", message =>
+                {
+                    Console.WriteLine("[rabbitmq_fanout] Consumed message: " + message);
+                });
+            }
         }
     }
 
@@ -177,19 +185,21 @@ namespace weblog
     {
         public static void DoWork()
         {
-            var helper = new RabbitMQHelper();
-            helper.ExchangeDeclare("systemTestTopicExchange", ExchangeType.Topic);
-            helper.CreateQueue("systemTestRabbitmqTopicQueue1");
-            helper.CreateQueue("systemTestRabbitmqTopicQueue2");
-            helper.CreateQueue("systemTestRabbitmqTopicQueue3");
-            helper.QueueBind("systemTestRabbitmqTopicQueue1", "systemTestTopicExchange", "test.topic.*.cake");
-            helper.QueueBind("systemTestRabbitmqTopicQueue2", "systemTestTopicExchange", "test.topic.vanilla.*");
-            helper.QueueBind("systemTestRabbitmqTopicQueue3", "systemTestTopicExchange", "test.topic.chocolate.*");
+            using (var helper = new RabbitMQHelper())
+            {
+                helper.ExchangeDeclare("systemTestTopicExchange", ExchangeType.Topic);
+                helper.CreateQueue("systemTestRabbitmqTopicQueue1");
+                helper.CreateQueue("systemTestRabbitmqTopicQueue2");
+                helper.CreateQueue("systemTestRabbitmqTopicQueue3");
+                helper.QueueBind("systemTestRabbitmqTopicQueue1", "systemTestTopicExchange", "test.topic.*.cake");
+                helper.QueueBind("systemTestRabbitmqTopicQueue2", "systemTestTopicExchange", "test.topic.vanilla.*");
+                helper.QueueBind("systemTestRabbitmqTopicQueue3", "systemTestTopicExchange", "test.topic.chocolate.*");
 
-            helper.ExchangePublish("systemTestTopicExchange", "test.topic.chocolate.cake", "hello world");
-            helper.ExchangePublish("systemTestTopicExchange", "test.topic.chocolate.icecream", "hello world");
-            helper.ExchangePublish("systemTestTopicExchange", "test.topic.vanilla.icecream", "hello world");
-            Console.WriteLine("[rabbitmq_topic] Produced messages");
+                helper.ExchangePublish("systemTestTopicExchange", "test.topic.chocolate.cake", "hello world");
+                helper.ExchangePublish("systemTestTopicExchange", "test.topic.chocolate.icecream", "hello world");
+                helper.ExchangePublish("systemTestTopicExchange", "test.topic.vanilla.icecream", "hello world");
+                Console.WriteLine("[rabbitmq_topic] Produced messages");
+            }
         }
     }
 
@@ -197,27 +207,29 @@ namespace weblog
     {
         public static void DoWork()
         {
-            var helper = new RabbitMQHelper();
-            helper.ExchangeDeclare("systemTestTopicExchange", ExchangeType.Topic);
-            helper.CreateQueue("systemTestRabbitmqTopicQueue1");
-            helper.CreateQueue("systemTestRabbitmqTopicQueue2");
-            helper.CreateQueue("systemTestRabbitmqTopicQueue3");
-            helper.QueueBind("systemTestRabbitmqTopicQueue1", "systemTestTopicExchange", "test.topic.*.cake");
-            helper.QueueBind("systemTestRabbitmqTopicQueue2", "systemTestTopicExchange", "test.topic.vanilla.*");
-            helper.QueueBind("systemTestRabbitmqTopicQueue3", "systemTestTopicExchange", "test.topic.chocolate.*");
+            using (var helper = new RabbitMQHelper())
+            {
+                helper.ExchangeDeclare("systemTestTopicExchange", ExchangeType.Topic);
+                helper.CreateQueue("systemTestRabbitmqTopicQueue1");
+                helper.CreateQueue("systemTestRabbitmqTopicQueue2");
+                helper.CreateQueue("systemTestRabbitmqTopicQueue3");
+                helper.QueueBind("systemTestRabbitmqTopicQueue1", "systemTestTopicExchange", "test.topic.*.cake");
+                helper.QueueBind("systemTestRabbitmqTopicQueue2", "systemTestTopicExchange", "test.topic.vanilla.*");
+                helper.QueueBind("systemTestRabbitmqTopicQueue3", "systemTestTopicExchange", "test.topic.chocolate.*");
 
-            helper.AddListener("systemTestRabbitmqTopicQueue1", message =>
-            {
-                Console.WriteLine("[rabbitmq_topic] Consumed message from queue1: " + message);
-            });
-            helper.AddListener("systemTestRabbitmqTopicQueue2", message =>
-            {
-                Console.WriteLine("[rabbitmq_topic] Consumed message from queue2: " + message);
-            });
-            helper.AddListener("systemTestRabbitmqTopicQueue3", message =>
-            {
-                Console.WriteLine("[rabbitmq_topic] Consumed message from queue3: " + message);
-            });
+                helper.AddListener("systemTestRabbitmqTopicQueue1", message =>
+                {
+                    Console.WriteLine("[rabbitmq_topic] Consumed message from queue1: " + message);
+                });
+                helper.AddListener("systemTestRabbitmqTopicQueue2", message =>
+                {
+                    Console.WriteLine("[rabbitmq_topic] Consumed message from queue2: " + message);
+                });
+                helper.AddListener("systemTestRabbitmqTopicQueue3", message =>
+                {
+                    Console.WriteLine("[rabbitmq_topic] Consumed message from queue3: " + message);
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## Motivation

Seeing some rare ( < 1%) test flakiness where the final topic doesn't appear on the list of checkpoints.

The message seems to be correctly published and consumed, as we see traces from both sides. However, we don't see the checkpoint in the test code.

When looking around I saw that the RabbitMQ connections weren't being disposed of. Potentially, this could fix the flakiness just by virtue of taking longer to close the RabbitMQ connection.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
