### PR TITLE
Add the dimension of feature owner

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -227,6 +227,7 @@ def _collect_item_metadata(item: pytest.Item):
         "details": details,
         "testDeclaration": test_declaration,
         "features": [marker.kwargs["feature_id"] for marker in item.iter_markers("features")],
+        "owners": list({marker.kwargs["owner"] for marker in item.iter_markers("owners")}),
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ junit_suite_name = "system_tests_suite"
 
 markers =[
     "scenario: run a test only for a specified scenario",
-    "features: declare the feature id"
+    "features: declare the feature id",
+    "owners: declare the owner of the test",
 ]
 
 python_files = "test_*.py *utils.py"

--- a/tests/test_miscs.py
+++ b/tests/test_miscs.py
@@ -2,10 +2,15 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2022 Datadog, Inc.
 
-from utils import weblog, interfaces, features
+from utils import weblog, interfaces, features, context
+
+# those tests are linked to unix_domain_sockets_support_for_traces only for UDS weblogs
+optional_uds_feature = (
+    features.unix_domain_sockets_support_for_traces if "uds" not in context.weblog_variant else features.not_reported
+)
 
 
-@features.unix_domain_sockets_support_for_traces
+@optional_uds_feature
 class Test_Basic:
     """Make sure the spans endpoint is successful"""
 

--- a/tests/test_semantic_conventions.py
+++ b/tests/test_semantic_conventions.py
@@ -142,8 +142,14 @@ def get_component_name(weblog_variant, language, span_name):
     return expected_component
 
 
+# those tests are linked to unix_domain_sockets_support_for_traces only for UDS weblogs
+optional_uds_feature = (
+    features.unix_domain_sockets_support_for_traces if "uds" not in context.weblog_variant else features.not_reported
+)
+
+
 @features.runtime_id_in_span_metadata_for_service_entry_spans
-@features.unix_domain_sockets_support_for_traces
+@optional_uds_feature
 @features.envoy_external_processing
 @scenarios.external_processing
 @scenarios.default

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5,7 +5,13 @@ import re
 from utils import context, weblog, interfaces, features, missing_feature, logger
 
 
-@features.unix_domain_sockets_support_for_traces
+# those tests are linked to unix_domain_sockets_support_for_traces only for UDS weblogs
+optional_uds_feature = (
+    features.unix_domain_sockets_support_for_traces if "uds" not in context.weblog_variant else features.not_reported
+)
+
+
+@optional_uds_feature
 class Test_Backend:
     """Misc test around agent/backend communication"""
 
@@ -40,7 +46,7 @@ class Test_Backend:
                 raise ValueError(f"Message {data['log_filename']} uses domain {domain} instead of {expected_domain}")
 
 
-@features.unix_domain_sockets_support_for_traces
+@optional_uds_feature
 class Test_Library:
     """Misc test around library/agent communication"""
 

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -1,6 +1,20 @@
+from enum import StrEnum
 import pytest
 
-from utils._context.core import context
+
+class _Owner(StrEnum):
+    unknown = "unknown"
+    asm = "ASM"  # application security monitoring
+    rp = "RP"  # reliability & performance
+    debugger = "debugger"
+
+
+def _mark_test_object(test_object, feature_id: int, owner: _Owner):
+    """Mark the test object with a feature ID"""
+    pytest.mark.features(feature_id=feature_id)(test_object)
+    pytest.mark.owners(owner=owner.value)(test_object)
+
+    return test_object
 
 
 class _Features:
@@ -9,11 +23,14 @@ class _Features:
     Data source is the feature parity dashboard https://feature-parity.us1.prod.dog/
     """
 
+    # this design seems clumsy, a basic python model would have been simpler?
+    # the reason behind this is only to have the fancy docstring in IDE
+    # with the link to the feature parity dashboard
+
     @staticmethod
     def not_reported(test_object):
         """Use this fake feature to not report a test to feature parity dashboard"""
-        pytest.mark.features(feature_id=-1)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=-1, owner=_Owner.rp)
 
     @staticmethod
     def trace_global_tags(test_object):
@@ -21,8 +38,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=1
         """
-        pytest.mark.features(feature_id=1)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=1, owner=_Owner.unknown)
 
     @staticmethod
     def trace_agent_connection(test_object):
@@ -30,8 +46,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=2
         """
-        pytest.mark.features(feature_id=2)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=2, owner=_Owner.unknown)
 
     @staticmethod
     def add_metadata_to_spans_via_tags_dd_trace_analytics_enabled(test_object):
@@ -39,8 +54,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=3
         """
-        pytest.mark.features(feature_id=3)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=3, owner=_Owner.unknown)
 
     @staticmethod
     def trace_search_automatic_config(test_object):
@@ -48,8 +62,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=4
         """
-        pytest.mark.features(feature_id=4)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=4, owner=_Owner.unknown)
 
     @staticmethod
     def log_injection(test_object):
@@ -57,8 +70,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=5
         """
-        pytest.mark.features(feature_id=5)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=5, owner=_Owner.unknown)
 
     @staticmethod
     def unix_domain_sockets_support_for_traces(test_object):
@@ -67,12 +79,7 @@ class _Features:
         https://feature-parity.us1.prod.dog/#/?feature=6
         """
 
-        if "uds" in context.weblog_variant:
-            pytest.mark.features(feature_id=6)(test_object)
-        else:
-            pytest.mark.features(feature_id=-1)(test_object)
-
-        return test_object
+        return _mark_test_object(test_object, feature_id=6, owner=_Owner.unknown)
 
     @staticmethod
     def unix_domain_sockets_automatic_detection(test_object):
@@ -80,8 +87,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=7
         """
-        pytest.mark.features(feature_id=7)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=7, owner=_Owner.unknown)
 
     @staticmethod
     def twl_customer_controls_ingestion_dd_trace_sampling_rules(test_object):
@@ -89,8 +95,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=8
         """
-        pytest.mark.features(feature_id=8)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=8, owner=_Owner.unknown)
 
     @staticmethod
     def synthetic_apm_http_header_span_tag_x_datadog_origin(test_object):
@@ -98,8 +103,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=9
         """
-        pytest.mark.features(feature_id=9)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=9, owner=_Owner.unknown)
 
     @staticmethod
     def log_tracer_status_at_startup(test_object):
@@ -107,8 +111,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=10
         """
-        pytest.mark.features(feature_id=10)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=10, owner=_Owner.unknown)
 
     @staticmethod
     def fargate_14_tagging_support(test_object):
@@ -116,8 +119,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=11
         """
-        pytest.mark.features(feature_id=11)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=11, owner=_Owner.unknown)
 
     @staticmethod
     def container_tagging(test_object):
@@ -125,8 +127,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=12
         """
-        pytest.mark.features(feature_id=12)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=12, owner=_Owner.unknown)
 
     @staticmethod
     def b3_headers_propagation(test_object):
@@ -134,8 +135,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=13
         """
-        pytest.mark.features(feature_id=13)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=13, owner=_Owner.unknown)
 
     @staticmethod
     def unix_domain_sockets_support_for_metrics(test_object):
@@ -143,8 +143,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=14
         """
-        pytest.mark.features(feature_id=14)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=14, owner=_Owner.unknown)
 
     @staticmethod
     def support_ddmeasured(test_object):
@@ -152,8 +151,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=15
         """
-        pytest.mark.features(feature_id=15)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=15, owner=_Owner.unknown)
 
     @staticmethod
     def dd_service_mapping(test_object):
@@ -161,8 +159,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=16
         """
-        pytest.mark.features(feature_id=16)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=16, owner=_Owner.unknown)
 
     @staticmethod
     def dogstatsd_agent_connection(test_object):
@@ -170,8 +167,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=17
         """
-        pytest.mark.features(feature_id=17)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=17, owner=_Owner.unknown)
 
     @staticmethod
     def http_headers_as_tags_dd_trace_header_tags(test_object):
