### PR TITLE
[python] endpoint discovery enabled for python weblogs

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -18,7 +18,7 @@ tests/:
         Test_API_Security_Sampling_With_Delay: v2.6.0
       test_endpoint_discovery.py:
         Test_Endpoint_Discovery:
-          '*': missing_feature
+          '*': v3.13.0.dev
           'django-poc': v3.12.0.dev
           'django-py3.13': v3.12.0.dev
           'python3.12': v3.12.0.dev

--- a/tests/appsec/api_security/test_endpoint_discovery.py
+++ b/tests/appsec/api_security/test_endpoint_discovery.py
@@ -80,12 +80,7 @@ class Test_Endpoint_Discovery:
         self.main_setup()
 
     @irrelevant(
-        (context.library, context.weblog_variant)
-        in [
-            ("python", "django-poc"),
-            ("python", "django-py3.13"),
-            ("python", "python3.12"),
-        ],
+        context.library in ["python"],
         reason="Not applicable to weblog variant",
     )
     def test_optional_type(self):
@@ -129,11 +124,9 @@ class Test_Endpoint_Discovery:
         self.main_setup()
 
     @irrelevant(
-        (context.library, context.weblog_variant)
+        context.library
         in [
-            ("python", "django-poc"),
-            ("python", "django-py3.13"),
-            ("python", "python3.12"),
+            "python",
         ],
         reason="Not applicable to weblog variant",
     )
@@ -154,12 +147,7 @@ class Test_Endpoint_Discovery:
         self.main_setup()
 
     @irrelevant(
-        (context.library, context.weblog_variant)
-        in [
-            ("python", "django-poc"),
-            ("python", "django-py3.13"),
-            ("python", "python3.12"),
-        ],
+        (context.library == "python" and context.weblog_variant != "fastapi"),
         reason="Not applicable to weblog variant",
     )
     @irrelevant(context.library == "dotnet", reason="Not applicable to weblog")
@@ -184,6 +172,9 @@ class Test_Endpoint_Discovery:
             ("python", "django-poc"),
             ("python", "django-py3.13"),
             ("python", "python3.12"),
+            ("python", "flask-poc"),
+            ("python", "uwsgi-poc"),
+            ("python", "uds-flask"),
         ],
         reason="Not applicable to weblog variant",
     )
@@ -207,10 +198,8 @@ class Test_Endpoint_Discovery:
         (context.library, context.weblog_variant)
         in [
             ("java", "spring-boot"),
-            ("python", "django-poc"),
-            ("python", "django-py3.13"),
-            ("python", "python3.12"),
-        ],
+        ]
+        or context.library == "python",
         reason="Not applicable to weblog variant",
     )
     @irrelevant(context.library == "dotnet", reason="Not applicable to weblog")
@@ -230,15 +219,9 @@ class Test_Endpoint_Discovery:
         self.main_setup()
 
     @irrelevant(
-        (context.library, context.weblog_variant)
-        in [
-            ("python", "django-poc"),
-            ("python", "django-py3.13"),
-            ("python", "python3.12"),
-        ],
+        context.library in ["python", "dotnet"],
         reason="Not applicable to weblog variant",
     )
-    @irrelevant(context.library == "dotnet", reason="Not applicable to weblog")
     def test_optional_metadata(self):
         endpoints = self._get_endpoints()
         found = False

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -103,9 +103,9 @@ async def custom_404_handler(request: Request, _):
     return JSONResponse({"error": 404}, status_code=404)
 
 
-@app.get("/", response_class=PlainTextResponse)
-@app.post("/", response_class=PlainTextResponse)
-@app.options("/", response_class=PlainTextResponse)
+@app.get("/", response_class=PlainTextResponse, status_code=200)
+@app.post("/", response_class=PlainTextResponse, status_code=200)
+@app.options("/", response_class=PlainTextResponse, status_code=200)
 async def root():
     return "Hello, World!"
 


### PR DESCRIPTION
## Motivation

After https://github.com/DataDog/dd-trace-py/pull/14382 and https://github.com/DataDog/dd-trace-py/pull/14396, we can enable endpoint discovery for all python weblogs.

## Changes

Enable tests and update irrelevant conditions for python
Also add status code data in fastapi weblog root endpoint.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
