### PR TITLE
Avoid using GITHUB_TOKEN for PR creation

### DIFF
--- a/.github/chainguard/self.update-agent-protobuf.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-agent-protobuf.create-pr.sts.yaml
@@ -1,0 +1,14 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/system-tests:ref:refs/heads/main
+
+claim_pattern:
+  event_name: (workflow_dispatch|schedule)
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/system-tests/\.github/workflows/update-agent-protobuf\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write
+

--- a/.github/workflows/update-agent-protobuf.yml
+++ b/.github/workflows/update-agent-protobuf.yml
@@ -3,24 +3,28 @@ name: Update agent protobuf deserializer
 on:
   workflow_dispatch: {}
   schedule:
-    - cron:  '00 02 * * 2-6'
+    - cron: "00 02 * * 2-6"
 
 jobs:
   main:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.0'
+          go-version: "1.24.0"
       - run: sudo apt-get update
       - run: sudo apt-get -y install protobuf-compiler
       - run: protoc --version && go version
       - name: Generate descriptor
         run: utils/scripts/update_protobuf.sh
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/system-tests
+          policy: self.update-agent-protobuf.create-pr
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
@@ -28,3 +32,4 @@ jobs:
           branch: actions/update-protobuf-descriptors
           title: Update protobuf descriptors
           body: Please check locally that everything is ok before merging
+          token: ${{ steps.octo-sts.outputs.token }}


### PR DESCRIPTION
## Motivation

Using the `GITHUB_TOKEN` for creation of PRs requires an insecure repository configuration to "Allow GitHub Actions to create and approve pull requests" which allows any person with write (push) access to a repository can bypass branch protection.

## Changes

To adjust the insecure setting, we need to first move workflows using the `GITHUB_TOKEN` to create PRs to dd-octo-sts. This PR adjusts the workflow and adds the required trust policy. Settings change will be performed afterwards.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
