### PR TITLE
Intercept HTTPS CONNECT tunnels in mocked backend mode

### DIFF
--- a/utils/proxy/core.py
+++ b/utils/proxy/core.py
@@ -6,11 +6,13 @@ from collections import defaultdict
 import json
 import logging
 import os
+import ssl
 from typing import Any, Literal
 from datetime import datetime, UTC
 
 from mitmproxy import master, options, http
 from mitmproxy.addons import errorcheck, default_addons
+from mitmproxy.connection import Client
 from mitmproxy.flow import Error as FlowError
 from mitmproxy.http import HTTPFlow, Request
 
@@ -31,6 +33,19 @@ os.umask(0)
 SIMPLE_TYPES = (bool, int, float, type(None))
 
 messages_counts: dict[str, int] = defaultdict(int)
+
+# Used to create the stub TLS server cert (mitmproxy CA is always present at startup).
+_MITMPROXY_CA_PEM = "/app/utils/proxy/.mitmproxy/mitmproxy-ca.pem"
+
+
+async def _mock_upstream_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    """Keep the mitmproxy ↔ upstream TLS leg alive; mitmproxy handles all actual HTTP."""
+    try:
+        await reader.read(1)
+    except (ConnectionResetError, asyncio.IncompleteReadError):
+        pass
+    finally:
+        writer.close()
 
 
 class ObjectDumpEncoder(json.JSONEncoder):
@@ -70,6 +85,11 @@ class _RequestLogger:
         self.internal_mocked_backend_responses = MockedBackendResponse.many_from_file()
         """Backend mocked responses valid for the entire session, controlled by scenarios"""
 
+        self._mock_upstream_server: asyncio.Server | None = None
+
+        self._original_connects: dict[str, tuple[str, int]] = {}
+        """for backend requests, since we mock the connect handshake, we need to store original host/port"""
+
     @staticmethod
     def get_error_response(message: bytes) -> http.Response:
         logger.error(message)
@@ -90,13 +110,43 @@ class _RequestLogger:
             logger.info(f"Store mocked {target} responses: {result}")
             flow.response = http.Response.make(200, b"Ok")
 
+    async def running(self) -> None:
+        if not self.mocked_backend:
+            return
+        ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ssl_ctx.load_cert_chain(_MITMPROXY_CA_PEM)
+        self._mock_upstream_server = await asyncio.start_server(
+            _mock_upstream_handler, "127.0.0.1", ProxyPorts.upstream_tls_server, ssl=ssl_ctx
+        )
+        logger.info(f"Mock upstream TLS server started on port {ProxyPorts.upstream_tls_server}")
+
+    def http_connect(self, flow: HTTPFlow) -> None:
+        proxy_port = flow.client_conn.sockname[1]
+        logger.info(f"Flow {flow.id}: CONNECT {flow.request.host}:{flow.request.port} using proxy port {proxy_port}")
+        if proxy_port == ProxyPorts.agent and self.mocked_backend:
+            # Redirect to local stub TLS server so mitmproxy can always complete tunnel setup.
+            # Without this, CONNECT handshake is performed to the backend, and if ever it fails,
+            # request() never fires.
+
+            logger.info(f"Flow {flow.id}: bypass CONNECT to 127.0.0.1:{ProxyPorts.upstream_tls_server}")
+            logger.debug(f"Flow {flow.id}: client connection id is: {flow.client_conn.id}")
+
+            self._original_connects[flow.client_conn.id] = flow.request.host, flow.request.port
+
+            flow.request.host = "127.0.0.1"
+            flow.request.port = ProxyPorts.upstream_tls_server
+
+    def clientdisconnected(self, client: Client) -> None:
+        self._original_connects.pop(client.id, None)
+
     def request(self, flow: HTTPFlow):
         # sockname is the local address (host, port) we received this connection on.
-        port = flow.client_conn.sockname[1]
+        proxy_port = flow.client_conn.sockname[1]
 
-        logger.info(f"{flow.request.method} {flow.request.pretty_url} using proxy port {port}")
+        logger.info(f"Flow {flow.id}: {flow.request.method} {flow.request.pretty_url} using proxy port {proxy_port}")
+        logger.info(f"Flow {flow.id}: client connection id is: {flow.client_conn.id}")
 
-        if port == ProxyPorts.proxy_commands:
+        if proxy_port == ProxyPorts.proxy_commands:
             if flow.request.path == MOCKED_TRACER_RESPONSES_PATH and flow.request.method == "PUT":
                 self._store_mocked_reponses(flow, target="tracer")
 
@@ -109,7 +159,7 @@ class _RequestLogger:
             return
 
         # if flow.request.headers.get("dd-protocol") == "otlp":
-        if port == ProxyPorts.open_telemetry_weblog:
+        if proxy_port == ProxyPorts.open_telemetry_weblog:
             # OTLP ingestion
             otlp_path = flow.request.headers.get("dd-otlp-path")
             if otlp_path == "agent":
