### PR TITLE
lambda-proxy: missing docker authentication

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -278,6 +278,7 @@ generate_system_tests_lambda_proxy_image:
   before_script:
     - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text)
     - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text)
+    - echo "$DOCKER_LOGIN_PASS" | docker login --username "$DOCKER_LOGIN" --password-stdin
   script:
       - ./build.sh -i lambda-proxy
       - docker push datadog/system-tests:lambda-proxy-v1

--- a/utils/build/docker/lambda_proxy/pyproject.toml
+++ b/utils/build/docker/lambda_proxy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lambda-proxy"
-version = "1.0.0"
+version = "1.0.1"
 description = "Minimal Flask app to proxy requests to an AWS RIE endpoint"
 requires-python = ">=3.13"
 dependencies = ["aws-sam-cli==1.141.0", "flask==3.1.1", "gunicorn==23.0.0"]


### PR DESCRIPTION
## Motivation

Still failing job: https://gitlab.ddbuild.io/DataDog/system-tests/-/jobs/1113737551

## Changes

Add missing docker login command.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
