### PR TITLE
[Java] Change missing_feature with irrelevant spring-boot-3-native

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -30,14 +30,14 @@ tests/:
           '*': v1.38.0
           akka-http: bug (APPSEC-56888)
           play: v1.51.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0
           vertx4: v1.51.0
         Test_API_Security_RC_ASM_DD_scanners:
           '*': v1.38.0
           akka-http: bug (APPSEC-56888)
           play: v1.51.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0
           vertx4: v1.51.0
       test_apisec_sampling.py:
@@ -45,21 +45,21 @@ tests/:
           '*': v1.48.0
           akka-http: bug (APPSEC-56888)
           play: v1.51.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0
           vertx4: v1.51.0
         Test_API_Security_Sampling_Different_Paths:
           '*': v1.48.0
           akka-http: bug (APPSEC-56888)
           play: v1.51.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0
           vertx4: v1.51.0
         Test_API_Security_Sampling_Different_Status:
           '*': v1.48.0
           akka-http: bug (APPSEC-56888)
           play: v1.51.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0
           vertx4: v1.51.0
         Test_API_Security_Sampling_Rate: irrelevant (new sampling algorithm implemented)
@@ -67,20 +67,20 @@ tests/:
           '*': v1.48.0
           akka-http: bug (APPSEC-56888)
           play: v1.51.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0
           vertx4: v1.51.0
       test_endpoint_discovery.py:
         Test_Endpoint_Discovery:
           '*': missing_feature
           spring-boot: v1.52.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_schemas.py:
         Test_Scanners:
           '*': v1.31.0
           akka-http: bug (APPSEC-56888)
           play: v1.51.0-SNAPSHOT
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: bug (APPSEC-57921)
           vertx3: v1.51.0-SNAPSHOT
           vertx4: v1.51.0-SNAPSHOT
@@ -88,21 +88,21 @@ tests/:
           '*': v1.31.0
           akka-http: bug (APPSEC-56888)
           play: v1.51.0-SNAPSHOT
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0-SNAPSHOT
           vertx4: v1.51.0-SNAPSHOT
         Test_Schema_Request_FormUrlEncoded_Body:
           '*': v1.31.0
           akka-http: bug (APPSEC-56888)
           play: v1.51.0-SNAPSHOT
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0-SNAPSHOT
           vertx4: v1.51.0-SNAPSHOT
         Test_Schema_Request_Headers:
           '*': v1.31.0
           akka-http: bug (APPSEC-56888)
           play: v1.51.0-SNAPSHOT
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0-SNAPSHOT
           vertx4: v1.51.0-SNAPSHOT
         Test_Schema_Request_Json_Body:
@@ -111,7 +111,7 @@ tests/:
           jersey-grizzly2: bug (APPSEC-56846)
           play: v1.51.0-SNAPSHOT
           resteasy-netty3: bug (APPSEC-56846)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0-SNAPSHOT
           vertx4: v1.51.0-SNAPSHOT
         Test_Schema_Request_Path_Parameters:
@@ -120,30 +120,30 @@ tests/:
           jersey-grizzly2: bug (APPSEC-56846)
           play: v1.51.0-SNAPSHOT
           resteasy-netty3: bug (APPSEC-56846)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0-SNAPSHOT
           vertx4: v1.51.0-SNAPSHOT
         Test_Schema_Request_Query_Parameters:
           '*': v1.31.0
           akka-http: bug (APPSEC-56888)
           play: v1.51.0-SNAPSHOT
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.51.0-SNAPSHOT
           vertx4: v1.51.0-SNAPSHOT
         Test_Schema_Response_Body:
           '*': v1.51.0-SNAPSHOT
           akka-http: bug (APPSEC-56888)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: missing_feature
         Test_Schema_Response_Body_env_var: missing_feature
         Test_Schema_Response_Headers:
           '*': v1.51.0-SNAPSHOT
           akka-http: bug (APPSEC-56888)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Schema_Response_on_Block:
           '*': v1.51.0-SNAPSHOT
           akka-http: bug (APPSEC-56888)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: missing_feature
     iast/:
       sink/:
@@ -159,7 +159,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: v1.11.0
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.12.0
             vertx4: v1.12.0
           TestCommandInjection_ExtendedLocation: missing_feature
@@ -167,7 +167,7 @@ tests/:
             '*': v1.47.0
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_email_html_injection.py:
           TestEmailHtmlInjection:
             '*': v1.47.0
@@ -176,7 +176,7 @@ tests/:
             play: missing_feature (No endpoint implemented)
             ratpack: missing_feature (No endpoint implemented)
             resteasy-netty3: missing_feature (No endpoint implemented)
