### PR TITLE
Cbeauchesne/prefix safeguard

### DIFF
--- a/.github/workflows/compute-impacted-libraries.yml
+++ b/.github/workflows/compute-impacted-libraries.yml
@@ -32,83 +32,11 @@ jobs:
           cat modified_files.txt
       - name: Compute impacted libraries
         id: compute
-        shell: python
         run: |
-          import json
-          import os
-          import re
-
-          github_context = json.loads(os.environ["GITHUB_CONTEXT"])
-
-          # temporary print to see what's hapenning on differents events
-          print(json.dumps(github_context, indent=2))
-
-          libraries = "cpp|cpp_httpd|cpp_nginx|dotnet|golang|java|nodejs|php|python|ruby|java_otel|python_otel|nodejs_otel"
-          result = set()
-
-          # do not include otel in system-tests CI by default, as the staging backend is not stable enough
-          # all_libraries = {"cpp", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby", "java_otel", "python_otel", "nodejs_otel"}
-          all_libraries = {"cpp", "cpp_httpd", "cpp_nginx", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby"}
-
-          if github_context["ref"] == "refs/heads/main":
-              print("Merge commit to main => run all libraries")
-              result |= all_libraries
-
-          elif github_context["event_name"] == "schedule":
-              print("Scheduled job => run all libraries")
-              result |= all_libraries
-
-          else:
-              pr_title = github_context["event"]["pull_request"]["title"].lower()
-              match = re.search(rf"^\[({libraries})(?:@([^\]]+))?\]", pr_title)
-              if match:
-                  print(f"PR title matchs => run {match[1]}")
-                  result.add(match[1])
-              else:
-                  print(f"Inspect modified files to determine impacted libraries...")
-                  with open("modified_files.txt", "r", encoding="utf-8") as f:
-                      files = f.readlines()
-
-                  for file in files:
-                      manifest_match = re.search(rf"^manifests/({libraries}).yml", file)
-                      weblog_match = re.search(rf"^utils/build/docker/({libraries})/", file)
-                      injection_match = re.search(rf"^lib-injection/build/docker/({libraries})/", file)
-
-                      if manifest_match:
-                          result.add(manifest_match[1])
-                      elif weblog_match:
-                          result.add(weblog_match[1])
-                      elif injection_match:
-                          result.add(injection_match[1])
-
-                      if not manifest_match and not weblog_match and not injection_match:
-                          print(f"{file} may impact any library => run all of them")
-                          result |= all_libraries
-                          break
-
-          populated_result = [
-            {
-              "library": library,
-              "version": "prod",
-            }
-            for library in sorted(result)
-          ] + [
-            {
-              "library": library,
-              "version": "dev",
-            }
-            for library in sorted(result)
-            if "otel" not in library and library not in ("cpp_nginx", )
-          ]
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
-              print(f"library_matrix={json.dumps(populated_result)}", file=fh)
-              print(f"libraries_with_dev={json.dumps([item['library'] for item in populated_result if item['version'] == 'dev'])}", file=fh)
-              print(f"desired_execution_time={600 if len(result) == 1 else 3600}", file=fh)
-
+          source venv/bin/activate
+          python utils/scripts/compute-impacted-libraries.py
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
-
       - name: Get target branch
         uses: ./.github/actions/get_target_branch
         id: get-target-branch

--- a/utils/scripts/compute-impacted-libraries.py
+++ b/utils/scripts/compute-impacted-libraries.py
@@ -1,0 +1,76 @@
+import json
+import os
+import re
+
+github_context = json.loads(os.environ["GITHUB_CONTEXT"])
+
+# temporary print to see what's hapenning on differents events
+print(json.dumps(github_context, indent=2))
+
+libraries = "cpp|cpp_httpd|cpp_nginx|dotnet|golang|java|nodejs|php|python|ruby|java_otel|python_otel|nodejs_otel"
+result = set()
+
+# do not include otel in system-tests CI by default, as the staging backend is not stable enough
+# all_libraries = {
+#   "cpp", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby", "java_otel", "python_otel", "nodejs_otel"
+# }
+all_libraries = {"cpp", "cpp_httpd", "cpp_nginx", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby"}
+
+if github_context["ref"] == "refs/heads/main":
+    print("Merge commit to main => run all libraries")
+    result |= all_libraries
+
+elif github_context["event_name"] == "schedule":
+    print("Scheduled job => run all libraries")
+    result |= all_libraries
+
+else:
+    pr_title = github_context["event"]["pull_request"]["title"].lower()
+    match = re.search(rf"^\[({libraries})(?:@([^\]]+))?\]", pr_title)
+    if match:
+        print(f"PR title matchs => run {match[1]}")
+        result.add(match[1])
+    else:
+        print("Inspect modified files to determine impacted libraries...")
+        with open("modified_files.txt", "r", encoding="utf-8") as f:
+            files = f.readlines()
+
+        for file in files:
+            manifest_match = re.search(rf"^manifests/({libraries}).yml", file)
+            weblog_match = re.search(rf"^utils/build/docker/({libraries})/", file)
+            injection_match = re.search(rf"^lib-injection/build/docker/({libraries})/", file)
+
+            if manifest_match:
+                result.add(manifest_match[1])
+            elif weblog_match:
+                result.add(weblog_match[1])
+            elif injection_match:
+                result.add(injection_match[1])
+
+            if not manifest_match and not weblog_match and not injection_match:
+                print(f"{file} may impact any library => run all of them")
+                result |= all_libraries
+                break
+
+populated_result = [
+    {
+        "library": library,
+        "version": "prod",
+    }
+    for library in sorted(result)
+] + [
+    {
+        "library": library,
+        "version": "dev",
+    }
+    for library in sorted(result)
+    if "otel" not in library and library not in ("cpp_nginx",)
+]
+
+with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+    print(f"library_matrix={json.dumps(populated_result)}", file=fh)
+    print(
+        f"libraries_with_dev={json.dumps([item['library'] for item in populated_result if item['version'] == 'dev'])}",
+        file=fh,
+    )
+    print(f"desired_execution_time={600 if len(result) == 1 else 3600}", file=fh)

--- a/utils/scripts/compute-impacted-libraries.py
+++ b/utils/scripts/compute-impacted-libraries.py
@@ -1,76 +1,84 @@
 import json
 import os
 import re
+import sys
 
-github_context = json.loads(os.environ["GITHUB_CONTEXT"])
 
-# temporary print to see what's hapenning on differents events
-print(json.dumps(github_context, indent=2))
+def main() -> None:
+    github_context = json.loads(os.environ["GITHUB_CONTEXT"])
 
-libraries = "cpp|cpp_httpd|cpp_nginx|dotnet|golang|java|nodejs|php|python|ruby|java_otel|python_otel|nodejs_otel"
-result = set()
+    # temporary print to see what's hapenning on differents events
+    print(json.dumps(github_context, indent=2))
 
-# do not include otel in system-tests CI by default, as the staging backend is not stable enough
-# all_libraries = {
-#   "cpp", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby", "java_otel", "python_otel", "nodejs_otel"
-# }
-all_libraries = {"cpp", "cpp_httpd", "cpp_nginx", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby"}
+    libraries = "cpp|cpp_httpd|cpp_nginx|dotnet|golang|java|nodejs|php|python|ruby|java_otel|python_otel|nodejs_otel"
+    result = set()
 
-if github_context["ref"] == "refs/heads/main":
-    print("Merge commit to main => run all libraries")
-    result |= all_libraries
+    # do not include otel in system-tests CI by default, as the staging backend is not stable enough
+    # all_libraries = {
+    #   "cpp", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby", "java_otel", "python_otel", "nodejs_otel"
+    # }
+    all_libraries = {"cpp", "cpp_httpd", "cpp_nginx", "dotnet", "golang", "java", "nodejs", "php", "python", "ruby"}
 
-elif github_context["event_name"] == "schedule":
-    print("Scheduled job => run all libraries")
-    result |= all_libraries
+    if github_context["ref"] == "refs/heads/main":
+        print("Merge commit to main => run all libraries")
+        result |= all_libraries
 
-else:
-    pr_title = github_context["event"]["pull_request"]["title"].lower()
-    match = re.search(rf"^\[({libraries})(?:@([^\]]+))?\]", pr_title)
-    if match:
-        print(f"PR title matchs => run {match[1]}")
-        result.add(match[1])
+    elif github_context["event_name"] == "schedule":
+        print("Scheduled job => run all libraries")
+        result |= all_libraries
+
     else:
+        pr_title = github_context["event"]["pull_request"]["title"].lower()
+        match = re.search(rf"^\[({libraries})(?:@([^\]]+))?\]", pr_title)
+        user_choice = None
+        if match:
+            print(f"PR title matchs => run {match[1]}")
+            user_choice = match[1]
+            result.add(user_choice)
+
         print("Inspect modified files to determine impacted libraries...")
+
         with open("modified_files.txt", "r", encoding="utf-8") as f:
-            files = f.readlines()
+            modified_files = f.readlines()
 
-        for file in files:
-            manifest_match = re.search(rf"^manifests/({libraries}).yml", file)
-            weblog_match = re.search(rf"^utils/build/docker/({libraries})/", file)
-            injection_match = re.search(rf"^lib-injection/build/docker/({libraries})/", file)
+        for file in modified_files:
+            match = re.search(rf"^(manifests|utils/build/docker|lib-injection/build/docker)/({libraries})(\./)", file)
 
-            if manifest_match:
-                result.add(manifest_match[1])
-            elif weblog_match:
-                result.add(weblog_match[1])
-            elif injection_match:
-                result.add(injection_match[1])
-
-            if not manifest_match and not weblog_match and not injection_match:
-                print(f"{file} may impact any library => run all of them")
+            if match:
+                library = match[2]
+                if user_choice is not None and library != user_choice:
+                    print(f"You've selected {user_choice}, but the modified file {file} impacts {library}.")
+                    sys.exit(1)
+            elif user_choice is not None:
+                result.add(user_choice)
+            else:
                 result |= all_libraries
-                break
 
-populated_result = [
-    {
-        "library": library,
-        "version": "prod",
-    }
-    for library in sorted(result)
-] + [
-    {
-        "library": library,
-        "version": "dev",
-    }
-    for library in sorted(result)
-    if "otel" not in library and library not in ("cpp_nginx",)
-]
+    populated_result = [
+        {
+            "library": library,
+            "version": "prod",
+        }
+        for library in sorted(result)
+    ] + [
+        {
+            "library": library,
+            "version": "dev",
+        }
+        for library in sorted(result)
+        if "otel" not in library and library not in ("cpp_nginx",)
+    ]
 
-with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
-    print(f"library_matrix={json.dumps(populated_result)}", file=fh)
-    print(
-        f"libraries_with_dev={json.dumps([item['library'] for item in populated_result if item['version'] == 'dev'])}",
-        file=fh,
-    )
-    print(f"desired_execution_time={600 if len(result) == 1 else 3600}", file=fh)
+    libraries_with_dev = [item["library"] for item in populated_result if item["version"] == "dev"]
+
+    with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+        print(f"library_matrix={json.dumps(populated_result)}", file=fh)
+        print(
+            f"libraries_with_dev={json.dumps(libraries_with_dev)}",
+            file=fh,
+        )
+        print(f"desired_execution_time={600 if len(result) == 1 else 3600}", file=fh)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

User tends to forget that a title prefix runs only the selected tracer

## Changes

If a file known to impact a tracer (manifest, docker) is modified, and a title prefix is used to select another tracer, the CI will break (both preventing the issue, and spread the knowledge).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
