### PR TITLE
add test for network.client.ip tag

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1151,6 +1151,7 @@ manifest:
   tests/test_span_events.py: incomplete_test_app (Weblog `/add_event` not implemented)
   tests/test_standard_tags.py::Test_StandardTagsClientIp: v2.26.0
   tests/test_standard_tags.py::Test_StandardTagsMethod: v2.0.0-prerelease
+  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp: v0.1  # unknown initial version
   tests/test_standard_tags.py::Test_StandardTagsReferrerHostname: missing_feature
   tests/test_standard_tags.py::Test_StandardTagsRoute: v2.13.0
   tests/test_standard_tags.py::Test_StandardTagsStatusCode: v2.0.0-prerelease

--- a/manifests/envoy.yml
+++ b/manifests/envoy.yml
@@ -36,6 +36,7 @@ manifest:
   tests/test_semantic_conventions.py: v1.72.0
   tests/test_semantic_conventions.py::Test_Meta::test_meta_component_tag: v2.3.0
   tests/test_standard_tags.py: v1.72.0
+  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp: v0.1  # unknown initial version
   tests/test_standard_tags.py::Test_StandardTagsReferrerHostname: missing_feature
   tests/test_standard_tags.py::Test_StandardTagsUrl::test_multiple_matching_substring: irrelevant (tracer did not yet implemented the new version of query parameters obfuscation regex)
   tests/test_standard_tags.py::Test_StandardTagsUrl::test_url_with_sensitive_query_string: irrelevant (tracer did not yet implemented the new version of query parameters obfuscation regex)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1432,6 +1432,7 @@ manifest:
     - declaration: missing_feature (missing fastly-client-ip, cf-connecting-ip, cf-connecting-ipv6)
       component_version: <1.69.0
   tests/test_standard_tags.py::Test_StandardTagsMethod: v1.39.0
+  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp: v0.1  # unknown initial version
   tests/test_standard_tags.py::Test_StandardTagsReferrerHostname: missing_feature
   tests/test_standard_tags.py::Test_StandardTagsRoute: v1.39.0
   tests/test_standard_tags.py::Test_StandardTagsStatusCode: v1.39.0

--- a/manifests/haproxy.yml
+++ b/manifests/haproxy.yml
@@ -33,6 +33,7 @@ manifest:
   tests/test_scrubbing.py: v2.4.0
   tests/test_semantic_conventions.py: v2.4.0
   tests/test_standard_tags.py: v2.4.0
+  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp: v0.1  # unknown initial version
   tests/test_standard_tags.py::Test_StandardTagsReferrerHostname: missing_feature
   tests/test_standard_tags.py::Test_StandardTagsUrl::test_multiple_matching_substring: irrelevant (tracer did not yet implemented the new version of query parameters obfuscation regex)
   tests/test_standard_tags.py::Test_StandardTagsUrl::test_url_with_sensitive_query_string: irrelevant (tracer did not yet implemented the new version of query parameters obfuscation regex)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4298,6 +4298,11 @@ manifest:
   tests/test_standard_tags.py::Test_StandardTagsMethod::test_method_trace:
     - weblog_declaration:
         spring-boot-payara: missing_feature (This weblog variant is currently not accepting TRACE)
+  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp:
+    - weblog_declaration:
+        "*": v0.93.0
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
+  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp::test_network_client_ip: missing_feature (APPSEC-62219)
   tests/test_standard_tags.py::Test_StandardTagsReferrerHostname: missing_feature
   tests/test_standard_tags.py::Test_StandardTagsRoute:
     - weblog_declaration:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2372,6 +2372,7 @@ manifest:
         nextjs: missing_feature  # nextjs makes some internal requests, so we have more than 1 rootspans
   tests/test_standard_tags.py::Test_StandardTagsClientIp::test_client_ip_with_appsec_event_and_vendor_headers: *ref_4_19_0
   tests/test_standard_tags.py::Test_StandardTagsMethod: v2.11.0
+  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp::test_network_client_ip: missing_feature (APPSEC-62220)
   tests/test_standard_tags.py::Test_StandardTagsReferrerHostname: missing_feature
   tests/test_standard_tags.py::Test_StandardTagsRoute:
     - weblog_declaration:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1070,6 +1070,7 @@ manifest:
   tests/test_span_events.py: incomplete_test_app (Weblog `/add_event` not implemented)
   tests/test_standard_tags.py::Test_StandardTagsMethod: v0.75.0
   tests/test_standard_tags.py::Test_StandardTagsMethod::test_method_trace: irrelevant (Trace method does not reach php-land)
