### PR TITLE
Make scenario and container immutable at init

### DIFF
--- a/tests/fuzzer/main.py
+++ b/tests/fuzzer/main.py
@@ -61,12 +61,12 @@ def main() -> None:
 
     network = create_network()
 
-    agent = AgentContainer(host_log_folder="logs_fuzzer", use_proxy=False)
-    agent.configure(replay=False)
+    agent = AgentContainer(use_proxy=False)
+    agent.configure(host_log_folder="logs_fuzzer", replay=False)
     agent.start(network)
 
-    weblog = WeblogContainer(host_log_folder="logs_fuzzer", use_proxy=False)
-    weblog.configure(replay=False)
+    weblog = WeblogContainer(use_proxy=False)
+    weblog.configure(host_log_folder="logs_fuzzer", replay=False)
     weblog.start(network)
     weblog.post_start()
 

--- a/tests/test_the_test/test_docker_scenario.py
+++ b/tests/test_the_test/test_docker_scenario.py
@@ -1,3 +1,4 @@
+from threading import RLock
 import pytest
 
 from utils._context._scenarios.endtoend import DockerScenario
@@ -9,6 +10,9 @@ class FakeContainer(_TestedContainer):
     def __init__(self, name, events=None) -> None:
         super().__init__(name=name, image_name=name)
         self._test_events = events if events is not None else []
+
+    def configure(self, *, host_log_folder, replay):  # noqa: ARG002
+        self._starting_lock = RLock()
 
     def start(self, network):  # noqa: ARG002
         self._test_events.append(f"start {self.name}")
@@ -40,6 +44,7 @@ def test_main():
             self._required_containers = [container_a, container_b, container_c, container_d]
 
     scenario = FakeScenario()
+    scenario.configure(None)
     scenario.pytest_sessionstart(None)
 
     assert events == ["start D", "start C", "start B", "start A"]

--- a/tests/test_the_test/test_docker_scenario.py
+++ b/tests/test_the_test/test_docker_scenario.py
@@ -7,7 +7,7 @@ from utils import scenarios
 
 class FakeContainer(_TestedContainer):
     def __init__(self, name, events=None) -> None:
-        super().__init__(name=name, image_name=name, host_log_folder="logs_test_the_test")
+        super().__init__(name=name, image_name=name)
         self._test_events = events if events is not None else []
 
     def start(self, network):  # noqa: ARG002

--- a/utils/_context/_scenarios/appsec_rasp.py
+++ b/utils/_context/_scenarios/appsec_rasp.py
@@ -27,7 +27,7 @@ class AppsecRaspScenario(EndToEndScenario):
             github_workflow="endtoend",
             scenario_groups=[scenario_groups.appsec, scenario_groups.appsec_rasp],
         )
-        self._internal_server = InternalServerContainer(self.host_log_folder)
+        self._internal_server = InternalServerContainer()
         self.weblog_container.depends_on.append(self._internal_server)
         self._required_containers.append(self._internal_server)
 

--- a/utils/_context/_scenarios/aws_lambda.py
+++ b/utils/_context/_scenarios/aws_lambda.py
@@ -37,13 +37,11 @@ class LambdaScenario(DockerScenario):
         super().__init__(name, github_workflow=github_workflow, doc=doc, scenario_groups=scenario_groups)
 
         self.lambda_weblog = LambdaWeblogContainer(
-            host_log_folder=self.host_log_folder,
             environment=weblog_env or {},
             volumes=weblog_volumes or {},
         )
 
         self.lambda_proxy_container = LambdaProxyContainer(
-            host_log_folder=self.host_log_folder,
             lambda_weblog_host=self.lambda_weblog.name,
             lambda_weblog_port=str(self.lambda_weblog.container_port),
         )

--- a/utils/_context/_scenarios/core.py
+++ b/utils/_context/_scenarios/core.py
@@ -206,4 +206,4 @@ class Scenario:
         pass
 
     def __str__(self) -> str:
-        return f"Scenario '{self.name}'"
+        return f"{self.__class__.__name__} '{self.name}'"

--- a/utils/_context/_scenarios/docker_ssi.py
+++ b/utils/_context/_scenarios/docker_ssi.py
@@ -41,8 +41,8 @@ class DockerSSIScenario(Scenario):
 
         self.agent_port = _get_free_port()
         self.agent_host = "localhost"
