### PR TITLE
test tracer flare when tracing disabled

### DIFF
--- a/tests/parametric/test_tracer_flare.py
+++ b/tests/parametric/test_tracer_flare.py
@@ -27,6 +27,19 @@ DEFAULT_ENVVARS = {
     "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.2",
 }
 
+PROFILING_NOTRACING_ENVVARS = {
+    "DD_SERVICE": TEST_SERVICE,
+    "DD_ENV": TEST_ENV,
+    # Needed for .NET until Telemetry V2 is released
+    "DD_INTERNAL_TELEMETRY_V2_ENABLED": "1",
+    # Decrease the heartbeat/poll intervals to speed up the tests
+    "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.2",
+    "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.2",
+    "DD_PROFILING_ENABLED": "true",
+    "DD_TRACE_ENABLED": "false",
+    "DD_APM_TRACING_ENABLED": "false",
+}
+
 
 def _tracer_flare_task_config() -> dict[str, Any]:
     return {
@@ -63,6 +76,22 @@ def _java_tracer_flare_filenames() -> set:
         "span_metrics.txt",
         "threads.txt",
         "tracer_health.txt",
+        "tracer_version.txt",
+        "tracer.log",
+    }
+
+
+def _java_tracer_profiling_notracing_flare_filenames() -> set:
+    return {
+        "classpath.txt",
+        "flare_info.txt",
+        "initial_config.txt",
+        "instrumenter_metrics.txt",
+        "instrumenter_state.txt",
+        "library_path.txt",
+        "profiler_config.txt",
+        "jvm_args.txt",
+        "threads.txt",
         "tracer_version.txt",
         "tracer.log",
     }
@@ -185,6 +214,18 @@ class TestTracerFlareV1:
         tracer_flare = trigger_tracer_flare_and_wait(test_agent, {})
         if context.library == "java":
             files = _java_tracer_flare_filenames()
+            assert_java_log_file(tracer_flare["flare_file"])
+            assert_expected_files(tracer_flare["flare_file"], files)
+
+    @missing_feature(library="nodejs", reason="Only plaintext files are sent presently")
+    @missing_feature(
+        context.library < "java@1.53.0", reason="before this version, tracer flare required tracing to be enabled "
+    )
+    @parametrize("library_env", [{**PROFILING_NOTRACING_ENVVARS}])
+    def test_tracer_profiling_notracing_flare_content(self, library_env, test_agent, test_library):
+        tracer_flare = trigger_tracer_flare_and_wait(test_agent, {})
+        if context.library == "java":
+            files = _java_tracer_profiling_notracing_flare_filenames()
             assert_java_log_file(tracer_flare["flare_file"])
             assert_expected_files(tracer_flare["flare_file"], files)
 

--- a/tests/parametric/test_tracer_flare.py
+++ b/tests/parametric/test_tracer_flare.py
@@ -219,7 +219,7 @@ class TestTracerFlareV1:
 
     @missing_feature(library="nodejs", reason="Only plaintext files are sent presently")
     @missing_feature(
-        context.library < "java@1.53.0", reason="before this version, tracer flare required tracing to be enabled "
+        context.library < "java@1.54.0", reason="before this version, tracer flare required tracing to be enabled "
     )
     @parametrize("library_env", [{**PROFILING_NOTRACING_ENVVARS}])
     def test_tracer_profiling_notracing_flare_content(self, library_env, test_agent, test_library):


### PR DESCRIPTION
## Motivation

Java - Test the tracer flare when tracing is disabled and profiling enabled

## Changes

Add a test "test_tracer_profiling_notracing_flare_content" in TestTracerFlareV1 to check the minimum list of files generated in the flare with this configuration (tracing is disabled, profiling enabled)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
