### PR TITLE
Docker SSI crashtracking: no java, no php, no ruby

### DIFF
--- a/tests/docker_ssi/test_docker_ssi_crash.py
+++ b/tests/docker_ssi/test_docker_ssi_crash.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 from utils import (
     bug,
     irrelevant,
+    missing_feature,
     scenarios,
     features,
     context,
@@ -36,7 +37,9 @@ class TestDockerSSICrash:
         self.r = TestDockerSSICrash._r
 
     @features.ssi_crashtracking
-    @bug(condition=context.library in ("java", "php", "ruby"), reason="INPLAT-11")
+    @missing_feature(
+        condition=context.library in ("java", "php", "ruby"), reason="No implemented the endpoint /crashme"
+    )
     @irrelevant(context.library == "python" and context.installed_language_runtime < "3.7.0")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
     @bug(context.library >= "python@3.0.0.dev", reason="INPLAT-603")

--- a/utils/scripts/ci_orchestrators/docker_ssi.json
+++ b/utils/scripts/ci_orchestrators/docker_ssi.json
@@ -2,7 +2,7 @@
     "scenario_matrix": [
         {
             "scenarios": [
-                "DOCKER_SSI","DOCKER_SSI_CRASHTRACKING"
+                "DOCKER_SSI"
             ],
             "weblogs": [
                 {
@@ -18,6 +18,21 @@
                     ],
                     "php": [
                         "php-app"
+                    ]
+                }
+            ]
+        },
+        {
+            "scenarios": [
+               "DOCKER_SSI_CRASHTRACKING"
+            ],
+            "weblogs": [
+                {
+                    "nodejs": [
+                        "js-app"
+                    ],
+                    "python": [
+                        "py-app"
                     ]
                 }
             ]


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The CI job matrix is not correctly configured. We don't have the endpoint for docker ssi crashtracking for: java, php and ruby. 
Also fix the decorators of the test method

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
