### PR TITLE
[.NET] Skip broken tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -450,6 +450,8 @@ tests/:
   debugger/:
     test_debugger_code_origins.py:
       Test_Debugger_Code_Origins: missing_feature
+    test_debugger_exception_replay.py:
+      Test_Debugger_Exception_Replay: missing_feature
     test_debugger_expression_language.py:
       Test_Debugger_Expression_Language: v2.50.0
     test_debugger_inproduct_enablement.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -450,8 +450,6 @@ tests/:
   debugger/:
     test_debugger_code_origins.py:
       Test_Debugger_Code_Origins: missing_feature
-    test_debugger_exception_replay.py:
-      Test_Debugger_Exception_Replay: bug # Broken snapshots, fixed in 5405
     test_debugger_expression_language.py:
       Test_Debugger_Expression_Language: v2.50.0
     test_debugger_inproduct_enablement.py:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -451,7 +451,7 @@ tests/:
     test_debugger_code_origins.py:
       Test_Debugger_Code_Origins: missing_feature
     test_debugger_exception_replay.py:
-      Test_Debugger_Exception_Replay: v2.50.0
+      Test_Debugger_Exception_Replay: bug # Broken snapshots, fixed in 5405
     test_debugger_expression_language.py:
       Test_Debugger_Expression_Language: v2.50.0
     test_debugger_inproduct_enablement.py:


### PR DESCRIPTION
## Motivation

Debugger snapshots are broken on .NET main repo

## Changes

Skip the broken tests

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
