### PR TITLE
[python] make sure that xmltodict is installed for fastapi

### DIFF
--- a/utils/build/build_python_base_images.sh
+++ b/utils/build/build_python_base_images.sh
@@ -4,19 +4,19 @@
 
 
 
-docker buildx build --load --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v1 .
-docker buildx build --load --progress=plain -f utils/build/docker/python/fastapi.base.Dockerfile -t datadog/system-tests:fastapi.base-v4 .
-docker buildx build --load --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v6 .
-docker buildx build --load --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v4 .
-docker buildx build --load --progress=plain -f utils/build/docker/python/flask-poc.base.Dockerfile -t datadog/system-tests:flask-poc.base-v9 .
-docker buildx build --load --progress=plain -f utils/build/docker/python/uwsgi-poc.base.Dockerfile -t datadog/system-tests:uwsgi-poc.base-v5 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v2 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/fastapi.base.Dockerfile -t datadog/system-tests:fastapi.base-v5 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v7 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v5 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/flask-poc.base.Dockerfile -t datadog/system-tests:flask-poc.base-v10 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/uwsgi-poc.base.Dockerfile -t datadog/system-tests:uwsgi-poc.base-v6 .
 
 if [ "$1" = "--push" ]; then
-      docker push datadog/system-tests:django-py3.13.base-v1
-      docker push datadog/system-tests:fastapi.base-v4
-      docker push datadog/system-tests:python3.12.base-v6
-      docker push datadog/system-tests:django-poc.base-v4
-      docker push datadog/system-tests:flask-poc.base-v9
-      docker push datadog/system-tests:uwsgi-poc.base-v5
+      docker push datadog/system-tests:django-py3.13.base-v2
+      docker push datadog/system-tests:fastapi.base-v5
+      docker push datadog/system-tests:python3.12.base-v7
+      docker push datadog/system-tests:django-poc.base-v5
+      docker push datadog/system-tests:flask-poc.base-v10
+      docker push datadog/system-tests:uwsgi-poc.base-v6
 fi
 

--- a/utils/build/docker/python/django-poc.Dockerfile
+++ b/utils/build/docker/python/django-poc.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:django-poc.base-v4
+FROM datadog/system-tests:django-poc.base-v5
 
 WORKDIR /app
 

--- a/utils/build/docker/python/django-poc.base.Dockerfile
+++ b/utils/build/docker/python/django-poc.base.Dockerfile
@@ -9,7 +9,7 @@ RUN python --version && curl --version
 # install python deps
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install --upgrade pip
-RUN pip install django pycryptodome gunicorn==21.2.0 gevent requests 'moto[ec2,s3,all]'==5.0.14 boto3==1.34.141
+RUN pip install django pycryptodome gunicorn==21.2.0 gevent requests 'moto[ec2,s3,all]'==5.0.14 boto3==1.34.141 xmltodict==0.14.2
 
 # Install Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y

--- a/utils/build/docker/python/django-py3.13.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:django-py3.13.base-v1
+FROM datadog/system-tests:django-py3.13.base-v2
 
 WORKDIR /app
 

--- a/utils/build/docker/python/django-py3.13.base.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.base.Dockerfile
@@ -9,7 +9,7 @@ RUN python --version && curl --version
 # install python deps
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install --upgrade pip
-RUN pip install django pycryptodome gunicorn gevent requests boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14
+RUN pip install django pycryptodome gunicorn gevent requests boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2
 
 # Install Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y

--- a/utils/build/docker/python/fastapi.Dockerfile
+++ b/utils/build/docker/python/fastapi.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:fastapi.base-v4
+FROM datadog/system-tests:fastapi.base-v5
 
 WORKDIR /app
 

--- a/utils/build/docker/python/fastapi.Dockerfile
+++ b/utils/build/docker/python/fastapi.Dockerfile
@@ -4,8 +4,6 @@ WORKDIR /app
 
 COPY utils/build/docker/python/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
-RUN python3.11 -m pip install --upgrade pip
-RUN python3.11 -m pip install PyYAML uvicorn requests psycopg2-binary python-multipart itsdangerous xmltodict
 
 COPY utils/build/docker/python/fastapi/app.sh /app/app.sh
 COPY utils/build/docker/python/fastapi/main.py /app/main.py

