### PR TITLE
[python] test(appsec): mark Test_Automated_User_Tracking

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -572,6 +572,7 @@ tests/:
         'django-poc': v3.7.0.dev (is v3.1.0.dev but weblog use new SDK now)
         'django-py3.13': v3.7.0.dev (is v3.1.0.dev but weblog use new SDK now)
         'python3.12': v3.7.0.dev (is v3.1.0.dev but weblog use new SDK now)
+        'fastapi': bug(APPSEC-59535)
     test_blocking_addresses.py:
       Test_BlockingGraphqlResolvers: missing_feature
       Test_Blocking_client_ip:


### PR DESCRIPTION
## Motivation

This test is failing, it is not flaky as I can reproduce it consistantly. To unblock CI, let's mark it as a known bug.

## Changes

Declare the `Test_Automated_User_Tracking` class as a bug for the `fastapi` weblog.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
