### PR TITLE
Remove stand alone experimental tests and scenarios

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -155,24 +155,15 @@ jobs:
     - name: Run APPSEC_STANDALONE_API_SECURITY scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"APPSEC_STANDALONE_API_SECURITY"')
       run: ./run.sh APPSEC_STANDALONE_API_SECURITY
-    - name: Run APPSEC_STANDALONE_EXPERIMENTAL scenario
-      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"APPSEC_STANDALONE_EXPERIMENTAL"')
-      run: ./run.sh APPSEC_STANDALONE_EXPERIMENTAL
     - name: Run TRACE_STATS_COMPUTATION scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"TRACE_STATS_COMPUTATION"')
       run: ./run.sh TRACE_STATS_COMPUTATION
     - name: Run IAST_STANDALONE scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"IAST_STANDALONE"')
       run: ./run.sh IAST_STANDALONE
-    - name: Run IAST_STANDALONE_EXPERIMENTAL scenario
-      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"IAST_STANDALONE_EXPERIMENTAL"')
-      run: ./run.sh IAST_STANDALONE_EXPERIMENTAL
     - name: Run SCA_STANDALONE scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"SCA_STANDALONE"')
       run: ./run.sh SCA_STANDALONE
-    - name: Run SCA_STANDALONE_EXPERIMENTAL scenario
-      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"SCA_STANDALONE_EXPERIMENTAL"')
-      run: ./run.sh SCA_STANDALONE_EXPERIMENTAL
     - name: Run IAST_DEDUPLICATION scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"IAST_DEDUPLICATION"')
       run: ./run.sh IAST_DEDUPLICATION

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -90,11 +90,8 @@ tests/:
     test_asm_standalone.py:
       Test_APISecurityStandalone: missing_feature
       Test_AppSecStandalone_NotEnabled: v1.7.0
-      Test_AppSecStandalone_UpstreamPropagation: irrelevant (V2 implemented)
       Test_AppSecStandalone_UpstreamPropagation_V2: v1.7.0
-      Test_IastStandalone_UpstreamPropagation: irrelevant
       Test_IastStandalone_UpstreamPropagation_V2: irrelevant
-      Test_SCAStandalone_Telemetry: irrelevant
       Test_SCAStandalone_Telemetry_V2: missing_feature
       Test_UserEventsStandalone_Automated: missing_feature
       Test_UserEventsStandalone_SDK_V1: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -320,11 +320,8 @@ tests/:
       Test_Basic: v1.28.6
     test_asm_standalone.py:
       Test_APISecurityStandalone: v3.17.0
-      Test_AppSecStandalone_UpstreamPropagation: missing_feature
       Test_AppSecStandalone_UpstreamPropagation_V2: v3.12.0
-      Test_IastStandalone_UpstreamPropagation: missing_feature
       Test_IastStandalone_UpstreamPropagation_V2: v3.12.0
-      Test_SCAStandalone_Telemetry: missing_feature
       Test_SCAStandalone_Telemetry_V2: missing_feature
       Test_UserEventsStandalone_Automated: v3.12.0
       Test_UserEventsStandalone_SDK_V1: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -416,11 +416,8 @@ tests/:
         gin: v1.37.0
     test_asm_standalone.py:
       Test_APISecurityStandalone: missing_feature
-      Test_AppSecStandalone_UpstreamPropagation: irrelevant (v2 is implemented)
       Test_AppSecStandalone_UpstreamPropagation_V2: v1.73.0-dev
-      Test_IastStandalone_UpstreamPropagation: missing_feature
       Test_IastStandalone_UpstreamPropagation_V2: missing_feature
-      Test_SCAStandalone_Telemetry: irrelevant (v2 is implemented)
       Test_SCAStandalone_Telemetry_V2: v2.0.0
       Test_UserEventsStandalone_Automated: missing_feature
       Test_UserEventsStandalone_SDK_V1: missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1215,20 +1215,11 @@ tests/:
         vertx3: bug (APPSEC-56870)
         vertx4: bug (APPSEC-56871)
       Test_AppSecStandalone_NotEnabled: missing_feature
-      Test_AppSecStandalone_UpstreamPropagation:
-        '*': v1.36.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_AppSecStandalone_UpstreamPropagation_V2:
         '*': v1.47.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      Test_IastStandalone_UpstreamPropagation:
-        '*': v1.36.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_IastStandalone_UpstreamPropagation_V2:
         '*': v1.47.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-      Test_SCAStandalone_Telemetry:
-        '*': v1.36.0
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       Test_SCAStandalone_Telemetry_V2:
         '*': v1.47.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -823,11 +823,8 @@ tests/:
     test_asm_standalone.py:
       Test_APISecurityStandalone: *ref_5_52_0
       Test_AppSecStandalone_NotEnabled: *ref_5_18_0
