### PR TITLE
fix(er): dictionary changed size during iteration

### DIFF
--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -135,7 +135,9 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                     if key in ["timestamp", "id", "exceptionId", "duration"]:
                         scrubbed_data[key] = "<scrubbed>"
                     else:
-                        scrubbed_data[key] = scrub_language(key, value, data)
+                        scrubbed_value = scrub_language(key, value, data)
+                        if scrubbed_value is not None:
+                            scrubbed_data[key] = scrubbed_value
 
                 return scrubbed_data
             elif isinstance(data, list):
@@ -210,7 +212,7 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                 return scrubbed
             return __scrub(value)
 
-        def __scrub_python(key, value, parent):
+        def __scrub_python(key, value, parent):  # noqa: ARG001
             if key == "@exception":
                 value["fields"] = "<scrubbed>"
                 return value
@@ -231,7 +233,7 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                 return scrubbed
 
             elif key == "type" and value == "er_snapshot":
-                del parent["type"]
+                return None
 
             return __scrub(value)
 


### PR DESCRIPTION
## Motivation

Fixes a bug introduced in https://github.com/DataDog/system-tests/pull/5232 where it raised "dictionary changed size during iteration"

## Changes

* In the `__scrub_python` function, when the key is `"type"` and the value is `"er_snapshot"`, the function now returns `None` instead of deleting the key from the parent, ensuring more consistent handling of this special case.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
