### PR TITLE
[Java] Mark test_extended_header_collection.py irrelevant

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1590,15 +1590,9 @@ tests/:
       Test_ExtendedRequestHeadersDataCollection: missing_feature
       Test_ExtendedResponseHeadersDataCollection: missing_feature
     test_extended_header_collection.py:
-      Test_ExtendedHeaderCollection:
-        '*': v1.50.0-SNAPSHOT
-        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
+      Test_ExtendedHeaderCollection: irrelevant (covered by v2 test_extended_data_collection.py)
     test_extended_request_body_collection.py:
-      Test_ExtendedRequestBodyCollection:
-        '*': v1.50.0-SNAPSHOT
-        akka-http: missing_feature (APPSEC-56196)
-        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
-        spring-boot-payara: missing_feature (APPSEC-54966)
+      Test_ExtendedRequestBodyCollection: irrelevant (covered by v2 test_extended_data_collection.py)
     test_fingerprinting.py:
       Test_Fingerprinting_Endpoint:
         '*': v1.39.0


### PR DESCRIPTION
## Motivation

Old implementation discarded so no need to run this tests, they were replaced by test_extended_data_collection.py

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
