### PR TITLE
Revert "Add non-.dev tracer flare version for Python"

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1087,7 +1087,7 @@ tests/:
       Test_TracerSCITagging: v1.12.0
       Test_TracerUniversalServiceTagging: v0.36.0
     test_tracer_flare.py:
-      TestTracerFlareV1: v3.12.0
+      TestTracerFlareV1: v3.12.0.dev
   remote_config/:
     test_remote_configuration.py:
       Test_RemoteConfigurationExtraServices: v2.1.0


### PR DESCRIPTION
Reverts DataDog/system-tests#5019

@christophe-papazian convinced me that it's wiser to have the version as .dev so it runs before the release.