### PR TITLE
Do not fails on library mismatch if a branch is specified

### DIFF
--- a/utils/scripts/compute-impacted-libraries.py
+++ b/utils/scripts/compute-impacted-libraries.py
@@ -47,10 +47,17 @@ def main() -> None:
         pr_title = os.environ.get("GITHUB_PR_TITLE", "").lower()
         match = re.search(rf"^\[({libraries})(?:@([^\]]+))?\]", pr_title)
         user_choice = None
+        branch_selector = None
+        prevent_library_selector_mismatch = True
         if match:
             print(f"PR title matchs => run {match[1]}")
             user_choice = match[1]
             result.add(user_choice)
+
+            # if users specified a branch, another job will prevent the merge
+            # so let user do what he/she wants :
+            branch_selector = match[2]
+            prevent_library_selector_mismatch = branch_selector is None
 
         print("Inspect modified files to determine impacted libraries...")
 
@@ -70,7 +77,7 @@ def main() -> None:
                     result.add(match[2])
                 else:
                     result |= all_libraries
-            else:  # noqa: PLR5501
+            elif prevent_library_selector_mismatch:
                 # user specified a library in the PR title
                 if match:
                     if match[2] != user_choice:


### PR DESCRIPTION
## Motivation

When a branch is specified : 

* a job prevent the PR to be merged, so we don't care if there is a library mismatch
* and the PR is in draft mode : it can be very convenient to run only one tracer during this phase

So there is no loophole if we allow to run the CI, even if other libraries are impacted

## Changes

If a branch name is set in title prefix (`[cpp@my-branch] Changes`), allow to run the CI, even if the change may impacts other libraries.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
