### PR TITLE
AAP service activation origin configuration metric

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -424,8 +424,10 @@ tests/:
       Test_RuntimeActivation: v2.16.0
       Test_RuntimeDeactivation: v2.16.0
     test_service_activation_metric.py:
+      TestServiceActivationEnvVarConfigurationMetric: missing_feature
       TestServiceActivationEnvVarMetric: missing_feature
       TestServiceActivationRemoteConfigMetric: missing_feature
+      TestServiceActivationRemoteConfigurationConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -495,8 +495,10 @@ tests/:
       Test_RuntimeActivation: v1.69.0
       Test_RuntimeDeactivation: v1.69.0
     test_service_activation_metric.py:
+      TestServiceActivationEnvVarConfigurationMetric: missing_feature
       TestServiceActivationEnvVarMetric: missing_feature
       TestServiceActivationRemoteConfigMetric: missing_feature
+      TestServiceActivationRemoteConfigurationConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1722,8 +1722,10 @@ tests/:
         play: v1.22.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
     test_service_activation_metric.py:
+      TestServiceActivationEnvVarConfigurationMetric: missing_feature
       TestServiceActivationEnvVarMetric: missing_feature
       TestServiceActivationRemoteConfigMetric: missing_feature
+      TestServiceActivationRemoteConfigurationConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution:
         '*': v1.2.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1032,8 +1032,10 @@ tests/:
       Test_RuntimeActivation: *ref_3_9_0
       Test_RuntimeDeactivation: *ref_3_9_0
     test_service_activation_metric.py:
+      TestServiceActivationEnvVarConfigurationMetric: missing_feature
       TestServiceActivationEnvVarMetric: *ref_5_55_0
       TestServiceActivationRemoteConfigMetric: *ref_5_55_0
+      TestServiceActivationRemoteConfigurationConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: *ref_5_3_0
     test_suspicious_attacker_blocking.py:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -421,8 +421,10 @@ tests/:
       Test_RuntimeActivation: v1.6.2
       Test_RuntimeDeactivation: v1.6.2
     test_service_activation_metric.py:
+      TestServiceActivationEnvVarConfigurationMetric: missing_feature
       TestServiceActivationEnvVarMetric: missing_feature
       TestServiceActivationRemoteConfigMetric: missing_feature
+      TestServiceActivationRemoteConfigurationConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: v0.95.0
     test_suspicious_attacker_blocking.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -757,10 +757,10 @@ tests/:
       Test_RuntimeActivation: v2.10.1
       Test_RuntimeDeactivation: v2.10.1
     test_service_activation_metric.py:
-      TestServiceActivationEnvVarConfigurationMetric: v3.12.0.dev
+      TestServiceActivationEnvVarConfigurationMetric: v3.13.0.dev
       TestServiceActivationEnvVarMetric: irrelevant (drop support in v3.12.0.dev)
       TestServiceActivationRemoteConfigMetric: irrelevant (drop support in v3.12.0.dev)
-      TestServiceActivationRemoteConfigurationConfigMetric: v3.12.0.dev
+      TestServiceActivationRemoteConfigurationConfigMetric: v3.13.0.dev
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -757,8 +757,10 @@ tests/:
       Test_RuntimeActivation: v2.10.1
       Test_RuntimeDeactivation: v2.10.1
     test_service_activation_metric.py:
-      TestServiceActivationEnvVarMetric: v3.11.0.dev
-      TestServiceActivationRemoteConfigMetric: v3.11.0.dev
+      TestServiceActivationEnvVarConfigurationMetric: v3.12.0.dev
+      TestServiceActivationEnvVarMetric: irrelevant (drop support in v3.12.0.dev)
+      TestServiceActivationRemoteConfigMetric: irrelevant (drop support in v3.12.0.dev)
+      TestServiceActivationRemoteConfigurationConfigMetric: v3.12.0.dev
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -739,10 +739,10 @@ tests/:
       Test_RuntimeActivation: v2.10.1
       Test_RuntimeDeactivation: v2.10.1
     test_service_activation_metric.py:
