### PR TITLE
Correctly deserialize v0.5 traces on buddies container

### DIFF
--- a/tests/integrations/crossed_integrations/test_sqs.py
+++ b/tests/integrations/crossed_integrations/test_sqs.py
@@ -23,6 +23,7 @@ class _BaseSQS:
             # we iterate the trace backwards to deal with the case of JS "aws.response" callback spans, which are similar for this test and test_sns_to_sqs.
             # Instead, we look for the custom span created after the "aws.response" span
             for span in reversed(trace):
+                assert isinstance(span, dict), f"Span is not a dict: {data['log_filename']}"
                 if not span.get("meta"):
                     continue
 

--- a/utils/_context/_scenarios/integrations.py
+++ b/utils/_context/_scenarios/integrations.py
@@ -109,7 +109,6 @@ class CrossedTracingLibraryScenario(EndToEndScenario):
             include_elasticmq=True,
             doc="Spawns a buddy for each supported language of APM, requires AWS authentication.",
             weblog_env={
-                "DD_TRACE_API_VERSION": "v0.4",
                 "SYSTEM_TESTS_AWS_URL": "http://localstack-main:4566",
                 "SYSTEM_TESTS_AWS_SQS_URL": "http://elasticmq:9324",
             },

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -111,6 +111,16 @@ def deserialize_http_message(
     raw_content_type = get_header_value("content-type", message["headers"])
     content_type = None if raw_content_type is None else raw_content_type.lower()
 
+    # Determine if the content is from a Datadog tracer
+    source_is_datadog_tracer = interface in (
+        "library",
+        "python_buddy",
+        "nodejs_buddy",
+        "java_buddy",
+        "ruby_buddy",
+        "golang_buddy",
+    )
+
     if not content or len(content) == 0:
         return None
 
@@ -123,11 +133,11 @@ def deserialize_http_message(
 
         return json_load()
 
-    if path == "/dogstatsd/v2/proxy" and interface == "library":
+    if path == "/dogstatsd/v2/proxy" and source_is_datadog_tracer:
         # TODO : how to deserialize this ?
         return content.decode(encoding="utf-8")
 
-    if interface == "library" and path == "/info":
+    if source_is_datadog_tracer and path == "/info":
         if key == "response":
             return json_load()
 
@@ -137,7 +147,7 @@ def deserialize_http_message(
     if content_type in ("application/msgpack", "application/msgpack, application/msgpack") or (path == "/v0.6/stats"):
         result = msgpack.unpackb(content, unicode_errors="replace", strict_map_key=False)
 
-        if interface == "library":
+        if source_is_datadog_tracer:
             if path == "/v0.4/traces":
                 _decode_unsigned_int_traces(result)
                 _deserialized_nested_json_from_trace_payloads(result, interface)


### PR DESCRIPTION
## Motivation

Buddies ships tracers, and those tracer can send trace to both `v0.4` and `v0.5` endpoints.

The last one is not correctly deserialized

## Changes

Correctly deserialize `v0.5` traces

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
