### PR TITLE
[ruby] Enable Endpoint Discovery tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -297,16 +297,16 @@ tests/:
       test_ssrf.py:
         Test_Ssrf_BodyJson: v2.14.0
         Test_Ssrf_BodyUrlEncoded: v2.14.0
-        Test_Ssrf_BodyXml: irrelevant # xml body not natively supported
+        Test_Ssrf_BodyXml: irrelevant  # xml body not natively supported
         Test_Ssrf_Capability: v2.15.0
         Test_Ssrf_Mandatory_SpanTags: v2.14.0
         Test_Ssrf_Optional_SpanTags: v2.14.0
-        Test_Ssrf_Rules_Version: missing_feature # requires Telemetry V2
+        Test_Ssrf_Rules_Version: missing_feature  # requires Telemetry V2
         Test_Ssrf_StackTrace: v2.14.0
         Test_Ssrf_Telemetry: v2.14.0
         Test_Ssrf_Telemetry_V2: missing_feature
         Test_Ssrf_UrlQuery: v2.14.0
-        Test_Ssrf_Waf_Version: missing_feature # requires Telemetry V2
+        Test_Ssrf_Waf_Version: missing_feature  # requires Telemetry V2
     waf/:
       test_addresses.py:
         Test_BodyJson: v1.8.0
@@ -317,7 +317,7 @@ tests/:
         Test_GraphQL: v2.3.0
         Test_GrpcServerMethod: missing_feature
         Test_Headers:
-          "*": v0.54.2 # assumed as the oldest supported version
+          "*": v0.54.2  # assumed as the oldest supported version
           sinatra14: missing_feature (endpoint not implemented)
           sinatra22: missing_feature (endpoint not implemented)
           sinatra32: missing_feature (endpoint not implemented)
@@ -732,8 +732,8 @@ tests/:
     test_dynamic_configuration.py:
       TestDynamicConfigSamplingRules: v2.0.0
       TestDynamicConfigTracingEnabled: missing_feature
-      TestDynamicConfigV1: bug (APMAPI-867) # theorical version is v1.13.0
-      TestDynamicConfigV1_EmptyServiceTargets: v2.8.0 # version unknown
+      TestDynamicConfigV1: bug (APMAPI-867)  # theorical version is v1.13.0
+      TestDynamicConfigV1_EmptyServiceTargets: v2.8.0  # version unknown
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_headers_baggage.py:
@@ -751,11 +751,11 @@ tests/:
       Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not supported)
       Test_Parametric_DDTrace_Baggage: missing_feature (baggage is not supported)
       Test_Parametric_DDTrace_Current_Span: incomplete_test_app (current span endpoint is not supported)
-      Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778) # set_name endpoint should set the resource name on a span (not the operation name)
+      Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778)  # set_name endpoint should set the resource name on a span (not the operation name)
       Test_Parametric_Otel_Baggage: missing_feature (otel baggage is not supported)
       Test_Parametric_Otel_Current_Span: incomplete_test_app (otel current span endpoint is not supported)
       Test_Parametric_Write_Log: missing_feature
-    test_partial_flushing.py: # Not configurable in a standard way
+    test_partial_flushing.py:  # Not configurable in a standard way
       Test_Partial_Flushing: missing_feature
     test_process_discovery.py:
       Test_ProcessDiscovery: v2.18.0
@@ -776,7 +776,7 @@ tests/:
       Test_TelemetrySCAEnvVar: v2.1.0
       Test_TelemetrySSIConfigs: missing_feature
     test_trace_sampling.py:
-      Test_Trace_Sampling_Basic: v1.0.0 # TODO what is the earliest version?
+      Test_Trace_Sampling_Basic: v1.0.0  # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: v2.0.0
       Test_Trace_Sampling_Globs_Feb2024_Revision: v2.0.0
       Test_Trace_Sampling_Resource: v2.0.0
@@ -871,7 +871,7 @@ tests/:
     Test_HeaderTags: v1.13.0
     Test_HeaderTags_Colon_Leading: v1.13.0
     Test_HeaderTags_Colon_Trailing: v1.13.0
-    Test_HeaderTags_DynamicConfig: bug (APMAPI-867) # theorical version is v2.0.0
+    Test_HeaderTags_DynamicConfig: bug (APMAPI-867)  # theorical version is v2.0.0
     Test_HeaderTags_Long: v1.13.0
     Test_HeaderTags_Short: v1.13.0
     Test_HeaderTags_Whitespace_Header: v1.13.0
@@ -885,11 +885,11 @@ tests/:
   test_protobuf.py: missing_feature
   test_resource_renaming.py: missing_feature
   test_sampling_rates.py:
