### PR TITLE
[nodejs] add sleep before retrying npm install

### DIFF
--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -404,7 +404,7 @@ COPY {nodejs_reldir}/*.js /usr/app/
 COPY {nodejs_reldir}/*.sh /usr/app/
 COPY {nodejs_reldir}/npm/* /usr/app/
 
-RUN npm install || npm install
+RUN npm install || sleep 60 && npm install
 
 COPY {nodejs_reldir}/../install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh

--- a/utils/build/docker/nodejs/express4-typescript.Dockerfile
+++ b/utils/build/docker/nodejs/express4-typescript.Dockerfile
@@ -29,7 +29,7 @@ CMD ./app.sh
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
 
-RUN npm install || npm install
+RUN npm install || sleep 60 && npm install
 RUN /binaries/install_ddtrace.sh
 RUN npm run build
 ENV DD_TRACE_HEADER_TAGS=user-agent

--- a/utils/build/docker/nodejs/express4.Dockerfile
+++ b/utils/build/docker/nodejs/express4.Dockerfile
@@ -13,9 +13,10 @@ WORKDIR /usr/app
 
 ENV NODE_ENV=production
 
-RUN npm install || npm install
+RUN npm install || sleep 60 && npm install
 RUN npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0" \
-  || npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
+  || sleep 60 \
+  && npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
 
 EXPOSE 7777
 

--- a/utils/build/docker/nodejs/express5.Dockerfile
+++ b/utils/build/docker/nodejs/express5.Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /usr/app
 
 ENV NODE_ENV=production
 
-RUN npm install || npm install
+RUN npm install || sleep 60 && npm install
 RUN npm install "express@5.0.1" || npm install "express@5.0.1"
 
 EXPOSE 7777

--- a/utils/build/docker/nodejs/fastify.Dockerfile
+++ b/utils/build/docker/nodejs/fastify.Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /usr/app
 
 ENV NODE_ENV=production
 
-RUN npm install || npm install
+RUN npm install || sleep 60 && npm install
 
 EXPOSE 7777
 

--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -11,7 +11,7 @@ COPY utils/build/docker/nodejs/nextjs /usr/app
 
 WORKDIR /usr/app
 
-RUN npm install || npm install
+RUN npm install || sleep 60 && npm install
 
 EXPOSE 7777
 

--- a/utils/build/docker/nodejs/uds-express4.Dockerfile
+++ b/utils/build/docker/nodejs/uds-express4.Dockerfile
@@ -13,9 +13,10 @@ WORKDIR /usr/app
 
 ENV NODE_ENV=production
 
-RUN npm install || npm install
+RUN npm install || sleep 60 && npm install
 RUN npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0" \
-  || npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
+  || sleep 60 \
+  && npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
 
 EXPOSE 7777
 

--- a/utils/build/docker/nodejs_otel/express4-otel.Dockerfile
+++ b/utils/build/docker/nodejs_otel/express4-otel.Dockerfile
@@ -15,9 +15,10 @@ WORKDIR /usr/app
 
 ENV NODE_ENV=production
 
-RUN npm install || npm install
+RUN npm install || sleep 60 && npm install
 RUN npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0" \
-  || npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
+  || sleep 60 \
+  && npm install "express@4.17.2" "apollo-server-express@3.13.0" "express-mongo-sanitize@2.2.0"
 
 EXPOSE 7777
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

When npm goes down, it usually takes a moment to get back up again (presumably because of load balancers), so immediately retrying can often fail again, but when rerunning the job ~30-60 seconds later it usually passes. This thus adds a pause before retrying so that we're not retrying too quickly.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Add sleep before retrying `npm install`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
