### PR TITLE
[Ruby] Enable Endpoint Discovery tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -22,7 +22,7 @@ tests/:
         Test_API_Security_Sampling_With_Delay: v2.18.0
       test_endpoint_discovery.py:
         Test_Endpoint_Discovery:
-          "*": missing_feature
+          "*": v2.22.0.dev
           rack: irrelevant (rack does not have a router)
           rails42: irrelevant
           sinatra14: missing_feature


### PR DESCRIPTION
## Motivation

Endpoint discovery feature is merged into dd-trace-rb again (it was reverted due to a flaky test):
https://github.com/DataDog/dd-trace-rb/pull/4948

## Changes

Endpoint Discovery tests are enabled for v2.22.0.dev and above.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