@@ -135,12 +185,12 @@ class _RequestLogger:
             else:
                 raise ValueError(f"Unknown OTLP ingestion path {otlp_path}")
 
-            logger.info(f"    => reverse proxy to {flow.request.pretty_url}")
+            logger.info(f"Flow {flow.id}: reverse proxy to {flow.request.pretty_url}")
 
-        elif port == ProxyPorts.otel_collector and self.mocked_backend:
+        elif proxy_port == ProxyPorts.otel_collector and self.mocked_backend:
             flow.response = http.Response.make(200, b"Ok")  # TODO : response accepted by collector
 
-        elif port in (
+        elif proxy_port in (
             ProxyPorts.python_buddy,
             ProxyPorts.nodejs_buddy,
             ProxyPorts.java_buddy,
@@ -153,8 +203,8 @@ class _RequestLogger:
                 self.tracing_agent_target_port,
             )
             flow.request.scheme = "http"
-            logger.info(f"    => reverse proxy to {flow.request.pretty_url}")
-        elif port == ProxyPorts.agent and self.mocked_backend:
+            logger.info(f"Flow {flow.id}: reverse proxy to {flow.request.pretty_url}")
+        elif proxy_port == ProxyPorts.agent and self.mocked_backend:
             # Since we are faking the backend (generating responses from
             # scratch), the logic is that the first mock satisfying the
             # condition wins. Consequently, we check runtime mocks (controlled
@@ -162,14 +212,21 @@ class _RequestLogger:
             # all scenarios).
             for mock in self.mocked_backend_responses + self.internal_mocked_backend_responses:
                 if mock.path == flow.request.path:
-                    logger.info(f"    => applying backend mock {mock}")
+                    logger.info(f"Flow {flow.id}: applying backend mock {mock}")
                     mock.execute(flow)
                     return
 
             # No mock matched - return generic success response
             if flow.request.path == "/support/flare":
+                logger.info(f"Flow {flow.id}: {flow.request.path}: forcing 200 status")
                 flow.response = http.Response.make(200, b"Ok")
+            elif flow.request.path.split("?")[0] in "/api/v1/validate":
+                logger.info(f"Flow {flow.id}: {flow.request.path}: forcing 200 status with valid content")
+                flow.response = http.Response.make(
+                    200, b'{"valid": true}', headers={"content-type": "application/json"}
+                )
             else:
+                logger.info(f"Flow {flow.id}: {flow.request.path}: forcing 202 status")
                 flow.response = http.Response.make(202, b"Ok")
 
     @staticmethod
@@ -178,36 +235,36 @@ class _RequestLogger:
 
     def response(self, flow: HTTPFlow):
         # sockname is the local address (host, port) we received this connection on.
-        port = flow.client_conn.sockname[1]
+        proxy_port = flow.client_conn.sockname[1]
 
-        if port == ProxyPorts.proxy_commands:
+        if proxy_port == ProxyPorts.proxy_commands:
             return
 
-        logger.info(f"    => {flow.request.pretty_url} Response {flow.response.status_code}")
+        logger.info(f"Flow {flow.id}: response status code is {flow.response.status_code}")
 
         self._modify_response(flow)
 
         # get the interface name
-        if port == ProxyPorts.otel_collector:
+        if proxy_port == ProxyPorts.otel_collector:
             interface = "otel_collector"
-        elif port == ProxyPorts.open_telemetry_weblog:
+        elif proxy_port == ProxyPorts.open_telemetry_weblog:
             interface = "open_telemetry"
-        elif port == ProxyPorts.weblog:
+        elif proxy_port == ProxyPorts.weblog:
             interface = "library"
-        elif port == ProxyPorts.python_buddy:
+        elif proxy_port == ProxyPorts.python_buddy:
             interface = "python_buddy"
-        elif port == ProxyPorts.nodejs_buddy:
+        elif proxy_port == ProxyPorts.nodejs_buddy:
             interface = "nodejs_buddy"
-        elif port == ProxyPorts.java_buddy:
+        elif proxy_port == ProxyPorts.java_buddy:
             interface = "java_buddy"
-        elif port == ProxyPorts.ruby_buddy:
+        elif proxy_port == ProxyPorts.ruby_buddy:
             interface = "ruby_buddy"
-        elif port == ProxyPorts.golang_buddy:
+        elif proxy_port == ProxyPorts.golang_buddy:
             interface = "golang_buddy"
-        elif port == ProxyPorts.agent:  # HTTPS port, as the agent use the proxy with HTTP_PROXY env var
+        elif proxy_port == ProxyPorts.agent:  # HTTPS port, as the agent use the proxy with HTTP_PROXY env var
             interface = "agent"
         else:
-            raise ValueError(f"Unknown port provenance for {flow.request}: {port}")
+            raise ValueError(f"Unknown port provenance for {flow.request}: {proxy_port}")
 
         # extract url info
         if "?" in flow.request.path:
@@ -222,12 +279,15 @@ class _RequestLogger:
         export_content_files_to = f"{log_foldename}/files"
         log_filename = f"{log_foldename}/{message_count:05d}_{path.replace('/', '_')}.json"
 
+        host, port = self._original_connects.get(flow.client_conn.id, (flow.request.host, flow.request.port))
+
         data = {
             "log_filename": log_filename,
             "path": path,
             "query": query,
-            "host": flow.request.host,
-            "port": flow.request.port,
+            "host": host,
+            "port": port,
+            "method": flow.request.method,
             "request": {
                 "timestamp_start": datetime.fromtimestamp(flow.request.timestamp_start, tz=UTC).isoformat(),
                 "headers": list(flow.request.headers.items()),
@@ -259,7 +319,7 @@ class _RequestLogger:
                 export_content_files_to=export_content_files_to,
             )
 
-        logger.info(f"    => Saving {flow.request.pretty_url} as {log_filename}")
+        logger.info(f"Flow {flow.id}: Saving as {log_filename}")
 
         with open(log_filename, "w", encoding="utf-8", opener=lambda path, flags: os.open(path, flags, 0o777)) as f:
             json.dump(data, f, indent=2, cls=ObjectDumpEncoder)
@@ -269,7 +329,7 @@ class _RequestLogger:
             # Apply tracer mocks (internal first, then runtime-controlled)
             for mocked_response in self.internal_mocked_tracer_responses + self.mocked_tracer_responses:
                 if mocked_response.path == flow.request.path:
-                    logger.info(f"    => applying tracer mock {mocked_response}")
+                    logger.info(f"Flow {flow.id}: applying tracer mock {mocked_response}")
                     mocked_response.execute(flow)
 
 
@@ -292,7 +352,16 @@ def start_proxy() -> None:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     listen_host = "::" if os.environ.get("SYSTEM_TESTS_IPV6") == "True" else "0.0.0.0"  # noqa: S104
-    opts = options.Options(mode=modes, listen_host=listen_host, confdir="/app/utils/proxy/.mitmproxy")
+    mocked_backend = os.environ.get("SYSTEM_TESTS_MOCKED_BACKEND") == "True"
+    opts = options.Options(
+        mode=modes,
+        listen_host=listen_host,
+        confdir="/app/utils/proxy/.mitmproxy",
+        # When mocking, generate TLS certs from SNI (no upstream fetch needed) and don't
+        # verify the stub server's self-signed cert.
+        upstream_cert=not mocked_backend,
+        ssl_insecure=mocked_backend,
+    )
     proxy = master.Master(opts, event_loop=loop)
     proxy.addons.add(*default_addons())
     proxy.addons.add(errorcheck.ErrorCheck())

--- a/utils/proxy/ports.py
+++ b/utils/proxy/ports.py
@@ -5,6 +5,10 @@ class ProxyPorts(IntEnum):
     """Proxy port are used by the proxy to determine the provenance of the request"""
 
     proxy_commands = 11111
+    """ Used to change proxy state (mostly what controls mocked responses)"""
+
+    upstream_tls_server = 11112
+    """ When backend is mocked, we need a fake TLS server that will answer to TLS handshake """
 
     weblog = 8126
     open_telemetry_weblog = 8127


### PR DESCRIPTION
## Motivation

In mocked_backend mode, the agent sends HTTPS requests to  backend (trace.agent.datadoghq.com, api.datadoghq.com, etc.) using HTTP_PROXY, which means it opens HTTPS CONNECT tunnels through the proxy. When the real backend is unreachable, mitmproxy fails the tunnel at the TLS setup, and `request()` is not fired.

And because `request()` never fired, the existing mock logic (which returns synthetic `202`/`200` responses) was bypassed entirely for these flows. 

Furthermore, if any of those  requests is a connectivity checks for the agent, it then consider that the backend is down, and does not try to send any data. In conequence, any assertion on agent side fails.

## Changes
                                                                      
- Stub TLS server (running() hook): when `mocked_backend=True`, starts a minimal asyncio TLS server on `127.0.0.1:11112` using the mitmproxy CA cert. It accepts connections and keeps them alive. Mitmproxy uses it purely to complete the TLS handshake leg; no actual data is forwarded through it.
- `http_connect()` hook: logs every CONNECT before any tunnel is established. For mocked agent flows, redirects the `CONNECT` destination to the stub server and saves the original (host, port) in _original_connects, keyed by `client_conn.id`.                                                                                              
- `response()`: restores the original (host, port) from _original_connects when building the saved JSON, so the
  file correctly reflects the real backend destination rather than 127.0.0.1.                                   
- mitmproxy options: upstream_cert=False (generate TLS certs from SNI without fetching the upstream cert) and  `ssl_insecure=True` (don't verify the stub server's self-signed cert) when in mocked mode.                      


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
