### PR TITLE
[rust] generate a dev version and install prod version from crates.io

### DIFF
--- a/tests/test_the_test/test_compute_libraries_and_scenarios.py
+++ b/tests/test_the_test/test_compute_libraries_and_scenarios.py
@@ -27,7 +27,7 @@ default_libs_with_prod = [
     "python",
     "python_lambda",
     "ruby",
-    "rust"
+    "rust",
 ]
 default_libs_with_dev = [
     "cpp",

--- a/tests/test_the_test/test_compute_libraries_and_scenarios.py
+++ b/tests/test_the_test/test_compute_libraries_and_scenarios.py
@@ -27,6 +27,7 @@ default_libs_with_prod = [
     "python",
     "python_lambda",
     "ruby",
+    "rust"
 ]
 default_libs_with_dev = [
     "cpp",

--- a/utils/build/docker/rust/install_ddtrace.sh
+++ b/utils/build/docker/rust/install_ddtrace.sh
@@ -16,10 +16,33 @@ fi
 
 if [ -e /binaries/dd-trace-rs ]; then
     echo "install from /binaries/datadog-opentelemetry with metrics-http and metrics-grpc features"
-    cargo add --path /binaries/dd-trace-rs/datadog-opentelemetry --features metrics-http,metrics-grpc
+
+    cd /binaries/dd-trace-rs
+
+    # get the version from the cargo.lock
+    current_version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "datadog-opentelemetry") | .version')
+    
+    # bump minor (middle segment); reset patch to 0 — expects MAJOR.MINOR.PATCH
+    IFS=. read -r major minor patch <<<"$current_version"
+    if [[ -z "${minor:-}" || -z "${patch:-}" ]]; then
+        echo "expected semver MAJOR.MINOR.PATCH, got: $current_version" >&2
+        exit 1
+    fi
+    new_version="${major}.$((minor + 1)).0"
+
+    if [ -e /binaries/dd-trace-rs/.git ]; then
+        dev_version="${new_version}-dev+$(git -C /binaries/dd-trace-rs rev-parse HEAD)"
+    else
+        dev_version="${new_version}-dev"
+    fi
+    
+    echo "generating dev version $dev_version from $current_version"
+    cargo release version -p datadog-opentelemetry "$dev_version" -x --no-confirm
+
+    cd /usr/app
+    cargo add --path /binaries/dd-trace-rs/datadog-opentelemetry --features metrics-http,metrics-grpc,logs-http,logs-grpc
 else
-    # TODO: add lastest release from crates.io
-    echo "install from --git $REPO_URL --tag $PROD_TAG with metrics-http and metrics-grpc features"
-    cargo add --git "$REPO_URL" --tag "$PROD_TAG" datadog-opentelemetry --features metrics-http,metrics-grpc
+    echo "install from crates.io with metrics-http and metrics-grpc features"
+    cargo add datadog-opentelemetry --features metrics-http,metrics-grpc,logs-http,logs-grpc
 fi
 

--- a/utils/build/docker/rust/install_ddtrace.sh
+++ b/utils/build/docker/rust/install_ddtrace.sh
@@ -13,6 +13,9 @@ if [ -e /binaries/rust-load-from-git ]; then
     git clone -b "$rev_or_branch" "$REPO_URL" /binaries/dd-trace-rs
 fi
 
+# remove previous depedency on datadog-opentelemetry
+cargo remove datadog-opentelemetry
+
 if [ -e /binaries/dd-trace-rs ]; then
     echo "install from /binaries/datadog-opentelemetry with metrics-http and metrics-grpc features"
 

--- a/utils/build/docker/rust/install_ddtrace.sh
+++ b/utils/build/docker/rust/install_ddtrace.sh
@@ -13,9 +13,6 @@ if [ -e /binaries/rust-load-from-git ]; then
     git clone -b "$rev_or_branch" "$REPO_URL" /binaries/dd-trace-rs
 fi
 
-# remove previous depedency on datadog-opentelemetry
-cargo remove datadog-opentelemetry
-
 if [ -e /binaries/dd-trace-rs ]; then
     echo "install from /binaries/datadog-opentelemetry with metrics-http and metrics-grpc features"
 
@@ -42,9 +39,12 @@ if [ -e /binaries/dd-trace-rs ]; then
     cargo release version -p datadog-opentelemetry "$dev_version" -x --no-confirm
 
     cd /usr/app
-    cargo add --path /binaries/dd-trace-rs/datadog-opentelemetry --features metrics-http,metrics-grpc,logs-http,logs-grpc
+    cargo add datadog-opentelemetry --path /binaries/dd-trace-rs/datadog-opentelemetry --features metrics-http,metrics-grpc,logs-http,logs-grpc
 else
     echo "install from crates.io with metrics-http and metrics-grpc features"
+
+    # remove previous depedency on datadog-opentelemetry and add the new one from crates.io
+    cargo remove datadog-opentelemetry || true
     cargo add datadog-opentelemetry --features metrics-http,metrics-grpc,logs-http,logs-grpc
 fi
 

--- a/utils/build/docker/rust/install_ddtrace.sh
+++ b/utils/build/docker/rust/install_ddtrace.sh
@@ -30,7 +30,7 @@ if [ -e /binaries/dd-trace-rs ]; then
     new_version="${major}.$((minor + 1)).0"
 
     if [ -e /binaries/dd-trace-rs/.git ]; then
-        dev_version="${new_version}-dev+$(git -C /binaries/dd-trace-rs rev-parse HEAD)"
+        dev_version="${new_version}-dev+$(git -C /binaries/dd-trace-rs rev-parse --short HEAD)"
     else
         dev_version="${new_version}-dev"
     fi

--- a/utils/build/docker/rust/install_ddtrace.sh
+++ b/utils/build/docker/rust/install_ddtrace.sh
@@ -5,7 +5,6 @@ set -eu
 cd /usr/app
 
 REPO_URL=https://github.com/DataDog/dd-trace-rs
-PROD_TAG=datadog-opentelemetry-v0.3.1
 
 if [ -e /binaries/rust-load-from-git ]; then
     rev_or_branch=$(</binaries/rust-load-from-git)
@@ -21,7 +20,7 @@ if [ -e /binaries/dd-trace-rs ]; then
 
     # get the version from the cargo.lock
     current_version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "datadog-opentelemetry") | .version')
