### PR TITLE
test(llmobs): update prompt tracking assertions for new tags

### DIFF
--- a/tests/integration_frameworks/llm/openai/test_openai_llmobs.py
+++ b/tests/integration_frameworks/llm/openai/test_openai_llmobs.py
@@ -551,6 +551,7 @@ class TestOpenAiPromptTracking(BaseOpenaiTest):
                     ),
                 }
             ],
+            prompt_multimodal=True,
         )
 
     def test_responses_create_with_prompt_mixed_inputs_url_preserved(
@@ -631,6 +632,7 @@ class TestOpenAiPromptTracking(BaseOpenaiTest):
                     ),
                 }
             ],
+            prompt_multimodal=True,
         )
 
 

--- a/tests/integration_frameworks/llm/utils.py
+++ b/tests/integration_frameworks/llm/utils.py
@@ -188,6 +188,9 @@ def assert_prompt_tracking(
     variables: dict,
     expected_chat_template: list[dict],
     expected_messages: list[dict],
+    *,
+    prompt_tracking_source: str = "auto",
+    prompt_multimodal: bool = False,
 ) -> None:
     """Helper to assert prompt tracking metadata and template extraction.
 
@@ -195,6 +198,8 @@ def assert_prompt_tracking(
     - Prompt metadata (id, version, variables)
     - chat_template reconstruction with {{variable}} placeholders
     - Rendered messages (with variables substituted)
+    - prompt_tracking_source tag (default: auto)
+    - prompt_multimodal tag (when True)
     """
     assert "prompt" in span_event["meta"]["input"], "Expected 'prompt' in span_event['meta']['input']"
 
@@ -214,4 +219,8 @@ def assert_prompt_tracking(
         f"Expected messages {expected_messages}, got {span_event['meta']['input']['messages']}"
     )
 
-    assert span_event.get("_dd", {}).get("prompt_tracking_auto") == 1
+    assert f"prompt_tracking_source:{prompt_tracking_source}" in span_event["tags"], (
+        f"Expected 'prompt_tracking_source:{prompt_tracking_source}' in tags"
+    )
+    if prompt_multimodal:
+        assert "prompt_multimodal:true" in span_event["tags"], "Expected 'prompt_multimodal:true' in tags"

--- a/tests/integration_frameworks/llm/utils.py
+++ b/tests/integration_frameworks/llm/utils.py
@@ -189,7 +189,7 @@ def assert_prompt_tracking(
     expected_chat_template: list[dict],
     expected_messages: list[dict],
     *,
-    prompt_tracking_source: str = "auto",
+    prompt_tracking_instrumentation_method: str = "auto",
     prompt_multimodal: bool = False,
 ) -> None:
     """Helper to assert prompt tracking metadata and template extraction.
@@ -198,7 +198,7 @@ def assert_prompt_tracking(
     - Prompt metadata (id, version, variables)
     - chat_template reconstruction with {{variable}} placeholders
     - Rendered messages (with variables substituted)
-    - prompt_tracking_source tag (default: auto)
+    - prompt_tracking_instrumentation_method tag (default: auto)
     - prompt_multimodal tag (when True)
     """
     assert "prompt" in span_event["meta"]["input"], "Expected 'prompt' in span_event['meta']['input']"
@@ -219,8 +219,8 @@ def assert_prompt_tracking(
         f"Expected messages {expected_messages}, got {span_event['meta']['input']['messages']}"
     )
 
-    assert f"prompt_tracking_source:{prompt_tracking_source}" in span_event["tags"], (
-        f"Expected 'prompt_tracking_source:{prompt_tracking_source}' in tags"
+    assert f"prompt_tracking_instrumentation_method:{prompt_tracking_instrumentation_method}" in span_event["tags"], (
+        f"Expected 'prompt_tracking_instrumentation_method:{prompt_tracking_instrumentation_method}' in tags"
     )
     if prompt_multimodal:
         assert "prompt_multimodal:true" in span_event["tags"], "Expected 'prompt_multimodal:true' in tags"

--- a/tests/integration_frameworks/llm/utils.py
+++ b/tests/integration_frameworks/llm/utils.py
@@ -213,3 +213,5 @@ def assert_prompt_tracking(
     assert span_event["meta"]["input"]["messages"] == expected_messages, (
         f"Expected messages {expected_messages}, got {span_event['meta']['input']['messages']}"
     )
+
+    assert span_event.get("_dd", {}).get("prompt_tracking_auto") == 1


### PR DESCRIPTION
## Motivation

Validate that tracers correctly emit prompt tracking tags for dd-go metric tagging.

### Related PRs

- dd-trace-js: https://github.com/DataDog/dd-trace-js/pull/7106
- dd-trace-py: https://github.com/DataDog/dd-trace-py/pull/15637
- dd-source: https://github.com/DataDog/dd-source/pull/323345

## Changes

Updates prompt tracking test assertions to validate new event tags instead of internal `_dd` fields:
- Asserts `prompt_tracking_instrumentation_method:auto` tag for auto-instrumented prompts
- Asserts `prompt_multimodal:true` tag for OpenAI prompts with image/file inputs

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] If PR title starts with `[<language>]`, double-check that only `<language>` is impacted by the change
* [ ] No system-tests internal is modified. Otherwise, I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added (or removed)?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
