### PR TITLE
Allow int or float value for telemetry_heartbeat_interval telemetry configuration value

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -367,14 +367,14 @@ class Test_Telemetry:
     def test_app_dependencies_loaded(self):
         """Test app-dependencies-loaded requests"""
 
-        test_loaded_dependencies: dict[str, dict[str, bool]] = {
+        test_loaded_dependencies = {
             "dotnet": {"NodaTime": False},
             "nodejs": {"glob": False},
             "java": {"httpclient": False},
             "ruby": {"bundler": False},
         }
 
-        test_defined_dependencies: dict[str, dict[str, bool]] = {
+        test_defined_dependencies = {
             "dotnet": {},
             "nodejs": {
                 "body-parser": False,
@@ -503,6 +503,19 @@ class Test_Telemetry:
                         # Handle different configuration structures - some might not have 'value' key
                         if cnf.get("name") == config_name_to_check:
                             config_value = cnf.get("value")
+                            # Accept both the expected value and its float version for telemetry_heartbeat_interval
+                            if expected_config_name == "telemetry_heartbeat_interval":
+                                try:
+                                    expected_float = float(expected_value)
+                                    config_float = float(config_value)
+                                    if config_float == expected_float:
+                                        config_found = True
+                                        configurations_present.append(expected_config_name)
+                                        break
+                                except Exception as e:
+                                    logger.debug(
+                                        f"Could not compare as float for config '{expected_config_name}': {e}"
+                                    )  # fallback to string comparison below
                             if config_value is not None and str(config_value).lower() == expected_value_str:
                                 config_found = True
                                 configurations_present.append(expected_config_name)


### PR DESCRIPTION
## Motivation
dd-trace-java stores the default value of telemetry_heartbeat_interval as an int, but resolves any configured values to a float. When DD_TELEMETRY_HEARTBEAT_INTERVAL=2 is set, dd-trace-java will report its value as `2.0` as expected.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
