### PR TITLE
K8s: use ddapm-test-agent:v1.31.1

### DIFF
--- a/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
+++ b/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
@@ -44,7 +44,7 @@ class K8sDatadog:
 
         container = client.V1Container(
             name="trace-agent",
-            image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest",
+            image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.31.1",
             image_pull_policy="Always",
             ports=[client.V1ContainerPort(container_port=8126, host_port=8126, name="traceport", protocol="TCP")],
             command=["ddapm-test-agent"],


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The latest tag of the apm_test_agent is failing. Quick fix: use the tag v1.31.1

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
