### PR TITLE
[python]: bump django-py3.13 weblog to gevent 25.8.2

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -730,7 +730,9 @@ tests/:
       Test_Main: v2.0.0
     test_remote_config_rule_changes.py:
       Test_AsmDdMultiConfiguration: v3.10.0.dev (partial support in v3.9.0)
-      Test_BlockingActionChangesWithRemoteConfig: v2.10.1
+      Test_BlockingActionChangesWithRemoteConfig:
+        '*': v2.10.1
+        django-py3.13: v3.15.0.dev (v2.10.1 but fixed incompatibility issue with gevent 25.8.2)
       Test_Empty_Config: v3.10.0
       Test_Multiple_Actions: v2.10.1
       Test_Unknown_Action: v2.10.1
@@ -1108,7 +1110,9 @@ tests/:
       TestTracerFlareV1: v3.12.0.dev
   remote_config/:
     test_remote_configuration.py:
-      Test_RemoteConfigurationExtraServices: v2.1.0
+      Test_RemoteConfigurationExtraServices:
+        '*': v2.1.1
+        django-py3.13: v3.15.0.dev (v2.1.1 but fixed incompatibility issue with gevent 25.8.2)
       Test_RemoteConfigurationUpdateSequenceASMDD: v2.9.0
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: missing_feature
       Test_RemoteConfigurationUpdateSequenceFeatures: v1.7.4

--- a/utils/build/build_python_base_images.sh
+++ b/utils/build/build_python_base_images.sh
@@ -4,7 +4,7 @@
 
 
 
-docker buildx build --load --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v4 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v5 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/fastapi.base.Dockerfile -t datadog/system-tests:fastapi.base-v6 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v9 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v7 .
@@ -12,11 +12,10 @@ docker buildx build --load --progress=plain -f utils/build/docker/python/flask-p
 docker buildx build --load --progress=plain -f utils/build/docker/python/uwsgi-poc.base.Dockerfile -t datadog/system-tests:uwsgi-poc.base-v7 .
 
 if [ "$1" = "--push" ]; then
-      docker push datadog/system-tests:django-py3.13.base-v4
+      docker push datadog/system-tests:django-py3.13.base-v5
       docker push datadog/system-tests:fastapi.base-v6
       docker push datadog/system-tests:python3.12.base-v9
       docker push datadog/system-tests:django-poc.base-v7
       docker push datadog/system-tests:flask-poc.base-v11
       docker push datadog/system-tests:uwsgi-poc.base-v7
 fi
-

--- a/utils/build/docker/python/django-py3.13.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:django-py3.13.base-v4
+FROM datadog/system-tests:django-py3.13.base-v5
 
 WORKDIR /app
 

--- a/utils/build/docker/python/django-py3.13.base.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.base.Dockerfile
@@ -8,8 +8,7 @@ RUN python --version && curl --version
 # install python deps
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install --upgrade pip
-RUN pip install django==5.2.4 pycryptodome==3.23.0 gunicorn==23.0.0 gevent==25.5.1 requests==2.32.4 boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2
+RUN pip install django==5.2.4 pycryptodome==3.23.0 gunicorn==23.0.0 gevent==25.8.2 requests==2.32.4 boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2
 
-# docker build --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v4 .
-# docker push datadog/system-tests:django-py3.13.base-v4
-
+# docker build --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v5 .
+# docker push datadog/system-tests:django-py3.13.base-v5

--- a/utils/build/docker/python/django-py3.13.base.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.base.Dockerfile
@@ -8,7 +8,7 @@ RUN python --version && curl --version
 # install python deps
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install --upgrade pip
-RUN pip install django==5.2.4 pycryptodome==3.23.0 gunicorn==23.0.0 gevent==25.8.2 requests==2.32.4 boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2
+RUN pip install django==5.2.6 pycryptodome==3.23.0 gunicorn==23.0.0 gevent==25.8.2 requests==2.32.4 boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2
 
 # docker build --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v5 .
 # docker push datadog/system-tests:django-py3.13.base-v5


### PR DESCRIPTION
## Motivation

Update the gevent version on a weblog to ensure that this version compatibility is tested.
This was resolved in: https://github.com/DataDog/dd-trace-py/pull/14530 

## Changes

- Update gevent from version 25.5.1 to 25.8.2.
- Update python manifest accordingly

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