-            spring-boot-3-native: missing_feature (No endpoint implemented)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature (No endpoint implemented)
             vertx4: missing_feature (No endpoint implemented)
           TestEmailHtmlInjection_ExtendedLocation: missing_feature
@@ -187,7 +187,7 @@ tests/:
             play: missing_feature (No endpoint implemented)
             ratpack: missing_feature (No endpoint implemented)
             resteasy-netty3: missing_feature (No endpoint implemented)
-            spring-boot-3-native: missing_feature (No endpoint implemented)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature (No endpoint implemented)
             vertx4: missing_feature (No endpoint implemented)
         test_hardcoded_passwords.py:
@@ -239,7 +239,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             spring-boot-openliberty: bug (APPSEC-51483)
             vertx3: missing_feature
             vertx4: missing_feature
@@ -250,7 +250,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             spring-boot-openliberty: bug (APPSEC-51483)
             vertx3: missing_feature
             vertx4: missing_feature
@@ -261,7 +261,7 @@ tests/:
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             spring-boot-openliberty: bug (APPSEC-54981)
           Test_InsecureAuthProtocol_ExtendedLocation: missing_feature
           Test_InsecureAuthProtocol_StackTrace:
@@ -269,7 +269,7 @@ tests/:
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             spring-boot-openliberty: bug (APPSEC-54981)
         test_insecure_cookie.py:
           TestInsecureCookie:
@@ -277,7 +277,7 @@ tests/:
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           TestInsecureCookieNameFilter: missing_feature
           TestInsecureCookie_ExtendedLocation: missing_feature
           TestInsecureCookie_StackTrace:
@@ -285,7 +285,7 @@ tests/:
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_ldap_injection.py:
           TestLDAPInjection:
             '*': v1.3.0
@@ -294,7 +294,7 @@ tests/:
             play: missing_feature (endpoint not implemented)
             ratpack: missing_feature (endpoint not implemented)
             resteasy-netty3: v1.11.0
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.12.0
             vertx4: v1.12.0
           TestLDAPInjection_ExtendedLocation: missing_feature
@@ -302,14 +302,14 @@ tests/:
             '*': v1.47.0
             play: missing_feature (endpoint not implemented)
             ratpack: missing_feature (endpoint not implemented)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_no_httponly_cookie.py:
           TestNoHttponlyCookie:
             '*': v1.18.0
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           TestNoHttponlyCookieNameFilter: missing_feature
           TestNoHttponlyCookie_ExtendedLocation: missing_feature
           TestNoHttponlyCookie_StackTrace:
@@ -317,14 +317,14 @@ tests/:
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_no_samesite_cookie.py:
           TestNoSamesiteCookie:
             '*': v1.18.0
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           TestNoSamesiteCookieNameFilter: missing_feature
           TestNoSamesiteCookie_ExtendedLocation: missing_feature
           TestNoSamesiteCookie_StackTrace:
@@ -332,7 +332,7 @@ tests/:
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_nosql_mongodb_injection.py:
           TestNoSqlMongodbInjection: missing_feature
           TestNoSqlMongodbInjection_ExtendedLocation: missing_feature
@@ -345,28 +345,28 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: v1.11.0
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.12.0
           TestPathTraversal_ExtendedLocation: missing_feature
           TestPathTraversal_StackTrace:
             '*': v1.47.0
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_reflection_injection.py:
           TestReflectionInjection:
             '*': v1.31.0
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           TestReflectionInjection_ExtendedLocation: missing_feature
           TestReflectionInjection_StackTrace:
             '*': v1.47.0
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_sql_injection.py:
           TestSqlInjection:
             '*': v1.1.0
@@ -375,21 +375,21 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: v1.11.0
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.12.0
           TestSqlInjection_ExtendedLocation: missing_feature
           TestSqlInjection_StackTrace:
             '*': v1.47.0
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_ssrf.py:
           TestSSRF:
             '*': v1.13.0
             akka-http: missing_feature (No endpoint implemented)
             play: missing_feature (No endpoint implemented)
             ratpack: missing_feature (No endpoint implemented)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx4: missing_feature (No endpoint implemented)
           TestSSRF_ExtendedLocation: missing_feature
           TestSSRF_StackTrace:
@@ -397,7 +397,7 @@ tests/:
             akka-http: missing_feature (No endpoint implemented)
             play: missing_feature (No endpoint implemented)
             ratpack: missing_feature (No endpoint implemented)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx4: missing_feature (No endpoint implemented)
         test_stacktrace_leak.py:
           TestStackTraceLeak: missing_feature
@@ -412,7 +412,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature
             vertx4: missing_feature
           Test_TrustBoundaryViolation_ExtendedLocation: missing_feature
@@ -423,7 +423,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature
             vertx4: missing_feature
         test_untrusted_deserialization.py:
