### PR TITLE
Update CODEOWNERS (apm-sdk-api to apm-sdk-capabilities)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,15 +11,15 @@
 /utils/build/docker/ruby*/ @DataDog/ruby-guild @DataDog/asm-ruby @DataDog/system-tests-core
 /utils/build/docker/rust*/ @DataDog/apm-rust @DataDog/system-tests-core
 
-/utils/telemetry/intake/ @DataDog/apm-sdk-api @DataDog/system-tests-core
+/utils/telemetry/intake/ @DataDog/apm-sdk-capabilities @DataDog/system-tests-core
 /utils/telemetry/intake/static/ @DataDog/apm-sdk
 
-/tests/parametric/ @mabdinur @DataDog/system-tests-core @DataDog/apm-sdk-api
+/tests/parametric/ @mabdinur @DataDog/system-tests-core @DataDog/apm-sdk-capabilities
 /tests/otel_tracing_e2e/ @DataDog/opentelemetry @DataDog/system-tests-core
 /tests/remote_config/ @DataDog/remote-config @DataDog/system-tests-core
 /tests/appsec/ @DataDog/asm-libraries @DataDog/system-tests-core
 /tests/debugger/ @DataDog/debugger @DataDog/system-tests-core
-/tests/test_telemetry.py @DataDog/libdatadog-telemetry @DataDog/apm-sdk-api @DataDog/system-tests-core
+/tests/test_telemetry.py @DataDog/libdatadog-telemetry @DataDog/apm-sdk-capabilities @DataDog/system-tests-core
 /tests/serverless @DataDog/serverless @DataDog/system-tests-core
 /tests/external_processing/ @DataDog/asm-libraries @DataDog/system-tests-core
 /tests/stream_processing_offload/ @DataDog/asm-libraries @DataDog/system-tests-core

--- a/tests/test_the_test/reportJunit_expected.xml
+++ b/tests/test_the_test/reportJunit_expected.xml
@@ -5,13 +5,13 @@
         </properties>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_pass">
             <properties>
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]"/>
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
                 <property name="dd_tags[systest.case.outcome]" value="passed"/>
             </properties>
         </testcase>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_fail" time="0.000">
             <properties>
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]"/>
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
                 <property name="dd_tags[systest.case.outcome]" value="failed"/>
             </properties>
             <failure message="Failed: dummy">self = &lt;tests.test_the_test.test_junit.Test_Cases object at 0x10cf01eb0&gt;
@@ -23,7 +23,7 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_skipped" time="0.000">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="skipped"/>
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]"/>
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
                 <property name="dd_tags[systest.case.declaration]" value="irrelevant"/>
                 <property name="dd_tags[systest.case.declarationDetails]" value="irrelevant"/>
             </properties>
@@ -31,7 +31,7 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
         </testcase>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_xfail" time="0.000">
             <properties>
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]"/>
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
                 <property name="dd_tags[systest.case.declaration]" value="bug"/>
                 <property name="dd_tags[systest.case.declarationDetails]" value="bug (APMRP-360)"/>
                 <property name="dd_tags[systest.case.outcome]" value="xfailed"/>
@@ -40,7 +40,7 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
         </testcase>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_xpass" time="0.000">
             <properties>
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]"/>
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
                 <property name="dd_tags[systest.case.declaration]" value="bug"/>
                 <property name="dd_tags[systest.case.declarationDetails]" value="bug (APMRP-360)"/>
                 <property name="dd_tags[systest.case.outcome]" value="xpassed"/>
@@ -49,7 +49,7 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_flaky" time="0.000">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="skipped"/>
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]"/>
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
                 <property name="dd_tags[systest.case.declaration]" value="flaky"/>
                 <property name="dd_tags[systest.case.declarationDetails]" value="flaky (APMRP-360)"/>
             </properties>
@@ -58,7 +58,7 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error_on_bug" time="0.000">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="xfailed" />
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]" />
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]" />
                 <property name="dd_tags[systest.case.declaration]" value="bug" />
                 <property name="dd_tags[systest.case.declarationDetails]" value="bug (APMRP-360)" />
             </properties>
@@ -67,7 +67,7 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error_on_missing_feature" time="0.000">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="xfailed" />
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]" />
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]" />
                 <property name="dd_tags[systest.case.declaration]" value="missing_feature" />
                 <property name="dd_tags[systest.case.declarationDetails]" value="missing_feature (APMRP-360)" />
             </properties>
@@ -76,7 +76,7 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error" time="0.000">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="error" />
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]" />
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]" />
             </properties>
             <error message="failed on setup with &quot;TypeError: nope!&quot;">@pytest.fixture
     def error_fixture():
@@ -88,7 +88,7 @@ tests/test_the_test/test_junit.py:15: TypeError</error>
         <testcase name="tests.test_the_test.test_junit.Test_Cases.test_force_skip">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="skipped"/>
-                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-api&quot;]"/>
+                <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
                 <property name="dd_tags[systest.case.declaration]" value="bug"/>
                 <property name="dd_tags[systest.case.declarationDetails]" value="bug (APMRP-360)"/>
             </properties>

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -16,7 +16,7 @@ class _Owner(StrEnum):
     remote_config = "@DataDog/remote-config"
     rp = "@DataDog/apm-reliability-and-performance"  # reliability & performance
     serverless = "@DataDog/serverless"
-    sdk_capabilities = "@DataDog/apm-sdk-api"
+    sdk_capabilities = "@DataDog/apm-sdk-capabilities"
     tracer = "n/a"  # legacy client libraries from feature parity dashboard, need to be adressed to good teams
 
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Team name changed from API to Capabilities a while ago - this change is required to reflect this in Github teams

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
