### PR TITLE
AWS SSI and Docker SSI: Implement Python tracer latest artifacts workaround

### DIFF
--- a/utils/build/ssi/base/install_script_ssi.sh
+++ b/utils/build/ssi/base/install_script_ssi.sh
@@ -6,9 +6,21 @@ if [ "${SSI_ENV}" == "dev" ]; then
     export DD_SITE="datad0g.com"
     export DD_INSTALLER_REGISTRY_URL='install.datad0g.com'
     export DD_injection_repo_url='datad0g.com'
+    #The latest_snapshot of python tracer version is 2.x we want to use 3.x. Get from repo.
+    #more details: https://datadoghq.atlassian.net/browse/APMSP-2259
+    echo "DD_LANG: ${DD_LANG}"
+    if [ "${DD_LANG}" == "python" ]; then
+    export DD_INSTALLER_LIBRARY_VERSION=$(TMP=$(mktemp -d); git -C "$TMP" init -q && git -C "$TMP" fetch -q --depth=2 https://github.com/Datadog/dd-trace-py.git main && (git -C "$TMP" rev-parse FETCH_HEAD^ || git -C "$TMP" rev-parse FETCH_HEAD); rm -rf "$TMP")
+    fi
+
 else
     export DD_SITE="datadoghq.com"
     export DD_injection_repo_url='datadoghq.com'
+    #The latest release of python tracer version is 2.x we want to use 3.x. Get from repo tags v3* and not rc*. We get the SHA of the tag.
+    #more details: https://datadoghq.atlassian.net/browse/APMSP-2259
+    if [ "${DD_LANG}" == "python" ]; then
+        export DD_INSTALLER_LIBRARY_VERSION=$(REPO=https://github.com/Datadog/dd-trace-py.git; TAG=$(git ls-remote --tags --refs "$REPO" 'v3*' | cut -f2 | sed 's#refs/tags/##' | grep -Eiv '(-?rc[0-9]*$)' | sort -V | tail -1); [ -z "$TAG" ] && { echo "No stable v3* tags found" >&2; exit 1; }; SHA=$(git ls-remote --tags "$REPO" "refs/tags/$TAG^{}" | cut -f1); [ -n "$SHA" ] || SHA=$(git ls-remote --tags "$REPO" "refs/tags/$TAG" | cut -f1); echo "$SHA")
+    fi
 fi
 
 #We want specfic library version (to run on tracers pipelines)

--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
@@ -11,8 +11,20 @@
       # To force the installer to pull from dev repositories -- agent config is set manually to datadoghq.com
       export DD_SITE="datad0g.com"
       export DD_INSTALLER_REGISTRY_URL='install.datad0g.com'
+      #The latest_snapshot of python tracer version is 2.x we want to use 3.x. Get from repo.
+      #more details: https://datadoghq.atlassian.net/browse/APMSP-2259
+      echo "DD_LANG: ${DD_LANG}"
+      if [ "${DD_LANG}" == "python" ]; then
+        export DD_INSTALLER_LIBRARY_VERSION=$(TMP=$(mktemp -d); git -C "$TMP" init -q && git -C "$TMP" fetch -q --depth=2 https://github.com/Datadog/dd-trace-py.git main && (git -C "$TMP" rev-parse FETCH_HEAD^ || git -C "$TMP" rev-parse FETCH_HEAD); rm -rf "$TMP")
+      fi
+
     else 
       export DD_SITE="datadoghq.com" 
+      #The latest release of python tracer version is 2.x we want to use 3.x. Get from repo tags v3* and not rc*. We get the SHA of the tag.
+      #more details: https://datadoghq.atlassian.net/browse/APMSP-2259
+      if [ "${DD_LANG}" == "python" ]; then
+        export DD_INSTALLER_LIBRARY_VERSION=$(REPO=https://github.com/Datadog/dd-trace-py.git; TAG=$(git ls-remote --tags --refs "$REPO" 'v3*' | cut -f2 | sed 's#refs/tags/##' | grep -Eiv '(-?rc[0-9]*$)' | sort -V | tail -1); [ -z "$TAG" ] && { echo "No stable v3* tags found" >&2; exit 1; }; SHA=$(git ls-remote --tags "$REPO" "refs/tags/$TAG^{}" | cut -f1); [ -n "$SHA" ] || SHA=$(git ls-remote --tags "$REPO" "refs/tags/$TAG" | cut -f1); echo "$SHA")
+      fi
     fi
 
     # Environment variables for the installer

--- a/utils/build/virtual_machine/provisions/auto-inject/repositories/autoinstall/execute_install_script.sh
+++ b/utils/build/virtual_machine/provisions/auto-inject/repositories/autoinstall/execute_install_script.sh
@@ -17,8 +17,19 @@ if [ "${DD_env}" == "dev" ]; then
     # To force the installer to pull from dev repositories -- agent config is set manually to datadoghq.com
     export DD_SITE="datad0g.com"
     export DD_INSTALLER_REGISTRY_URL='install.datad0g.com'
+      #The latest_snapshot of python tracer version is 2.x we want to use 3.x. Get from repo.
+      #more details: https://datadoghq.atlassian.net/browse/APMSP-2259
+      echo "DD_LANG: ${DD_LANG}"
+      if [ "${DD_LANG}" == "python" ]; then
+        export DD_INSTALLER_LIBRARY_VERSION=$(TMP=$(mktemp -d); git -C "$TMP" init -q && git -C "$TMP" fetch -q --depth=2 https://github.com/Datadog/dd-trace-py.git main && (git -C "$TMP" rev-parse FETCH_HEAD^ || git -C "$TMP" rev-parse FETCH_HEAD); rm -rf "$TMP")
+      fi
 else 
     export DD_SITE="datadoghq.com" 
+      #The latest release of python tracer version is 2.x we want to use 3.x. Get from repo tags v3* and not rc*. We get the SHA of the tag.
+      #more details: https://datadoghq.atlassian.net/browse/APMSP-2259
+      if [ "${DD_LANG}" == "python" ]; then
+        export DD_INSTALLER_LIBRARY_VERSION=$(REPO=https://github.com/Datadog/dd-trace-py.git; TAG=$(git ls-remote --tags --refs "$REPO" 'v3*' | cut -f2 | sed 's#refs/tags/##' | grep -Eiv '(-?rc[0-9]*$)' | sort -V | tail -1); [ -z "$TAG" ] && { echo "No stable v3* tags found" >&2; exit 1; }; SHA=$(git ls-remote --tags "$REPO" "refs/tags/$TAG^{}" | cut -f1); [ -n "$SHA" ] || SHA=$(git ls-remote --tags "$REPO" "refs/tags/$TAG" | cut -f1); echo "$SHA")
+      fi
 fi
 
 # Environment variables for the installer


### PR DESCRIPTION
## Summary

This PR implements a workaround for handling Python tracer latest artifacts in both AWS SSI and Docker SSI testing scenarios.

## Changes Made

### AWS SSI Changes
- Updated `auto-inject_installer_manual.yml` provision file to handle Python tracer latest artifacts
- Modified `execute_install_script.sh` to include workaround logic for Python tracer artifact resolution

### Docker SSI Changes  
- Updated `install_script_ssi.sh` to apply the same workaround for Docker SSI scenarios

## Files Modified
- `utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml`
- `utils/build/virtual_machine/provisions/auto-inject/repositories/autoinstall/execute_install_script.sh`
- `utils/build/ssi/base/install_script_ssi.sh`

## Testing

This workaround ensures that Python tracer latest artifacts are properly handled in both AWS SSI and Docker SSI test environments, addressing compatibility issues with the latest Python tracer versions.

## Impact

- ✅ Improves reliability of AWS SSI tests with Python tracers
- ✅ Enhances Docker SSI test compatibility
- ✅ No breaking changes to existing functionality
- ✅ Maintains backward compatibility

**Total changes:** 35 lines added across 3 files