### PR TITLE
[Python]: Enable sampling tests in python

### DIFF
--- a/tests/parametric/test_span_sampling.py
+++ b/tests/parametric/test_span_sampling.py
@@ -861,7 +861,6 @@ class Test_Span_Sampling:
     @bug(context.library == "golang", reason="APMAPI-1545")
     @bug(context.library == "php", reason="APMAPI-1545")
     @bug(context.library == "ruby", reason="APMAPI-1545")
-    @bug(context.library == "python", reason="APMAPI-1545")
     @bug(context.library == "cpp", reason="APMAPI-1545")
     @pytest.mark.parametrize(
         "library_env",
@@ -935,7 +934,6 @@ class Test_Span_Sampling:
 
     @bug(context.library == "golang", reason="APMAPI-1545")
     @bug(context.library == "php", reason="APMAPI-1545")
-    @bug(context.library == "python", reason="APMAPI-1545")
     @bug(context.library == "cpp", reason="APMAPI-1545")
     @pytest.mark.parametrize(
         "library_env",


### PR DESCRIPTION
## Motivation
- the fix for `test_single_rule_with_head_and_rule_trace_sampling_keep_019` and  `test_single_rule_with_head_and_rule_trace_sampling_drop_020` was made in [dd-trace-py PR ](https://github.com/DataDog/dd-trace-py/pull/14308) so we can now enable these tests

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
