### PR TITLE
[APISec] Fix API Sec priority when schema is present

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -309,7 +309,7 @@ tests/:
     test_alpha.py:
       Test_Basic: v1.28.6
     test_asm_standalone.py:
-      Test_APISecurityStandalone: missing_feature
+      Test_APISecurityStandalone: v3.17.0
       Test_AppSecStandalone_UpstreamPropagation: missing_feature
       Test_AppSecStandalone_UpstreamPropagation_V2: v3.12.0
       Test_IastStandalone_UpstreamPropagation: missing_feature

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -129,6 +129,14 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         else:
             return default_checks
 
+    @missing_feature(
+        condition=(
+            context.scenario.name == scenarios.appsec_standalone_api_security.name
+            and context.weblog_variant in ("django-poc", "django-py3.13", "python3.12")
+            and context.library < "python@3.11.0.dev"
+        ),
+        reason="APPSEC-57830 (python tracer was using MANUAL_KEEP for 1 trace in 60 seconds to keep instead of AUTO_KEEP)",
+    )
     def test_no_appsec_upstream__no_asm_event__is_kept_with_priority_1__from_minus_1(self):
         self.assert_product_is_enabled(self.check_r, self.tested_product)
         spans_checked = 0

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -120,6 +120,14 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
                 },
             )
 
+    def fix_priority_lambda(self, span, default_checks):
+        if "_dd.appsec.s.req.headers" in span["meta"]:
+            return {
+                "_sampling_priority_v1": lambda x: x == 2
+            }  # if we find evidence of API Sec schema, priority should be 2 (Manual Keep)
+        else:
+            return default_checks
+
     @bug(
         condition=(
             context.scenario.name == scenarios.appsec_standalone_api_security.name
@@ -135,7 +143,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
-            assert assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "metrics", self.fix_priority_lambda(span, tested_metrics))
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -181,7 +189,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
-            assert assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "metrics", self.fix_priority_lambda(span, tested_metrics))
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -227,7 +235,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
-            assert assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "metrics", self.fix_priority_lambda(span, tested_metrics))
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121
@@ -273,7 +281,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
-            assert assert_tags(trace[0], span, "metrics", tested_metrics)
+            assert assert_tags(trace[0], span, "metrics", self.fix_priority_lambda(span, tested_metrics))
 
             assert span["metrics"]["_dd.apm.enabled"] == 0  # if key missing -> APPSEC-55222
             assert span["trace_id"] == 1212121212121212121

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -4,6 +4,7 @@ import time
 
 from requests.structures import CaseInsensitiveDict
 
+from utils.dd_constants import SAMPLING_PRIORITY_KEY, SamplingPriority
 from utils.telemetry_utils import TelemetryUtils
 from utils import context, weblog, interfaces, scenarios, features, rfc, bug, missing_feature, irrelevant, logger, flaky
 
@@ -33,7 +34,7 @@ def assert_tags(first_trace, span, obj, expected_tags) -> bool:
         for tag, value in expected_tags.items():
             if value is None:
                 assert tag not in struct
-            elif tag == "_sampling_priority_v1":  # special case, it's a lambda to check for a condition
+            elif tag == SAMPLING_PRIORITY_KEY:  # special case, it's a lambda to check for a condition
                 assert value(struct[tag])
             else:
                 assert struct[tag] == value
@@ -123,7 +124,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
     def fix_priority_lambda(self, span, default_checks):
         if "_dd.appsec.s.req.headers" in span["meta"]:
             return {
-                "_sampling_priority_v1": lambda x: x == 2
+                SAMPLING_PRIORITY_KEY: lambda x: x == SamplingPriority.USER_KEEP
             }  # if we find evidence of API Sec schema, priority should be 2 (Manual Keep)
         else:
             return default_checks
