### PR TITLE
AWS SSI: Disable ubuntu 24.10

### DIFF
--- a/utils/virtual_machine/virtual_machines.json
+++ b/utils/virtual_machine/virtual_machines.json
@@ -189,7 +189,7 @@
             "os_branch": "ubuntu24",
             "os_cpu": "amd64",
             "default_vm": true,
-            "disabled": false
+            "disabled": true
         },
         {
             "name": "Ubuntu_24_10_arm64",
@@ -203,7 +203,7 @@
             "os_branch": "ubuntu24",
             "os_cpu": "arm64",
             "default_vm": false,
-            "disabled": false
+            "disabled": true
         },
         {
             "name": "Debian_12_amd64",


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The Ubuntu 24.10 repositories are broken. Temporarily disable the machine.
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