@@ -179,8 +175,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=18
         """
-        pytest.mark.features(feature_id=18)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=18, owner=_Owner.unknown)
 
     @staticmethod
     def dd_profiling_enabled(test_object):
@@ -188,8 +183,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=19
         """
-        pytest.mark.features(feature_id=19)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=19, owner=_Owner.unknown)
 
     @staticmethod
     def dogstatsd_unified_service_tagging(test_object):
@@ -197,8 +191,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=20
         """
-        pytest.mark.features(feature_id=20)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=20, owner=_Owner.unknown)
 
     @staticmethod
     def trace_log_exporting_for_aws_lambda(test_object):
@@ -206,8 +199,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=21
         """
-        pytest.mark.features(feature_id=21)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=21, owner=_Owner.unknown)
 
     @staticmethod
     def runtime_id_in_span_metadata_for_service_entry_spans(test_object):
@@ -215,8 +207,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=22
         """
-        pytest.mark.features(feature_id=22)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=22, owner=_Owner.unknown)
 
     @staticmethod
     def partial_flush(test_object):
@@ -224,8 +215,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=23
         """
-        pytest.mark.features(feature_id=23)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=23, owner=_Owner.unknown)
 
     @staticmethod
     def partial_flush_on_by_default(test_object):
@@ -233,8 +223,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=24
         """
-        pytest.mark.features(feature_id=24)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=24, owner=_Owner.unknown)
 
     @staticmethod
     def automatic_trace_id_injection_into_logs(test_object):
@@ -242,8 +231,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=25
         """
-        pytest.mark.features(feature_id=25)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=25, owner=_Owner.unknown)
 
     @staticmethod
     def mapping_http_status_codes_to_errors(test_object):
@@ -251,8 +239,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=26
         """
-        pytest.mark.features(feature_id=26)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=26, owner=_Owner.unknown)
 
     @staticmethod
     def log_pipelines_updated_for_log_injection(test_object):
@@ -260,16 +247,14 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=27
         """
-        pytest.mark.features(feature_id=27)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=27, owner=_Owner.unknown)
 
     @staticmethod
     def inject_service_env_version_into_logs(test_object):
         """Inject service, env, version into logs
         https://feature-parity.us1.prod.dog/#/?feature=28
         """
-        pytest.mark.features(feature_id=28)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=28, owner=_Owner.unknown)
 
     @staticmethod
     def top_level_detection_in_tracer(test_object):
@@ -277,8 +262,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=29
         """
-        pytest.mark.features(feature_id=29)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=29, owner=_Owner.unknown)
 
     @staticmethod
     def use_sampling_priorities_2_1_in_rules_based_sampler(test_object):
@@ -286,8 +270,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=30
         """
-        pytest.mark.features(feature_id=30)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=30, owner=_Owner.unknown)
 
     @staticmethod
     def trace_annotation(test_object):
@@ -295,8 +278,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=31
         """
-        pytest.mark.features(feature_id=31)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=31, owner=_Owner.unknown)
 
     @staticmethod
     def runtime_metrics(test_object):
@@ -304,8 +286,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=32
         """
-        pytest.mark.features(feature_id=32)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=32, owner=_Owner.unknown)
 
     @staticmethod
     def logs_throttling(test_object):
@@ -313,8 +294,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=33
         """
-        pytest.mark.features(feature_id=33)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=33, owner=_Owner.unknown)
 
     @staticmethod
     def post_processing_traces(test_object):
@@ -322,8 +302,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=34
         """
-        pytest.mark.features(feature_id=34)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=34, owner=_Owner.unknown)
 
     @staticmethod
     def span_baggage_item(test_object):
@@ -331,8 +310,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=35
         """
-        pytest.mark.features(feature_id=35)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=35, owner=_Owner.unknown)
 
     @staticmethod
     def tracer_health_metrics(test_object):
@@ -340,8 +318,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=36
         """
-        pytest.mark.features(feature_id=36)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=36, owner=_Owner.unknown)
 
     @staticmethod
     def kafka_tracing(test_object):
@@ -349,8 +326,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=37
         """
-        pytest.mark.features(feature_id=37)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=37, owner=_Owner.unknown)
 
     @staticmethod
     def numeric_tags_for_trace_search_analytics_step_1(test_object):
@@ -358,8 +334,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=38
         """
-        pytest.mark.features(feature_id=38)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=38, owner=_Owner.unknown)
 
     @staticmethod
     def grpc_integration_tags(test_object):
@@ -367,8 +342,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=39
         """
-        pytest.mark.features(feature_id=39)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=39, owner=_Owner.unknown)
 
     @staticmethod
     def dd_trace_config_file(test_object):
@@ -376,8 +350,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=40
         """
-        pytest.mark.features(feature_id=40)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=40, owner=_Owner.unknown)
 
     @staticmethod
     def dd_trace_methods(test_object):
@@ -385,8 +358,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=41
         """
-        pytest.mark.features(feature_id=41)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=41, owner=_Owner.unknown)
 
     @staticmethod
     def structured_log_injection(test_object):
@@ -394,8 +366,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=42
         """
-        pytest.mark.features(feature_id=42)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=42, owner=_Owner.unknown)
 
     @staticmethod
     def report_tracer_drop_rate_ddtracer_kr(test_object):
@@ -403,8 +374,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=43
         """
-        pytest.mark.features(feature_id=43)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=43, owner=_Owner.unknown)
 
     @staticmethod
     def obfuscation_of_pii_from_web_span_resource_names(test_object):
@@ -412,8 +382,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=44
         """
-        pytest.mark.features(feature_id=44)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=44, owner=_Owner.unknown)
 
     @staticmethod
     def windows_named_pipe_support_for_traces(test_object):
@@ -421,8 +390,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=45
         """
-        pytest.mark.features(feature_id=45)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=45, owner=_Owner.unknown)
 
     @staticmethod
     def setting_to_rename_service_by_tag_split_by_tag(test_object):
@@ -430,8 +398,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=46
         """
-        pytest.mark.features(feature_id=46)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=46, owner=_Owner.unknown)
 
     @staticmethod
     def collect_application_version_information(test_object):
@@ -439,8 +406,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=47
         """
-        pytest.mark.features(feature_id=47)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=47, owner=_Owner.unknown)
 
     @staticmethod
     def ensure_that_sampling_is_consistent_across_languages(test_object):
@@ -448,8 +414,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=48
         """
-        pytest.mark.features(feature_id=48)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=48, owner=_Owner.unknown)
 
     @staticmethod
     def user_troubleshooting_tool(test_object):
@@ -457,8 +422,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=49
         """
-        pytest.mark.features(feature_id=49)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=49, owner=_Owner.unknown)
 
     @staticmethod
     def option_to_remap_apm_error_response_severity_eg_404_to_error(test_object):
@@ -466,8 +430,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=50
         """
-        pytest.mark.features(feature_id=50)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=50, owner=_Owner.unknown)
 
     @staticmethod
     def trace_query_string_obfuscation(test_object):
@@ -475,8 +438,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=51
         """
-        pytest.mark.features(feature_id=51)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=51, owner=_Owner.unknown)
 
     @staticmethod
     def dd_trace_report_hostname(test_object):
@@ -484,8 +446,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=52
         """
-        pytest.mark.features(feature_id=52)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=52, owner=_Owner.unknown)
 
     @staticmethod
     def windows_named_pipe_support_for_metrics(test_object):
@@ -493,8 +454,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=53
         """
-        pytest.mark.features(feature_id=53)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=53, owner=_Owner.unknown)
 
     @staticmethod
     def ensure_consistent_http_client_integration_tags(test_object):
@@ -502,8 +462,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=54
         """
-        pytest.mark.features(feature_id=54)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=54, owner=_Owner.unknown)
 
     @staticmethod
     def aws_sdk_integration_tags(test_object):
