### PR TITLE
enable otel logs tests for nodejs

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -68,6 +68,7 @@ refs:
   - &ref_5_62_0 '>=5.62.0'  # dsm - new hashing algo
   - &ref_5_64_0 '>=5.64.0'  # Endpoints collection
   - &ref_5_66_0 '>=5.66.0'  # fastify rasp support
+  - &ref_5_70_0 '>=5.70.0'  # opentelemetry logs support
 tests/:
   apm_tracing_e2e/:
     test_otel.py:
@@ -1302,7 +1303,17 @@ tests/:
     test_otel_api_interoperability.py: missing_feature
     test_otel_env_vars.py:
       Test_Otel_Env_Vars: v5.11.0  #implemented in v5.11.0, v4.35.0, &v3.56.0
-    test_otel_logs.py: missing_feature
+    test_otel_logs.py:
+      Test_FR01_Enable_OTLP_Log_Collection: *ref_5_70_0
+      Test_FR03_Resource_Attributes: *ref_5_70_0
+      Test_FR04_Trace_Span_IDs: *ref_5_70_0
+      Test_FR05_Custom_Endpoints: *ref_5_70_0
+      Test_FR06_OTLP_Protocols: *ref_5_70_0
+      Test_FR07_Host_Name: *ref_5_70_0
+      Test_FR08_Custom_Headers: *ref_5_70_0
+      Test_FR09_Log_Injection: *ref_5_70_0
+      Test_FR10_Timeout_Configuration: *ref_5_70_0
+      Test_FR11_Telemetry: *ref_5_70_0
     test_otel_metrics.py: missing_feature
     test_otel_span_with_baggage.py:
       Test_Otel_Span_With_Baggage: *ref_5_32_0
@@ -1316,7 +1327,7 @@ tests/:
       Test_Parametric_OtelSpan_Start: bug (APMAPI-778)  # The expected span.kind tag is not set
       Test_Parametric_Otel_Baggage: missing_feature (baggage is not supported)
       Test_Parametric_Otel_Current_Span: incomplete_test_app (otel current_span endpoint is not supported)
-      Test_Parametric_Write_Log: missing_feature
+      Test_Parametric_Write_Log: *ref_5_70_0
     test_partial_flushing.py:
       Test_Partial_Flushing: bug (APMLP-270)
     test_process_discovery.py: missing_feature

--- a/tests/parametric/test_otel_logs.py
+++ b/tests/parametric/test_otel_logs.py
@@ -1,8 +1,9 @@
 import pytest
 import base64
 
-from utils import scenarios, features, logger
+from utils import scenarios, features, logger, irrelevant, context
 from utils.parametric._library_client import LogLevel
+from utils.parametric.spec.trace import find_only_span
 from urllib.parse import urlparse
 
 
@@ -53,10 +54,10 @@ def find_attributes(proto_object):
 
 
 @pytest.fixture
-def otlp_endpoint_library_env(library_env, endpoint_env, test_agent_container_name, test_agent_otlp_grpc_port):
+def otlp_endpoint_library_env(library_env, endpoint_env, test_agent_container_name, test_agent_otlp_http_port):
     """Set up a custom endpoint for OTLP logs."""
     prev_value = library_env.get(endpoint_env)
-    library_env[endpoint_env] = f"http://{test_agent_container_name}:{test_agent_otlp_grpc_port}"
+    library_env[endpoint_env] = f"http://{test_agent_container_name}:{test_agent_otlp_http_port}/v1/logs"
     yield library_env
     if prev_value is None:
         del library_env[endpoint_env]
@@ -174,11 +175,16 @@ class Test_FR04_Trace_Span_IDs:
         log_payloads = test_agent.wait_for_num_log_payloads(1)
         log_record = find_log_record(log_payloads, "test_logger", "test_dd_span_context_injection")
 
-        span_id = int(base64.b64decode(log_record["span_id"]).hex(), 16)
-        trace_id = int(base64.b64decode(log_record["trace_id"]).hex(), 16)
+        expected_span_id = base64.b64decode(log_record["span_id"]).hex()
+        expected_trace_id = base64.b64decode(log_record["trace_id"]).hex()
 
