### PR TITLE
[python] Revert "Enabled Python Enhanced Config Source Reporting System Tests"

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -691,6 +691,6 @@ tests/:
     Test_Metric_Generation_Enabled: v2.35.0
     Test_ProductsDisabled: v2.12.0
     Test_Telemetry: v2.12.0
-    Test_TelemetryEnhancedConfigReporting: missing_feature
+    Test_TelemetryConfigurationChaining: missing_feature
     Test_TelemetrySCAEnvVar: missing_feature
     Test_TelemetryV2: v2.35.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -882,6 +882,6 @@ tests/:
     Test_Metric_Generation_Enabled: missing_feature (checks for metrics from the tracer)
     Test_ProductsDisabled: v1.53
     Test_Telemetry: v1.49.0
-    Test_TelemetryEnhancedConfigReporting: missing_feature
+    Test_TelemetryConfigurationChaining: missing_feature
     Test_TelemetrySCAEnvVar: missing_feature
     Test_TelemetryV2: v1.49.1

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2312,6 +2312,6 @@ tests/:
     Test_Telemetry:
       '*': v0.108.1
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-    Test_TelemetryEnhancedConfigReporting: missing_feature
+    Test_TelemetryConfigurationChaining: missing_feature
     Test_TelemetrySCAEnvVar: missing_feature
     Test_TelemetryV2: v1.23.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1468,6 +1468,6 @@ tests/:
       '*': *ref_3_2_0
       nextjs: missing_feature
       uds-express4: *ref_3_7_0
-    Test_TelemetryEnhancedConfigReporting: missing_feature
+    Test_TelemetryConfigurationChaining: missing_feature
     Test_TelemetrySCAEnvVar: missing_feature
     Test_TelemetryV2: *ref_4_21_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -698,6 +698,6 @@ tests/:
     Test_Metric_Generation_Enabled: missing_feature
     Test_ProductsDisabled: missing_feature
     Test_Telemetry: v0.90
-    Test_TelemetryEnhancedConfigReporting: missing_feature
+    Test_TelemetryConfigurationChaining: missing_feature
     Test_TelemetrySCAEnvVar: v0.99.1
     Test_TelemetryV2: v0.90

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1265,8 +1265,6 @@ tests/:
     Test_Metric_Generation_Enabled: missing_feature
     Test_ProductsDisabled: v3.4.0
     Test_Telemetry: v1.16.0
-    Test_TelemetryEnhancedConfigReporting:
-      '*': irrelevant
-      flask-poc: v3.13.0
+    Test_TelemetryConfigurationChaining: missing_feature
     Test_TelemetrySCAEnvVar: missing_feature
     Test_TelemetryV2: v1.17.3

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -880,6 +880,6 @@ tests/:
     Test_Metric_Generation_Enabled: missing_feature
     Test_ProductsDisabled: v1.22.0
     Test_Telemetry: v1.4.0
-    Test_TelemetryEnhancedConfigReporting: missing_feature
+    Test_TelemetryConfigurationChaining: missing_feature
     Test_TelemetrySCAEnvVar: missing_feature
     Test_TelemetryV2: v1.11

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -565,13 +565,31 @@ class Test_Telemetry:
 
 
 @features.telemetry_app_started_event