@@ -511,8 +470,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=55
         """
-        pytest.mark.features(feature_id=55)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=55, owner=_Owner.unknown)
 
     @staticmethod
     def dont_set_username_tag_because_its_pii(test_object):
@@ -520,8 +478,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=56
         """
-        pytest.mark.features(feature_id=56)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=56, owner=_Owner.unknown)
 
     @staticmethod
     def trace_client_app_tagging(test_object):
@@ -529,8 +486,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=57
         """
-        pytest.mark.features(feature_id=57)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=57, owner=_Owner.unknown)
 
     @staticmethod
     def client_split_by_domain_service_host(test_object):
@@ -538,8 +494,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=58
         """
-        pytest.mark.features(feature_id=58)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=58, owner=_Owner.unknown)
 
     @staticmethod
     def horizontal_propagation_of_x_datadog_tags_between_services(test_object):
@@ -547,8 +502,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=59
         """
-        pytest.mark.features(feature_id=59)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=59, owner=_Owner.unknown)
 
     @staticmethod
     def vertical_propagation_of_x_datadog_tags_onto_each_chunk_root_span(test_object):
@@ -556,8 +510,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=60
         """
-        pytest.mark.features(feature_id=60)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=60, owner=_Owner.unknown)
 
     @staticmethod
     def creation_and_propagation_of_ddpdm(test_object):
@@ -565,8 +518,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=61
         """
-        pytest.mark.features(feature_id=61)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=61, owner=_Owner.unknown)
 
     @staticmethod
     def client_side_stats_supported(test_object):
@@ -574,8 +526,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=62
         """
-        pytest.mark.features(feature_id=62)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=62, owner=_Owner.unknown)
 
     @staticmethod
     def client_side_stats_on_by_default(test_object):
@@ -583,8 +534,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=63
         """
-        pytest.mark.features(feature_id=63)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=63, owner=_Owner.unknown)
 
     @staticmethod
     def instrumentation_telemetry_enabled_by_default(test_object):
@@ -592,8 +542,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=64
         """
-        pytest.mark.features(feature_id=64)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=64, owner=_Owner.unknown)
 
     @staticmethod
     def dd_instrumentation_telemetry_enabled_supported(test_object):
@@ -601,8 +550,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=65
         """
-        pytest.mark.features(feature_id=65)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=65, owner=_Owner.unknown)
 
     @staticmethod
     def app_environment_collected(test_object):
@@ -610,8 +558,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=66
         """
-        pytest.mark.features(feature_id=66)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=66, owner=_Owner.unknown)
 
     @staticmethod
     def dependencies_collected(test_object):
@@ -619,8 +566,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=67
         """
-        pytest.mark.features(feature_id=67)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=67, owner=_Owner.unknown)
 
     @staticmethod
     def integrations_enabled_collected(test_object):
@@ -628,8 +574,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=68
         """
-        pytest.mark.features(feature_id=68)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=68, owner=_Owner.unknown)
 
     @staticmethod
     def telemetry_configurations_collected(test_object):
@@ -637,8 +582,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=69
         """
-        pytest.mark.features(feature_id=69)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=69, owner=_Owner.unknown)
 
     @staticmethod
     def telemetry_heart_beat_collected(test_object):
@@ -646,8 +590,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=70
         """
-        pytest.mark.features(feature_id=70)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=70, owner=_Owner.unknown)
 
     @staticmethod
     def app_close_collected(test_object):
@@ -655,8 +598,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=71
         """
-        pytest.mark.features(feature_id=71)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=71, owner=_Owner.unknown)
 
     @staticmethod
     def redacted_error_logs_collected(test_object):
@@ -664,8 +606,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=72
         """
-        pytest.mark.features(feature_id=72)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=72, owner=_Owner.unknown)
 
     @staticmethod
     def telemetry_metrics_collected(test_object):
@@ -673,8 +614,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=73
         """
-        pytest.mark.features(feature_id=73)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=73, owner=_Owner.unknown)
 
     @staticmethod
     def telemetry_api_v2_implemented(test_object):
@@ -682,8 +622,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=74
         """
-        pytest.mark.features(feature_id=74)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=74, owner=_Owner.unknown)
 
     @staticmethod
     def app_client_configuration_change_event(test_object):
@@ -691,8 +630,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=75
         """
-        pytest.mark.features(feature_id=75)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=75, owner=_Owner.unknown)
 
     @staticmethod
     def app_product_change_event(test_object):
@@ -700,8 +638,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=76
         """
-        pytest.mark.features(feature_id=76)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=76, owner=_Owner.unknown)
 
     @staticmethod
     def app_extended_heartbeat_event(test_object):
@@ -709,8 +646,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=77
         """
-        pytest.mark.features(feature_id=77)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=77, owner=_Owner.unknown)
 
     @staticmethod
     def telemetry_message_batch(test_object):
@@ -718,8 +654,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=78
         """
-        pytest.mark.features(feature_id=78)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=78, owner=_Owner.unknown)
 
     @staticmethod
     def telemetry_app_started_event(test_object):
@@ -727,8 +662,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=79
         """
-        pytest.mark.features(feature_id=79)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=79, owner=_Owner.unknown)
 
     @staticmethod
     def dd_telemetry_dependency_collection_enabled_supported(test_object):
@@ -736,8 +670,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=80
         """
-        pytest.mark.features(feature_id=80)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=80, owner=_Owner.unknown)
 
     @staticmethod
     def additional_http_headers_supported(test_object):
@@ -745,8 +678,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=81
         """
-        pytest.mark.features(feature_id=81)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=81, owner=_Owner.unknown)
 
     @staticmethod
     def remote_config_object_supported(test_object):
@@ -754,8 +686,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=82
         """
-        pytest.mark.features(feature_id=82)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=82, owner=_Owner.unknown)
 
     @staticmethod
     def w3c_headers_injection_and_extraction(test_object):
@@ -763,8 +694,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=83
         """
-        pytest.mark.features(feature_id=83)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=83, owner=_Owner.unknown)
 
     @staticmethod
     def otel_api(test_object):
@@ -772,8 +702,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=84
         """
-        pytest.mark.features(feature_id=84)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=84, owner=_Owner.unknown)
 
     @staticmethod
     def trace_id_128_bit_generation_propagation(test_object):
@@ -781,8 +710,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=85
         """
-        pytest.mark.features(feature_id=85)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=85, owner=_Owner.unknown)
 
     @staticmethod
     def span_events(test_object):
@@ -790,8 +718,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=86
         """
-        pytest.mark.features(feature_id=86)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=86, owner=_Owner.unknown)
 
     @staticmethod
     def span_links(test_object):
@@ -799,8 +726,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=87
         """
-        pytest.mark.features(feature_id=87)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=87, owner=_Owner.unknown)
 
     @staticmethod
     def trace_client_ip_header(test_object):
@@ -808,8 +734,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=88
         """
-        pytest.mark.features(feature_id=88)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=88, owner=_Owner.unknown)
 
     @staticmethod
     def host_auto_instrumentation(test_object):
@@ -817,8 +742,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=89
         """
-        pytest.mark.features(feature_id=89)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=89, owner=_Owner.unknown)
 
     @staticmethod
     def container_auto_instrumentation(test_object):
@@ -826,8 +750,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=90
         """
-        pytest.mark.features(feature_id=90)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=90, owner=_Owner.unknown)
 
     @staticmethod
     def collect_http_post_data_and_headers(test_object):
@@ -835,8 +758,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=94
         """
-        pytest.mark.features(feature_id=94)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=94, owner=_Owner.unknown)
 
     @staticmethod
     def weak_hash_vulnerability_detection(test_object):
@@ -844,8 +766,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=96
         """
-        pytest.mark.features(feature_id=96)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=96, owner=_Owner.unknown)
 
     @staticmethod
     def db_integrations(test_object):
