### PR TITLE
[dotnet] Update dotnet code origin default expectations in system-tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -636,6 +636,7 @@ manifest:
   ? tests/debugger/test_debugger_expression_language.py::Test_Debugger_Expression_Language::test_expression_language_string_operations
   : bug (DEBUG-2560)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin: bug (DEBUG-4637)
+  tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin_Default_On: missing_feature (Temporarily disabled; enable from v3.42.0 later)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation: bug (DEBUG-4637)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Exception_Replay: v3.29.0
   ? tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Exception_Replay::test_inproduct_enablement_exception_replay_apm_multiconfig

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -788,6 +788,7 @@ manifest:
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_stackoverflow: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_expression_language.py::Test_Debugger_Expression_Language: missing_feature (feature not implemented)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin: missing_feature
+  tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin_Default_On: irrelevant (Scoped to dotnet rollout in this PR)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation: missing_feature
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Exception_Replay: missing_feature
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction: missing_feature (feature not implemented)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2908,6 +2908,7 @@ manifest:
         spring-boot-wildfly: v1.48.0
         uds-spring-boot: v1.48.0
     - declaration: missing_feature
+  tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin_Default_On: irrelevant (Scoped to dotnet rollout in this PR)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation:
     - weblog_declaration:
         "*": missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1506,6 +1506,7 @@ manifest:
         "*": *ref_5_83_0
         nextjs: irrelevant
     - declaration: flaky (DEBUG-5169)
+  tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin_Default_On: irrelevant (Scoped to dotnet rollout in this PR)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation:
     - weblog_declaration:
         "*": *ref_5_83_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -526,6 +526,7 @@ manifest:
   ? tests/debugger/test_debugger_expression_language.py::Test_Debugger_Expression_Language::test_expression_language_string_operations
   : '>=1.16.0'
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin: missing_feature
+  tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin_Default_On: irrelevant (Scoped to dotnet rollout in this PR)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation: missing_feature
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Exception_Replay: missing_feature
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1115,6 +1115,7 @@ manifest:
         "*": missing_feature
         *flask: v3.5.0
     - declaration: missing_feature
+  tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin_Default_On: irrelevant (Scoped to dotnet rollout in this PR)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation:
     - weblog_declaration:
         "*": missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -968,6 +968,7 @@ manifest:
     - declaration: missing_feature (Hash length not implemented)
       component_version: <=2.22.0
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin: missing_feature
+  tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin_Default_On: irrelevant (Scoped to dotnet rollout in this PR)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation: missing_feature
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Exception_Replay: missing_feature
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction:

--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import tests.debugger.utils as debugger
-from utils import context, features, irrelevant, logger, scenarios, slow
+from utils import context, features, logger, scenarios, slow
 import json
 import time
 
@@ -213,7 +213,6 @@ class Test_Debugger_InProduct_Enablement_Code_Origin(debugger.BaseDebuggerTest):
 
 @features.debugger_code_origins
 @scenarios.debugger_inproduct_enablement
-@irrelevant(context.library != "dotnet", reason="Only applicable to dotnet")
 @slow
 class Test_Debugger_InProduct_Enablement_Code_Origin_Default_On(debugger.BaseDebuggerTest):
     def setup_code_origin_enabled_by_default(self):

--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import tests.debugger.utils as debugger
-from utils import context, features, logger, scenarios, slow
+from utils import context, features, irrelevant, logger, scenarios, slow
 import json
 import time
 
@@ -209,3 +209,20 @@ class Test_Debugger_InProduct_Enablement_Code_Origin(debugger.BaseDebuggerTest):
         assert self.co_explicit_enabled, "Expected spans with code origin after explicit enable"
         assert self.co_empty_config, "Expected spans to continue emitting with empty config"
         assert self.co_explicit_disabled, "Expected spans to stop emitting after explicit disable"
