### PR TITLE
[Go] fix(go): add replace directives from the existing `go.mod` files

### DIFF
--- a/utils/build/docker/golang/install_ddtrace.sh
+++ b/utils/build/docker/golang/install_ddtrace.sh
@@ -14,12 +14,16 @@ CONTRIBS="$(go list -m all | grep github.com/DataDog/dd-trace-go/contrib | cut -
 if [ -e "/binaries/dd-trace-go" ]; then
     echo "Install from folder /binaries/dd-trace-go"
     go mod edit -replace "$MAIN_MODULE=/binaries/dd-trace-go"
-    for contrib in $CONTRIBS; do
-        path="${contrib#github.com/DataDog/dd-trace-go/}"
-        path="${path%/v2}"
-        echo "Install contrib $contrib from folder /binaries/dd-trace-go/$path"
-        go mod edit -replace "github.com/DataDog/dd-trace-go/$path/v2=/binaries/dd-trace-go/$path"
-    done
+    # Add replace directives for all dd-trace-go submodules (contribs and others
+    # like instrumentation/testutils/grpc).
+    while IFS= read -r gomod; do
+        moddir="$(dirname "$gomod")"
+        modname="$(grep '^module ' "$gomod" | awk '{print $2}')"
+        if [[ "$modname" == github.com/DataDog/dd-trace-go/* ]] && [[ "$modname" != "$MAIN_MODULE" ]]; then
+            echo "Install contrib $modname from folder $moddir"
+            go mod edit -replace "$modname=$moddir"
+        fi
+    done < <(find /binaries/dd-trace-go -name "go.mod" -not -path "*/_*")
 elif [ -e "/binaries/golang-load-from-go-get" ]; then
     echo "Install from go get"
     # Read the file into an array to ensure we capture all lines


### PR DESCRIPTION
## Motivation

Ensure that all the existing nested modules from `dd-trace-go` are included as `replace` directives when building from `/binaries`.

## Changes

Modifies `install_ddtrace.sh` to expand the current implementation - limited to contribs - to any nested modules in the `dd-trace-go` repository.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
