### PR TITLE
Update Telemetry Tests to take Highest Source

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1223,7 +1223,7 @@ tests/:
         '*': v1.36.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_SCAStandalone_Telemetry_V2:
-        '*': missing_feature (temporarily disabling while updating Java telemetry)
+        '*': v1.47.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_UserEventsStandalone_Automated:
         '*': v1.45.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1223,7 +1223,7 @@ tests/:
         '*': v1.36.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_SCAStandalone_Telemetry_V2:
-        '*': v1.47.0
+        '*': missing_feature (temporarily disabling while updating Java telemetry)
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_UserEventsStandalone_Automated:
         '*': v1.45.0

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -743,7 +743,12 @@ class BaseSCAStandaloneTelemetry:
                 continue
             configuration = content["payload"]["configuration"]
 
-            configuration_by_name = {**configuration_by_name, **{item["name"]: item for item in configuration}}
+            for item in configuration:
+                if (
+                    item["name"] not in configuration_by_name
+                    or configuration_by_name[item["name"]]["seq_id"] < item["seq_id"]
+                ):
+                    configuration_by_name[item["name"]] = item
 
         assert configuration_by_name
 

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -754,7 +754,6 @@ class BaseSCAStandaloneTelemetry:
                 # Sort seq_id for each config from highest to lowest
                 for payload in configuration_by_name.values():
                     payload.sort(key=lambda item: item["seq_id"], reverse=True)
-        # print(configuration_by_name)
         assert configuration_by_name
 
         dd_appsec_sca_enabled = TelemetryUtils.get_dd_appsec_sca_enabled_str(context.library)

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -747,15 +747,14 @@ class BaseSCAStandaloneTelemetry:
                 if item["name"] not in configuration_by_name:
                     configuration_by_name[item["name"]] = []
                 configuration_by_name[item["name"]].append(item)
-
         if len(configuration_by_name):
             # Checking if we need to sort due to multiple sources being sent for the same config
             sample_key = next(iter(configuration_by_name))
-            if "seq_id" in configuration_by_name[sample_key]:
+            if "seq_id" in configuration_by_name[sample_key][0]:
                 # Sort seq_id for each config from highest to lowest
                 for payload in configuration_by_name.values():
                     payload.sort(key=lambda item: item["seq_id"], reverse=True)
-
+        # print(configuration_by_name)
         assert configuration_by_name
 
         dd_appsec_sca_enabled = TelemetryUtils.get_dd_appsec_sca_enabled_str(context.library)


### PR DESCRIPTION
## Motivation

The recent OKR for Config Sources now reports telemetry for all Config Sources that have been set. This means that a single key can now have multiple telemetry entries, and the existing code accounts for the last one that is seen. Previously, system-tests stores the most recently processed source, which leads to inconsistencies since different tracers may send configs in different orders. The order of sources being sent is not enforced in the RFC. This PR updates the system-tests code to take in the highest precedence Config Source instead of the one most recently processed.

[RFC](https://docs.google.com/document/d/1vhIimn2vt4tDRSxsHn6vWSc8zYHl0Lv0Fk7CQps04C4/edit?tab=t.0#heading=h.7tw832mj0ztp)
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
