### PR TITLE
fix(er): avoid failing on new er_snapshot type

### DIFF
--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -210,7 +210,7 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                 return scrubbed
             return __scrub(value)
 
-        def __scrub_python(key, value, parent):  # noqa: ARG001
+        def __scrub_python(key, value, parent):
             if key == "@exception":
                 value["fields"] = "<scrubbed>"
                 return value
@@ -229,6 +229,10 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
 
                 scrubbed.append({"<runtime>": "<scrubbed>"})
                 return scrubbed
+
+            elif key == "type" and value == "er_snapshot":
+                del parent["type"]
+
             return __scrub(value)
 
         def __scrub_none(key, value, parent):  # noqa: ARG001


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/dd-trace-py/pull/14402 introduces a new field `type: "er_snapshot"` to exception replay snapshots. This ensures that the system-tests do not fail for the main branch.

## Changes

This pull request introduces a small but important change to the exception scrubbing logic in the debugger test suite. Specifically, it modifies how entries with a `"type"` of `"er_snapshot"` are handled during scrubbing.

* Exception scrubbing logic: In the `__scrub_python` function within `tests/debugger/test_debugger_exception_replay.py`, the code now removes the `"type"` field from the parent dictionary when its value is `"er_snapshot"`. This helps prevent sensitive or unnecessary type information from being retained in scrubbed test data.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
