### PR TITLE
fix(parametric): add retries when pulling agent image

### DIFF
--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -189,7 +189,7 @@ class ParametricScenario(Scenario):
 
         return result
 
-    @retry(delay=1, tries=5)
+    @retry(delay=10, tries=3)
     def _pull_test_agent_image(self):
         logger.stdout("Pulling test agent image...")
         _get_client().images.pull(self.TEST_AGENT_IMAGE)


### PR DESCRIPTION
## Motivation

This transient error was noticed in the Ruby CI [here](https://github.com/DataDog/dd-trace-rb/actions/runs/18102044463/job/51507937176?pr=4921):

> docker.errors.APIError: 500 Server Error for http+docker://localhost/v1.48/images/create?tag=v1.32.0&fromImage=ghcr.io%2Fdatadog%2Fdd-apm-test-agent%2Fddapm-test-agent: Internal Server Error ("Get "https://ghcr.io/v2/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)")

Adding some retries should improve the flakiness of this test.

## Changes

* Added the `retry` decorator to the `_pull_test_agent_image` method to automatically retry pulling the Docker image up to 5 times with a 1-second delay between attempts.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