-    
+
     # bump minor (middle segment); reset patch to 0 — expects MAJOR.MINOR.PATCH
     IFS=. read -r major minor patch <<<"$current_version"
     if [[ -z "${minor:-}" || -z "${patch:-}" ]]; then
@@ -35,7 +34,7 @@ if [ -e /binaries/dd-trace-rs ]; then
     else
         dev_version="${new_version}-dev"
     fi
-    
+
     echo "generating dev version $dev_version from $current_version"
     cargo release version -p datadog-opentelemetry "$dev_version" -x --no-confirm
 

--- a/utils/build/docker/rust/install_ddtrace.sh
+++ b/utils/build/docker/rust/install_ddtrace.sh
@@ -21,13 +21,13 @@ if [ -e /binaries/dd-trace-rs ]; then
     # get the version from the cargo.lock
     current_version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "datadog-opentelemetry") | .version')
 
-    # bump minor (middle segment); reset patch to 0 — expects MAJOR.MINOR.PATCH
+    # bump patch (right segment); — expects MAJOR.MINOR.PATCH
     IFS=. read -r major minor patch <<<"$current_version"
     if [[ -z "${minor:-}" || -z "${patch:-}" ]]; then
         echo "expected semver MAJOR.MINOR.PATCH, got: $current_version" >&2
         exit 1
     fi
-    new_version="${major}.$((minor + 1)).0"
+    new_version="${major}.${minor}.$((patch + 1))"
 
     if [ -e /binaries/dd-trace-rs/.git ]; then
         dev_version="${new_version}-dev+$(git -C /binaries/dd-trace-rs rev-parse --short HEAD)"

