### PR TITLE
[Java] Enabling `DD_TRACE_HEADER_TAGS` Wildcard Response Header tests 

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2220,7 +2220,10 @@ tests/:
     Test_HeaderTags_Whitespace_Val_Long: v0.102.0
     Test_HeaderTags_Whitespace_Val_Short: v0.102.0
     Test_HeaderTags_Wildcard_Request_Headers: missing_feature
-    Test_HeaderTags_Wildcard_Response_Headers: v1.51.0
+    Test_HeaderTags_Wildcard_Response_Headers:
+      '*': v1.51.0
+      'akka-http': irrelevant (integration injects Date header after bytecode injection occurs)
+      'play': irrelevant (integration injects Date header after bytecode injection occurs)
   test_profiling.py:
     Test_Profile:
       akka-http: v1.22.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2220,7 +2220,7 @@ tests/:
     Test_HeaderTags_Whitespace_Val_Long: v0.102.0
     Test_HeaderTags_Whitespace_Val_Short: v0.102.0
     Test_HeaderTags_Wildcard_Request_Headers: missing_feature
-    Test_HeaderTags_Wildcard_Response_Headers: missing_feature
+    Test_HeaderTags_Wildcard_Response_Headers: v1.51.0
   test_profiling.py:
     Test_Profile:
       akka-http: v1.22.0


### PR DESCRIPTION
## Motivation

Enabling `DD_TRACE_HEADER_TAGS` Wildcard Response Header tests since it has been released in dd-trace-java v1.51.0.

Note: `akka-http` and `play` inject the `Date` header after the tracer does bytecode injection, so they are considered as exceptions.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