-@scenarios.telemetry_enhanced_config_reporting
-class Test_TelemetryEnhancedConfigReporting:
-    """Test that configuration sources are sent with telemetry events of interest in correct precedence order under the app-started event feature"""
+@scenarios.telemetry_app_started_config_chaining
+class Test_TelemetryConfigurationChaining:
+    """Test that configuration sources are sent with app-started event in correct precedence order.
 
-    # tests that seq_id is correctly set for each configuration entry for a given configuration name based on the that SDKs
-    # precedence order as defined below
-    CONFIG_PRECEDENCE_ORDER = {
+    IMPORTANT: The order of configuration entries in the telemetry payload does NOT matter.
+    What matters is that the `seq_id` values reported for each configuration reflect the correct
+    precedence order as defined in `_ORIGIN_PRECEDENCE_ORDER`. This test verifies that for each
+    configuration, the `seq_id` increases as the origin precedence increases, regardless of the
+    order in which the entries appear in the payload.
+    """
+
+    # Official configuration origin precedence order (from lowest to highest precedence)
+    # Based on Node.js tracer implementation
+    _ORIGIN_PRECEDENCE_ORDER = [
+        "default",
+        "calculated",
+        "local_stable_config",
+        "env_var",
+        "fleet_stable_config",
+        "code",
+        "remote_config",
+    ]
+
+    # Test configuration constant for config chaining tests
+    _CONFIG_CHAINING_TEST_CONFIG = {
         "nodejs": {
             "configuration": {
                 "DD_LOGS_INJECTION": [
@@ -580,87 +598,146 @@ class Test_TelemetryEnhancedConfigReporting:
                     {"name": "DD_LOGS_INJECTION", "origin": "code", "value": True},
                 ],
             },
-        },
-        "python": {
-            "configuration": {
-                "DD_LOGS_INJECTION": [
-                    {"name": "DD_LOGS_INJECTION", "origin": "default", "value": True},
-                    {"name": "DD_LOGS_INJECTION", "origin": "env_var", "value": False},
-                    {"name": "DD_LOGS_INJECTION", "origin": "code", "value": True},
-                ],
-            },
-        },
+        },  # configurations should be ordered according to _ORIGIN_PRECEDENCE_ORDER
     }
 
-    @scenarios.telemetry_enhanced_config_reporting
-    def test_telemetry_events_seq_id(self):
-        """Assert that the seq_id is sent for each configuration entry in telemetry events of interest"""
+    @classmethod
+    def get_origin_precedence_order(cls) -> list[str]:
+        """Get the official configuration origin precedence order (lowest to highest)
+
+        Returns:
+            List of origin names in precedence order from lowest to highest
+
+        """
+        return cls._ORIGIN_PRECEDENCE_ORDER.copy()
+
+    @scenarios.telemetry_app_started_config_chaining
+    def test_app_started_config_chaining(self):
+        """Assert that all configuration sources read at start time are sent with the app-started event in the correct order"""
+        self._validate_config_chaining(require_seq_id=True)
+
+    @scenarios.telemetry_app_started_config_chaining
+    def test_app_started_config_chaining_no_seq_id(self):
+        """If for some reason the seq_id is not sent, assert that all configuration sources read at start time for a given configuration
+        are sent with the app-started event in the correct order
+        """
+        self._validate_config_chaining(require_seq_id=False)
+
+    def _validate_config_chaining(self, *, require_seq_id: bool = True) -> None:
+        """Common validation logic for configuration chaining tests
+
+        Args:
+            require_seq_id: Whether to require and validate seq_id presence and ordering
+
+        """
+        nodejs_expected_config = self._CONFIG_CHAINING_TEST_CONFIG["nodejs"]["configuration"]
 
         def validator(data):
-            # Some SDKs may send programmatic configuration changes in the app-client-configuration-change event
-            # so we need to check for all relevant events to ensure that seq_id is correct in the lifetime of the application
-            if get_request_type(data) not in ["app-started", "app-client-configuration-change"]:
+            if get_request_type(data) != "app-started":
                 return
 
             content = data["request"]["content"]
             configurations = content["payload"]["configuration"]
-            assert configurations, f"No configurations found in telemetry event: {configurations}"
 