-        assert span_id == span.span_id
-        assert trace_id == span.trace_id
+        root = find_only_span(test_agent.wait_for_num_traces(1))
+        root_tid = root["meta"].get("_dd.p.tid", "0" * 16)
+        trace_id = f"{root_tid}{root['trace_id']:016x}"
+        span_id = f"{root['span_id']:016x}"
+
+        assert expected_span_id == span_id, f"Expected span_id {expected_span_id}, got {span_id}, span: {root}"
+        assert expected_trace_id == trace_id, f"Expected trace_id {expected_trace_id}, got {trace_id}, span: {root}"
 
     @pytest.mark.parametrize(
         "library_env",
@@ -194,11 +200,15 @@ class Test_FR04_Trace_Span_IDs:
         log_payloads = test_agent.wait_for_num_log_payloads(1)
         log_record = find_log_record(log_payloads, "test_logger", "test_otel_span_context_injection")
 
-        span_id = int(base64.b64decode(log_record["span_id"]).hex(), 16)
-        trace_id = int(base64.b64decode(log_record["trace_id"]).hex(), 16)
+        expected_span_id = base64.b64decode(log_record["span_id"]).hex()
+        expected_trace_id = base64.b64decode(log_record["trace_id"]).hex()
 
-        assert span_id == span.span_id
-        assert trace_id == span.trace_id
+        root = find_only_span(test_agent.wait_for_num_traces(1))
+        root_tid = root["meta"].get("_dd.p.tid", "0" * 16)
+        trace_id = f"{root_tid}{root['trace_id']:016x}"
+        span_id = f"{root['span_id']:016x}"
+        assert expected_span_id == span_id, f"Expected span_id {expected_span_id}, got {span_id}, span: {root}"
+        assert expected_trace_id == trace_id, f"Expected trace_id {expected_trace_id}, got {trace_id}, span: {root}"
 
 
 @features.otel_logs_enabled
@@ -207,7 +217,7 @@ class Test_FR05_Custom_Endpoints:
     """FR05: Custom OTLP Endpoint Tests"""
 
     @pytest.mark.parametrize(
-        ("library_env", "endpoint_env", "test_agent_otlp_grpc_port"),
+        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
         [
             (
                 {"DD_LOGS_OTEL_ENABLED": "true", "DD_TRACE_DEBUG": None},
@@ -217,7 +227,7 @@ class Test_FR05_Custom_Endpoints:
         ],
     )
     def test_otlp_custom_endpoint(
-        self, library_env, endpoint_env, test_agent_otlp_grpc_port, otlp_endpoint_library_env, test_agent, test_library
+        self, library_env, endpoint_env, test_agent_otlp_http_port, otlp_endpoint_library_env, test_agent, test_library
     ):
         """Logs are exported to custom OTLP endpoint."""
         with test_library as library:
@@ -230,7 +240,7 @@ class Test_FR05_Custom_Endpoints:
         assert find_log_record(log_payloads, "test_logger", "test_otlp_custom_endpoint") is not None
 
     @pytest.mark.parametrize(
-        ("library_env", "endpoint_env", "test_agent_otlp_grpc_port"),
+        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
         [
             (
                 {
@@ -243,7 +253,7 @@ class Test_FR05_Custom_Endpoints:
         ],
     )
     def test_otlp_logs_custom_endpoint(
-        self, library_env, endpoint_env, test_agent_otlp_grpc_port, otlp_endpoint_library_env, test_agent, test_library
+        self, library_env, endpoint_env, test_agent_otlp_http_port, otlp_endpoint_library_env, test_agent, test_library
     ):
         """Logs are exported to custom OTLP logs endpoint."""
         with test_library as library:
@@ -302,6 +312,7 @@ class Test_FR07_Host_Name:
             },
         ],
     )
+    @irrelevant(context.library != "python", reason="DD_HOSTNAME is only supported in Python")
     def test_hostname_from_dd_hostname(self, test_agent, test_library, library_env):
         """host.name is set from DD_HOSTNAME."""
         with test_library as library:
@@ -476,7 +487,7 @@ class Test_FR09_Log_Injection:
     )
     def test_log_injection_when_otel_enabled(self, test_agent, test_library, library_env):
         """Log injection is disabled when OpenTelemetry Logs support is enabled."""
