### PR TITLE
Add force-execute input in official workflow

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: ''
+      force_execute:
+        description: "List of nodeid to force execute, separated by comma"
+        required: false
+        type: string
+        default: ''
       binaries_artifact:
         description: "Artifact name containing the binaries to test"
         default: ''
@@ -85,6 +90,7 @@ jobs:
       SYSTEM_TESTS_REPORT_ENVIRONMENT: ${{ inputs.ci_environment }}
       SYSTEM_TESTS_REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       SYSTEM_TESTS_SKIP_EMPTY_SCENARIO: ${{ inputs.skip_empty_scenarios }}
+      SYSTEM_TESTS_FORCE_EXECUTE: ${{ inputs.force_execute }}
     steps:
     - name: Compute ref
       id: compute_ref

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -11,6 +11,11 @@ on:
         default: ''
         required: false
         type: string
+      force_execute:
+        description: "List of nodeid to force execute, separated by comma"
+        required: false
+        type: string
+        default: ''
       ci_environment:
         description: "Which CI environment is running the tests, used for FPD"
         default: 'custom'
@@ -70,6 +75,7 @@ jobs:
     env:
       SYSTEM_TESTS_REPORT_ENVIRONMENT: ${{ inputs.ci_environment }}
       SYSTEM_TESTS_REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      SYSTEM_TESTS_FORCE_EXECUTE: ${{ inputs.force_execute }}
     steps:
       - name: Compute ref
         id: compute_ref

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -29,6 +29,11 @@ on:
         default: ''
         required: false
         type: string
+      force_execute:
+        description: "List of nodeid to force execute, separated by comma"
+        required: false
+        type: string
+        default: ''
       binaries_artifact:
         description: "Artifact name containing the binaries to test"
         default: ''
@@ -132,6 +137,7 @@ jobs:
       library: ${{ inputs.library }}
       ref: ${{ inputs.ref }}
       binaries_artifact: ${{ needs.compute_parameters.outputs.binaries_artifact }}
+      force_execute: ${{ inputs.force_execute }}
       ci_environment: ${{ needs.compute_parameters.outputs.ci_environment }}
       job_count: ${{ inputs.parametric_job_count }}
       job_matrix: ${{ needs.compute_parameters.outputs.parametric_job_matrix }}
@@ -232,6 +238,7 @@ jobs:
       weblog: ${{ matrix.job.weblog }}
       weblog_instance: ${{ matrix.job.weblog_instance }}
       scenarios: ${{ toJson(matrix.job.scenarios) }}
+      force_execute: ${{ inputs.force_execute }}
       build_buddies_images: ${{ inputs.build_buddies_images }}
       build_proxy_image: ${{ inputs.build_proxy_image }}
       binaries_artifact: binaries_${{ needs.compute_parameters.outputs.ci_environment }}_${{ inputs.library }}_${{ matrix.job.weblog }}_${{ needs.compute_parameters.outputs.unique_id }}

--- a/conftest.py
+++ b/conftest.py
@@ -145,6 +145,12 @@ def pytest_configure(config: pytest.Config) -> None:
     ):
         config.option.skip_empty_scenario = True
 
+    if not config.option.force_execute and "SYSTEM_TESTS_FORCE_EXECUTE" in os.environ:
+        config.option.force_execute = os.environ["SYSTEM_TESTS_FORCE_EXECUTE"].strip().split(",")
+
+    # clean input
+    config.option.force_execute = [item.strip() for item in config.option.force_execute]
+
     # First of all, we must get the current scenario
 
     current_scenario: Scenario | None = None

--- a/conftest.py
+++ b/conftest.py
@@ -149,7 +149,7 @@ def pytest_configure(config: pytest.Config) -> None:
         config.option.force_execute = os.environ["SYSTEM_TESTS_FORCE_EXECUTE"].strip().split(",")
 
     # clean input
-    config.option.force_execute = [item.strip() for item in config.option.force_execute]
+    config.option.force_execute = [item.strip() for item in config.option.force_execute if len(item.strip()) != 0]
 
     # First of all, we must get the current scenario
 
@@ -171,6 +171,7 @@ def pytest_configure(config: pytest.Config) -> None:
         config.option.xmlpath = f"{context.scenario.host_log_folder}/reportJunit.xml"
 
     configure_decorators(config)
+    logger.info(f"Force execute: {config.option.force_execute}")
 
 
 # Called at the very begening

--- a/tests/test_the_test/test_features.py
+++ b/tests/test_the_test/test_features.py
@@ -6,10 +6,6 @@ from .utils import run_system_tests
 FILENAME = "tests/test_the_test/test_features.py"
 
 
-def execute_process(forced_test):
-    return run_system_tests(test_path=FILENAME, forced_test=forced_test)
-
-
 @scenarios.mock_the_test
 @features.not_reported
 def test_schemas():

--- a/tests/test_the_test/test_force_option.py
+++ b/tests/test_the_test/test_force_option.py
@@ -1,3 +1,5 @@
+import pytest
+
 from utils import bug, irrelevant, scenarios
 
 from .utils import run_system_tests
@@ -5,37 +7,60 @@ from .utils import run_system_tests
 FILENAME = "tests/test_the_test/test_force_option.py"
 
 
