### PR TITLE
[HandsOffConfig] Activate default tests and one telemetry test

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -549,7 +549,7 @@ tests/:
       Test_Config_TraceEnabled: v3.3.0
       Test_Config_TraceLogDirectory: v3.3.0
       Test_Config_UnifiedServiceTagging: v3.3.0
-      Test_Stable_Config_Default: missing_feature
+      Test_Stable_Config_Default: v3.28.0
     test_crashtracking.py:
       Test_Crashtracking: v3.2.0
     test_dynamic_configuration.py:
@@ -588,7 +588,7 @@ tests/:
       Test_Consistent_Configs: missing_feature
       Test_Defaults: v2.49.0
       Test_Environment: v2.49.0
-      Test_Stable_Configuration_Origin: missing_feature
+      Test_Stable_Configuration_Origin: v3.28.0
       Test_TelemetryInstallSignature: v2.45.0
       Test_TelemetrySCAEnvVar: v2.50.0
       Test_TelemetrySSIConfigs: v2.53.0

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -394,8 +394,11 @@ SDK_DEFAULT_STABLE_CONFIG = {
     else "true"
     if context.library == "golang"
     else "false",  # Profiling is enabled as "1" by default in PHP if loaded. As for Go, the profiler must be started manually, so it is enabled by default when started
-    "dd_data_streams_enabled": "false",
+    "dd_data_streams_enabled": "false"
+    if context.library != "dotnet"
+    else "true",  # Data streams is now enabled by default in non-serverless environments in dotnet
     "dd_logs_injection": {
+        "dotnet": "true",
         "ruby": "true",
         "java": "true",
         "golang": None,

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -629,6 +629,7 @@ class Test_Stable_Configuration_Origin(StableConfigWriter):
             assert telemetry_item["value"]
 
     @missing_feature(context.library == "nodejs", reason="Not implemented")
+    @missing_feature(context.library == "dotnet", reason="Not implemented")
     @missing_feature(context.library <= "java@v1.53.0-SNAPSHOT", reason="Not implemented")
     @pytest.mark.parametrize(
         ("local_cfg", "library_env", "fleet_cfg", "fleet_config_id"),


### PR DESCRIPTION
## Motivation

Hands-off config has been merged and is now fully supported in .NET. 
Activation of 2 steps here:
- handsoff config main default test
- telemetry test (but not config-id) is reported

<!-- What inspired you to submit this pull request? -->

## Changes
Adapt weblog, adding some new configuration properties among which is profiler enabled


