### PR TITLE
[java] fix reporting of process tags test for spring-boot-3-native {

### DIFF
--- a/tests/apm_tracing_e2e/test_process_tags.py
+++ b/tests/apm_tracing_e2e/test_process_tags.py
@@ -1,12 +1,12 @@
 from utils import weblog, interfaces, scenarios, features, context
-from utils._decorators import missing_feature
+from utils._decorators import missing_feature, irrelevant
 from utils.interfaces._library.miscs import validate_process_tags
 
 
 @scenarios.tracing_config_nondefault
 @features.process_tags
 @missing_feature(
-    condition=context.library.name not in ("java", "golang") or context.weblog_variant == "spring-boot-3-native",
+    condition=context.library.name not in ("java", "golang"),
     reason="Not yet implemented",
 )
 class Test_Process_Tags:
@@ -29,6 +29,9 @@ class Test_Process_Tags:
     def setup_remote_config_process_tags(self):
         self.req = weblog.get("/status?code=200")
 
+    @irrelevant(
+        condition=context.weblog_variant == "spring-boot-3-native",
+    )
     def test_remote_config_process_tags(self):
         found = False
         for data in interfaces.library.get_data(path_filters="/v0.7/config"):
@@ -41,6 +44,9 @@ class Test_Process_Tags:
     def setup_telemetry_process_tags(self):
         self.req = weblog.get("/status?code=200")
 
+    @irrelevant(
+        condition=context.weblog_variant == "spring-boot-3-native",
+    )
     def test_telemetry_process_tags(self):
         found = False
         telemetry_data = list(interfaces.library.get_telemetry_data())


### PR DESCRIPTION
## Motivation

Only have relevant tests reported on feature parity dashboard for process tags.
- test_remote_config_process_tags, test_telemetry_process_tags can be ignored on springboot-native
- test_tracing_process_tags passes as it doesn't involve an agent, adding it

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
