### PR TITLE
[PHP] Enable stripe tests on PHP

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -357,7 +357,7 @@ manifest:
   tests/appsec/test_automated_login_events.py::Test_V3_Login_Events_Anon::test_login_wrong_user_failure_basic: missing_feature (Basic auth not implemented)
   tests/appsec/test_automated_login_events.py::Test_V3_Login_Events_Blocking: v1.8.0
   tests/appsec/test_automated_login_events.py::Test_V3_Login_Events_RC: v1.8.0
-  tests/appsec/test_automated_payment_events.py: missing_feature
+  tests/appsec/test_automated_payment_events.py: v1.17.0-dev
   tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_Session_Blocking: missing_feature
   tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_User_Blocking: v1.8.0
   tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_User_Tracking: v1.8.0

--- a/utils/build/docker/php/apache-mod/build.sh
+++ b/utils/build/docker/php/apache-mod/build.sh
@@ -71,10 +71,6 @@ if [[ "${PHP_MAJOR_VERSION}" -ge 8 ]] && [[ "${PHP_MINOR_VERSION}" -ge 1 ]]; the
     composer require "open-telemetry/sdk:^1.0.0" --prefer-dist --no-interaction
 fi
 
-# Install Stripe SDK. Must be done here (before ddtrace is installed) because
-# ddtrace injected into PHP ZTS builds causes composer to segfault at variant build time.
-composer require "stripe/stripe-php:^10.0" --no-interaction --ignore-platform-req=ext-mbstring
-
 # Set proper permissions
 chmod -R 755 /var/www/html/vendor
 find /var/www/html/vendor -type f -exec chmod 644 {} \;

--- a/utils/build/docker/php/apache-mod/build.sh
+++ b/utils/build/docker/php/apache-mod/build.sh
@@ -71,6 +71,10 @@ if [[ "${PHP_MAJOR_VERSION}" -ge 8 ]] && [[ "${PHP_MINOR_VERSION}" -ge 1 ]]; the
     composer require "open-telemetry/sdk:^1.0.0" --prefer-dist --no-interaction
 fi
 
+# Install Stripe SDK. Must be done here (before ddtrace is installed) because
+# ddtrace injected into PHP ZTS builds causes composer to segfault at variant build time.
+composer require "stripe/stripe-php:^10.0" --no-interaction --ignore-platform-req=ext-mbstring
+
 # Set proper permissions
 chmod -R 755 /var/www/html/vendor
 find /var/www/html/vendor -type f -exec chmod 644 {} \;

--- a/utils/build/docker/php/common/composer.gte8.2.json
+++ b/utils/build/docker/php/common/composer.gte8.2.json
@@ -5,6 +5,7 @@
         "weblog/acme": "*",
         "monolog/monolog": "*",
         "openai-php/client": "*",
