### PR TITLE
[cpp] use ubuntu:24.04 for kong to avoid kitware PPA

### DIFF
--- a/utils/build/docker/cpp_kong/kong.Dockerfile
+++ b/utils/build/docker/cpp_kong/kong.Dockerfile
@@ -1,19 +1,11 @@
-FROM ubuntu:22.04 AS build
+# ubuntu:24.04 ships with cmake 3.28 (minimum version required by dd-trace-cpp)
+FROM ubuntu:24.04 AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install cmake >= 3.28 from Kitware APT repo (dd-trace-cpp requires it;
-# Ubuntu 22.04 only ships cmake 3.22).
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        gpg wget ca-certificates software-properties-common && \
-    wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc \
-        | gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main" \
-        > /etc/apt/sources.list.d/kitware.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        cmake g++ make libcurl4-openssl-dev git jq curl unzip && \
+        ca-certificates cmake g++ make libcurl4-openssl-dev git jq curl unzip && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /builds /binaries


### PR DESCRIPTION
## Motivation

Too many apt-get update and installs on archive.ubuntu.com is causing build flakiness.

## Changes

Just use ubuntu:24.04 instead of ubuntu:22.04, so we get a more recent cmake version without setting up a PPA (saves one `apt-get update` call).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
