### PR TITLE
Reduce parametric logs verbosity

### DIFF
--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -32,6 +32,18 @@ from utils._context._scenarios.parametric import APMLibraryTestServer
 default_subprocess_run_timeout = 300
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    item._report_sections = list(filter(
+        lambda section: not (
+            "Library Output" in section[1] or 
+            "Test Agent Output" in section[1] or
+            False
+        ),
+        item._report_sections
+    ))
+    return(yield)
+
 @pytest.fixture
 def test_id(request: pytest.FixtureRequest) -> str:
     import uuid


### PR DESCRIPTION
## Motivation

Current log verbosity is too high and makes it harder to find error sources.

## Changes


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
