### PR TITLE
Ruby: Enable remaining AI Guard tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -33,7 +33,7 @@ manifest:
         uds-sinatra: irrelevant
   tests/ai_guard/test_ai_guard_sdk.py::Test_RootSpanUserKeep:
     - weblog_declaration:
-        "*": missing_feature
+        "*": v2.31.0-dev
         rails42: irrelevant
         rack: irrelevant
         sinatra14: irrelevant

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -53,7 +53,7 @@ manifest:
         uds-sinatra: irrelevant
   tests/ai_guard/test_ai_guard_sdk.py::Test_SDS_Findings_In_SDK_Response:
     - weblog_declaration:
-        "*": missing_feature
+        "*": v2.31.0-dev
         rails42: irrelevant
         rack: irrelevant
         sinatra14: irrelevant
@@ -63,7 +63,7 @@ manifest:
         uds-sinatra: irrelevant
   tests/ai_guard/test_ai_guard_sdk.py::Test_SensitiveDataScanning:
     - weblog_declaration:
-        "*": missing_feature
+        "*": v2.31.0-dev
         rails42: irrelevant
         rack: irrelevant
         sinatra14: irrelevant
@@ -71,7 +71,16 @@ manifest:
         sinatra32: irrelevant
         sinatra41: irrelevant
         uds-sinatra: irrelevant
-  tests/ai_guard/test_ai_guard_sdk.py::Test_Tag_Probabilities: missing_feature (APPSEC-61897)
+  tests/ai_guard/test_ai_guard_sdk.py::Test_Tag_Probabilities:
+    - weblog_declaration:
+        "*": v2.31.0-dev
+        rails42: irrelevant
+        rack: irrelevant
+        sinatra14: irrelevant
+        sinatra22: irrelevant
+        sinatra32: irrelevant
+        sinatra41: irrelevant
+        uds-sinatra: irrelevant
   tests/apm_tracing_e2e/test_otel.py::Test_Otel_Span: missing_feature (missing /e2e_otel_span endpoint on weblog)
   tests/apm_tracing_e2e/test_otel.py::Test_Otel_Span::test_distributed_otel_trace: irrelevant (Golang specific test with OTel Go contrib package)
   tests/apm_tracing_e2e/test_process_tags.py::Test_Process_Tags::test_remote_config_process_tags_svc: missing_feature

--- a/utils/build/docker/ruby/rails52/app/controllers/ai_guard_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/ai_guard_controller.rb
@@ -40,13 +40,13 @@ class AiGuardController < ApplicationController
       tags: result.tags,
       is_blocking_enabled: result.blocking_enabled?
     }
-    response_data[:tag_probs] = result.tag_probs if result.respond_to?(:tag_probs)
-    response_data[:sds] = result.sds if result.respond_to?(:sds)
+    response_data[:tag_probs] = result.tag_probabilities if result.respond_to?(:tag_probabilities)
+    response_data[:sds] = result.sds_findings if result.respond_to?(:sds_findings)
     render json: response_data
   rescue Datadog::AIGuard::AIGuardAbortError => e
     error_data = { action: e.action, reason: e.reason, tags: e.tags }
-    error_data[:tag_probs] = e.tag_probs if e.respond_to?(:tag_probs)
-    error_data[:sds] = e.sds if e.respond_to?(:sds)
+    error_data[:tag_probabilities] = e.tag_probabilities if e.respond_to?(:tag_probabilities)
+    error_data[:sds_findings] = e.sds_findings if e.respond_to?(:sds_findings)
     render json: error_data, status: 403
   rescue => e
     render json: {error: e.to_s, type: e.class.name}, status: 500

--- a/utils/build/docker/ruby/rails61/app/controllers/ai_guard_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/ai_guard_controller.rb
@@ -40,13 +40,13 @@ class AiGuardController < ApplicationController
       tags: result.tags,
       is_blocking_enabled: result.blocking_enabled?
     }
