### PR TITLE
System tests branch for dd-trace-java 1.60.2

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -294,7 +294,7 @@ jobs:
       - name: Install runner
         uses: ./.github/actions/install_runner
       - name: Download logs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           merge-multiple: false
           pattern: logs_*_${{ needs.compute_parameters.outputs.unique_id }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ variables:
     TEST: 1
 
 compute_pipeline:
-  image: registry.ddbuild.io/ci/libdatadog-build/system-tests:57161036
+  image: registry.ddbuild.io/ci/libdatadog-build/system-tests:100425777
   tags: ["arch:amd64"]
   stage: configure
   variables:
@@ -263,7 +263,7 @@ check_merge_labels:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"
 
 generate_system_tests_lambda_proxy_image:
-  image: registry.ddbuild.io/ci/libdatadog-build/ci_docker_base:67145216
+  image: registry.ddbuild.io/ci/libdatadog-build/ci_docker_base:100425777
   tags: ["docker-in-docker:amd64"]
   needs: []
   stage: system-tests-utils
@@ -297,7 +297,7 @@ generate_system_tests_lib_injection_images:
     - when: manual
 
 .delayed_base_job:
-    image: registry.ddbuild.io/ci/libdatadog-build/ci_docker_base:67145216
+    image: registry.ddbuild.io/ci/libdatadog-build/ci_docker_base:100425777
     tags: ["arch:amd64"]
     script:
         - echo "⏳ Waiting before triggering the child pipeline..."

--- a/.gitlab/ssi_gitlab-ci.yml
+++ b/.gitlab/ssi_gitlab-ci.yml
@@ -11,7 +11,7 @@ variables:
   PRIVATE_DOCKER_REGISTRY_USER: AWS
 
 ssi_tests:
-  image: registry.ddbuild.io/ci/libdatadog-build/ci_docker_base:67145216
+  image: registry.ddbuild.io/ci/libdatadog-build/ci_docker_base:100425777
   tags: ["arch:amd64"]
   stage: SSI_TESTS
   script:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3015,7 +3015,9 @@ manifest:
   tests/docker_ssi/test_docker_ssi.py::TestDockerSSIFeatures::test_instrumentation_source_ssi:
     - declaration: missing_feature (Not implemented yet)
       component_version: <1.52.0
-  tests/docker_ssi/test_docker_ssi_appsec.py::TestDockerSSIAppsecFeatures::test_telemetry_source_ssi: v1.59.0
+  tests/docker_ssi/test_docker_ssi_appsec.py::TestDockerSSIAppsecFeatures::test_telemetry_source_ssi:
+    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10788)
+      component_version: '>=1.60.1'
   tests/docker_ssi/test_docker_ssi_crash.py::TestDockerSSICrash::test_crash: missing_feature (No implemented the endpoint /crashme)
   tests/ffe/test_dynamic_evaluation.py:
     - weblog_declaration:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1618,9 +1618,7 @@ manifest:
         ratpack: missing_feature (endpoint not implemented)
         vertx3: missing_feature (endpoint not implemented)
         vertx4: missing_feature (endpoint not implemented)
-  tests/appsec/test_asm_standalone.py::Test_SCAStandalone_Telemetry_V2::test_telemetry_sca_enabled_propagated:
-    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10823)
-      component_version: '>=1.60.1'
+  tests/appsec/test_asm_standalone.py::Test_SCAStandalone_Telemetry_V2::test_telemetry_sca_enabled_propagated: v1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
   tests/appsec/test_asm_standalone.py::Test_UserEventsStandalone_Automated:
     - weblog_declaration:
         "*": v1.45.0
@@ -3018,9 +3016,7 @@ manifest:
   tests/docker_ssi/test_docker_ssi.py::TestDockerSSIFeatures::test_instrumentation_source_ssi:
     - declaration: missing_feature (Not implemented yet)
       component_version: <1.52.0
-  tests/docker_ssi/test_docker_ssi_appsec.py::TestDockerSSIAppsecFeatures::test_telemetry_source_ssi:
-    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10823)
-      component_version: '>=1.60.1'
+  tests/docker_ssi/test_docker_ssi_appsec.py::TestDockerSSIAppsecFeatures::test_telemetry_source_ssi: 1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
   tests/docker_ssi/test_docker_ssi_crash.py::TestDockerSSICrash::test_crash: missing_feature (No implemented the endpoint /crashme)
   tests/ffe/test_dynamic_evaluation.py:
     - weblog_declaration:
