### PR TITLE
fix(debugger): use correct DI upload flush interval env vars per library

### DIFF
--- a/utils/_context/_scenarios/debugger.py
+++ b/utils/_context/_scenarios/debugger.py
@@ -32,8 +32,15 @@ class DebuggerScenario(EndToEndScenario):
 
         library = self.weblog_infra.library_name
         if library == "python":
+            # Python v4.0+ only recognizes UPLOAD_INTERVAL_SECONDS, while v3.9 and
+            # earlier only recognizes UPLOAD_FLUSH_INTERVAL (both use seconds as the
+            # unit). Set both so it works regardless of the Python tracer version.
+            self.weblog_container.environment["DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS"] = "0.1"
             self.weblog_container.environment["DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL"] = "0.1"
-        else:
+        elif library == "nodejs":
+            self.weblog_container.environment["DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS"] = "0.1"
+        elif library in ("java", "dotnet"):
+            # Java and .NET use UPLOAD_FLUSH_INTERVAL in milliseconds
             self.weblog_container.environment["DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL"] = "100"
         if library == "golang":
             # The Go debugger is primarily implemented in the system-probe, so


### PR DESCRIPTION
## Motivation

While investigating a flaky Node.js debugger system test ([dd-trace-js#7923](https://github.com/DataDog/dd-trace-js/actions/runs/24248945642/job/70803098666?pr=7923)), I audited each tracer library to determine which environment variable they actually use for the dynamic instrumentation upload flush interval. The findings show that the previous catch-all `else` branch was incorrect for multiple libraries:

| Library | Env Variable | Unit |
|---------|-------------|------|
| **Python v4.0+** | `DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS` | seconds |
| **Python v3.9-** | `DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL` | seconds |
| **Node.js** | `DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS` | seconds |
| **Java** | `DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL` | milliseconds |
| **.NET** | `DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL` | milliseconds |
| **Ruby, Go, PHP** | N/A (no env var for this) | — |

Previously, only Python had a special case and everything else fell through to `DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL=100`. This meant Node.js silently ignored the setting and used its default 1s interval, and Ruby/Go/PHP had a no-op env var set.

## Changes

- **Python**: Set both `DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS=0.1` and `DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL=0.1` for backward compatibility across tracer versions (the old var was removed in v4.0).
- **Node.js**: Set `DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS=0.1`.
- **Java/.NET**: Explicitly set `DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL=100` (ms) only for these two libraries.
- **Ruby/Go/PHP**: No longer set a no-op environment variable.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
