### PR TITLE
resource renaming: update telemetry from dd-go

### DIFF
--- a/utils/telemetry/intake/static/config_norm_rules.json
+++ b/utils/telemetry/intake/static/config_norm_rules.json
@@ -304,6 +304,8 @@
     "DD_TRACE_WCF_RESOURCE_OBFUSCATION_ENABLED": "trace_wcf_obfuscation_enabled",
     "DD_TRACE_WCF_WEB_HTTP_RESOURCE_NAMES_ENABLED": "trace_wcf_web_http_resource_names_enabled",
     "DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH": "trace_x_datadog_tags_max_length",
+    "DD_TRACE_RESOURCE_RENAMING_ENABLED": "trace_resource_renaming_enabled",
+    "DD_TRACE_RESOURCE_RENAMING_ALWAYS_SIMPLIFIED_ENDPOINT": "trace_resource_renaming_always_simplified_endpoint",
     "DD_VERSION": "application_version",
     "FUNCTIONS_EXTENSION_VERSION": "aas_functions_runtime_version",
     "FUNCTIONS_WORKER_RUNTIME": "aas_functions_worker_runtime",


### PR DESCRIPTION
## Motivation

These two lines where introduced in https://github.com/DataDog/system-tests/pull/5267 but disappeared in a following PR (https://github.com/DataDog/system-tests/pull/5288/) because the PR to add them in dd-go was not merged yet.

## Changes

executed: `./utils/telemetry/intake/update.sh`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
