### PR TITLE
[Java] Restoring Debugger Tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1803,8 +1803,8 @@ tests/:
     test_debugger_exception_replay.py:
       Test_Debugger_Exception_Replay:
         '*': missing_feature
-        spring-boot: missing_feature (Temporarily disabling until Java PR is updated)
-        uds-spring-boot: missing_feature (Temporarily disabling until Java PR is updated)
+        spring-boot: v1.50.0
+        uds-spring-boot: v1.50.0
     test_debugger_expression_language.py:
       Test_Debugger_Expression_Language:
         '*': missing_feature


### PR DESCRIPTION

## Motivation

Same as https://github.com/DataDog/system-tests/pull/5066
Trying to get it merge so I push do refactoring here: https://github.com/DataDog/dd-trace-java/pull/9358

## Changes

This reverts commit 496df42fa1527130327ac54279309ffdbe91d6cc.

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
