### PR TITLE
Add WAF empty config system tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -410,6 +410,7 @@ tests/:
     test_remote_config_rule_changes.py:
       Test_AsmDdMultiConfiguration: missing_feature
       Test_BlockingActionChangesWithRemoteConfig: v3.4.0
+      Test_Empty_File: missing_feature
       Test_Multiple_Actions: v3.4.0
       Test_Unknown_Action: v3.4.0
       Test_UpdateRuleFileWithRemoteConfig: v3.5.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1674,6 +1674,9 @@ tests/:
       Test_BlockingActionChangesWithRemoteConfig:
         '*': v1.42.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      Test_Empty_File:
+        '*': missing_feature
+        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_Multiple_Actions:
         '*': v1.42.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1013,6 +1013,7 @@ tests/:
     test_remote_config_rule_changes.py:
       Test_AsmDdMultiConfiguration: *ref_5_59_0
       Test_BlockingActionChangesWithRemoteConfig: *ref_4_1_0
+      Test_Empty_File: missing_feature
       Test_Multiple_Actions: *ref_4_1_0
       Test_Unknown_Action: *ref_4_1_0
       Test_UpdateRuleFileWithRemoteConfig: *ref_3_19_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -409,6 +409,7 @@ tests/:
     test_remote_config_rule_changes.py:
       Test_AsmDdMultiConfiguration: missing_feature
       Test_BlockingActionChangesWithRemoteConfig: v1.6.2
+      Test_Empty_File: missing_feature
       Test_Multiple_Actions: v1.6.2
       Test_Unknown_Action: v1.6.2
       Test_UpdateRuleFileWithRemoteConfig: v1.6.2

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -741,6 +741,7 @@ tests/:
     test_remote_config_rule_changes.py:
       Test_AsmDdMultiConfiguration: v3.10.0.dev (partial support in v3.9.0)
       Test_BlockingActionChangesWithRemoteConfig: v2.10.1
+      Test_Empty_File: missing_feature
       Test_Multiple_Actions: v2.10.1
       Test_Unknown_Action: v2.10.1
       Test_UpdateRuleFileWithRemoteConfig: v2.16.0-rc (v2.11.0 but added telemetry and span tag support in 2.16)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -567,6 +567,7 @@ tests/:
     test_remote_config_rule_changes.py:
       Test_AsmDdMultiConfiguration: missing_feature
       Test_BlockingActionChangesWithRemoteConfig: missing_feature (the test relies on remote AppSec activation)
+      Test_Empty_File: missing_feature (the test relies on remote AppSec activation)
       Test_Multiple_Actions: missing_feature (the test relies on remote AppSec activation)
       Test_Unknown_Action: missing_feature (the test relies on remote AppSec activation)
       Test_UpdateRuleFileWithRemoteConfig: missing_feature (the test relies on remote AppSec activation)


### PR DESCRIPTION
## Motivation

Currently, a backend bug allows empty remote configuration to reach the WAF. This test is necessary to verify that tracers properly filter out such configurations.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
