### PR TITLE
test(debugger): increase timeout & add probe status asserts

### DIFF
--- a/tests/debugger/test_debugger_probe_snapshot.py
+++ b/tests/debugger/test_debugger_probe_snapshot.py
@@ -41,7 +41,11 @@ class BaseDebuggerProbeSnaphotTest(debugger.BaseDebuggerTest):
 
         ### send requests
         self.send_rc_probes()
-        self.wait_for_all_probes(statuses=["INSTALLED"])
+        if not self.wait_for_all_probes(statuses=["INSTALLED"], timeout=60):
+            self.setup_failures.append("Probes did not reach INSTALLED status")
+            # Stop the test if the probes did not reach INSTALLED status since the probe won't exist
+            # to send a snapshot.
+            return
 
         start_time = time.time()
         self.send_weblog_request(request_path)
@@ -50,7 +54,9 @@ class BaseDebuggerProbeSnaphotTest(debugger.BaseDebuggerTest):
         self.total_request_time = end_time - start_time
 
         self.wait_for_all_probes(statuses=["EMITTING"])
-        self.wait_for_snapshot_received()
+
+        if not self.wait_for_snapshot_received(timeout=60):
+            self.setup_failures.append("Snapshot was not received")
 
     def _assert(self):
         self.collect()

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -371,7 +371,8 @@ class BaseDebuggerTest:
                     continue
 
                 if not exception_snapshot:
-                    return True
+                    self._snapshot_found = True
+                    break
 
                 if "exceptionId" not in snapshot:
                     continue


### PR DESCRIPTION
## Motivation

There are flaky debugger tests that take the form:

```
ValueError: Snapshot log1eed7-5302-4f49-992d-549570e584c2 was not received.
```

Unfortunately, this doesn't give us enough information to properly fix the problem, so instead we'll fail from the setup directly. We also bump the timeout while waiting for the `INSTALLED` status and the snapshot because either of these will prevent the test from passing.

## Changes

* Added a timeout and failure handling when waiting for probes to reach the "INSTALLED" status. If probes do not reach this status within 60 seconds, a failure message is recorded and the setup process exits early.
* Added a timeout and failure handling when waiting for a snapshot to be received. If the snapshot is not received within 60 seconds, a failure message is recorded.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