-      Test_AppSecStandalone_UpstreamPropagation: irrelevant (due to v2)
       Test_AppSecStandalone_UpstreamPropagation_V2: *ref_5_40_0
-      Test_IastStandalone_UpstreamPropagation: irrelevant (due to v2)
       Test_IastStandalone_UpstreamPropagation_V2: *ref_5_40_0
-      Test_SCAStandalone_Telemetry: irrelevant (due to v2)
       Test_SCAStandalone_Telemetry_V2: *ref_5_40_0
       Test_UserEventsStandalone_Automated:
         '*': *ref_5_40_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -333,11 +333,8 @@ tests/:
     test_asm_standalone.py:
       Test_APISecurityStandalone: v1.11.0
       Test_AppSecStandalone_NotEnabled: v1.6.2
-      Test_AppSecStandalone_UpstreamPropagation: irrelevant (v2 is implemented)
       Test_AppSecStandalone_UpstreamPropagation_V2: v1.8.0
-      Test_IastStandalone_UpstreamPropagation: missing_feature
       Test_IastStandalone_UpstreamPropagation_V2: missing_feature
-      Test_SCAStandalone_Telemetry: irrelevant (v2 is implemented)
       Test_SCAStandalone_Telemetry_V2: v1.8.0
       Test_UserEventsStandalone_Automated: v1.8.0
       Test_UserEventsStandalone_SDK_V1: v1.8.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -524,14 +524,11 @@ tests/:
     test_asm_standalone.py:
       Test_APISecurityStandalone: v3.9.0.dev
       Test_AppSecStandalone_NotEnabled: v2.12.3
-      Test_AppSecStandalone_UpstreamPropagation: irrelevant (was v2.12.3 for all, v2.17.1 for uwsgi-poc but will be replaced by V2)
       Test_AppSecStandalone_UpstreamPropagation_V2: v3.2.0.dev
-      Test_IastStandalone_UpstreamPropagation: irrelevant (was v2.18.0.dev but will be replaced by V2)
       Test_IastStandalone_UpstreamPropagation_V2:
         '*': v3.2.0.dev
         flask-poc: v3.12.0.dev (is v3.2.0.dev but weblog was flaky before fix)
         uds-flask: v3.12.0.dev (is v3.2.0.dev but weblog was flaky before fix)
-      Test_SCAStandalone_Telemetry: irrelevant (was v2.19.0.dev but will be replaced by V2)
       Test_SCAStandalone_Telemetry_V2: v3.2.0.dev
       Test_UserEventsStandalone_Automated: v3.2.0.dev
       Test_UserEventsStandalone_SDK_V1: v3.9.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -351,11 +351,8 @@ tests/:
     test_asm_standalone.py:
       Test_APISecurityStandalone: v2.18.0
       Test_AppSecStandalone_NotEnabled: v2.13.0
-      Test_AppSecStandalone_UpstreamPropagation: irrelevant
       Test_AppSecStandalone_UpstreamPropagation_V2: v2.13.0
-      Test_IastStandalone_UpstreamPropagation: missing_feature
       Test_IastStandalone_UpstreamPropagation_V2: missing_feature
-      Test_SCAStandalone_Telemetry: irrelevant
       Test_SCAStandalone_Telemetry_V2: v2.13.0
       Test_UserEventsStandalone_Automated:
         "*": v2.20.0-dev

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -826,20 +826,6 @@ class Test_AppSecStandalone_NotEnabled:
 
 
 @rfc("https://docs.google.com/document/d/12NBx-nD-IoQEMiCRnJXneq4Be7cbtSc6pJLOFUWTpNE/edit")
-@features.appsec_standalone_experimental
-@scenarios.appsec_standalone_experimental
-@irrelevant(context.library > "java@v1.46.0", reason="V2 is implemented for newer versions")
-class Test_AppSecStandalone_UpstreamPropagation(BaseAppSecStandaloneUpstreamPropagation):
-    """APPSEC correctly propagates AppSec events in distributing tracing with DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED=true."""
-
-    def propagated_tag(self):
-        return "_dd.p.appsec"
-
-    def propagated_tag_value(self):
-        return "1"
-
-
-@rfc("https://docs.google.com/document/d/12NBx-nD-IoQEMiCRnJXneq4Be7cbtSc6pJLOFUWTpNE/edit")
 @features.appsec_standalone
 @scenarios.appsec_standalone
 class Test_AppSecStandalone_UpstreamPropagation_V2(BaseAppSecStandaloneUpstreamPropagation):
