### PR TITLE
Do not require API_KEY for PROFILING scenario

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -213,13 +213,10 @@ jobs:
     - name: Run PROFILING scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"PROFILING"')
       run: |
-        [[ -z "$DD_API_KEY" ]] && echo "Skipping: DD_API_KEY is not set" && exit 0
         cat /proc/sys/kernel/perf_event_paranoid
         sudo sysctl kernel.perf_event_paranoid=1
         sudo sysctl -p
         ./run.sh PROFILING
-      env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
     - name: Run TRACE_PROPAGATION_STYLE_W3C scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"TRACE_PROPAGATION_STYLE_W3C"')
       run: ./run.sh TRACE_PROPAGATION_STYLE_W3C

--- a/utils/_context/_scenarios/profiling.py
+++ b/utils/_context/_scenarios/profiling.py
@@ -37,7 +37,3 @@ class ProfilingScenario(EndToEndScenario):
             # profiling is known to be unstable on python3.11, and this value is here to fix that
             # it's not yet the default behaviour, but it will be in the future
             self.weblog_container.environment["DD_PROFILING_STACK_V2_ENABLED"] = "true"
-
-        elif library == "nodejs":
-            # for an unknown reason, /flush on nodejs takes days with a fake key on this scenario
-            self._require_api_key = True


### PR DESCRIPTION
## Motivation

node.js was freezing on this scenario with a fake since. Since we totally mock the backend, it's not happening anymore.

Furthermore, if ever an API_KEY was provided as an empty string, the scenario was failing at agent startup.

## Changes

Do not require anymore API_KEY for node.js, and do not set the env var in the official workflow.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