@@ -853,8 +774,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=98
         """
-        pytest.mark.features(feature_id=98)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=98, owner=_Owner.unknown)
 
     @staticmethod
     def weak_cipher_detection(test_object):
@@ -862,8 +782,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=100
         """
-        pytest.mark.features(feature_id=100)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=100, owner=_Owner.unknown)
 
     @staticmethod
     def threats_alpha_preview(test_object):
@@ -871,8 +790,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=110
         """
-        pytest.mark.features(feature_id=110)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=110, owner=_Owner.unknown)
 
     @staticmethod
     def procedure_to_debug_install(test_object):
@@ -880,8 +798,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=113
         """
-        pytest.mark.features(feature_id=113)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=113, owner=_Owner.unknown)
 
     @staticmethod
     def security_events_metadata(test_object):
@@ -889,8 +806,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=124
         """
-        pytest.mark.features(feature_id=124)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=124, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_rate_limiter(test_object):
@@ -898,8 +814,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=134
         """
-        pytest.mark.features(feature_id=134)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=134, owner=_Owner.unknown)
 
     @staticmethod
     def support_in_app_waf_metrics_report(test_object):
@@ -907,8 +822,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=140
         """
-        pytest.mark.features(feature_id=140)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=140, owner=_Owner.unknown)
 
     @staticmethod
     def user_monitoring(test_object):
@@ -916,8 +830,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=141
         """
-        pytest.mark.features(feature_id=141)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=141, owner=_Owner.unknown)
 
     @staticmethod
     def event_tracking_sdk_v2(test_object):
@@ -925,8 +838,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=372
         """
-        pytest.mark.features(feature_id=372)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=372, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_service_activation_origin_metric(test_object):
@@ -934,8 +846,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=471
         """
-        pytest.mark.features(feature_id=471)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=471, owner=_Owner.unknown)
 
     @staticmethod
     def serialize_waf_rules_without_limiting_their_sizes(test_object):
@@ -943,8 +854,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=142
         """
-        pytest.mark.features(feature_id=142)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=142, owner=_Owner.unknown)
 
     @staticmethod
     def threats_configuration(test_object):
@@ -952,8 +862,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=143
         """
-        pytest.mark.features(feature_id=143)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=143, owner=_Owner.unknown)
 
     @staticmethod
     def sensitive_data_obfuscation(test_object):
@@ -961,8 +870,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=144
         """
-        pytest.mark.features(feature_id=144)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=144, owner=_Owner.unknown)
 
     @staticmethod
     def propagation_of_user_id_rfc(test_object):
@@ -970,8 +878,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=146
         """
-        pytest.mark.features(feature_id=146)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=146, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_onboarding(test_object):
@@ -979,8 +886,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=154
         """
-        pytest.mark.features(feature_id=154)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=154, owner=_Owner.unknown)
 
     @staticmethod
     def changing_rules_using_rc(test_object):
@@ -988,8 +894,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=157
         """
-        pytest.mark.features(feature_id=157)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=157, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_shell_execution_tracing(test_object):
@@ -997,8 +902,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=158
         """
-        pytest.mark.features(feature_id=158)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=158, owner=_Owner.unknown)
 
     @staticmethod
     def custom_business_logic_events(test_object):
@@ -1006,8 +910,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=161
         """
-        pytest.mark.features(feature_id=161)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=161, owner=_Owner.unknown)
 
     @staticmethod
     def graphql_threats_detection(test_object):
@@ -1015,8 +918,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=162
         """
-        pytest.mark.features(feature_id=162)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=162, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_sql_injection(test_object):
@@ -1024,8 +926,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=165
         """
-        pytest.mark.features(feature_id=165)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=165, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_code_injection(test_object):
@@ -1033,8 +934,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=315
         """
-        pytest.mark.features(feature_id=315)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=315, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_command_injection(test_object):
@@ -1042,8 +942,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=166
         """
-        pytest.mark.features(feature_id=166)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=166, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_path_traversal(test_object):
@@ -1051,8 +950,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=167
         """
-        pytest.mark.features(feature_id=167)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=167, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_ldap_injection(test_object):
@@ -1060,8 +958,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=168
         """
-        pytest.mark.features(feature_id=168)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=168, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_header_injection(test_object):
@@ -1069,8 +966,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=203
         """
-        pytest.mark.features(feature_id=203)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=203, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_template_injection(test_object):
@@ -1078,8 +974,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=330
         """
-        pytest.mark.features(feature_id=330)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=330, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_request_parameter_value(test_object):
@@ -1087,8 +982,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=169
         """
-        pytest.mark.features(feature_id=169)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=169, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_request_parameter_name(test_object):
@@ -1096,8 +990,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=170
         """
-        pytest.mark.features(feature_id=170)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=170, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_header_value(test_object):
@@ -1105,8 +998,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=171
         """
-        pytest.mark.features(feature_id=171)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=171, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_header_name(test_object):
@@ -1114,8 +1006,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=172
         """
-        pytest.mark.features(feature_id=172)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=172, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_cookie_value(test_object):
@@ -1123,8 +1014,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=173
         """
-        pytest.mark.features(feature_id=173)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=173, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_cookie_name(test_object):
@@ -1132,8 +1022,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=174
         """
-        pytest.mark.features(feature_id=174)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=174, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_body(test_object):
@@ -1141,8 +1030,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=175
         """
-        pytest.mark.features(feature_id=175)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=175, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_kafka_key(test_object):
@@ -1150,8 +1038,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=277
         """
-        pytest.mark.features(feature_id=277)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=277, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_kafka_value(test_object):
@@ -1159,8 +1046,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=278
         """
-        pytest.mark.features(feature_id=278)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=278, owner=_Owner.unknown)
 
     @staticmethod
     def iast_graphql_resolver_argument(test_object):
@@ -1168,8 +1054,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=281
         """
-        pytest.mark.features(feature_id=281)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=281, owner=_Owner.unknown)
 
     @staticmethod
     def grpc_threats_management(test_object):
@@ -1177,8 +1062,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=176
         """
-        pytest.mark.features(feature_id=176)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=176, owner=_Owner.unknown)
 
     @staticmethod
     def waf_telemetry(test_object):
@@ -1186,16 +1070,14 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=178
         """
-        pytest.mark.features(feature_id=178)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=178, owner=_Owner.unknown)
 
     @staticmethod
     def kafkaspan_creationcontext_propagation_with_dd_trace(test_object):
         """[Kafka][Span Creation][Context Propagation] with dd-trace
         https://feature-parity.us1.prod.dog/#/?feature=192
         """
-        pytest.mark.features(feature_id=192)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=192, owner=_Owner.unknown)
 
     @staticmethod
     def open_tracing_api(test_object):
@@ -1203,8 +1085,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=196
         """
-        pytest.mark.features(feature_id=196)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=196, owner=_Owner.unknown)
 
     @staticmethod
     def custom_tracing_api(test_object):
@@ -1212,8 +1093,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=197
         """
-        pytest.mark.features(feature_id=197)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=197, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_hardcoded_passwords(test_object):
@@ -1221,8 +1101,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=290
         """
-        pytest.mark.features(feature_id=290)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=290, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_hardcoded_secrets(test_object):
@@ -1230,8 +1109,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=198
         """
-        pytest.mark.features(feature_id=198)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=198, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_request_blocking(test_object):
@@ -1239,8 +1117,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=199
         """
-        pytest.mark.features(feature_id=199)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=199, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_response_blocking(test_object):
@@ -1248,8 +1125,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=200
         """
-        pytest.mark.features(feature_id=200)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=200, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_blocking_action(test_object):
@@ -1257,8 +1133,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=201
         """
-        pytest.mark.features(feature_id=201)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=201, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_truncation_action(test_object):
@@ -1266,8 +1141,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=373
         """
-        pytest.mark.features(feature_id=373)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=373, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_client_ip_blocking(test_object):
@@ -1275,8 +1149,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=202
         """
-        pytest.mark.features(feature_id=202)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=202, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_header_injection(test_object):
@@ -1284,8 +1157,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=203
         """
