### PR TITLE
debugger: fix wait_for_all_probes to accumulate state across requests

### DIFF
--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -57,7 +57,8 @@ class BaseDebuggerProbeStatusTest(debugger.BaseDebuggerTest):
 
         ### send requests
         self.send_rc_probes()
-        self.wait_for_all_probes(statuses=["INSTALLED", "RECEIVED"])
+        if not self.wait_for_all_probes(statuses=["INSTALLED", "RECEIVED"]):
+            self.setup_failures.append(f"Timed out waiting for probe diagnostics: {self.probe_ids}")
 
     def _assert(self):
         self.collect()

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -392,11 +392,13 @@ class BaseDebuggerTest:
     def wait_for_all_probes(self, statuses: list[ProbeStatus], timeout: int = 30) -> bool:
         logger.debug("Wating for all probes")
         self._wait_successful = False
-        self._wait_found_ids: set[str] = set()
-        interfaces.agent.wait_for(lambda data: self._wait_for_all_probes(data, statuses=statuses), timeout=timeout)
+        found_ids: set[str] = set()
+        interfaces.agent.wait_for(
+            lambda data: self._wait_for_all_probes(data, statuses=statuses, found_ids=found_ids), timeout=timeout
+        )
         return self._wait_successful
 
-    def _wait_for_all_probes(self, data: dict[str, Any], statuses: list[ProbeStatus]):
+    def _wait_for_all_probes(self, data: dict[str, Any], statuses: list[ProbeStatus], found_ids: set[str]):
         def _check_all_probes_status(probe_diagnostics: ProbeDiagnosticsCollection, statuses: list[ProbeStatus]):
             statuses = statuses + ["ERROR"]
             logger.debug(f"Waiting for these probes to be in {statuses}: {self.probe_ids}")
@@ -409,17 +411,17 @@ class BaseDebuggerTest:
                 logger.debug(f"Probe {expected_id} observed status is {probe_status}")
 
                 if probe_status in statuses:
-                    self._wait_found_ids.add(expected_id)
+                    found_ids.add(expected_id)
                     continue
 
                 if self.get_tracer()["language"] == "dotnet" and statuses[0] == "INSTALLED":
                     probe = next(p for p in self.probe_definitions if p["id"] == expected_id)
                     # EMITTING is not implemented for dotnet span probe
                     if probe["type"] == "SPAN_PROBE":
-                        self._wait_found_ids.add(expected_id)
+                        found_ids.add(expected_id)
                         continue
 
-            return set(self.probe_ids).issubset(self._wait_found_ids)
+            return set(self.probe_ids).issubset(found_ids)
 
         log_filename_found = re.search(r"/(\d+)__", data["log_filename"])
         if not log_filename_found:

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -392,12 +392,11 @@ class BaseDebuggerTest:
     def wait_for_all_probes(self, statuses: list[ProbeStatus], timeout: int = 30) -> bool:
         logger.debug("Wating for all probes")
         self._wait_successful = False
+        self._wait_found_ids: set[str] = set()
         interfaces.agent.wait_for(lambda data: self._wait_for_all_probes(data, statuses=statuses), timeout=timeout)
         return self._wait_successful
 
     def _wait_for_all_probes(self, data: dict[str, Any], statuses: list[ProbeStatus]):
-        found_ids = set()
-
         def _check_all_probes_status(probe_diagnostics: ProbeDiagnosticsCollection, statuses: list[ProbeStatus]):
             statuses = statuses + ["ERROR"]
             logger.debug(f"Waiting for these probes to be in {statuses}: {self.probe_ids}")
@@ -410,17 +409,17 @@ class BaseDebuggerTest:
                 logger.debug(f"Probe {expected_id} observed status is {probe_status}")
 
                 if probe_status in statuses:
-                    found_ids.add(expected_id)
+                    self._wait_found_ids.add(expected_id)
                     continue
 
                 if self.get_tracer()["language"] == "dotnet" and statuses[0] == "INSTALLED":
                     probe = next(p for p in self.probe_definitions if p["id"] == expected_id)
                     # EMITTING is not implemented for dotnet span probe
                     if probe["type"] == "SPAN_PROBE":
-                        found_ids.add(expected_id)
+                        self._wait_found_ids.add(expected_id)
                         continue
 
-            return set(self.probe_ids).issubset(found_ids)
+            return set(self.probe_ids).issubset(self._wait_found_ids)
 
         log_filename_found = re.search(r"/(\d+)__", data["log_filename"])
         if not log_filename_found:


### PR DESCRIPTION
## Motivation

`wait_for_all_probes` was silently broken for tracers/agents that send probe diagnostics across multiple HTTP requests. The function recreated a local `found_ids` set on every callback invocation, meaning probe IDs discovered from earlier requests were lost. It could only return `True` if a single request happened to contain diagnostics for all probes — otherwise it always timed out and returned `False`.

This was never caught because the return value was discarded. When we tried to assert on it (to surface setup timeouts as clear test failures), the bug became visible: Ruby and Go tests failed consistently.

## Changes

1. **Fix `wait_for_all_probes` in `tests/debugger/utils.py`**: Move `found_ids` from a local variable (recreated each callback invocation) to instance state (`self._wait_found_ids`, initialized once before the wait loop). Probe IDs now accumulate correctly across multiple HTTP requests from the agent.

2. **Report setup timeouts in `tests/debugger/test_debugger_probe_status.py`**: Record a `setup_failures` entry when `wait_for_all_probes` times out, so it surfaces as a clear test failure via `assert_setup_ok()` rather than being silently ignored. Uses `setup_failures` instead of a bare `assert` to avoid crashing pytest during the collection phase.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)