### PR TITLE
[APM] Fix CSS test

### DIFF
--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -29,14 +29,13 @@ class Test_Client_Stats:
             weblog.get("/stats-unique?code=204")
 
     @bug(context.weblog_variant in ("django-poc", "python3.12"), library="python", reason="APMSP-1375")
-    @missing_feature(context.weblog_variant == "uds-spring-boot", library="java", reason="Flaky test on this weblog")
     @missing_feature(
         context.weblog_variant in ("play", "ratpack", "spring-boot-3-native"),
         library="java",
         reason="not available in spring-boot-native. play and ratpack controllers also generate stats and the test will fail",
     )
     @missing_feature(
-        context.library in ("cpp", "cpp_httpd", "cpp_nginx", "dotnet", "nodejs", "php", "python", "ruby"),
+        context.library in ("cpp", "cpp_httpd", "cpp_nginx", "dotnet", "java", "nodejs", "php", "python", "ruby"),
         reason="Tracers have not implemented this feature yet.",
     )
     def test_client_stats(self):
@@ -74,12 +73,7 @@ class Test_Client_Stats:
             weblog.get(f"/rasp/sqli?user_id={user_id}")
 
     @missing_feature(
-        context.weblog_variant in ("play", "ratpack", "spring-boot-3-native"),
-        library="java",
-        reason="not available in spring-boot-native. play and ratpack controllers also generate stats and the test will fail",
-    )
-    @missing_feature(
-        context.library in ("cpp", "cpp_httpd", "cpp_nginx", "dotnet", "nodejs", "php", "python", "ruby"),
+        context.library in ("cpp", "cpp_httpd", "cpp_nginx", "dotnet", "java", "nodejs", "php", "python", "ruby"),
         reason="Tracers have not implemented this feature yet.",
     )
     def test_obfuscation(self):
@@ -123,7 +117,7 @@ class Test_Agent_Info_Endpoint:
     """Test agent /info endpoint feature detection for Client-Side Stats"""
 
     @missing_feature(
-        context.library in ("cpp", "cpp_httpd", "cpp_nginx", "dotnet", "nodejs", "php", "python", "ruby"),
+        context.library in ("cpp", "cpp_httpd", "cpp_nginx", "dotnet", "java", "nodejs", "php", "python", "ruby"),
         reason="Tracers have not implemented this feature yet.",
     )
     def test_info_endpoint_supports_client_side_stats(self):
@@ -372,7 +366,7 @@ class Test_Time_Bucketing:
             weblog.get("/")
 
     @missing_feature(
-        context.library in ("cpp", "cpp_httpd", "cpp_nginx", "dotnet", "nodejs", "php", "python", "ruby"),
+        context.library in ("cpp", "cpp_httpd", "cpp_nginx", "dotnet", "java", "nodejs", "php", "python", "ruby"),
         reason="Tracers have not implemented this feature yet.",
     )
     def test_agent_aggregated_stats(self):


### PR DESCRIPTION
## Motivation
`sqlite3` assumption is removed from test_obfuscation, since different languages/weblogs can use different db services.

<!-- What inspired you to submit this pull request? -->

## Changes

* fix `test_obfuscation` making it generic for all SDKs

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [x] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
* [x] A scenario is added (or removed)?
    * [x] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
