### PR TITLE
[Java] Temporarily disable oss.sonatype.org to unblock Java builds

### DIFF
--- a/utils/build/docker/java/akka-http/pom.xml
+++ b/utils/build/docker/java/akka-http/pom.xml
@@ -240,5 +240,18 @@
         </plugins>
     </build>
 
+    <!--Enable when oss.sonatype.org is available again-->
+    <!--    <repositories>-->
+    <!--        <repository>-->
+    <!--            <id>sonatype-snapshots</id>-->
+    <!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+    <!--            <releases>-->
+    <!--                <enabled>false</enabled>-->
+    <!--            </releases>-->
+    <!--            <snapshots>-->
+    <!--                <enabled>true</enabled>-->
+    <!--            </snapshots>-->
+    <!--        </repository>-->
+    <!--    </repositories>-->
 
 </project>

--- a/utils/build/docker/java/jersey-grizzly2/pom.xml
+++ b/utils/build/docker/java/jersey-grizzly2/pom.xml
@@ -201,6 +201,19 @@
         </plugins>
     </build>
 
+    <!--Enable when oss.sonatype.org is available again-->
+    <!--    <repositories>-->
+    <!--        <repository>-->
+    <!--            <id>sonatype-snapshots</id>-->
+    <!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+    <!--            <releases>-->
+    <!--                <enabled>false</enabled>-->
+    <!--            </releases>-->
+    <!--            <snapshots>-->
+    <!--                <enabled>true</enabled>-->
+    <!--            </snapshots>-->
+    <!--        </repository>-->
+    <!--    </repositories>-->
 
     <properties>
         <jersey.version>3.0.4</jersey.version>

--- a/utils/build/docker/java/parametric/pom.xml
+++ b/utils/build/docker/java/parametric/pom.xml
@@ -26,6 +26,19 @@
         <dd-trace-api.version>[1.47.0,)</dd-trace-api.version>
     </properties>
 
+    <!--Enable when oss.sonatype.org is available again-->
+    <!--    <repositories>-->
+    <!--        <repository>-->
+    <!--            <id>sonatype-snapshots</id>-->
+    <!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+    <!--            <releases>-->
+    <!--                <enabled>false</enabled>-->
+    <!--            </releases>-->
+    <!--            <snapshots>-->
+    <!--                <enabled>true</enabled>-->
+    <!--            </snapshots>-->
+    <!--        </repository>-->
+    <!--    </repositories>-->
 
     <dependencies>
         <!-- Web server -->

--- a/utils/build/docker/java/play/pom.xml
+++ b/utils/build/docker/java/play/pom.xml
@@ -209,4 +209,17 @@
             </plugin>
         </plugins>
     </build>
+    <!--Enable when oss.sonatype.org is available again-->
+    <!--    <repositories>-->
+    <!--        <repository>-->
+    <!--            <id>sonatype-snapshots</id>-->
+    <!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+    <!--            <releases>-->
+    <!--                <enabled>false</enabled>-->
+    <!--            </releases>-->
+    <!--            <snapshots>-->
+    <!--                <enabled>true</enabled>-->
+    <!--            </snapshots>-->
+    <!--        </repository>-->
+    <!--    </repositories>-->
 </project>

--- a/utils/build/docker/java/ratpack/pom.xml
+++ b/utils/build/docker/java/ratpack/pom.xml
@@ -178,6 +178,19 @@
         </plugins>
     </build>
 
+    <!--Enable when oss.sonatype.org is available again-->
+    <!--    <repositories>-->
+    <!--        <repository>-->
+    <!--            <id>sonatype-snapshots</id>-->
+    <!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+    <!--            <releases>-->
+    <!--                <enabled>false</enabled>-->
+    <!--            </releases>-->
+    <!--            <snapshots>-->
+    <!--                <enabled>true</enabled>-->
+    <!--            </snapshots>-->
+    <!--        </repository>-->
+    <!--    </repositories>-->
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/utils/build/docker/java/resteasy-netty3/pom.xml
+++ b/utils/build/docker/java/resteasy-netty3/pom.xml
@@ -199,6 +199,19 @@
         </plugins>
     </build>
 
