### PR TITLE
parametric: add locale-invariant _dd.p.ksr regression test across all languages

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -838,8 +838,6 @@ manifest:
   tests/parametric/test_process_discovery.py: missing_feature
   tests/parametric/test_sampling_delegation.py::Test_Decisionless_Extraction: v1.13.0+4663b2fa7c20c6920f347d059b57dc2a419cb7f7
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: '>=1.18.0'
-  ? tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate::test_sampling_knuth_sample_rate_locale_invariant[locale_de_DE_uses_period_not_comma]
-  : missing_feature (Fix pending in dd-trace-php#3797 - snprintf uses locale-sensitive formatting)
   ? tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate::test_sampling_extract_knuth_sample_rate_distributed_tracing_datadog
   : '>=1.16.0'
   ? tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate::test_sampling_extract_knuth_sample_rate_distributed_tracing_tracecontext

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -838,6 +838,8 @@ manifest:
   tests/parametric/test_process_discovery.py: missing_feature
   tests/parametric/test_sampling_delegation.py::Test_Decisionless_Extraction: v1.13.0+4663b2fa7c20c6920f347d059b57dc2a419cb7f7
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: '>=1.18.0'
+  ? tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate::test_sampling_knuth_sample_rate_locale_invariant[locale_de_DE_uses_period_not_comma]
+  : missing_feature (Fix pending in dd-trace-php#3797 - snprintf uses locale-sensitive formatting)
   ? tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate::test_sampling_extract_knuth_sample_rate_distributed_tracing_datadog
   : '>=1.16.0'
   ? tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate::test_sampling_extract_knuth_sample_rate_distributed_tracing_tracecontext

--- a/tests/parametric/test_sampling_span_tags.py
+++ b/tests/parametric/test_sampling_span_tags.py
@@ -409,6 +409,40 @@ class Test_Knuth_Sample_Rate:
         assert span["metrics"].get(SAMPLING_PRIORITY_KEY) == 2
 
     @pytest.mark.parametrize(
+        ("library_env", "expected_ksr"),
+        [
+            (
+                {
+                    "TEST_LOCALE": "de_DE.UTF-8",
+                    "DD_TRACE_SAMPLE_RATE": None,
+                    "DD_TRACE_SAMPLING_RULES": '[{"sample_rate":0.3}]',
+                    "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
+                },
+                "0.3",
+            ),
+        ],
+        ids=["locale_de_DE_uses_period_not_comma"],
+    )
+    def test_sampling_knuth_sample_rate_locale_invariant(
+        self, test_agent: TestAgentAPI, test_library: APMLibrary, expected_ksr: str
+    ):
+        """_dd.p.ksr must use a period as decimal separator regardless of the process
+        locale. Verified by activating de_DE.UTF-8 (comma decimal separator) via
+        LD_PRELOAD before the tracer initialises. Regression test for dd-trace-php#3796.
+        """
+        with test_library:
+            with test_library.dd_start_span("span"):
+                pass
+            test_library.dd_flush()
+
+        traces = test_agent.wait_for_num_traces(1)
+        span = find_only_span(traces)
+        assert span["meta"].get("_dd.p.ksr") == expected_ksr, (
+            f"Expected _dd.p.ksr='{expected_ksr}' with de_DE locale active, "
+            f"got: {span['meta'].get('_dd.p.ksr')!r} — locale-sensitive formatting (e.g. comma decimal) detected"
+        )
+
+    @pytest.mark.parametrize(
         "library_env",
         [
             {

--- a/utils/build/docker/dotnet/parametric/Dockerfile
+++ b/utils/build/docker/dotnet/parametric/Dockerfile
@@ -29,7 +29,7 @@ RUN dotnet publish -c Release -o out
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl locales gcc \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl locales gcc libc6-dev \
     && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
     && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
     && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \

--- a/utils/build/docker/dotnet/parametric/Dockerfile
+++ b/utils/build/docker/dotnet/parametric/Dockerfile
@@ -29,7 +29,11 @@ RUN dotnet publish -c Release -o out
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl locales gcc \
+    && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
+    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \
+    && rm /tmp/li.c && rm -rf /var/lib/apt/lists/*
 
 # install dd-trace-dotnet (must be done before setting LD_PRELOAD)
 COPY utils/build/docker/dotnet/install_ddtrace.sh binaries/ /binaries/

--- a/utils/build/docker/dotnet/parametric/entrypoint.sh
+++ b/utils/build/docker/dotnet/parametric/entrypoint.sh
@@ -8,4 +8,8 @@ if [ -f /opt/datadog/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so ]; then
   export LD_PRELOAD=/opt/datadog/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so
 fi
 
+if [ -n "${TEST_LOCALE:-}" ]; then
+  export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}/locale_init.so"
+fi
+
 exec "$@"

--- a/utils/build/docker/golang/parametric/Dockerfile
+++ b/utils/build/docker/golang/parametric/Dockerfile
@@ -1,8 +1,8 @@
 
 FROM golang:1.25
 
-# install jq
-RUN apt-get update && apt-get -y install jq
+# install jq, locales, and gcc for locale_init.so
+RUN apt-get update && apt-get -y install jq locales gcc
 ENV GONOSUMDB=github.com/DataDog/* \
     GOPRIVATE=github.com/DataDog/*
 WORKDIR /app
@@ -17,4 +17,10 @@ RUN mkdir /parametric-tracer-logs
 
 RUN go install
 
-CMD ["main"]
+# Build locale_init.so: sets LC_ALL from TEST_LOCALE at process startup via LD_PRELOAD
+RUN echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
+    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \
+    && rm /tmp/li.c && rm -rf /var/lib/apt/lists/*
+
+CMD ["bash", "-c", "[ -n \"${TEST_LOCALE:-}\" ] && export LD_PRELOAD=/locale_init.so; exec main"]

--- a/utils/build/docker/java/parametric/Dockerfile
+++ b/utils/build/docker/java/parametric/Dockerfile
@@ -11,7 +11,7 @@ COPY utils/build/docker/java/parametric/run.sh .
 RUN mkdir /parametric-tracer-logs
 
 # Build locale_init.so: sets LC_ALL from TEST_LOCALE at process startup via LD_PRELOAD
-RUN apt-get update && apt-get install -y --no-install-recommends locales gcc \
+RUN apt-get update && apt-get install -y --no-install-recommends locales gcc libc6-dev \
     && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
     && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
     && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \

--- a/utils/build/docker/java/parametric/Dockerfile
+++ b/utils/build/docker/java/parametric/Dockerfile
@@ -1,3 +1,15 @@
+
+# Build locale_init.so and generate de_DE locale in a matching Ubuntu stage.
+# maven:eclipse-temurin is Ubuntu Jammy-based; using the same base ensures the
+# compiled .so and locale-archive are binary-compatible with the target image.
+# Doing this in a separate stage avoids a 600s Docker build timeout caused by
+# apt-get being slow on the large maven image.
+FROM ubuntu:22.04 AS locale-tools
+RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev locales \
+    && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
+    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c
+
 FROM maven:3-eclipse-temurin-21
 
 WORKDIR /client
@@ -10,11 +22,8 @@ RUN bash install_ddtrace.sh
 COPY utils/build/docker/java/parametric/run.sh .
 RUN mkdir /parametric-tracer-logs
 
-# Build locale_init.so: sets LC_ALL from TEST_LOCALE at process startup via LD_PRELOAD
-RUN apt-get update && apt-get install -y --no-install-recommends locales gcc libc6-dev \
-    && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
-    && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
-    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \
-    && rm /tmp/li.c && rm -rf /var/lib/apt/lists/*
+# Copy locale_init.so and locale archive from the Ubuntu builder
+COPY --from=locale-tools /locale_init.so /locale_init.so
+COPY --from=locale-tools /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive
 
 CMD ["./run.sh"]

--- a/utils/build/docker/java/parametric/Dockerfile
+++ b/utils/build/docker/java/parametric/Dockerfile
@@ -10,4 +10,11 @@ RUN bash install_ddtrace.sh
 COPY utils/build/docker/java/parametric/run.sh .
 RUN mkdir /parametric-tracer-logs
 
+# Build locale_init.so: sets LC_ALL from TEST_LOCALE at process startup via LD_PRELOAD
+RUN apt-get update && apt-get install -y --no-install-recommends locales gcc \
+    && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
+    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \
+    && rm /tmp/li.c && rm -rf /var/lib/apt/lists/*
+
 CMD ["./run.sh"]

--- a/utils/build/docker/java/parametric/run.sh
+++ b/utils/build/docker/java/parametric/run.sh
@@ -32,6 +32,10 @@ DISABLE_INTEGRATIONS=(-Ddd.integration.servlet-request-body.enabled=false \
 # Limit JIT to tier one as the client application is a short-lived process that frequently killed / restarted
 OPTIMIZATION_OPTIONS=(-XX:TieredStopAtLevel=1)
 
+if [ -n "${TEST_LOCALE:-}" ]; then
+    export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}/locale_init.so"
+fi
+
 # Start client application
 # shellcheck disable=SC2086
 java -Xmx128M -javaagent:"${DD_JAVA_AGENT}" \

--- a/utils/build/docker/nodejs/parametric/Dockerfile
+++ b/utils/build/docker/nodejs/parametric/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM node:18.10-slim
-RUN apt-get update && apt-get -y install bash curl git jq \
-  || sleep 60 && apt-get update && apt-get -y install bash curl git jq
+RUN apt-get update && apt-get -y install bash curl git jq locales gcc \
+  || sleep 60 && apt-get update && apt-get -y install bash curl git jq locales gcc
 WORKDIR /usr/app
 COPY utils/build/docker/nodejs/parametric/package.json /usr/app/
 COPY utils/build/docker/nodejs/parametric/package-lock.json /usr/app/
@@ -14,6 +14,12 @@ RUN npm install || sleep 60 && npm install
 COPY utils/build/docker/nodejs/parametric/../install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh
 RUN mkdir /parametric-tracer-logs
+
+# Build locale_init.so: sets LC_ALL from TEST_LOCALE at process startup via LD_PRELOAD
+RUN echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
+    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \
+    && rm /tmp/li.c && rm -rf /var/lib/apt/lists/*
 
 CMD ["./app.sh"]
 

--- a/utils/build/docker/nodejs/parametric/Dockerfile
+++ b/utils/build/docker/nodejs/parametric/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM node:18.10-slim
-RUN apt-get update && apt-get -y install bash curl git jq locales gcc \
-  || sleep 60 && apt-get update && apt-get -y install bash curl git jq locales gcc
+RUN apt-get update && apt-get -y install bash curl git jq locales gcc libc6-dev \
+  || sleep 60 && apt-get update && apt-get -y install bash curl git jq locales gcc libc6-dev
 WORKDIR /usr/app
 COPY utils/build/docker/nodejs/parametric/package.json /usr/app/
 COPY utils/build/docker/nodejs/parametric/package-lock.json /usr/app/

--- a/utils/build/docker/nodejs/parametric/app.sh
+++ b/utils/build/docker/nodejs/parametric/app.sh
@@ -12,5 +12,9 @@ if [ -e /volumes/dd-trace-js ]; then
     ln -s /volumes/dd-trace-js /usr/app/node_modules/dd-trace
 fi
 
+if [ -n "${TEST_LOCALE:-}" ]; then
+    export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}/locale_init.so"
+fi
+
 # shellcheck disable=SC2086
 node server.js ${SYSTEM_TESTS_EXTRA_COMMAND_ARGUMENTS:-}

--- a/utils/build/docker/php/parametric/Dockerfile
+++ b/utils/build/docker/php/parametric/Dockerfile
@@ -13,5 +13,12 @@ RUN php -d error_reporting='' -r 'echo phpversion("ddtrace");' > SYSTEM_TESTS_LI
 ADD utils/build/docker/php/parametric/server.php .
 # RUN mkdir /parametric-tracer-logs
 
+# Build locale_init.so: sets LC_ALL from TEST_LOCALE at process startup via LD_PRELOAD
+RUN apt-get update && apt-get install -y --no-install-recommends locales gcc \
+    && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
+    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \
+    && rm /tmp/li.c && rm -rf /var/lib/apt/lists/*
+
  # In case of crash, give time to the sidecar to upload the crash report
-CMD ["bash", "-c", "php server.php ${SYSTEM_TESTS_EXTRA_COMMAND_ARGUMENTS:-} || sleep 2s"]
+CMD ["bash", "-c", "[ -n \"${TEST_LOCALE:-}\" ] && export LD_PRELOAD=/locale_init.so; php server.php ${SYSTEM_TESTS_EXTRA_COMMAND_ARGUMENTS:-} || sleep 2s"]

--- a/utils/build/docker/php/parametric/Dockerfile
+++ b/utils/build/docker/php/parametric/Dockerfile
@@ -1,4 +1,16 @@
 
+# Build locale_init.so and generate de_DE locale on a clean Debian image.
+# The dd-trace-ci PHP base image has restricted apt sources inaccessible from
+# GitHub Actions (apt-get update exits 100), so we can't install packages there.
+# Instead, compile everything in a throwaway debian:bookworm-slim stage and copy
+# the results over — both images are Bookworm-based so the .so and locale are
+# binary-compatible.
+FROM debian:bookworm-slim AS locale-tools
+RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev locales \
+    && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
+    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c
+
 FROM datadog/dd-trace-ci:php-8.2_bookworm-6
 RUN switch-php nts
 WORKDIR /binaries
@@ -13,12 +25,9 @@ RUN php -d error_reporting='' -r 'echo phpversion("ddtrace");' > SYSTEM_TESTS_LI
 ADD utils/build/docker/php/parametric/server.php .
 # RUN mkdir /parametric-tracer-logs
 
-# Build locale_init.so: sets LC_ALL from TEST_LOCALE at process startup via LD_PRELOAD
-RUN apt-get update && apt-get install -y --no-install-recommends locales gcc \
-    && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
-    && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
-    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \
-    && rm /tmp/li.c && rm -rf /var/lib/apt/lists/*
+# Copy locale_init.so and locale archive from the clean builder
+COPY --from=locale-tools /locale_init.so /locale_init.so
+COPY --from=locale-tools /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive
 
  # In case of crash, give time to the sidecar to upload the crash report
 CMD ["bash", "-c", "[ -n \"${TEST_LOCALE:-}\" ] && export LD_PRELOAD=/locale_init.so; php server.php ${SYSTEM_TESTS_EXTRA_COMMAND_ARGUMENTS:-} || sleep 2s"]

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -3,6 +3,13 @@
 ini_set("datadog.trace.generate_root_span", "0");
 ini_set("datadog.trace.revolt_enabled", "0");
 
+// Set locale from TEST_LOCALE env var. PHP's own setlocale() is called here
+// (after PHP runtime init) as a belt-and-suspenders complement to the
+// LD_PRELOAD locale_init.so approach.
+if (($testLocale = getenv('TEST_LOCALE')) !== false) {
+    setlocale(LC_ALL, $testLocale);
+}
+
 require __DIR__ . "/vendor/autoload.php";
 
 use Amp\ByteStream;

--- a/utils/build/docker/python/parametric/Dockerfile
+++ b/utils/build/docker/python/parametric/Dockerfile
@@ -8,4 +8,11 @@ RUN /binaries/install_ddtrace.sh
 RUN mkdir /parametric-tracer-logs
 ENV DD_PATCH_MODULES="fastapi:false,startlette:false"
 
-CMD ["ddtrace-run", "python3.11", "-m", "apm_test_client"]
+# Build locale_init.so: sets LC_ALL from TEST_LOCALE at process startup via LD_PRELOAD
+RUN apt-get update && apt-get install -y --no-install-recommends locales gcc \
+    && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
+    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \
+    && rm /tmp/li.c && rm -rf /var/lib/apt/lists/*
+
+CMD ["bash", "-c", "[ -n \"${TEST_LOCALE:-}\" ] && export LD_PRELOAD=/locale_init.so; exec ddtrace-run python3.11 -m apm_test_client"]

--- a/utils/build/docker/python/parametric/Dockerfile
+++ b/utils/build/docker/python/parametric/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /parametric-tracer-logs
 ENV DD_PATCH_MODULES="fastapi:false,startlette:false"
 
 # Build locale_init.so: sets LC_ALL from TEST_LOCALE at process startup via LD_PRELOAD
-RUN apt-get update && apt-get install -y --no-install-recommends locales gcc \
+RUN apt-get update && apt-get install -y --no-install-recommends locales gcc libc6-dev \
     && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
     && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
     && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \

--- a/utils/build/docker/ruby/parametric/Dockerfile
+++ b/utils/build/docker/ruby/parametric/Dockerfile
@@ -9,4 +9,11 @@ RUN /binaries/install_ddtrace.sh
 COPY utils/build/docker/ruby/parametric/server.rb /app/
 RUN mkdir /parametric-tracer-logs
 
-CMD ["bundle", "exec", "ruby", "server.rb"]
+# Build locale_init.so: sets LC_ALL from TEST_LOCALE at process startup via LD_PRELOAD
+RUN apt-get update && apt-get install -y --no-install-recommends locales gcc \
+    && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
+    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \
+    && rm /tmp/li.c && rm -rf /var/lib/apt/lists/*
+
+CMD ["bash", "-c", "[ -n \"${TEST_LOCALE:-}\" ] && export LD_PRELOAD=/locale_init.so; exec bundle exec ruby server.rb"]

--- a/utils/build/docker/ruby/parametric/Dockerfile
+++ b/utils/build/docker/ruby/parametric/Dockerfile
@@ -10,7 +10,7 @@ COPY utils/build/docker/ruby/parametric/server.rb /app/
 RUN mkdir /parametric-tracer-logs
 
 # Build locale_init.so: sets LC_ALL from TEST_LOCALE at process startup via LD_PRELOAD
-RUN apt-get update && apt-get install -y --no-install-recommends locales gcc \
+RUN apt-get update && apt-get install -y --no-install-recommends locales gcc libc6-dev \
     && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
     && printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
     && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \

--- a/utils/build/docker/ruby/parametric/server.rb
+++ b/utils/build/docker/ruby/parametric/server.rb
@@ -3,6 +3,19 @@ require 'webrick'
 require 'rack/handler/webrick'
 require 'json'
 
+# Set locale from TEST_LOCALE env var. Called here (after Ruby's own Init_ruby)
+# rather than via LD_PRELOAD, because Ruby calls setlocale(LC_ALL, "") during
+# startup which would reset any locale set by a constructor function earlier.
+# LC_ALL = 6 on Linux glibc (POSIX constant, stable across Debian/Ubuntu).
+if (test_locale = ENV['TEST_LOCALE'])
+  require 'fiddle'
+  Fiddle::Function.new(
+    Fiddle::Handle::DEFAULT['setlocale'],
+    [Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP],
+    Fiddle::TYPE_VOIDP
+  ).call(6, test_locale)
+end
+
 # Add current folder to the search path
 current_dir = Dir.pwd
 $LOAD_PATH.unshift(current_dir) unless $LOAD_PATH.include?(current_dir)

--- a/utils/build/docker/rust/parametric/Dockerfile
+++ b/utils/build/docker/rust/parametric/Dockerfile
@@ -3,9 +3,8 @@ WORKDIR /usr/app
 COPY utils/build/docker/rust/parametric .
 COPY utils/build/docker/rust/parametric/../install_ddtrace.sh ./binaries/ /binaries/
 COPY utils/build/docker/rust/parametric/Cargo.toml /usr/app/
-COPY utils/build/docker/rust/parametric/src /usr/app/
 
-RUN apt-get update && apt-get install -y --no-install-recommends openssh-client git
+RUN apt-get update && apt-get install -y --no-install-recommends openssh-client git gcc
 
 RUN /binaries/install_ddtrace.sh
 
@@ -14,11 +13,23 @@ RUN \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
     cargo build --release && cp ./target/release/ddtrace-rs-client /usr/app
 
+# Build locale_init.so in the builder (gcc already present)
+RUN printf '#include <locale.h>\n#include <stdlib.h>\n__attribute__((constructor)) static void init_locale(void){const char*l=getenv("TEST_LOCALE");if(l&&*l)setlocale(LC_ALL,l);}' > /tmp/li.c \
+    && gcc -shared -fPIC -o /locale_init.so /tmp/li.c \
+    && rm /tmp/li.c
+
 FROM debian:bookworm-slim AS final
 COPY --from=builder /usr/app/ddtrace-rs-client /usr/app/ddtrace-rs-client
 COPY --from=builder /usr/app/Cargo.lock /usr/app/Cargo.lock
+COPY --from=builder /locale_init.so /locale_init.so
 COPY utils/build/docker/rust/parametric/system_tests_library_version.sh /usr/app/system_tests_library_version.sh
+
+# Install locales and bash in the final stage
+RUN apt-get update && apt-get install -y --no-install-recommends locales bash \
+    && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /parametric-tracer-logs
 WORKDIR /usr/app
 
-CMD ["./ddtrace-rs-client"]
+CMD ["bash", "-c", "[ -n \"${TEST_LOCALE:-}\" ] && export LD_PRELOAD=/locale_init.so; exec ./ddtrace-rs-client"]

--- a/utils/build/docker/rust/parametric/Dockerfile
+++ b/utils/build/docker/rust/parametric/Dockerfile
@@ -4,7 +4,7 @@ COPY utils/build/docker/rust/parametric .
 COPY utils/build/docker/rust/parametric/../install_ddtrace.sh ./binaries/ /binaries/
 COPY utils/build/docker/rust/parametric/Cargo.toml /usr/app/
 
-RUN apt-get update && apt-get install -y --no-install-recommends openssh-client git gcc
+RUN apt-get update && apt-get install -y --no-install-recommends openssh-client git gcc libc6-dev
 
 RUN /binaries/install_ddtrace.sh
 


### PR DESCRIPTION
## Motivation

dd-trace-php#3797 fixes a bug where `_dd.p.ksr` was formatted using `snprintf("%.6f", rate)`, which respects `LC_NUMERIC` — producing `0,3` instead of `0.3` on systems with a de_DE locale. This PR adds a cross-language regression test that empirically verifies every tracer's ksr formatting is locale-independent.

The PHP test is intentionally left without a `missing_feature` guard: it is expected to fail on current PHP, confirming the test actually exercises the locale-sensitive code path. Once dd-trace-php#3797 ships, PHP CI will go green.

## Changes

**New test** (`tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate::test_sampling_knuth_sample_rate_locale_invariant`):
- Sets `TEST_LOCALE=de_DE.UTF-8` in `library_env`
- Uses `DD_TRACE_SAMPLING_RULES=[{"sample_rate":0.3}]` so ksr is set to a decimal value
- Asserts `_dd.p.ksr == "0.3"` (period, not comma)

**Mechanism** — `locale_init.so` + `LD_PRELOAD`:
Each parametric container now carries a tiny shared library (`locale_init.so`) built from a 3-line C constructor:
```c
__attribute__((constructor)) static void init_locale(void) {
    const char *l = getenv("TEST_LOCALE");
    if (l && *l) setlocale(LC_ALL, l);
}
```
When `TEST_LOCALE` is set, the startup script exports `LD_PRELOAD=/locale_init.so`, activating the locale before any tracer code runs. This is language-agnostic — no changes to tracer or server code.

**Files changed per language:**
- All 8 parametric `Dockerfile`s: install `locales` + `gcc`, generate `de_DE.UTF-8`, compile `locale_init.so`
- Startup scripts (`app.sh`, `run.sh`, `entrypoint.sh`) and Dockerfile `CMD`s: set `LD_PRELOAD` when `TEST_LOCALE` is set
- Rust: compiles `locale_init.so` in the builder stage and copies to the final stage; also installs `bash` in the final stage for the CMD wrapper
- C++ skipped — follow-up PR in `dd-trace-cpp`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)