### PR TITLE
Disable Code Origin by default in FastAPI

### DIFF
--- a/utils/build/docker/python/fastapi.Dockerfile
+++ b/utils/build/docker/python/fastapi.Dockerfile
@@ -16,6 +16,7 @@ COPY utils/build/docker/python/iast.py /app/iast.py
 ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 ENV DD_REMOTECONFIG_POLL_SECONDS=1
 ENV _DD_APPSEC_DEDUPLICATION_ENABLED=false
+ENV DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
 
 # docker startup
 CMD ./app.sh


### PR DESCRIPTION
## Motivation

We are making Code Origin enabled by default and some of the existing FastAPI tests fail because of the new code origin tags that are not expected in payloads. Relevant scenarios still enable code origin explicitly, so this is essentially a no-op compared to the current configuration defaults.

## Changes

We disable Code Origin by default in FastAPI to allow most of the scenario that expect specific payloads to avoid receiving unexpected code origin tags that would make the tests fail. Because Code Origin was originally off by default, the scenarios that test that feature explicitly enable it already, so this is effectively a no-op.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