-        pytest.mark.features(feature_id=203)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=203, owner=_Owner.unknown)
 
     @staticmethod
     def api_security_schemas(test_object):
@@ -1293,8 +1165,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=204
         """
-        pytest.mark.features(feature_id=204)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=204, owner=_Owner.unknown)
 
     @staticmethod
     def span_links_through_datadog_api(test_object):
@@ -1302,8 +1173,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=205
         """
-        pytest.mark.features(feature_id=205)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=205, owner=_Owner.unknown)
 
     @staticmethod
     def cassandra_support(test_object):
@@ -1311,8 +1181,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=206
         """
-        pytest.mark.features(feature_id=206)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=206, owner=_Owner.unknown)
 
     @staticmethod
     def mysql_support(test_object):
@@ -1320,8 +1189,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=207
         """
-        pytest.mark.features(feature_id=207)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=207, owner=_Owner.unknown)
 
     @staticmethod
     def mssql_support(test_object):
@@ -1329,8 +1197,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=225
         """
-        pytest.mark.features(feature_id=225)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=225, owner=_Owner.unknown)
 
     @staticmethod
     def postgres_support(test_object):
@@ -1338,8 +1205,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=208
         """
-        pytest.mark.features(feature_id=208)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=208, owner=_Owner.unknown)
 
     @staticmethod
     def database_monitoring_correlation(test_object):
@@ -1347,8 +1213,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=209
         """
-        pytest.mark.features(feature_id=209)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=209, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_support_for_http(test_object):
@@ -1356,8 +1221,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=210
         """
-        pytest.mark.features(feature_id=210)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=210, owner=_Owner.unknown)
 
     @staticmethod
     def debugger(test_object):
@@ -1365,8 +1229,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=211
         """
-        pytest.mark.features(feature_id=211)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=211, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_support_for_kafka(test_object):
@@ -1374,8 +1237,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=212
         """
-        pytest.mark.features(feature_id=212)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=212, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_support_for_rabbitmq(test_object):
@@ -1383,8 +1245,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=213
         """
-        pytest.mark.features(feature_id=213)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=213, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_support_for_rabbitmq_fanout(test_object):
@@ -1392,8 +1253,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=214
         """
-        pytest.mark.features(feature_id=214)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=214, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_support_for_rabbitmq_topicexchange(test_object):
@@ -1401,8 +1261,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=215
         """
-        pytest.mark.features(feature_id=215)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=215, owner=_Owner.unknown)
 
     @staticmethod
     def mongo_support(test_object):
@@ -1410,8 +1269,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=216
         """
-        pytest.mark.features(feature_id=216)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=216, owner=_Owner.unknown)
 
     @staticmethod
     def otel_mysql_support(test_object):
@@ -1419,8 +1277,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=217
         """
-        pytest.mark.features(feature_id=217)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=217, owner=_Owner.unknown)
 
     @staticmethod
     def otel_mssql_support(test_object):
@@ -1428,8 +1285,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=226
         """
-        pytest.mark.features(feature_id=226)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=226, owner=_Owner.unknown)
 
     @staticmethod
     def otel_postgres_support(test_object):
@@ -1437,8 +1293,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=218
         """
-        pytest.mark.features(feature_id=218)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=218, owner=_Owner.unknown)
 
     @staticmethod
     def sql_support(test_object):
@@ -1446,8 +1301,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=219
         """
-        pytest.mark.features(feature_id=219)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=219, owner=_Owner.unknown)
 
     @staticmethod
     def dynamic_configuration(test_object):
@@ -1455,8 +1309,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=220
         """
-        pytest.mark.features(feature_id=220)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=220, owner=_Owner.unknown)
 
     @staticmethod
     def datadog_headers_propagation(test_object):
@@ -1464,8 +1317,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=221
         """
-        pytest.mark.features(feature_id=221)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=221, owner=_Owner.unknown)
 
     @staticmethod
     def single_span_sampling(test_object):
@@ -1473,8 +1325,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=222
         """
-        pytest.mark.features(feature_id=222)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=222, owner=_Owner.unknown)
 
     @staticmethod
     def tracer_flare(test_object):
@@ -1482,8 +1333,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=223
         """
-        pytest.mark.features(feature_id=223)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=223, owner=_Owner.unknown)
 
     @staticmethod
     def profiling(test_object):
@@ -1491,8 +1341,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=224
         """
-        pytest.mark.features(feature_id=224)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=224, owner=_Owner.unknown)
 
     @staticmethod
     def trace_sampling(test_object):
@@ -1500,8 +1349,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=227
         """
-        pytest.mark.features(feature_id=227)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=227, owner=_Owner.unknown)
 
     @staticmethod
     def telemetry_instrumentation(test_object):
@@ -1509,8 +1357,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=229
         """
-        pytest.mark.features(feature_id=229)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=229, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_logs(test_object):
@@ -1518,8 +1365,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=230
         """
-        pytest.mark.features(feature_id=230)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=230, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_miscs_internals(test_object):
@@ -1527,8 +1373,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=231
         """
-        pytest.mark.features(feature_id=231)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=231, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_scrubbing(test_object):
@@ -1536,8 +1381,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=232
         """
-        pytest.mark.features(feature_id=232)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=232, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_standard_tags_client_ip(test_object):
@@ -1545,8 +1389,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=233
         """
-        pytest.mark.features(feature_id=233)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=233, owner=_Owner.asm)
 
     @staticmethod
     def waf_features(test_object):
@@ -1554,8 +1397,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=234
         """
-        pytest.mark.features(feature_id=234)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=234, owner=_Owner.asm)
 
     @staticmethod
     def waf_rules(test_object):
@@ -1563,8 +1405,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=235
         """
-        pytest.mark.features(feature_id=235)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=235, owner=_Owner.asm)
 
     @staticmethod
     def iast_sink_hsts_missing_header(test_object):
@@ -1572,8 +1413,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=236
         """
-        pytest.mark.features(feature_id=236)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=236, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_http_only_cookie(test_object):
@@ -1581,8 +1421,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=237
         """
-        pytest.mark.features(feature_id=237)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=237, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_insecure_cookie(test_object):
@@ -1590,8 +1429,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=238
         """
-        pytest.mark.features(feature_id=238)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=238, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_samesite_cookie(test_object):
@@ -1599,8 +1437,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=240
         """
-        pytest.mark.features(feature_id=240)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=240, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_ssrf(test_object):
@@ -1608,8 +1445,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=241
         """
-        pytest.mark.features(feature_id=241)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=241, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_trustboundaryviolation(test_object):
@@ -1617,8 +1453,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=242
         """
-        pytest.mark.features(feature_id=242)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=242, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_unvalidatedforward(test_object):
@@ -1626,8 +1461,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=243
         """
-        pytest.mark.features(feature_id=243)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=243, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_unvalidatedheader(test_object):
@@ -1635,8 +1469,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=244
         """
-        pytest.mark.features(feature_id=244)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=244, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_unvalidatedredirect(test_object):
@@ -1644,8 +1477,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=245
         """
-        pytest.mark.features(feature_id=245)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=245, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_weakrandomness(test_object):
@@ -1653,8 +1485,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=246
         """
-        pytest.mark.features(feature_id=246)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=246, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_xcontentsniffing(test_object):
@@ -1662,8 +1493,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=247
         """
-        pytest.mark.features(feature_id=247)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=247, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_xpathinjection(test_object):
@@ -1671,8 +1501,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=248
         """
-        pytest.mark.features(feature_id=248)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=248, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_xss(test_object):
@@ -1680,8 +1509,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=249
         """
-        pytest.mark.features(feature_id=249)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=249, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_multipart(test_object):
@@ -1689,8 +1517,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=250
         """
-        pytest.mark.features(feature_id=250)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=250, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_path(test_object):
@@ -1698,8 +1525,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=251
         """
