### PR TITLE
Add variant in test names in Junit reports

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -541,6 +541,13 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
                     testcase.attrib["name"] = testcase.attrib["classname"] + "." + testcase.attrib["name"]
                     del testcase.attrib["classname"]
 
+                if context.weblog_variant:
+                    name = testcase.attrib["name"]
+                    if name.endswith("]"):
+                        testcase.attrib["name"] = f"{name[:-1]}, {context.weblog_variant}]"
+                    else:
+                        testcase.attrib["name"] = f"{name}[{context.weblog_variant}]"
+
             junit_report.write(session.config.option.xmlpath)
 
         try:

--- a/tests/test_the_test/reportJunit_expected.xml
+++ b/tests/test_the_test/reportJunit_expected.xml
@@ -3,7 +3,7 @@
         <properties>
             <property name="dd_tags[systest.suite.context.scenario]" value="MOCK_THE_TEST" />
         </properties>
-        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error" time="0.000">
+        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error[spring]" time="0.000">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="error" />
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]" />
@@ -15,7 +15,7 @@ E       TypeError: nope!
 
 tests/test_the_test/test_junit.py:15: TypeError</error>
         </testcase>
-        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error_on_bug" time="0.000">
+        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error_on_bug[spring]" time="0.000">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="xfailed" />
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]" />
@@ -24,7 +24,7 @@ tests/test_the_test/test_junit.py:15: TypeError</error>
             </properties>
             <skipped type="pytest.xfail" message="bug (APMRP-360)" />
         </testcase>
-        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error_on_missing_feature" time="0.000">
+        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_error_on_missing_feature[spring]" time="0.000">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="xfailed" />
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]" />
@@ -33,7 +33,7 @@ tests/test_the_test/test_junit.py:15: TypeError</error>
             </properties>
             <skipped type="pytest.xfail" message="missing_feature (APMRP-360)" />
         </testcase>
-        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_fail" time="0.000">
+        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_fail[spring]" time="0.000">
             <properties>
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
                 <property name="dd_tags[systest.case.outcome]" value="failed"/>
@@ -44,7 +44,7 @@ tests/test_the_test/test_junit.py:15: TypeError</error>
 E       Failed: dummy
 tests/test_the_test/test_junit.py:20: Failed</failure>
         </testcase>
-        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_flaky" time="0.000">
+        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_flaky[spring]" time="0.000">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="skipped"/>
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
@@ -53,7 +53,7 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
             </properties>
             <skipped type="pytest.skip" message="flaky (APMRP-360)">/Users/charles.debeauchesne/repos/system-tests/tests/test_the_test/test_junit.py:34: flaky (APMRP-360)</skipped>
         </testcase>
-        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_force_skip">
+        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_force_skip[spring]">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="skipped"/>
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
@@ -62,13 +62,13 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
             </properties>
             <skipped message="bug (APMRP-360)" type="pytest.skip">system-tests/tests/test_the_test/test_junit.py:01: bug (APMRP-360)</skipped>
         </testcase>
-        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_pass">
+        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_pass[spring]">
             <properties>
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
                 <property name="dd_tags[systest.case.outcome]" value="passed"/>
             </properties>
         </testcase>
-        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_skipped" time="0.000">
+        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_skipped[spring]" time="0.000">
             <properties>
                 <property name="dd_tags[systest.case.outcome]" value="skipped"/>
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
@@ -76,7 +76,7 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
             </properties>
             <skipped type="pytest.skip" message="irrelevant">/Users/charles.debeauchesne/repos/system-tests/tests/test_the_test/test_junit.py:22: irrelevant</skipped>
         </testcase>
-        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_xfail" time="0.000">
+        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_xfail[spring]" time="0.000">
             <properties>
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
                 <property name="dd_tags[systest.case.declaration]" value="bug"/>
@@ -85,7 +85,7 @@ tests/test_the_test/test_junit.py:20: Failed</failure>
             </properties>
             <skipped type="pytest.xfail" message="bug (APMRP-360)" />
         </testcase>
-        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_xpass" time="0.000">
+        <testcase name="tests.test_the_test.test_junit.Test_Cases.test_xpass[spring]" time="0.000">
             <properties>
                 <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
                 <property name="dd_tags[systest.case.declaration]" value="bug"/>


### PR DESCRIPTION
## Motivation

Without this information, flaky and all consolidation metrics fails in test Optimization

## Changes

In Junit, test names contains weblog_variant information

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
