### PR TITLE
Attribute internal errors to RP team

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -568,6 +568,16 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
                     testcase.attrib["name"] = testcase.attrib["classname"] + "." + testcase.attrib["name"]
                     del testcase.attrib["classname"]
 
+                if testcase.attrib["name"] == "pytest.internal":
+                    properties = ET.Element("properties")
+                    testcase.append(properties)
+                    properties.append(
+                        ET.Element(
+                            "property",
+                            {"name": "test.codeowners", "value": '["@DataDog/apm-reliability-and-performance"]'},
+                        )
+                    )
+
                 if context.weblog_variant:
                     name = testcase.attrib["name"]
                     if name.endswith("]"):


### PR DESCRIPTION
## Motivation

When an internal errors occurs during pytest hooks, a synthetic `testcase` is reported through junit, and pushed to test optim.

But this test case does not have any owners, triggerring our "no owner" monitor.

## Changes

Attribute any internal error to @DataDog/apm-reliability-and-performance

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