+    <!--Enable when oss.sonatype.org is available again-->
+    <!--    <repositories>-->
+    <!--        <repository>-->
+    <!--            <id>sonatype-snapshots</id>-->
+    <!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+    <!--            <releases>-->
+    <!--                <enabled>false</enabled>-->
+    <!--            </releases>-->
+    <!--            <snapshots>-->
+    <!--                <enabled>true</enabled>-->
+    <!--            </snapshots>-->
+    <!--        </repository>-->
+    <!--    </repositories>-->
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/utils/build/docker/java/spring-boot-3-native/pom.xml
+++ b/utils/build/docker/java/spring-boot-3-native/pom.xml
@@ -23,6 +23,19 @@
         <dd-trace-api.version>[1.47.0,)</dd-trace-api.version>
     </properties>
 
+    <!--Enable when oss.sonatype.org is available again-->
+    <!--    <repositories>-->
+    <!--        <repository>-->
+    <!--            <id>sonatype-snapshots</id>-->
+    <!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+    <!--            <releases>-->
+    <!--                <enabled>false</enabled>-->
+    <!--            </releases>-->
+    <!--            <snapshots>-->
+    <!--                <enabled>true</enabled>-->
+    <!--            </snapshots>-->
+    <!--        </repository>-->
+    <!--    </repositories>-->
 
     <dependencies>
         <dependency>

--- a/utils/build/docker/java/spring-boot/pom.xml
+++ b/utils/build/docker/java/spring-boot/pom.xml
@@ -493,4 +493,17 @@
         <packaging.type>jar</packaging.type>
         <dd-trace-api.version>[1.47.0,)</dd-trace-api.version>
     </properties>
+    <!--Enable when oss.sonatype.org is available again-->
+    <!--    <repositories>-->
+    <!--        <repository>-->
+    <!--            <id>sonatype-snapshots</id>-->
+    <!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+    <!--            <releases>-->
+    <!--                <enabled>false</enabled>-->
+    <!--            </releases>-->
+    <!--            <snapshots>-->
+    <!--                <enabled>true</enabled>-->
+    <!--            </snapshots>-->
+    <!--        </repository>-->
+    <!--    </repositories>-->
 </project>

--- a/utils/build/docker/java/vertx3/pom.xml
+++ b/utils/build/docker/java/vertx3/pom.xml
@@ -187,6 +187,19 @@
         </plugins>
     </build>
 
+    <!--Enable when oss.sonatype.org is available again-->
+    <!--    <repositories>-->
+    <!--        <repository>-->
+    <!--            <id>sonatype-snapshots</id>-->
+    <!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+    <!--            <releases>-->
+    <!--                <enabled>false</enabled>-->
+    <!--            </releases>-->
+    <!--            <snapshots>-->
+    <!--                <enabled>true</enabled>-->
+    <!--            </snapshots>-->
+    <!--        </repository>-->
+    <!--    </repositories>-->
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/utils/build/docker/java/vertx4/pom.xml
+++ b/utils/build/docker/java/vertx4/pom.xml
@@ -186,6 +186,19 @@
             </plugin>
         </plugins>
     </build>
+<!--Enable when oss.sonatype.org is available again-->
+<!--    <repositories>-->
+<!--        <repository>-->
+<!--            <id>sonatype-snapshots</id>-->
+<!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+<!--            <releases>-->
+<!--                <enabled>false</enabled>-->
+<!--            </releases>-->
+<!--            <snapshots>-->
+<!--                <enabled>true</enabled>-->
+<!--            </snapshots>-->
+<!--        </repository>-->
+<!--    </repositories>-->
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/utils/build/docker/java_otel/spring-boot/pom.xml
+++ b/utils/build/docker/java_otel/spring-boot/pom.xml
@@ -488,4 +488,17 @@
         <packaging.type>jar</packaging.type>
         <dd-trace-api.version>[1.47.0,)</dd-trace-api.version>
     </properties>
+    <!--Enable when oss.sonatype.org is available again-->
+    <!--    <repositories>-->
+    <!--        <repository>-->
+    <!--            <id>sonatype-snapshots</id>-->
+    <!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+    <!--            <releases>-->
+    <!--                <enabled>false</enabled>-->
+    <!--            </releases>-->
+    <!--            <snapshots>-->
+    <!--                <enabled>true</enabled>-->
+    <!--            </snapshots>-->
+    <!--        </repository>-->
+    <!--    </repositories>-->
 </project>


### PR DESCRIPTION
## Motivation

The repository oss.sonatype.org is currently under maintenance, which is causing issues when downloading dependencies and breaking Java builds.

As a temporary workaround—and while we look for a more stable solution—the repository has been commented out to unblock the system-tests builds.

For reference, this is the original PR that introduced the repository:
https://github.com/DataDog/system-tests/pull/4310 

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
