### PR TITLE
Extend stats schemas to comply with RFC specs

### DIFF
--- a/utils/interfaces/schemas/agent/api/v0.2/stats-request.json
+++ b/utils/interfaces/schemas/agent/api/v0.2/stats-request.json
@@ -1,41 +1,80 @@
 {
   "$id": "/agent/api/v0.2/stats-request.json",
   "type": "object",
+  "required": ["Stats"],
   "properties": {
     "Stats": {
       "type": "array",
+      "description": "Array of ClientStatsPayload containing deployment-level information",
       "items": {
         "type": "object",
+        "required": ["Hostname", "Env", "Version", "Stats", "Lang", "TracerVersion", "RuntimeID", "Sequence", "Service", "ProcessTags"],
         "properties": {
+          "Hostname": { "type": "string", "description": "Tracer hostname" },
+          "Env": { "type": "string", "description": "Environment" },
+          "Version": { "type": "string", "description": "Service version" },
           "Stats": {
             "type": "array",
+            "description": "Time-bucketed stats",
             "items": {
               "type": "object",
+              "required": ["Start", "Duration", "Stats"],
               "properties": {
-                "Start": { "type": "integer" },
-                "Duration": { "type": "integer" },
+                "Start": { "type": "integer", "minimum": 0, "description": "Bucket start time (nanoseconds)" },
+                "Duration": { "type": "integer", "minimum": 0, "description": "Bucket duration (nanoseconds)" },
                 "Stats": {
                   "type": "array",
+                  "description": "Grouped stats",
                   "items": {
                     "type": "object",
+                    "required": ["Service", "Name", "Resource", "Type", "Hits", "Errors", "Duration", "OkSummary", "ErrorSummary", "Synthetics", "TopLevelHits", "IsTraceRoot"],
                     "properties": {
-                      "Service": { "type": "string" },
-                      "Name": { "type": "string" },
-                      "Resource": { "type": "string" }
-                    },
-                    "required": ["Service", "Name", "Resource"]
+                      "Service": { "type": "string", "description": "Service name" },
+                      "Name": { "type": "string", "description": "Span name" },
+                      "Resource": { "type": "string", "description": "Resource name" },
+                      "HTTPStatusCode": { "type": "integer", "description": "HTTP status code" },
+                      "Type": { "type": "string", "description": "Span type" },
+                      "DBType": { "type": "string", "description": "Database type (reserved)" },
+                      "Hits": { "type": "integer", "minimum": 0, "description": "Total span count" },
+                      "Errors": { "type": "integer", "minimum": 0, "description": "Error span count" },
+                      "Duration": { "type": "integer", "minimum": 0, "description": "Total duration (nanoseconds)" },
+                      "OkSummary": { "type": "string", "description": "DDSketch for OK spans" },
+                      "ErrorSummary": { "type": "string", "description": "DDSketch for error spans" },
+                      "Synthetics": { "type": "boolean", "description": "Synthetics traffic flag" },
+                      "TopLevelHits": { "type": "integer", "minimum": 0, "description": "Top-level span count" },
+                      "SpanKind": { "type": "string", "description": "Span kind" },
+                      "PeerTags": { 
+                        "type": "array", 
+                        "items": { "type": "string" },
+                        "description": "Peer tags"
+                      },
+                      "IsTraceRoot": { "type": "integer", "description": "Trace root flag" },
+                      "GRPCStatusCode": { "type": "string", "description": "gRPC status code" }
+                    }
                   }
-                }
-              },
-              "required": ["Start", "Duration", "Stats"]
+                },
+                "AgentTimeShift": { "type": "integer", "description": "Agent time shift adjustment" }
+              }
             }
-          }
-        },
-        "required": ["Stats"]
+          },
+          "Lang": { "type": "string", "description": "Language identifier" },
+          "TracerVersion": { "type": "string", "description": "Tracer version" },
+          "RuntimeID": { "type": "string", "description": "Runtime identifier" },
+          "Sequence": { "type": "integer", "minimum": 0, "description": "Sequence number" },
+          "AgentAggregation": { "type": "string", "description": "Agent aggregation type" },
+          "Service": { "type": "string", "description": "Main service name" },
+          "ContainerID": { "type": "string", "description": "Container ID" },
+          "Tags": { 
+            "type": "array", 
+            "items": { "type": "string" },
+            "description": "Container tags"
+          },
+          "GitCommitSha": { "type": "string", "description": "Git commit SHA" },
+          "ImageTag": { "type": "string", "description": "Container image tag" },
+          "ProcessTagsHash": { "type": "integer", "description": "Process tags hash" },
+          "ProcessTags": { "type": "string", "description": "Process tags string" }
+        }
       }
     }
-  },
-  "required": [
-    "Stats"
-  ]
+  }
 }

