### PR TITLE
[dotnet] update dotnet capabilities for DI

### DIFF
--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -253,6 +253,7 @@ DEFAULT_SUPPORTED_CAPABILITIES_BY_LANG: dict[str, set[Capabilities]] = {
 class TestDynamicConfigTracingEnabled:
     @parametrize("library_env", [{**DEFAULT_ENVVARS}])
     @bug(context.library == "java", reason="APMAPI-1225")
+    @missing_feature(context.library < "dotnet@3.28.0", reason="Added new capabilities", force_skip=True)
     def test_default_capability_completeness(self, library_env, test_agent, test_library):
         """Ensure the RC request contains the expected default capabilities per language, no more and no less."""
         if context.library is not None and context.library.name is not None:

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -224,6 +224,10 @@ DEFAULT_SUPPORTED_CAPABILITIES_BY_LANG: dict[str, set[Capabilities]] = {
         Capabilities.APM_TRACING_ENABLED,
         Capabilities.APM_TRACING_SAMPLE_RULES,
         Capabilities.ASM_AUTO_USER_INSTRUM_MODE,
+        Capabilities.APM_TRACING_ENABLE_DYNAMIC_INSTRUMENTATION,
+        Capabilities.APM_TRACING_ENABLE_EXCEPTION_REPLAY,
+        Capabilities.APM_TRACING_ENABLE_CODE_ORIGIN,
+        Capabilities.APM_TRACING_ENABLE_LIVE_DEBUGGING,
     },
     "cpp": {
         Capabilities.APM_TRACING_SAMPLE_RATE,


### PR DESCRIPTION
## Motivation

The dotnet tracer adds new RC capabilities for remote enabling DI products. This PR add those capabilies to the dotnet `DEFAULT_SUPPORTED_CAPABILITIES_BY_LANG` 

## Changes

`Capabilities.APM_TRACING_ENABLE_DYNAMIC_INSTRUMENTATION,
        Capabilities.APM_TRACING_ENABLE_EXCEPTION_REPLAY,
        Capabilities.APM_TRACING_ENABLE_CODE_ORIGIN,
        Capabilities.APM_TRACING_ENABLE_LIVE_DEBUGGING,`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
