### PR TITLE
[java] Activating xpass tests for java

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -81,7 +81,7 @@ tests/:
           akka-http: bug (APPSEC-56888)
           play: v1.51.0-SNAPSHOT
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-          spring-boot-payara: bug (APPSEC-57921)
+          spring-boot-payara: v1.54.0-SNAPSHOT+c2aec92b86
           vertx3: v1.51.0-SNAPSHOT
           vertx4: v1.51.0-SNAPSHOT
         Test_Schema_Request_Cookies:
@@ -110,7 +110,7 @@ tests/:
           akka-http: bug (APPSEC-56888)
           jersey-grizzly2: bug (APPSEC-56846)
           play: v1.51.0-SNAPSHOT
-          resteasy-netty3: bug (APPSEC-56846)
+          resteasy-netty3: v1.54.0-SNAPSHOT+c2aec92b86
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
           vertx3: v1.51.0-SNAPSHOT
           vertx4: v1.51.0-SNAPSHOT
@@ -743,7 +743,7 @@ tests/:
         TestSamplingByRouteMethodCount:
           '*': v1.51.0-SNAPSHOT
           akka-http: bug (APPSEC-57926)
-          play: bug (APPSEC-57926)
+          play: v1.54.0-SNAPSHOT+c2aec92b86
           ratpack: bug (APPSEC-58210)
           spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       test_security_controls.py:
@@ -1952,26 +1952,26 @@ tests/:
     crossed_integrations/:
       test_kafka.py:
         Test_Kafka:
-          "*": irrelevant
+          '*': irrelevant
           spring-boot: v0.2.0  # real version not known
       test_kinesis.py:
         Test_Kinesis_PROPAGATION_VIA_MESSAGE_ATTRIBUTES:
-          "*": irrelevant
+          '*': irrelevant
           spring-boot: v0.2.0  # real version not known
       test_rabbitmq.py:
         Test_RabbitMQ_Trace_Context_Propagation:
-          "*": irrelevant
+          '*': irrelevant
           spring-boot: v0.2.0  # real version not known
       test_sns_to_sqs.py:
         Test_SNS_Propagation:
-          "*": irrelevant
+          '*': irrelevant
           spring-boot: v1.38.0
       test_sqs.py:
         Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS:
-          "*": irrelevant
+          '*': irrelevant
           spring-boot: v0.2.0  # real version not known
         Test_SQS_PROPAGATION_VIA_MESSAGE_ATTRIBUTES:
-          "*": irrelevant
+          '*': irrelevant
           spring-boot: v0.2.0  # real version not known
     test_cassandra.py:
       Test_Cassandra: bug (APMAPI-729)
@@ -1989,50 +1989,50 @@ tests/:
       Test_Dbm: missing_feature
     test_dsm.py:
       Test_DsmContext_Extraction_Base64:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: v0.2.0  # version unknown
       Test_DsmContext_Injection_Base64:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: v0.2.0  # version unknown
       Test_DsmHttp:
         '*': missing_feature
         spring-boot: v1.12.1
       Test_DsmKafka:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: v1.13.0
       Test_DsmKinesis:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: v1.13.0
       Test_DsmRabbitmq:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: v1.13.0
       Test_DsmRabbitmq_FanoutExchange:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: v1.13.0
       Test_DsmRabbitmq_TopicExchange:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: v1.13.0
       Test_DsmSNS:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: v1.38.0
       Test_DsmSQS:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: v0.2.0  # real version not known
       Test_Dsm_Manual_Checkpoint_Inter_Process:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: bug (AIDM-325)
       Test_Dsm_Manual_Checkpoint_Intra_Process:
-        "*": irrelevant
-        spring-boot: bug (AIDM-325)
+        '*': irrelevant
+        spring-boot: v1.54.0-SNAPSHOT+c2aec92b86
     test_inferred_proxy.py:  # Moved this block here
       Test_AWS_API_Gateway_Inferred_Span_Creation:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: missing_feature (feature not completed yet)
       Test_AWS_API_Gateway_Inferred_Span_Creation_With_Distributed_Context:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: missing_feature (feature not completed yet)
       Test_AWS_API_Gateway_Inferred_Span_Creation_With_Error:
-        "*": irrelevant
+        '*': irrelevant
         spring-boot: missing_feature (feature not completed yet)
     test_mongo.py:
       Test_Mongo: bug (APMAPI-729)
@@ -2070,7 +2070,7 @@ tests/:
       TestDynamicConfigV2: v1.31.0
     test_headers_baggage.py:
       Test_Headers_Baggage: missing_feature
-      Test_Headers_Baggage_Span_Tags: missing_feature
+      Test_Headers_Baggage_Span_Tags: v1.54.0-SNAPSHOT+c2aec92b86
     test_otel_api_interoperability.py: missing_feature
     test_otel_env_vars.py:
       Test_Otel_Env_Vars: v1.35.2
@@ -2165,12 +2165,12 @@ tests/:
     Test_Config_ClientIPHeader_Precedence: missing_feature (does not support x-forwarded header)
     Test_Config_ClientTagQueryString_Configured:
       '*': v1.43.0
-      'vertx3': irrelevant (endpoint not implemented)
-      'vertx4': irrelevant (endpoint not implemented)
+      vertx3: irrelevant (endpoint not implemented)
+      vertx4: irrelevant (endpoint not implemented)
     Test_Config_ClientTagQueryString_Empty:
       '*': v1.43.0