--- a/utils/build/docker/rust/parametric/Cargo.lock
+++ b/utils/build/docker/rust/parametric/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-opentelemetry"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -950,9 +950,9 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libdd-common"
-version = "2.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5593b91f61eee38cddc9fdcbc99c9fad697b5d925e226bd500d86b4295380b"
+checksum = "c779949577250487179d904508f18750070e9a01eb58dce378409ec5fa066f3b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -981,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline"
-version = "2.0.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2704d0fcc9281cc844a63d15188aecc84d45725b77e489cc04ad30959b2000"
+checksum = "358411451d99011f13c7628acee25dc144f2bbeade87acf10fa7d5ffce1053dc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1020,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-dogstatsd-client"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a457381568835e7c3646f3f2d44ff4f3ebcda44d87332e2fdaeb20e6a8365dcd"
+checksum = "e6f8eca39d1e2ef6267cf77fc51eb7ebc7d4f44827e150b4d317c29d8c33bf87"
 dependencies = [
  "anyhow",
  "cadence",
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-telemetry"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7bb67a865fe7e8a16aacc7bc43a805fb3b907c713e0b212e7a7abe6e0735cb"
+checksum = "78774ffce79da677602829d7fe27468283e5349010e974257233edf4cd12b783"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1068,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-normalization"
-version = "1.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a737b43f01d6a0cbd1399c5b89863a5d2663fe7b19bf1d3ea28048abab396353"
+checksum = "ab12e095f3589d02ceed76556e7aa8a1b5bc928a900e143b624e2331294e54b5"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -1078,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "2.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0a54921e03174f3ff7ad8506ff9e13637e546ef0b1f369ae463eacebda8e88"
+checksum = "1809242895edc53ac51a21287829f42474e749dbc222ea7f414cb3f0d1f91d4e"
 dependencies = [
  "prost",
  "serde",
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "1.0.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea447dc8a5d84c6b5eb6ea877c4fea4149fd29f6b45fcfc5cfd7edf82a18e056"
+checksum = "d92b882863f7c531d51e73f7bc5930c705e47829332128d9bdcad0fea3b2b942"
 dependencies = [
  "hashbrown 0.15.5",
  "libdd-ddsketch",
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "2.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a59e9a0a41bb17d06fb85a70db3be04e53ddfb8f61a593939bb9677729214db"
+checksum = "870506e9bb79c93ce5bbfe9d715c53c7ea393a177c7299f0bf43745c0adea0c7"
 dependencies = [
  "anyhow",
  "bytes",

--- a/utils/build/docker/rust/parametric/Cargo.toml
+++ b/utils/build/docker/rust/parametric/Cargo.toml
@@ -35,4 +35,4 @@ opentelemetry-stdout    = { version = "0.31.0", features = ["trace", "logs"] }
 opentelemetry-semantic-conventions = { version = "0.31.0" }
 
 
-datadog-opentelemetry  = { path = "../../../../../binaries/dd-trace-rs/datadog-opentelemetry", features = ["logs-grpc", "logs-http"] }
+datadog-opentelemetry  = { path = "../../../../../binaries/dd-trace-rs/datadog-opentelemetry", features = ["metrics-grpc", "metrics-http", "logs-grpc", "logs-http"] }

--- a/utils/build/docker/rust/parametric/Cargo.toml
+++ b/utils/build/docker/rust/parametric/Cargo.toml
@@ -7,6 +7,9 @@ license       = "Apache-2.0"
 readme        = "README.md"
 publish       = false
 
+resolver      = "3"
+rust-version  = "1.85.1" # should match Dockerfile rustc version
+
 [[bin]]
 name = "ddtrace-rs-client"
 path = "src/main.rs"

--- a/utils/build/docker/rust/parametric/Dockerfile
+++ b/utils/build/docker/rust/parametric/Dockerfile
@@ -5,7 +5,9 @@ COPY utils/build/docker/rust/parametric/../install_ddtrace.sh ./binaries/ /binar
 COPY utils/build/docker/rust/parametric/Cargo.toml /usr/app/
 COPY utils/build/docker/rust/parametric/src /usr/app/
 
-RUN apt-get update && apt-get install -y --no-install-recommends openssh-client git
+RUN apt-get update && apt-get install -y --no-install-recommends openssh-client git jq build-essential perl libssl-dev
+
+RUN cargo install cargo-release@0.25.18 --locked
 
 RUN /binaries/install_ddtrace.sh
 

--- a/utils/scripts/compute_libraries_and_scenarios.py
+++ b/utils/scripts/compute_libraries_and_scenarios.py
@@ -151,7 +151,6 @@ class LibraryProcessor:
                 "version": "prod",
             }
             for library in sorted(self.selected)
-            if library not in ("rust",)
         ] + [
             {
                 "library": library,


### PR DESCRIPTION
## Motivation

Enable prod tests for rust tracer

## Changes

Modify `install_ddtrace.sh‎` to:
- `dev`: generate dinamically a version for the tracer based on: the next minor version, `-dev` sufix and `+<githash>` (for example `0.4.0-dev+961440933807d6354f7af5098e61e605ed137495`) and use it when adding the dep via path
- `prod`: add the latest published crate in crates.io

I have modified `test_compute_libraries_and_scenarios.py`‎ and `compute_libraries_and_scenarios.py` to enable `prod` and it seems it's working but it might be necessary to modify others.


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