--- a/utils/build/docker/python/fastapi.Dockerfile
+++ b/utils/build/docker/python/fastapi.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY utils/build/docker/python/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 RUN python3.11 -m pip install --upgrade pip
-RUN python3.11 -m pip install PyYAML uvicorn requests psycopg2-binary python-multipart itsdangerous
+RUN python3.11 -m pip install PyYAML uvicorn requests psycopg2-binary python-multipart itsdangerous xmltodict
 
 COPY utils/build/docker/python/fastapi/app.sh /app/app.sh
 COPY utils/build/docker/python/fastapi/main.py /app/main.py

--- a/utils/build/docker/python/fastapi.base.Dockerfile
+++ b/utils/build/docker/python/fastapi.base.Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && apt-get install -y curl git gcc g++ make cmake
 RUN python --version && curl --version
 
 # install python deps
-RUN pip install fastapi uvicorn cryptography==42.0.8 pycryptodome python-multipart jinja2
+RUN pip install --upgrade pip
+RUN pip install PyYAML fastapi uvicorn requests cryptography==42.0.8 pycryptodome python-multipart jinja2 psycopg2-binary itsdangerous xmltodict==0.14.2
 
 # Install Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y

--- a/utils/build/docker/python/flask-poc.Dockerfile
+++ b/utils/build/docker/python/flask-poc.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:flask-poc.base-v9
+FROM datadog/system-tests:flask-poc.base-v10
 
 WORKDIR /app
 

--- a/utils/build/docker/python/flask-poc.base.Dockerfile
+++ b/utils/build/docker/python/flask-poc.base.Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update \
 RUN apt update && apt install -y pkg-config default-libmysqlclient-dev pkg-config
 
 #pip install driver pymysql and pyodbc(mssql)
-RUN pip install pymysql==1.1.1 cryptography==42.0.8 pyodbc==5.1.0 'moto[ec2,s3,all]'==5.0.14
+RUN pip install --upgrade pip
+RUN pip install pymysql==1.1.1 cryptography==42.0.8 pyodbc==5.1.0 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2
 
 # install python deps
 # Tracer does not support flask 2.3.0 or higher, pin the flask version for now

--- a/utils/build/docker/python/python3.12.Dockerfile
+++ b/utils/build/docker/python/python3.12.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:python3.12.base-v6
+FROM datadog/system-tests:python3.12.base-v7
 
 WORKDIR /app
 

--- a/utils/build/docker/python/python3.12.base.Dockerfile
+++ b/utils/build/docker/python/python3.12.base.Dockerfile
@@ -9,7 +9,7 @@ RUN python --version && curl --version
 # install python deps
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install --upgrade pip
-RUN pip install django pycryptodome gunicorn gevent requests boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14
+RUN pip install django pycryptodome gunicorn gevent requests boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2
 
 # Install Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y

--- a/utils/build/docker/python/uds-flask.Dockerfile
+++ b/utils/build/docker/python/uds-flask.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:flask-poc.base-v9
+FROM datadog/system-tests:flask-poc.base-v10
 
 WORKDIR /app
 

--- a/utils/build/docker/python/uwsgi-poc.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:uwsgi-poc.base-v5
+FROM datadog/system-tests:uwsgi-poc.base-v6
 
 WORKDIR /app
 

--- a/utils/build/docker/python/uwsgi-poc.base.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.base.Dockerfile
@@ -11,8 +11,9 @@ RUN apt update && apt install -y pkg-config default-libmysqlclient-dev pkg-confi
 
 # install python deps
 # Tracer does not support flask 2.3.0 or higher, pin the flask version for now
+RUN pip install --upgrade pip
 RUN pip install 'flask[async]'==2.2.4 flask-login==0.6.3 uWSGI==2.0.26 gevent==24.2.1 requests==2.32.3 pycryptodome==3.20.0 psycopg2-binary==2.9.9 confluent-kafka==2.1.1 graphene==3.4.3
-RUN pip install 'moto[ec2,s3,all]'==5.0.14
+RUN pip install 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2
 RUN pip install boto3==1.34.141 kombu==5.3.7 mock==5.1.0 asyncpg==0.29.0 aiomysql==0.2.0 mysql-connector-python==9.0.0 mysqlclient==2.2.4 urllib3==1.26.19 PyMySQL==1.1.1
 
 # Install Rust toolchain


### PR DESCRIPTION
## Motivation

xmltodict is used in the python weblogs but not installed. It works now because it's a transitive dependency of the python tracer, but will fail if the tracer is dropping it.

## Changes

This PR install xmltodict explicitely in the weblog base images.
Also small install refactor for fastapi

APPSEC-58429

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
