### PR TITLE
Leftover for Merge APPSEC_AND_RC_ENABLED scenario into APPSEC_API_SERURITY_RC

### DIFF
--- a/tests/appsec/test_extended_data_collection.py
+++ b/tests/appsec/test_extended_data_collection.py
@@ -46,7 +46,7 @@ EXTENDED_DATA_COLLECTION_RULE = (
 
 
 @features.appsec_extended_data_collection
-@scenarios.appsec_and_rc_enabled
+@scenarios.appsec_api_security_rc
 class Test_ExtendedDataCollectionCapability:
     """Validate that ASM_EXTENDED_DATA_COLLECTION (44) capability is sent"""
 
@@ -55,7 +55,7 @@ class Test_ExtendedDataCollectionCapability:
 
 
 @features.appsec_extended_data_collection
-@scenarios.appsec_and_rc_enabled
+@scenarios.appsec_api_security_rc
 class Test_ExtendedRequestHeadersDataCollection:
     """Test extended data collection using remote config rules and actions"""
 
@@ -254,7 +254,7 @@ class Test_ExtendedRequestHeadersDataCollection:
 
 
 @features.appsec_extended_data_collection
-@scenarios.appsec_and_rc_enabled
+@scenarios.appsec_api_security_rc
 class Test_ExtendedResponseHeadersDataCollection:
     """Test extended response headers data collection using remote config rules and actions"""
 
@@ -418,7 +418,7 @@ class Test_ExtendedResponseHeadersDataCollection:
 
 
 @features.appsec_extended_data_collection
-@scenarios.appsec_and_rc_enabled
+@scenarios.appsec_api_security_rc
 class Test_ExtendedRequestBodyCollection:
     """Test extended request body data collection using remote config rules and actions"""
 

--- a/tests/appsec/test_ip_blocking_full_denylist.py
+++ b/tests/appsec/test_ip_blocking_full_denylist.py
@@ -28,7 +28,7 @@ class Test_AppSecIPBlockingFullDenylist(BaseFullDenyListTest):
 
     @missing_feature(weblog_variant="spring-boot" and context.library < "java@0.111.0")
     @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
-    @bug(context.library < "ruby@2.11.0-dev", reason="APMRP-56691")
+    @bug(context.library < "ruby@2.11.0-dev", reason="APPSEC-56691")
     def test_blocked_ips(self):
         """Test blocked ips are enforced"""
 

--- a/tests/appsec/test_user_blocking_full_denylist.py
+++ b/tests/appsec/test_user_blocking_full_denylist.py
@@ -34,7 +34,7 @@ class Test_UserBlocking_FullDenylist(BaseFullDenyListTest):
     @bug(context.library < "ruby@1.12.1", reason="APMRP-360")
     @bug(context.library >= "java@1.22.0" and context.library < "java@1.35.0", reason="APMRP-360")
     @bug(library="java", weblog_variant="spring-boot-payara", reason="APPSEC-56006")
-    @bug(context.library < "ruby@2.11.0-dev", reason="APMRP-56691")
+    @bug(context.library < "ruby@2.11.0-dev", reason="APPSEC-56691")
     def test_blocking_test(self):
         """Test with a denylisted user"""
 


### PR DESCRIPTION


## Motivation

Fix PR race, and we are not using merge queue.
This PR https://github.com/DataDog/system-tests/pull/5060 added two tests in appsec_and_rc_enabled
And this PR https://github.com/DataDog/system-tests/pull/5318 removed this scenario.
The CI on the second PR was executed before the merge of the first PR :crying_blood:

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
