### PR TITLE
Harden internal server

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1456,7 +1456,8 @@ class InternalServerContainer(TestedContainer):
             name="internal_server",
             host_log_folder=host_log_folder,
             healthcheck={"test": "wget http://internal_server:8089", "retries": 10},
-            command="/bin/sh /app/app.sh",
+            working_dir="/app",
+            command="uvicorn app:app --host 0.0.0.0 --port 8089",
             volumes={
                 "./utils/build/docker/internal_server/app.py": {"bind": "/app/app.py", "mode": "ro"},
                 "./utils/build/docker/internal_server/app.sh": {"bind": "/app/app.sh", "mode": "ro"},

--- a/utils/build/docker/internal_server/app.sh
+++ b/utils/build/docker/internal_server/app.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-python -m pip install "fastapi[standard]==0.116.1"
-python -m fastapi run  --port 8089 /app/app.py


### PR DESCRIPTION
## Motivation

The previous command was using `python -m fastapi run --port 8089 /app/app.py`. But to use `-m fastapi`, fastapi must be install with the `[standard]` option, which is not present in `demisto/fastapi` images. It was previsouly installed at run time, but then prone to pypi instability or lags : https://github.com/DataDog/system-tests-dashboard/actions/runs/17632926485/job/50104546742#step:69:82

## Changes

* Do not use the fastapi CLI, but directly call `uvicorn app:app`.
* It also saves a file, as the command can be directly set on the container definition
 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
