### PR TITLE
do not check domain for intake.profile requests from agent

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -15,11 +15,18 @@ optional_uds_feature = (
 class Test_Backend:
     """Misc test around agent/backend communication"""
 
-    @missing_feature(context.agent_version < "7.67.0-dev")
+    @missing_feature(condition=True)  # intake.profile does not use FQDN helper
     def test_good_backend(self):
         """Agent reads and use DD_SITE env var"""
-        expected_domain: str = context.dd_site
+        self._assert_good_backend(expected_domain=context.dd_site)
 
+    @missing_feature(context.agent_version < "7.67.0-dev")
+    def test_good_backend_partial(self):
+        """Agent reads and use DD_SITE env var"""
+        self._assert_good_backend(expected_domain=context.dd_site, excluded_sub_domains=("intake.profile",))
+
+    @staticmethod
+    def _assert_good_backend(expected_domain: str, excluded_sub_domains: tuple[str, ...] = ()) -> None:
         # agent performs some requests to perform a connectivity check
         # those requests use those 4 domains, regardless the value of DD_SITE
         # https://docs.datadoghq.com/agent/configuration/network/?site=us5
@@ -32,18 +39,27 @@ class Test_Backend:
 
         # if DD_SITE is set to a known datadog backend, then the agent adds a tailing '.' at the end
         # to make it a FQDN, and save useless DNS requests. See https://github.com/DataDog/datadog-agent/pull/36972
-
         if re.match(r"(?:datadoghq|datad0g)\.(?:com|eu)$|ddog-gov\.com$", expected_domain):
             expected_domain = expected_domain + "."
 
         for data in interfaces.agent.get_data():
             host: str = data["host"]
+
+            if host.startswith(excluded_sub_domains):
+                logger.debug(f"{data['log_filename']} host: {host} -> ignored subdomain")
+                continue
+
+            if host in connectivity_check_hosts:
+                logger.debug(f"{data['log_filename']} host: {host} -> connectivity host, ignored")
+                continue
+
             domain: str = host[-len(expected_domain) :]
 
-            logger.debug(f"{data['log_filename']} host: {host}")
-
-            if not domain.endswith(expected_domain) and host not in connectivity_check_hosts:
+            if not domain.endswith(expected_domain):
+                logger.error(f"{data['log_filename']} host: {host}")
                 raise ValueError(f"Message {data['log_filename']} uses domain {domain} instead of {expected_domain}")
+
+            logger.info(f"{data['log_filename']} host: {host}")
 
 
 @optional_uds_feature


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