@@ -3667,22 +3663,18 @@ manifest:
     - component_version: ">=1.57.0"
       declaration: flaky (APMAPI-1785)
   tests/parametric/test_telemetry.py::Test_Consistent_Configs: missing_feature
-  tests/parametric/test_telemetry.py::Test_Defaults: '>=1.31.0 <1.60.1'  # temporarily disabling until Java PR is merged (https://github.com/DataDog/dd-trace-java/pull/10823)
-  tests/parametric/test_telemetry.py::Test_Environment: '>=1.31.0 <1.60.1'  # temporarily disabling until Java PR is merged (https://github.com/DataDog/dd-trace-java/pull/10823)
+  tests/parametric/test_telemetry.py::Test_Defaults: v1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
+  tests/parametric/test_telemetry.py::Test_Environment: v1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
   tests/parametric/test_telemetry.py::Test_Environment::test_telemetry_otel_env_hiding: missing_feature (Not implemented)
   tests/parametric/test_telemetry.py::Test_Environment::test_telemetry_otel_env_invalid: missing_feature (Not implemented)
-  tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin: '>=1.47.0-SNAPSHOT <1.60.1'
-  tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_config_id:
-    - declaration: missing_feature (Not implemented)
-      component_version: <=1.53.0-SNAPSHOT
-    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10823)
-      component_version: '>=1.60.1'
+  tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin: 1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
+  tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_config_id: 1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
   ? tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_origin_extended_configs_temporary_use_case
   : irrelevant (temporary use case for python, ruby and nodejs)
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature: v1.27.0
-  tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: '>=1.34.0 <1.60.1'  # temporarily disabling until Java PR is merged (https://github.com/DataDog/dd-trace-java/pull/10823)
+  tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: v1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant
-  tests/parametric/test_telemetry.py::Test_TelemetrySSIConfigs: '>=1.51.0 <1.60.1'  # temporarily disabling until Java PR is merged (https://github.com/DataDog/dd-trace-java/pull/10823)
+  tests/parametric/test_telemetry.py::Test_TelemetrySSIConfigs: v1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_Basic: v0.111.0
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_Globs: v1.25.1
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_Globs_Feb2024_Revision: v1.30.0
@@ -4223,9 +4215,8 @@ manifest:
   tests/test_telemetry.py::Test_Telemetry::test_app_product_change: missing_feature (Weblog GET/enable_product and app-product-change event is not implemented yet.)
   tests/test_telemetry.py::Test_Telemetry::test_app_started_client_configuration:  # Created by easy win activation script
     - weblog_declaration:
+        "*": v1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
-    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10823)
-      component_version: '>=1.60.1'
   tests/test_telemetry.py::Test_Telemetry::test_app_started_is_first_message:  # Created by easy win activation script
     - weblog_declaration:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
@@ -4247,10 +4238,8 @@ manifest:
     - weblog_declaration:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
   tests/test_telemetry.py::Test_TelemetryEnhancedConfigReporting:
-    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10823)
-      component_version: '>=1.60.1'
     - weblog_declaration:
-        "*": v1.54.0-SNAPSHOT
+        "*": v1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
   tests/test_telemetry.py::Test_TelemetrySCAEnvVar: missing_feature
   tests/test_telemetry.py::Test_TelemetryV2: v1.23.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1618,6 +1618,9 @@ manifest:
         ratpack: missing_feature (endpoint not implemented)
         vertx3: missing_feature (endpoint not implemented)
         vertx4: missing_feature (endpoint not implemented)
+  tests/appsec/test_asm_standalone.py::Test_SCAStandalone_Telemetry_V2::test_telemetry_sca_enabled_propagated:
+    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10823)
+      component_version: '>=1.60.1'
   tests/appsec/test_asm_standalone.py::Test_UserEventsStandalone_Automated:
     - weblog_declaration:
         "*": v1.45.0
@@ -3016,7 +3019,7 @@ manifest:
     - declaration: missing_feature (Not implemented yet)
       component_version: <1.52.0
   tests/docker_ssi/test_docker_ssi_appsec.py::TestDockerSSIAppsecFeatures::test_telemetry_source_ssi:
-    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10788)
+    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10823)
       component_version: '>=1.60.1'
   tests/docker_ssi/test_docker_ssi_crash.py::TestDockerSSICrash::test_crash: missing_feature (No implemented the endpoint /crashme)
   tests/ffe/test_dynamic_evaluation.py:
@@ -3664,20 +3667,22 @@ manifest:
     - component_version: ">=1.57.0"
       declaration: flaky (APMAPI-1785)
   tests/parametric/test_telemetry.py::Test_Consistent_Configs: missing_feature
