### PR TITLE
Wait for all the buckets when asserting metrics

### DIFF
--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -1,6 +1,6 @@
+import time
 import pytest
 from utils import interfaces, weblog, features, scenarios, missing_feature, context, bug, logger
-from utils._decorators import flaky
 
 """
 Test scenarios we want:
@@ -46,6 +46,8 @@ class Test_Client_Stats:
         ok_top_hits = 0
         no_content_hits = 0
         no_content_top_hits = 0
+        # wait for 10 seconds to be sure all the buckets are flushed (better than be flaky)
+        time.sleep(10)
         for s in interfaces.agent.get_stats(resource="GET /stats-unique"):
             stats_count += 1
             logger.debug(f"asserting on {s}")
@@ -79,12 +81,14 @@ class Test_Client_Stats:
         or context.library <= "java@1.52.1",
         reason="Tracers have not implemented this feature yet.",
     )
-    @flaky(library="java", reason="LANGPLAT-760")
+    @missing_feature(weblog_variant="spring-boot-3-native", reason="rasp endpoint not implemented")
     def test_obfuscation(self):
         stats_count = 0
         hits = 0
         top_hits = 0
         resource = "SELECT * FROM users WHERE id = ?"
+        # wait for 10 seconds to be sure all the buckets are flushed (better than be flaky)
+        time.sleep(10)
         for s in interfaces.agent.get_stats(resource):
             stats_count += 1
             logger.debug(f"asserting on {s}")


### PR DESCRIPTION
Stat buckets are flushed on a regular basis (10 seconds). It can happen, under load, that the x requets take time and in between only one bucket is flushed.
However, after finishing the requests, the test is asking for agent stats payload and will obtain only 1 with partial data.
To be correct, the test must wait 10 additional seconds (it can be done perhaps better but it's better than have flakes) in order to be sure that all the payloads are considered when counting

Wait for all the buckets to be flushed when testing stats. 

## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
