### PR TITLE
lambda: add three new lambda events with python weblogs

### DIFF
--- a/manifests/python_lambda.yml
+++ b/manifests/python_lambda.yml
@@ -5,33 +5,43 @@ tests/:
       test_schemas.py:
         Test_Scanners:
           "*": v8.113.0
+          alb: missing_feature
           function-url: missing_feature
         Test_Schema_Request_Cookies:
           "*": v8.113.0
+          alb: missing_feature
           function-url: missing_feature
         Test_Schema_Request_FormUrlEncoded_Body:
           "*": v8.113.0
+          alb: missing_feature
           function-url: missing_feature
         Test_Schema_Request_Headers:
           "*": v8.113.0
+          alb: missing_feature
           function-url: missing_feature
         Test_Schema_Request_Json_Body:
           "*": v8.113.0
+          alb: missing_feature
           function-url: missing_feature
         Test_Schema_Request_Path_Parameters:
           "*": v8.113.0
+          alb: missing_feature
           function-url: missing_feature
         Test_Schema_Request_Query_Parameters:
           "*": v8.113.0
+          alb: missing_feature
           function-url: missing_feature
         Test_Schema_Response_Body:
           "*": v8.113.0
+          alb: missing_feature
           function-url: missing_feature
         Test_Schema_Response_Headers:
           "*": v8.113.0
+          alb: missing_feature
           function-url: missing_feature
         Test_Schema_Response_on_Block:
           "*": v8.113.0
+          alb: missing_feature
           function-url: missing_feature
     waf/:
       test_blocking.py:
@@ -49,6 +59,7 @@ tests/:
       Test_Blocking_request_method: v8.113.0
       Test_Blocking_request_path_params:
         "*": v8.113.0
+        alb: irrelevant (application-load-balancer event type does not support path params)
         function-url: irrelevant (function-url event type does not support path params)
       Test_Blocking_request_query: v8.113.0
       Test_Blocking_request_uri: v8.113.0

--- a/manifests/python_lambda.yml
+++ b/manifests/python_lambda.yml
@@ -3,16 +3,36 @@ tests/:
   appsec/:
     api_security/:
       test_schemas.py:
-        Test_Scanners: v8.113.0
-        Test_Schema_Request_Cookies: v8.113.0
-        Test_Schema_Request_FormUrlEncoded_Body: v8.113.0
-        Test_Schema_Request_Headers: v8.113.0
-        Test_Schema_Request_Json_Body: v8.113.0
-        Test_Schema_Request_Path_Parameters: v8.113.0
-        Test_Schema_Request_Query_Parameters: v8.113.0
-        Test_Schema_Response_Body: v8.113.0
-        Test_Schema_Response_Headers: v8.113.0
-        Test_Schema_Response_on_Block: v8.113.0
+        Test_Scanners:
+          "*": v8.113.0
+          function-url: missing_feature
+        Test_Schema_Request_Cookies:
+          "*": v8.113.0
+          function-url: missing_feature
+        Test_Schema_Request_FormUrlEncoded_Body:
+          "*": v8.113.0
+          function-url: missing_feature
+        Test_Schema_Request_Headers:
+          "*": v8.113.0
+          function-url: missing_feature
+        Test_Schema_Request_Json_Body:
+          "*": v8.113.0
+          function-url: missing_feature
+        Test_Schema_Request_Path_Parameters:
+          "*": v8.113.0
+          function-url: missing_feature
+        Test_Schema_Request_Query_Parameters:
+          "*": v8.113.0
+          function-url: missing_feature
+        Test_Schema_Response_Body:
+          "*": v8.113.0
+          function-url: missing_feature
+        Test_Schema_Response_Headers:
+          "*": v8.113.0
+          function-url: missing_feature
+        Test_Schema_Response_on_Block:
+          "*": v8.113.0
+          function-url: missing_feature
     waf/:
       test_blocking.py:
         Test_Blocking: v8.113.0
@@ -27,7 +47,9 @@ tests/:
       Test_Blocking_request_cookies: v8.113.0
       Test_Blocking_request_headers: v8.113.0
       Test_Blocking_request_method: v8.113.0