-        pytest.mark.features(feature_id=251)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=251, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_uri(test_object):
@@ -1707,8 +1533,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=252
         """
-        pytest.mark.features(feature_id=252)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=252, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_mongodb_injection(test_object):
@@ -1716,8 +1541,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=253
         """
-        pytest.mark.features(feature_id=253)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=253, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_user_blocking(test_object):
@@ -1725,16 +1549,14 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=254
         """
-        pytest.mark.features(feature_id=254)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=254, owner=_Owner.unknown)
 
     @staticmethod
     def decisionless_extraction(test_object):
         """Sampling behavior when extracted trace context does not convey a sampling decision
         https://feature-parity.us1.prod.dog/#/?feature=261
         """
-        pytest.mark.features(feature_id=261)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=261, owner=_Owner.unknown)
 
     @staticmethod
     def semantic_core_validations(test_object):
@@ -1742,8 +1564,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=262
         """
-        pytest.mark.features(feature_id=262)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=262, owner=_Owner.unknown)
 
     @staticmethod
     def aws_sqs_span_creationcontext_propagation_via_xray_header_with_dd_trace(
@@ -1753,8 +1574,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=263
         """
-        pytest.mark.features(feature_id=263)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=263, owner=_Owner.unknown)
 
     @staticmethod
     def aws_sqs_span_creationcontext_propagation_via_message_attributes_with_dd_trace(
@@ -1764,8 +1584,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=264
         """
-        pytest.mark.features(feature_id=264)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=264, owner=_Owner.unknown)
 
     @staticmethod
     def agent_remote_configuration(test_object):
@@ -1773,8 +1592,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=265
         """
-        pytest.mark.features(feature_id=265)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=265, owner=_Owner.unknown)
 
     @staticmethod
     def data_integrity(test_object):
@@ -1782,8 +1600,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=266
         """
-        pytest.mark.features(feature_id=266)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=266, owner=_Owner.unknown)
 
     @staticmethod
     def library_scrubbing(test_object):
@@ -1791,8 +1608,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=267
         """
-        pytest.mark.features(feature_id=267)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=267, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_support_for_sqs(test_object):
@@ -1800,8 +1616,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=268
         """
-        pytest.mark.features(feature_id=268)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=268, owner=_Owner.unknown)
 
     @staticmethod
     def api_security_configuration(test_object):
@@ -1809,8 +1624,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=269
         """
-        pytest.mark.features(feature_id=269)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=269, owner=_Owner.unknown)
 
     @staticmethod
     def rabbitmq_span_creationcontext_propagation_with_dd_trace(test_object):
@@ -1818,8 +1632,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=270
         """
-        pytest.mark.features(feature_id=270)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=270, owner=_Owner.unknown)
 
     @staticmethod
     def aws_sns_span_creationcontext_propagation_via_message_attributes_with_dd_trace(
@@ -1829,8 +1642,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=271
         """
-        pytest.mark.features(feature_id=271)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=271, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_support_for_sns(test_object):
@@ -1838,8 +1650,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=273
         """
-        pytest.mark.features(feature_id=273)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=273, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_insecure_auth_protocol(test_object):
@@ -1847,8 +1658,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=272
         """
-        pytest.mark.features(feature_id=272)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=272, owner=_Owner.unknown)
 
     @staticmethod
     def container_auto_installation_script(test_object):
@@ -1856,8 +1666,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=274
         """
-        pytest.mark.features(feature_id=274)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=274, owner=_Owner.unknown)
 
     @staticmethod
     def host_auto_installation_script(test_object):
@@ -1865,8 +1674,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=275
         """
-        pytest.mark.features(feature_id=275)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=275, owner=_Owner.unknown)
 
     @staticmethod
     def host_block_list(test_object):
@@ -1874,8 +1682,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=276
         """
-        pytest.mark.features(feature_id=276)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=276, owner=_Owner.unknown)
 
     @staticmethod
     def aws_kinesis_span_creationcontext_propagation_via_message_attributes_with_dd_trace(
@@ -1885,8 +1692,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=280
         """
-        pytest.mark.features(feature_id=280)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=280, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_support_for_base64_encoding(test_object):
@@ -1894,8 +1700,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=284
         """
-        pytest.mark.features(feature_id=284)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=284, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_support_context_injection_base64(test_object):
@@ -1903,8 +1708,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=287
         """
-        pytest.mark.features(feature_id=287)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=287, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_support_for_kinesis(test_object):
@@ -1912,8 +1716,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=282
         """
-        pytest.mark.features(feature_id=282)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=282, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_reflection_injection(test_object):
@@ -1921,8 +1724,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=279
         """
-        pytest.mark.features(feature_id=279)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=279, owner=_Owner.unknown)
 
     @staticmethod
     def embeded_git_reference(test_object):
@@ -1930,8 +1732,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=286
         """
-        pytest.mark.features(feature_id=286)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=286, owner=_Owner.unknown)
 
     @staticmethod
     def k8s_admission_controller(test_object):
@@ -1939,8 +1740,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=288
         """
-        pytest.mark.features(feature_id=288)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=288, owner=_Owner.unknown)
 
     @staticmethod
     def f_otel_interoperability(test_object):
@@ -1948,8 +1748,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=289
         """
-        pytest.mark.features(feature_id=289)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=289, owner=_Owner.unknown)
 
     @staticmethod
     def debugger_pii_redaction(test_object):
@@ -1957,8 +1756,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=291
         """
-        pytest.mark.features(feature_id=291)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=291, owner=_Owner.unknown)
 
     @staticmethod
     def installer_auto_instrumentation(test_object):
@@ -1966,8 +1764,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=292
         """
-        pytest.mark.features(feature_id=292)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=292, owner=_Owner.unknown)
 
     @staticmethod
     def rasp_local_file_inclusion(test_object):
@@ -1975,8 +1772,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=293
         """
-        pytest.mark.features(feature_id=293)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=293, owner=_Owner.unknown)
 
     @staticmethod
     def rasp_server_side_request_forgery(test_object):
@@ -1984,8 +1780,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=294
         """
-        pytest.mark.features(feature_id=294)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=294, owner=_Owner.unknown)
 
     @staticmethod
     def rasp_sql_injection(test_object):
@@ -1993,8 +1788,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=295
         """
-        pytest.mark.features(feature_id=295)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=295, owner=_Owner.unknown)
 
     @staticmethod
     def database_monitoring_support(test_object):
@@ -2002,8 +1796,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=296
         """
-        pytest.mark.features(feature_id=296)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=296, owner=_Owner.unknown)
 
     @staticmethod
     def rasp_stack_trace(test_object):
@@ -2011,8 +1804,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=297
         """
-        pytest.mark.features(feature_id=297)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=297, owner=_Owner.unknown)
 
     @staticmethod
     def rasp_span_tags(test_object):
@@ -2020,8 +1812,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=298
         """
-        pytest.mark.features(feature_id=298)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=298, owner=_Owner.unknown)
 
     @staticmethod
     def debugger_expression_language(test_object):
@@ -2029,8 +1820,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=303
         """
-        pytest.mark.features(feature_id=303)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=303, owner=_Owner.unknown)
 
     @staticmethod
     def auto_instrumentation_profiling(test_object):
@@ -2038,8 +1828,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=302
         """
-        pytest.mark.features(feature_id=302)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=302, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_standalone_experimental(test_object):
@@ -2047,8 +1836,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=305
         """
-        pytest.mark.features(feature_id=305)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=305, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_standalone(test_object):
@@ -2056,8 +1844,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=355
         """
-        pytest.mark.features(feature_id=355)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=355, owner=_Owner.unknown)
 
     @staticmethod
     def iast_standalone_experimental(test_object):
@@ -2065,8 +1852,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=319
         """
-        pytest.mark.features(feature_id=319)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=319, owner=_Owner.unknown)
 
     @staticmethod
     def iast_standalone(test_object):
@@ -2074,8 +1860,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=356
         """
