### PR TITLE
parametric: skip failing cpp tests

### DIFF
--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -232,6 +232,7 @@ class Test_Config_RateLimit:
     )
     @flaky(library="java", reason="APMAPI-908")
     @bug(context.library == "golang", reason="APMAPI-1030")
+    @bug(context.library == "cpp", reason="APMAPI-511")
     def test_setting_trace_rate_limit_strict(self, library_env, test_agent, test_library):
         with test_library:
             with test_library.dd_start_span(name="s1"):

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -199,6 +199,7 @@ class Test_Config_TraceAgentURL:
     @missing_feature(context.library == "php", reason="does not support ipv6 hostname")
     @missing_feature(context.library == "golang", reason="does not support ipv6 hostname")
     @missing_feature(context.library == "python", reason="does not support ipv6 hostname")
+    @missing_feature(context.library == "cpp", reason="does not support ipv6 hostname")
     def test_dd_agent_host_ipv6(self, library_env, test_agent, test_library):
         with test_library as t:
             resp = t.config()

--- a/tests/parametric/test_headers_tracecontext.py
+++ b/tests/parametric/test_headers_tracecontext.py
@@ -12,7 +12,7 @@ import pytest
 
 from utils.parametric.spec.tracecontext import get_tracecontext
 from utils.parametric.spec.trace import find_span_in_traces, find_only_span
-from utils import missing_feature, context, scenarios, features
+from utils import missing_feature, bug, context, scenarios, features
 
 parametrize = pytest.mark.parametrize
 
@@ -224,6 +224,7 @@ class Test_Headers_Tracecontext:
         assert traceparent.trace_id != "12345678901234567890123456789012"
 
     @temporary_enable_optin_tracecontext()
+    @bug(context.library == "cpp", reason="APMAPI-1599")
     def test_traceparent_version_illegal_characters(self, test_agent, test_library):
         """Harness sends an invalid traceparent with illegal characters in version
         expects a valid traceparent from the output header, with a newly generated trace_id


### PR DESCRIPTION
## Motivation

Unblock CI

## Changes

- Skips cpp tests that fail after the latest dd-trace-cpp release (v1.1.0)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
