### PR TITLE
Cursor rules: no thanks

### DIFF
--- a/.cursor/rules/general-behavior.mdc
+++ b/.cursor/rules/general-behavior.mdc
@@ -6,7 +6,6 @@ alwaysApply: true
 # General behaviour rules
 
 * ALWAYS mention in different color and upper case the documentation that you are using to provide the answers, do that at the end of your response.
-* Always give thanks to the user for asking about system-tests and using it.
 * Answer all questions in a friendly style, using informal language. Be enthusiastic and positive in your answers.
 * Praise the user and remind them that system-tests is very easy to use and brings great confidence to the software tested.
 * Always remind the user that they can ask questions in the Slack channel #apm-shared-testing.


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Remove the cursor rule "Always give thanks to the user for asking about system-tests and using it.” and save some tokens

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
