### PR TITLE
isolate appsec rasp

### DIFF
--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -22,6 +22,7 @@ from .docker_ssi import DockerSSIScenario
 from .external_processing import ExternalProcessingScenario
 from .ipv6 import IPV6Scenario
 from .appsec_low_waf_timeout import AppsecLowWafTimeout
+from utils._context._scenarios.appsec_rasp import AppsecRaspScenario
 
 update_environ_with_local_env()
 
@@ -1005,19 +1006,7 @@ class _Scenarios:
         doc="Validates the crashtracking for ssi on a docker environment",
         scenario_groups=[scenario_groups.all, scenario_groups.docker_ssi],
     )
-    appsec_rasp = EndToEndScenario(
-        "APPSEC_RASP",
-        weblog_env={
-            "DD_APPSEC_RASP_ENABLED": "true",
-            "DD_APPSEC_RULES": "/appsec_rasp_ruleset.json",
-            # added to test Test_ExtendedRequestBodyCollection
-            "DD_APPSEC_RASP_COLLECT_REQUEST_BODY": "true",
-        },
-        weblog_volumes={"./tests/appsec/rasp/rasp_ruleset.json": {"bind": "/appsec_rasp_ruleset.json", "mode": "ro"}},
-        doc="Enable APPSEC RASP",
-        github_workflow="endtoend",
-        scenario_groups=[scenario_groups.appsec, scenario_groups.appsec_rasp],
-    )
+    appsec_rasp = AppsecRaspScenario()
 
     appsec_rasp_non_blocking = EndToEndScenario(
         "APPSEC_RASP_NON_BLOCKING",

--- a/utils/_context/_scenarios/appsec_rasp.py
+++ b/utils/_context/_scenarios/appsec_rasp.py
@@ -1,0 +1,26 @@
+import pytest
+
+from utils._context._scenarios.endtoend import EndToEndScenario
+from utils._context._scenarios.core import scenario_groups
+
+
+class AppsecRaspScenario(EndToEndScenario):
+    def __init__(self):
+        super().__init__(
+            "APPSEC_RASP",
+            weblog_env={
+                "DD_APPSEC_RASP_ENABLED": "true",
+                "DD_APPSEC_RULES": "/appsec_rasp_ruleset.json",
+                # added to test Test_ExtendedRequestBodyCollection
+                "DD_APPSEC_RASP_COLLECT_REQUEST_BODY": "true",
+            },
+            weblog_volumes={
+                "./tests/appsec/rasp/rasp_ruleset.json": {"bind": "/appsec_rasp_ruleset.json", "mode": "ro"}
+            },
+            doc="Enable APPSEC RASP",
+            github_workflow="endtoend",
+            scenario_groups=[scenario_groups.appsec, scenario_groups.appsec_rasp],
+        )
+
+    def configure(self, config: pytest.Config):
+        super().configure(config)

--- a/utils/scripts/compute_impacted_scenario.py
+++ b/utils/scripts/compute_impacted_scenario.py
@@ -158,6 +158,7 @@ def main() -> None:
                     r"utils/_context/_scenarios/aws_lambda\.py": scenario_groups.lambda_end_to_end,
                     r"utils/_context/_scenarios/auto_injection\.py": scenario_groups.onboarding,
                     r"utils/_context/_scenarios/default\.py": scenarios.default,
+                    r"utils/_context/_scenarios/appsec_rasp\.py": scenarios.appsec_rasp,
                     r"utils/_context/_scenarios/endtoend\.py": scenario_groups.end_to_end,
                     r"utils/_context/_scenarios/integrations\.py": scenario_groups.integrations,
                     r"utils/_context/_scenarios/ipv6\.py": scenario_groups.ipv6,


### PR DESCRIPTION
## Motivation

Isolating appsec rasp scenario to be able to work on it more easily

This scenario will be used to include API10 tests.

APPSEC-58715

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
