### PR TITLE
Merge APPSEC_REQUEST_BLOCKING scenario into APPSEC_BLOCKING_FULL_DENYLIST

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -305,9 +305,6 @@ jobs:
     - name: Run APPSEC_BLOCKING_FULL_DENYLIST scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"APPSEC_BLOCKING_FULL_DENYLIST"')
       run: ./run.sh APPSEC_BLOCKING_FULL_DENYLIST
-    - name: Run APPSEC_REQUEST_BLOCKING scenario
-      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"APPSEC_REQUEST_BLOCKING"')
-      run: ./run.sh APPSEC_REQUEST_BLOCKING
     - name: Run APPSEC_AND_RC_ENABLED scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"APPSEC_AND_RC_ENABLED"')
       run: ./run.sh APPSEC_AND_RC_ENABLED

--- a/tests/appsec/test_request_blocking.py
+++ b/tests/appsec/test_request_blocking.py
@@ -11,7 +11,7 @@ from utils import weblog
 
 @features.appsec_request_blocking
 @features.envoy_external_processing
-@scenarios.appsec_request_blocking
+@scenarios.appsec_blocking_full_denylist
 @scenarios.external_processing
 class Test_AppSecRequestBlocking:
     """A library should block requests when a rule is set to blocking mode."""

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -279,14 +279,6 @@ class _Scenarios:
         scenario_groups=[scenario_groups.appsec],
     )
 
-    appsec_request_blocking = EndToEndScenario(
-        "APPSEC_REQUEST_BLOCKING",
-        rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None},
-        doc="",
-        scenario_groups=[scenario_groups.appsec],
-    )
-
     appsec_and_rc_enabled = EndToEndScenario(
         "APPSEC_AND_RC_ENABLED",
         rc_api_enabled=True,


### PR DESCRIPTION
## Motivation

As the system-tests repository grows, we need to ensure efficient test matrix management by preventing duplicate scenarios and identifying opportunities to merge similar EndToEnd scenarios. Duplicate scenarios waste CI resources and increase maintenance overhead without providing additional test coverage.

## Changes
remove APPSEC_REQUEST_BLOCKING scenario and replace annotated tests with APPSEC_BLOCKING_FULL_DENYLIST

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
