### PR TITLE
fix: use case insensitive comparator for headers

### DIFF
--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -1173,7 +1173,8 @@ class Test_UserEventsStandalone_SDK_V1:
 
             # Some tracers use true while others use yes
             assert any(
-                ["Datadog-Client-Computed-Stats", trueish] in data["request"]["headers"] for trueish in ["yes", "true"]
+                header.lower() == "datadog-client-computed-stats" and value.lower() in ["yes", "true"]
+                for header, value in data["request"]["headers"]
             )
             return span["meta"]
 
@@ -1236,7 +1237,8 @@ class Test_UserEventsStandalone_SDK_V2:
 
             # Some tracers use true while others use yes
             assert any(
-                ["Datadog-Client-Computed-Stats", trueish] in data["request"]["headers"] for trueish in ["yes", "true"]
+                header.lower() == "datadog-client-computed-stats" and value.lower() in ["yes", "true"]
+                for header, value in data["request"]["headers"]
             )
             return span["meta"]
 


### PR DESCRIPTION
## Motivation

[Test fail in dd-trace-py CI](https://github.com/DataDog/dd-trace-py/actions/runs/16353240674/job/46205711082?pr=13071) due to case sensitive comparison.

## Changes

Like other header tests, made sure that header key comparison is done without considering the case sensitivity.
Similar to the fix from #4630.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
