### PR TITLE
Remove KUBERNETES_SERVICE_ACCOUNT_OVERWRITE

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,6 @@ stages:
   - system-tests-utils
 
 variables:
-    # Do not modify this - must be the repository name for Kubernetes gitlab runners to run
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: system-tests #helm-charts
     TEST: 1
 
 compute_pipeline:


### PR DESCRIPTION
<details open><summary>

# Problem
</summary>

This repo has a reference to an unused variable as can be seen by the
warning printed in the logs:
```
WARNING: KUBERNETES_SERVICE_ACCOUNT_OVERWRITE variable is no longer used.
WARNING: The service account is now auto-assigned.
```
</details>

<details open><summary>

# Solution
</summary>

Remove the service account overwrite that is no longer used.
I suspect this yaml is also exported and giving the illusion to other repos
that they overwrite the service account and have access to ci.system-tests*
SSM parameters which is not the case. Examples:
https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/1064964347
[Widget here](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%22486234852809%3Aparameter%2Fci.system-tests.fp-api-key%22%20%22AccessDeniedException%22&agg_m=count&agg_m_source=base&agg_q=%40ci.pipeline.name&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&flat_group_bys=true&messageDisplay=inline&refresh_mode=sliding&sort_m=count&sort_t=count&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=timeseries&x_missing=true&from_ts=1754314999664&to_ts=1754487799664&live=true)

</details>