+        "guzzlehttp/guzzle": "*",
         "stripe/stripe-php": "^10.0"
     },
     "repositories": [

--- a/utils/build/docker/php/common/composer.gte8.2.json
+++ b/utils/build/docker/php/common/composer.gte8.2.json
@@ -6,7 +6,8 @@
         "monolog/monolog": "*",
         "openai-php/client": "*",
         "guzzlehttp/guzzle": "*",
-        "stripe/stripe-php": "^10.0"
+        "stripe/stripe-php": "^10.0",
+        "open-telemetry/sdk": "^1.0.0"
     },
     "repositories": [
         {

--- a/utils/build/docker/php/common/composer.gte8.2.json
+++ b/utils/build/docker/php/common/composer.gte8.2.json
@@ -5,9 +5,7 @@
         "weblog/acme": "*",
         "monolog/monolog": "*",
         "openai-php/client": "*",
-        "guzzlehttp/guzzle": "*",
-        "stripe/stripe-php": "^10.0",
-        "open-telemetry/sdk": "^1.0.0"
+        "stripe/stripe-php": "^10.0"
     },
     "repositories": [
         {

--- a/utils/build/docker/php/common/composer.gte8.2.json
+++ b/utils/build/docker/php/common/composer.gte8.2.json
@@ -5,7 +5,8 @@
         "weblog/acme": "*",
         "monolog/monolog": "*",
         "openai-php/client": "*",
-        "guzzlehttp/guzzle": "*"
+        "guzzlehttp/guzzle": "*",
+        "stripe/stripe-php": "^10.0"
     },
     "repositories": [
         {

--- a/utils/build/docker/php/common/composer.json
+++ b/utils/build/docker/php/common/composer.json
@@ -3,7 +3,8 @@
     "type": "project",
     "require": {
         "weblog/acme": "*",
-        "monolog/monolog": "*"
+        "monolog/monolog": "*",
+        "stripe/stripe-php": "^10.0"
     },
     "repositories": [
         {

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -170,12 +170,16 @@ if [[ $IS_APACHE -eq 1 ]]; then
 fi
 
 # Install stripe SDK if not already present (base images may predate this dependency).
-# Skip when open-telemetry is present: those PHP >=8.1 base images have extra packages
-# installed via `composer require` that are not in the committed composer files, and
-# running `composer require` again would incorrectly remove them.
+# Use the correct composer file for the PHP version so we don't orphan open-telemetry
+# packages that were added to PHP >=8.2 base images via composer.gte8.2.json.
 if command -v composer &>/dev/null \
     && [ -f /var/www/html/composer.json ] \
-    && ! [ -d /var/www/html/vendor/stripe ] \
-    && ! [ -d /var/www/html/vendor/open-telemetry ]; then
-  cd /var/www/html && composer require stripe/stripe-php "^10.0" --no-interaction --ignore-platform-req=ext-mbstring || true
+    && ! [ -d /var/www/html/vendor/stripe ]; then
+  PHP_MAJOR=$(php -r 'echo PHP_MAJOR_VERSION;')
+  PHP_MINOR=$(php -r 'echo PHP_MINOR_VERSION;')
+  STRIPE_COMPOSER_FILE=composer.json
+  if [ "$PHP_MAJOR" -gt 8 ] || { [ "$PHP_MAJOR" -eq 8 ] && [ "$PHP_MINOR" -ge 2 ]; }; then
+    STRIPE_COMPOSER_FILE=composer.gte8.2.json
+  fi
+  cd /var/www/html && COMPOSER="$STRIPE_COMPOSER_FILE" composer require stripe/stripe-php "^10.0" --no-interaction --ignore-platform-req=ext-mbstring || true
 fi

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -11,7 +11,15 @@ if [ "$(printf '%s\n' "$PHP_VERSION" "8.2" | sort -V | head -n1)" = "8.2" ]; the
 fi
 if [ -f "$COMPOSER" ] && grep -Fq 'stripe/stripe-php' "$COMPOSER"; then
   apt-get update -qq && apt-get install -y --no-install-recommends unzip
-  COMPOSER_DISCARD_CHANGES=true composer require stripe/stripe-php "^10.0" --no-interaction --ignore-platform-req=ext-mbstring
+  if [[ "$(printf '%s\n' "$PHP_VERSION" "8.1" | sort -V | head -n1)" = "8.1" ]]; then
+    # Also require open-telemetry/sdk so composer does not remove it from vendor/:
+    # the Dockerfile ADD overwrites composer.json with the repo version (which has
+    # stripe but not OTel), causing a bare `composer require stripe` to drop OTel
+    # from the resolved tree and wipe it from vendor/.
+    COMPOSER_DISCARD_CHANGES=true composer require stripe/stripe-php "^10.0" "open-telemetry/sdk:^1.0.0" --no-interaction --ignore-platform-req=ext-mbstring
+  else
+    COMPOSER_DISCARD_CHANGES=true composer require stripe/stripe-php "^10.0" --no-interaction --ignore-platform-req=ext-mbstring
+  fi
 fi
 
 cd /binaries

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -169,16 +169,22 @@ if [[ $IS_APACHE -eq 1 ]]; then
   fi
 fi
 
-# Install stripe SDK if not already present (base images may predate this dependency).
-# Use --no-update to add stripe to the JSON without touching the lock file, then
-# do a partial update (stripe only) — partial updates never remove other packages
-# (e.g. open-telemetry) that live in the lock but not in our composer JSON.
-# Detect which composer file the base image used from the lock file name.
+# Install stripe SDK if not already present. Must run before ddtrace is loaded into
+# PHP (i.e. in the base image build), because ddtrace causes PHP ZTS builds to segfault
+# when composer runs after installation. This block is a fallback for non-ZTS FPM images
+# where ddtrace does not segfault composer.
+#
+# For PHP 8.1 FPM: the base image has open-telemetry in vendor but not in our composer.json.
+# Add it back before updating to prevent composer from removing it as an orphaned package.
 if command -v composer &>/dev/null \
     && [ -f /var/www/html/composer.json ] \
     && ! [ -d /var/www/html/vendor/stripe ]; then
   cd /var/www/html
   [ -f composer.gte8.2.lock ] && export COMPOSER=composer.gte8.2.json
+  ACTIVE_JSON="${COMPOSER:-composer.json}"
+  if [ -d vendor/open-telemetry ] && ! grep -q '"open-telemetry' "$ACTIVE_JSON"; then
+    composer require "open-telemetry/sdk:^1.0.0" --no-update --no-interaction
+  fi
   composer require stripe/stripe-php "^10.0" --no-update --no-interaction --ignore-platform-req=ext-mbstring \
     && composer update stripe/stripe-php --no-interaction --ignore-platform-req=ext-mbstring \
     || true

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -169,23 +169,12 @@ if [[ $IS_APACHE -eq 1 ]]; then
   fi
 fi
 
-# Install stripe SDK if not already present. Must run before ddtrace is loaded into
-# PHP (i.e. in the base image build), because ddtrace causes PHP ZTS builds to segfault
-# when composer runs after installation. This block is a fallback for non-ZTS FPM images
-# where ddtrace does not segfault composer.
-#
-# For PHP 8.1 FPM: the base image has open-telemetry in vendor but not in our composer.json.
-# Add it back before updating to prevent composer from removing it as an orphaned package.
-if command -v composer &>/dev/null \
-    && [ -f /var/www/html/composer.json ] \
-    && ! [ -d /var/www/html/vendor/stripe ]; then
-  cd /var/www/html
-  [ -f composer.gte8.2.lock ] && export COMPOSER=composer.gte8.2.json
-  ACTIVE_JSON="${COMPOSER:-composer.json}"
-  if [ -d vendor/open-telemetry ] && ! grep -q '"open-telemetry' "$ACTIVE_JSON"; then
-    composer require "open-telemetry/sdk:^1.0.0" --no-update --no-interaction
-  fi
-  composer require stripe/stripe-php "^10.0" --no-update --no-interaction --ignore-platform-req=ext-mbstring \
-    && composer update stripe/stripe-php --no-interaction --ignore-platform-req=ext-mbstring \
-    || true
+
+cd /var/www/html
+export COMPOSER=composer.json
+if [ "$(printf '%s\n' "$PHP_VERSION" "8.2" | sort -V | head -n1)" = "8.2" ]; then
+	export COMPOSER=composer.gte8.2.json
+fi
+if [ -f "$COMPOSER" ] && grep -Fq 'stripe/stripe-php' "$COMPOSER"; then
+  composer require stripe/stripe-php "^10.0" --no-interaction --ignore-platform-req=ext-mbstring || true
 fi

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -10,7 +10,8 @@ if [ "$(printf '%s\n' "$PHP_VERSION" "8.2" | sort -V | head -n1)" = "8.2" ]; the
 	export COMPOSER=composer.gte8.2.json
 fi
 if [ -f "$COMPOSER" ] && grep -Fq 'stripe/stripe-php' "$COMPOSER"; then
-  composer require stripe/stripe-php "^10.0" --no-interaction --ignore-platform-req=ext-mbstring || true
+  apt-get update -qq && apt-get install -y --no-install-recommends unzip
+  COMPOSER_DISCARD_CHANGES=true composer require stripe/stripe-php "^10.0" --no-interaction --ignore-platform-req=ext-mbstring
 fi
 
 cd /binaries

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -4,6 +4,15 @@ set -eux
 
 IS_APACHE=${1:-0}
 
+cd /var/www/html
+export COMPOSER=composer.json
+if [ "$(printf '%s\n' "$PHP_VERSION" "8.2" | sort -V | head -n1)" = "8.2" ]; then
+	export COMPOSER=composer.gte8.2.json
+fi
+if [ -f "$COMPOSER" ] && grep -Fq 'stripe/stripe-php' "$COMPOSER"; then
+  composer require stripe/stripe-php "^10.0" --no-interaction --ignore-platform-req=ext-mbstring || true
+fi
+
 cd /binaries
 
 ARCH=$(uname -m)
@@ -167,14 +176,4 @@ if [[ $IS_APACHE -eq 1 ]]; then
   if [ -f "$APACHE_PHP_CONF" ] && grep -q '"/dbm/"' "$APACHE_PHP_CONF" && ! grep -q 'stub_dbm' "$APACHE_PHP_CONF"; then
       sed -i '/\"\/dbm\/\"/a\        RewriteRule "^\/stub_dbm" "\/stub_dbm.php" [QSA,L]' "$APACHE_PHP_CONF"
   fi
-fi
-
-
-cd /var/www/html
-export COMPOSER=composer.json
-if [ "$(printf '%s\n' "$PHP_VERSION" "8.2" | sort -V | head -n1)" = "8.2" ]; then
-	export COMPOSER=composer.gte8.2.json
-fi
-if [ -f "$COMPOSER" ] && grep -Fq 'stripe/stripe-php' "$COMPOSER"; then
-  composer require stripe/stripe-php "^10.0" --no-interaction --ignore-platform-req=ext-mbstring || true
 fi

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -170,16 +170,16 @@ if [[ $IS_APACHE -eq 1 ]]; then
 fi
 
 # Install stripe SDK if not already present (base images may predate this dependency).
-# Use the correct composer file for the PHP version so we don't orphan open-telemetry
-# packages that were added to PHP >=8.2 base images via composer.gte8.2.json.
+# Use --no-update to add stripe to the JSON without touching the lock file, then
+# do a partial update (stripe only) — partial updates never remove other packages
+# (e.g. open-telemetry) that live in the lock but not in our composer JSON.
+# Detect which composer file the base image used from the lock file name.
 if command -v composer &>/dev/null \
     && [ -f /var/www/html/composer.json ] \
     && ! [ -d /var/www/html/vendor/stripe ]; then
-  PHP_MAJOR=$(php -r 'echo PHP_MAJOR_VERSION;')
-  PHP_MINOR=$(php -r 'echo PHP_MINOR_VERSION;')
-  STRIPE_COMPOSER_FILE=composer.json
-  if [ "$PHP_MAJOR" -gt 8 ] || { [ "$PHP_MAJOR" -eq 8 ] && [ "$PHP_MINOR" -ge 2 ]; }; then
-    STRIPE_COMPOSER_FILE=composer.gte8.2.json
-  fi
-  cd /var/www/html && COMPOSER="$STRIPE_COMPOSER_FILE" composer require stripe/stripe-php "^10.0" --no-interaction --ignore-platform-req=ext-mbstring || true
+  cd /var/www/html
+  [ -f composer.gte8.2.lock ] && export COMPOSER=composer.gte8.2.json
+  composer require stripe/stripe-php "^10.0" --no-update --no-interaction --ignore-platform-req=ext-mbstring \
+    && composer update stripe/stripe-php --no-interaction --ignore-platform-req=ext-mbstring \
+    || true
 fi

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -169,7 +169,13 @@ if [[ $IS_APACHE -eq 1 ]]; then
   fi
 fi
 
-# Install stripe SDK if not already present (base images may predate this dependency)
-if command -v composer &>/dev/null && [ -f /var/www/html/composer.json ] && ! [ -d /var/www/html/vendor/stripe ]; then
-  cd /var/www/html && composer require stripe/stripe-php "^10.0" --prefer-dist --no-interaction
+# Install stripe SDK if not already present (base images may predate this dependency).
+# Skip when open-telemetry is present: those PHP >=8.1 base images have extra packages
+# installed via `composer require` that are not in the committed composer files, and
+# running `composer require` again would incorrectly remove them.
+if command -v composer &>/dev/null \
+    && [ -f /var/www/html/composer.json ] \
+    && ! [ -d /var/www/html/vendor/stripe ] \
+    && ! [ -d /var/www/html/vendor/open-telemetry ]; then
+  cd /var/www/html && composer require stripe/stripe-php "^10.0" --no-interaction --ignore-platform-req=ext-mbstring || true
 fi

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -168,3 +168,8 @@ if [[ $IS_APACHE -eq 1 ]]; then
       sed -i '/\"\/dbm\/\"/a\        RewriteRule "^\/stub_dbm" "\/stub_dbm.php" [QSA,L]' "$APACHE_PHP_CONF"
   fi
 fi
+
+# Install stripe SDK if not already present (base images may predate this dependency)
+if command -v composer &>/dev/null && [ -f /var/www/html/composer.json ] && ! [ -d /var/www/html/vendor/stripe ]; then
+  cd /var/www/html && composer require stripe/stripe-php "^10.0" --prefer-dist --no-interaction
+fi

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -4,6 +4,10 @@ set -eux
 
 IS_APACHE=${1:-0}
 
+if [ -z "$PHP_VERSION" ]; then
+  PHP_VERSION=$(php -r "echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;")
+fi
+
 cd /var/www/html
 export COMPOSER=composer.json
 if [ "$(printf '%s\n' "$PHP_VERSION" "8.2" | sort -V | head -n1)" = "8.2" ]; then

--- a/utils/build/docker/php/common/rewrite-rules.conf
+++ b/utils/build/docker/php/common/rewrite-rules.conf
@@ -39,3 +39,6 @@ RewriteRule "^/exceptionreplay/(.*)$" "/debugger/exceptionreplay/$1" [QSA]
 RewriteRule "^/llm$" "/llm/"
 RewriteRule "^/stats-unique$" "/stats-unique/"
 RewriteRule "^/await-agent-info$" "/await-agent-info/"
+RewriteRule "^/stripe/webhook$" "/stripe_webhook.php" [QSA,L]
+RewriteRule "^/stripe/create_checkout_session$" "/stripe_create_checkout_session.php" [QSA,L]
+RewriteRule "^/stripe/create_payment_intent$" "/stripe_create_payment_intent.php" [QSA,L]

--- a/utils/build/docker/php/common/stripe_create_checkout_session.php
+++ b/utils/build/docker/php/common/stripe_create_checkout_session.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once '/var/www/html/vendor/autoload.php';
+
+header('Content-Type: application/json');
+
+try {
+    // Configure Stripe client
+    \Stripe\Stripe::setApiKey('sk_FAKE');
+    \Stripe\Stripe::$apiBase = 'http://internal_server:8089';
+
+    // Get JSON request body
+    $input = file_get_contents('php://input');
+    $data = json_decode($input, true);
+
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        throw new Exception('Invalid JSON: ' . json_last_error_msg());
+    }
+
+    // Create checkout session with the request body data
+    $result = \Stripe\Checkout\Session::create($data);
+
+    // Return the result as JSON
+    echo json_encode($result);
+} catch (\Stripe\Exception\ApiErrorException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/utils/build/docker/php/common/stripe_create_payment_intent.php
+++ b/utils/build/docker/php/common/stripe_create_payment_intent.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once '/var/www/html/vendor/autoload.php';
+
+header('Content-Type: application/json');
+
+try {
+    // Configure Stripe client
+    \Stripe\Stripe::setApiKey('sk_FAKE');
+    \Stripe\Stripe::$apiBase = 'http://internal_server:8089';
+
+    // Get JSON request body
+    $input = file_get_contents('php://input');
+    $data = json_decode($input, true);
+
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        throw new Exception('Invalid JSON: ' . json_last_error_msg());
+    }
+
+    // Create payment intent with the request body data
+    $result = \Stripe\PaymentIntent::create($data);
+
+    // Return the result as JSON
+    echo json_encode($result);
+} catch (\Stripe\Exception\ApiErrorException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/utils/build/docker/php/common/stripe_webhook.php
+++ b/utils/build/docker/php/common/stripe_webhook.php
@@ -1,0 +1,36 @@
+<?php
+
+require_once '/var/www/html/vendor/autoload.php';
+
+header('Content-Type: application/json');
+
+try {
+    // Configure Stripe client
+    \Stripe\Stripe::setApiKey('sk_FAKE');
+    \Stripe\Stripe::$apiBase = 'http://internal_server:8089';
+
+    // Get raw request body
+    $payload = file_get_contents('php://input');
+
+    // Get Stripe signature from header
+    $sigHeader = $_SERVER['HTTP_STRIPE_SIGNATURE'] ?? '';
+
+    // Webhook secret
+    $webhookSecret = 'whsec_FAKE';
+
+    // Construct and verify the event
+    $event = \Stripe\Webhook::constructEvent(
+        $payload,
+        $sigHeader,
+        $webhookSecret
+    );
+
+    // Return the event.data.object as JSON
+    echo json_encode($event->data->object);
+} catch (\Stripe\Exception\SignatureVerificationException $e) {
+    http_response_code(403);
+    echo json_encode(['error' => $e->getMessage()]);
+} catch (Exception $e) {
+    http_response_code(403);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/utils/build/docker/php/php-fpm/build.sh
+++ b/utils/build/docker/php/php-fpm/build.sh
@@ -31,7 +31,7 @@ nala update
 printf '#!/bin/sh\n\nexit 101\n' > /usr/sbin/policy-rc.d
 chmod +x /usr/sbin/policy-rc.d
 
-nala install -y --no-install-recommends tzdata publicsuffix curl apache2 libapache2-mod-fcgid jq ca-certificates git php$PHP_VERSION-fpm php$PHP_VERSION-curl apache2 php$PHP_VERSION-mysql php$PHP_VERSION-pgsql php$PHP_VERSION-xml php$PHP_VERSION-mongodb
+nala install -y --no-install-recommends tzdata publicsuffix curl apache2 libapache2-mod-fcgid jq ca-certificates git unzip php$PHP_VERSION-fpm php$PHP_VERSION-curl apache2 php$PHP_VERSION-mysql php$PHP_VERSION-pgsql php$PHP_VERSION-xml php$PHP_VERSION-mongodb
 
 rm -rf /usr/sbin/policy-rc.d
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
###  Enable Stripe automated payment event tests for PHP

  Adds the Stripe PHP SDK to the PHP weblog containers and implements the three endpoints required by tests/appsec/test_automated_payment_events.py, enabling the test suite for PHP.

### Changes

  Weblog endpoints (new PHP files):
  - stripe_create_checkout_session.php — POST /stripe/create_checkout_session
  - stripe_create_payment_intent.php — POST /stripe/create_payment_intent
  - stripe_webhook.php — POST /stripe/webhook

  All three route through a fake Stripe API key pointed at internal_server:8089 (the mocked backend).

###   Build infrastructure:
  - composer.json / composer.gte8.2.json — adds stripe/stripe-php:^10.0 as a dependency
  - apache-mod/build.sh — installs the Stripe SDK before ddtrace, because ddtrace injection into ZTS builds causes composer to segfault at image-build time
  - install_ddtrace.sh — re-runs composer require stripe/stripe-php after ddtrace installation (for non-apache builds), installing unzip as a prerequisite
  - php-fpm/build.sh — adds unzip to the base package install (required by composer)
  - rewrite-rules.conf — adds Apache rewrite rules for the three /stripe/* routes