-            for cnf in configurations:
-                assert "seq_id" in cnf, f"Configuration missing seq_id: {cnf}"
-                assert cnf["seq_id"] is not None, f"Configuration has null seq_id: {cnf}"
+            if require_seq_id:
+                # Assert that each configuration has a seq_id
+                for cnf in configurations:
+                    assert "seq_id" in cnf, f"Configuration missing seq_id: {cnf}"
+                    assert cnf["seq_id"] is not None, f"Configuration has null seq_id: {cnf}"
+
+                # Sort configurations by seq_id in ascending order (lowest to highest precedence)
+                configurations.sort(key=lambda cnf: cnf["seq_id"])
+            else:
+                # For the no_seq_id test, configurations might not have seq_id
+                # Sort by name to have a consistent order for comparison
+                configurations.sort(key=lambda cnf: cnf.get("name", ""))
+
+            self._validate_configuration_chains(configurations, nodejs_expected_config, require_seq_id=require_seq_id)
 
         self.validate_library_telemetry_data(validator)
 
-    @scenarios.telemetry_enhanced_config_reporting
-    def test_telemetry_enhanced_config_reporting_precedence(self):
-        """Assert that the seq_id for each configuration entry for a given configuration name matches the origin precedence"""
-
-        def validator(data):
-            # Create array of configs that match the config name
-            matching_configs = []
-            config_name = list(self.CONFIG_PRECEDENCE_ORDER[context.library.name]["configuration"].keys())[0]
-            config_precedence_order = self.CONFIG_PRECEDENCE_ORDER[context.library.name]["configuration"][config_name]
-            for telemetry_payload in data:
-                # Some SDKs may send programmatic configuration changes in the app-client-configuration-change event
-                # so we need to check for all relevant events to ensure that seq_id is correct in the lifetime of the application
-                if get_request_type(telemetry_payload) not in ["app-started", "app-client-configuration-change"]:
-                    continue
-                else:
-                    content = telemetry_payload["request"]["content"]
-                    configurations = content["payload"]["configuration"]
-                    assert configurations, f"No configurations found in telemetry event: {configurations}"
-                    for cnf in configurations:
-                        if cnf["name"] == config_name:
-                            assert "seq_id" in cnf, f"Configuration missing seq_id: {cnf}"
-                            assert cnf["seq_id"] is not None, f"Configuration has null seq_id: {cnf}"
-                            matching_configs.append(cnf)
-
-            assert (
-                len(matching_configs) == len(config_precedence_order)
-            ), f"Expected {len(config_precedence_order)} configurations for {config_name}, but found {len(matching_configs)}"
-            # order by seq_id
-            matching_configs.sort(key=lambda x: x["seq_id"])
-
-            for i in range(len(matching_configs) - 1):
-                assert matching_configs[i]["name"] == config_precedence_order[i]["name"]
-                assert matching_configs[i]["origin"] == config_precedence_order[i]["origin"]
-                assert matching_configs[i]["value"] == config_precedence_order[i]["value"]
-
-        self.validate_library_telemetry_data(validator, success_by_default=False, get_all_data_at_once=True)
-
-    def validate_library_telemetry_data(self, validator, *, success_by_default=False, get_all_data_at_once=False):
+    def validate_library_telemetry_data(self, validator, *, success_by_default=False):
         """Reuse telemetry validation method from Test_Telemetry"""
         telemetry_data = list(interfaces.library.get_telemetry_data(flatten_message_batches=False))
 
         if len(telemetry_data) == 0 and not success_by_default:
             raise ValueError("No telemetry data to validate on")
 