-        self._weblog_injection = DockerSSIContainer(host_log_folder=self.host_log_folder, extra_env_vars=extra_env_vars)
-        self._agent_container = APMTestAgentContainer(host_log_folder=self.host_log_folder, agent_port=self.agent_port)
+        self._weblog_injection = DockerSSIContainer(extra_env_vars=extra_env_vars)
+        self._agent_container = APMTestAgentContainer(agent_port=self.agent_port)
 
         self._required_containers: list[TestedContainer] = []
         self._required_containers.append(self._agent_container)
@@ -123,7 +123,7 @@ class DockerSSIScenario(Scenario):
 
         for container in self._required_containers:
             try:
-                container.configure(replay=self.replay)
+                container.configure(host_log_folder=self.host_log_folder, replay=self.replay)
             except Exception as e:
                 logger.error("Failed to configure container ", e)
                 logger.stdout("ERROR configuring container. check log file for more details")

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -90,7 +90,6 @@ class DockerScenario(Scenario):
 
         if self.use_proxy:
             self.proxy_container = ProxyContainer(
-                host_log_folder=self.host_log_folder,
                 rc_api_enabled=rc_api_enabled,
                 meta_structs_disabled=meta_structs_disabled,
                 span_events=span_events,
@@ -101,31 +100,31 @@ class DockerScenario(Scenario):
             self._required_containers.append(self.proxy_container)
 
         if include_postgres_db:
-            self._supporting_containers.append(PostgresContainer(host_log_folder=self.host_log_folder))
+            self._supporting_containers.append(PostgresContainer())
 
         if include_mongo_db:
-            self._supporting_containers.append(MongoContainer(host_log_folder=self.host_log_folder))
+            self._supporting_containers.append(MongoContainer())
 
         if include_cassandra_db:
-            self._supporting_containers.append(CassandraContainer(host_log_folder=self.host_log_folder))
+            self._supporting_containers.append(CassandraContainer())
 
         if include_kafka:
-            self._supporting_containers.append(KafkaContainer(host_log_folder=self.host_log_folder))
+            self._supporting_containers.append(KafkaContainer())
 
         if include_rabbitmq:
-            self._supporting_containers.append(RabbitMqContainer(host_log_folder=self.host_log_folder))
+            self._supporting_containers.append(RabbitMqContainer())
 
         if include_mysql_db:
-            self._supporting_containers.append(MySqlContainer(host_log_folder=self.host_log_folder))
+            self._supporting_containers.append(MySqlContainer())
 
         if include_sqlserver:
-            self._supporting_containers.append(MsSqlServerContainer(host_log_folder=self.host_log_folder))
+            self._supporting_containers.append(MsSqlServerContainer())
 
         if include_localstack:
-            self._supporting_containers.append(LocalstackContainer(host_log_folder=self.host_log_folder))
+            self._supporting_containers.append(LocalstackContainer())
 
         if include_elasticmq:
-            self._supporting_containers.append(ElasticMQContainer(host_log_folder=self.host_log_folder))
+            self._supporting_containers.append(ElasticMQContainer())
 
         self._required_containers.extend(self._supporting_containers)
 
@@ -142,7 +141,7 @@ class DockerScenario(Scenario):
             self.components["docker.Cgroup"] = docker_info.get("CgroupVersion", None)
 
         for container in reversed(self._required_containers):
-            container.configure(replay=self.replay)
+            container.configure(host_log_folder=self.host_log_folder, replay=self.replay)
 
     def get_container_by_dd_integration_name(self, name: str):
         for container in self._required_containers:
@@ -307,9 +306,7 @@ class EndToEndScenario(DockerScenario):
 
         self._require_api_key = require_api_key
 
-        self.agent_container = AgentContainer(
-            host_log_folder=self.host_log_folder, use_proxy=use_proxy_for_agent, environment=agent_env
-        )
+        self.agent_container = AgentContainer(use_proxy=use_proxy_for_agent, environment=agent_env)
 
         if use_proxy_for_agent:
             self.agent_container.depends_on.append(self.proxy_container)
@@ -329,7 +326,6 @@ class EndToEndScenario(DockerScenario):
         )
 
         self.weblog_container = WeblogContainer(
-            self.host_log_folder,
             environment=weblog_env,
             tracer_sampling_rate=tracer_sampling_rate,
             appsec_enabled=appsec_enabled,
@@ -373,7 +369,6 @@ class EndToEndScenario(DockerScenario):
                 BuddyContainer(
                     f"{language}_buddy",
                     image_name,
-                    self.host_log_folder,
                     host_port=host_port,
                     trace_agent_port=trace_agent_port,
                     environment=weblog_env,

--- a/utils/_context/_scenarios/external_processing.py
+++ b/utils/_context/_scenarios/external_processing.py
@@ -29,14 +29,13 @@ class ExternalProcessingScenario(DockerScenario):
             rc_api_enabled=rc_api_enabled,
         )
 
-        self._agent_container = AgentContainer(self.host_log_folder)
+        self._agent_container = AgentContainer()
         self._external_processing_container = ExternalProcessingContainer(
-            self.host_log_folder,
             env=extproc_env,
             volumes=extproc_volumes,
         )
-        self._envoy_container = EnvoyContainer(self.host_log_folder)
-        self._http_app_container = DummyServerContainer(self.host_log_folder)
+        self._envoy_container = EnvoyContainer()
+        self._http_app_container = DummyServerContainer()
 
         self._agent_container.depends_on.append(self.proxy_container)
         self._external_processing_container.depends_on.append(self.proxy_container)

--- a/utils/_context/_scenarios/k8s_lib_injection.py
+++ b/utils/_context/_scenarios/k8s_lib_injection.py
@@ -324,14 +324,12 @@ class WeblogInjectionScenario(Scenario):
     def __init__(self, name, doc, github_workflow=None, scenario_groups=None) -> None:
         super().__init__(name, doc=doc, github_workflow=github_workflow, scenario_groups=scenario_groups)
 
-        self._mount_injection_volume = MountInjectionVolume(
-            host_log_folder=self.host_log_folder, name="volume-injector"
-        )
-        self._weblog_injection = WeblogInjectionInitContainer(host_log_folder=self.host_log_folder)
+        self._mount_injection_volume = MountInjectionVolume(name="volume-injector")
+        self._weblog_injection = WeblogInjectionInitContainer()
 
         self._required_containers: list[TestedContainer] = []
         self._required_containers.append(self._mount_injection_volume)
-        self._required_containers.append(APMTestAgentContainer(host_log_folder=self.host_log_folder))
+        self._required_containers.append(APMTestAgentContainer())
         self._required_containers.append(self._weblog_injection)
 
     def configure(self, config: pytest.Config):  # noqa: ARG002
@@ -345,7 +343,7 @@ class WeblogInjectionScenario(Scenario):
         self._weblog_injection.set_environment_for_library(self.library)
 
         for container in self._required_containers:
-            container.configure(replay=self.replay)
+            container.configure(host_log_folder=self.host_log_folder, replay=self.replay)
 
     def _create_network(self):
         self._network = create_network()

--- a/utils/_context/_scenarios/open_telemetry.py
+++ b/utils/_context/_scenarios/open_telemetry.py
@@ -60,12 +60,12 @@ class OpenTelemetryScenario(DockerScenario):
             include_sqlserver=include_sqlserver,
         )
         if include_agent:
