### PR TITLE
chore(telemetry): update env vars

### DIFF
--- a/utils/telemetry/intake/static/python_config_rules.json
+++ b/utils/telemetry/intake/static/python_config_rules.json
@@ -27,7 +27,9 @@
         "python_build_gnu_type": "python_build_gnu_type",
         "python_host_gnu_type": "python_host_gnu_type",
         "python_soabi": "python_soabi",
-        "trace_report_handled_exceptions": "trace_report_handled_exceptions"
+        "trace_report_handled_exceptions": "trace_report_handled_exceptions",
+        "DD_TRACE_EXPERIMENTAL_LONG_RUNNING_FLUSH_INTERVAL": "trace_experimental_long_running_flush_interval",
+        "DD_TRACE_EXPERIMENTAL_LONG_RUNNING_INITIAL_FLUSH_INTERVAL": "trace_experimental_long_running_initial_flush_interval"
     },
     "prefix_block_list": [],
     "redaction_list": [],


### PR DESCRIPTION
## Motivation

tests.test_telemetry.test_config_telemetry_completeness was failing as we introduce two new config env variables in python tracer related to long running span.

## Changes

Introduced two new env variables for the python tracer. 

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
