### PR TITLE
Migration to dd-sts to replace datadog API keys for test optim uploads

### DIFF
--- a/.github/actions/push_to_test_optim/action.yml
+++ b/.github/actions/push_to_test_optim/action.yml
@@ -19,19 +19,27 @@ runs:
       run: echo "Skipping TestOptim push for dependabot PRs"
 
     - name: Install datadog-ci
-      if: github.event.pull_request.user.login != 'dependabot[bot]' && inputs.datadog_api_key != ''
+      if: github.event.pull_request.user.login != 'dependabot[bot]'
       shell: bash
       run: npm install -g @datadog/datadog-ci || sleep 60 && npm install -g @datadog/datadog-ci
 
     - name: checkout owner repo
-      if: github.event.pull_request.user.login != 'dependabot[bot]' && inputs.datadog_api_key != ''
+      if: github.event.pull_request.user.login != 'dependabot[bot]'
       uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       with:
         path: repo
 
+    - name: Get Datadog credentials
+      id: dd-sts
+      if: github.event.pull_request.user.login != 'dependabot[bot]'
+      continue-on-error: true
+      uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+      with:
+        policy: system-tests 
+
     # https://docs.datadoghq.com/tests/setup/junit_xml/?tab=linux
     - name: Push results
-      if: github.event.pull_request.user.login != 'dependabot[bot]' && inputs.datadog_api_key != ''
+      if: github.event.pull_request.user.login != 'dependabot[bot]'
       shell: bash
       run: |
         cd repo
@@ -43,5 +51,5 @@ runs:
           --xpath-tag "test.codeowners=/testcase/properties/property[@name='test.codeowners']"
       env:
         DATADOG_SITE: ${{ inputs.datadog_site }}
-        DATADOG_API_KEY:  ${{ inputs.datadog_api_key }}
+        DATADOG_API_KEY:  ${{ inputs.datadog_api_key != '' && inputs.datadog_api_key || steps.dd-sts.outputs.api_key }}
         DD_TAGS: ${{ inputs.ci_environment != '' && format('test.configuration.ci_environment:{0}', inputs.ci_environment) || '' }}

--- a/.github/actions/push_to_test_optim/action.yml
+++ b/.github/actions/push_to_test_optim/action.yml
@@ -35,7 +35,7 @@ runs:
       continue-on-error: true
       uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
       with:
-        policy: system-tests 
+        policy: system-tests
 
     # https://docs.datadoghq.com/tests/setup/junit_xml/?tab=linux
     - name: Push results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
       fail-fast: false
     uses: ./.github/workflows/system-tests.yml
     permissions:
+      contents: read
       id-token: write
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,6 @@ jobs:
       fail-fast: false
     uses: ./.github/workflows/system-tests.yml
     permissions:
-      contents: read
-      packages: write
       id-token: write
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -175,6 +175,8 @@ jobs:
     if: needs.compute_parameters.outputs.parametric_enable == 'true'
     uses: ./.github/workflows/run-parametric.yml
     secrets: inherit
+    permissions:
+      id-token: write
     with:
       library: ${{ inputs.library }}
       ref: ${{ inputs.ref }}
@@ -261,6 +263,8 @@ jobs:
       fail-fast: false
     uses: ./.github/workflows/run-end-to-end.yml
     secrets: inherit
+    permissions:
+      id-token: write
     with:
       runs_on: ${{ matrix.job.runs_on }}
       library: ${{ matrix.job.library }}

--- a/docs/CI/github-actions.md
+++ b/docs/CI/github-actions.md
@@ -32,6 +32,7 @@ jobs:
       secrets: inherit
       permissions:
         contents: read
+        id-token: write
       with:
         library: java
         binaries_artifact: binaries
@@ -52,12 +53,21 @@ jobs:
 | `force_execute`                  | Comma-separated list of tests to run even if they are skipped by manifest or decorators         | string  | false    | *empty*       |
 | `library`                        | Library to test                                                                                 | string  | true     | —             |
 | `parametric_job_count`           | How many jobs should be used to run PARAMETRIC scenario                                         | number  | false    | 1             |
-| `push_to_test_optimization`      | Push tests results to DataDog Test Optimization. Requires TEST_OPTIMIZATION_API_KEY secrets     | boolean | false    | false         |
+| `push_to_test_optimization`      | Push tests results to DataDog Test Optimization. Uses `TEST_OPTIMIZATION_API_KEY` secret if set, otherwise fetches credentials automatically via dd-sts (recommended) | boolean | false    | false         |
 | `test_optimization_datadog_site` | DataDog site to use for test optimization                                                       | string  | false    | datadoghq.com |
 | `ref`                            | system-tests ref to run the tests on (can be any valid branch, tag or SHA in system-tests repo) | string  | false    | main          |
 | `scenarios`                      | Comma-separated list scenarios to run                                                           | string  | false    | DEFAULT       |
 | `scenarios_groups`               | Comma-separated list of scenarios groups to run                                                 | string  | false    | *empty*       |
 | `skip_empty_scenarios`           | Skip scenarios that contain only xfail or irrelevant tests                                      | boolean | false    | false         |
+
+## Permissions
+
+The following permissions are always required:
+
+| Permission       | Reason                                                      |
+| ---------------- | ----------------------------------------------------------- |
+| `contents: read` | Checkout the repository                                     |
+| `id-token: write` | Required by downstream workflows to fetch Datadog credentials via dd-sts. GitHub validates this upfront, so it must be granted even if test optimization is disabled |
 
 ## Secrets
 
@@ -73,7 +83,7 @@ For some purposes, secrets are used in the workflow:
 | DD_API_KEY_3                           |
 | DD_APP_KEY_3                           |
 | DOCKERHUB_USERNAME and DOCKERHUB_TOKEN | If both are set, all docker pull are authenticated, which offer higher rate limit
-| TEST_OPTIMIZATION_API_KEY              | The DD_API_KEY to use to push tests runs to DataDog Test Optimization
+| TEST_OPTIMIZATION_API_KEY              | The DD_API_KEY to use to push tests runs to DataDog Test Optimization. **Deprecated**: prefer not setting this and letting dd-sts fetch credentials automatically
 
 
 You can sends them ,either by using `secrets: inherit` ([doc](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idsecretsinherit)), or [use explicit secret ids](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idsecretssecret_id)


### PR DESCRIPTION
Replace long-lived \`TEST_OPTIMIZATION_API_KEY\` with short-lived OIDC credentials via \`dd-sts-action\`.

  **Changes:**
  - \`push_to_test_optim\` action: removes the \`datadog_api_key != ''\` guard so steps run for all non-dependabot PRs; adds a \`dd-sts-action\` step (policy: \`system-tests\`, \`continue-on-error: true\`) to fetch credentials
  automatically; \`DATADOG_API_KEY\` falls back to the STS-fetched key if the explicit secret is empty
  - \`ci.yml\`: replaces \`packages: write\` with \`id-token: write\`
  - \`system-tests.yml\`: adds \`id-token: write\` to parametric and end-to-end job calls
  - \`docs/CI/github-actions.md\`: documents \`id-token: write\` requirement and marks \`TEST_OPTIMIZATION_API_KEY\` as deprecated