-    Test_SampleRateFunction: v2.15.0 # real version unknown
-    Test_SamplingDecisionAdded: v2.12.1 # real version unknown
-    Test_SamplingDecisions: v2.15.0 # real version unknown
-    Test_SamplingDeterminism: v2.12.1 # real version unknown
-    Test_SamplingRates: v2.15.0 # real version unknown
+    Test_SampleRateFunction: v2.15.0  # real version unknown
+    Test_SamplingDecisionAdded: v2.12.1  # real version unknown
+    Test_SamplingDecisions: v2.15.0  # real version unknown
+    Test_SamplingDeterminism: v2.12.1  # real version unknown
+    Test_SamplingRates: v2.15.0  # real version unknown
   test_scrubbing.py:
     Test_UrlField: missing_feature (Needs weblog endpoint)
     Test_UrlQuery: v1.0.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -24,6 +24,7 @@ tests/:
         Test_Endpoint_Discovery:
           "*": v2.22.0.dev
           rack: irrelevant (rack does not have a router)
+          rails42: irrelevant
           sinatra14: missing_feature
           sinatra22: missing_feature
           sinatra32: missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -21,7 +21,14 @@ tests/:
         Test_API_Security_Sampling_Rate: irrelevant
         Test_API_Security_Sampling_With_Delay: v2.18.0
       test_endpoint_discovery.py:
-        Test_Endpoint_Discovery: missing_feature
+        Test_Endpoint_Discovery:
+          "*": v2.22.0.dev
+          rack: irrelevant (rack does not have a router)
+          sinatra14: missing_feature
+          sinatra22: missing_feature
+          sinatra32: missing_feature
+          sinatra41: missing_feature
+          uds-sinatra: missing_feature
       test_schemas.py:
         Test_Scanners: v2.19.0
         Test_Schema_Request_Cookies: v1.15.0
@@ -290,16 +297,16 @@ tests/:
       test_ssrf.py:
         Test_Ssrf_BodyJson: v2.14.0
         Test_Ssrf_BodyUrlEncoded: v2.14.0
-        Test_Ssrf_BodyXml: irrelevant  # xml body not natively supported
+        Test_Ssrf_BodyXml: irrelevant # xml body not natively supported
         Test_Ssrf_Capability: v2.15.0
         Test_Ssrf_Mandatory_SpanTags: v2.14.0
         Test_Ssrf_Optional_SpanTags: v2.14.0
-        Test_Ssrf_Rules_Version: missing_feature  # requires Telemetry V2
+        Test_Ssrf_Rules_Version: missing_feature # requires Telemetry V2
         Test_Ssrf_StackTrace: v2.14.0
         Test_Ssrf_Telemetry: v2.14.0
         Test_Ssrf_Telemetry_V2: missing_feature
         Test_Ssrf_UrlQuery: v2.14.0
-        Test_Ssrf_Waf_Version: missing_feature  # requires Telemetry V2
+        Test_Ssrf_Waf_Version: missing_feature # requires Telemetry V2
     waf/:
       test_addresses.py:
         Test_BodyJson: v1.8.0
@@ -310,7 +317,7 @@ tests/:
         Test_GraphQL: v2.3.0
         Test_GrpcServerMethod: missing_feature
         Test_Headers:
-          "*": v0.54.2  # assumed as the oldest supported version
+          "*": v0.54.2 # assumed as the oldest supported version
           sinatra14: missing_feature (endpoint not implemented)
           sinatra22: missing_feature (endpoint not implemented)
           sinatra32: missing_feature (endpoint not implemented)
@@ -725,8 +732,8 @@ tests/:
     test_dynamic_configuration.py:
       TestDynamicConfigSamplingRules: v2.0.0
       TestDynamicConfigTracingEnabled: missing_feature
-      TestDynamicConfigV1: bug (APMAPI-867)  # theorical version is v1.13.0
-      TestDynamicConfigV1_EmptyServiceTargets: v2.8.0  # version unknown
+      TestDynamicConfigV1: bug (APMAPI-867) # theorical version is v1.13.0
+      TestDynamicConfigV1_EmptyServiceTargets: v2.8.0 # version unknown
       TestDynamicConfigV1_ServiceTargets: missing_feature
       TestDynamicConfigV2: missing_feature
     test_headers_baggage.py:
@@ -744,11 +751,11 @@ tests/:
       Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not supported)
       Test_Parametric_DDTrace_Baggage: missing_feature (baggage is not supported)
       Test_Parametric_DDTrace_Current_Span: incomplete_test_app (current span endpoint is not supported)
-      Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778)  # set_name endpoint should set the resource name on a span (not the operation name)
+      Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778) # set_name endpoint should set the resource name on a span (not the operation name)
       Test_Parametric_Otel_Baggage: missing_feature (otel baggage is not supported)
       Test_Parametric_Otel_Current_Span: incomplete_test_app (otel current span endpoint is not supported)
       Test_Parametric_Write_Log: missing_feature
-    test_partial_flushing.py:  # Not configurable in a standard way
+    test_partial_flushing.py: # Not configurable in a standard way
       Test_Partial_Flushing: missing_feature
     test_process_discovery.py:
       Test_ProcessDiscovery: v2.18.0
@@ -769,7 +776,7 @@ tests/:
       Test_TelemetrySCAEnvVar: v2.1.0
       Test_TelemetrySSIConfigs: missing_feature
     test_trace_sampling.py:
-      Test_Trace_Sampling_Basic: v1.0.0  # TODO what is the earliest version?
+      Test_Trace_Sampling_Basic: v1.0.0 # TODO what is the earliest version?
       Test_Trace_Sampling_Globs: v2.0.0
       Test_Trace_Sampling_Globs_Feb2024_Revision: v2.0.0
       Test_Trace_Sampling_Resource: v2.0.0
@@ -846,10 +853,10 @@ tests/:
     Test_Span_Links_Omit_Tracestate_From_Conflicting_Contexts: missing_feature (implementation specs have not been determined)
   test_graphql.py:
     Test_GraphQLOperationErrorReporting:
-      '*': missing_feature
+      "*": missing_feature
       graphql23: v2.22.1-dev
     Test_GraphQLOperationErrorTracking:
-      '*': missing_feature
+      "*": missing_feature
       graphql23: missing_feature
   test_identify.py:
     Test_Basic: v1.0.0
@@ -864,7 +871,7 @@ tests/:
     Test_HeaderTags: v1.13.0
     Test_HeaderTags_Colon_Leading: v1.13.0
     Test_HeaderTags_Colon_Trailing: v1.13.0
-    Test_HeaderTags_DynamicConfig: bug (APMAPI-867)  # theorical version is v2.0.0
+    Test_HeaderTags_DynamicConfig: bug (APMAPI-867) # theorical version is v2.0.0
     Test_HeaderTags_Long: v1.13.0
     Test_HeaderTags_Short: v1.13.0
     Test_HeaderTags_Whitespace_Header: v1.13.0
@@ -878,11 +885,11 @@ tests/:
   test_protobuf.py: missing_feature
   test_resource_renaming.py: missing_feature
   test_sampling_rates.py:
-    Test_SampleRateFunction: v2.15.0  # real version unknown
-    Test_SamplingDecisionAdded: v2.12.1  # real version unknown
-    Test_SamplingDecisions: v2.15.0  # real version unknown
-    Test_SamplingDeterminism: v2.12.1  # real version unknown
-    Test_SamplingRates: v2.15.0  # real version unknown
+    Test_SampleRateFunction: v2.15.0 # real version unknown
+    Test_SamplingDecisionAdded: v2.12.1 # real version unknown
+    Test_SamplingDecisions: v2.15.0 # real version unknown
+    Test_SamplingDeterminism: v2.12.1 # real version unknown
+    Test_SamplingRates: v2.15.0 # real version unknown
   test_scrubbing.py:
     Test_UrlField: missing_feature (Needs weblog endpoint)
     Test_UrlQuery: v1.0.0

--- a/tests/appsec/api_security/test_endpoint_discovery.py
+++ b/tests/appsec/api_security/test_endpoint_discovery.py
@@ -124,7 +124,7 @@ class Test_Endpoint_Discovery:
         self.main_setup()
 
     @irrelevant(
-        context.library in ["dotnet", "nodejs", "python"],
+        context.library in ["dotnet", "nodejs", "python", "ruby"],
         reason="Not supported",
     )
     @missing_feature(context.library == "java" and context.weblog_variant in ["spring-boot"])
@@ -146,7 +146,7 @@ class Test_Endpoint_Discovery:
         (context.library == "python" and context.weblog_variant != "fastapi"),
         reason="Not applicable to weblog variant",
     )
-    @irrelevant(context.library in ["dotnet", "nodejs"], reason="Not supported")
+    @irrelevant(context.library in ["dotnet", "nodejs", "ruby"], reason="Not supported")
     def test_optional_response_body_type(self):
         endpoints = self._get_endpoints()
         found = False
@@ -172,7 +172,7 @@ class Test_Endpoint_Discovery:
         (context.library == "python" and context.weblog_variant != "fastapi"),
         reason="Not applicable to weblog variant",
     )
-    @irrelevant(context.library in ["dotnet", "nodejs"], reason="Not supported")
+    @irrelevant(context.library in ["dotnet", "nodejs", "ruby"], reason="Not supported")
     def test_optional_response_code(self):
         endpoints = self._get_endpoints()
         found = False
@@ -193,7 +193,7 @@ class Test_Endpoint_Discovery:
         reason="Not applicable to weblog variant",
     )
     @irrelevant(
-        context.library in ["dotnet", "nodejs", "python"],
+        context.library in ["dotnet", "nodejs", "python", "ruby"],
         reason="Not supported",
     )
     def test_optional_authentication(self):
@@ -212,7 +212,7 @@ class Test_Endpoint_Discovery:
         self.main_setup()
 
     @irrelevant(
-        context.library in ["python", "dotnet", "nodejs"],
+        context.library in ["python", "dotnet", "nodejs", "ruby"],
         reason="Not supported",
     )
     def test_optional_metadata(self):


### PR DESCRIPTION
## Motivation

We have a [PR](https://github.com/DataDog/dd-trace-rb/pull/4919) that adds Endpoint Collection to the ruby tracer.

## Changes

This enables endpoints collection tests for Ruby.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