-  tests/parametric/test_telemetry.py::Test_Defaults: v1.31.0
-  tests/parametric/test_telemetry.py::Test_Environment: v1.31.0
+  tests/parametric/test_telemetry.py::Test_Defaults: '>=1.31.0 <1.60.1'  # temporarily disabling until Java PR is merged (https://github.com/DataDog/dd-trace-java/pull/10823)
+  tests/parametric/test_telemetry.py::Test_Environment: '>=1.31.0 <1.60.1'  # temporarily disabling until Java PR is merged (https://github.com/DataDog/dd-trace-java/pull/10823)
   tests/parametric/test_telemetry.py::Test_Environment::test_telemetry_otel_env_hiding: missing_feature (Not implemented)
   tests/parametric/test_telemetry.py::Test_Environment::test_telemetry_otel_env_invalid: missing_feature (Not implemented)
-  tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin: v1.47.0-SNAPSHOT
+  tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin: '>=1.47.0-SNAPSHOT <1.60.1'
   tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_config_id:
     - declaration: missing_feature (Not implemented)
       component_version: <=1.53.0-SNAPSHOT
+    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10823)
+      component_version: '>=1.60.1'
   ? tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_origin_extended_configs_temporary_use_case
   : irrelevant (temporary use case for python, ruby and nodejs)
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature: v1.27.0
-  tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: v1.34.0
+  tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: '>=1.34.0 <1.60.1'  # temporarily disabling until Java PR is merged (https://github.com/DataDog/dd-trace-java/pull/10823)
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant
-  tests/parametric/test_telemetry.py::Test_TelemetrySSIConfigs: v1.51.0
+  tests/parametric/test_telemetry.py::Test_TelemetrySSIConfigs: '>=1.51.0 <1.60.1'  # temporarily disabling until Java PR is merged (https://github.com/DataDog/dd-trace-java/pull/10823)
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_Basic: v0.111.0
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_Globs: v1.25.1
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_Globs_Feb2024_Revision: v1.30.0
@@ -4219,6 +4224,8 @@ manifest:
   tests/test_telemetry.py::Test_Telemetry::test_app_started_client_configuration:  # Created by easy win activation script
     - weblog_declaration:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
+    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10823)
+      component_version: '>=1.60.1'
   tests/test_telemetry.py::Test_Telemetry::test_app_started_is_first_message:  # Created by easy win activation script
     - weblog_declaration:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
@@ -4240,6 +4247,8 @@ manifest:
     - weblog_declaration:
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)
   tests/test_telemetry.py::Test_TelemetryEnhancedConfigReporting:
+    - declaration: missing_feature (Temporarily disabling until Java PR is merged https://github.com/DataDog/dd-trace-java/pull/10823)
+      component_version: '>=1.60.1'
     - weblog_declaration:
         "*": v1.54.0-SNAPSHOT
         spring-boot-3-native: missing_feature (GraalVM. Tracing support only)

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -16,20 +16,24 @@ from .conftest import APMLibrary
 
 
 telemetry_name_mapping: dict[str, dict[str, str | list[str]]] = {
+    "instrumentation_source": {
+        "java": "DD_INSTRUMENTATION_SOURCE",
+    },
     "ssi_injection_enabled": {
         "python": "DD_INJECTION_ENABLED",
-        "java": "injection_enabled",
+        "java": "DD_INJECTION_ENABLED",
         "ruby": "DD_INJECTION_ENABLED",
         "golang": ["DD_INJECTION_ENABLED", "injection_enabled"],
     },
     "ssi_forced_injection_enabled": {
         "python": "DD_INJECT_FORCE",
         "ruby": "DD_INJECT_FORCE",
-        "java": "inject_force",
+        "java": "DD_INJECT_FORCE",
         "golang": ["DD_INJECT_FORCE", "inject_force"],
     },
     "trace_sample_rate": {
         "dotnet": "DD_TRACE_SAMPLE_RATE",
+        "java": "DD_TRACE_SAMPLE_RATE",
         "nodejs": "DD_TRACE_SAMPLE_RATE",
         "python": "DD_TRACE_SAMPLE_RATE",
         "ruby": "DD_TRACE_SAMPLE_RATE",
@@ -42,16 +46,25 @@ telemetry_name_mapping: dict[str, dict[str, str | list[str]]] = {
         "php": "trace.logs_enabled",
         "ruby": "tracing.log_injection",
         "golang": ["DD_LOGS_INJECTION", "trace.logs_enabled"],
+        "java": "DD_LOGS_INJECTION_ENABLED",
     },
     "trace_header_tags": {
         "dotnet": "DD_TRACE_HEADER_TAGS",
         "nodejs": "DD_TRACE_HEADER_TAGS",
         "python": "DD_TRACE_HEADER_TAGS",
         "golang": ["DD_TRACE_HEADER_TAGS", "trace_header_tags"],
+        "java": "DD_TRACE_HEADER_TAGS",
     },
-    "trace_tags": {"dotnet": "DD_TAGS", "nodejs": "DD_TAGS", "python": "DD_TAGS", "golang": ["DD_TAGS", "trace_tags"]},
+    "trace_tags": {
+        "dotnet": "DD_TAGS",
+        "java": "DD_TRACE_TAGS",
+        "nodejs": "DD_TAGS",
+        "python": "DD_TAGS",
+        "golang": ["DD_TAGS", "trace_tags"],
+    },
     "trace_enabled": {
         "dotnet": "DD_TRACE_ENABLED",
+        "java": "DD_TRACE_ENABLED",
         "nodejs": "tracing",
         "python": "DD_TRACE_ENABLED",
         "ruby": "tracing.enabled",
@@ -63,6 +76,7 @@ telemetry_name_mapping: dict[str, dict[str, str | list[str]]] = {
         "python": "DD_PROFILING_ENABLED",
         "ruby": "profiling.enabled",
         "golang": ["DD_PROFILING_ENABLED", "profiling_enabled"],
+        "java": "DD_PROFILING_ENABLED",
     },
     "appsec_enabled": {
         "dotnet": "DD_APPSEC_ENABLED",
@@ -70,14 +84,17 @@ telemetry_name_mapping: dict[str, dict[str, str | list[str]]] = {
         "python": "DD_APPSEC_ENABLED",
         "ruby": "appsec.enabled",
         "golang": ["DD_APPSEC_ENABLED", "appsec_enabled"],
+        "java": "DD_APPSEC_ENABLED",
     },
     "data_streams_enabled": {
         "dotnet": "DD_DATA_STREAMS_ENABLED",
         "nodejs": "dsmEnabled",
         "python": "DD_DATA_STREAMS_ENABLED",
+        "java": "DD_DATA_STREAMS_ENABLED",
         "golang": ["DD_DATA_STREAMS_ENABLED", "data_streams_enabled"],
     },
     "runtime_metrics_enabled": {
+        "java": "DD_RUNTIME_METRICS_ENABLED",
         "dotnet": "DD_RUNTIME_METRICS_ENABLED",
         "nodejs": "runtime.metrics.enabled",
         "python": "DD_RUNTIME_METRICS_ENABLED",
@@ -85,6 +102,7 @@ telemetry_name_mapping: dict[str, dict[str, str | list[str]]] = {
         "golang": ["DD_RUNTIME_METRICS_ENABLED", "runtime_metrics_enabled"],
     },
     "dynamic_instrumentation_enabled": {
+        "java": "DD_DYNAMIC_INSTRUMENTATION_ENABLED",
         "dotnet": "DD_DYNAMIC_INSTRUMENTATION_ENABLED",
         "nodejs": "dynamicInstrumentation.enabled",
         "python": "DD_DYNAMIC_INSTRUMENTATION_ENABLED",
@@ -94,19 +112,20 @@ telemetry_name_mapping: dict[str, dict[str, str | list[str]]] = {
     },
     "trace_debug_enabled": {
         "php": "trace.debug",
-        "java": "trace_debug",
+        "java": "DD_TRACE_DEBUG",
         "ruby": "DD_TRACE_DEBUG",
         "python": "DD_TRACE_DEBUG",
         "golang": ["trace_debug_enabled", "DD_TRACE_DEBUG"],
     },
     "tags": {
-        "java": "trace_tags",
+        "java": "DD_TRACE_TAGS",
         "dotnet": "DD_TAGS",
         "python": "DD_TAGS",
         "nodejs": "DD_TAGS",
         "golang": ["DD_TAGS", "trace_tags"],
     },
     "trace_propagation_style": {
+        "java": "DD_TRACE_PROPAGATION_STYLE",
         "dotnet": "DD_TRACE_PROPAGATION_STYLE",
         "php": "trace.propagation_style",
         "golang": ["DD_TRACE_PROPAGATION_STYLE", "trace.propagation_style"],

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -461,7 +461,7 @@ class Test_Telemetry:
             "python": {},
             "cpp_nginx": {"trace_agent_port": trace_agent_port},
             "cpp_httpd": {"trace_agent_port": trace_agent_port},
-            "java": {"trace_agent_port": trace_agent_port, "telemetry_heartbeat_interval": 2},
+            "java": {"DD_TRACE_AGENT_PORT": trace_agent_port, "DD_TELEMETRY_HEARTBEAT_INTERVAL": 2},
             "ruby": {"DD_AGENT_TRANSPORT": "TCP"},
             "golang": {"lambda_mode": False},
         }
@@ -489,7 +489,7 @@ class Test_Telemetry:
                         if cnf.get("name") == config_name_to_check:
                             config_value = cnf.get("value")
                             # Accept both the expected value and its float version for telemetry_heartbeat_interval
-                            if expected_config_name == "telemetry_heartbeat_interval":
+                            if expected_config_name == "DD_TELEMETRY_HEARTBEAT_INTERVAL":
                                 try:
                                     expected_float = float(expected_value)
                                     config_float = float(config_value)
@@ -589,7 +589,7 @@ class Test_TelemetryEnhancedConfigReporting:
             ],
         },
         "java": {
-            "name": "logs_injection_enabled",
+            "name": "DD_LOGS_INJECTION_ENABLED",
             "precedence": [
                 {"origin": "default", "value": "true"},
                 {

--- a/utils/scripts/ci_orchestrators/aws_ssi.json
+++ b/utils/scripts/ci_orchestrators/aws_ssi.json
@@ -381,7 +381,9 @@
                 ],
                 "excluded_os_names": [
                     "Debian_11_amd64",
-                    "Debian_11_arm64"
+                    "Debian_11_arm64",
+                    "Debian_12_amd64",
+                    "Debian_12_arm64"
                 ]
             },
             {
@@ -390,7 +392,9 @@
                     "Ubuntu_23_04_arm64",
                     "windows_server_2022_amd64",
                     "Debian_11_amd64",
-                    "Debian_11_arm64"
+                    "Debian_11_arm64",
+                    "Debian_12_amd64",
+                    "Debian_12_arm64"
                 ]
             },
             {
@@ -399,7 +403,9 @@
                     "Ubuntu_23_04_arm64",
                     "windows_server_2022_amd64",
                     "Debian_11_amd64",
-                    "Debian_11_arm64"
+                    "Debian_11_arm64",
+                    "Debian_12_amd64",
+                    "Debian_12_arm64"
                 ]
             },
             {
@@ -416,6 +422,7 @@
                     "Debian_11_amd64",
                     "Debian_11_arm64",
                     "Debian_12_amd64",
+                    "Debian_12_arm64",
                     "OracleLinux_9_2_amd64",
                     "OracleLinux_9_2_arm64",
                     "OracleLinux_9_3_amd64",
@@ -445,7 +452,9 @@
                     "Ubuntu_24_10_amd64",
                     "Ubuntu_24_10_arm64",
                     "Debian_11_amd64",
-                    "Debian_11_arm64"
+                    "Debian_11_arm64",
+                    "Debian_12_amd64",
+                    "Debian_12_arm64"
                 ]
             },
             {
@@ -457,7 +466,9 @@
                     "Ubuntu_24_10_amd64",
                     "Ubuntu_24_10_arm64",
                     "Debian_11_amd64",
-                    "Debian_11_arm64"
+                    "Debian_11_arm64",
+                    "Debian_12_amd64",
+                    "Debian_12_arm64"
                 ]
             }
         ],

--- a/utils/telemetry_utils.py
+++ b/utils/telemetry_utils.py
@@ -19,9 +19,7 @@ class TelemetryUtils:
     @staticmethod
     def get_dd_appsec_sca_enabled_str(library: ComponentVersion) -> str:
         result = "DD_APPSEC_SCA_ENABLED"
-        if library == "java":
-            result = "appsec_sca_enabled"
-        elif library == "nodejs":
+        if library == "nodejs":
             result = "appsec.sca.enabled"
         elif library in ("php", "ruby"):
             result = "appsec.sca_enabled"


### PR DESCRIPTION
## Motivation

`dd-trace-java` needs to release `1.60.2` patch. We typically pin system tests to the version that `1.60.0` was released off of (SHA: 61f7ee29e7432cba821a4d303c95929160bd23fd); however, given recent Datadog enterprise GitHub Actions policy changes, we need to cherry-pick a few additional commits for compatibility.

This branch is pinned in `dd-trace-java` in https://github.com/DataDog/dd-trace-java/pull/10898

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
