### PR TITLE
Add css obfuscation test [APMSP-2764]

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -183,6 +183,9 @@ jobs:
     - name: Run TRACE_STATS_COMPUTATION scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"TRACE_STATS_COMPUTATION"')
       run: ./run.sh TRACE_STATS_COMPUTATION
+    - name: Run TRACE_STATS_COMPUTATION_OBFUSCATION_DISABLED scenario
+      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"TRACE_STATS_COMPUTATION_OBFUSCATION_DISABLED"')
+      run: ./run.sh TRACE_STATS_COMPUTATION_OBFUSCATION_DISABLED
     - name: Run IAST_STANDALONE scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"IAST_STANDALONE"')
       run: ./run.sh IAST_STANDALONE

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -186,6 +186,15 @@ jobs:
     - name: Run TRACE_STATS_COMPUTATION_OBFUSCATION_DISABLED scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"TRACE_STATS_COMPUTATION_OBFUSCATION_DISABLED"')
       run: ./run.sh TRACE_STATS_COMPUTATION_OBFUSCATION_DISABLED
+    - name: Run TRACE_STATS_COMPUTATION_FUTURE_OBFUSCATION_VERSION scenario
+      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"TRACE_STATS_COMPUTATION_FUTURE_OBFUSCATION_VERSION"')
+      run: ./run.sh TRACE_STATS_COMPUTATION_FUTURE_OBFUSCATION_VERSION
+    - name: Run TRACE_STATS_COMPUTATION_MISSING_OBFUSCATION_VERSION scenario
+      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"TRACE_STATS_COMPUTATION_MISSING_OBFUSCATION_VERSION"')
+      run: ./run.sh TRACE_STATS_COMPUTATION_MISSING_OBFUSCATION_VERSION
+    - name: Run TRACE_STATS_COMPUTATION_OBFUSCATION_VERSION_ZERO scenario
+      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"TRACE_STATS_COMPUTATION_OBFUSCATION_VERSION_ZERO"')
+      run: ./run.sh TRACE_STATS_COMPUTATION_OBFUSCATION_VERSION_ZERO
     - name: Run IAST_STANDALONE scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"IAST_STANDALONE"')
       run: ./run.sh IAST_STANDALONE

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -305,6 +305,11 @@ manifest:
   tests/parametric/test_tracer_flare.py::TestTracerFlareV1::test_tracer_flare_content_with_debug: missing_feature  # Created by easy win activation script
   tests/parametric/test_tracer_flare.py::TestTracerFlareV1::test_tracer_flare_with_debug: missing_feature  # Created by easy win activation script
   tests/parametric/test_tracer_flare.py::TestTracerFlareV1::test_tracer_profiling_notracing_flare_content: missing_feature  # Created by easy win activation script
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_library_conf.py::Test_ExtractBehavior_Default::test_multiple_tracecontexts: missing_feature (baggage is not implemented, also remove DD_TRACE_PROPAGATION_STYLE_EXTRACT workaround in containers.py)
   tests/test_library_conf.py::Test_ExtractBehavior_Default::test_single_tracecontext: missing_feature (baggage is not implemented, also remove DD_TRACE_PROPAGATION_STYLE_EXTRACT workaround in containers.py)

--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -109,6 +109,11 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats::test_is_trace_root: missing_feature  # Created by easy win activation script
   tests/stats/test_stats.py::Test_Client_Stats::test_obfuscation: missing_feature  # Created by easy win activation script
   tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Peer_Tags: missing_feature  # Created by easy win activation script
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats: missing_feature  # Created by easy win activation script

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -359,6 +359,11 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats::test_is_trace_root: missing_feature  # Created by easy win activation script
   tests/stats/test_stats.py::Test_Client_Stats::test_obfuscation: missing_feature  # Created by easy win activation script
   tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Peer_Tags: missing_feature  # Created by easy win activation script
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats: missing_feature  # Created by easy win activation script

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1067,6 +1067,11 @@ manifest:
     - weblog_declaration:
         uds: '>=3.43.0'
         poc: '>=3.43.0'
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Peer_Tags:
     - weblog_declaration:
         uds: '>=3.43.0'

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1290,6 +1290,11 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Drop_P0s::test_client_drop_p0s_false: v2.6.0
   tests/stats/test_stats.py::Test_Client_Stats::test_grpc_status_code: irrelevant (variant has no gRPC endpoint)
   tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service: missing_feature (Go does not set top-level Service field in stats payload)
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_baggage.py::Test_Baggage_Headers_Api_Datadog: incomplete_test_app (/otel_drop_in_baggage_api_datadog endpoint is not implemented)
   tests/test_baggage.py::Test_Baggage_Headers_Api_OTel: incomplete_test_app (/otel_drop_in_baggage_api_otel endpoint is not implemented)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3925,7 +3925,11 @@ manifest:
     - weblog_declaration:
         "*": v1.54.0
         spring-boot-3-native: missing_feature (rasp endpoint not implemented)
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation::test_obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source:
     - weblog_declaration:
         "*": v0.0.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3925,6 +3925,7 @@ manifest:
     - weblog_declaration:
         "*": v1.54.0
         spring-boot-3-native: missing_feature (rasp endpoint not implemented)
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation::test_obfuscation: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source:
     - weblog_declaration:
         "*": v0.0.0

--- a/manifests/java_otel.yml
+++ b/manifests/java_otel.yml
@@ -60,6 +60,11 @@ manifest:
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature
   tests/parametric/test_tracer.py::Test_TracerServiceNameSource: irrelevant
   tests/parametric/test_tracer.py::Test_TracerUniversalServiceTagging::test_tracer_service_name_environment_variable: "missing_feature (FIXME: library test client sets empty string as the service name)"
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_library_conf.py::Test_HeaderTags_DynamicConfig::test_tracing_client_http_header_tags_apm_multiconfig: missing_feature (APM_TRACING_MULTICONFIG is not supported in any language yet)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)

--- a/manifests/nodejs_otel.yml
+++ b/manifests/nodejs_otel.yml
@@ -77,6 +77,11 @@ manifest:
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature
   tests/parametric/test_tracer.py::Test_TracerServiceNameSource: irrelevant
   tests/parametric/test_tracer.py::Test_TracerUniversalServiceTagging::test_tracer_service_name_environment_variable: "missing_feature (FIXME: library test client sets empty string as the service name)"
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_library_conf.py::Test_HeaderTags_DynamicConfig::test_tracing_client_http_header_tags_apm_multiconfig: missing_feature (APM_TRACING_MULTICONFIG is not supported in any language yet)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -967,6 +967,11 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats::test_disable: v1.17.0
   tests/stats/test_stats.py::Test_Client_Stats::test_grpc_status_code: missing_feature (PHP does not support gRPC)
   tests/stats/test_stats.py::Test_Client_Stats::test_obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_baggage.py::Test_Baggage_Headers_Basic: incomplete_test_app (/make_distant_call endpoint is not correctly implemented)
   tests/test_baggage.py::Test_Baggage_Headers_Malformed: incomplete_test_app (/make_distant_call endpoint is not correctly implemented)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2090,6 +2090,11 @@ manifest:
     - weblog_declaration:
         "*": v2.8.0
   tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service: missing_feature (Python does not set top-level Service field in stats payload)
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: '>=4.10.1'
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: '>=4.10.1'
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: '>=4.10.1'
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: '>=4.10.1'
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: '>=4.10.1'
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats_bucket_alignment:  # Modified by easy win activation script
     - weblog_declaration:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2090,11 +2090,11 @@ manifest:
     - weblog_declaration:
         "*": v2.8.0
   tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service: missing_feature (Python does not set top-level Service field in stats payload)
