### PR TITLE
[python]: fix semver parsing bug in fastapi weblog

### DIFF
--- a/tests/appsec/test_automated_user_and_session_tracking.py
+++ b/tests/appsec/test_automated_user_and_session_tracking.py
@@ -4,7 +4,6 @@
 
 
 from typing import Any
-from utils import bug
 from utils import context
 from utils import features
 from utils import interfaces
@@ -47,7 +46,6 @@ def login_data(context, user, password):
 
 
 @rfc("https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw")
-@bug(context.library >= "python@3.16.0-rc1", reason="APPSEC-59541")
 @features.user_monitoring
 class Test_Automated_User_Tracking:
     def setup_user_tracking_auto(self):
@@ -247,7 +245,6 @@ class Test_Automated_Session_Blocking:
         )
 
     @missing_feature(context.library == "dotnet", reason="Session ids can't be set.")
-    @bug(context.library >= "python@3.16.0-rc1", reason="APPSEC-59541")
     def test_session_blocking(self):
         assert self.r_create_session.status_code == 200
 

--- a/utils/build/build_python_base_images.sh
+++ b/utils/build/build_python_base_images.sh
@@ -5,7 +5,7 @@
 
 
 docker buildx build --load --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v5 .
-docker buildx build --load --progress=plain -f utils/build/docker/python/fastapi.base.Dockerfile -t datadog/system-tests:fastapi.base-v6 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/fastapi.base.Dockerfile -t datadog/system-tests:fastapi.base-v7 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v9 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v7 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/flask-poc.base.Dockerfile -t datadog/system-tests:flask-poc.base-v11 .
@@ -13,7 +13,7 @@ docker buildx build --load --progress=plain -f utils/build/docker/python/uwsgi-p
 
 if [ "$1" = "--push" ]; then
       docker push datadog/system-tests:django-py3.13.base-v5
-      docker push datadog/system-tests:fastapi.base-v6
+      docker push datadog/system-tests:fastapi.base-v7
       docker push datadog/system-tests:python3.12.base-v9
       docker push datadog/system-tests:django-poc.base-v7
       docker push datadog/system-tests:flask-poc.base-v11

--- a/utils/build/build_python_base_images.sh
+++ b/utils/build/build_python_base_images.sh
@@ -4,18 +4,18 @@
 
 
 
-docker buildx build --load --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v5 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v6 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/fastapi.base.Dockerfile -t datadog/system-tests:fastapi.base-v7 .
-docker buildx build --load --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v9 .
-docker buildx build --load --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v7 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v10 .
+docker buildx build --load --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v8 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/flask-poc.base.Dockerfile -t datadog/system-tests:flask-poc.base-v11 .
 docker buildx build --load --progress=plain -f utils/build/docker/python/uwsgi-poc.base.Dockerfile -t datadog/system-tests:uwsgi-poc.base-v7 .
 
 if [ "$1" = "--push" ]; then
-      docker push datadog/system-tests:django-py3.13.base-v5
+      docker push datadog/system-tests:django-py3.13.base-v6
       docker push datadog/system-tests:fastapi.base-v7
-      docker push datadog/system-tests:python3.12.base-v9
-      docker push datadog/system-tests:django-poc.base-v7
+      docker push datadog/system-tests:python3.12.base-v10
+      docker push datadog/system-tests:django-poc.base-v8
       docker push datadog/system-tests:flask-poc.base-v11
       docker push datadog/system-tests:uwsgi-poc.base-v7
 fi

--- a/utils/build/docker/python/django-poc.Dockerfile
+++ b/utils/build/docker/python/django-poc.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:django-poc.base-v7
+FROM datadog/system-tests:django-poc.base-v8
 
 WORKDIR /app
 

--- a/utils/build/docker/python/django-poc.base.Dockerfile
+++ b/utils/build/docker/python/django-poc.base.Dockerfile
@@ -9,8 +9,7 @@ RUN python --version && curl --version
 # install python deps
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install --upgrade pip
-RUN pip install django==5.2.4 pycryptodome==3.23.0 gunicorn==21.2.0 gevent==25.5.1 requests==2.32.4 boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2
+RUN pip install django==5.2.4 pycryptodome==3.23.0 gunicorn==21.2.0 gevent==25.5.1 requests==2.32.4 boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2 zope.event==5.1.1 zope.interface==7.2
 
-# docker build --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v7 .
-# docker push datadog/system-tests:django-poc.base-v7
-
+# docker build --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v8 .
+# docker push datadog/system-tests:django-poc.base-v8

--- a/utils/build/docker/python/django-py3.13.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:django-py3.13.base-v5
+FROM datadog/system-tests:django-py3.13.base-v6
 
 WORKDIR /app
 

