### PR TITLE
feat(er): Ensure APM_MULTICONFIG compat works

### DIFF
--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -5,6 +5,7 @@
 import tests.debugger.utils as debugger
 from utils import features, scenarios, missing_feature, context, logger
 import json
+import time
 
 TIMEOUT = 5
 
@@ -67,43 +68,53 @@ class Test_Debugger_InProduct_Enablement_Exception_Replay(debugger.BaseDebuggerT
     ############ exception replay ############
     _max_retries = 2
 
+    def _send_config(
+        self,
+        enabled: bool | None = None,
+        service_name: str = "weblog",
+        env: str = "system-tests",
+        *,
+        reset: bool = True,
+    ):
+        self.send_rc_apm_tracing(exception_replay_enabled=enabled, service_name=service_name, env=env, reset=reset)
+
+    def _wait_for_exception_snapshot_received(self, request_path, exception_message):
+        self.weblog_responses = []
+
+        retries = 0
+        snapshot_found = False
+
+        while not snapshot_found and retries < self._max_retries:
+            logger.debug(f"Waiting for snapshot, retry #{retries}")
+
+            self.send_weblog_request(request_path, reset=False)
+            snapshot_found = self.wait_for_exception_snapshot_received(exception_message, TIMEOUT)
+
+            retries += 1
+
+        return snapshot_found
+
     def setup_inproduct_enablement_exception_replay(self):
-        def _send_config(enabled=None):
-            self.send_rc_apm_tracing(exception_replay_enabled=enabled)
-
-        def _wait_for_exception_snapshot_received(request_path, exception_message):
-            self.weblog_responses = []
-
-            retries = 0
-            snapshot_found = False
-
-            while not snapshot_found and retries < self._max_retries:
-                logger.debug(f"Waiting for snapshot, retry #{retries}")
-
-                self.send_weblog_request(request_path, reset=False)
-                snapshot_found = self.wait_for_exception_snapshot_received(exception_message, TIMEOUT)
-
-                retries += 1
-
-            return snapshot_found
-
+        self.start_time = int(time.time() * 1000)
         self.initialize_weblog_remote_config()
         self.weblog_responses = []
 
-        self.er_initial_enabled = not _wait_for_exception_snapshot_received(
+        self.er_initial_enabled = not self._wait_for_exception_snapshot_received(
             "/exceptionreplay/simple", "simple exception"
         )
 
-        _send_config(enabled=True)
-        self.er_explicit_enabled = _wait_for_exception_snapshot_received("/exceptionreplay/simple", "simple exception")
+        self._send_config(enabled=True)
+        self.er_explicit_enabled = self._wait_for_exception_snapshot_received(
+            "/exceptionreplay/simple", "simple exception"
+        )
 
-        _send_config()
-        self.er_empty_config = _wait_for_exception_snapshot_received(
+        self._send_config()
+        self.er_empty_config = self._wait_for_exception_snapshot_received(
             "/exceptionreplay/recursion?depth=1", "recursion exception depth 1"
         )
 
-        _send_config(enabled=False)
-        self.er_explicit_disabled = not _wait_for_exception_snapshot_received(
+        self._send_config(enabled=False)
+        self.er_explicit_disabled = not self._wait_for_exception_snapshot_received(
             "/exceptionreplay/multiframe", "multiple stack frames exception"
         )
 
@@ -115,6 +126,46 @@ class Test_Debugger_InProduct_Enablement_Exception_Replay(debugger.BaseDebuggerT
         assert self.er_explicit_enabled, "Expected snapshots to be emitting after enabling exception replay"
         assert self.er_empty_config, "Expected snapshots to continue emitting with empty config"
         assert self.er_explicit_disabled, "Expected snapshots to stop emitting after explicit disable"
+
+    def setup_inproduct_enablement_exception_replay_apm_multiconfig(self):
+        self.start_time = int(time.time() * 1000)
+        self.initialize_weblog_remote_config()
+        self.weblog_responses = []
+
+        # Set a config with the wildcard service and env and ER=false.
+        self._send_config(enabled=False, service_name="*", env="*")
+        self.er_initial_enabled = not self._wait_for_exception_snapshot_received(
+            "/exceptionreplay/simple", "simple exception"
+        )
+
+        # Set a config with the wildcard service and env and ER=true.
+        self._send_config(enabled=True, service_name="*", env="*")
+        self.er_apm_multiconfig_enabled = self._wait_for_exception_snapshot_received(
+            "/exceptionreplay/simple", "simple exception"
+        )
+
+        # Set a config with the weblog service and env and ER=false.
+        self._send_config(enabled=False, service_name="weblog", env="system-tests", reset=False)
+        self.er_disabled_by_service_name = not self._wait_for_exception_snapshot_received(
+            "/exceptionreplay/recursion?depth=1", "recursion exception depth 1"
+        )
+
+        # Set a config with the wildcard service and env and ER=true.
+        self._send_config(enabled=True, service_name="*", env="*", reset=False)
+        self.er_apm_multiconfig_enabled_2 = not self._wait_for_exception_snapshot_received(
+            "/exceptionreplay/multiframe", "multiple stack frames exception"
+        )
+
+    @missing_feature(context.library == "python", force_skip=True)
+    @missing_feature(context.library == "java", force_skip=True)
+    def test_inproduct_enablement_exception_replay_apm_multiconfig(self):
+        self.assert_rc_state_not_error()
+        self.assert_all_weblog_responses_ok(expected_code=500)
+
+        assert self.er_initial_enabled, "Expected snapshots to not be emitting when exception replay was disabled"
+        assert self.er_apm_multiconfig_enabled, "Expected snapshots to be emitting after enabling exception replay"
+        assert self.er_disabled_by_service_name, "Expected snapshots to stop emitting after service name override"
+        assert self.er_apm_multiconfig_enabled_2, "Expected snapshots to not be emitting after service name override"
 
 
 @features.debugger_inproduct_enablement

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -265,6 +265,8 @@ def build_apm_tracing_command(
     live_debugging_enabled: bool | None = None,
     code_origin_enabled: bool | None = None,
     dynamic_sampling_enabled: bool | None = None,
+    service_name: str | None = "weblog",
+    env: str | None = "system-tests",
 ):
     lib_config: dict[str, str | bool] = {
         "library_language": "all",
@@ -287,6 +289,7 @@ def build_apm_tracing_command(
         "schema_version": "v1.0.0",
         "action": "enable",
         "lib_config": lib_config,
+        "service_target": {"service": service_name, "env": env},
     }
 
     path_payloads = {"datadog/2/APM_TRACING/config_overrides/config": config}
@@ -299,6 +302,8 @@ def send_apm_tracing_command(
     live_debugging_enabled: bool | None = None,
     code_origin_enabled: bool | None = None,
     dynamic_sampling_enabled: bool | None = None,
+    service_name: str | None = "weblog",
+    env: str | None = "system-tests",
     version: int = 1,
 ) -> RemoteConfigStateResults:
     raw_payload = build_apm_tracing_command(
@@ -308,6 +313,8 @@ def send_apm_tracing_command(
         live_debugging_enabled=live_debugging_enabled,
         code_origin_enabled=code_origin_enabled,
         dynamic_sampling_enabled=dynamic_sampling_enabled,
+        service_name=service_name,
+        env=env,
     )
 
     return send_state(raw_payload)


### PR DESCRIPTION
## Motivation

This is still in development for Java and Python here:

- https://github.com/DataDog/dd-trace-java/pull/9360
- https://github.com/DataDog/dd-trace-py/pull/14364

But we want to have system-tests upfront to ensure it's functioning correctly for Sept releases.

Refs: DEBUG-4399, RFC [here](https://docs.google.com/document/d/1J4azr17gJQipGhyWIWuBArkhe1UfStKx7XZRmjqjhqQ/edit?tab=t.b22x9owvguir#bookmark=id.b1ax8s38udhl).

## Changes

* Added `service_name` and `env` parameters to remote config command builders and senders in `utils/_remote_config.py`, allowing remote config commands to target specific services and environments. [[1]](diffhunk://#diff-2292f6ce4c43b4a840e9c5b6700005492210ac1482363bd8bd0e4099cf1edf14R268-R269) [[2]](diffhunk://#diff-2292f6ce4c43b4a840e9c5b6700005492210ac1482363bd8bd0e4099cf1edf14R305-R306) [[3]](diffhunk://#diff-2292f6ce4c43b4a840e9c5b6700005492210ac1482363bd8bd0e4099cf1edf14R316-R317)
* Updated the config payload to include the `service_target` field, enabling precise control over which service and environment the configuration applies to.
* Added new test setup and assertions in `Test_Debugger_InProduct_Enablement_Exception_Replay` to verify exception replay enablement behavior when multiple remote config overrides are present, including service-level and wildcard targeting.
* Refactored helper methods in the test class to accept service and environment parameters, improving flexibility and reusability.
* Modified snapshot filtering logic to exclude snapshots created before the test start time, preventing cross-test interference when multiple tests share the same file.
* Updated `send_rc_apm_tracing` in `utils.py` to support the new service and environment parameters, ensuring all remote config commands can be properly targeted. [[1]](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821R215-R216) [[2]](diffhunk://#diff-5aa50041bb3e8e68ee5b4f6e8a4bb5ab11fbad82b8555f9a8eae433e83a3c821R233-R234)
* Added a missing import for `time` to support timestamp-based filtering in tests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
