### PR TITLE
blocking on forwarded ip

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -339,6 +339,7 @@ tests/:
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
       Test_Blocking_client_ip: v2.27.0
+      Test_Blocking_client_ip_with_forwarded: missing_feature
       Test_Blocking_request_body: v2.29.0
       Test_Blocking_request_body_multipart: missing_feature
       Test_Blocking_request_cookies: v2.29.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -423,6 +423,7 @@ tests/:
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
       Test_Blocking_client_ip: v1.51.0
+      Test_Blocking_client_ip_with_forwarded: missing_feature
       Test_Blocking_request_body: missing_feature
       Test_Blocking_request_body_multipart: irrelevant (Body blocking happens through SDK)
       Test_Blocking_request_cookies:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1353,6 +1353,7 @@ tests/:
         spring-boot-openliberty: v0.115.0
         vertx3: v1.7.0
         vertx4: v1.7.0
+      Test_Blocking_client_ip_with_forwarded: missing_feature
       Test_Blocking_request_body:
         '*': v1.15.0
         akka-http: v1.22.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -863,6 +863,7 @@ tests/:
         express5: missing_feature  # graphql not yet compatible with express5
         nextjs: irrelevant  # nextjs is not related with graphql
       Test_Blocking_client_ip: *ref_3_19_0
+      Test_Blocking_client_ip_with_forwarded: missing_feature
       Test_Blocking_request_body:
         '*': *ref_3_19_0
         fastify: *ref_5_57_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -351,6 +351,8 @@ tests/:
       Test_Automated_User_Tracking: v1.8.0
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
+      Test_Blocking_client_ip: missing_feature (unknown version)
+      Test_Blocking_client_ip_with_forwarded: missing_feature
       Test_Blocking_request_body: irrelevant (Php does not accept url encoded entries without key)
       Test_Blocking_request_body_multipart: v1.6.2
       Test_Blocking_response_headers: irrelevant (On php it is not possible change the status code once its header is sent)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -560,6 +560,7 @@ tests/:
         django-poc: v1.10
         fastapi: v2.4.0
         flask-poc: v1.10
+      Test_Blocking_client_ip_with_forwarded: v3.13.0.dev
       Test_Blocking_request_body:
         '*': v1.16.1
         django-poc: v3.7.0.dev (is v1.10 but weblog use new SDK now)

--- a/manifests/python_lambda.yml
+++ b/manifests/python_lambda.yml
@@ -20,6 +20,7 @@ tests/:
       Test_Basic: v7.112.0
     test_blocking_addresses.py:
       Test_Blocking_client_ip: v8.113.0
+      Test_Blocking_client_ip_with_forwarded: missing_feature
       Test_Blocking_request_body: v8.113.0
       Test_Blocking_request_body_multipart: v8.113.0
       Test_Blocking_request_cookies: v8.113.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -419,6 +419,7 @@ tests/:
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: v2.4.0
       Test_Blocking_client_ip: v1.0.0
+      Test_Blocking_client_ip_with_forwarded: missing_feature
       Test_Blocking_request_body: v1.0.0
       Test_Blocking_request_body_multipart: v1.0.0
       Test_Blocking_request_cookies: v1.0.0

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -69,7 +69,6 @@ class Test_Blocking_client_ip:
 @features.appsec_request_blocking
 @features.envoy_external_processing
 @scenarios.appsec_blocking
-@scenarios.appsec_lambda_blocking
 @scenarios.external_processing_blocking
 class Test_Blocking_client_ip_with_forwarded:
     """Test if blocking is supported on http.client_ip address"""


### PR DESCRIPTION
## Motivation

Forwarded is now used as a source of ip data

## Changes

Test if we can block on forwarded header.
Enable it for Python after last changes on main.

APPSEC-58261

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
