### PR TITLE
chore: disabling event tracking SDK v2 for Go

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -425,15 +425,15 @@ tests/:
       Test_UserLoginSuccessEvent: v1.47.0
       Test_UserLoginSuccessEvent_Metrics: v2.1.0-dev
     test_event_tracking_v2.py:
-      Test_UserLoginFailureEventV2_HeaderCollection_AppsecDisabled: v2.1.0-dev
-      Test_UserLoginFailureEventV2_HeaderCollection_AppsecEnabled: v2.1.0-dev
+      Test_UserLoginFailureEventV2_HeaderCollection_AppsecDisabled: bug (LANGPLAT-583)
+      Test_UserLoginFailureEventV2_HeaderCollection_AppsecEnabled: bug (LANGPLAT-583)
       Test_UserLoginFailureEventV2_Libddwaf: v2.1.0-dev
       Test_UserLoginFailureEventV2_Metrics_AppsecDisabled: v2.1.0-dev
       Test_UserLoginFailureEventV2_Metrics_AppsecEnabled: v2.1.0-dev
       Test_UserLoginFailureEventV2_Tags_AppsecDisabled: v2.1.0-dev
       Test_UserLoginFailureEventV2_Tags_AppsecEnabled: v2.1.0-dev
-      Test_UserLoginSuccessEventV2_HeaderCollection_AppsecDisabled: v2.1.0-dev
-      Test_UserLoginSuccessEventV2_HeaderCollection_AppsecEnabled: v2.1.0-dev
+      Test_UserLoginSuccessEventV2_HeaderCollection_AppsecDisabled: bug (LANGPLAT-583)
+      Test_UserLoginSuccessEventV2_HeaderCollection_AppsecEnabled: bug (LANGPLAT-583)
       Test_UserLoginSuccessEventV2_Libddwaf: v2.1.0-dev
       Test_UserLoginSuccessEventV2_Metrics_AppsecDisabled: v2.1.0-dev
       Test_UserLoginSuccessEventV2_Metrics_AppsecEnabled: v2.1.0-dev

--- a/tests/appsec/test_event_tracking_v2.py
+++ b/tests/appsec/test_event_tracking_v2.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import weblog, interfaces, features, scenarios, irrelevant, bug
+from utils import weblog, interfaces, features, scenarios, irrelevant
 from tests.appsec.utils import find_series
 from abc import ABC, abstractmethod
 
@@ -201,7 +201,6 @@ class BaseUserLoginSuccessEventV2HeaderCollection(ABC):
 
         self.r = weblog.post("/user_login_success_event_v2", json=data, headers=HEADERS)
 
-    @bug(library="golang", reason="LANGPLAT-583")
     @abstractmethod
     def test_user_login_success_header_collection(self):
         raise AssertionError("Not implemented")
@@ -462,7 +461,6 @@ class BaseUserLoginFailureEventV2HeaderCollection(ABC):
 
         self.r = weblog.post("/user_login_failure_event_v2", json=data, headers=HEADERS)
 
-    @bug(library="golang", reason="LANGPLAT-583")
     @abstractmethod
     def test_user_login_failure_header_collection(self):
         raise AssertionError("Not implemented")


### PR DESCRIPTION
## Motivation

`main` is broken due to ATO tests after releasing `dd-trace-go` `v2.1.0`. It seems that tests are sending requests to the test endpoints with a set of headers but they are not set as tags when asserted.

The requests should include them because of this code:

```
class BaseUserLoginFailureEventV2HeaderCollection(ABC):
    """Test collected headers in AppSec User Login Failure Event SDK v2"""

    def setup_user_login_failure_header_collection(self):
        data = {"login": LOGIN_SAFE, "exists": "false"}

        self.r = weblog.post("/user_login_failure_event_v2", json=data, headers=HEADERS)

# ...

class BaseUserLoginSuccessEventV2HeaderCollection(ABC):
    """Test headers are collected in AppSec User Login Success Event SDK v2"""

    def setup_user_login_success_header_collection(self):
        data = {"login": LOGIN_SAFE, "user_id": USER_ID_SAFE}

        self.r = weblog.post("/user_login_success_event_v2", json=data, headers=HEADERS)
```

That `HEADERS` are later asserted:

```
            for header in HEADERS:
                assert f"http.request.headers.{header.lower()}" in span["meta"], f"Can't find {header} in span's meta"
```

It contains a handful of values:

```
IP_HEADERS = {
    "X-Forwarded-For": "42.42.42.42, 43.43.43.43",
    "X-Client-IP": "42.42.42.42, 43.43.43.43",
    "X-Real-IP": "42.42.42.42, 43.43.43.43",
    "X-Forwarded": "42.42.42.42, 43.43.43.43",
    "X-Cluster-Client-IP": "42.42.42.42, 43.43.43.43",
    "Forwarded-For": "42.42.42.42, 43.43.43.43",
    "Forwarded": "42.42.42.42, 43.43.43.43",
    "Via": "42.42.42.42, 43.43.43.43",
    "True-Client-IP": "42.42.42.42, 43.43.43.43",
}

HEADERS = {
    "Accept": "text/html",
    "Accept-Encoding": "br;q=1.0, gzip;q=0.8, *;q=0.1",
    "Accept-Language": "en-GB, *;q=0.5",
    "Content-Language": "en-GB",
    "Content-Type": "application/json; charset=utf-8",
    "Host": "127.0.0.1:1234",
    "User-Agent": "Benign User Agent 1.0",
    **IP_HEADERS,
}
```

If we check one of [the failing tests](https://github.com/DataDog/system-tests-dashboard/actions/runs/16257264985/job/45895850599#step:64:236), we can compare the tags and see that only the `user-agent` is present (under the prefix `http.request.headers`):

```
  "meta": {
    "http.useragent": "Benign User Agent 1.0 rid/YCHQFGAPOSLPYMDKDGSQNZGWCDAYAJNCNJPB",
    "appsec.events.users.login.failure.usr.exists": "false",
    "_dd.p.ts": "02",
    "component": "go-chi/chi.v5",
    "http.url": "http://127.0.0.1:1234/user_login_failure_event_v2",
    "runtime-id": "1966da03-465a-4da1-8756-d6b8710e1e2f",
    "_dd.appsec.event_rules.version": "1.2.6",
    "http.method": "POST",
    "_dd.appsec.events.users.login.failure.sdk": "true",
    "version": "1.0.0",
    "appsec.event": "true",
    "http.status_code": "200",
    "_dd.p.dm": "-5",
    "http.request.headers.user-agent": "Benign User Agent 1.0 rid/YCHQFGAPOSLPYMDKDGSQNZGWCDAYAJNCNJPB",
    "key1": "val1",
    "go_execution_traced": "yes",
    "span.kind": "server",
    "http.host": "127.0.0.1:1234",
    "key2": "val2",
    "_dd.runtime_family": "go",
    "appsec.events.users.login.failure.track": "true",
    "http.route": "/user_login_failure_event_v2",
    "_dd.p.tid": "6874879400000000",
    "env": "system-tests",
    "appsec.events.users.login.failure.usr.login": "login_safe",
    "_dd.origin": "appsec",
    "language": "go"
  },
```

Ticket LANGPLAT-583 created to manage the fix by the right team.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
