### PR TITLE
Add FFE_FLAG_CONFIGURATION_RULES Capabilities Bit

### DIFF
--- a/utils/dd_constants.py
+++ b/utils/dd_constants.py
@@ -81,6 +81,7 @@ class Capabilities(IntEnum):
     ASM_TRACE_TAGGING_RULES = 43
     ASM_EXTENDED_DATA_COLLECTION = 44
     APM_TRACING_MULTICONFIG = 45
+    FFE_FLAG_CONFIGURATION_RULES = 46
 
 
 class SamplingPriority(IntEnum):


### PR DESCRIPTION
## Motivation

FF&E integration into Node.js tracer

## Changes

adds FFE_FLAG_CONFIGURATION_RULES bit 46 to constants

## Notes

See capability bit PR here: https://github.com/DataDog/dd-go/pull/200760