### PR TITLE
process-discovery: Fix test for nodejs

### DIFF
--- a/tests/parametric/test_process_discovery.py
+++ b/tests/parametric/test_process_discovery.py
@@ -1,5 +1,7 @@
 """Test the instrumented process discovery mechanism feature."""
 
+import os
+import re
 import pytest
 import json
 import msgpack
@@ -8,12 +10,44 @@ from utils import features, scenarios, context
 from utils._context.component_version import Version
 
 
-def find_dd_memfds(test_library, pid: int) -> list[str]:
-    rc, out = test_library.container_exec_run(f"find /proc/{pid}/fd -lname '/memfd:datadog-tracer-info*'")
-    if not rc:
+def find_dd_memfds(test_library) -> list[str]:
+    # We don't know the pid of the process we're instrumenting, so we need to
+    # search for the memfd file in all running processes. We're in a container
+    # so we only have processes involved in the test so this should be safe.
+    #
+    # Get a list of running pids first and then check the fds for each of them,
+    # since running find on the entire /proc directory errors out without
+    # returning any results.
+    _, out = test_library.container_exec_run("ls /proc")
+    # Ignore return code since it could fail if files disappear mid-way
+    if not out:
         return []
 
-    return out.split()
+    for pid in out.split():
+        if not pid.isdigit():
+            continue
+
+        base = f"/proc/{pid}/fd"
+        _, ls = test_library.container_exec_run(f"ls -l {base}")
+        if not ls:
+            continue
+
+        found = []
+        for line in ls.splitlines():
+            # lrwx------ 1 root root 64 Aug 11 11:59 141 -> /memfd:datadog-tracer-info-VtF1ucAJ (deleted)
+            match = re.search(r"(\d+) -> (.*)", line)
+            if not match:
+                continue
+
+            fd = match.group(1)
+            target = match.group(2)
+
+            if target.startswith("/memfd:datadog-tracer-info"):
+                found.append(os.path.join(base, fd))
+
+        return found
+
+    return []
 
 
 def validate_schema(payload: str) -> bool:
@@ -65,10 +99,7 @@ class Test_ProcessDiscovery:
     def test_metadata_content(self, test_library, library_env):
         """Verify the content of the memfd file matches the expected metadata format and structure"""
         with test_library:
-            # NOTE(@dmehala): the server is started on container is always pid 1.
-            # That's a strong assumption :hehe:
-            # Maybe we should use `pidof pidof parametric-http-server` instead.
-            memfds = find_dd_memfds(test_library, 1)
+            memfds = find_dd_memfds(test_library)
             assert len(memfds) == 1
 
             rc, tracer_metadata = read_memfd(test_library, memfds[0])


### PR DESCRIPTION
## Motivation


Discovered while trying to test https://github.com/DataDog/dd-trace-js/pull/6228

## Changes

The assumption that pid 1 is the traced process doesn't hold, fix it.

Note that currently the nodejs test is (1) still marked as missing feature and (2) still fails due to a bug in the tracer implementation (will be fixed in an upcoming release).

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
