### PR TITLE
fix(debugger): waiting for snapshots from emitting probes

### DIFF
--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -47,7 +47,7 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
             logger.debug(f"Waiting for snapshot, retry #{retries}")
 
             self.send_weblog_request(request_path, reset=False)
-            snapshot_found = self.wait_for_exception_snapshot_received(exception_message, timeout)
+            snapshot_found = self.wait_for_snapshot_received(exception_message, timeout)
             timeout = _timeout_next
 
             retries += 1
@@ -540,7 +540,7 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                 logger.debug(f"Waiting for snapshot for shape: {shape}, retry #{retries}")
                 self.send_weblog_request(f"/exceptionreplay/rps?shape={shape}", reset=False)
 
-                shapes[shape] = self.wait_for_exception_snapshot_received(shape, timeout)
+                shapes[shape] = self.wait_for_snapshot_received(shape, timeout)
                 if self.get_tracer()["language"] == "python":
                     time.sleep(1)
 

--- a/tests/debugger/test_debugger_expression_language.py
+++ b/tests/debugger/test_debugger_expression_language.py
@@ -20,6 +20,7 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
         self.wait_for_all_probes(statuses=["INSTALLED"])
         self.send_weblog_request(request_path)
         self.wait_for_all_probes(statuses=["EMITTING"])
+        self.wait_for_snapshot_received()
 
     ############ assert ############
     def _assert(self, expected_response: int):

--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -88,7 +88,7 @@ class Test_Debugger_InProduct_Enablement_Exception_Replay(debugger.BaseDebuggerT
             logger.debug(f"Waiting for snapshot, retry #{retries}")
 
             self.send_weblog_request(request_path, reset=False)
-            snapshot_found = self.wait_for_exception_snapshot_received(exception_message, TIMEOUT)
+            snapshot_found = self.wait_for_snapshot_received(exception_message, TIMEOUT)
 
             retries += 1
 

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -126,6 +126,7 @@ class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
         self.wait_for_all_probes(statuses=["INSTALLED"])
         self.send_weblog_request("/debugger/pii")
         self.wait_for_all_probes(statuses=["EMITTING"])
+        self.wait_for_snapshot_received()
 
     ############ assert ############
     def _assert(self, excluded_identifiers=None, *, line_probe=False):

--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -50,6 +50,7 @@ class BaseDebuggerProbeSnaphotTest(debugger.BaseDebuggerTest):
         self.total_request_time = end_time - start_time
 
         self.wait_for_all_probes(statuses=["EMITTING"])
+        self.wait_for_snapshot_received()
 
     def _assert(self):
         self.collect()


### PR DESCRIPTION
## Motivation

Tracers generally send probe status information, e.g. `INSTALLED`, `EMITTING`, etc. separately from snapshots. We should wait until we receive one snapshot before continuing forward to the assertions. This will hopefully help with some of the flaky tests we've seen.

## Changes

* Replaced the method `wait_for_exception_snapshot_received` with a more generic `wait_for_snapshot_received` in `tests/debugger/utils.py`. The new method supports both exception and regular snapshots, improving code reuse and clarity.
* Updated all references in test files (`test_debugger_exception_replay.py`, `test_debugger_inproduct_enablement.py`) to use `wait_for_snapshot_received` instead of the old exception-specific method. [[1]](diffhunk://#diff-43e04c36ee82364f1e3c0f3ac0b347186780960192aefc9c7332c1bf850cad4aL50-R50) [[2]](diffhunk://#diff-43e04c36ee82364f1e3c0f3ac0b347186780960192aefc9c7332c1bf850cad4aL543-R543) [[3]](diffhunk://#diff-135ca610dddeac86144e105f8298016e5a239965d43a0adc97fee2f437541bcdL91-R91)
* Added calls to `wait_for_snapshot_received` in the setup routines of several test files (`test_debugger_expression_language.py`, `test_debugger_pii.py`, `test_debugger_probe_snapshot.py`) to ensure snapshots are received before proceeding with assertions. [[1]](diffhunk://#diff-0539d5c323dff80a4f41945f9e8cef220330f0a29fe480e03d2105bfa4c6dc5eR23) [[2]](diffhunk://#diff-2cc81d31929c49f7bdc8fa6992d99f5d975abaea0843ee29909de7bf042d1728R129) [[3]](diffhunk://#diff-838dccab9204ff2351b256cb32211afd0bd44a0cf4ff368044354f987b8dd462R53)
* Enhanced the internal logic of `_wait_for_snapshot_received` to distinguish between regular and exception snapshots, returning early for regular snapshots and checking for `exceptionId` for exception snapshots.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