-      TestServiceActivationEnvVarConfigurationMetric: v3.13.0.dev
+      TestServiceActivationEnvVarConfigurationMetric: v3.12.0.dev
       TestServiceActivationEnvVarMetric: irrelevant (drop support in v3.12.0.dev)
       TestServiceActivationRemoteConfigMetric: irrelevant (drop support in v3.12.0.dev)
-      TestServiceActivationRemoteConfigurationConfigMetric: v3.13.0.dev
+      TestServiceActivationRemoteConfigurationConfigMetric: v3.12.0.dev
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -506,8 +506,10 @@ tests/:
       Test_RuntimeActivation: missing_feature
       Test_RuntimeDeactivation: missing_feature
     test_service_activation_metric.py:
+      TestServiceActivationEnvVarConfigurationMetric: missing_feature
       TestServiceActivationEnvVarMetric: missing_feature
       TestServiceActivationRemoteConfigMetric: missing_feature
+      TestServiceActivationRemoteConfigurationConfigMetric: missing_feature
     test_shell_execution.py:
       Test_ShellExecution: missing_feature
     test_suspicious_attacker_blocking.py:

--- a/tests/appsec/test_customconf.py
+++ b/tests/appsec/test_customconf.py
@@ -36,13 +36,13 @@ class Test_CorruptedRules_Telemetry:
         self.r_2 = weblog.get("/waf", params={"attack": "<script>"})
 
     def test_waf_init_and_config_errors_tags(self):
-        waf_init_series = find_series("generate-metrics", "appsec", ["waf.init"])
+        waf_init_series = find_series("appsec", ["waf.init"])
         waf_init_metric = [
             d for d in waf_init_series if "event_rules_version:unknown" in d["tags"] and "success:false" in d["tags"]
         ]
         assert waf_init_metric, "waf.init missing 'success:false' or 'event_rules_version:unknown' tag"
 
-        waf_config_errors_series = find_series("generate-metrics", "appsec", ["waf.config_errors"])
+        waf_config_errors_series = find_series("appsec", ["waf.config_errors"])
         waf_config_errors_metric = [d for d in waf_config_errors_series if "event_rules_version:unknown" in d["tags"]]
         assert waf_config_errors_metric, "waf.config_errors missing 'event_rules_version:unknown' tag"
 

--- a/tests/appsec/test_event_tracking.py
+++ b/tests/appsec/test_event_tracking.py
@@ -96,7 +96,7 @@ class Test_UserLoginSuccessEvent_Metrics:
 
     def test_user_login_success_event(self):
         # Call the user login success SDK and validate tags
-        series = find_series("generate-metrics", "appsec", ["sdk.event"])
+        series = find_series("appsec", ["sdk.event"])
 
         assert series
 
@@ -169,7 +169,7 @@ class Test_UserLoginFailureEvent_Metrics:
 
     def test_user_login_success_event(self):
         # Call the user login success SDK and validate tags
-        series = find_series("generate-metrics", "appsec", ["sdk.event"])
+        series = find_series("appsec", ["sdk.event"])
 
         assert series
 
@@ -220,7 +220,7 @@ class Test_CustomEvent_Metrics:
 
     def test_user_login_success_event(self):
         # Call the user login success SDK and validate tags
-        series = find_series("generate-metrics", "appsec", ["sdk.event"])
+        series = find_series("appsec", ["sdk.event"])
 
         assert series
 

--- a/tests/appsec/test_event_tracking_v2.py
+++ b/tests/appsec/test_event_tracking_v2.py
@@ -265,7 +265,7 @@ class BaseUserLoginSuccessEventV2Metrics:
 
         assert self.r.status_code == 200
 