-        with test_library as library, library.dd_start_span("test_span") as span:
+        with test_library as library, library.otel_start_span("test_span") as span:
             library.write_log(
                 "test_log_injection_disabled_when_otel_enabled", LogLevel.INFO, "test_logger", span_id=span.span_id
             )
@@ -581,7 +592,7 @@ class Test_FR11_Telemetry:
     """Test OTLP Logs generated via OpenTelemetry API generate telemetry configurations and metrics."""
 
     @pytest.mark.parametrize(
-        ("library_env", "endpoint_env", "test_agent_otlp_grpc_port"),
+        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
         [
             (
                 {
@@ -590,7 +601,7 @@ class Test_FR11_Telemetry:
                     "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1",
                     "OTEL_EXPORTER_OTLP_TIMEOUT": "30000",
                     "OTEL_EXPORTER_OTLP_HEADERS": "api-key=key,other-config-value=value",
-                    "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+                    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
                 },
                 "OTEL_EXPORTER_OTLP_ENDPOINT",
                 4320,
@@ -598,7 +609,7 @@ class Test_FR11_Telemetry:
         ],
     )
     def test_telemetry_exporter_configurations(
-        self, library_env, endpoint_env, test_agent_otlp_grpc_port, otlp_endpoint_library_env, test_agent, test_library
+        self, library_env, endpoint_env, test_agent_otlp_http_port, otlp_endpoint_library_env, test_agent, test_library
     ):
         """Test configurations starting with OTEL_EXPORTER_OTLP_ are sent to the instrumentation telemetry intake."""
         with test_library as library:
@@ -610,22 +621,24 @@ class Test_FR11_Telemetry:
         configurations_by_name = test_agent.wait_for_telemetry_configurations()
 
         for expected_env, expected_value in [
-            ("OTEL_EXPORTER_OTLP_TIMEOUT", 30000),
+            ("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"),
             ("OTEL_EXPORTER_OTLP_HEADERS", "api-key=key,other-config-value=value"),
-            ("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc"),
+            ("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
             ("OTEL_EXPORTER_OTLP_ENDPOINT", library_env["OTEL_EXPORTER_OTLP_ENDPOINT"]),
         ]:
             # Find configuration with env_var origin (since these are set via environment variables)
             config = test_agent.get_telemetry_config_by_origin(
                 configurations_by_name, expected_env, "env_var", fallback_to_first=True
             )
-            assert config is not None, f"No configuration found for '{expected_env}'"
             assert (
-                config.get("value") == expected_value
+                config is not None
+            ), f"No configuration found for '{expected_env}', configurations: {configurations_by_name}"
+            assert (
+                str(config.get("value", "")) == expected_value.lower()
             ), f"Expected {expected_env} to be {expected_value}, configuration: {config}"
 
     @pytest.mark.parametrize(
-        ("library_env", "endpoint_env", "test_agent_otlp_grpc_port"),
+        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
         [
             (
                 {
@@ -634,7 +647,7 @@ class Test_FR11_Telemetry:
                     "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1",
                     "OTEL_EXPORTER_OTLP_LOGS_TIMEOUT": "30000",
                     "OTEL_EXPORTER_OTLP_LOGS_HEADERS": "api-key=key,other-config-value=value",
-                    "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": "grpc",
+                    "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": "http/protobuf",
                 },
                 "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
                 4325,
@@ -642,7 +655,7 @@ class Test_FR11_Telemetry:
         ],
     )
     def test_telemetry_exporter_logs_configurations(
-        self, library_env, endpoint_env, test_agent_otlp_grpc_port, otlp_endpoint_library_env, test_agent, test_library
+        self, library_env, endpoint_env, test_agent_otlp_http_port, otlp_endpoint_library_env, test_agent, test_library
     ):
         """Test Teleemtry configurations starting with OTEL_EXPORTER_OTLP_LOGS_ are sent to the instrumentation telemetry intake."""
         with test_library as library:
@@ -656,7 +669,7 @@ class Test_FR11_Telemetry:
         for expected_env, expected_value in [
             ("OTEL_EXPORTER_OTLP_LOGS_TIMEOUT", 30000),
             ("OTEL_EXPORTER_OTLP_LOGS_HEADERS", "api-key=key,other-config-value=value"),
-            ("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "grpc"),
+            ("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "http/protobuf"),
             ("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", library_env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"]),
         ]:
             # Find configuration with env_var origin (since these are set via environment variables)
@@ -674,7 +687,7 @@ class Test_FR11_Telemetry:
             {
                 "DD_LOGS_OTEL_ENABLED": "true",
                 "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1",
-                "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+                "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
                 "DD_TRACE_DEBUG": None,
             },
         ],
@@ -694,5 +707,5 @@ class Test_FR11_Telemetry:
             assert len(metric.get("points", [])) > 0, f"Expected at least 1 point, got {metric}"
             assert metric.get("common") is True, f"Expected common, got {metric}"
             assert metric.get("tags") is not None, f"Expected tags, got {metric}"
-            assert "protocol:grpc" in metric.get("tags")
+            assert "protocol:http" in metric.get("tags")
             assert "encoding:protobuf" in metric.get("tags")

--- a/tests/parametric/test_parametric_endpoints.py
+++ b/tests/parametric/test_parametric_endpoints.py
@@ -738,7 +738,9 @@ class Test_Parametric_Otel_Trace_Flush:
 @scenarios.parametric
 @features.parametric_endpoint_parity
 class Test_Parametric_Write_Log:
-    @incomplete_test_app(context.library != "python", reason="Logs endpoint is only implemented in python app")
+    @incomplete_test_app(
+        context.library not in ["python", "nodejs"], reason="Logs endpoint is only implemented in python app"
+    )
     def test_write_log(self, test_agent, test_library):
         """Validates that /log/write creates a log message with the specified parameters.
 

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -347,6 +347,51 @@ app.get('/trace/config', (req, res) => {
   });
 });
 
+app.post("/log/write", (req, res) => {
+  const { logs } = require('@opentelemetry/api-logs')
+
+  const logger = logs.getLogger(req?.body?.logger_name)
+  const otelSpan = otelSpans[req?.body?.span_id]
+  const ddSpan = spans[req?.body?.span_id]
+  let context = undefined
+  if (otelSpan) {
+    context = trace.setSpan(ROOT_CONTEXT, otelSpan)
+  } else if (ddSpan) {
+    const ddSpanContext = ddSpan.context()
+    const sp = {spanId: ddSpanContext.toSpanId(true), traceId: ddSpanContext.toTraceId(true), flags: ddSpanContext._sampling.priority >= 0 ? 1 : 0}
+    context = trace.setSpanContext(ROOT_CONTEXT, sp)
+  }
+
+  logger.emit({
+    severityText: req.body.level,
+    body: req.body.message,
+    context: context
+  })
+  res.status(200).json({})
+})
+
+app.post("/log/otel/flush", (req, res) => {
+  const { logs } = require('@opentelemetry/api-logs')
+
+  try {
+    // Get the current logs provider
+    const logsProvider = logs.getLoggerProvider()
+    const providerType = logsProvider.constructor.name
+
+    // Force flush all logs with timeout
+    const timeoutMs = (req.body.seconds || 5) * 1000
+    logsProvider.forceFlush(timeoutMs)
+      .then(() => {
+        res.status(200).json({ success: true, message: providerType })
+      })
+      .catch((error) => {
+        res.status(200).json({ success: false, message: `Error: ${error.message}` })
+      })
+  } catch (error) {
+    res.status(200).json({ success: false, message: `Error: ${error.message}` })
+  }
+})
+
 app.post("/trace/otel/add_event", (req, res) => {
   const { span_id, name, timestamp, attributes } = req.body;
   const span = otelSpans[span_id]


### PR DESCRIPTION
## Motivation

Enables otel logs tests for nodejs

## Changes

Updates tests to be compatible with nodejs implementation

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
