### PR TITLE
chore(ssi): decrease timeout

### DIFF
--- a/.gitlab/ssi_gitlab-ci.yml
+++ b/.gitlab/ssi_gitlab-ci.yml
@@ -21,7 +21,7 @@ ssi_tests:
     extends: .base_job_k8s_docker_ssi
     needs: []
     allow_failure: false
-    timeout: 30 minutes
+    timeout: 8 minutes
     variables:
       # Force gitlab to keep the exit code as 3 if the job fails with exit code 3
       FF_USE_NEW_BASH_EVAL_STRATEGY: true

--- a/utils/scripts/ci_orchestrators/gitlab_exporter.py
+++ b/utils/scripts/ci_orchestrators/gitlab_exporter.py
@@ -325,7 +325,7 @@ def print_docker_ssi_gitlab_pipeline(
                     "source venv/bin/activate",
                     "echo 'Running SSI tests'",
                     (
-                        'timeout 1200s ./run.sh $SCENARIO --ssi-weblog "$WEBLOG" '
+                        'timeout 460s ./run.sh $SCENARIO --ssi-weblog "$WEBLOG" '
                         '--ssi-library "$TEST_LIBRARY" --ssi-base-image "$IMAGE" '
                         '--ssi-arch "$ARCH" --ssi-installable-runtime "$RUNTIME" '
                         "--ssi-env $ONBOARDING_FILTER_ENV"


### PR DESCRIPTION
APPSEC-61450

## Motivation

Some SSI jobs can rarely froze, and we have to wait for the overall timeout for a failure (30 minutes) while it almost always passes under 4 minutes. Decrease the timeout to 8 minutes.

## Changes

Decrease the timeout to 8 minutes.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