--- a/utils/build/docker/python/django-py3.13.base.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.base.Dockerfile
@@ -8,7 +8,7 @@ RUN python --version && curl --version
 # install python deps
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install --upgrade pip
-RUN pip install django==5.2.6 pycryptodome==3.23.0 gunicorn==23.0.0 gevent==25.8.2 requests==2.32.4 boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2
+RUN pip install django==5.2.6 pycryptodome==3.23.0 gunicorn==23.0.0 gevent==25.8.2 requests==2.32.4 boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2 zope.event==5.1.1 zope.interface==7.2
 
-# docker build --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v5 .
-# docker push datadog/system-tests:django-py3.13.base-v5
+# docker build --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v6 .
+# docker push datadog/system-tests:django-py3.13.base-v6

--- a/utils/build/docker/python/fastapi.Dockerfile
+++ b/utils/build/docker/python/fastapi.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:fastapi.base-v6
+FROM datadog/system-tests:fastapi.base-v7
 
 WORKDIR /app
 

--- a/utils/build/docker/python/fastapi.base.Dockerfile
+++ b/utils/build/docker/python/fastapi.base.Dockerfile
@@ -8,7 +8,7 @@ RUN python --version && curl --version
 
 # install python deps
 RUN pip install --upgrade pip
-RUN pip install PyYAML fastapi uvicorn requests cryptography==42.0.8 pycryptodome python-multipart jinja2 psycopg2-binary itsdangerous xmltodict==0.14.2
+RUN pip install PyYAML fastapi uvicorn requests cryptography==42.0.8 pycryptodome python-multipart jinja2 psycopg2-binary packaging==25.0 itsdangerous xmltodict==0.14.2
 
 RUN mkdir app
 WORKDIR /app

--- a/utils/build/docker/python/fastapi.base.Dockerfile
+++ b/utils/build/docker/python/fastapi.base.Dockerfile
@@ -13,5 +13,5 @@ RUN pip install PyYAML fastapi uvicorn requests cryptography==42.0.8 pycryptodom
 RUN mkdir app
 WORKDIR /app
 
-# docker build --progress=plain -f utils/build/docker/python/fastapi.base.Dockerfile -t datadog/system-tests:fastapi.base-v6 .
-# docker push datadog/system-tests:fastapi.base-v6
+# docker build --progress=plain -f utils/build/docker/python/fastapi.base.Dockerfile -t datadog/system-tests:fastapi.base-v7 .
+# docker push datadog/system-tests:fastapi.base-v7

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel
 import requests
 import urllib3
 import xmltodict
+from packaging.version import Version
 from starlette.middleware.sessions import SessionMiddleware
 
 import ddtrace
@@ -56,13 +57,9 @@ except ImportError:
 app = FastAPI()
 
 # Custom middleware
-try:
-    maj, min, patch, *_ = getattr(ddtrace, "__version__", "0.0.0").split(".")
-    current_ddtrace_version = (int(maj), int(min), int(patch))
-except Exception:
-    current_ddtrace_version = (0, 0, 0)
+current_ddtrace_version = Version(getattr(ddtrace, "__version__", "0.0.0"))
 
-if current_ddtrace_version >= (3, 1, 0):
+if current_ddtrace_version >= Version("3.1.0"):
     """custom middleware only supported after PR 12413"""
 
     @app.middleware("http")

--- a/utils/build/docker/python/python3.12.Dockerfile
+++ b/utils/build/docker/python/python3.12.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:python3.12.base-v9
+FROM datadog/system-tests:python3.12.base-v10
 
 WORKDIR /app
 

--- a/utils/build/docker/python/python3.12.base.Dockerfile
+++ b/utils/build/docker/python/python3.12.base.Dockerfile
@@ -9,8 +9,8 @@ RUN python --version && curl --version
 # install python deps
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install --upgrade pip
-RUN pip install django==5.2.4 pycryptodome==3.23.0 gunicorn==23.0.0 gevent==25.5.1 requests==2.32.4 boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2
+RUN pip install django==5.2.4 pycryptodome==3.23.0 gunicorn==23.0.0 gevent==25.5.1 requests==2.32.4 boto3==1.34.141 'moto[ec2,s3,all]'==5.0.14 xmltodict==0.14.2 zope.event==5.1.1 zope.interface==7.2
 
-# docker build --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v9 .
-# docker push datadog/system-tests:python3.12.base-v9
 
+# docker build --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v10 .
+# docker push datadog/system-tests:python3.12.base-v10


### PR DESCRIPTION
## Motivation

Some tests failed on rc1 for the fastapi weblog but not for other commits: https://github.com/DataDog/system-tests/pull/5439.

The reason is that a middleware was not properly installed as `int("0rc1")` raises an Exception that used to make the version default to `(0, 0, 0)` which was below `(3, 1, 0)`.

## Changes

Use the `packaging` dependency to handle semver correctly and simply.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