-    response_data[:tag_probs] = result.tag_probs if result.respond_to?(:tag_probs)
-    response_data[:sds] = result.sds if result.respond_to?(:sds)
+    response_data[:tag_probs] = result.tag_probabilities if result.respond_to?(:tag_probabilities)
+    response_data[:sds] = result.sds_findings if result.respond_to?(:sds_findings)
     render json: response_data
   rescue Datadog::AIGuard::AIGuardAbortError => e
     error_data = { action: e.action, reason: e.reason, tags: e.tags }
-    error_data[:tag_probs] = e.tag_probs if e.respond_to?(:tag_probs)
-    error_data[:sds] = e.sds if e.respond_to?(:sds)
+    error_data[:tag_probabilities] = e.tag_probabilities if e.respond_to?(:tag_probabilities)
+    error_data[:sds_findings] = e.sds_findings if e.respond_to?(:sds_findings)
     render json: error_data, status: 403
   rescue => e
     render json: {error: e.to_s, type: e.class.name}, status: 500

--- a/utils/build/docker/ruby/rails72/app/controllers/ai_guard_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/ai_guard_controller.rb
@@ -40,13 +40,13 @@ class AiGuardController < ApplicationController
       tags: result.tags,
       is_blocking_enabled: result.blocking_enabled?
     }
-    response_data[:tag_probs] = result.tag_probs if result.respond_to?(:tag_probs)
-    response_data[:sds] = result.sds if result.respond_to?(:sds)
+    response_data[:tag_probs] = result.tag_probabilities if result.respond_to?(:tag_probabilities)
+    response_data[:sds] = result.sds_findings if result.respond_to?(:sds_findings)
     render json: response_data
   rescue Datadog::AIGuard::AIGuardAbortError => e
     error_data = { action: e.action, reason: e.reason, tags: e.tags }
-    error_data[:tag_probs] = e.tag_probs if e.respond_to?(:tag_probs)
-    error_data[:sds] = e.sds if e.respond_to?(:sds)
+    error_data[:tag_probabilities] = e.tag_probabilities if e.respond_to?(:tag_probabilities)
+    error_data[:sds_findings] = e.sds_findings if e.respond_to?(:sds_findings)
     render json: error_data, status: 403
   rescue => e
     render json: {error: e.to_s, type: e.class.name}, status: 500

--- a/utils/build/docker/ruby/rails80/app/controllers/ai_guard_controller.rb
+++ b/utils/build/docker/ruby/rails80/app/controllers/ai_guard_controller.rb
@@ -41,13 +41,13 @@ class AiGuardController < ApplicationController
       tags: result.tags,
       is_blocking_enabled: result.blocking_enabled?
     }
-    response_data[:tag_probs] = result.tag_probs if result.respond_to?(:tag_probs)
-    response_data[:sds] = result.sds if result.respond_to?(:sds)
+    response_data[:tag_probs] = result.tag_probabilities if result.respond_to?(:tag_probabilities)
+    response_data[:sds] = result.sds_findings if result.respond_to?(:sds_findings)
     render json: response_data
   rescue Datadog::AIGuard::AIGuardAbortError => e
     error_data = { action: e.action, reason: e.reason, tags: e.tags }
-    error_data[:tag_probs] = e.tag_probs if e.respond_to?(:tag_probs)
-    error_data[:sds] = e.sds if e.respond_to?(:sds)
+    error_data[:tag_probabilities] = e.tag_probabilities if e.respond_to?(:tag_probabilities)
+    error_data[:sds_findings] = e.sds_findings if e.respond_to?(:sds_findings)
     render json: error_data, status: 403
   rescue => e
     render json: {error: e.to_s, type: e.class.name}, status: 500


### PR DESCRIPTION
## Motivation

We want to enable remaining AI guard tests for Ruby, they should all be passing now.

## Changes

All AI Guard tests are enabled for Ruby now via the manifest file.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
