### PR TITLE
Replace TRACE method with PUT in api10 test with body

### DIFF
--- a/docs/weblog/README.md
+++ b/docs/weblog/README.md
@@ -111,10 +111,11 @@ OK\n
 ### GET /external_request
 ### POST /external_request
 ### TRACE /external_request
+### PUT /external_request
 
 This endpoint is used for downstream requests test, using an addtional component hosting a fastapi application defined in `/utils/build/docker/internal_server/app.py`
 
-It must open a request on `http://internal_server:8089/mirror/{status}{url_extra}` with the same method as the method used to call this endpoint (GET, POST or TRACE).
+It must open a request on `http://internal_server:8089/mirror/{status}{url_extra}` with the same method as the method used to call this endpoint (GET, POST, TRACE or PUT).
 
 If a body was sent, it must also be sent to `internal_server` with the same content type. (whatever is the method used)
 

--- a/tests/appsec/rasp/rasp_ruleset.json
+++ b/tests/appsec/rasp/rasp_ruleset.json
@@ -371,7 +371,7 @@
               }
             ],
             "list": [
-              "TRACE"
+              "TRACE", "PUT"
             ]
           },
           "operator": "exact_match"

--- a/tests/appsec/rasp/test_api10.py
+++ b/tests/appsec/rasp/test_api10.py
@@ -188,7 +188,7 @@ class Test_API10_all(API10):
 
     def setup_api10(self):
         self.r = weblog.request(
-            "TRACE",
+            "PUT",
             "/external_request?" + urllib.parse.urlencode(self.PARAMS),
             data=json.dumps(self.BODY),
             headers={"Content-Type": "application/json"},

--- a/utils/build/docker/internal_server/app.py
+++ b/utils/build/docker/internal_server/app.py
@@ -17,6 +17,7 @@ async def root():
 @app.get("/mirror/{status}", response_class=fastapi.responses.JSONResponse)
 @app.trace("/mirror/{status}", response_class=fastapi.responses.JSONResponse)
 @app.post("/mirror/{status}", response_class=fastapi.responses.JSONResponse)
+@app.put("/mirror/{status}", response_class=fastapi.responses.JSONResponse)
 async def mirror(status: int, request: fastapi.Request):
     """Mirror GET endpoint
 

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -1088,7 +1088,7 @@ def s3_multipart_upload(request):
 
 
 @csrf_exempt
-@require_http_methods(["GET", "TRACE", "POST"])
+@require_http_methods(["GET", "TRACE", "POST", "PUT"])
 def external_request(request):
     import urllib.request
     import urllib.error

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -1280,6 +1280,7 @@ def return_headers(request: Request):
 @app.get("/external_request", response_class=JSONResponse, status_code=200)
 @app.post("/external_request", response_class=JSONResponse, status_code=200)
 @app.trace("/external_request", response_class=JSONResponse, status_code=200)
+@app.put("/external_request", response_class=JSONResponse, status_code=200)
 async def external_request(request: Request):
     queries = {k: str(v) for k, v in request.query_params.items()}
     status = queries.pop("status", "200")

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -1991,7 +1991,7 @@ def view_iast_sc_iv_overloaded_insecure():
     return Response("OK")
 
 
-@app.route("/external_request", methods=["GET", "TRACE", "POST"])
+@app.route("/external_request", methods=["GET", "TRACE", "POST", "PUT"])
 def external_request():
     import urllib.request
     import urllib.error


### PR DESCRIPTION
## Motivation

TRACE requests are not allowed to include a body according to the [specification](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.8), which can cause issues with client libraries that block such requests.

## Changes

Use the PUT method instead of TRACE in tests that require a request body.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
