### PR TITLE
Fix flaky span sampling test (sss009) by increasing sample size

### DIFF
--- a/tests/parametric/test_span_sampling.py
+++ b/tests/parametric/test_span_sampling.py
@@ -294,13 +294,17 @@ class Test_Span_Sampling:
         """Test sample rate comes close to expected number of spans sampled. We do this by setting the
         sample_rate to 0.5, and then making sure that about half of the spans have span sampling tags and
         half do not.
+
+        With 200 traces and a 0.5 sample rate, the expected number of sampled spans is 100
+        (std dev ~7.07). The acceptable range [60, 140] is ~5.7 standard deviations from the
+        mean, giving a theoretical failure probability of ~1 in 85 million.
         """
-        # make 100 new traces, each with one span
-        for _ in range(100):
+        # make 200 new traces, each with one span
+        for _ in range(200):
             with test_library, test_library.dd_start_span(name="web.request", service="webserver"):
                 pass
-        traces = test_agent.wait_for_num_traces(num=100)
-        assert len(traces) == 100
+        traces = test_agent.wait_for_num_traces(num=200)
+        assert len(traces) == 200
         sampled = []
         unsampled = []
 
@@ -311,8 +315,8 @@ class Test_Span_Sampling:
             else:
                 unsampled.append(trace)
 
-        assert len(sampled) in range(30, 70)
-        assert len(unsampled) in range(30, 70)
+        assert len(sampled) in range(60, 141)
+        assert len(unsampled) in range(60, 141)
 
     @pytest.mark.parametrize(
         "library_env",


### PR DESCRIPTION
## Motivation

`test_sampling_rate_not_absolute_value_sss009[library_env0, parametric-python]` is flaky on main. The most recent failure: `assert 72 in range(30, 70)` — 72 spans sampled out of 100 with a 0.5 sample rate.

The test is inherently statistical: span sampling in dd-trace-py uses a deterministic hash of the span ID (`span_id * KNUTH_FACTOR % 2^64`), and span IDs come from a Rust PRNG seeded from OS entropy. There is no way to seed the RNG from the test side.

With n=100 and p=0.5 (σ=5), the bounds `range(30, 70)` — i.e. [30, 69] — provide only ~4σ coverage, giving a theoretical failure rate of ~1 in 15,000. Empirically over the last 90 days: 1 failure in 759 runs.

## Changes

Increase sample size from 100 to 200 traces and scale bounds proportionally to [60, 140].

With n=200 and p=0.5:
- σ = √(200 × 0.5 × 0.5) ≈ 7.07
- Bounds [60, 140] = ±5.7σ from the mean
- Theoretical failure probability: ~1 in 85 million

This eliminates flakiness while preserving the same ±40% proportional tolerance the test originally intended.

## Workflow

1. :warning: Create your PR as draft :warning:
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

:sos: [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) :sos:

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)