### PR TITLE
skip test for old python tracer versions

### DIFF
--- a/tests/appsec/iast/sink/test_command_injection.py
+++ b/tests/appsec/iast/sink/test_command_injection.py
@@ -23,6 +23,7 @@ class TestCommandInjection(BaseSinkTest):
 
     @missing_feature(library="nodejs", reason="Endpoint not implemented")
     @missing_feature(library="java", reason="Endpoint not implemented")
+    @missing_feature(context.library < "python@3.0.0", reason="Endpoint not implemented")
     def test_secure(self):
         super().test_secure()
 


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/dd-trace-py/actions/runs/16373446947/job/46267846615?pr=14051

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