-        pytest.mark.features(feature_id=356)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=356, owner=_Owner.unknown)
 
     @staticmethod
     def sca_standalone_experimental(test_object):
@@ -2083,8 +1868,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=320
         """
-        pytest.mark.features(feature_id=320)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=320, owner=_Owner.unknown)
 
     @staticmethod
     def sca_standalone(test_object):
@@ -2092,8 +1876,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=357
         """
-        pytest.mark.features(feature_id=357)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=357, owner=_Owner.unknown)
 
     @staticmethod
     def security_events_metastruct(test_object):
@@ -2101,8 +1884,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=314
         """
-        pytest.mark.features(feature_id=314)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=314, owner=_Owner.unknown)
 
     @staticmethod
     def host_auto_installation_script_profiling(test_object):
@@ -2110,8 +1892,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=306
         """
-        pytest.mark.features(feature_id=306)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=306, owner=_Owner.unknown)
 
     @staticmethod
     def container_auto_installation_script_profiling(test_object):
@@ -2119,8 +1900,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=307
         """
-        pytest.mark.features(feature_id=307)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=307, owner=_Owner.unknown)
 
     @staticmethod
     def container_auto_instrumentation_profiling(test_object):
@@ -2128,8 +1908,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=310
         """
-        pytest.mark.features(feature_id=310)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=310, owner=_Owner.unknown)
 
     @staticmethod
     def host_guardrail(test_object):
@@ -2137,8 +1916,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=308
         """
-        pytest.mark.features(feature_id=308)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=308, owner=_Owner.unknown)
 
     @staticmethod
     def container_guardrail(test_object):
@@ -2146,8 +1924,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=309
         """
-        pytest.mark.features(feature_id=309)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=309, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_support_for_manual_checkpoints(test_object):
@@ -2155,8 +1932,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=327
         """
-        pytest.mark.features(feature_id=327)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=327, owner=_Owner.unknown)
 
     @staticmethod
     def suspicious_attacker_blocking(test_object):
@@ -2164,8 +1940,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=311
         """
-        pytest.mark.features(feature_id=311)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=311, owner=_Owner.unknown)
 
     @staticmethod
     def user_id_collection_modes(test_object):
@@ -2173,8 +1948,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=312
         """
-        pytest.mark.features(feature_id=312)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=312, owner=_Owner.unknown)
 
     @staticmethod
     def fingerprinting(test_object):
@@ -2182,8 +1956,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=313
         """
-        pytest.mark.features(feature_id=313)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=313, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_untrusted_deserialization(test_object):
@@ -2191,8 +1964,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=316
         """
-        pytest.mark.features(feature_id=316)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=316, owner=_Owner.unknown)
 
     @staticmethod
     def crashtracking(test_object):
@@ -2200,8 +1972,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=317
         """
-        pytest.mark.features(feature_id=317)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=317, owner=_Owner.unknown)
 
     @staticmethod
     def rasp_shell_injection(test_object):
@@ -2209,8 +1980,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=318
         """
-        pytest.mark.features(feature_id=318)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=318, owner=_Owner.unknown)
 
     @staticmethod
     def rasp_command_injection(test_object):
@@ -2218,8 +1988,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=345
         """
-        pytest.mark.features(feature_id=345)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=345, owner=_Owner.unknown)
 
     @staticmethod
     def debugger_exception_replay(test_object):
@@ -2227,8 +1996,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=321
         """
-        pytest.mark.features(feature_id=321)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=321, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_path_parameter(test_object):
@@ -2236,8 +2004,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=324
         """
-        pytest.mark.features(feature_id=324)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=324, owner=_Owner.unknown)
 
     @staticmethod
     def iast_source_sql(test_object):
@@ -2245,8 +2012,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=344
         """
-        pytest.mark.features(feature_id=344)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=344, owner=_Owner.unknown)
 
     @staticmethod
     def ssi_guardrails(test_object):
@@ -2254,8 +2020,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=322
         """
-        pytest.mark.features(feature_id=322)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=322, owner=_Owner.unknown)
 
     @staticmethod
     def ssi_crashtracking(test_object):
@@ -2263,8 +2028,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=340
         """
-        pytest.mark.features(feature_id=340)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=340, owner=_Owner.unknown)
 
     @staticmethod
     def ssi_service_naming(test_object):
@@ -2272,8 +2036,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=326
         """
-        pytest.mark.features(feature_id=326)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=326, owner=_Owner.unknown)
 
     @staticmethod
     def ssi_service_tracking(test_object):
@@ -2281,8 +2044,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=327
         """
-        pytest.mark.features(feature_id=327)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=327, owner=_Owner.unknown)
 
     @staticmethod
     def serverless_span_pointers(test_object):
@@ -2290,8 +2052,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=328
         """
-        pytest.mark.features(feature_id=328)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=328, owner=_Owner.unknown)
 
     @staticmethod
     def aws_api_gateway_inferred_span_creation(test_object):
@@ -2299,9 +2060,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=341
         """
-        pytest.mark.features(feature_id=341)(test_object)
-
-        return test_object
+        return _mark_test_object(test_object, feature_id=341, owner=_Owner.unknown)
 
     @staticmethod
     def parametric_endpoint_parity(test_object):
@@ -2309,8 +2068,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=339
         """
-        pytest.mark.features(feature_id=339)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=339, owner=_Owner.unknown)
 
     @staticmethod
     def iast_stack_trace(test_object):
@@ -2318,8 +2076,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=329
         """
-        pytest.mark.features(feature_id=329)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=329, owner=_Owner.unknown)
 
     @staticmethod
     def iast_extended_location(test_object):
@@ -2327,8 +2084,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=364
         """
-        pytest.mark.features(feature_id=364)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=364, owner=_Owner.unknown)
 
     @staticmethod
     def djm_ssi_k8s(test_object):
@@ -2336,8 +2092,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=342
         """
-        pytest.mark.features(feature_id=342)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=342, owner=_Owner.unknown)
 
     @staticmethod
     def adaptive_sampling(test_object):
@@ -2345,8 +2100,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=346
         """
-        pytest.mark.features(feature_id=346)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=346, owner=_Owner.unknown)
 
     @staticmethod
     def agent_host_ipv6(test_object):
@@ -2354,8 +2108,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=347
         """
-        pytest.mark.features(feature_id=347)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=347, owner=_Owner.unknown)
 
     @staticmethod
     def datadog_baggage_headers(test_object):
@@ -2363,8 +2116,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=389
         """
-        pytest.mark.features(feature_id=389)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=389, owner=_Owner.unknown)
 
     @staticmethod
     def iast_security_controls(test_object):
@@ -2372,8 +2124,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=343
         """
-        pytest.mark.features(feature_id=343)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=343, owner=_Owner.unknown)
 
     @staticmethod
     def graphql_query_error_reporting(test_object):
@@ -2381,8 +2132,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=354
         """
-        pytest.mark.features(feature_id=354)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=354, owner=_Owner.unknown)
 
     @staticmethod
     def envoy_external_processing(test_object):
@@ -2390,8 +2140,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=350
         """
-        pytest.mark.features(feature_id=350)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=350, owner=_Owner.unknown)
 
     @staticmethod
     def context_propagation_extract_behavior(test_object):
@@ -2399,8 +2148,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=353
         """
-        pytest.mark.features(feature_id=353)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=353, owner=_Owner.unknown)
 
     @staticmethod
     def iast_sink_email_html_injection(test_object):
@@ -2408,8 +2156,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=358
         """
-        pytest.mark.features(feature_id=358)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=358, owner=_Owner.unknown)
 
     @staticmethod
     def language_specifics(test_object):
@@ -2417,8 +2164,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=359
         """
-        pytest.mark.features(feature_id=359)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=359, owner=_Owner.unknown)
 
     @staticmethod
     def debugger_code_origins(test_object):
