### PR TITLE
Remove appsec-beta

### DIFF
--- a/utils/build/docker/python/install_ddtrace.sh
+++ b/utils/build/docker/python/install_ddtrace.sh
@@ -13,7 +13,7 @@ if [ -e "dd-trace-py" ]; then
 elif [ "$(ls *.whl | wc -l)" = "1" ]; then
     path=$(readlink -f $(ls *.whl))
     echo "Install ddtrace from ${path}"
-    pip install "ddtrace[appsec-beta] @ file://${path}"
+    pip install "ddtrace @ file://${path}"
 elif [ $(ls python-load-from-pip | wc -l) = 1 ]; then
     echo "Install ddtrace from $(cat python-load-from-pip)"
     pip install "$(cat python-load-from-pip)"
@@ -23,7 +23,7 @@ elif [ $(ls *.whl | wc -l) = 0 ]; then
 elif [ "$(ls *$PYTHON_VERSION*.whl | wc -l)" = "1" ]; then
     path=$(readlink -f $(ls *$PYTHON_VERSION*.whl))
     echo "Install ddtrace from ${path} (selected automatically)"
-    pip install "ddtrace[appsec-beta] @ file://${path}"
+    pip install "ddtrace @ file://${path}"
 else
     echo "ERROR: Found several usable wheel files in binaries/, abort."
     exit 1


### PR DESCRIPTION
## Motivation

Old option not in use anymore.

## Changes

Removed the appsec-beta option for dd-trace-py wheel install.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