-            self.agent_container = AgentContainer(host_log_folder=self.host_log_folder, use_proxy=True)
+            self.agent_container = AgentContainer(use_proxy=True)
             self._required_containers.append(self.agent_container)
         if include_collector:
-            self.collector_container = OpenTelemetryCollectorContainer(self.host_log_folder)
+            self.collector_container = OpenTelemetryCollectorContainer()
             self._required_containers.append(self.collector_container)
-        self.weblog_container = WeblogContainer(self.host_log_folder, environment=weblog_env)
+        self.weblog_container = WeblogContainer(environment=weblog_env)
         if include_agent:
             self.weblog_container.depends_on.append(self.agent_container)
         if include_collector:

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -77,6 +77,8 @@ def create_inject_volume():
 
 class TestedContainer:
     _container: Container = None
+    _starting_lock: RLock
+    host_log_folder: str
 
     # https://docker-py.readthedocs.io/en/stable/containers.html
     def __init__(
@@ -89,7 +91,6 @@ class TestedContainer:
         command: str | list[str] | None = None,
         environment: dict[str, str | None] | None = None,
         healthcheck: dict | None = None,
-        host_log_folder: str,
         local_image_only: bool = False,
         ports: dict | None = None,
         security_opt: list[str] | None = None,
@@ -101,7 +102,6 @@ class TestedContainer:
     ) -> None:
         self.name = name
         self.host_project_dir = os.environ.get("SYSTEM_TESTS_HOST_PROJECT_DIR", str(Path.cwd()))
