### PR TITLE
Disable process tags for integration tests

### DIFF
--- a/utils/_context/_scenarios/integrations.py
+++ b/utils/_context/_scenarios/integrations.py
@@ -32,6 +32,7 @@ class IntegrationsScenario(EndToEndScenario):
             weblog_env={
                 "DD_DBM_PROPAGATION_MODE": "full",
                 "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA": "v1",
+                "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": "false",
                 "AWS_ACCESS_KEY_ID": "my-access-key",
                 "AWS_SECRET_ACCESS_KEY": "my-access-key",
                 "DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED": "true",


### PR DESCRIPTION
## Motivation

Process tags collection is going to be enabled by default in java. The issue with DSM tests is that the process tags are influencing the base_hash and they are volatile (they can depend to the command line, path of application , etc).
This makes difficult asserting on predefined hardcoded checkpoint values. 
Looking at `test_dsm.py` it appears that there are a lot of conditionals depending also to the weblog language.

For java, one thing that can be done, is to try accessing the `ProcessTags` class by reflection and set the tags to an hardcoded value when the application stats so that they can be tested consistently. However this solution is fragile if that class will be moved in dd-trace-java.

I think that, right now, disabling for that scenario, is the quickest trade-off. 

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