@@ -434,7 +434,7 @@ tests/:
             play: missing_feature (No endpoint implemented)
             ratpack: missing_feature (No endpoint implemented)
             resteasy-netty3: missing_feature (No endpoint implemented)
-            spring-boot-3-native: missing_feature (No endpoint implemented)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature (No endpoint implemented)
             vertx4: missing_feature (No endpoint implemented)
           TestUntrustedDeserialization_ExtendedLocation: missing_feature
@@ -445,7 +445,7 @@ tests/:
             play: missing_feature (No endpoint implemented)
             ratpack: missing_feature (No endpoint implemented)
             resteasy-netty3: missing_feature (No endpoint implemented)
-            spring-boot-3-native: missing_feature (No endpoint implemented)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature (No endpoint implemented)
             vertx4: missing_feature (No endpoint implemented)
         test_unvalidated_redirect.py:
@@ -454,7 +454,7 @@ tests/:
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             spring-boot-jetty: v1.17.0
             vertx3: v1.16.0
             vertx4: v1.17.0
@@ -464,13 +464,13 @@ tests/:
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           TestUnvalidatedRedirect:
             '*': v1.15.0
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             spring-boot-jetty: v1.17.0
             vertx4: v1.17.0
           TestUnvalidatedRedirect_ExtendedLocation: missing_feature
@@ -479,7 +479,7 @@ tests/:
             akka-http: missing_feature
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_unvalidated_redirect_forward.py:
           TestUnvalidatedForward:
             '*': v1.15.0
@@ -488,7 +488,7 @@ tests/:
             play: missing_feature (No endpoint implemented)
             ratpack: irrelevant (No forward)
             resteasy-netty3: irrelevant (No forward)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.16.0
             vertx4: v1.17.0
           TestUnvalidatedForward_ExtendedLocation: missing_feature
@@ -499,41 +499,41 @@ tests/:
             play: missing_feature (No endpoint implemented)
             ratpack: irrelevant (No forward)
             resteasy-netty3: irrelevant (No forward)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_weak_cipher.py:
           TestWeakCipher:
             '*': v0.108.0
             play: missing_feature (no endpoint)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           TestWeakCipher_ExtendedLocation: missing_feature
           TestWeakCipher_StackTrace:
             '*': v1.47.0
             play: missing_feature (no endpoint)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_weak_hash.py:
           TestDeduplication:
             '*': v0.108.0
             play: missing_feature (no endpoint)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           TestWeakHash:
             '*': v0.108.0
             play: missing_feature (no endpoint)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           TestWeakHash_ExtendedLocation: missing_feature
           TestWeakHash_StackTrace:
             '*': v1.47.0
             play: missing_feature (no endpoint)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_weak_randomness.py:
           TestWeakRandomness:
             '*': v1.15.0
             play: missing_feature (no endpoint)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           TestWeakRandomness_ExtendedLocation: missing_feature
           TestWeakRandomness_StackTrace:
             '*': v1.47.0
             play: missing_feature (no endpoint)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_xcontent_sniffing.py:
           Test_XContentSniffing:
             '*': v1.22.0
@@ -542,7 +542,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             spring-boot-openliberty: bug (APPSEC-54981)
             vertx3: missing_feature
             vertx4: missing_feature
@@ -553,7 +553,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             spring-boot-openliberty: bug (APPSEC-54981)
             vertx3: missing_feature
             vertx4: missing_feature
@@ -563,13 +563,13 @@ tests/:
             '*': v1.18.0
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           TestXPathInjection_ExtendedLocation: missing_feature
           TestXPathInjection_StackTrace:
             '*': v1.47.0
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         test_xss.py:
           TestXSS:
             '*': v1.19.0
@@ -578,7 +578,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature
             vertx4: missing_feature
           TestXSS_ExtendedLocation: missing_feature
@@ -589,7 +589,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature
             vertx4: missing_feature
       source/:
@@ -601,7 +601,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.12.0
             vertx4: v1.12.0
         test_cookie_name.py:
@@ -611,7 +611,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.12.0
             vertx4: v1.12.0
         test_cookie_value.py:
@@ -622,7 +622,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: v1.11.0
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.12.0
             vertx4: v1.12.0
         test_graphql_resolver.py:
@@ -635,7 +635,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.12.0
             vertx4: v1.12.0
         test_header_value.py:
@@ -646,7 +646,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: v1.11.0
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.12.0
             vertx4: v1.12.0
         test_kafka_key.py:
@@ -657,7 +657,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature
             vertx4: missing_feature
         test_kafka_value.py:
@@ -668,7 +668,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature
             vertx4: missing_feature
         test_multipart.py:
@@ -679,7 +679,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature
             vertx4: missing_feature
         test_parameter_name.py:
@@ -689,7 +689,7 @@ tests/:
             jersey-grizzly2: v1.15.0
             play: missing_feature
             ratpack: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.12.0
             vertx4: v1.12.0
         test_parameter_value.py:
@@ -700,7 +700,7 @@ tests/:
             play: v1.22.0
             ratpack: missing_feature
             resteasy-netty3: v1.11.0
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: v1.12.0
             vertx4: v1.12.0
         test_path.py:
@@ -711,7 +711,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature
             vertx4: missing_feature
         test_path_parameter.py:
@@ -725,7 +725,7 @@ tests/:
             play: missing_feature (endpoint not implemented)
             ratpack: missing_feature (endpoint not implemented)
             resteasy-netty3: missing_feature (endpoint not implemented)
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature (endpoint not implemented)
             vertx4: missing_feature (endpoint not implemented)
         test_uri.py:
@@ -736,7 +736,7 @@ tests/:
             play: missing_feature
             ratpack: missing_feature
             resteasy-netty3: missing_feature
-            spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+            spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
             vertx3: missing_feature
             vertx4: missing_feature
       test_sampling_by_route_method_count.py:
@@ -745,13 +745,13 @@ tests/:
           akka-http: bug (APPSEC-57926)
           play: bug (APPSEC-57926)
           ratpack: bug (APPSEC-58210)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_security_controls.py:
         TestSecurityControls:
           '*': v1.46.0
           play: missing_feature
           ratpack: missing_feature
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     rasp/:
       test_api10.py:
         Test_API10_all: missing_feature
@@ -765,255 +765,255 @@ tests/:
         Test_Cmdi_BodyJson:
           '*': v1.45.0
           akka-http: missing_feature (APPSEC-56196)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx4: v1.47.0
         Test_Cmdi_BodyUrlEncoded:
           '*': v1.45.0
           akka-http: missing_feature (APPSEC-56196)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
         Test_Cmdi_BodyXml:
           '*': v1.45.0
           akka-http: missing_feature (APPSEC-55780)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55788)
           vertx4: missing_feature (APPSEC-55786)
         Test_Cmdi_Capability:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Cmdi_Mandatory_SpanTags:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Cmdi_Optional_SpanTags:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Cmdi_Rules_Version:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Cmdi_StackTrace:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Cmdi_Telemetry:
           '*': v1.45.0
           akka-http: missing_feature (APPSEC-56196)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Cmdi_Telemetry_V2: missing_feature
         Test_Cmdi_Telemetry_Variant_Tag:
           '*': v1.45.0
           akka-http: missing_feature (APPSEC-56196)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Cmdi_UrlQuery:
           '*': v1.45.0
           akka-http: missing_feature (APPSEC-56196)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
         Test_Cmdi_Waf_Version:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_lfi.py:
         Test_Lfi_BodyJson:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx4: v1.47.0
         Test_Lfi_BodyUrlEncoded:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
         Test_Lfi_BodyXml:
           '*': v1.40.0
           akka-http: missing_feature (APPSEC-55780)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55788)
           vertx4: missing_feature (APPSEC-55786)
         Test_Lfi_Capability:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Lfi_Mandatory_SpanTags:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Lfi_Optional_SpanTags:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Lfi_RC_CustomAction: missing_feature (APPSEC-54930)
         Test_Lfi_Rules_Version:
           '*': v1.43.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Lfi_StackTrace:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Lfi_Telemetry:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Lfi_Telemetry_Multiple_Exploits: missing_feature
         Test_Lfi_Telemetry_V2: missing_feature
         Test_Lfi_UrlQuery:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
         Test_Lfi_Waf_Version:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_shi.py:
         Test_Shi_BodyJson:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx4: v1.47.0
         Test_Shi_BodyUrlEncoded:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
         Test_Shi_BodyXml:
           '*': v1.45.0
           akka-http: missing_feature (APPSEC-55780)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55788)
           vertx4: missing_feature (APPSEC-55786)
         Test_Shi_Capability:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Shi_Mandatory_SpanTags:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Shi_Optional_SpanTags:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Shi_Rules_Version:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Shi_StackTrace:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Shi_Telemetry:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Shi_Telemetry_V2: missing_feature
         Test_Shi_Telemetry_Variant_Tag:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Shi_UrlQuery:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
         Test_Shi_Waf_Version:
           '*': v1.45.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       # SQLi was introduced in v1.38.0 (with RASP disabled by default, but was flaky)
 
       test_sqli.py:
         Test_Sqli_BodyJson:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx4: v1.47.0
         Test_Sqli_BodyUrlEncoded:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: v1.40.0  # issue in context propagation in 1.39.0
           vertx4: v1.40.0  # issue in context propagation in 1.39.0
         Test_Sqli_BodyXml:
           '*': v1.39.0
           akka-http: missing_feature (APPSEC-55780)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55788)
           vertx4: missing_feature (APPSEC-55786)
         Test_Sqli_Capability:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Sqli_Mandatory_SpanTags:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.40.0  # issue in context propagation in 1.39.0
           vertx4: v1.40.0  # issue in context propagation in 1.39.0
         Test_Sqli_Optional_SpanTags:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.40.0  # issue in context propagation in 1.39.0
           vertx4: v1.40.0  # issue in context propagation in 1.39.0
         Test_Sqli_Rules_Version:
           '*': v1.43.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Sqli_StackTrace:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.40.0  # issue in context propagation in 1.39.0
           vertx4: v1.40.0  # issue in context propagation in 1.39.0
         Test_Sqli_Telemetry:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v1.40.0  # issue in context propagation in 1.39.0
           vertx4: v1.40.0  # issue in context propagation in 1.39.0
         Test_Sqli_Telemetry_V2: missing_feature
         Test_Sqli_UrlQuery:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: v1.40.0  # issue in context propagation in 1.39.0
           vertx4: v1.40.0  # issue in context propagation in 1.39.0
         Test_Sqli_Waf_Version:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_ssrf.py:
         Test_Ssrf_BodyJson:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781, APPSEC-55785)
         Test_Ssrf_BodyUrlEncoded:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781)
         Test_Ssrf_BodyXml:
           '*': v1.39.0
           akka-http: missing_feature (APPSEC-55780)
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781, APPSEC-55788)
           vertx4: missing_feature (APPSEC-55781, APPSEC-55786)
         Test_Ssrf_Capability:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Ssrf_Mandatory_SpanTags:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx4: missing_feature (APPSEC-55781)
         Test_Ssrf_Optional_SpanTags:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx4: missing_feature (APPSEC-55781)
         Test_Ssrf_Rules_Version:
           '*': v1.43.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Ssrf_StackTrace:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781)
         Test_Ssrf_Telemetry:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781)
         Test_Ssrf_Telemetry_V2: missing_feature
         Test_Ssrf_UrlQuery:
           '*': v1.39.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: missing_feature (APPSEC-54966)
           vertx3: missing_feature (APPSEC-55781)
           vertx4: missing_feature (APPSEC-55781)
         Test_Ssrf_Waf_Version:
           '*': v1.40.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     waf/:
       test_addresses.py:
         Test_BodyJson:
