### PR TITLE
Set apm-sdk-capabilities as owner for config/telemetry/sampling tests.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@
 /utils/telemetry/intake/static/ @DataDog/apm-sdk
 
 /tests/parametric/ @mabdinur @DataDog/system-tests-core @DataDog/apm-sdk-capabilities
+/tests/parametric/test_config_consistency.py @DataDog/apm-sdk-capabilities
 /tests/otel_tracing_e2e/ @DataDog/opentelemetry @DataDog/system-tests-core
 /tests/remote_config/ @DataDog/remote-config @DataDog/system-tests-core
 /tests/appsec/ @DataDog/asm-libraries @DataDog/system-tests-core

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -60,7 +60,7 @@ class _Features:
         https://feature-parity.us1.prod.dog/#/?feature=2
         """
         return _mark_test_object(
-            test_object, feature_id=2, owner=_Owner.tracer
+            test_object, feature_id=2, owner=_Owner.sdk_capabilities
         )  # library/config, tracing/configuration, tracing/configuration/consistency
 
     @staticmethod
@@ -191,7 +191,7 @@ class _Features:
         https://feature-parity.us1.prod.dog/#/?feature=17
         """
         return _mark_test_object(
-            test_object, feature_id=17, owner=_Owner.tracer
+            test_object, feature_id=17, owner=_Owner.sdk_capabilities
         )  # tracing/configuration, tracing/configuration/consistency
 
     @staticmethod
@@ -2246,7 +2246,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=365
         """
-        return _mark_test_object(test_object, feature_id=365, owner=_Owner.tracer)  # library/config
+        return _mark_test_object(test_object, feature_id=365, owner=_Owner.sdk_capabilities)
 
     @staticmethod
     def single_span_ingestion_control(test_object):
@@ -2287,7 +2287,7 @@ class _Features:
         https://feature-parity.us1.prod.dog/#/?feature=374
         """
         return _mark_test_object(
-            test_object, feature_id=374, owner=_Owner.tracer
+            test_object, feature_id=374, owner=_Owner.sdk_capabilities
         )  # tracing/configuration, tracing/configuration/consistency
 
     @staticmethod
@@ -2297,7 +2297,7 @@ class _Features:
         https://feature-parity.us1.prod.dog/#/?feature=375
         """
         return _mark_test_object(
-            test_object, feature_id=375, owner=_Owner.tracer
+            test_object, feature_id=375, owner=_Owner.sdk_capabilities
         )  # tracing/configuration, tracing/configuration/consistency
 
     @staticmethod
@@ -2317,7 +2317,7 @@ class _Features:
         https://feature-parity.us1.prod.dog/#/?feature=377
         """
         return _mark_test_object(
-            test_object, feature_id=377, owner=_Owner.tracer
+            test_object, feature_id=377, owner=_Owner.sdk_capabilities
         )  # tracing/configuration, tracing/configuration/consistency
 
     @staticmethod
@@ -2357,7 +2357,7 @@ class _Features:
         https://feature-parity.us1.prod.dog/#/?feature=384
         """
         return _mark_test_object(
-            test_object, feature_id=384, owner=_Owner.tracer
+            test_object, feature_id=384, owner=_Owner.sdk_capabilities
         )  # tracing/configuration, tracing/configuration/consistency
 
     @staticmethod


### PR DESCRIPTION
## Changes

Set relevant ownership for config/telemetry/sampling tests.

@bm1549 if you think some of them does not belong to @DataDog/apm-sdk-capabilities , could you help me find which team would own those features?

@DataDog/apm-sdk

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
