### PR TITLE
[golang] reactiveate test impacted by LANGPLAT-583 on dev

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -425,15 +425,15 @@ tests/:
       Test_UserLoginSuccessEvent: v1.47.0
       Test_UserLoginSuccessEvent_Metrics: v2.1.0-dev
     test_event_tracking_v2.py:
-      Test_UserLoginFailureEventV2_HeaderCollection_AppsecDisabled: bug (LANGPLAT-583)
-      Test_UserLoginFailureEventV2_HeaderCollection_AppsecEnabled: bug (LANGPLAT-583)
+      Test_UserLoginFailureEventV2_HeaderCollection_AppsecDisabled: v2.2.0-dev  # LANGPLAT-583
+      Test_UserLoginFailureEventV2_HeaderCollection_AppsecEnabled: v2.2.0-dev  # LANGPLAT-583
       Test_UserLoginFailureEventV2_Libddwaf: v2.1.0-dev
       Test_UserLoginFailureEventV2_Metrics_AppsecDisabled: v2.1.0-dev
       Test_UserLoginFailureEventV2_Metrics_AppsecEnabled: v2.1.0-dev
       Test_UserLoginFailureEventV2_Tags_AppsecDisabled: v2.1.0-dev
       Test_UserLoginFailureEventV2_Tags_AppsecEnabled: v2.1.0-dev
-      Test_UserLoginSuccessEventV2_HeaderCollection_AppsecDisabled: bug (LANGPLAT-583)
-      Test_UserLoginSuccessEventV2_HeaderCollection_AppsecEnabled: bug (LANGPLAT-583)
+      Test_UserLoginSuccessEventV2_HeaderCollection_AppsecDisabled: v2.2.0-dev  # LANGPLAT-583
+      Test_UserLoginSuccessEventV2_HeaderCollection_AppsecEnabled: v2.2.0-dev  # LANGPLAT-583
       Test_UserLoginSuccessEventV2_Libddwaf: v2.1.0-dev
       Test_UserLoginSuccessEventV2_Metrics_AppsecDisabled: v2.1.0-dev
       Test_UserLoginSuccessEventV2_Metrics_AppsecEnabled: v2.1.0-dev


### PR DESCRIPTION
## Motivation

Those tests are failing only for `golang@2.1.0`, but are fine on master -> reactivate them.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