@@ -1021,20 +1021,20 @@ tests/:
           akka-http: v1.22.0
           play: v1.22.0
           ratpack: v0.99.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v0.99.0
           vertx4: v1.47.0
         Test_BodyRaw:
           '*': missing_feature
           akka-http: v1.22.0
           play: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_BodyUrlEncoded:
           '*': v0.95.1
           akka-http: v1.22.0
           play: v1.22.0
           ratpack: v0.99.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-undertow: v0.98.0
           vertx3: v0.99.0
         Test_BodyXml:
@@ -1042,20 +1042,20 @@ tests/:
           akka-http: missing_feature (no built-in XML unmarshalling to instrument)
           play: v1.23.0
           ratpack: v0.99.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: missing_feature
           vertx4: bug (APPSEC-54983)
         Test_Cookies:
           akka-http: v1.22.0
           play: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_FullGrpc: missing_feature
         Test_GraphQL: missing_feature
         Test_GrpcServerMethod: missing_feature
         Test_Headers:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_PathParams:
           '*': v0.95.1
           akka-http: missing_feature (unclear how to implement; matching doesn't happen in one go)
@@ -1063,23 +1063,23 @@ tests/:
           play: v1.22.0
           ratpack: v0.99.0
           resteasy-netty3: v1.15.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: v0.99.0
         Test_ResponseStatus:
           '*': v0.88.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_UrlQuery:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_UrlQueryKey:
           '*': v0.100.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_UrlRaw:
           '*': v0.87.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_gRPC:
           '*': v0.96.0
           akka-http: irrelevant
@@ -1088,7 +1088,7 @@ tests/:
           ratpack: irrelevant
           resteasy-netty3: irrelevant
           spring-boot: v0.109.0  # APPSEC-5426
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           vertx3: irrelevant
           vertx4: irrelevant
       test_blocking.py:
@@ -1099,131 +1099,131 @@ tests/:
           play: v1.22.0
           ratpack: v1.7.0
           resteasy-netty3: v1.7.0
-          spring-boot-3-native: missing_feature
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-openliberty: v1.3.0
           vertx3: v1.7.0
         Test_Blocking_strip_response_headers:
           '*': missing_feature
           akka-http: v1.22.0
           play: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_CustomBlockingResponse:
           '*': v1.11.0
           akka-http: v1.22.0
           play: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_custom_rules.py:
         Test_CustomRules:
           '*': v1.51.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_exclusions.py:
         Test_Exclusions:
           '*': v1.6.0
           akka-http: v1.22.0
           play: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_miscs.py:
         Test_404:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_CorrectOptionProcessing:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_MultipleAttacks:
           '*': v0.92.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_MultipleHighlight:
           '*': v0.95.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_reports.py:
         Test_Monitoring:
           '*': v0.100.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_rules.py:
         Test_CommandInjection:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_DiscoveryScan:
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
           spring-boot-payara: bug (APPSEC-52334)
         Test_HttpProtocol:
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_JavaCodeInjection:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_JsInjection:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_LFI:
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_NoSqli:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_PhpCodeInjection:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_RFI:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_SQLI:
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_SSRF:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_Scanners:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         Test_XSS:
           '*': v0.87.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_telemetry.py:
         Test_TelemetryMetrics:
           '*': v1.12.0
           akka-http: v1.22.0
-          spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+          spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       test_truncation.py:
         Test_Truncation: missing_feature
     test_alpha.py:
       Test_Basic:
         '*': v0.87.0
         akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_asm_standalone.py:
       Test_APISecurityStandalone:
         '*': v1.50.0-SNAPSHOT
         akka-http: bug (APPSEC-56888)
         play: bug (APPSEC-56869)
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         vertx3: bug (APPSEC-56870)
         vertx4: bug (APPSEC-56871)
       Test_AppSecStandalone_NotEnabled: missing_feature
       Test_AppSecStandalone_UpstreamPropagation_V2:
         '*': v1.47.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_IastStandalone_UpstreamPropagation_V2:
         '*': v1.47.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_SCAStandalone_Telemetry_V2:
         '*': v1.47.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_UserEventsStandalone_Automated:
         '*': v1.45.0
         akka-http: missing_feature (login endpoints not implemented)
@@ -1262,7 +1262,7 @@ tests/:
       Test_V2_Login_Events_RC: irrelevant (v1.38.0, replaced by V3)
       Test_V3_Auto_User_Instrum_Mode_Capability:
         '*': v1.45.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_V3_Login_Events:
         '*': v1.45.0
         akka-http: missing_feature (login endpoints not implemented)
@@ -1348,19 +1348,19 @@ tests/:
         play: v1.22.0
         ratpack: v1.6.0
         resteasy-netty3: v1.7.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-openliberty: v0.115.0
         vertx3: v1.7.0
         vertx4: v1.7.0
       Test_Blocking_client_ip_with_K8_private_ip: missing_feature
       Test_Blocking_client_ip_with_forwarded:
         '*': v1.53.0-SNAPSHOT
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_Blocking_request_body:
         '*': v1.15.0
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-payara: bug (APPSEC-54985)
       Test_Blocking_request_body_multipart:
         '*': v1.15.0
@@ -1369,7 +1369,7 @@ tests/:
         play: v1.22.0
         ratpack: missing_feature
         resteasy-netty3: missing_feature
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-openliberty: bug (APPSEC-54985)
         spring-boot-payara: bug (APPSEC-54985)
       Test_Blocking_request_cookies:
@@ -1380,7 +1380,7 @@ tests/:
         ratpack: v1.6.0
         resteasy-netty3: v1.7.0
         spring-boot: v0.110.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-jetty: v0.111.0
         spring-boot-openliberty: v0.115.0  # Supported since 0.111.0 but bugged in <0.115.0.
         spring-boot-payara: v1.35.0  # earlier, but real version not known
@@ -1397,7 +1397,7 @@ tests/:
         ratpack: v1.6.0
         resteasy-netty3: v1.7.0
         spring-boot: v0.110.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-jetty: v0.111.0
         spring-boot-openliberty: v0.115.0  # Supported since 0.111.0 but bugged in <0.115.0.
         spring-boot-payara: v1.35.0  # earlier, but real version not known
@@ -1414,7 +1414,7 @@ tests/:
         ratpack: v1.6.0
         resteasy-netty3: v1.7.0
         spring-boot: v0.110.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-jetty: v0.111.0
         spring-boot-openliberty: v0.115.0  # Supported since 0.111.0 but bugged in <0.115.0.
         spring-boot-payara: v1.35.0  # earlier, but real version not known
@@ -1427,7 +1427,7 @@ tests/:
         '*': v1.15.0
         akka-http: missing_feature (path parameters not suported)
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-payara: bug (APPSEC-52335)
       Test_Blocking_request_query:
         '*': missing_feature
@@ -1437,7 +1437,7 @@ tests/:
         ratpack: v1.6.0
         resteasy-netty3: v1.7.0
         spring-boot: v0.110.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-jetty: v0.111.0
         spring-boot-openliberty: v0.115.0  # Supported since 0.111.0 but bugged in <0.115.0.
         spring-boot-payara: v1.35.0  # earlier, but real version not known
@@ -1454,7 +1454,7 @@ tests/:
         ratpack: v1.6.0
         resteasy-netty3: v1.7.0
         spring-boot: v0.110.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-jetty: v0.111.0
         spring-boot-openliberty: v0.115.0  # Supported since 0.111.0 but bugged in <0.115.0.
         spring-boot-payara: v1.35.0  # earlier, but real version not known
@@ -1467,11 +1467,11 @@ tests/:
         '*': missing_feature
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_Blocking_response_status:
         '*': v1.22.0
         jersey-grizzly2: missing_feature
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-openliberty: v1.20.0
         spring-boot-payara: missing_feature
       Test_Blocking_user_id:
@@ -1481,46 +1481,46 @@ tests/:
         play: v1.22.0
         ratpack: v1.6.0
         resteasy-netty3: v1.7.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-openliberty: v0.115.0
         spring-boot-payara: bug (APPSEC-54966)
         vertx3: v1.7.0
         vertx4: v1.7.0
       Test_Suspicious_Request_Blocking:
         '*': v1.6.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_client_ip.py:
       Test_StandardTagsClientIp: v0.114.0
     test_conf.py:
       Test_ConfigurationVariables:
         '*': v0.100.0
         akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_ConfigurationVariables_New_Obfuscation:
         '*': v1.51.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_customconf.py:
       Test_ConfRuleSet:
         '*': v0.93.0
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_CorruptedRules:
         '*': v0.93.0
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_CorruptedRules_Telemetry: missing_feature
       Test_MissingRules:
         '*': v0.93.0
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_NoLimitOnWafRules:
         '*': v0.97.0
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_event_tracking.py:
       Test_CustomEvent:
         '*': v1.8.0
@@ -1592,12 +1592,12 @@ tests/:
     test_extended_header_collection.py:
       Test_ExtendedHeaderCollection:
         '*': v1.50.0-SNAPSHOT
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_extended_request_body_collection.py:
       Test_ExtendedRequestBodyCollection:
         '*': v1.50.0-SNAPSHOT
         akka-http: missing_feature (APPSEC-56196)
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-payara: missing_feature (APPSEC-54966)
     test_fingerprinting.py:
       Test_Fingerprinting_Endpoint:
@@ -1653,7 +1653,7 @@ tests/:
     test_identify.py:
       Test_Basic:
         '*': v1.48.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_ip_blocking_full_denylist.py:
       Test_AppSecIPBlockingFullDenylist:
         '*': v0.111.0
@@ -1661,17 +1661,17 @@ tests/:
         ratpack: v1.7.0
         resteasy-netty3: v1.7.0
         spring-boot: v0.110.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-openliberty: v0.115.0
         vertx3: v1.7.0
     test_logs.py:
       Test_Standardization:
         akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_StandardizationBlockMode: missing_feature
     test_metastruct.py:
       Test_SecurityEvents_Appsec_Metastruct_Disabled:
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_SecurityEvents_Appsec_Metastruct_Enabled: missing_feature (APPSEC-4766)
       Test_SecurityEvents_Iast_Metastruct_Disabled: missing_feature (APPSEC-4766)
       Test_SecurityEvents_Iast_Metastruct_Enabled: missing_feature (APPSEC-4766)
@@ -1679,65 +1679,65 @@ tests/:
       Test_Main:
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_remote_config_rule_changes.py:
       Test_AsmDdMultiConfiguration:
         '*': v1.51.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_BlockingActionChangesWithRemoteConfig:
         '*': v1.42.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_Empty_Config:
         '*': missing_feature
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_Invalid_Config: missing_feature
       Test_Multiple_Actions:
         '*': v1.42.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_Unknown_Action:
         '*': v1.42.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_UpdateRuleFileWithRemoteConfig:
         '*': v1.42.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_reports.py:
       Test_AttackTimestamp:
         akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_ExtraTagsFromRule:
         '*': v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_Info:
         '*': v0.87.0
         akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_RequestHeaders:
         akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_StatusCode:
         '*': v0.92.0
         akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_TagsFromRule:
         akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_request_blocking.py:
       Test_AppSecRequestBlocking:
         '*': v1.9.0
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_runtime_activation.py:
       Test_RuntimeActivation:
         '*': v0.115.0
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_RuntimeDeactivation:
         '*': v0.115.0
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_service_activation_metric.py:
       TestServiceActivationEnvVarConfigurationMetric: missing_feature
       TestServiceActivationEnvVarMetric: missing_feature
@@ -1751,13 +1751,13 @@ tests/:
         play: missing_feature (endpoint not implemented)
         ratpack: missing_feature (endpoint not implemented)
         resteasy-netty3: missing_feature (endpoint not implemented)
-        spring-boot-3-native: missing_feature (disabled on GraalVM)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         vertx3: missing_feature (endpoint not implemented)
         vertx4: missing_feature (endpoint not implemented)
     test_suspicious_attacker_blocking.py:
       Test_Suspicious_Attacker_Blocking:
         '*': v1.39.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_trace_tagging.py:
       Test_TraceTaggingRules: missing_feature
       Test_TraceTaggingRulesRcCapability: missing_feature
@@ -1766,26 +1766,26 @@ tests/:
         '*': v0.104.0
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_AppSecObfuscator:
         '*': v0.113.0
         akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_CollectDefaultRequestHeader:
         '*': v1.35.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_CollectRespondHeaders:
         '*': v0.102.0
         akka-http: v1.22.0
         play: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_ExternalWafRequestsIdentification:
         '*': v1.35.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_RetainTraces:
         '*': v0.92.0
         akka-http: v1.22.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     test_user_blocking_full_denylist.py:
       Test_UserBlocking_FullDenylist:
         '*': v0.111.0
@@ -1793,7 +1793,7 @@ tests/:
         ratpack: v1.7.0
         resteasy-netty3: v1.7.0
         spring-boot: v0.110.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         spring-boot-openliberty: v0.115.0
         vertx3: v1.7.0
     test_versions.py:
@@ -2119,21 +2119,21 @@ tests/:
     test_remote_configuration.py:
       Test_RemoteConfigurationExtraServices:
         '*': v1.31.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_RemoteConfigurationSemVer:
         '*': v1.4.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_RemoteConfigurationUpdateSequenceASMDD:
         '*': v1.4.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_RemoteConfigurationUpdateSequenceASMDDNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceFeatures:
         '*': v1.4.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: irrelevant (cache is implemented)
       Test_RemoteConfigurationUpdateSequenceLiveDebugging:
         '*': v1.4.0
-        spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
   serverless/:
     span_pointers/:
       aws/:
@@ -2213,12 +2213,12 @@ tests/:
     Test_Config_RuntimeMetrics_Default: v0.64.0
     Test_Config_RuntimeMetrics_Enabled:
       '*': v0.64.0
-      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       spring-boot-openliberty: incomplete_test_app (needs investigation to understand why test is failing)
       spring-boot-wildfly: incomplete_test_app (needs investigation to understand why test is failing)
     Test_Config_RuntimeMetrics_Enabled_WithRuntimeId:
       '*': v0.64.0
-      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
       spring-boot-openliberty: incomplete_test_app (needs investigation to understand why test is failing)
       spring-boot-wildfly: incomplete_test_app (needs investigation to understand why test is failing)
     Test_Config_UnifiedServiceTagging_CustomService: v1.39.0
@@ -2238,7 +2238,7 @@ tests/:
   test_identify.py:
     Test_Basic:
       '*': v1.48.0
-      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     Test_Propagate:
       # XXX: spring-boot-3-native would have a higher version
       '*': v0.111.0
@@ -2261,7 +2261,7 @@ tests/:
       spring-boot: v1.48.0
     Test_HeaderTags:
       '*': v1.35.0
-      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     Test_HeaderTags_Colon_Leading: v0.102.0
     Test_HeaderTags_Colon_Trailing: v0.102.0
     Test_HeaderTags_DynamicConfig: missing_feature
@@ -2317,7 +2317,7 @@ tests/:
       '*': v0.114.0
       akka-http: v1.22.0
       play: v1.22.0
-      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     Test_StandardTagsMethod: v0.102.0
     Test_StandardTagsReferrerHostname: missing_feature
     Test_StandardTagsRoute:
@@ -2332,19 +2332,19 @@ tests/:
     Test_Log_Generation: missing_feature
     Test_MessageBatch:
       '*': v1.23.0
-      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     Test_Metric_Generation_Disabled:
       '*': v1.23.0
-      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     Test_Metric_Generation_Enabled:
       '*': v1.23.0
-      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     Test_ProductsDisabled:
       '*': v1.48.0
-      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     Test_Telemetry:
       '*': v0.108.1
-      spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+      spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     Test_TelemetryEnhancedConfigReporting: missing_feature
     Test_TelemetrySCAEnvVar: missing_feature
     Test_TelemetryV2: v1.23.0


### PR DESCRIPTION
## Motivation

The spring-boot-3-native weblog variant is currently marked as a missing_feature in most tests. This causes the tests to still run for that variant, even though we’re not planning to support it anytime soon. Marking it as irrelevant instead will prevent those tests from running, helping to reduce unnecessary execution and lighten the load on the pipelines.

## Changes

Change missing_feature with irrelevant spring-boot-3-native

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
