### PR TITLE
config_telemetry: Ensure python reports True/False for logs injection

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1024,7 +1024,7 @@ tests/:
       Test_Config_TraceEnabled: v2.12.2
       Test_Config_TraceLogDirectory: missing_feature
       Test_Config_UnifiedServiceTagging: v2.12.2
-      Test_Stable_Config_Default: v3.11.0  # default value of log injection changed in v3.10.0
+      Test_Stable_Config_Default: v3.12.0.dev  # default value of log injection changed in v3.12.0
     test_crashtracking.py:
       Test_Crashtracking: v2.11.2
     test_dynamic_configuration.py:

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -396,7 +396,7 @@ SDK_DEFAULT_STABLE_CONFIG = {
         "ruby": "true",
         "java": "true",
         "golang": None,
-        "python": "structured",
+        "python": "true",
         "nodejs": "structured",
     }.get(context.library.name, "false"),  # Enabled by default in ruby
 }


### PR DESCRIPTION
## Motivation

The default value of DD_LOGS_INJECTION is being reverted back to a boolean with default values of True/False. The telemetry emitted by the python tracer should match this change.

## Changes

- Default value of DD_LOGS_INJECTION is no longer structured, it will be true.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