@@ -132,7 +133,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         self.assert_product_is_enabled(self.check_r, self.tested_product)
         spans_checked = 0
         tested_meta = {self.propagated_tag(): None, "_dd.p.other": "1"}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x < 2}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x < 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -178,7 +179,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         self.assert_product_is_enabled(self.check_r, self.tested_product)
         spans_checked = 0
         tested_meta = {self.propagated_tag(): None, "_dd.p.other": "1"}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x < 2}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x < 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -224,7 +225,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         self.assert_product_is_enabled(self.check_r, self.tested_product)
         spans_checked = 0
         tested_meta = {self.propagated_tag(): None, "_dd.p.other": "1"}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x < 2}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x < 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -270,7 +271,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         self.assert_product_is_enabled(self.check_r, self.tested_product)
         spans_checked = 0
         tested_meta = {self.propagated_tag(): None, "_dd.p.other": "1"}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x < 2}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x < 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -314,7 +315,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
     def test_no_upstream_appsec_propagation__with_asm_event__is_kept_with_priority_2__from_minus_1(self):
         spans_checked = 0
         tested_meta = {self.propagated_tag(): self.propagated_tag_value()}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -358,7 +359,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
     def test_no_upstream_appsec_propagation__with_asm_event__is_kept_with_priority_2__from_0(self):
         spans_checked = 0
         tested_meta = {self.propagated_tag(): self.propagated_tag_value()}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -404,7 +405,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         self.assert_product_is_enabled(self.check_r, self.tested_product)
         spans_checked = 0
         tested_meta = {self.propagated_tag(): self.propagated_tag_value()}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x in [0, 2]}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x in [0, 2]}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -449,7 +450,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         self.assert_product_is_enabled(self.check_r, self.tested_product)
         spans_checked = 0
         tested_meta = {self.propagated_tag(): self.propagated_tag_value()}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x in [1, 2]}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x in [1, 2]}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -494,7 +495,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         self.assert_product_is_enabled(self.check_r, self.tested_product)
         spans_checked = 0
         tested_meta = {self.propagated_tag(): self.propagated_tag_value()}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -536,7 +537,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
     def test_any_upstream_propagation__with_asm_event__raises_priority_to_2__from_minus_1(self):
         spans_checked = 0
         tested_meta = {self.propagated_tag(): self.propagated_tag_value()}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -578,7 +579,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
     def test_any_upstream_propagation__with_asm_event__raises_priority_to_2__from_0(self):
         spans_checked = 0
         tested_meta = {self.propagated_tag(): self.propagated_tag_value()}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -620,7 +621,7 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
     def test_any_upstream_propagation__with_asm_event__raises_priority_to_2__from_1(self):
         spans_checked = 0
         tested_meta = {self.propagated_tag(): self.propagated_tag_value()}
-        tested_metrics = {"_sampling_priority_v1": lambda x: x == 2}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x == 2}
 
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -714,7 +715,7 @@ class BaseSCAStandaloneTelemetry:
         # test standalone is enabled and dropping traces
         spans_checked = 0
         for _, __, span in list(interfaces.library.get_spans(request0)) + list(interfaces.library.get_spans(request1)):
-            if span["metrics"]["_sampling_priority_v1"] <= 0 and span["metrics"]["_dd.apm.enabled"] == 0:
+            if span["metrics"][SAMPLING_PRIORITY_KEY] <= 0 and span["metrics"]["_dd.apm.enabled"] == 0:
                 spans_checked += 1
 
         assert spans_checked > 0
@@ -916,7 +917,7 @@ class Test_APISecurityStandalone(BaseAppSecStandaloneUpstreamPropagation):
         """Check if trace is retained with expected sampling priority"""
 
         spans_checked = 0
-        tested_metrics = {"_sampling_priority_v1": lambda x: x == 2 if should_be_retained else x <= 0}
+        tested_metrics = {SAMPLING_PRIORITY_KEY: lambda x: x == 2 if should_be_retained else x <= 0}
         for data, trace, span in interfaces.library.get_spans(request=request):
             assert span["trace_id"] == 1212121212121212121
             assert trace[0]["trace_id"] == 1212121212121212121

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -128,13 +128,6 @@ class BaseAsmStandaloneUpstreamPropagation(ABC):
         else:
             return default_checks
 
-    @bug(
-        condition=(
-            context.scenario.name == scenarios.appsec_standalone_api_security.name
-            and context.weblog_variant in ("django-poc", "django-py3.13", "python3.12")
-        ),
-        reason="APPSEC-57830",
-    )
     def test_no_appsec_upstream__no_asm_event__is_kept_with_priority_1__from_minus_1(self):
         self.assert_product_is_enabled(self.check_r, self.tested_product)
         spans_checked = 0


### PR DESCRIPTION
## Motivation
In API Sec standalone tests, if a schema is extracted in a span without a security event, the priority will be manual keep, and many tests are expecting a span with drop priority.

<!-- What inspired you to submit this pull request? -->

## Changes
Add a function to fix the expected span priority based upon the presence of API Sec schema in the span

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
