### PR TITLE
Temporary ignore hosts used by dev agent

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 import re
-from utils import context, weblog, interfaces, features, missing_feature
+from utils import context, weblog, interfaces, features, missing_feature, logger
 
 
 @features.unix_domain_sockets_support_for_traces
@@ -14,6 +14,9 @@ class Test_Backend:
         """Agent reads and use DD_SITE env var"""
         expected_domain: str = context.dd_site
 
+        # temporary skip, waiting for more details from agent team
+        ignored_hosts = ("apt.datadoghq.com", "install.datadoghq.com", "yum.datadoghq.com", "keys.datadoghq.com")
+
         # if DD_SITE is set to a known datadog backend, then the agent adds a tailing '.' at the end
         # to make it a FQDN, and save useless DNS requests. See https://github.com/DataDog/datadog-agent/pull/36972
 
@@ -21,10 +24,13 @@ class Test_Backend:
             expected_domain = expected_domain + "."
 
         for data in interfaces.agent.get_data():
-            domain: str = data["host"][-len(expected_domain) :]
+            host: str = data["host"]
+            domain: str = host[-len(expected_domain) :]
 
-            if not domain.endswith(expected_domain):
-                raise ValueError(f"Message #{data['log_filename']} uses host {domain} instead of {expected_domain}")
+            logger.debug(f"{data['log_filename']} host: {host}")
+
+            if not domain.endswith(expected_domain) and host not in ignored_hosts:
+                raise ValueError(f"Message {data['log_filename']} uses domain {domain} instead of {expected_domain}")
 
 
 @features.unix_domain_sockets_support_for_traces


### PR DESCRIPTION
## Motivation

A change (probably DataDog/datadog-agent#37919, this [change](https://github.com/DataDog/datadog-agent/pull/37919/files#diff-820d736bbf58fd9715c761e38cdb20eab5ec137f14efa72be2a15718494e2820R43-R46)) introduced requests to : 

* "apt.datadoghq.com"
*  "install.datadoghq.com"
*  "yum.datadoghq.com"
*  "keys.datadoghq.com"

Regardless the value of DD_SITE. 

## Changes

Waiting for more details from agent team, ignore those hosts in domain check.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
