### PR TITLE
AWS SSI: Enable Oracle Linux again

### DIFF
--- a/utils/virtual_machine/virtual_machines.json
+++ b/utils/virtual_machine/virtual_machines.json
@@ -494,7 +494,7 @@
             "os_branch": "oracle_linux",
             "os_cpu": "amd64",
             "default_vm": false,
-            "disabled": true
+            "disabled": false
         },
         {
             "name": "OracleLinux_9_3_arm64",
@@ -508,7 +508,7 @@
             "os_branch": "oracle_linux",
             "os_cpu": "arm64",
             "default_vm": false,
-            "disabled": true
+            "disabled": false
         },
         {
             "name": "OracleLinux_9_2_amd64",
@@ -522,7 +522,7 @@
             "os_branch": "oracle_linux",
             "os_cpu": "amd64",
             "default_vm": false,
-            "disabled": true
+            "disabled": false
         },
         {
             "name": "OracleLinux_9_2_arm64",
@@ -536,7 +536,7 @@
             "os_branch": "oracle_linux",
             "os_cpu": "arm64",
             "default_vm": false,
-            "disabled": true
+            "disabled": false
         },
         {
             "name": "OracleLinux_8_8_amd64",
@@ -550,7 +550,7 @@
             "os_branch": "oracle_linux",
             "os_cpu": "amd64",
             "default_vm": false,
-            "disabled": true
+            "disabled": false
         },
         {
             "name": "OracleLinux_8_8_arm64",
@@ -564,7 +564,7 @@
             "os_branch": "oracle_linux",
             "os_cpu": "arm64",
             "default_vm": false,
-            "disabled": true
+            "disabled": false
         },
         {
             "name": "AlmaLinux_8_amd64",


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The oracle linux vm have been disabled due to a problem.

## Changes

<!-- A brief description of the change being made with this pull request. -->
The AMI are regenerated. Enable the machines again

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
