### PR TITLE
[golang] give more time to build parametric/golang

### DIFF
--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -249,8 +249,10 @@ class ParametricScenario(Scenario):
             env = os.environ.copy()
             env["DOCKER_SCAN_SUGGEST"] = "false"  # Docker outputs an annoying synk message on every build
 
-            # python tracer takes more than 5mn to build
-            timeout = default_subprocess_run_timeout if apm_test_server_definition.lang != "python" else 600
+            # python and golang tracer takes more than 5mn to build
+            timeout = (
+                default_subprocess_run_timeout if apm_test_server_definition.lang not in ("python", "golang") else 600
+            )
 
             p = subprocess.run(
                 cmd,

--- a/utils/scripts/load-binary.sh
+++ b/utils/scripts/load-binary.sh
@@ -168,6 +168,12 @@ fi
 TARGET=$1
 VERSION=${2:-'dev'}
 
+GH_TOKEN="${GH_TOKEN:-$GITHUB_TOKEN}"
+GITHUB_AUTH_HEADER=()
+if [ -n "$GH_TOKEN" ]; then
+  GITHUB_AUTH_HEADER=(-H "Authorization: Bearer $GH_TOKEN")
+fi
+
 echo "Load $VERSION binary for $TARGET"
 
 cd binaries/
@@ -238,7 +244,7 @@ elif [ "$TARGET" = "golang" ]; then
 
     LIBRARY_TARGET_BRANCH="${LIBRARY_TARGET_BRANCH:-main}"
     echo "load last commit on $LIBRARY_TARGET_BRANCH for DataDog/dd-trace-go"
-    COMMIT_ID=$(curl -sS --fail "https://api.github.com/repos/DataDog/dd-trace-go/branches/$LIBRARY_TARGET_BRANCH" | jq -r .commit.sha)
+    COMMIT_ID=$(curl -sS --fail "${GITHUB_AUTH_HEADER[@]}" "https://api.github.com/repos/DataDog/dd-trace-go/branches/$LIBRARY_TARGET_BRANCH" | jq -r .commit.sha)
 
     echo "Using github.com/DataDog/dd-trace-go/v2@$COMMIT_ID"
     echo "github.com/DataDog/dd-trace-go/v2@$COMMIT_ID" > golang-load-from-go-get


### PR DESCRIPTION
## Motivation

golang parametric test container can takes more than 5mn to build : https://github.com/DataDog/system-tests-dashboard/actions/runs/16361481218/job/46230058312#step:6:59

## Changes

Give 10mn before timeout.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
