### PR TITLE
[nodejs] fix local dd-trace linking regression

### DIFF
--- a/utils/build/docker/nodejs/anthropic_app/system_tests_library_version.sh
+++ b/utils/build/docker/nodejs/anthropic_app/system_tests_library_version.sh
@@ -4,10 +4,9 @@ set -e
 
 if [ -e /volumes/dd-trace-js ]; then
     {
-        cd /volumes/dd-trace-js
-        npm link
-        cd /usr/app
-        npm link dd-trace
+        mkdir -p /usr/app/node_modules
+        rm -rf /usr/app/node_modules/dd-trace
+        ln -s /volumes/dd-trace-js /usr/app/node_modules/dd-trace
     } > /dev/null 2>&1 || {
         echo "Error during linking dd-trace from /volumes/dd-trace-js" >&2
         exit 1

--- a/utils/build/docker/nodejs/app.sh
+++ b/utils/build/docker/nodejs/app.sh
@@ -7,8 +7,7 @@ fi
 set -e
 
 if [ -e /volumes/dd-trace-js ]; then
-    cd /volumes/dd-trace-js
-    npm link
-    cd /usr/app
-    npm link dd-trace
+    mkdir -p /usr/app/node_modules
+    rm -rf /usr/app/node_modules/dd-trace
+    ln -s /volumes/dd-trace-js /usr/app/node_modules/dd-trace
 fi

--- a/utils/build/docker/nodejs/google_genai_app/system_tests_library_version.sh
+++ b/utils/build/docker/nodejs/google_genai_app/system_tests_library_version.sh
@@ -4,10 +4,9 @@ set -e
 
 if [ -e /volumes/dd-trace-js ]; then
     {
-        cd /volumes/dd-trace-js
-        npm link
-        cd /usr/app
-        npm link dd-trace
+        mkdir -p /usr/app/node_modules
+        rm -rf /usr/app/node_modules/dd-trace
+        ln -s /volumes/dd-trace-js /usr/app/node_modules/dd-trace
     } > /dev/null 2>&1 || {
         echo "Error during linking dd-trace from /volumes/dd-trace-js" >&2
         exit 1

--- a/utils/build/docker/nodejs/openai_app/system_tests_library_version.sh
+++ b/utils/build/docker/nodejs/openai_app/system_tests_library_version.sh
@@ -4,10 +4,9 @@ set -e
 
 if [ -e /volumes/dd-trace-js ]; then
     {
-        cd /volumes/dd-trace-js
-        npm link
-        cd /usr/app
-        npm link dd-trace
+        mkdir -p /usr/app/node_modules
+        rm -rf /usr/app/node_modules/dd-trace
+        ln -s /volumes/dd-trace-js /usr/app/node_modules/dd-trace
     } > /dev/null 2>&1 || {
         echo "Error during linking dd-trace from /volumes/dd-trace-js" >&2
         exit 1

--- a/utils/build/docker/nodejs/parametric/app.sh
+++ b/utils/build/docker/nodejs/parametric/app.sh
@@ -7,10 +7,9 @@ fi
 set -e
 
 if [ -e /volumes/dd-trace-js ]; then
-    cd /volumes/dd-trace-js
-    npm link
-    cd /usr/app
-    npm link dd-trace
+    mkdir -p /usr/app/node_modules
+    rm -rf /usr/app/node_modules/dd-trace
+    ln -s /volumes/dd-trace-js /usr/app/node_modules/dd-trace
 fi
 
 # shellcheck disable=SC2086

--- a/utils/build/docker/nodejs/parametric/system_tests_library_version.sh
+++ b/utils/build/docker/nodejs/parametric/system_tests_library_version.sh
@@ -4,10 +4,9 @@ set -e
 
 if [ -e /volumes/dd-trace-js ]; then
     {
-        cd /volumes/dd-trace-js
-        npm link
-        cd /usr/app
-        npm link dd-trace
+        mkdir -p /usr/app/node_modules
+        rm -rf /usr/app/node_modules/dd-trace
+        ln -s /volumes/dd-trace-js /usr/app/node_modules/dd-trace
     } > /dev/null 2>&1 || {
         echo "Error during linking dd-trace from /volumes/dd-trace-js" >&2
         exit 1


### PR DESCRIPTION
## Motivation

Local linking of the Node.js tracer in `system-tests` regressed after `@dd-trace-js/package.json` started to include scripts that run during `npm link`. Our local test workflow depended on `npm link` against the mounted `dd-trace-js` checkout, so Node.js system test images stopped picking up local tracer changes reliably.

## Changes

Replace the `npm link` / `npm link dd-trace` flow with a direct symlink from `/usr/app/node_modules/dd-trace` to `/volumes/dd-trace-js`.

Apply the same fix across the shared Node.js startup scripts and the Node.js `system_tests_library_version.sh` scripts used by the Anthropic, Google GenAI, OpenAI, and parametric test apps.

This restores local tracer linking while avoiding link-time package scripts in the mounted `dd-trace-js` checkout.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