+  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp::test_network_client_ip: missing_feature (APPSEC-62222)
   tests/test_standard_tags.py::Test_StandardTagsReferrerHostname: v1.9.0
   tests/test_standard_tags.py::Test_StandardTagsRoute: missing_feature
   tests/test_standard_tags.py::Test_StandardTagsStatusCode: v0.75.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2202,6 +2202,7 @@ manifest:
         uwsgi-poc: v4.3.1  # Modified by easy win activation script
   tests/test_standard_tags.py::Test_StandardTagsClientIp: v2.7.0
   tests/test_standard_tags.py::Test_StandardTagsMethod: v1.2.1
+  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp: bug (APPSEC-62204)
   tests/test_standard_tags.py::Test_StandardTagsReferrerHostname: v3.4.0
   tests/test_standard_tags.py::Test_StandardTagsRoute:
     - weblog_declaration:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1994,6 +1994,7 @@ manifest:
   tests/test_standard_tags.py::Test_StandardTagsClientIp: v1.10.1
   tests/test_standard_tags.py::Test_StandardTagsClientIp::test_client_ip_with_appsec_event_and_vendor_headers: missing_feature (missing fastly-client-ip, cf-connecting-ip, cf-connecting-ipv6)
   tests/test_standard_tags.py::Test_StandardTagsMethod: v1.8.0
+  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp::test_network_client_ip: missing_feature (APPSEC-62224)
   tests/test_standard_tags.py::Test_StandardTagsReferrerHostname: missing_feature
   tests/test_standard_tags.py::Test_StandardTagsRoute:
     - weblog_declaration:

--- a/tests/test_standard_tags.py
+++ b/tests/test_standard_tags.py
@@ -206,6 +206,52 @@ class Test_StandardTagsRoute:
         interfaces.library.add_span_tag_validation(request=self.r, tags=tags)
 
 
+@features.security_events_metadata
+@scenarios.go_proxies_default
+@scenarios.default
+class Test_StandardTagsNetworkClientIp:
+    """Tests to verify that libraries annotate spans with correct network.client.ip tags.
+    This can run on any scenario with either DD_APPSEC_ENABLED=true or DD_TRACE_CLIENT_IP_ENABLED=true.
+    """
+
+    PUBLIC_IP = "43.43.43.43"
+
+    def _setup(self, endpoint: str = "/", extra_headers: dict[str, str] | None = None):
+        headers = {"x-client-ip": self.PUBLIC_IP}
+        if extra_headers:
+            headers.update(extra_headers)
+        self.r = weblog.get(endpoint, headers=headers)
+
+    def _test(self):
+        span = interfaces.library.get_root_span(self.r)
+        assert span
+        meta = span.get("meta", {})
+        assert meta
+        assert "network.client.ip" in meta
+        network_client_ip = meta["network.client.ip"]
+        assert network_client_ip
+        assert network_client_ip != self.PUBLIC_IP
+        # http.client_ip resolves proxy headers, while network.client.ip does not, so both should be different here.
+        http_client_ip = meta.get("http.client_ip")
+        assert http_client_ip
+        assert network_client_ip != http_client_ip
+        assert http_client_ip == self.PUBLIC_IP
+
+    def setup_network_client_ip(self):
+        self._setup()
+
+    def test_network_client_ip(self):
+        """Test network.client.ip is reported and different from http.client_ip."""
+        self._test()
+
+    def setup_network_client_ip_with_attack(self):
+        self._setup(endpoint="/waf", extra_headers={"user-agent": "Arachni/v1"})
+
+    def test_network_client_ip_with_attack(self):
+        """Test network.client.ip is reported on ASM attacks. This is a special case to map the legacy behavior where this header would only be added on attacks, and not the general case."""
+        self._test()
+
+
 @rfc("https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution")
 @features.security_events_metadata
 @scenarios.go_proxies_default


### PR DESCRIPTION
## Motivation

To align `network.client.ip` behavior, adding a system test. Most tracers already implemented collection of `network.client.ip` correctly. There was some ambiguity as to _when_ to collect it. With most tracers collecting it only for AppSec events.

The spec is now amended to ensure that `network.client.ip` is collected for all HTTP request when the activation conditions are met. These are the same as for `http.client_ip`: when `DD_APPSEC_ENABLED=true` or `DD_TRACE_CLIENT_IP_ENABLED=true` are set.

[APPSEC-62223](https://datadoghq.atlassian.net/browse/APPSEC-62223)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APPSEC-62223]: https://datadoghq.atlassian.net/browse/APPSEC-62223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