### PR TITLE
config_telemetry: dotnet reports true for logs injection

### DIFF
--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -398,6 +398,7 @@ SDK_DEFAULT_STABLE_CONFIG = {
         "golang": None,
         "python": "true",
         "nodejs": "true",
+        "dotnet": "true",
     }.get(context.library.name, "false"),  # Enabled by default in ruby
 }
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

The default value of DD_LOGS_INJECTION is being changes to True. The telemetry emitted by the dotnet tracer should match this change. 

Note: Test_Stable_Config_Default test is disabled for dotnet with missing_feature flag

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
