### PR TITLE
Deactivate profiling by default on nginx

### DIFF
--- a/utils/build/docker/cpp_nginx/nginx.Dockerfile
+++ b/utils/build/docker/cpp_nginx/nginx.Dockerfile
@@ -105,7 +105,4 @@ RUN ./install_ddtrace.sh
 # Profiling setup
 RUN ./install_ddprof.sh /usr/local/bin
 
-# With or without the native profiler
-ARG DDPROF_ENABLE="yes"
-ENV DDPROF_ENABLE=${DDPROF_ENABLE}
 CMD ["./app.sh"]

--- a/utils/build/docker/cpp_nginx/nginx/app.sh
+++ b/utils/build/docker/cpp_nginx/nginx/app.sh
@@ -6,7 +6,8 @@ if [[ $DD_TRACE_DEBUG = true ]]; then
   sed -i 's/\(error_log [^ ]* \)info;/\1debug;/' /etc/nginx/nginx.conf
 fi
 
-if [[ "${DDPROF_ENABLE:-,,}" == "yes" ]]; then
+# ddprof is not in a tracer, it is a wrapper around executable
+if [[ "${DD_PROFILING_ENABLED:-,,}" == "true" ]]; then
   ddprof -l notice nginx -g 'daemon off;'
 else
   nginx -g 'daemon off;'

--- a/utils/proxy/_deserializer.py
+++ b/utils/proxy/_deserializer.py
@@ -201,13 +201,13 @@ def deserialize_http_message(
     if content_type and content_type.startswith("multipart/form-data;"):
         decoded = []
         for part in MultipartDecoder(content, raw_content_type).parts:
-            headers = {k.decode("utf-8"): v.decode("utf-8") for k, v in part.headers.items()}
+            headers: dict[str, str] = {k.decode("utf-8").lower(): v.decode("utf-8") for k, v in part.headers.items()}
             item: dict[str, Any] = {"headers": headers}
 
             content_type_part = ""
 
             for name, value in headers.items():
-                if name.lower() == "content-type":
+                if name == "content-type":
                     content_type_part = value.lower()
                     break
 
@@ -250,10 +250,12 @@ def deserialize_http_message(
 def _deserialize_file_in_multipart_form_data(
     path: str, item: dict, headers: dict, export_content_files_to: str, content: bytes
 ) -> None:
-    content_disposition = headers.get("Content-Disposition", "")
+    content_disposition = headers.get("content-disposition", "<not set>")
 
     if not content_disposition.startswith("form-data"):
-        item["system-tests-error"] = "Unknown content-disposition, please contact #apm-shared-testing"
+        item["system-tests-error"] = (
+            f"Unknown content-disposition: {content_disposition}, please contact #apm-shared-testing"
+        )
         item["content"] = None
 
     else:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
