### PR TITLE
parametric: upgrade Test Agent to v1.32.0 and Fix Span Event Serialization Tests

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -730,11 +730,11 @@ class Test_Otel_Span_Methods:
         )
 
     @missing_feature(
-        context.library != "golang@1.66.0-dev" and context.library < "golang@1.67.0", reason="Implemented in v1.67.0"
+        context.library in ("dotnet", "golang", "ruby"),
+        reason="Newer agents/testagents enabled native span event serialization by default",
     )
     @missing_feature(context.library < "php@1.3.0", reason="Not implemented")
     @missing_feature(context.library < "java@1.40.0", reason="Not implemented")
-    @missing_feature(context.library < "ruby@2.3.0", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.17.0", reason="Implemented in v5.17.0 & v4.41.0")
     @missing_feature(context.library < "python@2.9.0", reason="Not implemented")
     def test_otel_add_event_meta_serialization(self, test_agent, test_library):
@@ -799,10 +799,12 @@ class Test_Otel_Span_Methods:
         root_span = find_span(trace, span.span_id)
         assert "error" not in root_span or root_span["error"] == 0
 
-    @missing_feature(context.library == "golang", reason="Not implemented")
+    @missing_feature(
+        context.library in ("dotnet", "golang", "ruby"),
+        reason="Newer agents/testagents enabled native span event serialization by default",
+    )
     @missing_feature(context.library < "php@1.3.0", reason="Not implemented")
     @missing_feature(context.library < "java@1.40.0", reason="Not implemented")
-    @missing_feature(context.library < "ruby@2.3.0", reason="Not implemented")
     @missing_feature(context.library < "nodejs@5.17.0", reason="Implemented in v5.17.0 & v4.41.0")
     @missing_feature(context.library < "python@2.9.0", reason="Not implemented")
     def test_otel_record_exception_meta_serialization(self, test_agent, test_library):
@@ -845,12 +847,14 @@ class Test_Otel_Span_Methods:
         if context.library != "php":
             assert "error.type" in root_span["meta"]
 
-    @missing_feature(context.library == "golang", reason="Not implemented")
     @missing_feature(context.library < "php@1.3.0", reason="Not implemented")
     @missing_feature(context.library < "java@1.40.0", reason="Not implemented")
-    @missing_feature(context.library < "ruby@2.3.0", reason="Not implemented")
     @missing_feature(context.library == "nodejs", reason="Otel Node.js API does not support attributes")
     @missing_feature(context.library < "python@2.9.0", reason="Not implemented")
+    @missing_feature(
+        context.library in ("dotnet", "golang", "ruby"),
+        reason="Newer agents/testagents enabled native span event serialization by default",
+    )
     def test_otel_record_exception_attributes_serialization(self, test_agent, test_library):
         """Tests the Span.RecordException API (requires Span.AddEvent API support)
         and its serialization into the Datadog error tags and the 'events' tag

--- a/tests/parametric/test_parametric_endpoints.py
+++ b/tests/parametric/test_parametric_endpoints.py
@@ -6,7 +6,6 @@ When in doubt refer to the python implementation as the source of truth via
 the OpenAPI schema: https://github.com/DataDog/system-tests/blob/44281005e9d2ddec680f31b2813eb90af831c0fc/docs/scenarios/parametric.md#shared-interface
 """
 
-import json
 import pytest
 import time
 
@@ -14,6 +13,7 @@ from utils.parametric.spec.trace import find_trace
 from utils.parametric.spec.trace import find_span
 from utils.parametric.spec.trace import find_span_in_traces
 from utils.parametric.spec.trace import retrieve_span_links
+from utils.parametric.spec.trace import retrieve_span_events
 from utils.parametric.spec.trace import find_only_span
 from utils import irrelevant, bug, scenarios, features, context
 from opentelemetry.trace import SpanKind
@@ -625,9 +625,9 @@ class Test_Parametric_OtelSpan_Events:
 
         traces = test_agent.wait_for_num_traces(1)
         span = find_only_span(traces)
-        assert "events" in span["meta"]
-        events = json.loads(span["meta"]["events"])
-        assert len(events) == 1
+        events = retrieve_span_events(span)
+        assert events is not None
+        assert len(events) == 1, f"events: {events}"
         assert events[0]["name"] == "some_event"
         assert events[0]["time_unix_nano"] == 1730393556000000000
         assert events[0]["attributes"]["key"] == "value"
@@ -648,9 +648,9 @@ class Test_Parametric_OtelSpan_Events:
 
         traces = test_agent.wait_for_num_traces(1)
         span = find_only_span(traces)
-        assert "events" in span["meta"]
-        events = json.loads(span["meta"]["events"])
-        assert len(events) == 1
+        events = retrieve_span_events(span)
+        assert events is not None
+        assert len(events) == 1, f"events: {events}"
         assert events[0]["name"].lower() in ["exception", "error"]
         assert events[0]["attributes"]["error.key"] == "value"
 

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -81,7 +81,7 @@ class APMLibraryTestServer:
 
 
 class ParametricScenario(Scenario):
-    TEST_AGENT_IMAGE = "ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.20.0"
+    TEST_AGENT_IMAGE = "ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.32.0"
     apm_test_server_definition: APMLibraryTestServer
 
     class PersistentParametricTestConf(dict):


### PR DESCRIPTION
## Motivation


Upgrades test agent used in parametric tests to v1.32.0. v1.21.0 introduced native span serialization support with breaks som existing tests. This feature changed how span events are serialized (testagent broadcasts support for native span serializatio via the /info endpoint, which impacts trace encoding). 

The core motivation for this upgrade is to use the new otlp metrics and logs endpoints in parametric tests.

## Changes

- Upgraded test agent to v1.21.0
- Fixed span event serialization test assertions to match new native serialization format
- Updated `retrieve_span_events` function to work with new serialization behavior

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