-      Test_Blocking_request_path_params: v8.113.0
+      Test_Blocking_request_path_params:
+        "*": v8.113.0
+        function-url: irrelevant (function-url event type does not support path params)
       Test_Blocking_request_query: v8.113.0
       Test_Blocking_request_uri: v8.113.0
       Test_Blocking_response_headers: v8.113.0

--- a/manifests/python_lambda.yml
+++ b/manifests/python_lambda.yml
@@ -6,73 +6,124 @@ tests/:
         Test_Scanners:
           "*": v8.113.0
           alb: missing_feature
+          alb-multi: missing_feature
           function-url: missing_feature
         Test_Schema_Request_Cookies:
           "*": v8.113.0
           alb: missing_feature
+          alb-multi: missing_feature
           function-url: missing_feature
         Test_Schema_Request_FormUrlEncoded_Body:
           "*": v8.113.0
           alb: missing_feature
+          alb-multi: missing_feature
           function-url: missing_feature
         Test_Schema_Request_Headers:
           "*": v8.113.0
           alb: missing_feature
+          alb-multi: missing_feature
           function-url: missing_feature
         Test_Schema_Request_Json_Body:
           "*": v8.113.0
           alb: missing_feature
+          alb-multi: missing_feature
           function-url: missing_feature
         Test_Schema_Request_Path_Parameters:
           "*": v8.113.0
           alb: missing_feature
+          alb-multi: missing_feature
           function-url: missing_feature
         Test_Schema_Request_Query_Parameters:
           "*": v8.113.0
           alb: missing_feature
+          alb-multi: missing_feature
           function-url: missing_feature
         Test_Schema_Response_Body:
           "*": v8.113.0
           alb: missing_feature
+          alb-multi: missing_feature
           function-url: missing_feature
         Test_Schema_Response_Headers:
           "*": v8.113.0
           alb: missing_feature
+          alb-multi: missing_feature
           function-url: missing_feature
         Test_Schema_Response_on_Block:
           "*": v8.113.0
           alb: missing_feature
+          alb-multi: missing_feature
           function-url: missing_feature
     waf/:
       test_blocking.py:
-        Test_Blocking: v8.113.0
+        Test_Blocking:
+          "*": v8.113.0
+          alb-multi: bug (APPSEC-58787)
+        Test_Blocking_strip_response_headers:
+          "*": v8.113.0
+          alb-multi: bug (APPSEC-58787)
+        Test_CustomBlockingResponse:
+          "*": v8.113.0
+          alb-multi: bug (APPSEC-58787)
     test_alpha.py:
       Test_Basic: v7.112.0
     test_blocking_addresses.py:
-      Test_Blocking_client_ip: v8.113.0
-      Test_Blocking_client_ip_with_K8_private_ip: v8.113.0
+      Test_Blocking_client_ip:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Blocking_client_ip_with_K8_private_ip:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
       Test_Blocking_client_ip_with_forwarded: missing_feature
-      Test_Blocking_request_body: v8.113.0
-      Test_Blocking_request_body_multipart: v8.113.0
-      Test_Blocking_request_cookies: v8.113.0
-      Test_Blocking_request_headers: v8.113.0
-      Test_Blocking_request_method: v8.113.0
+      Test_Blocking_request_body:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Blocking_request_body_multipart:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Blocking_request_cookies:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Blocking_request_headers:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Blocking_request_method:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
       Test_Blocking_request_path_params:
         "*": v8.113.0
         alb: irrelevant (application-load-balancer event type does not support path params)
+        alb-multi: irrelevant (application-load-balancer event type does not support path params)
         function-url: irrelevant (function-url event type does not support path params)
-      Test_Blocking_request_query: v8.113.0
-      Test_Blocking_request_uri: v8.113.0
-      Test_Blocking_response_headers: v8.113.0
-      Test_Blocking_response_status: v8.113.0
-      Test_Blocking_user_id: v8.113.0
-      Test_Suspicious_Request_Blocking: v8.113.0
+      Test_Blocking_request_query:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Blocking_request_uri:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Blocking_response_headers:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Blocking_response_status:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Blocking_user_id:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Suspicious_Request_Blocking:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
     test_conf.py:
       Test_ConfigurationVariables_New_Obfuscation: v8.113.0
     test_fingerprinting.py:
