### PR TITLE
Revert dd-sts migration due to permission issues in lib repos

### DIFF
--- a/.github/actions/push_to_test_optim/action.yml
+++ b/.github/actions/push_to_test_optim/action.yml
@@ -6,12 +6,8 @@ inputs:
     default: datadoghq.com
   datadog_api_key:
     description: "A valid DD_API_KEY"
-    default: ""
   ci_environment:
     description: "CI environment running the tests (dev/prod/custom), used for Test Optimization tagging"
-    default: ""
-  dd_sts_policy:
-    description: "dd-sts policy to use to get a datadog API key (required if datadog_api_key is not set)"
     default: ""
 
 runs:
@@ -23,26 +19,19 @@ runs:
       run: echo "Skipping TestOptim push for dependabot PRs"
 
     - name: Install datadog-ci
-      if: github.event.pull_request.user.login != 'dependabot[bot]' && (inputs.datadog_api_key != '' || inputs.dd_sts_policy != '')
+      if: github.event.pull_request.user.login != 'dependabot[bot]' && inputs.datadog_api_key != ''
       shell: bash
       run: npm install -g @datadog/datadog-ci || sleep 60 && npm install -g @datadog/datadog-ci
 
     - name: checkout owner repo
-      if: github.event.pull_request.user.login != 'dependabot[bot]' && (inputs.datadog_api_key != '' || inputs.dd_sts_policy != '')
+      if: github.event.pull_request.user.login != 'dependabot[bot]' && inputs.datadog_api_key != ''
       uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       with:
         path: repo
 
-    - name: Get Datadog credentials
-      id: dd-sts
-      if: inputs.dd_sts_policy != ''
-      uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
-      with:
-        policy: ${{ inputs.dd_sts_policy }}
-
     # https://docs.datadoghq.com/tests/setup/junit_xml/?tab=linux
     - name: Push results
-      if: github.event.pull_request.user.login != 'dependabot[bot]' && (inputs.datadog_api_key != '' || inputs.dd_sts_policy != '')
+      if: github.event.pull_request.user.login != 'dependabot[bot]' && inputs.datadog_api_key != ''
       shell: bash
       run: |
         cd repo
@@ -54,5 +43,5 @@ runs:
           --xpath-tag "test.codeowners=/testcase/properties/property[@name='test.codeowners']"
       env:
         DATADOG_SITE: ${{ inputs.datadog_site }}
-        DATADOG_API_KEY:  ${{ inputs.datadog_api_key != '' && inputs.datadog_api_key || steps.dd-sts.outputs.api_key }}
+        DATADOG_API_KEY:  ${{ inputs.datadog_api_key }}
         DD_TAGS: ${{ inputs.ci_environment != '' && format('test.configuration.ci_environment:{0}', inputs.ci_environment) || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -93,7 +92,6 @@ jobs:
       _system_tests_dev_mode: ${{ matrix.version == 'dev' }}
       _system_tests_library_target_branch_map: ${{ needs.compute_libraries_and_scenarios.outputs.target-branch-map }}
       push_to_test_optimization: true
-      dd_sts_policy: system-tests
 
   exotics:
     name: Exotics scenarios

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -101,11 +101,6 @@ on:
         default: "datadoghq.com"
         required: false
         type: string
-      dd_sts_policy:
-        description: "dd-sts policy to use to get a Datadog API key for Test Optimization"
-        default: ""
-        required: false
-        type: string
 
 jobs:
   main:
@@ -551,4 +546,3 @@ jobs:
         datadog_api_key: ${{ secrets.TEST_OPTIMIZATION_API_KEY }}
         datadog_site: ${{ inputs.test_optimization_datadog_site }}
         ci_environment: ${{ inputs.ci_environment }}
-        dd_sts_policy: ${{ inputs.dd_sts_policy }}

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -76,11 +76,6 @@ on:
         default: "datadoghq.com"
         required: false
         type: string
-      dd_sts_policy:
-        description: "dd-sts policy to use to get a Datadog API key for Test Optimization"
-        default: ""
-        required: false
-        type: string
     secrets:
       TEST_OPTIMIZATION_API_KEY:
         description: "API key for pushing test results to DataDog Test Optimization"
@@ -171,4 +166,3 @@ jobs:
           datadog_api_key: ${{ secrets.TEST_OPTIMIZATION_API_KEY }}
           datadog_site: ${{ inputs.test_optimization_datadog_site }}
           ci_environment: ${{ inputs.ci_environment }}
-          dd_sts_policy: ${{ inputs.dd_sts_policy }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -124,6 +124,11 @@ on:
         default: "datadoghq.com"
         required: false
         type: string
+      dd_sts_policy:
+        description: "dd-sts policy to use to get a Datadog API key for Test Optimization"
+        default: ""
+        required: false
+        type: string
 
     secrets:
       DOCKERHUB_USERNAME:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -124,11 +124,6 @@ on:
         default: "datadoghq.com"
         required: false
         type: string
-      dd_sts_policy:
-        description: "dd-sts policy to use to get a Datadog API key for Test Optimization"
-        default: ""
-        required: false
-        type: string
 
     secrets:
       DOCKERHUB_USERNAME:
@@ -175,8 +170,6 @@ jobs:
     if: needs.compute_parameters.outputs.parametric_enable == 'true'
     uses: ./.github/workflows/run-parametric.yml
     secrets: inherit
-    permissions:
-      id-token: write
     with:
       library: ${{ inputs.library }}
       ref: ${{ inputs.ref }}
@@ -189,7 +182,6 @@ jobs:
       unique_id: ${{ needs.compute_parameters.outputs.unique_id }}
       push_to_test_optimization: ${{ inputs.push_to_test_optimization }}
       test_optimization_datadog_site: ${{ inputs.test_optimization_datadog_site }}
-      dd_sts_policy: ${{ inputs.dd_sts_policy }}
 
   build_end_to_end:
     name: Build end-to-end (${{ matrix.weblog.name }})
@@ -264,8 +256,6 @@ jobs:
       fail-fast: false
     uses: ./.github/workflows/run-end-to-end.yml
     secrets: inherit
-    permissions:
-      id-token: write
     with:
       runs_on: ${{ matrix.job.runs_on }}
       library: ${{ matrix.job.library }}
@@ -282,7 +272,6 @@ jobs:
       artifact_retention_days: ${{ inputs.artifact_retention_days }}
       push_to_test_optimization: ${{ inputs.push_to_test_optimization }}
       test_optimization_datadog_site: ${{ inputs.test_optimization_datadog_site }}
-      dd_sts_policy: ${{ inputs.dd_sts_policy }}
       _build_buddies_images: ${{ inputs._build_buddies_images }}
       _build_proxy_image: ${{ inputs._build_proxy_image }}
       _build_lambda_proxy_image: ${{ inputs._build_lambda_proxy_image }}


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
