### PR TITLE
Use missing_feature and incomplete_test_app for Test Optimization

### DIFF
--- a/tests/test_the_test/reportJunit_expected.xml
+++ b/tests/test_the_test/reportJunit_expected.xml
@@ -1,6 +1,5 @@
 <testsuites>
-    <testsuite name="system_tests_suite" errors="1" failures="1" skipped="6" tests="10" time="0.747"
-        timestamp="2025-09-12T08:58:47.879135" hostname="COMP-C02FL1L0ML87">
+    <testsuite name="system_tests_suite" errors="1" failures="1" skipped="6" tests="10" time="0.747" timestamp="2025-09-12T08:58:47.879135" hostname="COMP-C02FL1L0ML87">
         <properties>
             <property name="dd_tags[systest.suite.context.scenario]" value="MOCK_THE_TEST" />
         </properties>
@@ -23,10 +22,10 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
         </testcase>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_skipped" time="0.000">
             <properties>
+                <property name="dd_tags[systest.case.outcome]" value="skipped"/>
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]"/>
                 <property name="dd_tags[systest.case.declaration]" value="irrelevant"/>
                 <property name="dd_tags[systest.case.declarationDetails]" value="irrelevant"/>
-                <property name="dd_tags[systest.case.outcome]" value="skipped"/>
             </properties>
             <skipped type="pytest.skip" message="irrelevant">/Users/charles.debeauchesne/repos/system-tests/tests/test_the_test/test_junit.py:22: irrelevant</skipped>
         </testcase>
@@ -49,37 +48,35 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
         </testcase>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_flaky" time="0.000">
             <properties>
+                <property name="dd_tags[systest.case.outcome]" value="skipped"/>
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]"/>
                 <property name="dd_tags[systest.case.declaration]" value="flaky"/>
                 <property name="dd_tags[systest.case.declarationDetails]" value="flaky (APMRP-360)"/>
-                <property name="dd_tags[systest.case.outcome]" value="skipped"/>
             </properties>
             <skipped type="pytest.skip" message="flaky (APMRP-360)">/Users/charles.debeauchesne/repos/system-tests/tests/test_the_test/test_junit.py:34: flaky (APMRP-360)</skipped>
         </testcase>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error_on_bug" time="0.000">
             <properties>
+                <property name="dd_tags[systest.case.outcome]" value="xfailed" />
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]" />
                 <property name="dd_tags[systest.case.declaration]" value="bug" />
                 <property name="dd_tags[systest.case.declarationDetails]" value="bug (APMRP-360)" />
-                <property name="dd_tags[systest.case.outcome]" value="xfailed" />
             </properties>
             <skipped type="pytest.xfail" message="bug (APMRP-360)" />
         </testcase>
-        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error_on_missing_feature"
-            time="0.000">
+        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error_on_missing_feature" time="0.000">
             <properties>
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]" />
-                <property name="dd_tags[systest.case.declaration]" value="notImplemented" />
-                <property name="dd_tags[systest.case.declarationDetails]"
-                    value="missing_feature (APMRP-360)" />
                 <property name="dd_tags[systest.case.outcome]" value="xfailed" />
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]" />
+                <property name="dd_tags[systest.case.declaration]" value="missing_feature" />
+                <property name="dd_tags[systest.case.declarationDetails]" value="missing_feature (APMRP-360)" />
             </properties>
             <skipped type="pytest.xfail" message="missing_feature (APMRP-360)" />
         </testcase>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error" time="0.000">
             <properties>
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]" />
                 <property name="dd_tags[systest.case.outcome]" value="error" />
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]" />
             </properties>
             <error message="failed on setup with &quot;TypeError: nope!&quot;">@pytest.fixture
     def error_fixture():
@@ -90,10 +87,10 @@ tests/test_the_test/test_junit.py:15: TypeError</error>
         </testcase>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_force_skip">
             <properties>
+                <property name="dd_tags[systest.case.outcome]" value="skipped"/>
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]"/>
                 <property name="dd_tags[systest.case.declaration]" value="bug"/>
                 <property name="dd_tags[systest.case.declarationDetails]" value="bug (APMRP-360)"/>
-                <property name="dd_tags[systest.case.outcome]" value="skipped"/>
             </properties>
             <skipped message="bug (APMRP-360)" type="pytest.skip">system-tests/tests/test_the_test/test_junit.py:01: bug (APMRP-360)</skipped>
         </testcase>


### PR DESCRIPTION
## Motivation

Reduce cognitive load for user in Test Optimization : query tag must be the same value as the one they use in system-tests

## Changes

Use `missing_feature` as declaration instead of `notImplemented`
Use `incomplete_test_app` as declaration instead of `incompleteTestApp`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
