### PR TITLE
feat(di): Tracers should write to debugger/v2/input when available

### DIFF
--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -197,6 +197,29 @@ class Test_Debugger_Line_Probe_Snaphots(BaseDebuggerProbeSnaphotTest):
         self._assert()
         self._validate_snapshots()
 
+    def setup_log_line_snapshot_debug_track(self):
+        self.use_debugger_endpoint = True
+        self._setup("probe_snapshot_log_line", "/debugger/log", "log", lines=None)
+
+    @missing_feature(reason="Not yet implemented")
+    def test_log_line_snapshot_debug_track(self):
+        """Test that the library sends snapshots to the debug track endpoint (fallback or not)"""
+        self._assert()
+        self._validate_snapshots()
+
+    def setup_log_line_snapshot_new_destination(self):
+        self.use_debugger_endpoint = True
+        self._setup("probe_snapshot_log_line", "/debugger/log", "log", lines=None)
+
+    @missing_feature(reason="Not yet implemented")
+    def test_log_line_snapshot_new_destination(self):
+        """Test that the library sends snapshots to the debugger/v2/input endpoint"""
+        self._assert()
+        self._validate_snapshots()
+        assert (
+            self._debugger_v2_input_snapshots_received()
+        ), "Snapshots were not received at the debugger/v2/input endpoint"
+
     ### span decoration probe ###
     def setup_span_decoration_line_snapshot(self):
         self._setup(

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -13,13 +13,16 @@ from urllib.parse import parse_qs
 from utils import interfaces, remote_config, weblog, context, logger
 from utils.dd_constants import RemoteConfigApplyState as ApplyState
 
-
+# Agent paths
 _CONFIG_PATH = "/v0.7/config"
 _DEBUGGER_PATH = "/api/v2/debugger"
 _LOGS_PATH = "/api/v2/logs"
 _TRACES_PATH = "/api/v0.2/traces"
 _SYMBOLS_PATH = "/symdb/v1/input"
 _TELEMETRY_PATH = "/api/v2/apmtelemetry"
+
+# Library paths
+_DEBUGGER_V2_INPUT_PATH = "/debugger/v2/input"
 
 _CUR_DIR = str(Path(__file__).resolve().parent)
 
@@ -84,6 +87,8 @@ class BaseDebuggerTest:
     weblog_responses: list = []
 
     setup_failures: list = []
+
+    use_debugger_endpoint: bool = False
 
     def initialize_weblog_remote_config(self) -> None:
         if self.get_tracer()["language"] in ["ruby"]:
@@ -515,10 +520,16 @@ class BaseDebuggerTest:
 
     def _collect_snapshots(self):
         def _get_snapshot_hash():
+            agent_logs_endpoint_requests = []
+
             # Collect snapshots from both the logs and debugger endpoints for compatibility for when we switched
             # snapshots to the debugger endpoint.
-            agent_logs_endpoint_requests = list(interfaces.agent.get_data(_LOGS_PATH))
-            agent_logs_endpoint_requests += list(interfaces.agent.get_data(_DEBUGGER_PATH))
+            if not self.use_debugger_endpoint:
+                agent_logs_endpoint_requests += list(interfaces.agent.get_data(_LOGS_PATH))
+                agent_logs_endpoint_requests += list(interfaces.agent.get_data(_DEBUGGER_PATH))
+            else:
+                agent_logs_endpoint_requests += list(interfaces.agent.get_data(_DEBUGGER_PATH))
+
             snapshot_hash: dict = {}
 
             for request in agent_logs_endpoint_requests:
@@ -537,6 +548,18 @@ class BaseDebuggerTest:
             return snapshot_hash
 
         self.probe_snapshots = _get_snapshot_hash()
+
+    def _debugger_v2_input_snapshots_received(self):
+        """Test that the library sends snapshots to the debugger/v2/input endpoint"""
+        tracer_requests = interfaces.library.get_data(_DEBUGGER_V2_INPUT_PATH)
+        for request in tracer_requests:
+            content = request["request"]["content"]
+            if content:
+                for item in content:
+                    snapshot = item.get("debugger", {}).get("snapshot") or item.get("debugger.snapshot")
+                    if snapshot:
+                        return True
+        return False
 
     def _collect_spans(self):
         def _get_spans_hash():


### PR DESCRIPTION
## Motivation

We are working on redirecting snapshots from the logs track to the debugger intake. We are doing this with a fallback for backwards compatibility with the agent.

The fallback works like so:

1. Write the snapshots to the `/debugger/v2/input` endpoint when available, otherwise
2. Fallback and write snapshots to the `/debugger/v1/diagnostics` endpoint.

These two tests `test_log_line_snapshot_debug_track` and `test_log_line_snapshot_new_destination` should cover both of these cases.

Refs: DEBUG-4420

## Changes

* Added two new test methods (`test_log_line_snapshot_debug_track` and `test_log_line_snapshot_new_destination`) in `test_debugger_probe_snapshot.py` to verify snapshot delivery to `/debugger/log` and `/debugger/v2/input` endpoints, respectively. These tests are currently marked as not yet implemented.
* Introduced the `_DEBUGGER_V2_INPUT_PATH` constant in `utils.py` to define the new library endpoint for debugger snapshots.
* Added a `use_debugger_endpoint` flag to the `BaseDebuggerTest` class to control which endpoint is used for collecting snapshots during tests.
* Updated the snapshot collection logic in `_collect_snapshots` to respect the `use_debugger_endpoint` flag, ensuring requests are gathered from the correct endpoints based on the test configuration.
* Added the `_debugger_v2_input_snapshots_received` helper method to check if snapshots have been received at the `/debugger/v2/input` endpoint.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
