### PR TITLE
Remove cleanup parameter for pull_images (not a valid input)

### DIFF
--- a/.github/workflows/run-stream-processing-offload.yml
+++ b/.github/workflows/run-stream-processing-offload.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Pull images
         uses: ./.github/actions/pull_images
         with:
-          cleanup: "false"
           library: golang
           weblog: golang-dummy
           scenarios: '["STREAM_PROCESSING_OFFLOAD", "STREAM_PROCESSING_OFFLOAD_BLOCKING"]'

--- a/utils/scripts/compute_impacted_scenario.py
+++ b/utils/scripts/compute_impacted_scenario.py
@@ -142,6 +142,7 @@ def main() -> None:
                     r"\.github/workflows/run-open-telemetry\.yml": scenario_groups.open_telemetry,
                     r"\.github/workflows/run-parametric\.yml": scenarios.parametric,
                     r"\.github/workflows/run-exotics\.yml": scenario_groups.exotics,
+                    r"\.github/workflows/run-stream-processing-offload\.yml": scenario_groups.stream_processing_offload,
                     r"\.github/.*": None,
                     r"\.gitlab/ssi_gitlab-ci.yml": [
                         scenario_groups.onboarding,


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
