### PR TITLE
[python] relax condition for lazy waf initialization

### DIFF
--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -59,9 +59,9 @@ class Test_TelemetryMetrics:
             "success",
         }
         series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
-        # TODO(Python). Gunicorn creates 2 process (main gunicorn process + X child workers). It generates two init
+        # Gunicorn creates 2 process (main gunicorn process + X child workers). It may generates two init (but not always as initialization is now lazy)
         if context.library == "python" and context.weblog_variant not in ("fastapi", "uwsgi-poc"):
-            assert len(series) == 2
+            assert len(series) in (1, 2)
         else:
             assert len(series) == 1
         s = series[0]


### PR DESCRIPTION
Preparing a refactor of aap product load mechanism, with lazy waf initialisation, this PR relax a special condition for python telemetry test. 

Context: Before refactor, if appsec was enabled, the waf was initialized both in the root process and the work process. Now, if RC is not enabled, the root process should not process any web request, and the waf should not be initialized. 
However, if RC is enabled, the waf will get RC updates, and so it will be initialized.

APPSEC-57505

related tracer changes: https://github.com/DataDog/dd-trace-py/pull/14244

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
