### PR TITLE
Clarify Test_TelemetryConfigurationChaining subtest logic with a comment

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -567,7 +567,14 @@ class Test_Telemetry:
 @features.telemetry_app_started_event
 @scenarios.telemetry_app_started_config_chaining
 class Test_TelemetryConfigurationChaining:
-    """Test that configuration sources are sent with app-started event in correct precedence order"""
+    """Test that configuration sources are sent with app-started event in correct precedence order.
+
+    IMPORTANT: The order of configuration entries in the telemetry payload does NOT matter.
+    What matters is that the `seq_id` values reported for each configuration reflect the correct
+    precedence order as defined in `_ORIGIN_PRECEDENCE_ORDER`. This test verifies that for each
+    configuration, the `seq_id` increases as the origin precedence increases, regardless of the
+    order in which the entries appear in the payload.
+    """
 
     # Official configuration origin precedence order (from lowest to highest precedence)
     # Based on Node.js tracer implementation
@@ -660,10 +667,14 @@ class Test_TelemetryConfigurationChaining:
             validator(data)
 
     def _validate_precedence_order(self, chain: list) -> None:
-        """Validate that a configuration chain follows the official precedence order
+        """Validate that a configuration chain follows the official precedence order.
 
         Args:
-            chain: List of configuration items with 'origin' keys
+            chain: List of configuration items with 'origin' keys.
+
+        NOTE: This method is used to check that the origins in a configuration chain are in the correct
+        precedence order. In the context of this test, the actual order in the payload is not important;
+        only the relationship between origin precedence and seq_id is validated in the main test logic.
 
         """
         precedence_map = {origin: i for i, origin in enumerate(self._ORIGIN_PRECEDENCE_ORDER)}


### PR DESCRIPTION
## Motivation
I was confused why the `_validate_precedence_order` subtest was checking for order of the configuration entries, because order does not matter for the implementation perspective. It turned out that the test logic was pre-sorting entries by sequence_id before using this helper, hence why order matters.
Because I was confused, others might be too. So, I clarified the intention here with a comment.

## Changes
Annotate test logic for clarity.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