-def execute_process(forced_test):
-    return run_system_tests(test_path=FILENAME, forced_test=forced_test)
+def execute_process(scenario=scenarios.mock_the_test, forced_test=None, env: dict[str, str] | None = None):
+    return run_system_tests(scenario=scenario.name, test_path=FILENAME, forced_test=forced_test, env=env)
 
 
 @scenarios.test_the_test
 class Test_ForceOption:
     def test_force_bug(self):
         nodeid = f"{FILENAME}::Test_Direct::test_bug"
-        tests = execute_process(nodeid)
+        tests = execute_process(forced_test=nodeid)
 
         assert tests[nodeid]["outcome"] == "passed"
 
     def test_force_irrelevant(self):
         nodeid = f"{FILENAME}::Test_Direct::test_irrelevant"
-        tests = execute_process(nodeid)
+        tests = execute_process(forced_test=nodeid)
 
         assert tests[nodeid]["outcome"] == "passed"
 
     def test_force_bug_nested(self):
         nodeid = f"{FILENAME}::Test_Bug::test_forced"
-        tests = execute_process(nodeid)
+        tests = execute_process(forced_test=nodeid)
 
         assert tests[f"{FILENAME}::Test_Bug::test_not_executed"]["outcome"] == "xpassed"
         assert tests[nodeid]["outcome"] == "passed", "The test should be forced, so not xpassed"
 
     def test_force_irrelevant_nested(self):
         nodeid = f"{FILENAME}::Test_Irrelevant::test_forced"
-        tests = execute_process(nodeid)
+        tests = execute_process(forced_test=nodeid)
 
         assert tests[f"{FILENAME}::Test_Irrelevant::test_not_executed"]["outcome"] == "skipped"
         assert tests[nodeid]["outcome"] == "passed", "The test should be forced, so not xpassed"
+
+    def test_force_in_another_scenario(self):
+        nodeid = f"{FILENAME}::Test_Another::test_main"
+
+        tests = execute_process(forced_test=nodeid)
+        assert nodeid not in tests
+
+        tests = execute_process(scenario=scenarios.mock_the_test_2, forced_test=nodeid)
+        assert nodeid in tests
+        assert tests[nodeid]["outcome"] == "passed"  # force to execute
+
+    def test_with_env(self):
+        nodeid_forced = f"{FILENAME}::Test_Another::test_main"
+        nodeid_skipped = f"{FILENAME}::Test_Another::test_skipped"
+
+        env = {"SYSTEM_TESTS_FORCE_EXECUTE": f"{nodeid_forced},<other_nodeid>"}
+
+        tests = execute_process(scenario=scenarios.mock_the_test_2, env=env)
+        assert nodeid_forced in tests
+        assert nodeid_skipped in tests
+
+        assert tests[nodeid_forced]["outcome"] == "passed"  # force to execute
+        assert tests[nodeid_skipped]["outcome"] == "xfailed"
 
 
 @bug(condition=True, reason="FAKE-001")
@@ -67,3 +92,14 @@ class Test_Direct:
     @irrelevant(condition=True)
     def test_irrelevant(self):
         assert True
+
+
+@scenarios.mock_the_test_2
+class Test_Another:
+    @bug(condition=True, reason="FAKE-001")
+    def test_main(self):
+        assert True
+
+    @bug(condition=True, reason="FAKE-001")
+    def test_skipped(self):
+        pytest.fail("Expected failure")

--- a/tests/test_the_test/test_group_rules.py
+++ b/tests/test_the_test/test_group_rules.py
@@ -21,6 +21,7 @@ def test_tracer_release():
         # list of scenario that will never be part of tracer release
         scenarios.fuzzer,
         scenarios.mock_the_test,
+        scenarios.mock_the_test_2,
         scenarios.test_the_test,
         scenarios.todo,
         # Is it targeting tracers ?

--- a/tests/test_the_test/test_strict.py
+++ b/tests/test_the_test/test_strict.py
@@ -8,7 +8,7 @@ FILENAME = "tests/test_the_test/test_strict.py"
 @scenarios.test_the_test
 class Test_StrictMode:
     def test_strict_missing_features(self):
-        tests = run_system_tests(test_path=FILENAME, xfail_strict=True)
+        tests = run_system_tests(test_path=FILENAME, xfail_strict=True, expected_return_code=1)
 
         assert tests[f"{FILENAME}::test_strict_bug"]["outcome"] == "failed"
         assert tests[f"{FILENAME}::test_strict_missing_feature"]["outcome"] == "failed"

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -29,6 +29,7 @@ class _Scenarios:
     todo = Scenario("TODO", doc="scenario that skips tests not yet executed", github_workflow=None)
     test_the_test = TestTheTestScenario("TEST_THE_TEST", doc="Small scenario that check system-tests internals")
     mock_the_test = TestTheTestScenario("MOCK_THE_TEST", doc="Mock scenario that check system-tests internals")
+    mock_the_test_2 = TestTheTestScenario("MOCK_THE_TEST_2", doc="Mock scenario that check system-tests internals")
 
     default = DefaultScenario("DEFAULT")
 

--- a/utils/scripts/grep-nightly-logs.py
+++ b/utils/scripts/grep-nightly-logs.py
@@ -39,8 +39,8 @@ def main(
     branch: str = "main",
 ) -> None:
     environ = get_environ()
-    gh_token = environ["GH_TOKEN"]
-    headers = {"Authorization": f"token {gh_token}"}
+    github_token = environ["GITHUB_TOKEN"]
+    headers = {"Authorization": f"token {github_token}"}
 
     url = f"https://api.github.com/repos/{repo_slug}/actions/workflows/{workflow_file}/runs?"
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
