### PR TITLE
remove docker prune before pulling images

### DIFF
--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -26,6 +26,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Free some place for scenarios known to require lot of images
+      if: ${{ (inputs.cleanup == 'true') && (contains(inputs.scenarios, '"INTEGRATIONS"') || contains(inputs.scenarios, '"CROSSED_TRACING_LIBRARIES"')) }}
+      shell: bash
+      run: |
+        df -h
+
+        echo "Removing docker images, dotnet, android, ghc, and CodeQL cache to free space"
+
+        sudo rm -rf /usr/local/lib/android  # 9Gb!
+        sudo rm -rf /opt/hostedtoolcache/CodeQL  # 5Gb !
+        sudo rm -rf /usr/share/dotnet # 1Gb
+
+        # sudo docker image prune --all --force  # if ever needed, but it's slow. Only 3Gb
+
+        df -h
+
     - name: Get image list
       shell: bash
       run: |

--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -26,22 +26,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Free some place for scenarios known to require lot of images
-      if: ${{ (inputs.cleanup == 'true') && (contains(inputs.scenarios, '"INTEGRATIONS"') || contains(inputs.scenarios, '"CROSSED_TRACING_LIBRARIES"')) }}
-      shell: bash
-      run: |
-        df -h
-
-        echo "Removing docker images, dotnet, android, ghc, and CodeQL cache to free space"
-
-        sudo rm -rf /usr/local/lib/android  # 9Gb!
-        sudo rm -rf /opt/hostedtoolcache/CodeQL  # 5Gb !
-        sudo rm -rf /usr/share/dotnet # 1Gb
-
-        # sudo docker image prune --all --force  # if ever needed, but it's slow. Only 3Gb
-
-        df -h
-
     - name: Get image list
       shell: bash
       run: |

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -117,6 +117,7 @@ jobs:
     - name: Pull images
       uses: ./.github/actions/pull_images
       with:
+        cleanup: "false"
         library: ${{ inputs.library }}
         weblog: ${{ inputs.weblog }}
         scenarios: ${{ inputs.scenarios }}

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -75,7 +75,7 @@ env:
 jobs:
   main:
     name: "${{ inputs.weblog }} ${{ inputs.weblog_instance }}"
-    runs-on: ${{ contains(fromJSON('["CROSSED_TRACING_LIBRARIES", "INTEGRATIONS"]'), inputs.scenario) && 'ubuntu-latest-16-cores' || 'ubuntu-latest' }}
+    runs-on: ${{ (contains(inputs.scenarios, 'CROSSED_TRACING_LIBRARIES') || contains(inputs.scenarios, 'INTEGRATIONS')) && 'ubuntu-latest-16-cores' || 'ubuntu-latest' }}
     env:
       SYSTEM_TESTS_REPORT_ENVIRONMENT: ${{ inputs.ci_environment }}
       SYSTEM_TESTS_REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -75,7 +75,7 @@ env:
 jobs:
   main:
     name: "${{ inputs.weblog }} ${{ inputs.weblog_instance }}"
-    runs-on: ubuntu-latest
+    runs-on: ${{ contains(fromJSON('["CROSSED_TRACING_LIBRARIES", "INTEGRATIONS"]'), inputs.scenario) && 'ubuntu-latest-16-cores' || 'ubuntu-latest' }}
     env:
       SYSTEM_TESTS_REPORT_ENVIRONMENT: ${{ inputs.ci_environment }}
       SYSTEM_TESTS_REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/run-external-processing.yml
+++ b/.github/workflows/run-external-processing.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Pull images
         uses: ./.github/actions/pull_images
         with:
+          cleanup: "false"
           library: golang
           weblog: golang-dummy
           scenarios: '["EXTERNAL_PROCESSING", "EXTERNAL_PROCESSING_BLOCKING"]'


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Running `docker prune` takes 5+ minutes, so we should instead use larger machines with more storage to run scenarios that need more space. Ideally we'd use smaller Docker images, but some of them are really difficult to reduce the size of as the software on them is large to begin with.

Fixes regression from https://github.com/DataDog/dd-trace-js/pull/5884

## Changes

<!-- A brief description of the change being made with this pull request. -->

Remove docker prune before pulling images.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
