### PR TITLE
Add a github-token-file parameter for build

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -188,13 +188,25 @@ jobs:
       - name: Log binaries contents
         if : ${{ needs.compute_parameters.outputs.binaries_artifact != '' }}
         run: ls -la binaries/
+      - name: Export github token to a file
+        run: echo "${{ secrets.GITHUB_TOKEN }}" > "$RUNNER_TEMP/github_token.txt"
       - name: Build weblog base images
         if: inputs.library == 'python' && inputs.build_python_base_images
         run: |
           ./utils/build/build_python_base_images.sh
       - name: Build weblog
         id: build
-        run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh ${{ inputs.library }} -i weblog -w ${{ matrix.weblog }} -s
+        run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh ${{ inputs.library }} -i weblog -w ${{ matrix.weblog }} -s --github-token-file "$RUNNER_TEMP/github_token.txt"
+      - name: Remove secrets
+        if: always()
+        run: |
+          TOKEN_FILE="$RUNNER_TEMP/github_token.txt"
+          if [ -f "$TOKEN_FILE" ]; then
+            echo "Removing token file at $TOKEN_FILE"
+            rm -f "$TOKEN_FILE"
+          else
+            echo "Token file not found — nothing to clean up"
+          fi
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -57,6 +57,7 @@ print_usage() {
     echo -e "  ${CYAN}--weblog-variant <var>${NC}     Weblog variant (env: WEBLOG_VARIANT)."
     echo -e "  ${CYAN}--images <images>${NC}          Comma-separated list of images to build (env: BUILD_IMAGES, default: ${DEFAULT_BUILD_IMAGES})."
     echo -e "  ${CYAN}--docker${NC}                   Build docker image instead of local install (env: DOCKER_MODE, default: ${DEFAULT_DOCKER_MODE})."
+    echo -e "  ${CYAN}--github-token-file <file>${NC} Path to a file containing a GitHub token used for authenticated operations (e.g. cloning private repos, accessing the API)."
     echo -e "  ${CYAN}--extra-docker-args <args>${NC} Extra arguments passed to docker build (env: EXTRA_DOCKER_ARGS)."
     echo -e "  ${CYAN}--cache-mode <mode>${NC}        Cache mode (env: DOCKER_CACHE_MODE)."
     echo -e "  ${CYAN}--platform <platform>${NC}      Target Docker platform."
@@ -216,11 +217,24 @@ build() {
 
                 DOCKERFILE=utils/build/docker/${TEST_LIBRARY}/${WEBLOG_VARIANT}.Dockerfile
 
+                GITHUB_TOKEN_SECRET_ARG=()
+
+                if [ -n "${GITHUB_TOKEN_FILE:-}" ]; then
+                    if [ ! -f "$GITHUB_TOKEN_FILE" ]; then
+                        echo "Error: GitHub token file not found at $GITHUB_TOKEN_FILE" >&2
+                        exit 1
+                    fi
+
+                    echo "Using GitHub token from $GITHUB_TOKEN_FILE"
+                    GITHUB_TOKEN_SECRET_ARG=(--secret id=github_token,src="$GITHUB_TOKEN_FILE")
+                fi
+
                 docker buildx build \
                     --build-arg BUILDKIT_INLINE_CACHE=1 \
                     --load \
                     --progress=plain \
                     ${DOCKER_PLATFORM_ARGS} \
+                    "${GITHUB_TOKEN_SECRET_ARG[@]}" \
                     -f ${DOCKERFILE} \
                     --label "system-tests-library=${TEST_LIBRARY}" \
                     --label "system-tests-weblog-variant=${WEBLOG_VARIANT}" \
@@ -269,6 +283,7 @@ while [[ "$#" -gt 0 ]]; do
         -c|--cache-mode) DOCKER_CACHE_MODE="$2"; shift ;;
         -p|--docker-platform) DOCKER_PLATFORM="--platform $2"; shift ;;
         -s|--save-to-binaries) SAVE_TO_BINARIES=1 ;;
+        --github-token-file) GITHUB_TOKEN_FILE="$2"; shift ;;
         --binary-url) BINARY_URL="$2"; shift ;;
         --binary-path) BINARY_PATH="$2"; shift ;;
         --list-libraries) COMMAND=list-libraries ;;
@@ -291,6 +306,7 @@ BUILD_IMAGES="${BUILD_IMAGES:-${DEFAULT_BUILD_IMAGES}}"
 TEST_LIBRARY="${TEST_LIBRARY:-${DEFAULT_TEST_LIBRARY}}"
 BINARY_PATH="${BINARY_PATH:-}"
 BINARY_URL="${BINARY_URL:-}"
+GITHUB_TOKEN_FILE="${GITHUB_TOKEN_FILE:-}"
 
 if [[ "${BUILD_IMAGES}" =~ /weblog/ && ! -d "${SCRIPT_DIR}/docker/${TEST_LIBRARY}" ]]; then
     echo "Library ${TEST_LIBRARY} not found"

--- a/utils/build/docker/dotnet/poc.Dockerfile
+++ b/utils/build/docker/dotnet/poc.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 # install dd-trace-dotnet (must be done before setting LD_PRELOAD)
 COPY utils/build/docker/dotnet/install_ddtrace.sh binaries/ /binaries/
-RUN /binaries/install_ddtrace.sh
+RUN --mount=type=secret,id=github_token /binaries/install_ddtrace.sh
 
 # Enable Datadog .NET SDK
 ENV CORECLR_ENABLE_PROFILING=1

--- a/utils/build/docker/dotnet/uds.Dockerfile
+++ b/utils/build/docker/dotnet/uds.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 # install dd-trace-dotnet (must be done before setting LD_PRELOAD)
 COPY utils/build/docker/dotnet/install_ddtrace.sh binaries/ /binaries/
-RUN /binaries/install_ddtrace.sh
+RUN --mount=type=secret,id=github_token /binaries/install_ddtrace.sh
 
 # Enable Datadog .NET SDK
 ENV CORECLR_ENABLE_PROFILING=1


### PR DESCRIPTION
## Motivation

Some weblog requires few github API call to build, and we may hit rate limit if those calls are not authenticated

## Changes

Add a `--github-token-file` parameter to `build.sh`, an properly send the value to docker build using `--secert` parameter

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