-        self.host_log_folder = host_log_folder
         self.allow_old_container = allow_old_container
 
         self.image = ImageInfo(image_name, local_image_only=local_image_only)
@@ -117,7 +117,6 @@ class TestedContainer:
         self.volumes = volumes or {}
         self.ports = ports or {}
         self.depends_on: list[TestedContainer] = []
-        self._starting_lock = RLock()
         self._starting_thread: Thread | None = None
         self.stdout_interface = stdout_interface
         self.working_dir = working_dir
@@ -146,9 +145,11 @@ class TestedContainer:
         """Returns the image list that will be loaded to be able to run/build the container"""
         return [self.image.name]
 
-    def configure(self, *, replay: bool):
+    def configure(self, *, host_log_folder: str, replay: bool):
+        self.host_log_folder = host_log_folder
         if not replay:
             self.stop_previous_container()
+            self._starting_lock = RLock()
 
             Path(self.log_folder_path).mkdir(exist_ok=True, parents=True)
             Path(f"{self.log_folder_path}/logs").mkdir(exist_ok=True, parents=True)
@@ -472,7 +473,6 @@ class SqlDbTestedContainer(TestedContainer):
         name: str,
         *,
         image_name: str,
-        host_log_folder: str,
         db_user: str,
         environment: dict[str, str | None] | None = None,
         allow_old_container: bool = False,