-        if get_all_data_at_once:
-            validator(telemetry_data)
-        else:
-            for data in telemetry_data:
-                validator(data)
+        for data in telemetry_data:
+            validator(data)
+
+    def _validate_precedence_order(self, chain: list) -> None:
+        """Validate that a configuration chain follows the official precedence order.
+
+        Args:
+            chain: List of configuration items with 'origin' keys.
+
+        NOTE: This method is used to check that the origins in a configuration chain are in the correct
+        precedence order. In the context of this test, the actual order in the payload is not important;
+        only the relationship between origin precedence and seq_id is validated in the main test logic.
+
+        """
+        precedence_map = {origin: i for i, origin in enumerate(self._ORIGIN_PRECEDENCE_ORDER)}
+
+        for i in range(len(chain) - 1):
+            current_origin = chain[i]["origin"]
+            next_origin = chain[i + 1]["origin"]
+
+            current_precedence = precedence_map.get(current_origin, -1)
+            next_precedence = precedence_map.get(next_origin, -1)
+
+            assert current_precedence < next_precedence, (
+                f"Configuration precedence order violation: '{current_origin}' "
+                f"(precedence {current_precedence}) should come before '{next_origin}' "
+                f"(precedence {next_precedence}) according to {self._ORIGIN_PRECEDENCE_ORDER}"
+            )
+
+    def _validate_configuration_chains(
+        self, configurations: list, expected_config: dict, *, require_seq_id: bool
+    ) -> None:
+        """Validate individual configuration chains against expected values
+
+        Args:
+            configurations: Actual configurations from telemetry data
+            expected_config: Expected configuration structure
+            require_seq_id: Whether to validate seq_id ordering
+
+        """
+        for cnf_name, expected_chain in expected_config.items():
+            # Filter actual entries for this configuration name
+            actual_chain = [cnf for cnf in configurations if cnf["name"] == cnf_name]
+
+            assert len(actual_chain) == len(expected_chain), (
+                f"Config '{cnf_name}': expected {len(expected_chain)} items, " f"found {len(actual_chain)}"
+            )
+
+            # Validate that the expected chain follows precedence order
+            self._validate_precedence_order(expected_chain)
+
+            # Validate that the actual chain follows precedence order
+            self._validate_precedence_order(actual_chain)
+
+            for i, (actual, expected) in enumerate(zip(actual_chain, expected_chain, strict=False)):
+                # Validate origin
+                assert actual["origin"] == expected["origin"], (
+                    f"Config '{cnf_name}[{i}]': origin mismatch - "
+                    f"expected '{expected['origin']}', got '{actual['origin']}'"
+                )
+
+                # Validate value
+                assert actual["value"] == expected["value"], (
+                    f"Config '{cnf_name}[{i}]': value mismatch - "
+                    f"expected {expected['value']}, got {actual['value']}"
+                )
+
+                # Validate seq_id ordering if required
+                if require_seq_id and i < len(actual_chain) - 1:
+                    next_item = actual_chain[i + 1]
+                    assert actual["seq_id"] < next_item["seq_id"], (
+                        f"Config '{cnf_name}': seq_id not in ascending order - "
+                        f"item[{i}] seq_id={actual['seq_id']} should be less than "
+                        f"item[{i+1}] seq_id={next_item['seq_id']}"
+                    )
 
 
 @features.telemetry_instrumentation

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -128,8 +128,8 @@ class _Scenarios:
         scenario_groups=[scenario_groups.telemetry],
     )
 
-    telemetry_enhanced_config_reporting = EndToEndScenario(
-        "TELEMETRY_ENHANCED_CONFIG_REPORTING",
+    telemetry_app_started_config_chaining = EndToEndScenario(
+        "TELEMETRY_APP_STARTED_CONFIG_CHAINING",
         weblog_env={
             "DD_LOGS_INJECTION": "false",
             "CONFIG_CHAINING_TEST": "true",

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -87,13 +87,6 @@ if os.environ.get("INCLUDE_RABBITMQ", "true") == "true":
     from integrations.messaging.rabbitmq import rabbitmq_produce
 
 import ddtrace
-
-# This mimics a scenario where a user has one config setting set in multiple sources
-# so that config chaining data is sent
-if os.environ.get("CONFIG_CHAINING_TEST", "").lower() == "true":
-    from ddtrace import config
-
-    config._logs_injection = True
 from ddtrace.appsec import trace_utils as appsec_trace_utils
 from ddtrace.internal.datastreams import data_streams_processor
 from ddtrace.internal.datastreams.processor import DsmPathwayCodec


### PR DESCRIPTION
Reverts DataDog/system-tests#5044

This is seemingly breaking tests in dd-trace-js. It's an optimistic revert to address the issue.