-      'vertx3': irrelevant (endpoint not implemented)
-      'vertx4': irrelevant (endpoint not implemented)
+      vertx3: irrelevant (endpoint not implemented)
+      vertx4: irrelevant (endpoint not implemented)
     Test_Config_HttpClientErrorStatuses_Default:
       '*': irrelevant (500 error)
       spring-boot: v1.41.1
@@ -2191,17 +2191,17 @@ tests/:
       spring-boot: v1.42.0
     Test_Config_LogInjection_128Bit_TraceId_Disabled:
       '*': incomplete_test_app (weblog endpoint not implemented)
-      'spring-boot-3-native': v1.48.0
+      spring-boot-3-native: v1.48.0
     Test_Config_LogInjection_128Bit_TraceId_Enabled:
       '*': incomplete_test_app (weblog endpoint not implemented)
-      'spring-boot-3-native': v1.48.0
+      spring-boot-3-native: v1.48.0
     Test_Config_LogInjection_Default_Structured: missing_feature (dd attributes are not injected into logs))
     Test_Config_LogInjection_Default_Unstructured:
       '*': incomplete_test_app (weblog endpoint not implemented)
-      'spring-boot-3-native': v1.48.0
+      spring-boot-3-native: v1.48.0
     Test_Config_LogInjection_Enabled:
       '*': incomplete_test_app (weblog endpoint not implemented)
-      'spring-boot-3-native': v1.48.0
+      spring-boot-3-native: v1.48.0
     Test_Config_ObfuscationQueryStringRegexp_Configured: v1.39.0
     Test_Config_ObfuscationQueryStringRegexp_Default: v1.39.0
     Test_Config_ObfuscationQueryStringRegexp_Empty: v1.39.0
@@ -2210,12 +2210,12 @@ tests/:
       '*': v0.64.0
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       spring-boot-openliberty: incomplete_test_app (needs investigation to understand why test is failing)
-      spring-boot-wildfly: incomplete_test_app (needs investigation to understand why test is failing)
+      spring-boot-wildfly: v1.54.0-SNAPSHOT+c2aec92b86
     Test_Config_RuntimeMetrics_Enabled_WithRuntimeId:
       '*': v0.64.0
       spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
       spring-boot-openliberty: incomplete_test_app (needs investigation to understand why test is failing)
-      spring-boot-wildfly: incomplete_test_app (needs investigation to understand why test is failing)
+      spring-boot-wildfly: v1.54.0-SNAPSHOT+c2aec92b86
     Test_Config_UnifiedServiceTagging_CustomService: v1.39.0
     Test_Config_UnifiedServiceTagging_Default: v1.39.0
   test_data_integrity.py:
@@ -2240,7 +2240,23 @@ tests/:
     Test_Propagate_Legacy:
       # XXX: spring-boot-3-native would have a higher version
       '*': v0.111.0
-  test_ipv6.py: missing_feature (APMAPI-869)
+  test_ipv6.py:
+    Test_Basic:
+      akka-http: v1.54.0-SNAPSHOT+c2aec92b86
+      jersey-grizzly2: v1.54.0-SNAPSHOT+c2aec92b86
+      play: v1.54.0-SNAPSHOT+c2aec92b86
+      ratpack: v1.54.0-SNAPSHOT+c2aec92b86
+      resteasy-netty3: v1.54.0-SNAPSHOT+c2aec92b86
+      spring-boot: v1.54.0-SNAPSHOT+c2aec92b86
+      spring-boot-3-native: v1.54.0-SNAPSHOT+c2aec92b86
+      spring-boot-jetty: v1.54.0-SNAPSHOT+c2aec92b86
+      spring-boot-openliberty: v1.54.0-SNAPSHOT+c2aec92b86
+      spring-boot-payara: v1.54.0-SNAPSHOT+c2aec92b86
+      spring-boot-undertow: v1.54.0-SNAPSHOT+c2aec92b86
+      spring-boot-wildfly: v1.54.0-SNAPSHOT+c2aec92b86
+      uds-spring-boot: v1.54.0-SNAPSHOT+c2aec92b86
+      vertx3: v1.54.0-SNAPSHOT+c2aec92b86
+      vertx4: v1.54.0-SNAPSHOT+c2aec92b86
   test_library_conf.py:
     Test_ExtractBehavior_Default:
       '*': incomplete_test_app (weblog endpoint not implemented)
@@ -2269,14 +2285,14 @@ tests/:
     Test_HeaderTags_Wildcard_Request_Headers: missing_feature
     Test_HeaderTags_Wildcard_Response_Headers:
       '*': v1.51.0
-      'akka-http': irrelevant (integration injects Date header after bytecode injection occurs)
-      'play': irrelevant (integration injects Date header after bytecode injection occurs)
+      akka-http: irrelevant (integration injects Date header after bytecode injection occurs)
+      play: irrelevant (integration injects Date header after bytecode injection occurs)
   test_profiling.py:
     Test_Profile:
       akka-http: v1.22.0
       spring-boot-3-native: v1.39.0
-      vertx3: missing_feature (Endpoint not implemented)
-      vertx4: missing_feature (Endpoint not implemented)
+      vertx3: v1.54.0-SNAPSHOT+c2aec92b86
+      vertx4: v1.54.0-SNAPSHOT+c2aec92b86
   test_protobuf.py:
     Test_Protobuf:
       '*': missing_feature


### PR DESCRIPTION
## Motivation

Some tests are currently passing but not yet activated. This leaves related features unprotected against regressions.

## Changes

Update manifest file to enable xpass tests.
Note: the updates are generated automatically this may lead to some yaml formatting modifications without any test activation.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