@@ -491,7 +491,6 @@ class SqlDbTestedContainer(TestedContainer):
         super().__init__(
             image_name=image_name,
             name=name,
-            host_log_folder=host_log_folder,
             environment=environment,
             stdout_interface=stdout_interface,
             healthcheck=healthcheck,
@@ -565,7 +564,6 @@ class ProxyContainer(TestedContainer):
     def __init__(
         self,
         *,
-        host_log_folder: str,
         rc_api_enabled: bool,
         meta_structs_disabled: bool,
         span_events: bool,
@@ -584,12 +582,10 @@ class ProxyContainer(TestedContainer):
         super().__init__(
             image_name="datadog/system-tests:proxy-v1",
             name="proxy",
-            host_log_folder=host_log_folder,
             environment={
                 "DD_SITE": os.environ.get("DD_SITE"),
                 "DD_API_KEY": os.environ.get("DD_API_KEY", _FAKE_DD_API_KEY),
                 "DD_APP_KEY": os.environ.get("DD_APP_KEY"),
-                "SYSTEM_TESTS_HOST_LOG_FOLDER": host_log_folder,
                 "SYSTEM_TESTS_RC_API_ENABLED": str(rc_api_enabled),
                 "SYSTEM_TESTS_AGENT_SPAN_META_STRUCTS_DISABLED": str(meta_structs_disabled),
                 "SYSTEM_TESTS_AGENT_SPAN_EVENTS": str(span_events),
@@ -598,7 +594,6 @@ class ProxyContainer(TestedContainer):
             },
             working_dir="/app",
             volumes={
-                f"./{host_log_folder}/interfaces/": {"bind": f"/app/{host_log_folder}/interfaces", "mode": "rw"},
                 "./utils/": {"bind": "/app/utils/", "mode": "ro"},
             },
             ports={f"{ProxyPorts.proxy_commands}/tcp": ("127.0.0.1", self.command_host_port)},
@@ -609,12 +604,15 @@ class ProxyContainer(TestedContainer):
             },
         )
 
+    def configure(self, *, host_log_folder: str, replay: bool):
+        self.volumes[f"./{self.host_log_folder}/interfaces/"] = {"bind": "/app/logs/interfaces", "mode": "rw"}
+        super().configure(host_log_folder=host_log_folder, replay=replay)
+
 
 class LambdaProxyContainer(TestedContainer):
     def __init__(
         self,
         *,
-        host_log_folder: str,
         lambda_weblog_host: str,
         lambda_weblog_port: str,
     ) -> None:
@@ -626,7 +624,6 @@ class LambdaProxyContainer(TestedContainer):
         super().__init__(
             image_name="datadog/system-tests:lambda-proxy-v1",
             name="lambda-proxy",
-            host_log_folder=host_log_folder,
             environment={
                 "RIE_HOST": lambda_weblog_host,
                 "RIE_PORT": lambda_weblog_port,
@@ -651,9 +648,7 @@ class AgentContainer(TestedContainer):
     apm_receiver_port: int = 8127
     dogstatsd_port: int = 8125
 
-    def __init__(
-        self, host_log_folder: str, *, use_proxy: bool = True, environment: dict[str, str | None] | None = None
-    ) -> None:
+    def __init__(self, *, use_proxy: bool = True, environment: dict[str, str | None] | None = None) -> None:
         environment = environment or {}
         environment.update(
             {
@@ -673,7 +668,6 @@ class AgentContainer(TestedContainer):
         super().__init__(
             image_name=self._get_image_name(),
             name="agent",
-            host_log_folder=host_log_folder,
             environment=environment,
             healthcheck={
                 "test": f"curl --fail --silent --show-error --max-time 2 http://localhost:{self.apm_receiver_port}/info",
@@ -718,7 +712,6 @@ class BuddyContainer(TestedContainer):
         self,
         name: str,
         image_name: str,
-        host_log_folder: str,
         host_port: int,
         trace_agent_port: int,
         environment: dict[str, str | None],
@@ -726,7 +719,6 @@ class BuddyContainer(TestedContainer):
         super().__init__(
             name=name,
             image_name=image_name,
-            host_log_folder=host_log_folder,
             healthcheck={"test": "curl --fail --silent --show-error --max-time 2 localhost:7777", "retries": 60},
             ports={"7777/tcp": host_port},
             environment={
@@ -797,7 +789,6 @@ class WeblogContainer(TestedContainer):
 
     def __init__(
         self,
-        host_log_folder: str,
         *,
         environment: dict[str, str | None] | None = None,
         tracer_sampling_rate: float | None = None,
@@ -817,7 +808,6 @@ class WeblogContainer(TestedContainer):
         self.container_grpc_port = 7778
 
         volumes = {} if volumes is None else volumes
-        volumes[f"./{host_log_folder}/docker/weblog/logs/"] = {"bind": "/var/log/system-tests", "mode": "rw"}
 
         base_environment: dict[str, str | None] = {
             # Datadog setup
@@ -874,7 +864,6 @@ class WeblogContainer(TestedContainer):
         super().__init__(
             image_name="system_tests/weblog",
             name="weblog",
-            host_log_folder=host_log_folder,
             environment=environment,
             volumes=volumes,
             # ddprof's perf event open is blocked by default by docker's seccomp profile
@@ -948,8 +937,10 @@ class WeblogContainer(TestedContainer):
 
         return result
 
-    def configure(self, *, replay: bool):
-        super().configure(replay=replay)
+    def configure(self, *, host_log_folder: str, replay: bool):
+        super().configure(host_log_folder=host_log_folder, replay=replay)
+
+        self.volumes[f"./{self.host_log_folder}/docker/weblog/logs/"] = {"bind": "/var/log/system-tests", "mode": "rw"}
 
         self.weblog_variant = self.image.labels["system-tests-weblog-variant"]
 
@@ -1060,7 +1051,6 @@ class WeblogContainer(TestedContainer):
 class LambdaWeblogContainer(WeblogContainer):
     def __init__(
         self,
-        host_log_folder: str,
         *,
         environment: dict[str, str | None] | None = None,
         volumes: dict | None = None,
@@ -1091,7 +1081,6 @@ class LambdaWeblogContainer(WeblogContainer):
         )
 
         super().__init__(
-            host_log_folder,
             environment=environment,
             volumes=volumes,
         )
@@ -1110,11 +1099,10 @@ class LambdaWeblogContainer(WeblogContainer):
 
 
 class PostgresContainer(SqlDbTestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         super().__init__(
             image_name="postgres:alpine",
             name="postgres",
-            host_log_folder=host_log_folder,
             healthcheck={"test": "pg_isready -q -U postgres -d system_tests_dbname", "retries": 30},
             user="postgres",
             environment={"POSTGRES_PASSWORD": "password", "PGPORT": "5433"},
@@ -1134,19 +1122,16 @@ class PostgresContainer(SqlDbTestedContainer):
 
 
 class MongoContainer(TestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
-        super().__init__(
-            image_name="mongo:latest", name="mongodb", host_log_folder=host_log_folder, allow_old_container=True
-        )
+    def __init__(self) -> None:
+        super().__init__(image_name="mongo:latest", name="mongodb", allow_old_container=True)
 
 
 class KafkaContainer(TestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         super().__init__(
             # TODO: Look into apache/kafka-native but it doesn't include scripts.
             image_name="apache/kafka:3.7.1",
             name="kafka",
-            host_log_folder=host_log_folder,
             environment={
                 "KAFKA_PROCESS_ROLES": "broker,controller",
                 "KAFKA_NODE_ID": "1",
@@ -1191,32 +1176,29 @@ class KafkaContainer(TestedContainer):
 
 
 class CassandraContainer(TestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         super().__init__(
             image_name="cassandra:latest",
             name="cassandra_db",
-            host_log_folder=host_log_folder,
             allow_old_container=True,
         )
 
 
 class RabbitMqContainer(TestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         super().__init__(
             image_name="rabbitmq:3.12-management-alpine",
             name="rabbitmq",
-            host_log_folder=host_log_folder,
             allow_old_container=True,
             ports={"5672": ("127.0.0.1", 5672)},
         )
 
 
 class ElasticMQContainer(TestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         super().__init__(
             image_name="softwaremill/elasticmq-native:1.6.11",
             name="elasticmq",
-            host_log_folder=host_log_folder,
             environment={"ELASTICMQ_OPTS": "-Dnode-address.hostname=0.0.0.0"},
             ports={9324: 9324},
             volumes={"/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"}},
@@ -1225,7 +1207,7 @@ class ElasticMQContainer(TestedContainer):
 
 
 class LocalstackContainer(TestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         super().__init__(
             image_name="localstack/localstack:4.1",
             name="localstack-main",
@@ -1240,14 +1222,13 @@ class LocalstackContainer(TestedContainer):
                 "SQS_PROVIDER": "elasticmq",
                 "DOCKER_HOST": "unix:///var/run/docker.sock",
             },
-            host_log_folder=host_log_folder,
             ports={"4566": ("127.0.0.1", 4566)},
             volumes={"/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"}},
         )
 
 
 class MySqlContainer(SqlDbTestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         super().__init__(
             image_name="mysql/mysql-server:8.0.32",
             name="mysqldb",
@@ -1260,7 +1241,6 @@ class MySqlContainer(SqlDbTestedContainer):
                 "MYSQL_PASSWORD": "mysqldb",
             },
             allow_old_container=True,
-            host_log_folder=host_log_folder,
             healthcheck={"test": "/healthcheck.sh", "retries": 60},
             dd_integration_service="mysql",
             db_user="mysqldb",
@@ -1271,9 +1251,7 @@ class MySqlContainer(SqlDbTestedContainer):
 
 
 class MsSqlServerContainer(SqlDbTestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
-        self.data_mssql = f"./{host_log_folder}/data-mssql"
-
+    def __init__(self) -> None:
         healthcheck = {
             # Using 127.0.0.1 here instead of localhost to avoid using IPv6 in some systems.
             # -C : trust self signed certificates
@@ -1288,9 +1266,8 @@ class MsSqlServerContainer(SqlDbTestedContainer):
             user="root",
             environment={"ACCEPT_EULA": "1", "MSSQL_SA_PASSWORD": "yourStrong(!)Password"},
             allow_old_container=True,
-            host_log_folder=host_log_folder,
             ports={"1433/tcp": ("127.0.0.1", 1433)},
-            #  volumes={self.data_mssql: {"bind": "/var/opt/mssql/data", "mode": "rw"}},
+            #  volumes={f"./{host_log_folder}/data-mssql": {"bind": "/var/opt/mssql/data", "mode": "rw"}},
             healthcheck=healthcheck,
             dd_integration_service="mssql",
             db_user="SA",
@@ -1301,7 +1278,7 @@ class MsSqlServerContainer(SqlDbTestedContainer):
 
 
 class OpenTelemetryCollectorContainer(TestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         image = os.environ.get("SYSTEM_TESTS_OTEL_COLLECTOR_IMAGE", "otel/opentelemetry-collector-contrib:0.110.0")
         self._otel_config_host_path = "./utils/build/docker/otelcol-config.yaml"
 
@@ -1320,7 +1297,6 @@ class OpenTelemetryCollectorContainer(TestedContainer):
             command="--config=/etc/otelcol-config.yml",
             environment={},
             volumes={self._otel_config_host_path: {"bind": "/etc/otelcol-config.yml", "mode": "ro"}},
-            host_log_folder=host_log_folder,
             ports={"13133/tcp": ("0.0.0.0", 13133)},  # noqa: S104
         )
 
@@ -1353,11 +1329,10 @@ class OpenTelemetryCollectorContainer(TestedContainer):
 
 
 class APMTestAgentContainer(TestedContainer):
-    def __init__(self, host_log_folder: str, agent_port: int = 8126) -> None:
+    def __init__(self, agent_port: int = 8126) -> None:
         super().__init__(
             image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.20.0",
             name="ddapm-test-agent",
-            host_log_folder=host_log_folder,
             environment={
                 "SNAPSHOT_CI": "0",
                 "DD_APM_RECEIVER_SOCKET": "/var/run/datadog/apm.socket",
@@ -1369,16 +1344,18 @@ class APMTestAgentContainer(TestedContainer):
             },
             ports={agent_port: ("127.0.0.1", agent_port)},
             allow_old_container=False,
-            volumes={f"./{host_log_folder}/interfaces/test_agent_socket": {"bind": "/var/run/datadog/", "mode": "rw"}},
         )
+
+    def configure(self, *, host_log_folder: str, replay: bool) -> None:
+        self.volumes[f"./{host_log_folder}/interfaces/test_agent_socket"] = {"bind": "/var/run/datadog/", "mode": "rw"}
+        return super().configure(host_log_folder=host_log_folder, replay=replay)
 
 
 class MountInjectionVolume(TestedContainer):
-    def __init__(self, host_log_folder: str, name: str) -> None:
+    def __init__(self, name: str) -> None:
         super().__init__(
             image_name="",
             name=name,
-            host_log_folder=host_log_folder,
             command="/bin/true",
             volumes={_VOLUME_INJECTOR_NAME: {"bind": "/datadog-init/package", "mode": "rw"}},
         )
@@ -1397,11 +1374,10 @@ class MountInjectionVolume(TestedContainer):
 
 
 class WeblogInjectionInitContainer(TestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         super().__init__(
             image_name="docker.io/library/weblog-injection:latest",
             name="weblog-injection-init",
-            host_log_folder=host_log_folder,
             ports={"18080": ("127.0.0.1", 8080)},
             allow_old_container=True,
             volumes={_VOLUME_INJECTOR_NAME: {"bind": "/datadog-lib", "mode": "rw"}},
@@ -1417,7 +1393,7 @@ class WeblogInjectionInitContainer(TestedContainer):
 
 
 class DockerSSIContainer(TestedContainer):
-    def __init__(self, host_log_folder: str, extra_env_vars: dict | None = None) -> None:
+    def __init__(self, extra_env_vars: dict | None = None) -> None:
         environment = {
             "DD_DEBUG": "true",
             "DD_TRACE_DEBUG": "true",
@@ -1430,13 +1406,15 @@ class DockerSSIContainer(TestedContainer):
         super().__init__(
             image_name="docker.io/library/weblog-injection:latest",
             name="weblog-injection",
-            host_log_folder=host_log_folder,
             ports={"18080": ("127.0.0.1", 18080), "8080": ("127.0.0.1", 8080), "9080": ("127.0.0.1", 9080)},
             healthcheck={"test": "sh /healthcheck.sh", "retries": 60},
             allow_old_container=False,
             environment=cast(dict[str, str | None], environment),
-            volumes={f"./{host_log_folder}/interfaces/test_agent_socket": {"bind": "/var/run/datadog/", "mode": "rw"}},
         )
+
+    def configure(self, *, host_log_folder: str, replay: bool) -> None:
+        self.volumes[f"./{host_log_folder}/interfaces/test_agent_socket"] = {"bind": "/var/run/datadog/", "mode": "rw"}
+        super().configure(host_log_folder=host_log_folder, replay=replay)
 
     def get_env(self, env_var: str):
         """Get env variables from the container"""
@@ -1445,21 +1423,19 @@ class DockerSSIContainer(TestedContainer):
 
 
 class DummyServerContainer(TestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         super().__init__(
             image_name="jasonrm/dummy-server:latest",
             name="http-app",
-            host_log_folder=host_log_folder,
             healthcheck={"test": "wget http://localhost:8080", "retries": 10},
         )
 
 
 class InternalServerContainer(TestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         super().__init__(
             image_name="demisto/fastapi:0.116.1.4266494",
             name="internal_server",
-            host_log_folder=host_log_folder,
             healthcheck={"test": "wget http://internal_server:8089", "retries": 10},
             working_dir="/app",
             command="uvicorn app:app --host 0.0.0.0 --port 8089",
@@ -1471,13 +1447,12 @@ class InternalServerContainer(TestedContainer):
 
 
 class EnvoyContainer(TestedContainer):
-    def __init__(self, host_log_folder: str) -> None:
+    def __init__(self) -> None:
         from utils import weblog
 
         super().__init__(
             image_name="envoyproxy/envoy:v1.31-latest",
             name="envoy",
-            host_log_folder=host_log_folder,
             volumes={"./tests/external_processing/envoy.yaml": {"bind": "/etc/envoy/envoy.yaml", "mode": "ro"}},
             ports={"80": ("127.0.0.1", weblog.port)},
             healthcheck={
@@ -1495,7 +1470,6 @@ class ExternalProcessingContainer(TestedContainer):
 
     def __init__(
         self,
-        host_log_folder: str,
         env: dict[str, str | None] | None,
         volumes: dict[str, dict[str, str]] | None,
     ) -> None:
@@ -1522,7 +1496,6 @@ class ExternalProcessingContainer(TestedContainer):
         super().__init__(
             image_name=image,
             name="extproc",
-            host_log_folder=host_log_folder,
             volumes=volumes,
             environment=environment,
             healthcheck={

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -605,8 +605,8 @@ class ProxyContainer(TestedContainer):
         )
 
     def configure(self, *, host_log_folder: str, replay: bool):
-        self.volumes[f"./{self.host_log_folder}/interfaces/"] = {"bind": "/app/logs/interfaces", "mode": "rw"}
         super().configure(host_log_folder=host_log_folder, replay=replay)
+        self.volumes[f"./{host_log_folder}/interfaces/"] = {"bind": "/app/logs/interfaces", "mode": "rw"}
 
 
 class LambdaProxyContainer(TestedContainer):
@@ -1347,8 +1347,11 @@ class APMTestAgentContainer(TestedContainer):
         )
 
     def configure(self, *, host_log_folder: str, replay: bool) -> None:
-        self.volumes[f"./{host_log_folder}/interfaces/test_agent_socket"] = {"bind": "/var/run/datadog/", "mode": "rw"}
-        return super().configure(host_log_folder=host_log_folder, replay=replay)
+        super().configure(host_log_folder=host_log_folder, replay=replay)
+        self.volumes[f"./{self.host_log_folder}/interfaces/test_agent_socket"] = {
+            "bind": "/var/run/datadog/",
+            "mode": "rw",
+        }
 
 
 class MountInjectionVolume(TestedContainer):
@@ -1413,8 +1416,11 @@ class DockerSSIContainer(TestedContainer):
         )
 
     def configure(self, *, host_log_folder: str, replay: bool) -> None:
-        self.volumes[f"./{host_log_folder}/interfaces/test_agent_socket"] = {"bind": "/var/run/datadog/", "mode": "rw"}
         super().configure(host_log_folder=host_log_folder, replay=replay)
+        self.volumes[f"./{self.host_log_folder}/interfaces/test_agent_socket"] = {
+            "bind": "/var/run/datadog/",
+            "mode": "rw",
+        }
 
     def get_env(self, env_var: str):
         """Get env variables from the container"""

--- a/utils/proxy/core.py
+++ b/utils/proxy/core.py
@@ -43,7 +43,7 @@ class _RequestLogger:
         logger.addHandler(handler)
         logger.setLevel(logging.DEBUG)
 
-        self.host_log_folder = os.environ.get("SYSTEM_TESTS_HOST_LOG_FOLDER", "logs")
+        self.host_log_folder = "logs"
 
         self.rc_api_enabled = os.environ.get("SYSTEM_TESTS_RC_API_ENABLED") == "True"
         self.mocked_backend = os.environ.get("SYSTEM_TEST_MOCKED_BACKEND") == "True"


### PR DESCRIPTION
## Motivation

Supporting @jandro996 initiative to merge scenario that can be mergable, it turns out that many differences in scenario/container object was not specific to those classes, but derivated from context execution. One noticeable exemple is `host_log_folder`, which depends on scenario name, and does not change anything in `TestedContainer` logic.

It makes the script that detect difference complex, because it must ignores those properties.

## Changes

`Scenario` and `TestedContainer`'s `__init__` methods only takes immutable arguments. The `configure` method will handle any properties that may change during the execution. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
