### PR TITLE
[Java] Add api10 routes to vert3 weblog

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -754,13 +754,27 @@ tests/:
           spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
     rasp/:
       test_api10.py:
-        Test_API10_all: missing_feature
-        Test_API10_request_body: missing_feature
-        Test_API10_request_headers: missing_feature
-        Test_API10_request_method: missing_feature
-        Test_API10_response_body: missing_feature
-        Test_API10_response_headers: missing_feature
-        Test_API10_response_status: missing_feature
+        Test_API10_all:
+          '*': missing_feature
+          vertx3: v1.54.0
+        Test_API10_request_body:
+          '*': missing_feature
+          vertx3: v1.54.0
+        Test_API10_request_headers:
+          '*': missing_feature
+          vertx3: v1.54.0
+        Test_API10_request_method:
+          '*': missing_feature
+          vertx3: v1.54.0
+        Test_API10_response_body:
+          '*': missing_feature
+          vertx3: v1.54.0
+        Test_API10_response_headers:
+          '*': missing_feature
+          vertx3: v1.54.0
+        Test_API10_response_status:
+          '*': missing_feature
+          vertx3: v1.54.0
       test_cmdi.py:
         Test_Cmdi_BodyJson:
           '*': v1.45.0

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
@@ -9,6 +9,7 @@ import com.datadoghq.system_tests.iast.utils.CryptoExamples;
 import com.datadoghq.vertx3.iast.routes.IastSinkRouteProvider;
 import com.datadoghq.vertx3.iast.routes.IastSourceRouteProvider;
 import com.datadoghq.vertx3.iast.routes.IastSamplingRouteProvider;
+import com.datadoghq.vertx3.rasp.Api10RouteProvider;
 import com.datadoghq.vertx3.rasp.RaspRouteProvider;
 import datadog.appsec.api.blocking.Blocking;
 import datadog.appsec.api.login.EventTrackerV2;
@@ -434,6 +435,7 @@ public class Main {
 
         iastRouteProviders().forEach(provider -> provider.accept(router));
         raspRouteProviders().forEach(provider -> provider.accept(router));
+
         server.requestHandler(router::accept).listen(7777);
     }
 
@@ -446,7 +448,7 @@ public class Main {
     }
 
     private static Stream<Consumer<Router>> raspRouteProviders() {
-        return Stream.of(new RaspRouteProvider(DATA_SOURCE));
+        return Stream.of(new RaspRouteProvider(DATA_SOURCE), new Api10RouteProvider());
     }
 
     private static Map<String, String> asMetadataMap(final JsonObject metadata) {

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/rasp/Api10RouteProvider.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/rasp/Api10RouteProvider.java
@@ -1,0 +1,101 @@
+package com.datadoghq.vertx3.rasp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class Api10RouteProvider implements Consumer<Router> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Api10RouteProvider.class);
+    private static final String INTERNAL_SERVER_URL = "http://internal_server:8089/mirror/%s%s";
+
+
+    private final ObjectMapper mapper;
+    private final OkHttpClient client;
+
+    public Api10RouteProvider() {
+        mapper = new ObjectMapper();
+        client = new OkHttpClient.Builder().proxy(Proxy.NO_PROXY).build();
+    }
+
+    @Override
+    public void accept(final Router router) {
+        router.route("/external_request").handler(BodyHandler.create());
+        router.route().path("/external_request")
+                .blockingHandler(rc -> {
+                    try {
+                        final Request downstream = prepareRequest(rc);
+                        final Response response = client.newCall(downstream).execute();
+                        rc.response().setStatusCode(200).end(parseResponse(response).encode());
+                    } catch (Throwable e) {
+                        LOGGER.error("Failed to parse request", e);
+                        JsonObject json = new JsonObject().put("error", e.getMessage());
+                        rc.response().setStatusCode(500).end(json.encode());
+                    }
+                });
+    }
+
+    private Request prepareRequest(final RoutingContext rc) throws IOException {
+        final HttpServerRequest request = rc.request();
+        String urlExtra = "";
+        int status = 200;
+        final Request.Builder downstream = new Request.Builder();
+        for (final String name : request.params().names()) {
+            final String value = request.getParam(name);
+            if ("status".equalsIgnoreCase(name)) {
+                status = Integer.parseInt(value);
+            } else if ("url_extra".equalsIgnoreCase(name)) {
+                urlExtra = value;
+            } else {
+                downstream.header(name, value);
+            }
+        }
+        downstream.url(new URL(String.format(INTERNAL_SERVER_URL, status, urlExtra)));
+        RequestBody body = null;
+        final String contentType = request.getHeader("Content-Type");
+        if (contentType != null) {
+            body = RequestBody.create(MediaType.parse(contentType), rc.getBody().getBytes());
+        }
+        downstream.method(request.rawMethod(), body);
+        return downstream.build();
+    }
+
+    private JsonObject parseResponse(final Response response) throws IOException {
+        final JsonObject result = new JsonObject();
+        result.put("status", response.code());
+        final ResponseBody body = response.body();
+        if (response.code() >= 200 && response.code() < 300) {
+            if (body != null) {
+                result.put("payload", mapper.readValue(body.bytes(), Map.class));
+            }
+            final Map<String, Object> headers = new HashMap<>();
+            for (final String header : response.headers().names()) {
+                final List<String> value = response.headers(header);
+                headers.put(header, value.size() == 1 ? value.get(0) : value);
+            }
+            result.put("headers", headers);
+        } else {
+            result.put("error", body != null ? body.string() : "Unknown error");
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Motivation

This PR ensures that downstream http requests analyzer tests run in the Java tracer

## Changes

Add api10 routes to Java vert3 weblog

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
