### PR TITLE
[nodejs] Flag all security controls test as flaky for `fastify` variant

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -501,7 +501,7 @@ tests/:
       test_security_controls.py:
         TestSecurityControls:
           '*': *ref_5_37_0
-          fastify: *ref_5_61_0
+          fastify: flaky (APPSEC-58724)
           nextjs: missing_feature
     rasp/:
       test_api10.py:

--- a/tests/appsec/iast/test_security_controls.py
+++ b/tests/appsec/iast/test_security_controls.py
@@ -90,7 +90,6 @@ class TestSecurityControls:
         self.setup_iast_is_enabled()
         self.r = weblog.post("/iast/sc/s/not-configured", data={"param": "param"})
 
-    @flaky(context.library == "nodejs" and context.weblog_variant == "fastify", reason="APPSEC-58724")
     def test_no_vulnerability_suppression_with_a_sanitizer_configured_for_a_different_vulnerability(self):
         self.assert_iast_is_enabled(self.check_r)
         assert_iast_vulnerability(

--- a/tests/appsec/iast/test_security_controls.py
+++ b/tests/appsec/iast/test_security_controls.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import features, rfc, weblog, irrelevant, context
+from utils import features, rfc, weblog, irrelevant
 from tests.appsec.iast.utils import BaseSinkTest, assert_iast_vulnerability, assert_metric
 
 

--- a/tests/appsec/iast/test_security_controls.py
+++ b/tests/appsec/iast/test_security_controls.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-from utils import features, rfc, weblog, irrelevant, flaky, context
+from utils import features, rfc, weblog, irrelevant, context
 from tests.appsec.iast.utils import BaseSinkTest, assert_iast_vulnerability, assert_metric
 
 


### PR DESCRIPTION
## Motivation

Security controls tests have proven to be flaky for the `fastify` variant.

## Changes

Flag security controls as flaky for fastify variant in Node.js manifest.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
