### PR TITLE
Mark CSS obfuscation test as flaky for java

### DIFF
--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -1,5 +1,6 @@
 import pytest
 from utils import interfaces, weblog, features, scenarios, missing_feature, context, bug, logger
+from utils._decorators import flaky
 
 """
 Test scenarios we want:
@@ -78,7 +79,7 @@ class Test_Client_Stats:
         or context.library <= "java@1.52.1",
         reason="Tracers have not implemented this feature yet.",
     )
-    @missing_feature(weblog_variant="spring-boot-3-native", reason="rasp endpoint not implemented")
+    @flaky(library="java", reason="LANGPLAT-760")
     def test_obfuscation(self):
         stats_count = 0
         hits = 0


### PR DESCRIPTION
## Motivation

CSS obfuscation tests is flaky under load and counts may vary. 
It uses a rasp endpoint that might not behave as expected in java.
Marking as flaky. Logged a ticket.

```
______________________ Test_Client_Stats.test_obfuscation ______________________



self = <tests.stats.test_stats.Test_Client_Stats object at 0x7f161b773890>

    @missing_feature(

        context.library in ("cpp", "cpp_httpd", "cpp_nginx", "dotnet", "nodejs", "php", "python", "ruby")

        or context.library <= "java@1.52.1",

        reason="Tracers have not implemented this feature yet.",

    )

    @missing_feature(weblog_variant="spring-boot-3-native", reason="rasp endpoint not implemented")

    def test_obfuscation(self):

        stats_count = 0

        hits = 0

        top_hits = 0

        resource = "SELECT * FROM users WHERE id = ?"

        for s in interfaces.agent.get_stats(resource):

            stats_count += 1

            logger.debug(f"asserting on {s}")

            hits += s["Hits"]

            top_hits += s["TopLevelHits"]

            assert s["Type"] == "sql", "expect 'sql' type"

        assert (

            stats_count <= 4

        ), "expect <= 4 stats"  # Normally this is exactly 2 but in certain high load this can flake and result in additional payloads where hits are split across two payloads

>       assert hits == top_hits == 4, "expect exactly 4 'OK' hits and top level hits across all payloads"

E       AssertionError: expect exactly 4 'OK' hits and top level hits across all payloads

E       assert 3 == 4

tests/stats/test_stats.py:96: AssertionError
```

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