@@ -2426,8 +2172,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=360
         """
-        pytest.mark.features(feature_id=360)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=360, owner=_Owner.unknown)
 
     @staticmethod
     def debugger_probe_budgets(test_object):
@@ -2435,8 +2180,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=368
         """
-        pytest.mark.features(feature_id=368)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=368, owner=_Owner.unknown)
 
     @staticmethod
     def debugger_method_probe(test_object):
@@ -2444,8 +2188,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=392
         """
-        pytest.mark.features(feature_id=392)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=392, owner=_Owner.unknown)
 
     @staticmethod
     def debugger_line_probe(test_object):
@@ -2453,8 +2196,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=393
         """
-        pytest.mark.features(feature_id=393)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=393, owner=_Owner.unknown)
 
     @staticmethod
     def debugger_symdb(test_object):
@@ -2462,8 +2204,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=370
         """
-        pytest.mark.features(feature_id=370)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=370, owner=_Owner.unknown)
 
     @staticmethod
     def otel_propagators_api(test_object):
@@ -2471,8 +2212,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=361
         """
-        pytest.mark.features(feature_id=361)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=361, owner=_Owner.unknown)
 
     @staticmethod
     def stable_configuration_support(test_object):
@@ -2480,8 +2220,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=365
         """
-        pytest.mark.features(feature_id=365)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=365, owner=_Owner.unknown)
 
     @staticmethod
     def single_span_ingestion_control(test_object):
@@ -2489,8 +2228,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=366
         """
-        pytest.mark.features(feature_id=366)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=366, owner=_Owner.unknown)
 
     @staticmethod
     def process_discovery(test_object):
@@ -2498,8 +2236,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=367
         """
-        pytest.mark.features(feature_id=367)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=367, owner=_Owner.unknown)
 
     @staticmethod
     def debugger_inproduct_enablement(test_object):
@@ -2507,8 +2244,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=369
         """
-        pytest.mark.features(feature_id=369)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=369, owner=_Owner.unknown)
 
     @staticmethod
     def datastreams_monitoring_protobuf_schema_tracking(test_object):
@@ -2516,8 +2252,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=371
         """
-        pytest.mark.features(feature_id=371)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=371, owner=_Owner.unknown)
 
     @staticmethod
     def trace_enablement(test_object):
@@ -2525,8 +2260,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=374
         """
-        pytest.mark.features(feature_id=374)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=374, owner=_Owner.unknown)
 
     @staticmethod
     def trace_log_directory(test_object):
@@ -2534,8 +2268,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=375
         """
-        pytest.mark.features(feature_id=375)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=375, owner=_Owner.unknown)
 
     @staticmethod
     def trace_experimental_features(test_object):
@@ -2543,8 +2276,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=376
         """
-        pytest.mark.features(feature_id=376)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=376, owner=_Owner.unknown)
 
     @staticmethod
     def trace_rate_limiting(test_object):
@@ -2552,17 +2284,15 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=377
         """
-        pytest.mark.features(feature_id=377)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=377, owner=_Owner.unknown)
 
     @staticmethod
     def trace_http_server_error_statuses(test_object):
         """Enforces standardized behaviors for configurations across the tracing libraries.
 
-        https://feature-parity.us1.prod.dog/#/?feature=378
+        https://feature-parity.us1.prod.dog/#/?feature=379
         """
-        pytest.mark.features(feature_id=379)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=379, owner=_Owner.unknown)
 
     @staticmethod
     def trace_http_client_error_statuses(test_object):
@@ -2570,8 +2300,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=381
         """
-        pytest.mark.features(feature_id=381)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=381, owner=_Owner.unknown)
 
     @staticmethod
     def trace_http_client_tag_query_string(test_object):
@@ -2579,8 +2308,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=382
         """
-        pytest.mark.features(feature_id=382)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=382, owner=_Owner.unknown)
 
     @staticmethod
     def unified_service_tagging(test_object):
@@ -2588,8 +2316,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=384
         """
-        pytest.mark.features(feature_id=384)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=384, owner=_Owner.unknown)
 
     @staticmethod
     def integration_enablement(test_object):
@@ -2597,8 +2324,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=385
         """
-        pytest.mark.features(feature_id=385)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=385, owner=_Owner.unknown)
 
     @staticmethod
     def log_injection_128bit_traceid(test_object):
@@ -2606,8 +2332,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=387
         """
-        pytest.mark.features(feature_id=387)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=387, owner=_Owner.unknown)
 
     @staticmethod
     def iast_schema(test_object):
@@ -2615,8 +2340,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=394
         """
-        pytest.mark.features(feature_id=394)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=394, owner=_Owner.unknown)
 
     @staticmethod
     def iast_vuln_sampling_route_method_count_algorithm(test_object):
@@ -2624,8 +2348,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=395
         """
-        pytest.mark.features(feature_id=395)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=395, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_collect_all_headers(test_object):
@@ -2633,8 +2356,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=390
         """
-        pytest.mark.features(feature_id=390)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=390, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_collect_request_body(test_object):
@@ -2642,8 +2364,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=391
         """
-        pytest.mark.features(feature_id=391)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=391, owner=_Owner.unknown)
 
     @staticmethod
     def referrer_hostname(test_object):
@@ -2651,8 +2372,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=396
         """
-        pytest.mark.features(feature_id=396)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=396, owner=_Owner.unknown)
 
     @staticmethod
     def baggage_span_tags(test_object):
@@ -2660,8 +2380,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=470
         """
-        pytest.mark.features(feature_id=470)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=470, owner=_Owner.unknown)
 
     @staticmethod
     def remote_config_semantic_versioning(test_object):
@@ -2669,8 +2388,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=472
         """
-        pytest.mark.features(feature_id=472)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=472, owner=_Owner.unknown)
 
     @staticmethod
     def process_tags(test_object):
@@ -2678,8 +2396,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=475
         """
-        pytest.mark.features(feature_id=475)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=475, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_rc_asm_dd_multiconfig(test_object):
@@ -2687,8 +2404,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=473
         """
-        pytest.mark.features(feature_id=473)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=473, owner=_Owner.unknown)
 
     @staticmethod
     def appsec_trace_tagging_rules(test_object):
@@ -2696,8 +2412,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=474
         """
-        pytest.mark.features(feature_id=474)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=474, owner=_Owner.unknown)
 
     @staticmethod
     def unstructured_log_injection(test_object):
@@ -2705,8 +2420,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=477
         """
-        pytest.mark.features(feature_id=477)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=477, owner=_Owner.unknown)
 
     @staticmethod
     def auto_instrumentation_appsec(test_object):
@@ -2714,8 +2428,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=478
         """
-        pytest.mark.features(feature_id=478)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=478, owner=_Owner.unknown)
 
     @staticmethod
     def host_auto_installation_script_appsec(test_object):
@@ -2723,8 +2436,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=479
         """
-        pytest.mark.features(feature_id=479)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=479, owner=_Owner.unknown)
 
     @staticmethod
     def container_auto_installation_script_appsec(test_object):
@@ -2732,8 +2444,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=480
         """
-        pytest.mark.features(feature_id=480)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=480, owner=_Owner.unknown)
 
     @staticmethod
     def ssi_injection_metadata(test_object):
@@ -2741,8 +2452,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=481
         """
-        pytest.mark.features(feature_id=481)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=481, owner=_Owner.unknown)
 
     @staticmethod
     def api_security_endpoint_discovery(test_object):
@@ -2750,8 +2460,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=483
         """
-        pytest.mark.features(feature_id=483)(test_object)
-        return test_object
+        return _mark_test_object(test_object, feature_id=483, owner=_Owner.unknown)
 
 
 features = _Features()


### PR DESCRIPTION
## Motivation

when system-tests fails, it may be complicated to get the owner. This change add a owner property to each tests, thanks to the existing features decorator.

It'll allow to cook better output message, and allow direct notifications

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
