### PR TITLE
Partial fix for DEBUG-4541: line is not required for field symbol

### DIFF
--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -663,12 +663,6 @@ class EndToEndScenario(DockerScenario):
             ),
             _SchemaBug(
                 endpoint="/symdb/v1/input",
-                data_path="$[].content.scopes[].scopes[].symbols[]",
-                condition=self.library >= "golang@2.4.0-dev" and self.name == "DEBUGGER_SYMDB",
-                ticket="DEBUG-4541",
-            ),
-            _SchemaBug(
-                endpoint="/symdb/v1/input",
                 data_path="$[].content",
                 condition=self.library >= "golang@2.4.0-dev" and self.name == "DEBUGGER_SYMDB",
                 ticket="DEBUG-4541",

--- a/utils/interfaces/schemas/library/symdb/v1/input-request.json
+++ b/utils/interfaces/schemas/library/symdb/v1/input-request.json
@@ -23,7 +23,17 @@
     },
     "symbol": {
       "type": "object",
-      "required": ["line", "name", "symbol_type", "type"],
+      "if": {
+        "properties": {
+          "symbol_type": {"const": "field"}
+        }
+      },
+      "then": {
+        "required": ["name", "symbol_type", "type"]
+      },
+      "else": {
+        "required": ["line", "name", "symbol_type", "type"]
+      },
       "properties": {
         "language_specifics": { "type": "object" },
         "line": { "type": "integer" },


### PR DESCRIPTION
## Motivation

the `line` property on `symbol` objet is not required when `symbol_type=field`.

## Changes

JSON schema shenanigans!

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