@@ -853,20 +839,6 @@ class Test_AppSecStandalone_UpstreamPropagation_V2(BaseAppSecStandaloneUpstreamP
 
 
 @rfc("https://docs.google.com/document/d/12NBx-nD-IoQEMiCRnJXneq4Be7cbtSc6pJLOFUWTpNE/edit")
-@features.iast_standalone_experimental
-@scenarios.iast_standalone_experimental
-@irrelevant(context.library > "java@v1.46.0", reason="V2 is implemented for newer versions")
-class Test_IastStandalone_UpstreamPropagation(BaseIastStandaloneUpstreamPropagation):
-    """IAST correctly propagates AppSec events in distributing tracing with DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED=true."""
-
-    def propagated_tag(self):
-        return "_dd.p.appsec"
-
-    def propagated_tag_value(self):
-        return "1"
-
-
-@rfc("https://docs.google.com/document/d/12NBx-nD-IoQEMiCRnJXneq4Be7cbtSc6pJLOFUWTpNE/edit")
 @features.iast_standalone
 @scenarios.iast_standalone
 class Test_IastStandalone_UpstreamPropagation_V2(BaseIastStandaloneUpstreamPropagation):
@@ -877,20 +849,6 @@ class Test_IastStandalone_UpstreamPropagation_V2(BaseIastStandaloneUpstreamPropa
 
     def propagated_tag_value(self):
         return "02"
-
-
-@rfc("https://docs.google.com/document/d/12NBx-nD-IoQEMiCRnJXneq4Be7cbtSc6pJLOFUWTpNE/edit")
-@features.sca_standalone_experimental
-@scenarios.sca_standalone_experimental
-@irrelevant(context.library > "java@v1.46.0", reason="V2 is implemented for newer versions")
-class Test_SCAStandalone_Telemetry(BaseSCAStandaloneTelemetry):
-    """Tracer correctly propagates SCA telemetry in distributing tracing with DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED=true."""
-
-    def propagated_tag(self):
-        return "_dd.p.appsec"
-
-    def propagated_tag_value(self):
-        return "1"
 
 
 @rfc("https://docs.google.com/document/d/12NBx-nD-IoQEMiCRnJXneq4Be7cbtSc6pJLOFUWTpNE/edit")

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -431,38 +431,11 @@ class _Scenarios:
         scenario_groups=[scenario_groups.appsec, scenario_groups.essentials],
     )
 
-    appsec_standalone_experimental = EndToEndScenario(
-        "APPSEC_STANDALONE_EXPERIMENTAL",
-        weblog_env={
-            "DD_APPSEC_ENABLED": "true",
-            "DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED": "true",
-            "DD_IAST_ENABLED": "false",
-        },
-        doc="Appsec standalone mode (APM opt out) V2",
-        scenario_groups=[scenario_groups.appsec],
-    )
-
     iast_standalone = EndToEndScenario(
         "IAST_STANDALONE",
         weblog_env={
             "DD_APPSEC_ENABLED": "false",
             "DD_APM_TRACING_ENABLED": "false",
-            "DD_IAST_ENABLED": "true",
-            "DD_IAST_DETECTION_MODE": "FULL",
-            "DD_IAST_DEDUPLICATION_ENABLED": "false",
-            "DD_IAST_REQUEST_SAMPLING": "100",
-            "DD_IAST_VULNERABILITIES_PER_REQUEST": "10",
-            "DD_IAST_MAX_CONTEXT_OPERATIONS": "10",
-        },
-        doc="Source code vulnerability standalone mode (APM opt out)",
-        scenario_groups=[scenario_groups.appsec],
-    )
-
-    iast_standalone_experimental = EndToEndScenario(
-        "IAST_STANDALONE_EXPERIMENTAL",
-        weblog_env={
-            "DD_APPSEC_ENABLED": "false",
-            "DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED": "true",
             "DD_IAST_ENABLED": "true",
             "DD_IAST_DETECTION_MODE": "FULL",
             "DD_IAST_DEDUPLICATION_ENABLED": "false",
@@ -483,19 +456,6 @@ class _Scenarios:
             "DD_IAST_ENABLED": "false",
             "DD_TELEMETRY_DEPENDENCY_RESOLUTION_PERIOD_MILLIS": "1",
             "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
-        },
-        doc="SCA standalone mode (APM opt out)",
-        scenario_groups=[scenario_groups.appsec],
-    )
-
-    sca_standalone_experimental = EndToEndScenario(
-        "SCA_STANDALONE_EXPERIMENTAL",
-        weblog_env={
-            "DD_APPSEC_ENABLED": "false",
-            "DD_APPSEC_SCA_ENABLED": "true",
-            "DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED": "true",
-            "DD_IAST_ENABLED": "false",
-            "DD_TELEMETRY_DEPENDENCY_RESOLUTION_PERIOD_MILLIS": "1",
         },
         doc="SCA standalone mode (APM opt out)",
         scenario_groups=[scenario_groups.appsec],


### PR DESCRIPTION
## Motivation

As the system-tests repository grows, we need to ensure efficient test matrix management by preventing duplicate scenarios and identifying opportunities to merge similar EndToEnd scenarios. Duplicate scenarios waste CI resources and increase maintenance overhead without providing additional test coverage.

## Changes

Remove standalone experimental scenario and tests as all tracers that implemented the v1 feature already migrated to v2

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
