### PR TITLE
Change default declaration to missing_feature

### DIFF
--- a/utils/_decorators.py
+++ b/utils/_decorators.py
@@ -344,6 +344,6 @@ def _resolve_declaration(released_declaration: str | dict[str, str]) -> str | No
         if "*" in released_declaration:
             return released_declaration["*"]
 
-        return None
+        return _DecoratorType.MISSING_FEATURE
 
     raise TypeError(f"Unsuported release info: {released_declaration}")


### PR DESCRIPTION
## Motivation

Isn't it tiring to have to write this ?
```yaml
Test_class:
  variant1: v1
  variant2: v2
  '*': missing_feature
```
The reason why we have to do this right now is because the default behavior when there is no declaration for a test, is to just run it. I think it should be missing_feature by default instead so we can do this:
```yaml
Test_class:
  variant1: v1
  variant2: v2
```

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