--- a/utils/interfaces/schemas/library/v0.6/stats-request.json
+++ b/utils/interfaces/schemas/library/v0.6/stats-request.json
@@ -1,40 +1,59 @@
 {
   "$id": "/library/v0.6/stats-request.json",
-  "required": ["Version", "Env", "Hostname", "Stats"],
+  "type": "object",
+  "required": ["Hostname", "Env", "Version", "Stats", "Lang", "TracerVersion", "RuntimeID", "Sequence", "Service", "ProcessTags", "GitCommitSha"],
   "properties": {
-    "Version": { "type": "string", "minLength": 1 },
-    "Env": { "type": "string", "minLength": 1 },
-    "Hostname": { "type": "string" },
+    "Hostname": { "type": "string", "description": "Tracer hostname from configuration" },
+    "Env": { "type": "string", "minLength": 1, "description": "Environment tag (never empty, defaults to 'unknown-env')" },
+    "Version": { "type": "string", "description": "Service version from configuration" },
     "Stats": {
       "type": "array",
+      "description": "Array of ClientStatsBucket containing time-bucketed statistics",
       "items": {
         "type": "object",
         "required": ["Start", "Duration", "Stats"],
         "properties": {
-          "Start": { "type": "integer", "minimum": 0 },
-          "Duration": { "type": "integer", "minimum": 0 },
+          "Start": { "type": "integer", "minimum": 0, "description": "Bucket start time in nanoseconds" },
+          "Duration": { "type": "integer", "minimum": 0, "description": "Bucket duration in nanoseconds" },
           "Stats": {
             "type": "array",
+            "description": "Array of ClientGroupedStats containing aggregated statistics",
             "items": {
               "type": "object",
+              "required": ["Service", "Name", "Resource", "Type", "Hits", "Errors", "Duration", "OkSummary", "ErrorSummary", "Synthetics", "TopLevelHits", "IsTraceRoot"],
               "properties": {
-                "Name": { "type": "string" },
-                "Resource": { "type": "string" },
-                "Synthetics": { "type": "boolean" },
-                "HTTPStatusCode": { "type": "integer" },
-                "Hits": { "type": "integer" },
-                "TopLevelHits": { "type": "integer" },
-                "Duration": { "type": "integer" },
-                "Errors": { "type": "integer" },
-                "OkSummary": { "type": "string" },
-                "ErrorSummary": { "type": "string" },
-                "Service": { "type": "string" },
-                "Type": { "type": "string" }
+                "Service": { "type": "string", "description": "Service name from span" },
+                "Name": { "type": "string", "description": "Span operation name" },
+                "Resource": { "type": "string", "description": "Resource name (obfuscated if agent obfuscation is enabled)" },
+                "HTTPStatusCode": { "type": "integer", "description": "HTTP status code extracted from span metadata/metrics" },
+                "Type": { "type": "string", "description": "Span type (e.g., 'web', 'db', 'cache', 'custom')" },
+                "Hits": { "type": "integer", "minimum": 0, "description": "Total span count (converted to uint64 using stochastic rounding)" },
+                "Errors": { "type": "integer", "minimum": 0, "description": "Error span count (converted to uint64 using stochastic rounding)" },
+                "Duration": { "type": "integer", "minimum": 0, "description": "Total duration in nanoseconds (converted to uint64 using stochastic rounding)" },
+                "OkSummary": { "type": "string", "description": "DDSketch bytes for OK spans (1% relative accuracy)" },
+                "ErrorSummary": { "type": "string", "description": "DDSketch bytes for error spans (1% relative accuracy)" },
+                "Synthetics": { "type": "boolean", "description": "True if span origin starts with 'synthetics'" },
+                "TopLevelHits": { "type": "integer", "minimum": 0, "description": "Top-level span count (converted to uint64 using stochastic rounding)" },
+                "SpanKind": { "type": "string", "description": "Span kind value from span metadata (server, client, producer, consumer)" },
+                "PeerTags": { 
+                  "type": "array", 
+                  "items": { "type": "string" },
+                  "description": "Peer tags array from span metadata (based on agent peer tags configuration)"
+                },
+                "IsTraceRoot": { "type": "integer", "description": "TRUE if span parentID == 0, FALSE otherwise" },
+                "GRPCStatusCode": { "type": "string", "description": "gRPC status code from span metadata" }
               }
             }
           }
         }
       }
-    }
+    },
+    "Lang": { "type": "string", "description": "Language identifier (e.g., 'go', 'python', 'java')" },
+    "TracerVersion": { "type": "string", "description": "Tracer library version" },
+    "RuntimeID": { "type": "string", "description": "Runtime identifier for message uniqueness" },
+    "Sequence": { "type": "integer", "minimum": 0, "description": "Sequence number for message uniqueness" },
+    "Service": { "type": "string", "description": "Main service name from configuration" },
+    "ProcessTags": { "type": "string", "description": "Process tags string (populated at flush time)" },
+    "GitCommitSha": { "type": "string", "description": "Git commit SHA (only when CI Visibility is enabled)" }
   }
 }

--- a/utils/interfaces/schemas/library/v0.6/stats-request.json
+++ b/utils/interfaces/schemas/library/v0.6/stats-request.json
@@ -1,7 +1,7 @@
 {
   "$id": "/library/v0.6/stats-request.json",
   "type": "object",
-  "required": ["Hostname", "Env", "Version", "Stats", "Lang", "TracerVersion", "RuntimeID", "Sequence", "Service", "ProcessTags", "GitCommitSha"],
+  "required": ["Hostname", "Env", "Version", "Stats", "TracerVersion", "RuntimeID", "Sequence", "Service"],
   "properties": {
     "Hostname": { "type": "string", "description": "Tracer hostname from configuration" },
     "Env": { "type": "string", "minLength": 1, "description": "Environment tag (never empty, defaults to 'unknown-env')" },
@@ -20,7 +20,7 @@
             "description": "Array of ClientGroupedStats containing aggregated statistics",
             "items": {
               "type": "object",
-              "required": ["Service", "Name", "Resource", "Type", "Hits", "Errors", "Duration", "OkSummary", "ErrorSummary", "Synthetics", "TopLevelHits", "IsTraceRoot"],
+              "required": ["Service", "Name", "Resource", "Type", "Hits", "Errors", "Duration", "OkSummary", "ErrorSummary", "Synthetics", "TopLevelHits"],
               "properties": {
                 "Service": { "type": "string", "description": "Service name from span" },
                 "Name": { "type": "string", "description": "Span operation name" },


### PR DESCRIPTION
## Motivation

Update Client Stat payload schema reflecting the current state

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