+
+
+@features.debugger_code_origins
+@scenarios.debugger_inproduct_enablement
+@irrelevant(context.library != "dotnet", reason="Only applicable to dotnet")
+@slow
+class Test_Debugger_InProduct_Enablement_Code_Origin_Default_On(debugger.BaseDebuggerTest):
+    def setup_code_origin_enabled_by_default(self):
+        self.initialize_weblog_remote_config()
+        self.send_weblog_request("/")
+        self.code_origin_enabled_by_default = self.wait_for_code_origin_span(TIMEOUT)
+
+    def test_code_origin_enabled_by_default(self):
+        self.assert_setup_ok()
+        self.assert_all_weblog_responses_ok()
+
+        assert self.code_origin_enabled_by_default, "Expected code origin enabled by default"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -848,7 +848,7 @@ class Test_ProductsDisabled:
 
     @scenarios.telemetry_app_started_products_disabled
     def test_debugger_products_disabled(self):
-        """Assert DI and ER are disabled by default, while code origin follows library defaults."""
+        """Assert DI and ER are disabled by default, and code origin config is reported."""
         data_found = False
         config_norm_rules = load_telemetry_json("config_norm_rules")
         lang_configs = get_lang_configs()
@@ -888,12 +888,11 @@ class Test_ProductsDisabled:
         assert di_config == "false", "DI should be disabled by default"
         assert er_config == "false", "Exception Replay should be disabled by default"
 
-        expected_co = "false"
         if context.library == "dotnet" and context.library.version >= "3.42.0":
-            expected_co = "true"
+            assert co_config in {"false", "true"}, "Code Origin for Spans should be reported in telemetry"
+            return
 
-        expected_co_state = "enabled" if expected_co == "true" else "disabled"
-        assert co_config == expected_co, f"Code Origin for Spans should be {expected_co_state} by default"
+        assert co_config == "false", "Code Origin for Spans should be disabled by default"
 
 
 @features.dd_telemetry_dependency_collection_enabled_supported

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -848,7 +848,7 @@ class Test_ProductsDisabled:
 
     @scenarios.telemetry_app_started_products_disabled
     def test_debugger_products_disabled(self):
-        """Assert that the debugger products are disabled by default including DI, and ER"""
+        """Assert DI and ER are disabled by default, while code origin follows library defaults."""
         data_found = False
         config_norm_rules = load_telemetry_json("config_norm_rules")
         lang_configs = get_lang_configs()
@@ -887,7 +887,13 @@ class Test_ProductsDisabled:
         assert data_found, "No app-started event found in telemetry data"
         assert di_config == "false", "DI should be disabled by default"
         assert er_config == "false", "Exception Replay should be disabled by default"
-        assert co_config == "false", "Code Origin for Spans should be disabled by default"
+
+        expected_co = "false"
+        if context.library == "dotnet" and context.library.version >= "3.42.0":
+            expected_co = "true"
+
+        expected_co_state = "enabled" if expected_co == "true" else "disabled"
+        assert co_config == expected_co, f"Code Origin for Spans should be {expected_co_state} by default"
 
 
 @features.dd_telemetry_dependency_collection_enabled_supported


### PR DESCRIPTION
## Motivation

The dd-trace-dotnet change that enables Code Origin by default starting in v3.42.0 made the existing system-tests expectations stale for dotnet. In particular, `Test_ProductsDisabled::test_debugger_products_disabled` still needs to verify that Dynamic Instrumentation and Exception Replay are disabled by default, but for dotnet >= 3.42.0 it should no longer require a fixed Code Origin default. Instead, it should only require that code_origin_for_spans_enabled is reported, keeping system-tests compatible with both main and the code-origin-default-on branch until the dedicated default-on test is enabled.

## Changes

Relax the telemetry assertion in `Test_ProductsDisabled::test_debugger_products_disabled` so dotnet >= 3.42.0 accepts either code_origin_for_spans_enabled=false or true, while still requiring the config to be present.
Keep the existing default-disabled assertions for Dynamic Instrumentation and Exception Replay unchanged.

Add `tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin_Default_On` to verify that Code Origin is enabled by default for the dotnet rollout.
Scope that test through manifests rather than a test decorator by marking it irrelevant in the non-dotnet manifests.
Keep the new default-on test disabled in manifests/dotnet.yml for now, with the intent to enable it later from v3.42.0.
No scenarios were added, removed, or renamed. Only tests/ and manifests/ were modified.