### PR TITLE
parametric: Add force_skip for unimplemented OTLP Metrics

### DIFF
--- a/tests/parametric/test_otel_metrics.py
+++ b/tests/parametric/test_otel_metrics.py
@@ -2,7 +2,7 @@ import pytest
 
 from hypothesis import given, settings, HealthCheck, strategies as st
 
-from utils import features, scenarios
+from utils import context, features, missing_feature, scenarios
 from urllib.parse import urlparse
 
 EXPECTED_TAGS = [("foo", "bar1"), ("baz", "qux1")]
@@ -178,6 +178,14 @@ def get_expected_bucket_counts(entries: list[int], bucket_boundaries: list[float
 
 @scenarios.parametric
 @features.otel_metrics_api
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Configuration_Enabled:
     """Tests the enablement and disablement of the OTel Metrics API through the following configurations:
     - DD_METRICS_OTEL_ENABLED
@@ -256,6 +264,14 @@ class Test_Otel_Metrics_Configuration_Enabled:
 
 @scenarios.parametric
 @features.otel_metrics_api
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Api_MeterProvider:
     """Tests the OpenTelemetry MeterProvider API functionality.
 
@@ -380,6 +396,14 @@ class Test_Otel_Metrics_Api_MeterProvider:
 
 @scenarios.parametric
 @features.otel_metrics_api
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Api_Meter:
     """Tests the OpenTelemetry Meter API functionality.
 
@@ -684,6 +708,14 @@ class Test_Otel_Metrics_Api_Meter:
 
 @scenarios.parametric
 @features.otel_metrics_api
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Api_Instrument:
     """Tests the OpenTelemetry Instrument API functionality.
 
@@ -1467,6 +1499,14 @@ class Test_Otel_Metrics_Api_Instrument:
 
 @features.otel_metrics_api
 @scenarios.parametric
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Configuration_Metric_Export_Interval:
     """Tests the OpenTelemetry metrics export interval configuration.
 
@@ -1552,6 +1592,14 @@ class Test_Otel_Metrics_Configuration_Metric_Export_Interval:
 
 @features.otel_metrics_api
 @scenarios.parametric
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Configuration_Metric_Export_Timeout:
     """Tests the OpenTelemetry metrics export timeout configuration.
 
@@ -1637,6 +1685,14 @@ class Test_Otel_Metrics_Configuration_Metric_Export_Timeout:
 
 @scenarios.parametric
 @features.otel_metrics_api
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Configuration_Temporality_Preference:
     """Tests the OpenTelemetry metrics aggregation temporality preference configuration.
 
@@ -1935,6 +1991,14 @@ class Test_Otel_Metrics_Configuration_Temporality_Preference:
 
 @scenarios.parametric
 @features.otel_metrics_api
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Endpoint:
     """Tests the OpenTelemetry OTLP exporter metrics endpoint configuration.
 
@@ -2085,6 +2149,14 @@ class Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Endpoint:
 
 @features.otel_metrics_api
 @scenarios.parametric
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Headers:
     """Tests the OpenTelemetry OTLP exporter metrics headers configuration.
 
@@ -2157,6 +2229,14 @@ class Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Headers:
 
 @features.otel_metrics_api
 @scenarios.parametric
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Protocol:
     """Tests the OpenTelemetry OTLP exporter metrics protocol configuration.
 
@@ -2226,6 +2306,14 @@ class Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Protocol:
 
 @features.otel_metrics_api
 @scenarios.parametric
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Timeout:
     """Tests the OpenTelemetry OTLP exporter metrics timeout configuration.
 
@@ -2324,6 +2412,14 @@ class Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Timeout:
 
 @features.otel_metrics_api
 @scenarios.parametric
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Host_Name:
     """Tests the OpenTelemetry metrics host name configuration.
 
@@ -2442,6 +2538,14 @@ class Test_Otel_Metrics_Host_Name:
 
 @scenarios.parametric
 @features.otel_metrics_api
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Resource_Attributes:
     """Tests the OpenTelemetry metrics resource attributes configuration.
 
@@ -2585,6 +2689,14 @@ class Test_Otel_Metrics_Resource_Attributes:
 
 @features.otel_metrics_api
 @scenarios.parametric
+@missing_feature(context.library == "cpp", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "dotnet", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "golang", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "java", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "nodejs", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "php", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "ruby", reason="Not yet implemented", force_skip=True)
+@missing_feature(context.library == "rust", reason="Not yet implemented", force_skip=True)
 class Test_Otel_Metrics_Telemetry:
     """Tests the OpenTelemetry metrics telemetry configuration reporting.
 


### PR DESCRIPTION
## Motivation

We noticed increased times in the parametric runs for non-Python languages after https://github.com/DataDog/system-tests/pull/5106 was merged. These tests are expected to fail due to requiring a brand new feature and new parametric application endpoints.

## Changes

Add force_skip for all class with unimplemented languages in the test_otel_metrics.py. This is because the tests requires the implementation of a new library feature AND new parametric endpoints, so we should not run them since we otherwise would be waiting on polling timeouts for non-existent OTLP metrics.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
