### PR TITLE
Add test for incorrect trace+span sampling with propagated sampling decision

### DIFF
--- a/tests/parametric/test_span_sampling.py
+++ b/tests/parametric/test_span_sampling.py
@@ -862,6 +862,7 @@ class Test_Span_Sampling:
     @bug(context.library == "php", reason="APMAPI-1545")
     @bug(context.library == "ruby", reason="APMAPI-1545")
     @bug(context.library == "python", reason="APMAPI-1545")
+    @bug(context.library == "cpp", reason="APMAPI-1545")
     @pytest.mark.parametrize(
         "library_env",
         [
@@ -935,6 +936,7 @@ class Test_Span_Sampling:
     @bug(context.library == "golang", reason="APMAPI-1545")
     @bug(context.library == "php", reason="APMAPI-1545")
     @bug(context.library == "python", reason="APMAPI-1545")
+    @bug(context.library == "cpp", reason="APMAPI-1545")
     @pytest.mark.parametrize(
         "library_env",
         [


### PR DESCRIPTION
## Motivation

I started activating some remote rules on Datadog account for Go services, and it resulted in the incorrect flagging of `ingestion_reason:remote_rule` for some traces which should be `ingestion_reason:rum`.
After digging more, I realized trace rule were applied when they shouldn't.

The added test here isn't exhaustive but catches exactly the issue I'm facing on production. I'm not sure it is the right file to put it (since it mixes spans sampling and trace sampling) but hopefully, this isn't mattering too much.


## Changes

Add test `test_single_rule_with_head_and_rule_trace_sampling_keep_019` and `test_single_rule_with_head_and_rule_trace_sampling_drop_020` to ensure trace sampling and span sampling applies properly when there is already a parent sampling decision.


Note: CI is currently red in Python because of `TestServiceActivationEnvVarMetric.test_service_activation_metric`, I'll rebase whenever it gets fixed on `main`.

