### PR TITLE
nginx: enable test for http.endpoint tag

### DIFF
--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -434,7 +434,8 @@ manifest:
   tests/test_profiling.py::Test_Profile::test_process_tags: missing_feature
   tests/test_profiling.py::Test_Profile::test_process_tags_svc: missing_feature
   tests/test_protobuf.py: missing_feature
-  tests/test_resource_renaming.py: missing_feature
+  tests/test_resource_renaming.py::Test_Resource_Renaming_HTTP_Endpoint_Tag: v1.19.2
+  tests/test_resource_renaming.py::Test_Resource_Renaming_Stats_Aggregation_Keys: missing_feature (dd-trace-cpp does not support stats)
   tests/test_rum_injection.py: irrelevant (RUM injection only supported for Java)
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction: v1.0.0  # real version unknown

--- a/tests/test_resource_renaming.py
+++ b/tests/test_resource_renaming.py
@@ -51,7 +51,10 @@ class Test_Resource_Renaming_HTTP_Endpoint_Tag:
 
     def test_http_endpoint_edge_cases(self):
         """Test that edge cases are handled correctly"""
-        assert get_endpoint_tag(self.r_long_path) == "/resource_renaming/a/b/c/d/e/f/g"
+        assert get_endpoint_tag(self.r_long_path) in (
+            "/resource_renaming/a/b/c/d/e/f/g",
+            "/resource_renaming/a/b/c/d/e/f/g/",
+        )
         assert get_endpoint_tag(self.r_empty_segments) == "/resource_renaming/double/slash"
 
 

--- a/utils/build/docker/cpp_nginx/nginx/nginx-waf.conf
+++ b/utils/build/docker/cpp_nginx/nginx/nginx-waf.conf
@@ -28,6 +28,11 @@ http {
           try_files /hello.html =404;
         }
 
+        location ~ ^/resource_renaming/ {
+            root /builds;
+            try_files /hello.html =404;
+        }
+
         location /mysql {
           # can't use `return`
           try_files /non_existent =404;

--- a/utils/build/docker/cpp_nginx/nginx/nginx.conf
+++ b/utils/build/docker/cpp_nginx/nginx/nginx.conf
@@ -18,6 +18,11 @@ http {
           try_files /hello.html =404;
         }
 
+        location ~ ^/resource_renaming/ {
+            root /builds;
+            try_files /hello.html =404;
+        }
+
         location /mysql {
           # can't use `return`
           try_files /non_existent =404;


### PR DESCRIPTION
## Motivation

Enables the http.endpoint tag tests. See https://github.com/DataDog/nginx-datadog/pull/267 and https://github.com/DataDog/dd-trace-cpp/pull/260

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
