### PR TITLE
golang(parametric): disable client-side p0 trace dropping in test client

### DIFF
--- a/utils/build/docker/golang/parametric/Dockerfile
+++ b/utils/build/docker/golang/parametric/Dockerfile
@@ -15,4 +15,11 @@ RUN mkdir /parametric-tracer-logs
 
 RUN go install
 
+# Disable client-side p0 trace dropping so the test agent receives all traces
+# regardless of sampling priority. Without this, Go drops p0 traces before
+# transport (DD_TRACE_STATS_COMPUTATION_ENABLED defaults to true in dd-trace-go,
+# and the test agent advertises client_drop_p0s:true), causing parametric tests
+# with very low sampling rates to receive 0 traces.
+ENV DD_TRACE_STATS_COMPUTATION_ENABLED=false
+
 CMD ["main"]


### PR DESCRIPTION
## Motivation

The Go parametric tests for `Test_Knuth_Sample_Rate` were failing with `ValueError: Number (1) of traces not available from test agent, got 0` for test cases using very low sampling rates (e.g. `sample_rate=0.000001`).

Root cause: `DD_TRACE_STATS_COMPUTATION_ENABLED` defaults to `true` in dd-trace-go. The test agent (ddapm-test-agent) advertises `client_drop_p0s: true` and exposes `/v0.6/stats`, so Go's `canDropP0s()` returns `true`. When a sampling rule sets `UserReject` priority, Go drops the trace entirely before transport — the test agent receives nothing.

Other tracers are not affected:
- **Python**: `_compute_stats_enabled` defaults to `False`
- **Node.js**: no client-side p0 dropping mechanism
- **Java**: the test agent's `"version": "test"` fails `AgentVersion.isVersionBelow()` (unparseable → treated as below minimum), so `supportsClientSideStats = false`

## Changes

Set `DD_TRACE_STATS_COMPUTATION_ENABLED=false` in the Go parametric Dockerfile so the test client behaves consistently with all other language test clients: all traces reach the test agent regardless of sampling priority.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)