### PR TITLE
appsec: Fix util functions that retrieve telemetry metrics and configs

### DIFF
--- a/tests/appsec/utils.py
+++ b/tests/appsec/utils.py
@@ -5,17 +5,13 @@ from utils import remote_config
 from utils.dd_constants import RemoteConfigApplyState
 
 
-def _get_telemetry_payload(request_type: str) -> Generator:
-    for data in interfaces.library.get_telemetry_data():
-        content = data["request"]["content"]
-        if content.get("request_type") != request_type:
-            continue
-        yield content["payload"]
-
-
 def find_series(namespace: str, metrics: list[str]) -> list:
     series = []
-    for payload in _get_telemetry_payload("generate-metrics"):
+    for data in interfaces.library.get_telemetry_data():
+        content = data["request"]["content"]
+        if content.get("request_type") != "generate-metrics":
+            continue
+        payload = content["payload"]
         fallback_namespace = payload.get("namespace")
         for serie in payload["series"]:
             computed_namespace = serie.get("namespace", fallback_namespace)
@@ -25,7 +21,11 @@ def find_series(namespace: str, metrics: list[str]) -> list:
 
 
 def find_configuration() -> Generator:
-    for payload in _get_telemetry_payload("app-client-configuration-change"):
+    for data in interfaces.library.get_telemetry_data():
+        content = data["request"]["content"]
+        if content.get("request_type") not in ["app-started", "app-client-configuration-change"]:
+            continue
+        payload = content["payload"]
         yield payload.get("configuration")
 
 


### PR DESCRIPTION
## Motivation

- `find_series`  function do not support retreiving metrics from telemetry payloads with the `message-batch` request type
- `find_configurations` function does not support retrieving configurations from telemetry payloads with `app-started` and `message-batch` request type.

## Changes

- This PR ensures that appsec tests parse telemetry payloads in a consistent manner. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
