### PR TITLE
.github/workflows: allow devflow/merge to be running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,9 @@ jobs:
         max-retries: '120'
         # Ignore gitlab jobs that are not K8S_LIB* (K8s lib injection) or *DOC (docker ssi) or *DO5A (docker ssi crashtracking)
         # https://regex101.com/r/Bo5Kpn/1
+        # Also ignore the job that waits for the tests to succeed before adding
+        # to the merge queue.
 
         ignored-name-patterns: |
           dd-gitlab/(?!K8S_LIB).*$(?<!DOC)(?<!DO5A)
+          devflow/merge


### PR DESCRIPTION
## Motivation

By not ignoring the devflow job, we had a sad situation where by clicking the merge button, you prevent the job from ever being mergable.

## Changes

Ignore `devflow/merge` in all-jobs-are-green.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