-      Test_Fingerprinting_Endpoint_Preprocessor: v8.113.0
-      Test_Fingerprinting_Header_And_Network_Preprocessor: v8.113.0
-      Test_Fingerprinting_Session_Preprocessor: v8.113.0
+      Test_Fingerprinting_Endpoint_Preprocessor:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Fingerprinting_Header_And_Network_Preprocessor:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
+      Test_Fingerprinting_Session_Preprocessor:
+        "*": v8.113.0
+        alb-multi: bug (APPSEC-58787)
     test_only_python.py:
       Test_ImportError: v7.112.0
     test_reports.py:

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -736,6 +736,11 @@ class Test_Suspicious_Request_Blocking:
         )
 
     @irrelevant(
+        library="python_lambda",
+        weblog_variant="function-url",
+        reason="function-url event type does not support path params",
+    )
+    @irrelevant(
         context.library == "ruby" and context.weblog_variant == "rack",
         reason="Rack don't send anything to the server.request.path_params WAF address",
     )
@@ -758,6 +763,11 @@ class Test_Suspicious_Request_Blocking:
             headers={"content-type": "text/plain", "client": "malicious-header-kCgvxrYeiwUSYkAuniuGktdvzXYEPSff"},
         )
 
+    @irrelevant(
+        library="python_lambda",
+        weblog_variant="function-url",
+        reason="function-url event type does not support path params",
+    )
     @irrelevant(
         context.library == "ruby" and context.weblog_variant == "rack",
         reason="Rack don't send anything to the server.request.path_params WAF address",

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -737,7 +737,7 @@ class Test_Suspicious_Request_Blocking:
 
     @irrelevant(
         library="python_lambda",
-        condition=context.weblog_variant in ("function-url", "alb"),
+        condition=context.weblog_variant in ("function-url", "alb", "alb-multi"),
         reason="function-url event type does not support path params",
     )
     @irrelevant(
@@ -765,7 +765,7 @@ class Test_Suspicious_Request_Blocking:
 
     @irrelevant(
         library="python_lambda",
-        condition=context.weblog_variant in ("function-url", "alb"),
+        condition=context.weblog_variant in ("function-url", "alb", "alb-multi"),
         reason="function-url event type does not support path params",
     )
     @irrelevant(

--- a/tests/appsec/test_blocking_addresses.py
+++ b/tests/appsec/test_blocking_addresses.py
@@ -737,7 +737,7 @@ class Test_Suspicious_Request_Blocking:
 
     @irrelevant(
         library="python_lambda",
-        weblog_variant="function-url",
+        condition=context.weblog_variant in ("function-url", "alb"),
         reason="function-url event type does not support path params",
     )
     @irrelevant(
@@ -765,7 +765,7 @@ class Test_Suspicious_Request_Blocking:
 
     @irrelevant(
         library="python_lambda",
-        weblog_variant="function-url",
+        condition=context.weblog_variant in ("function-url", "alb"),
         reason="function-url event type does not support path params",
     )
     @irrelevant(

--- a/utils/_context/_scenarios/aws_lambda.py
+++ b/utils/_context/_scenarios/aws_lambda.py
@@ -63,7 +63,7 @@ class LambdaScenario(DockerScenario):
     def configure(self, config: pytest.Config):
         super().configure(config)
 
-        allowed_event_types = "apigateway-rest", "apigateway-http"
+        allowed_event_types = "apigateway-rest", "apigateway-http", "function-url"
         event_type = self.lambda_weblog.image.labels.get("system-tests.lambda-proxy.event-type")
         if event_type not in allowed_event_types:
             pytest.exit(

--- a/utils/_context/_scenarios/aws_lambda.py
+++ b/utils/_context/_scenarios/aws_lambda.py
@@ -63,7 +63,7 @@ class LambdaScenario(DockerScenario):
     def configure(self, config: pytest.Config):
         super().configure(config)
 
-        allowed_event_types = "apigateway-rest", "apigateway-http", "function-url"
+        allowed_event_types = "apigateway-rest", "apigateway-http", "function-url", "application-load-balancer"
         event_type = self.lambda_weblog.image.labels.get("system-tests.lambda-proxy.event-type")
         if event_type not in allowed_event_types:
             pytest.exit(

--- a/utils/_context/_scenarios/aws_lambda.py
+++ b/utils/_context/_scenarios/aws_lambda.py
@@ -63,7 +63,13 @@ class LambdaScenario(DockerScenario):
     def configure(self, config: pytest.Config):
         super().configure(config)
 
-        allowed_event_types = "apigateway-rest", "apigateway-http", "function-url", "application-load-balancer"
+        allowed_event_types = (
+            "apigateway-rest",
+            "apigateway-http",
+            "function-url",
+            "application-load-balancer",
+            "application-load-balancer-multi",
+        )
         event_type = self.lambda_weblog.image.labels.get("system-tests.lambda-proxy.event-type")
         if event_type not in allowed_event_types:
             pytest.exit(

--- a/utils/build/docker/lambda_proxy/alb.py
+++ b/utils/build/docker/lambda_proxy/alb.py
@@ -67,12 +67,14 @@ def parse_alb_lambda_output(payload: str, multi: bool) -> tuple[int, dict[str, s
     resp = json.loads(payload)
 
     status = int(resp["statusCode"])
-    body_field = resp.get("body") or ""
+    body_field = resp.get("body")
 
     if resp.get("isBase64Encoded", False):
         body_bytes = base64.b64decode(body_field)
     else:
-        body_bytes = (body_field).encode()
+        if isinstance(body_field, dict):
+            body_field = json.dumps(body_field)
+        body_bytes = body_field.encode()
 
     if multi:
         headers = resp["multiValueHeaders"]

--- a/utils/build/docker/lambda_proxy/alb.py
+++ b/utils/build/docker/lambda_proxy/alb.py
@@ -1,0 +1,82 @@
+from collections import defaultdict
+import json
+import base64
+from flask import Request
+
+TARGET_GROUP_ARN = "arn:aws:elasticloadbalancing:local:000000000000:targetgroup/local-proxy/0000000000000000"
+
+
+def _should_base64_encode(content_type: str, body: bytes) -> bool:
+    """
+    Decide whether the body must be base64-encoded, following ALB rules:
+      * ALB always encodes when `content-encoding` is present.
+      * Else it encodes unless the type is plaintext (text/*, json, xml, js) **or**
+        the caller tells us this is a "known good" textual type.
+    """
+    if not body:
+        return False
+
+    if "content-encoding" in (content_type or ""):
+        return True
+
+    text_like = (
+        content_type.startswith("text/")
+        or content_type.startswith("application/json")
+        or content_type.startswith("application/xml")
+        or content_type.startswith("application/javascript")
+    )
+
+    return not text_like
+
+
+def build_alb_event(request: Request, multi: bool) -> dict:
+    """
+    Transform a Flask request into the ALB invocation event format.
+    doc: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#receive-event-from-load-balancer
+    """
+    raw_body = request.get_data() or b""
+    is_b64 = _should_base64_encode(request.content_type, raw_body)
+    body = base64.b64encode(raw_body).decode() if is_b64 else raw_body.decode(errors="replace")
+
+    event = {
+        "requestContext": {"elb": {"targetGroupArn": TARGET_GROUP_ARN}},
+        "httpMethod": request.method,
+        "path": request.path,
+        "body": body,
+        "isBase64Encoded": is_b64,
+    }
+
+    if multi:
+        event["multiValueQueryStringParameters"] = request.args.to_dict(flat=False)
+        multi_value_headers = defaultdict(list)
+        for k, v in request.headers.to_wsgi_list():
+            multi_value_headers[k].append(v)
+        event["multiValueHeaders"] = dict(multi_value_headers)
+    else:
+        event["queryStringParameters"] = request.args.to_dict(flat=True)
+        event["headers"] = dict(request.headers)
+
+    return event
+
+
+def parse_alb_lambda_output(payload: str, multi: bool) -> tuple[int, dict[str, str | list[str]], bytes]:
+    """
+    Convert the JSON response expected from an ALB_triggered Lambda into pieces
+    doc: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#respond-to-the-load-balancer
+    """
+    resp = json.loads(payload)
+
+    status = int(resp["statusCode"])
+    body_field = resp.get("body") or ""
+
+    if resp.get("isBase64Encoded", False):
+        body_bytes = base64.b64decode(body_field)
+    else:
+        body_bytes = (body_field).encode()
+
+    if multi:
+        headers = resp["multiValueHeaders"]
+    else:
+        headers = resp["headers"]
+
+    return status, headers, body_bytes

--- a/utils/build/docker/python_lambda/alb-multi.Dockerfile
+++ b/utils/build/docker/python_lambda/alb-multi.Dockerfile
@@ -1,0 +1,21 @@
+FROM public.ecr.aws/lambda/python:3.13
+
+RUN dnf install -y unzip findutils socat
+
+# Add the Datadog Extension
+RUN mkdir -p /opt/extensions
+COPY --from=public.ecr.aws/datadog/lambda-extension:latest /opt/. /opt/
+
+COPY utils/build/docker/python_lambda/install_datadog_lambda.sh binaries* /binaries/
+RUN /binaries/install_datadog_lambda.sh
+
+# Setup the aws_lambda handler
+COPY utils/build/docker/python_lambda/function/. ${LAMBDA_TASK_ROOT}
+RUN pip install -r ${LAMBDA_TASK_ROOT}/requirements.txt
+
+ENV DD_LAMBDA_HANDLER=handler.lambda_handler
+ENV SYSTEM_TEST_WEBLOG_LAMBDA_EVENT_TYPE=application-load-balancer-multi
+
+LABEL system-tests.lambda-proxy.event-type=application-load-balancer-multi
+
+ENTRYPOINT ["/bin/sh"]

--- a/utils/build/docker/python_lambda/alb.Dockerfile
+++ b/utils/build/docker/python_lambda/alb.Dockerfile
@@ -1,0 +1,21 @@
+FROM public.ecr.aws/lambda/python:3.13
+
+RUN dnf install -y unzip findutils socat
+
+# Add the Datadog Extension
+RUN mkdir -p /opt/extensions
+COPY --from=public.ecr.aws/datadog/lambda-extension:latest /opt/. /opt/
+
+COPY utils/build/docker/python_lambda/install_datadog_lambda.sh binaries* /binaries/
+RUN /binaries/install_datadog_lambda.sh
+
+# Setup the aws_lambda handler
+COPY utils/build/docker/python_lambda/function/. ${LAMBDA_TASK_ROOT}
+RUN pip install -r ${LAMBDA_TASK_ROOT}/requirements.txt
+
+ENV DD_LAMBDA_HANDLER=handler.lambda_handler
+ENV SYSTEM_TEST_WEBLOG_LAMBDA_EVENT_TYPE=application-load-balancer
+
+LABEL system-tests.lambda-proxy.event-type=application-load-balancer
+
+ENTRYPOINT ["/bin/sh"]

--- a/utils/build/docker/python_lambda/function-url.Dockerfile
+++ b/utils/build/docker/python_lambda/function-url.Dockerfile
@@ -1,0 +1,21 @@
+FROM public.ecr.aws/lambda/python:3.13
+
+RUN dnf install -y unzip findutils socat
+
+# Add the Datadog Extension
+RUN mkdir -p /opt/extensions
+COPY --from=public.ecr.aws/datadog/lambda-extension:latest /opt/. /opt/
+
+COPY utils/build/docker/python_lambda/install_datadog_lambda.sh binaries* /binaries/
+RUN /binaries/install_datadog_lambda.sh
+
+# Setup the aws_lambda handler
+COPY utils/build/docker/python_lambda/function/. ${LAMBDA_TASK_ROOT}
+RUN pip install -r ${LAMBDA_TASK_ROOT}/requirements.txt
+
+ENV DD_LAMBDA_HANDLER=handler.lambda_handler
+ENV SYSTEM_TEST_WEBLOG_LAMBDA_EVENT_TYPE=function-url
+
+LABEL system-tests.lambda-proxy.event-type=function-url
+
+ENTRYPOINT ["/bin/sh"]

--- a/utils/build/docker/python_lambda/function/handler.py
+++ b/utils/build/docker/python_lambda/function/handler.py
@@ -1,9 +1,10 @@
+from collections import defaultdict
 import logging
 import os
 import urllib
 import urllib.parse
 
-from typing import Any
+from typing import Any, override
 
 from aws_lambda_powertools.event_handler import (
     APIGatewayRestResolver,
@@ -31,7 +32,7 @@ elif LAMBDA_EVENT_TYPE == "apigateway-http":
     app = APIGatewayHttpResolver()
 elif LAMBDA_EVENT_TYPE == "function-url":
     app = LambdaFunctionUrlResolver()
-elif LAMBDA_EVENT_TYPE == "application-load-balancer":
+elif LAMBDA_EVENT_TYPE in ("application-load-balancer", "application-load-balancer-multi"):
     app = ALBResolver()
 else:
     logger.error(
@@ -51,6 +52,18 @@ def version_info():
     }
 
 
+def get_query_string_parameters() -> dict[str, str] | dict[str, list[str]]:
+    return app.current_event.query_string_parameters or app.current_event.multi_value_query_string_parameters
+
+
+def get_query_string_value(key) -> str:
+    if value := app.current_event.get_query_string_value(key):
+        return value
+    if value := app.current_event.get_multi_value_query_string_values(key):
+        return value[0]
+    return ""
+
+
 @app.get("/")
 @app.post("/")
 @app.route("/", method="OPTIONS")
@@ -60,7 +73,7 @@ def root():
 
 @app.get("/headers")
 def headers():
-    return Response(status_code=200, body="OK", headers={"Content-Language": "en-US", "Content-Type": "text/plain"})
+    return Response(status_code=200, body="OK", content_type="text/plain", headers={"Content-Language": "en-US"})
 
 
 @app.get("/healthcheck")
@@ -113,7 +126,7 @@ def tag_value(tag_value: str, status_code: int):
         status_code=status_code,
         content_type="text/plain",
         body="Value tagged",
-        headers=app.current_event.query_string_parameters,
+        headers=get_query_string_parameters(),
     )
 
 
@@ -169,7 +182,7 @@ def tag_value_post(tag_value: str, status_code: int):
 
 @app.get("/users")
 def users():
-    user = app.current_event.query_string_parameters.get("user", "")
+    user = get_query_string_value("user")
     set_user(
         tracer,
         user_id=user,

--- a/utils/build/docker/python_lambda/function/handler.py
+++ b/utils/build/docker/python_lambda/function/handler.py
@@ -5,7 +5,11 @@ import urllib.parse
 
 from typing import Any
 
-from aws_lambda_powertools.event_handler import APIGatewayRestResolver, APIGatewayHttpResolver
+from aws_lambda_powertools.event_handler import (
+    APIGatewayRestResolver,
+    APIGatewayHttpResolver,
+    LambdaFunctionUrlResolver,
+)
 from aws_lambda_powertools.utilities.typing.lambda_context import LambdaContext
 from aws_lambda_powertools.shared.cookies import Cookie
 from aws_lambda_powertools.event_handler import Response
@@ -24,6 +28,8 @@ if LAMBDA_EVENT_TYPE == "apigateway-rest":
     app = APIGatewayRestResolver()
 elif LAMBDA_EVENT_TYPE == "apigateway-http":
     app = APIGatewayHttpResolver()
+elif LAMBDA_EVENT_TYPE == "function-url":
+    app = LambdaFunctionUrlResolver()
 else:
     logger.error(
         f"Unsupported Lambda event type: {LAMBDA_EVENT_TYPE}",

--- a/utils/build/docker/python_lambda/function/handler.py
+++ b/utils/build/docker/python_lambda/function/handler.py
@@ -8,6 +8,7 @@ from typing import Any
 from aws_lambda_powertools.event_handler import (
     APIGatewayRestResolver,
     APIGatewayHttpResolver,
+    ALBResolver,
     LambdaFunctionUrlResolver,
 )
 from aws_lambda_powertools.utilities.typing.lambda_context import LambdaContext
@@ -30,6 +31,8 @@ elif LAMBDA_EVENT_TYPE == "apigateway-http":
     app = APIGatewayHttpResolver()
 elif LAMBDA_EVENT_TYPE == "function-url":
     app = LambdaFunctionUrlResolver()
+elif LAMBDA_EVENT_TYPE == "application-load-balancer":
+    app = ALBResolver()
 else:
     logger.error(
         f"Unsupported Lambda event type: {LAMBDA_EVENT_TYPE}",


### PR DESCRIPTION
## Motivation

To finalize the work started with https://github.com/DataDog/system-tests/pull/5155, by adding the last three remaining http event types.

## Changes

Following the same pattern as the previous PR:
- modify lambda-proxy to support lambda function url service, application load balancer and application load balancer multi header
- add corresponding python_lambda weblogs
- update the manifests and decorators with known irrelevant features and bugs 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
