### PR TITLE
ci: migrate generate_system_tests_lib_injection_images job to golden path runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -273,6 +273,8 @@ generate_system_tests_lambda_proxy_image:
 
 generate_system_tests_lib_injection_images:
   extends: .base_job_k8s_docker_ssi
+  # override tags until base_job_k8s_docker_ssi is updated
+  tags: ["arch:amd64"]
   needs: []
   stage: system-tests-utils
   allow_failure: true

--- a/.gitlab/ssi_gitlab-ci.yml
+++ b/.gitlab/ssi_gitlab-ci.yml
@@ -154,8 +154,49 @@ ssi_tests:
         paths:
             - reports/
 
+.k8s_lib_injection_weblog_build_base:
+  extends: .base_job_k8s_docker_ssi
+  # override tags until base_job_k8s_docker_ssi is updated
+  # the tests are manipulating the images and running kind
+  tags: ["arch:amd64"]
+  stage: K8S_LIB_INJECTION
+  needs: []
+  allow_failure: false
+  timeout: 20 minutes
+  variables:
+    FF_USE_NEW_BASH_EVAL_STRATEGY: true
+  script:
+    - aws ecr get-login-password | docker login --username ${PRIVATE_DOCKER_REGISTRY_USER} --password-stdin ${PRIVATE_DOCKER_REGISTRY}
+    - export PRIVATE_DOCKER_REGISTRY_TOKEN=$(aws ecr get-login-password --region us-east-1)
+    - SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i runner
+    - source venv/bin/activate
+    - |
+      if [ "$CI_PROJECT_NAME" = "system-tests" ] && [ "$CI_PIPELINE_SOURCE" != "schedule" ]; then
+        TAG_NAME=$([ "$CI_COMMIT_BRANCH" = "main" ] && echo "latest" || echo "$CI_COMMIT_BRANCH" | tr '/' '-')
+        ./lib-injection/build/build_lib_injection_weblog.sh -w "${K8S_WEBLOG}" -l "${TEST_LIBRARY}" \
+          --push-tag "${PRIVATE_DOCKER_REGISTRY}/system-tests/${K8S_WEBLOG}:${TAG_NAME}" \
+          --docker-platform "linux/arm64,linux/amd64"
+      else
+        TAG_NAME="latest"
+      fi
+    - echo "TAG_NAME=${TAG_NAME}" > weblog_build_${K8S_WEBLOG}_${TEST_LIBRARY}.env
+  artifacts:
+    reports:
+      dotenv: weblog_build_${K8S_WEBLOG}_${TEST_LIBRARY}.env
+    expire_in: 1 hour
+  retry:
+    max: 2
+    when:
+      - unknown_failure
+      - data_integrity_failure
+      - runner_system_failure
+      - scheduler_failure
+      - api_failure
+
 .k8s_lib_injection_base:
   extends: .base_job_k8s_docker_ssi
+  # override tags until base_job_k8s_docker_ssi is updated
+  # the tests are manipulating the images and running kind
   needs: []
   stage: K8S_LIB_INJECTION
   allow_failure: false
@@ -164,23 +205,9 @@ ssi_tests:
     # Force gitlab to keep the exit code as 3 if the job fails with exit code 3
     FF_USE_NEW_BASH_EVAL_STRATEGY: true
   script:
-    - SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh -i runner # rebuild runner in case there were changes
-    - source venv/bin/activate
-    - python --version
-    - pip freeze
     - aws ecr get-login-password | docker login --username ${PRIVATE_DOCKER_REGISTRY_USER} --password-stdin ${PRIVATE_DOCKER_REGISTRY}
     - export PRIVATE_DOCKER_REGISTRY_TOKEN=$(aws ecr get-login-password --region us-east-1)
-    - |
-      if [ "$CI_PROJECT_NAME" = "system-tests" ] && [ "$CI_PIPELINE_SOURCE" != "schedule" ]; then
-        TAG_NAME=$([ "$CI_COMMIT_BRANCH" = "main" ] && echo "latest" || echo "$CI_COMMIT_BRANCH" | tr '/' '-')
-        ./lib-injection/build/build_lib_injection_weblog.sh -w ${K8S_WEBLOG} -l ${TEST_LIBRARY} \
-          --push-tag ${PRIVATE_DOCKER_REGISTRY}/system-tests/${K8S_WEBLOG}:${TAG_NAME} \
-          --docker-platform linux/arm64,linux/amd64
-      else
-        TAG_NAME="latest"
-      fi
     - ./run.sh ${K8S_SCENARIO} --k8s-library ${TEST_LIBRARY} --k8s-weblog ${K8S_WEBLOG} --k8s-weblog-img ${K8S_WEBLOG_IMG}:${TAG_NAME} --k8s-lib-init-img ${K8S_LIB_INIT_IMG} --k8s-injector-img ${K8S_INJECTOR_IMG} --k8s-cluster-img ${K8S_CLUSTER_IMG} --report-run-url $CI_JOB_URL --report-environment ${REPORT_ENVIRONMENT}
-
   after_script: |
     kind delete clusters --all || true
     mkdir -p reports

--- a/lib-injection/build/build_lib_injection_images.sh
+++ b/lib-injection/build/build_lib_injection_images.sh
@@ -28,7 +28,6 @@ variants=(["dd-lib-dotnet-init-test-app"]="dotnet"
           ["dd-lib-ruby-init-test-rails-gemsrb"]="ruby"
           ["dd-lib-php-init-test-app"]="php"
           )
-docker buildx create --name multiarch --driver docker-container --use
 
 for variant in "${!variants[@]}"; do
     language="${variants[$variant]}"

--- a/lib-injection/build/build_lib_injection_weblog.sh
+++ b/lib-injection/build/build_lib_injection_weblog.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 echo "SCRIPT_DIR: $SCRIPT_DIR"
@@ -138,8 +138,11 @@ done
 echo "Building docker weblog image using variant [${WEBLOG_VARIANT}] and library [${TEST_LIBRARY}]"
 echo "Target platforms: ${DOCKER_PLATFORM}"
 
-# Setup buildx
-setup_buildx
+# In CI environments, the builder instance is pre-configured for us.
+# We check DOCKER_HOST to know if we're running on a Docker in Docker runner
+if [[ -z "${CI:-}" && -z "$DOCKER_HOST" ]]; then
+    setup_buildx
+fi
 
 CURRENT_DIR=$(pwd)
 cd $WEBLOG_FOLDER


### PR DESCRIPTION
## Motivation

This repo is still using `runner:main` and `runner:docker` which are legacy runners that will be decommissioned soon due to running on EOL OS.

## Changes

Migrate the jobs to the kubernetes runners since we can do docker builds in K8s via buildkit and the other jobs don't access docker at all.

Relevant docs:
- [Migrate off runner docker and runner main](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/4574317825/Migrate+off+runner+docker+and+runner+main)
- [Building Container Images on Kubernetes](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3230269995/Building+Container+Images+on+Kubernetes)
- [Runner docker and docker-arm migration](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3317203267/Runner+docker+and+docker-arm+migration)
> [!NOTE]
> For any questions, contact us on [#ci-runner-docker-deprecation](https://dd.enterprise.slack.com/archives/C069CKY4NQ6)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
