### PR TITLE
[golang] APPSEC-57080 Fix path params not working on net-http servemux instrum

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -469,8 +469,8 @@ tests/:
       Test_Blocking_response_status: missing_feature
       Test_Blocking_user_id: v1.51.0
       Test_Suspicious_Request_Blocking:
-        net-http-orchestrion: missing_feature (path params are not supported)
         '*': v2.3.0-dev
+        net-http-orchestrion: missing_feature (path params are not supported)
     test_client_ip.py:
       Test_StandardTagsClientIp: v1.44.1
     test_conf.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -468,7 +468,9 @@ tests/:
       Test_Blocking_response_headers: missing_feature
       Test_Blocking_response_status: missing_feature
       Test_Blocking_user_id: v1.51.0
-      Test_Suspicious_Request_Blocking: v2.3.0-dev
+      Test_Suspicious_Request_Blocking:
+        net-http-orchestrion: missing_feature (path params are not supported)
+        '*': v2.3.0-dev
     test_client_ip.py:
       Test_StandardTagsClientIp: v1.44.1
     test_conf.py:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -468,7 +468,7 @@ tests/:
       Test_Blocking_response_headers: missing_feature
       Test_Blocking_response_status: missing_feature
       Test_Blocking_user_id: v1.51.0
-      Test_Suspicious_Request_Blocking: flaky (APPSEC-57080)
+      Test_Suspicious_Request_Blocking: v2.3.0-dev
     test_client_ip.py:
       Test_StandardTagsClientIp: v1.44.1
     test_conf.py:


### PR DESCRIPTION

## Motivation

FIx missing path params on net-http

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
