### PR TITLE
SSI: ruby remove inplat-103 decorators

### DIFF
--- a/tests/auto_inject/test_auto_inject_chaos.py
+++ b/tests/auto_inject/test_auto_inject_chaos.py
@@ -1,5 +1,5 @@
 import requests
-from utils import scenarios, features, context, bug, irrelevant, missing_feature, logger
+from utils import scenarios, features, context, irrelevant, missing_feature, logger
 from utils.onboarding.weblog_interface import warmup_weblog
 from utils.onboarding.wait_for_tcp_port import wait_for_port
 import tests.auto_inject.utils as base
@@ -86,12 +86,6 @@ class BaseAutoInjectChaos(base.AutoInjectBaseTest):
 @features.installer_auto_instrumentation
 @scenarios.chaos_installer_auto_injection
 class TestAutoInjectChaos(BaseAutoInjectChaos):
-    @bug(
-        context.vm_os_branch in ["redhat", "amazon_linux2"]
-        and context.vm_os_cpu == "arm64"
-        and context.weblog_variant == "test-app-ruby",
-        reason="INPLAT-103",
-    )
     @irrelevant(
         context.vm_name in ["Amazon_Linux_2023_amd64", "Amazon_Linux_2023_arm64"],
         reason="LD library failures impact on the docker engine, causes flakiness",
@@ -109,12 +103,6 @@ class TestAutoInjectChaos(BaseAutoInjectChaos):
         self._test_install(virtual_machine)
         logger.info(f"Done test_install for : [{virtual_machine.name}]")
 
-    @bug(
-        context.vm_os_branch in ["redhat", "amazon_linux2"]
-        and context.vm_os_cpu == "arm64"
-        and context.weblog_variant == "test-app-ruby",
-        reason="INPLAT-103",
-    )
     @missing_feature(context.vm_os_branch == "windows", reason="Not implemented on Windows")
     @irrelevant(
         context.vm_name in ["AlmaLinux_8_amd64", "AlmaLinux_8_arm64", "OracleLinux_8_8_amd64", "OracleLinux_8_8_arm64"]

--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -7,12 +7,6 @@ import tests.auto_inject.utils as base
 @features.host_auto_installation_script
 @scenarios.host_auto_injection_install_script
 class TestHostAutoInjectInstallScript(base.AutoInjectBaseTest):
-    @bug(
-        context.vm_os_branch in ["redhat", "amazon_linux2"]
-        and context.vm_os_cpu == "arm64"
-        and context.weblog_variant == "test-app-ruby",
-        reason="INPLAT-103",
-    )
     @missing_feature(context.vm_os_branch == "windows", reason="Not implemented on Windows")
     def test_install(self):
         self._test_install(context.virtual_machine)
@@ -160,12 +154,6 @@ class TestInstallerAutoInjectManual(base.AutoInjectBaseTest):
     # on the installer. As we can not only uninstall the injector, we are skipping
     # the uninstall test today
 
-    @bug(
-        context.vm_os_branch in ["redhat", "amazon_linux2"]
-        and context.vm_os_cpu == "arm64"
-        and context.weblog_variant == "test-app-ruby",
-        reason="INPLAT-103",
-    )
     @irrelevant(condition=context.weblog_variant == "test-app-dotnet-iis")
     def test_install_uninstall(self):
         virtual_machine = context.virtual_machine
@@ -188,12 +176,6 @@ class TestInstallerAutoInjectManual(base.AutoInjectBaseTest):
 @scenarios.simple_installer_auto_injection
 @scenarios.multi_installer_auto_injection
 class TestSimpleInstallerAutoInjectManual(base.AutoInjectBaseTest):
-    @bug(
-        context.vm_os_branch in ["redhat", "amazon_linux2"]
-        and context.vm_os_cpu == "arm64"
-        and context.weblog_variant == "test-app-ruby",
-        reason="INPLAT-103",
-    )
     @irrelevant(
         context.library > "python@2.21.0" and context.installed_language_runtime < "3.8.0",
         reason="python 3.7 is not supported on ddtrace >= 3.x",

--- a/tests/auto_inject/test_blocklist_auto_inject.py
+++ b/tests/auto_inject/test_blocklist_auto_inject.py
@@ -1,7 +1,7 @@
 import uuid
 from scp import SCPClient
 
-from utils import scenarios, context, features, irrelevant, bug, logger
+from utils import scenarios, context, features, irrelevant, logger
 from utils.onboarding.injection_log_parser import command_injection_skipped
 
 
@@ -72,12 +72,6 @@ class TestAutoInjectBlockListInstallManualHost(_AutoInjectBlockListBaseTest):
         or "alpine" in context.weblog_variant
         or "buildpack" in context.weblog_variant
     )
-    @bug(
-        context.vm_os_branch in ["redhat", "amazon_linux2"]
-        and context.vm_os_cpu == "arm64"
-        and context.library == "ruby",
-        reason="INPLAT-103",
-    )
     def test_builtin_block_commands(self):
         """Check that commands are skipped from the auto injection. This commands are defined on the buildIn processes to block"""
         virtual_machine = context.virtual_machine
@@ -91,12 +85,6 @@ class TestAutoInjectBlockListInstallManualHost(_AutoInjectBlockListBaseTest):
         condition="container" in context.weblog_variant
         or "alpine" in context.weblog_variant
         or "buildpack" in context.weblog_variant
-    )
-    @bug(
-        context.vm_os_branch in ["redhat", "amazon_linux2"]
-        and context.vm_os_cpu == "arm64"
-        and context.library == "ruby",
-        reason="INPLAT-103",
     )
     def test_builtin_block_args(self):
         """Check that we are blocking command with args. These args are defined in the buildIn args ignore list for each language."""
@@ -113,12 +101,6 @@ class TestAutoInjectBlockListInstallManualHost(_AutoInjectBlockListBaseTest):
         condition="container" in context.weblog_variant
         or "alpine" in context.weblog_variant
         or "buildpack" in context.weblog_variant
-    )
-    @bug(
-        context.vm_os_branch in ["redhat", "amazon_linux2"]
-        and context.vm_os_cpu == "arm64"
-        and context.library == "ruby",
-        reason="INPLAT-103",
     )
     def test_builtin_instrument_args(self):
         """Check that we are instrumenting the command with args that it should be instrumented. The args are not included on the buildIn args list"""

--- a/utils/scripts/ci_orchestrators/aws_ssi.json
+++ b/utils/scripts/ci_orchestrators/aws_ssi.json
@@ -600,7 +600,10 @@
                     "RedHat_9_0_amd64",
                     "RedHat_9_0_arm64",
                     "Ubuntu_24_10_amd64",
-                    "Ubuntu_24_10_arm64"
+                    "Ubuntu_24_10_arm64",
+                    "Amazon_Linux_2_arm64",
+                    "RedHat_8_6_arm64",
+                    "Rocky_Linux_8_arm64"
                 ]
             },
             {


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The failures for "redhat" branches and amazon linux 2 (all arm64) are related with the app, that cannot build due a requirements. Remove this machine from the workflow and remove the bug decorators

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
