### PR TITLE
[python] add pip freeze to keep track of all versions in the logs

### DIFF
--- a/utils/build/docker/python/django/app.sh
+++ b/utils/build/docker/python/django/app.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ "${UDS_WEBLOG:-}" = "1" ]; then
-   ./set-uds-transport.sh
-fi
+echo "--- PIP FREEZE ---"
+python -m pip freeze
+echo "------------------"
 
 if [[ $(python -c 'import sys; print(sys.version_info >= (3,12))') == "True" ]]; then
     ddtrace-run gunicorn -w 1 -b 0.0.0.0:7777 --header-map dangerous --access-logfile - django_app.wsgi -k gevent

--- a/utils/build/docker/python/fastapi/app.sh
+++ b/utils/build/docker/python/fastapi/app.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+echo "--- PIP FREEZE ---"
+python -m pip freeze
+echo "------------------"
+
 ddtrace-run uvicorn main:app --host 0.0.0.0 --port 7777 --log-config=log_conf.yaml

--- a/utils/build/docker/python/flask/app.sh
+++ b/utils/build/docker/python/flask/app.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo "--- PIP FREEZE ---"
+python -m pip freeze
+echo "------------------"
+
 if [[ ${UDS_WEBLOG:-} = "1" ]]; then
     ./set-uds-transport.sh
 fi

--- a/utils/build/docker/python/uwsgi-poc.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.Dockerfile
@@ -21,6 +21,9 @@ ENV UWSGI_ENABLED=true
 # note, only thread mode is supported
 # https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#uwsgi
 RUN echo '#!/bin/bash \n\
+echo "--- PIP FREEZE ---"\n\
+python -m pip freeze\n\
+echo "------------------"\n\
 uwsgi --http :7777 -w app:app --threads 2 --enable-threads --lazy-apps --import=ddtrace.bootstrap.sitecustomize\n' > app.sh
 RUN chmod +x app.sh
 CMD ./app.sh


### PR DESCRIPTION
## Motivation

We need more easy visibility of what dependencies were installed for the weblogs and tracers

## Changes

Add a pip freeze in the launch script just before the application start.
Also remove UDS test in django script (this is only a thing for uds flask).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