-  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: '>=4.10.1'
-  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: '>=4.10.1'
-  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: '>=4.10.1'
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: '>=4.10.1'
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: '>=4.10.1'
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: '>=4.11.0'
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: '>=4.11.0'
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: '>=4.11.0'
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: '>=4.11.0'
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: '>=4.11.0'
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats_bucket_alignment:  # Modified by easy win activation script
     - weblog_declaration:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2090,11 +2090,11 @@ manifest:
     - weblog_declaration:
         "*": v2.8.0
   tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service: missing_feature (Python does not set top-level Service field in stats payload)
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: '>=4.10.1'
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: '>=4.10.1'
   tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: '>=4.10.1'
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: '>=4.10.1'
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: '>=4.10.1'
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: '>=4.10.1'
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: '>=4.10.1'
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats_bucket_alignment:  # Modified by easy win activation script
     - weblog_declaration:

--- a/manifests/python_lambda.yml
+++ b/manifests/python_lambda.yml
@@ -322,6 +322,11 @@ manifest:
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature
   tests/parametric/test_tracer.py::Test_TracerServiceNameSource: irrelevant
   tests/parametric/test_tracer.py::Test_TracerUniversalServiceTagging::test_tracer_service_name_environment_variable: "missing_feature (FIXME: library test client sets empty string as the service name)"
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_library_conf.py::Test_HeaderTags_DynamicConfig::test_tracing_client_http_header_tags_apm_multiconfig: missing_feature (APM_TRACING_MULTICONFIG is not supported in any language yet)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)

--- a/manifests/python_otel.yml
+++ b/manifests/python_otel.yml
@@ -69,6 +69,11 @@ manifest:
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature
   tests/parametric/test_tracer.py::Test_TracerServiceNameSource: irrelevant
   tests/parametric/test_tracer.py::Test_TracerUniversalServiceTagging::test_tracer_service_name_environment_variable: "missing_feature (FIXME: library test client sets empty string as the service name)"
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_library_conf.py::Test_HeaderTags_DynamicConfig::test_tracing_client_http_header_tags_apm_multiconfig: missing_feature (APM_TRACING_MULTICONFIG is not supported in any language yet)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2426,6 +2426,11 @@ manifest:
         sinatra41: missing_feature
         sinatra22: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service: missing_feature (Ruby does not set top-level Service field in stats payload)
+  tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats:  # Created by easy win activation script
     - weblog_declaration:

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -277,6 +277,96 @@ class Test_Client_Stats_Future_Obfuscation_Version:
             )
 
 
+@features.client_side_stats_supported
+@scenarios.trace_stats_computation_missing_obfuscation_version
+class Test_Client_Stats_Missing_Obfuscation_Version:
+    """Test that the SDK skips client-side obfuscation when the agent does not advertise obfuscation_version"""
+
+    def setup_no_obfuscation(self):
+        """Setup for missing obfuscation version test - generates SQL spans"""
+        test_user_ids = ["1", "2", "admin", "test"]
+        for user_id in test_user_ids:
+            weblog.get(f"/rasp/sqli?user_id={user_id}")
+
+    def test_no_obfuscation(self):
+        """Test that the SDK does not obfuscate stats and does not send the obfuscation header
+        when the agent does not advertise obfuscation_version in /info.
+
+        Validates:
+        - Datadog-Obfuscation-Version header is NOT present on any stats payload
+        - SQL resource names are NOT obfuscated (raw literals still present)
+        """
+        sql_stats = []
+        obfuscation_header_found = False
+
+        for data in interfaces.library.get_data("/v0.6/stats"):
+            headers = {h[0].lower(): h[1] for h in data["request"]["headers"]}
+            if "datadog-obfuscation-version" in headers:
+                obfuscation_header_found = True
+
+            payload = data["request"]["content"]
+            for bucket in payload.get("Stats", []):
+                for stat in bucket.get("Stats", []):
+                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT"):
+                        sql_stats.append(stat)
+
+        assert not obfuscation_header_found, (
+            "Datadog-Obfuscation-Version header should NOT be present when agent does not advertise obfuscation_version"
+        )
+
+        assert len(sql_stats) == 4, "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
+        for stat in sql_stats:
+            assert "?" not in stat["Resource"], (
+                f"SQL resource should NOT be obfuscated when agent does not advertise obfuscation_version, "
+                f"but got: '{stat['Resource']}'"
+            )
+
+
+@features.client_side_stats_supported
+@scenarios.trace_stats_computation_obfuscation_version_zero
+class Test_Client_Stats_Obfuscation_Version_Zero:
+    """Test that the SDK skips client-side obfuscation when the agent advertises obfuscation_version=0"""
+
+    def setup_no_obfuscation(self):
+        """Setup for obfuscation version zero test - generates SQL spans"""
+        test_user_ids = ["1", "2", "admin", "test"]
+        for user_id in test_user_ids:
+            weblog.get(f"/rasp/sqli?user_id={user_id}")
+
+    def test_no_obfuscation(self):
+        """Test that the SDK does not obfuscate stats and does not send the obfuscation header
+        when the agent advertises obfuscation_version=0.
+
+        Validates:
+        - Datadog-Obfuscation-Version header is NOT present on any stats payload
+        - SQL resource names are NOT obfuscated (raw literals still present)
+        """
+        sql_stats = []
+        obfuscation_header_found = False
+
+        for data in interfaces.library.get_data("/v0.6/stats"):
+            headers = {h[0].lower(): h[1] for h in data["request"]["headers"]}
+            if "datadog-obfuscation-version" in headers:
+                obfuscation_header_found = True
+
+            payload = data["request"]["content"]
+            for bucket in payload.get("Stats", []):
+                for stat in bucket.get("Stats", []):
+                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT"):
+                        sql_stats.append(stat)
+
+        assert not obfuscation_header_found, (
+            "Datadog-Obfuscation-Version header should NOT be present when agent advertises obfuscation_version=0"
+        )
+
+        assert len(sql_stats) == 4, "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
+        for stat in sql_stats:
+            assert "?" not in stat["Resource"], (
+                f"SQL resource should NOT be obfuscated when agent advertises obfuscation_version=0, "
+                f"but got: '{stat['Resource']}'"
+            )
+
+
 @features.service_override_source
 @scenarios.trace_stats_computation
 class Test_Stats_Service_Source:

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -174,7 +174,7 @@ class Test_Client_Stats_With_Client_Obfuscation:
 
         assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
 
-        assert len(sql_stats) > 0, "Expected at least one SQL stats entry"
+        assert len(sql_stats) == 4, "Expected at least one SQL stats entry"
         for stat in sql_stats:
             assert stat["Resource"] == want, f"Expected obfuscated resource '{want}', got '{stat['Resource']}'"
 
