### PR TITLE
[Python] parametric: update python app to match sampling changes

### DIFF
--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -711,11 +711,13 @@ def get_ddtrace_version() -> Tuple[int, int, int]:
 def _global_sampling_rate():
     for rule in ddtrace.tracer._sampler.rules:
         if (
-            rule.service == SamplingRule.NO_RULE
-            and rule.name == SamplingRule.NO_RULE
-            and rule.resource == SamplingRule.NO_RULE
-            and rule.tags == SamplingRule.NO_RULE
-            and rule.provenance == "default"
+            # Note: SamplingRule.NO_RULE was removed in ddtrace v3.12.0
+            # but we keep it here for compatibility with older versions
+            rule.service == getattr(SamplingRule, "NO_RULE", None)
+            and rule.name == getattr(SamplingRule, "NO_RULE", None)
+            and rule.resource == getattr(SamplingRule, "NO_RULE", None)
+            and rule.tags == getattr(SamplingRule, "NO_RULE", {})
+            and rule.provenance in ("default", None)
         ):
             return rule.sample_rate
     return 1.0


### PR DESCRIPTION
## Motivation

Update python parametric app to support https://github.com/DataDog/dd-trace-py/pull/14126

## Changes

- Find default sampling rule by matching on SamplingRule.NO_RULE for older tracers and None for the next release of ddtrace. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