-        series = find_series("generate-metrics", "appsec", ["sdk.event"])
+        series = find_series("appsec", ["sdk.event"])
 
         assert series
         assert any(validate_metric_type_and_version("login_success", "v2", s) for s in series), [
@@ -524,7 +524,7 @@ class BaseUserLoginFailureEventV2Metrics:
 
         assert self.r.status_code == 200
 
-        series = find_series("generate-metrics", "appsec", ["sdk.event"])
+        series = find_series("appsec", ["sdk.event"])
 
         assert series
         assert any(validate_metric_type_and_version("login_failure", "v2", s) for s in series), [

--- a/tests/appsec/test_remote_config_rule_changes.py
+++ b/tests/appsec/test_remote_config_rule_changes.py
@@ -222,7 +222,7 @@ class Test_UpdateRuleFileWithRemoteConfig:
         assert self.config_state_5.state == rc.ApplyState.ACKNOWLEDGED
 
         # Check for rule version in telemetry
-        series = find_series("generate-metrics", "appsec", ["waf.requests", "waf.init", "waf.updates"])
+        series = find_series("appsec", ["waf.requests", "waf.init", "waf.updates"])
         rule_versions = set()
         for s in series:
             for t in s.get("tags", ()):

--- a/tests/appsec/utils.py
+++ b/tests/appsec/utils.py
@@ -1,20 +1,32 @@
+from collections.abc import Generator
+
 from utils import interfaces
 from utils import remote_config
 from utils.dd_constants import RemoteConfigApplyState
 
 
-def find_series(request_type: str, namespace: str, metrics: list[str]) -> list:
-    series = []
+def _get_telemetry_payload(request_type: str) -> Generator:
     for data in interfaces.library.get_telemetry_data():
         content = data["request"]["content"]
         if content.get("request_type") != request_type:
             continue
-        fallback_namespace = content["payload"].get("namespace")
-        for serie in content["payload"]["series"]:
+        yield content["payload"]
+
+
+def find_series(namespace: str, metrics: list[str]) -> list:
+    series = []
+    for payload in _get_telemetry_payload("generate-metrics"):
+        fallback_namespace = payload.get("namespace")
+        for serie in payload["series"]:
             computed_namespace = serie.get("namespace", fallback_namespace)
             if computed_namespace == namespace and serie["metric"] in metrics:
                 series.append(serie)
     return series
+
+
+def find_configuration() -> Generator:
+    for payload in _get_telemetry_payload("app-client-configuration-change"):
+        yield payload.get("configuration")
 
 
 class BaseFullDenyListTest:

--- a/tests/appsec/waf/test_truncation.py
+++ b/tests/appsec/waf/test_truncation.py
@@ -47,7 +47,7 @@ class Test_Truncation:
         # * 1 of leeway depending on how leafs of the tree are counted
         assert 20 <= int(metrics["_dd.appsec.truncated.container_depth"]) <= 28
 
-        waf_requests_series = find_series("generate-metrics", "appsec", ["waf.requests"])
+        waf_requests_series = find_series("appsec", ["waf.requests"])
         has_input_truncated = any("input_truncated:true" in series["tags"] for series in waf_requests_series)
         assert has_input_truncated, "Expected at least one serie to have input_truncated:true tag"
 
@@ -57,7 +57,7 @@ class Test_Truncation:
         )
         assert all_have_input_truncated_tag, "Expected all series to have input_truncated tag"
 
-        count_series = find_series("generate-metrics", "appsec", ["waf.input_truncated"])
+        count_series = find_series("appsec", ["waf.input_truncated"])
         input_truncated = count_series[0] if count_series else None
 
         assert input_truncated is not None, "No telemetry data received for metric appsec.waf.input_truncated"


### PR DESCRIPTION
## Motivation

There was a misunderstanding with this task: it's not a telemetry metric, it's a configuration metric

Python PR: https://github.com/DataDog/dd-trace-py/pull/14198
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