@@ -218,7 +218,7 @@ class Test_Client_Stats_With_Client_Obfuscation_Disabled:
 
         assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
 
-        assert len(sql_stats) > 0, "Expected at least one SQL stats entry"
+        assert len(sql_stats) == 4, "Expected at least one SQL stats entry"
         # NormalizeOnly mode preserves string literals including surrounding single quotes.
         # The SQL uses string-quoted IDs (e.g. WHERE id='1'), so after normalization the
         # suffix appears as e.g. "'1'" (with quotes). Accept both quoted and unquoted forms
@@ -269,7 +269,7 @@ class Test_Client_Stats_Future_Obfuscation_Version:
             "Datadog-Obfuscation-Version header should NOT be present when agent reports a future obfuscation version"
         )
 
-        assert len(sql_stats) > 0, "Expected at least one SQL stats entry"
+        assert len(sql_stats) == 4, "Expected at least one SQL stats entry"
         for stat in sql_stats:
             assert "?" not in stat["Resource"], (
                 f"SQL resource should NOT be obfuscated when agent reports a future obfuscation version, "

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -161,8 +161,8 @@ class Test_Client_Stats_With_Client_Obfuscation:
             headers = {h[0].lower(): h[1] for h in data["request"]["headers"]}
             if "datadog-obfuscation-version" in headers:
                 obfuscation_header_found = True
-                assert headers["datadog-obfuscation-version"] == "1", (
-                    f"Expected obfuscation version '1', got '{headers['datadog-obfuscation-version']}'"
+                assert int(headers["datadog-obfuscation-version"])  >= 1, (
+                    f"Expected obfuscation version to be >= 1, got '{headers['datadog-obfuscation-version']}'"
                 )
 
             payload = data["request"]["content"]

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -168,7 +168,7 @@ class Test_Client_Stats_With_Client_Obfuscation:
             payload = data["request"]["content"]
             for bucket in payload.get("Stats", []):
                 for stat in bucket.get("Stats", []):
-                    if stat.get("Type") == "sql":
+                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT"):
                         sql_stats.append(stat)
 
         assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
@@ -211,7 +211,7 @@ class Test_Client_Stats_With_Client_Obfuscation_Disabled:
             payload = data["request"]["content"]
             for bucket in payload.get("Stats", []):
                 for stat in bucket.get("Stats", []):
-                    if stat.get("Type") == "sql":
+                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT"):
                         sql_stats.append(stat)
 
         assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
@@ -254,7 +254,7 @@ class Test_Client_Stats_Future_Obfuscation_Version:
             payload = data["request"]["content"]
             for bucket in payload.get("Stats", []):
                 for stat in bucket.get("Stats", []):
-                    if stat.get("Type") == "sql":
+                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT"):
                         sql_stats.append(stat)
 
         assert not obfuscation_header_found, (

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -1,5 +1,6 @@
 import contextlib
 import pytest
+
 from utils import features, interfaces, logger, scenarios, weblog
 
 """
@@ -134,7 +135,7 @@ class Test_Client_Stats:
         )
 
 
-@features.client_side_stats_supported  # FIXME: create a new feature ?
+@features.client_side_stats_supported
 @scenarios.trace_stats_computation
 class Test_Client_Stats_With_Client_Obfuscation:
     """Test client-side stats do the obfuscation before-hand when available"""
@@ -178,10 +179,11 @@ class Test_Client_Stats_With_Client_Obfuscation:
             assert stat["Resource"] == want, f"Expected obfuscated resource '{want}', got '{stat['Resource']}'"
 
 
-@features.client_side_stats_supported  # FIXME: create a new feature ?
+@features.client_side_stats_supported
 @scenarios.trace_stats_computation_obfuscation_disabled
 class Test_Client_Stats_With_Client_Obfuscation_Disabled:
     """Test that libraries read the agent /info to respect the obfuscation config"""
+
     TEST_USER_IDS = ["1", "2", "admin", "test"]
 
     def setup_obfuscation(self):
@@ -230,7 +232,7 @@ class Test_Client_Stats_With_Client_Obfuscation_Disabled:
             assert query.removeprefix(want_prefix) in accepted_suffixes
 
 
-@features.client_side_stats_supported  # FIXME: create a new feature ?
+@features.client_side_stats_supported
 @scenarios.trace_stats_computation_future_obfuscation_version
 class Test_Client_Stats_Future_Obfuscation_Version:
     """Test that the SDK skips client-side obfuscation when the agent advertises a future/unknown obfuscation version"""

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -218,7 +218,9 @@ class Test_Client_Stats_With_Client_Obfuscation_Disabled:
 
         assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
 
-        assert len(sql_stats) == 4, "Expected 4 distincs SQL stats entry, because obfuscation was not applied client-side"
+        assert len(sql_stats) == 4, (
+            "Expected 4 distincs SQL stats entry, because obfuscation was not applied client-side"
+        )
         # NormalizeOnly mode preserves string literals including surrounding single quotes.
         # The SQL uses string-quoted IDs (e.g. WHERE id='1'), so after normalization the
         # suffix appears as e.g. "'1'" (with quotes). Accept both quoted and unquoted forms
@@ -314,7 +316,9 @@ class Test_Client_Stats_Missing_Obfuscation_Version:
             "Datadog-Obfuscation-Version header should NOT be present when agent does not advertise obfuscation_version"
         )
 
-        assert len(sql_stats) == 4, "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
+        assert len(sql_stats) == 4, (
+            "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
+        )
         for stat in sql_stats:
             assert "?" not in stat["Resource"], (
                 f"SQL resource should NOT be obfuscated when agent does not advertise obfuscation_version, "
@@ -359,7 +363,9 @@ class Test_Client_Stats_Obfuscation_Version_Zero:
             "Datadog-Obfuscation-Version header should NOT be present when agent advertises obfuscation_version=0"
         )
 
-        assert len(sql_stats) == 4, "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
+        assert len(sql_stats) == 4, (
+            "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
+        )
         for stat in sql_stats:
             assert "?" not in stat["Resource"], (
                 f"SQL resource should NOT be obfuscated when agent advertises obfuscation_version=0, "

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -133,7 +133,8 @@ class Test_Client_Stats:
             f"Expected a gRPC stats entry with GRPCStatusCode=0, got: {grpc_stats}"
         )
 
-@features.client_side_stats_supported # FIXME: create a new feature ?
+
+@features.client_side_stats_supported  # FIXME: create a new feature ?
 @scenarios.trace_stats_computation
 class Test_Client_Stats_With_Client_Obfuscation:
     """Test client-side stats do the obfuscation before-hand when available"""
@@ -170,21 +171,11 @@ class Test_Client_Stats_With_Client_Obfuscation:
                     if stat.get("Type") == "sql":
                         sql_stats.append(stat)
 
-        assert obfuscation_header_found, (
-            "Datadog-Obfuscation-Version header not found on any stats payload"
-        )
+        assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
 
         assert len(sql_stats) > 0, "Expected at least one SQL stats entry"
-        total_hits = 0
         for stat in sql_stats:
-            assert stat["Resource"] == want, (
-                f"Expected obfuscated resource '{want}', got '{stat['Resource']}'"
-            )
-            total_hits += stat["Hits"]
-
-        assert total_hits == 4, (
-            f"Expected 4 SQL hits (one per query), got {total_hits}"
-        )
+            assert stat["Resource"] == want, f"Expected obfuscated resource '{want}', got '{stat['Resource']}'"
 
 
 @features.service_override_source

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -161,7 +161,7 @@ class Test_Client_Stats_With_Client_Obfuscation:
             headers = {h[0].lower(): h[1] for h in data["request"]["headers"]}
             if "datadog-obfuscation-version" in headers:
                 obfuscation_header_found = True
-                assert int(headers["datadog-obfuscation-version"])  >= 1, (
+                assert int(headers["datadog-obfuscation-version"]) >= 1, (
                     f"Expected obfuscation version to be >= 1, got '{headers['datadog-obfuscation-version']}'"
                 )
 

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -179,6 +179,52 @@ class Test_Client_Stats_With_Client_Obfuscation:
 
 
 @features.client_side_stats_supported  # FIXME: create a new feature ?
+@scenarios.trace_stats_computation_obfuscation_disabled
+class Test_Client_Stats_With_Client_Obfuscation_Disabled:
+    """Test that libraries read the agent /info to respect the obfuscation config"""
+    TEST_USER_IDS = ["1", "2", "admin", "test"]
+
+    def setup_obfuscation(self):
+        """Setup for obfuscation test - generates SQL spans for obfuscation testing"""
+        for user_id in self.TEST_USER_IDS:
+            weblog.get(f"/rasp/sqli?user_id={user_id}")
+
+    def test_obfuscation(self):
+        """Test that SQL resources are obfuscated before stats aggregation.
+
+        Validates:
+        - Datadog-Obfuscation-Version header is present on stats payloads
+        - SQL resource names are not obfuscated, only normalized
+        """
+        want_prefix = "SELECT * FROM users WHERE id = "
+        sql_stats = []
+        obfuscation_header_found = False
+
+        for data in interfaces.library.get_data("/v0.6/stats"):
+            headers = {h[0].lower(): h[1] for h in data["request"]["headers"]}
+            if "datadog-obfuscation-version" in headers:
+                obfuscation_header_found = True
+                assert int(headers["datadog-obfuscation-version"]) >= 1, (
+                    f"Expected obfuscation version to be >= 1, got '{headers['datadog-obfuscation-version']}'"
+                )
+
+            payload = data["request"]["content"]
+            for bucket in payload.get("Stats", []):
+                for stat in bucket.get("Stats", []):
+                    if stat.get("Type") == "sql":
+                        sql_stats.append(stat)
+
+        assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
+
+        assert len(sql_stats) > 0, "Expected at least one SQL stats entry"
+        for stat in sql_stats:
+            query = stat["Resource"]
+            # assert that query is in the form SELECT * FROM users WHERE id = [one of the user ids]
+            assert query.startswith(want_prefix)
+            assert query.removeprefix(want_prefix) in self.TEST_USER_IDS
+
+
+@features.client_side_stats_supported  # FIXME: create a new feature ?
 @scenarios.trace_stats_computation_future_obfuscation_version
 class Test_Client_Stats_Future_Obfuscation_Version:
     """Test that the SDK skips client-side obfuscation when the agent advertises a future/unknown obfuscation version"""

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -178,6 +178,51 @@ class Test_Client_Stats_With_Client_Obfuscation:
             assert stat["Resource"] == want, f"Expected obfuscated resource '{want}', got '{stat['Resource']}'"
 
 
+@features.client_side_stats_supported  # FIXME: create a new feature ?
+@scenarios.trace_stats_computation_future_obfuscation_version
+class Test_Client_Stats_Future_Obfuscation_Version:
+    """Test that the SDK skips client-side obfuscation when the agent advertises a future/unknown obfuscation version"""
+
+    def setup_no_obfuscation(self):
+        """Setup for future obfuscation version test - generates SQL spans"""
+        test_user_ids = ["1", "2", "admin", "test"]
+        for user_id in test_user_ids:
+            weblog.get(f"/rasp/sqli?user_id={user_id}")
+
+    def test_no_obfuscation(self):
+        """Test that the SDK does not obfuscate stats and does not send the obfuscation header
+        when the agent reports an obfuscation_version higher than what the SDK supports (99).
+
+        Validates:
+        - Datadog-Obfuscation-Version header is NOT present on any stats payload
+        - SQL resource names are NOT obfuscated (raw literals still present)
+        """
+        sql_stats = []
+        obfuscation_header_found = False
+
+        for data in interfaces.library.get_data("/v0.6/stats"):
+            headers = {h[0].lower(): h[1] for h in data["request"]["headers"]}
+            if "datadog-obfuscation-version" in headers:
+                obfuscation_header_found = True
+
+            payload = data["request"]["content"]
+            for bucket in payload.get("Stats", []):
+                for stat in bucket.get("Stats", []):
+                    if stat.get("Type") == "sql":
+                        sql_stats.append(stat)
+
+        assert not obfuscation_header_found, (
+            "Datadog-Obfuscation-Version header should NOT be present when agent reports a future obfuscation version"
+        )
+
+        assert len(sql_stats) > 0, "Expected at least one SQL stats entry"
+        for stat in sql_stats:
+            assert "?" not in stat["Resource"], (
+                f"SQL resource should NOT be obfuscated when agent reports a future obfuscation version, "
+                f"but got: '{stat['Resource']}'"
+            )
+
+
 @features.service_override_source
 @scenarios.trace_stats_computation
 class Test_Stats_Service_Source:

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -219,8 +219,8 @@ class Test_Client_Stats_With_Client_Obfuscation_Disabled:
         assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
 
         unique_resources = {stat["Resource"] for stat in sql_stats}
-        assert len(unique_resources) == 4, (
-            "Expected 4 distinct SQL stats entries, because obfuscation was not applied client-side"
+        assert len(unique_resources) >= 4, (
+            "Expected at least 4 distinct SQL stats entries, because obfuscation was not applied client-side"
         )
         # NormalizeOnly mode preserves string literals including surrounding single quotes.
         # The SQL uses string-quoted IDs (e.g. WHERE id='1'), so after normalization the
@@ -273,8 +273,8 @@ class Test_Client_Stats_Future_Obfuscation_Version:
         )
 
         unique_resources = {stat["Resource"] for stat in sql_stats}
-        assert len(unique_resources) == 4, (
-            "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
+        assert len(unique_resources) >= 4, (
+            "Expected at least 4 distinct SQL stats entries because obfuscation was not applied client-side"
         )
         for stat in sql_stats:
             assert "?" not in stat["Resource"], (
@@ -321,8 +321,8 @@ class Test_Client_Stats_Missing_Obfuscation_Version:
         )
 
         unique_resources = {stat["Resource"] for stat in sql_stats}
-        assert len(unique_resources) == 4, (
-            "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
+        assert len(unique_resources) >= 4, (
+            "Expected at least 4 distinct SQL stats entries because obfuscation was not applied client-side"
         )
         for stat in sql_stats:
             assert "?" not in stat["Resource"], (
@@ -369,8 +369,8 @@ class Test_Client_Stats_Obfuscation_Version_Zero:
         )
 
         unique_resources = {stat["Resource"] for stat in sql_stats}
-        assert len(unique_resources) == 4, (
-            "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
+        assert len(unique_resources) >= 4, (
+            "Expected at least 4 distinct SQL stats entries because obfuscation was not applied client-side"
         )
         for stat in sql_stats:
             assert "?" not in stat["Resource"], (

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -217,11 +217,17 @@ class Test_Client_Stats_With_Client_Obfuscation_Disabled:
         assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
 
         assert len(sql_stats) > 0, "Expected at least one SQL stats entry"
+        # NormalizeOnly mode preserves string literals including surrounding single quotes.
+        # The SQL uses string-quoted IDs (e.g. WHERE id='1'), so after normalization the
+        # suffix appears as e.g. "'1'" (with quotes). Accept both quoted and unquoted forms
+        # to be compatible with tracers that may strip the quotes.
+        quoted_user_ids = {f"'{uid}'" for uid in self.TEST_USER_IDS}
+        accepted_suffixes = set(self.TEST_USER_IDS) | quoted_user_ids
         for stat in sql_stats:
             query = stat["Resource"]
             # assert that query is in the form SELECT * FROM users WHERE id = [one of the user ids]
             assert query.startswith(want_prefix)
-            assert query.removeprefix(want_prefix) in self.TEST_USER_IDS
+            assert query.removeprefix(want_prefix) in accepted_suffixes
 
 
 @features.client_side_stats_supported  # FIXME: create a new feature ?

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -218,8 +218,9 @@ class Test_Client_Stats_With_Client_Obfuscation_Disabled:
 
         assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
 
-        assert len(sql_stats) == 4, (
-            "Expected 4 distincs SQL stats entry, because obfuscation was not applied client-side"
+        unique_resources = {stat["Resource"] for stat in sql_stats}
+        assert len(unique_resources) == 4, (
+            "Expected 4 distinct SQL stats entries, because obfuscation was not applied client-side"
         )
         # NormalizeOnly mode preserves string literals including surrounding single quotes.
         # The SQL uses string-quoted IDs (e.g. WHERE id='1'), so after normalization the
@@ -271,7 +272,10 @@ class Test_Client_Stats_Future_Obfuscation_Version:
             "Datadog-Obfuscation-Version header should NOT be present when agent reports a future obfuscation version"
         )
 
-        assert len(sql_stats) == 4, "Expected at least one SQL stats entry"
+        unique_resources = {stat["Resource"] for stat in sql_stats}
+        assert len(unique_resources) == 4, (
+            "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
+        )
         for stat in sql_stats:
             assert "?" not in stat["Resource"], (
                 f"SQL resource should NOT be obfuscated when agent reports a future obfuscation version, "
@@ -316,7 +320,8 @@ class Test_Client_Stats_Missing_Obfuscation_Version:
             "Datadog-Obfuscation-Version header should NOT be present when agent does not advertise obfuscation_version"
         )
 
-        assert len(sql_stats) == 4, (
+        unique_resources = {stat["Resource"] for stat in sql_stats}
+        assert len(unique_resources) == 4, (
             "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
         )
         for stat in sql_stats:
@@ -363,7 +368,8 @@ class Test_Client_Stats_Obfuscation_Version_Zero:
             "Datadog-Obfuscation-Version header should NOT be present when agent advertises obfuscation_version=0"
         )
 
-        assert len(sql_stats) == 4, (
+        unique_resources = {stat["Resource"] for stat in sql_stats}
+        assert len(unique_resources) == 4, (
             "Expected 4 distinct SQL stats entries because obfuscation was not applied client-side"
         )
         for stat in sql_stats:

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -174,7 +174,7 @@ class Test_Client_Stats_With_Client_Obfuscation:
 
         assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
 
-        assert len(sql_stats) == 4, "Expected at least one SQL stats entry"
+        assert len(sql_stats) >= 1, "Expected at least one SQL stats entry"
         for stat in sql_stats:
             assert stat["Resource"] == want, f"Expected obfuscated resource '{want}', got '{stat['Resource']}'"
 
@@ -218,7 +218,7 @@ class Test_Client_Stats_With_Client_Obfuscation_Disabled:
 
         assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
 
-        assert len(sql_stats) == 4, "Expected at least one SQL stats entry"
+        assert len(sql_stats) == 4, "Expected 4 distincs SQL stats entry, because obfuscation was not applied client-side"
         # NormalizeOnly mode preserves string literals including surrounding single quotes.
         # The SQL uses string-quoted IDs (e.g. WHERE id='1'), so after normalization the
         # suffix appears as e.g. "'1'" (with quotes). Accept both quoted and unquoted forms

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -69,20 +69,14 @@ class Test_Client_Stats:
             weblog.get(f"/rasp/sqli?user_id={user_id}")
 
     def test_obfuscation(self):
-        stats_count = 0
         hits = 0
         top_hits = 0
-        resource = "SELECT * FROM users WHERE id = ?"
-        # wait for 10 seconds to be sure all the buckets are flushed (better than be flaky)
-        for s in interfaces.agent.get_stats(resource):
-            stats_count += 1
+        for s in interfaces.agent.get_stats():
+            if s["Type"] != "sql" or "?" not in s["Resource"]:
+                continue
             logger.debug(f"asserting on {s}")
             hits += s["Hits"]
             top_hits += s["TopLevelHits"]
-            assert s["Type"] == "sql", "expect 'sql' type"
-        assert stats_count <= 4, (
-            "expect <= 4 stats"
-        )  # Normally this is exactly 2 but in certain high load this can flake and result in additional payloads where hits are split across two payloads
         assert hits == top_hits >= 4, "expect at least 4 'OK' hits and top level hits across all payloads"
 
     def test_is_trace_root(self):
@@ -154,7 +148,6 @@ class Test_Client_Stats_With_Client_Obfuscation:
         - SQL resource names are obfuscated (literals replaced with ?)
         - All 4 distinct queries are aggregated into a single obfuscated resource bucket
         """
-        want = "SELECT * FROM users WHERE id = ?"
         sql_stats = []
         obfuscation_header_found = False
 
@@ -176,7 +169,7 @@ class Test_Client_Stats_With_Client_Obfuscation:
 
         assert len(sql_stats) >= 1, "Expected at least one SQL stats entry"
         for stat in sql_stats:
-            assert stat["Resource"] == want, f"Expected obfuscated resource '{want}', got '{stat['Resource']}'"
+            assert "?" in stat["Resource"], f"Expected obfuscated resource (containing '?'), got '{stat['Resource']}'"
 
 
 @features.client_side_stats_supported
@@ -198,7 +191,6 @@ class Test_Client_Stats_With_Client_Obfuscation_Disabled:
         - Datadog-Obfuscation-Version header is present on stats payloads
         - SQL resource names are not obfuscated, only normalized
         """
-        want_prefix = "SELECT * FROM users WHERE id = "
         sql_stats = []
         obfuscation_header_found = False
 
@@ -222,17 +214,6 @@ class Test_Client_Stats_With_Client_Obfuscation_Disabled:
         assert len(unique_resources) >= 4, (
             "Expected at least 4 distinct SQL stats entries, because obfuscation was not applied client-side"
         )
-        # NormalizeOnly mode preserves string literals including surrounding single quotes.
-        # The SQL uses string-quoted IDs (e.g. WHERE id='1'), so after normalization the
-        # suffix appears as e.g. "'1'" (with quotes). Accept both quoted and unquoted forms
-        # to be compatible with tracers that may strip the quotes.
-        quoted_user_ids = {f"'{uid}'" for uid in self.TEST_USER_IDS}
-        accepted_suffixes = set(self.TEST_USER_IDS) | quoted_user_ids
-        for stat in sql_stats:
-            query = stat["Resource"]
-            # assert that query is in the form SELECT * FROM users WHERE id = [one of the user ids]
-            assert query.startswith(want_prefix)
-            assert query.removeprefix(want_prefix) in accepted_suffixes
 
 
 @features.client_side_stats_supported
@@ -265,7 +246,7 @@ class Test_Client_Stats_Future_Obfuscation_Version:
             payload = data["request"]["content"]
             for bucket in payload.get("Stats", []):
                 for stat in bucket.get("Stats", []):
-                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT * FROM users"):
+                    if stat.get("Type") == "sql" and "WHERE" in stat["Resource"]:
                         sql_stats.append(stat)
 
         assert not obfuscation_header_found, (
@@ -313,7 +294,7 @@ class Test_Client_Stats_Missing_Obfuscation_Version:
             payload = data["request"]["content"]
             for bucket in payload.get("Stats", []):
                 for stat in bucket.get("Stats", []):
-                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT * FROM users"):
+                    if stat.get("Type") == "sql" and "WHERE" in stat["Resource"]:
                         sql_stats.append(stat)
 
         assert not obfuscation_header_found, (
@@ -361,7 +342,7 @@ class Test_Client_Stats_Obfuscation_Version_Zero:
             payload = data["request"]["content"]
             for bucket in payload.get("Stats", []):
                 for stat in bucket.get("Stats", []):
-                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT * FROM users"):
+                    if stat.get("Type") == "sql" and "WHERE" in stat["Resource"]:
                         sql_stats.append(stat)
 
         assert not obfuscation_header_found, (

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -133,6 +133,59 @@ class Test_Client_Stats:
             f"Expected a gRPC stats entry with GRPCStatusCode=0, got: {grpc_stats}"
         )
 
+@features.client_side_stats_supported # FIXME: create a new feature ?
+@scenarios.trace_stats_computation
+class Test_Client_Stats_With_Client_Obfuscation:
+    """Test client-side stats do the obfuscation before-hand when available"""
+
+    def setup_obfuscation(self):
+        """Setup for obfuscation test - generates SQL spans for obfuscation testing"""
+        test_user_ids = ["1", "2", "admin", "test"]
+        for user_id in test_user_ids:
+            weblog.get(f"/rasp/sqli?user_id={user_id}")
+
+    def test_obfuscation(self):
+        """Test that SQL resources are obfuscated before stats aggregation.
+
+        Validates:
+        - Datadog-Obfuscation-Version header is present on stats payloads
+        - SQL resource names are obfuscated (literals replaced with ?)
+        - All 4 distinct queries are aggregated into a single obfuscated resource bucket
+        """
+        want = "SELECT * FROM users WHERE id = ?"
+        sql_stats = []
+        obfuscation_header_found = False
+
+        for data in interfaces.library.get_data("/v0.6/stats"):
+            headers = {h[0].lower(): h[1] for h in data["request"]["headers"]}
+            if "datadog-obfuscation-version" in headers:
+                obfuscation_header_found = True
+                assert headers["datadog-obfuscation-version"] == "1", (
+                    f"Expected obfuscation version '1', got '{headers['datadog-obfuscation-version']}'"
+                )
+
+            payload = data["request"]["content"]
+            for bucket in payload.get("Stats", []):
+                for stat in bucket.get("Stats", []):
+                    if stat.get("Type") == "sql":
+                        sql_stats.append(stat)
+
+        assert obfuscation_header_found, (
+            "Datadog-Obfuscation-Version header not found on any stats payload"
+        )
+
+        assert len(sql_stats) > 0, "Expected at least one SQL stats entry"
+        total_hits = 0
+        for stat in sql_stats:
+            assert stat["Resource"] == want, (
+                f"Expected obfuscated resource '{want}', got '{stat['Resource']}'"
+            )
+            total_hits += stat["Hits"]
+
+        assert total_hits == 4, (
+            f"Expected 4 SQL hits (one per query), got {total_hits}"
+        )
+
 
 @features.service_override_source
 @scenarios.trace_stats_computation

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -265,7 +265,7 @@ class Test_Client_Stats_Future_Obfuscation_Version:
             payload = data["request"]["content"]
             for bucket in payload.get("Stats", []):
                 for stat in bucket.get("Stats", []):
-                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT"):
+                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT * FROM users"):
                         sql_stats.append(stat)
 
         assert not obfuscation_header_found, (
@@ -313,7 +313,7 @@ class Test_Client_Stats_Missing_Obfuscation_Version:
             payload = data["request"]["content"]
             for bucket in payload.get("Stats", []):
                 for stat in bucket.get("Stats", []):
-                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT"):
+                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT * FROM users"):
                         sql_stats.append(stat)
 
         assert not obfuscation_header_found, (
@@ -361,7 +361,7 @@ class Test_Client_Stats_Obfuscation_Version_Zero:
             payload = data["request"]["content"]
             for bucket in payload.get("Stats", []):
                 for stat in bucket.get("Stats", []):
-                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT"):
+                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT * FROM users"):
                         sql_stats.append(stat)
 
         assert not obfuscation_header_found, (

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -147,7 +147,7 @@ class _Scenarios:
     )
 
     trace_stats_computation_obfuscation_disabled = EndToEndScenario(
-        name="TRACE_STATS_COMPUTATION",
+        name="TRACE_STATS_COMPUTATION_OBFUSCATION_DISABLED",
         # Same as trace_stats_computation but with the agent being configured with obfuscation disabled, to test that
         # the SDK correctly reads the obfuscation config from agent's /info and respects it.
         weblog_env={

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -155,11 +155,11 @@ class _Scenarios:
             "DD_TRACE_COMPUTE_STATS": "true",
             "DD_TRACE_FEATURES": "discovery",
             "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+        },
+        agent_env={
             "DD_APM_SQL_OBFUSCATION_MODE": "normalize_only",
         },
-        doc=(
-            "End to end testing with DD_TRACE_COMPUTE_STATS=1 and obfuscation disabled."
-        ),
+        doc=("End to end testing with DD_TRACE_COMPUTE_STATS=1 and obfuscation disabled."),
         scenario_groups=[scenario_groups.appsec],
     )
 

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -146,6 +146,23 @@ class _Scenarios:
         scenario_groups=[scenario_groups.appsec],
     )
 
+    trace_stats_computation_obfuscation_disabled = EndToEndScenario(
+        name="TRACE_STATS_COMPUTATION",
+        # Same as trace_stats_computation but with the agent being configured with obfuscation disabled, to test that
+        # the SDK correctly reads the obfuscation config from agent's /info and respects it.
+        weblog_env={
+            "DD_TRACE_STATS_COMPUTATION_ENABLED": "true",  # default env var for CSS
+            "DD_TRACE_COMPUTE_STATS": "true",
+            "DD_TRACE_FEATURES": "discovery",
+            "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+            "DD_APM_SQL_OBFUSCATION_MODE": "normalize_only",
+        },
+        doc=(
+            "End to end testing with DD_TRACE_COMPUTE_STATS=1 and obfuscation disabled."
+        ),
+        scenario_groups=[scenario_groups.appsec],
+    )
+
     sampling = EndToEndScenario(
         "SAMPLING",
         tracer_sampling_rate=0.5,

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -146,6 +146,44 @@ class _Scenarios:
         scenario_groups=[scenario_groups.appsec],
     )
 
+    trace_stats_computation_missing_obfuscation_version = EndToEndScenario(
+        name="TRACE_STATS_COMPUTATION_MISSING_OBFUSCATION_VERSION",
+        # Same as trace_stats_computation but with the agent not advertising obfuscation_version
+        # in /info, to test that the SDK correctly falls back to no client-side obfuscation.
+        weblog_env={
+            "DD_TRACE_STATS_COMPUTATION_ENABLED": "true",  # default env var for CSS
+            "DD_TRACE_COMPUTE_STATS": "true",
+            "DD_TRACE_FEATURES": "discovery",
+            "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+        },
+        obfuscation_version="MISSING",
+        doc=(
+            "End to end testing with DD_TRACE_COMPUTE_STATS=1 and agent not advertising obfuscation_version. "
+            "Tests that tracers correctly skip client-side obfuscation and omit the Datadog-Obfuscation-Version "
+            "header when the agent does not advertise any obfuscation version."
+        ),
+        scenario_groups=[scenario_groups.appsec],
+    )
+
+    trace_stats_computation_obfuscation_version_zero = EndToEndScenario(
+        name="TRACE_STATS_COMPUTATION_OBFUSCATION_VERSION_ZERO",
+        # Same as trace_stats_computation but with the agent advertising obfuscation_version=0,
+        # to test that the SDK treats version 0 as "not supported" and skips client-side obfuscation.
+        weblog_env={
+            "DD_TRACE_STATS_COMPUTATION_ENABLED": "true",  # default env var for CSS
+            "DD_TRACE_COMPUTE_STATS": "true",
+            "DD_TRACE_FEATURES": "discovery",
+            "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+        },
+        obfuscation_version=0,
+        doc=(
+            "End to end testing with DD_TRACE_COMPUTE_STATS=1 and agent reporting obfuscation_version: 0. "
+            "Tests that tracers correctly skip client-side obfuscation and omit the Datadog-Obfuscation-Version "
+            "header when the agent advertises obfuscation_version=0."
+        ),
+        scenario_groups=[scenario_groups.appsec],
+    )
+
     trace_stats_computation_obfuscation_disabled = EndToEndScenario(
         name="TRACE_STATS_COMPUTATION_OBFUSCATION_DISABLED",
         # Same as trace_stats_computation but with the agent being configured with obfuscation disabled, to test that

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -100,6 +100,7 @@ class _Scenarios:
             "DD_TRACE_COMPUTE_STATS": "true",
             "DD_TRACE_FEATURES": "discovery",
             "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+            "_DD_TRACE_STATS_COMPUTATION_EXPERIMENTAL_CLIENT_OBFUSCATION_ENABLED": "true",
         },
         doc=(
             "End to end testing with DD_TRACE_COMPUTE_STATS=1. This feature compute stats at tracer level, and"
@@ -117,6 +118,7 @@ class _Scenarios:
             "DD_TRACE_COMPUTE_STATS": "true",
             "DD_TRACE_FEATURES": "discovery",
             "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+            "_DD_TRACE_STATS_COMPUTATION_EXPERIMENTAL_CLIENT_OBFUSCATION_ENABLED": "true",
         },
         client_drop_p0s=False,
         doc=(
@@ -136,6 +138,7 @@ class _Scenarios:
             "DD_TRACE_COMPUTE_STATS": "true",
             "DD_TRACE_FEATURES": "discovery",
             "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+            "_DD_TRACE_STATS_COMPUTATION_EXPERIMENTAL_CLIENT_OBFUSCATION_ENABLED": "true",
         },
         obfuscation_version=99,
         doc=(
@@ -155,6 +158,7 @@ class _Scenarios:
             "DD_TRACE_COMPUTE_STATS": "true",
             "DD_TRACE_FEATURES": "discovery",
             "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+            "_DD_TRACE_STATS_COMPUTATION_EXPERIMENTAL_CLIENT_OBFUSCATION_ENABLED": "true",
         },
         obfuscation_version="MISSING",
         doc=(
@@ -174,6 +178,7 @@ class _Scenarios:
             "DD_TRACE_COMPUTE_STATS": "true",
             "DD_TRACE_FEATURES": "discovery",
             "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+            "_DD_TRACE_STATS_COMPUTATION_EXPERIMENTAL_CLIENT_OBFUSCATION_ENABLED": "true",
         },
         obfuscation_version=0,
         doc=(
@@ -193,6 +198,7 @@ class _Scenarios:
             "DD_TRACE_COMPUTE_STATS": "true",
             "DD_TRACE_FEATURES": "discovery",
             "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+            "_DD_TRACE_STATS_COMPUTATION_EXPERIMENTAL_CLIENT_OBFUSCATION_ENABLED": "true",
         },
         agent_env={
             "DD_APM_SQL_OBFUSCATION_MODE": "normalize_only",

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -126,6 +126,26 @@ class _Scenarios:
         scenario_groups=[scenario_groups.appsec],
     )
 
+    trace_stats_computation_future_obfuscation_version = EndToEndScenario(
+        name="TRACE_STATS_COMPUTATION_FUTURE_OBFUSCATION_VERSION",
+        # Same as trace_stats_computation but with the agent advertising an obfuscation_version
+        # higher than what any current SDK supports (99), to test that the SDK correctly falls
+        # back to no client-side obfuscation when it encounters an unknown/future version.
+        weblog_env={
+            "DD_TRACE_STATS_COMPUTATION_ENABLED": "true",  # default env var for CSS
+            "DD_TRACE_COMPUTE_STATS": "true",
+            "DD_TRACE_FEATURES": "discovery",
+            "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+        },
+        obfuscation_version=99,
+        doc=(
+            "End to end testing with DD_TRACE_COMPUTE_STATS=1 and agent reporting obfuscation_version: 99. "
+            "Tests that tracers correctly skip client-side obfuscation and omit the Datadog-Obfuscation-Version "
+            "header when the agent advertises an obfuscation version higher than what the SDK supports."
+        ),
+        scenario_groups=[scenario_groups.appsec],
+    )
+
     sampling = EndToEndScenario(
         "SAMPLING",
         tracer_sampling_rate=0.5,

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -1,3 +1,4 @@
+from typing import Literal
 import os
 import pytest
 
@@ -46,7 +47,7 @@ class DockerScenario(Scenario):
         meta_structs_disabled: bool = False,
         span_events: bool = True,
         client_drop_p0s: bool | None = None,
-        obfuscation_version: int | None = None,
+        obfuscation_version: int | None | Literal["MISSING"] = None,
         extra_containers: tuple[type[TestedContainer], ...] = (),
     ) -> None:
         super().__init__(name, doc=doc, github_workflow=github_workflow, scenario_groups=scenario_groups)
@@ -204,7 +205,7 @@ class EndToEndScenario(DockerScenario):
         meta_structs_disabled: bool = False,
         span_events: bool = True,
         client_drop_p0s: bool | None = None,
-        obfuscation_version: int | None = None,
+        obfuscation_version: int | None | Literal["MISSING"] = None,
         runtime_metrics_enabled: bool = False,
         backend_interface_timeout: int = 0,
         include_buddies: bool = False,

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -46,6 +46,7 @@ class DockerScenario(Scenario):
         meta_structs_disabled: bool = False,
         span_events: bool = True,
         client_drop_p0s: bool | None = None,
+        obfuscation_version: int | None = None,
         extra_containers: tuple[type[TestedContainer], ...] = (),
     ) -> None:
         super().__init__(name, doc=doc, github_workflow=github_workflow, scenario_groups=scenario_groups)
@@ -57,6 +58,7 @@ class DockerScenario(Scenario):
         self.meta_structs_disabled = False
         self.span_events = span_events
         self.client_drop_p0s = client_drop_p0s
+        self.obfuscation_version = obfuscation_version
 
         if not self.use_proxy and self.rc_api_enabled:
             raise ValueError("rc_api_enabled requires use_proxy")
@@ -74,6 +76,7 @@ class DockerScenario(Scenario):
                 meta_structs_disabled=meta_structs_disabled,
                 span_events=span_events,
                 client_drop_p0s=client_drop_p0s,
+                obfuscation_version=obfuscation_version,
                 enable_ipv6=enable_ipv6,
                 mocked_backend=mocked_backend,
             )
@@ -201,6 +204,7 @@ class EndToEndScenario(DockerScenario):
         meta_structs_disabled: bool = False,
         span_events: bool = True,
         client_drop_p0s: bool | None = None,
+        obfuscation_version: int | None = None,
         runtime_metrics_enabled: bool = False,
         backend_interface_timeout: int = 0,
         include_buddies: bool = False,
@@ -226,6 +230,7 @@ class EndToEndScenario(DockerScenario):
             meta_structs_disabled=meta_structs_disabled,
             span_events=span_events,
             client_drop_p0s=client_drop_p0s,
+            obfuscation_version=obfuscation_version,
         )
 
         self._use_proxy_for_agent = use_proxy_for_agent

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -4,7 +4,7 @@ import re
 import stat
 import sys
 import json
-from typing import cast
+from typing import cast, Literal
 from http import HTTPStatus
 from pathlib import Path
 import time
@@ -590,7 +590,7 @@ class ProxyContainer(TestedContainer):
         meta_structs_disabled: bool,
         span_events: bool,
         client_drop_p0s: bool | None = None,
-        obfuscation_version: int | None = None,
+        obfuscation_version: int | None | Literal["MISSING"] = None,
         enable_ipv6: bool,
         mocked_backend: bool = True,
     ) -> None:

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -28,6 +28,7 @@ from utils.proxy.mocked_response import (
     MockedBackendResponse,
     SetSpanEventFlags,
     SetClientDropP0s,
+    SetObfuscationVersion,
     AddRemoteConfigEndpoint,
     StaticJsonMockedTracerResponse,
 )
@@ -589,6 +590,7 @@ class ProxyContainer(TestedContainer):
         meta_structs_disabled: bool,
         span_events: bool,
         client_drop_p0s: bool | None = None,
+        obfuscation_version: int | None = None,
         enable_ipv6: bool,
         mocked_backend: bool = True,
     ) -> None:
@@ -634,6 +636,9 @@ class ProxyContainer(TestedContainer):
 
         if client_drop_p0s is not None:
             self.internal_mocked_tracer_responses.append(SetClientDropP0s(client_drop_p0s=client_drop_p0s))
+
+        if obfuscation_version is not None:
+            self.internal_mocked_tracer_responses.append(SetObfuscationVersion(obfuscation_version=obfuscation_version))
 
         if rc_api_enabled:
             # add the remote config endpoint on available agent endpoints

--- a/utils/proxy/mocked_response.py
+++ b/utils/proxy/mocked_response.py
@@ -7,7 +7,7 @@ from http import HTTPStatus
 import json
 import os
 import re
-from typing import Self
+from typing import Self, Literal
 
 import requests
 
@@ -358,14 +358,17 @@ class SetObfuscationVersion(_InternalMockedTracerResponse):
     omit the Datadog-Obfuscation-Version header from stats payloads.
     """
 
-    def __init__(self, *, obfuscation_version: int):
+    def __init__(self, *, obfuscation_version: int | Literal["MISSING"]):
         super().__init__(path="/info")
         self.obfuscation_version = obfuscation_version
 
     def execute(self, flow: HTTPFlow) -> None:
         if flow.response.status_code == HTTPStatus.OK:
             c = json.loads(flow.response.content)
-            c["obfuscation_version"] = self.obfuscation_version
+            if self.obfuscation_version == "MISSING":
+                del c["obfuscation_version"]
+            else:
+                c["obfuscation_version"] = self.obfuscation_version
             flow.response.content = json.dumps(c).encode()
 
     def to_json(self) -> dict:

--- a/utils/proxy/mocked_response.py
+++ b/utils/proxy/mocked_response.py
@@ -350,6 +350,31 @@ class SetClientDropP0s(_InternalMockedTracerResponse):
         }
 
 
+class SetObfuscationVersion(_InternalMockedTracerResponse):
+    """Override the obfuscation_version field in the agent's /info response.
+
+    This controls which obfuscation version the agent advertises. When set to a version
+    higher than what the SDK supports, the SDK should skip client-side obfuscation and
+    omit the Datadog-Obfuscation-Version header from stats payloads.
+    """
+
+    def __init__(self, *, obfuscation_version: int):
+        super().__init__(path="/info")
+        self.obfuscation_version = obfuscation_version
+
+    def execute(self, flow: HTTPFlow) -> None:
+        if flow.response.status_code == HTTPStatus.OK:
+            c = json.loads(flow.response.content)
+            c["obfuscation_version"] = self.obfuscation_version
+            flow.response.content = json.dumps(c).encode()
+
+    def to_json(self) -> dict:
+        return {
+            "type": self.__class__.__name__,
+            "obfuscation_version": self.obfuscation_version,
+        }
+
+
 class MockedBackendResponse(MockedResponse):
     """Base class for mocking responses from backend to agent.
 


### PR DESCRIPTION

## TODO
- [x] add a missing obfuscation_version test
- [x] add a obfuscation_version = 0 test
- [x] enable tests in manifest once enabled in dd-trace-py

## Motivation
- Test that libraries obfuscate spans before sending them to `/stats`

## Changes
- new tests

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
