### PR TITLE
[cpp] harden git clone DataDog/dd-trace-cpp

### DIFF
--- a/utils/build/docker/cpp/parametric/install_ddtrace.sh
+++ b/utils/build/docker/cpp/parametric/install_ddtrace.sh
@@ -12,7 +12,7 @@ git_clone(){
 }
 
 git_clone_latest_release (){
-   url_to_clone="https://github.com/DataDog/dd-trace-cpp"
+   url_to_clone="https://github.com/DataDog/dd-trace-cpp.git"
    latest_release=$(curl -s  https://api.github.com/repos/DataDog/dd-trace-cpp/releases/latest | jq '.tag_name'| tr -d '"')
    echo "$latest_release" > SYSTEM_TESTS_LIBRARY_VERSION
    git_clone "$url_to_clone" "$latest_release"


### PR DESCRIPTION
## Motivation

`git clone` fails time to time : https://github.com/DataDog/system-tests-dashboard/actions/runs/18117537112/job/51556111662#step:6:236

As stated @zacharycmontoya 

> I wonder if it's because the git clone URL is https://github.com/DataDog/dd-trace-cpp  which doesn't include the .git in the path. We could see if setting the URL to https://github.com/DataDog/dd-trace-cpp.git would be more reliable

## Changes

add the `.git` extension to the URL used to close DataDog/dd-trace-cpp

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
