### PR TITLE
ruby: enable apm standalone tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -398,7 +398,7 @@ manifest:
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Telemetry_V2: missing_feature
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_UrlQuery: v2.14.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: missing_feature  # requires Telemetry V2
-  tests/appsec/smoke_tests/test_apm_standalone.py: v2.31.0.dev  # was inccorectly declared as v2.31.0
+  tests/appsec/smoke_tests/test_apm_standalone.py: v2.30.0
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_RemoteConfig::test_rasp_blocking_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_UserEvents:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -399,7 +399,8 @@ manifest:
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_UrlQuery: v2.14.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: missing_feature  # requires Telemetry V2
   tests/appsec/smoke_tests/test_apm_standalone.py: v2.30.0
-  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp: missing_feature
+  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_lfi_smoke: missing_feature
+  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_shi_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_RemoteConfig::test_rasp_blocking_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_UserEvents:
     - weblog_declaration:
@@ -409,7 +410,8 @@ manifest:
         sinatra32: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
         sinatra41: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
         uds-sinatra: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
-  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp: missing_feature
+  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_lfi_smoke: missing_feature
+  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_shi_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_RemoteConfig::test_rasp_blocking_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_UserEvents:
     - weblog_declaration:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -398,7 +398,7 @@ manifest:
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Telemetry_V2: missing_feature
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_UrlQuery: v2.14.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: missing_feature  # requires Telemetry V2
-  tests/appsec/smoke_tests/test_apm_standalone.py: missing_feature  # was inccorectly declared as v2.31.0
+  tests/appsec/smoke_tests/test_apm_standalone.py: v2.31.0.dev  # was inccorectly declared as v2.31.0
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_RemoteConfig::test_rasp_blocking_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_UserEvents:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -401,9 +401,19 @@ manifest:
   tests/appsec/smoke_tests/test_apm_standalone.py: v2.30.0
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_lfi_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_shi_smoke: missing_feature
+  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_sqli_smoke:
+    - weblog_declaration:
+        "*": v2.30.0
+        rack: irrelevant
+        sinatra14: irrelevant
+        sinatra22: irrelevant
+        sinatra32: irrelevant
+        sinatra41: irrelevant
+        uds-sinatra: irrelevant
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_RemoteConfig::test_rasp_blocking_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_UserEvents:
     - weblog_declaration:
+        "*": v2.30.0
         rack: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
         sinatra14: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
         sinatra22: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
@@ -412,9 +422,19 @@ manifest:
         uds-sinatra: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_lfi_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_shi_smoke: missing_feature
+  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_sqli_smoke:
+    - weblog_declaration:
+        "*": v2.30.0
+        rack: irrelevant
+        sinatra14: irrelevant
+        sinatra22: irrelevant
+        sinatra32: irrelevant
+        sinatra41: irrelevant
+        uds-sinatra: irrelevant
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_RemoteConfig::test_rasp_blocking_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_UserEvents:
     - weblog_declaration:
+        "*": v2.30.0
         rack: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
         sinatra14: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
         sinatra22: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)

--- a/tests/appsec/smoke_tests/utils.py
+++ b/tests/appsec/smoke_tests/utils.py
@@ -275,6 +275,14 @@ class BaseRemoteConfigSmokeTests:
 
     def test_rasp_blocking_smoke(self) -> None:
         assert self.r.status_code == 403
+        _assert_rasp_attack(
+            self.r,
+            "rasp-930-100",
+            {
+                "resource": {"address": "server.io.fs.file", "value": "../etc/passwd"},
+                "params": {"address": "server.request.query", "value": "../etc/passwd"},
+            },
+        )
 
     def setup_ip_blocking_smoke(self) -> None:
         config = {

--- a/tests/appsec/smoke_tests/utils.py
+++ b/tests/appsec/smoke_tests/utils.py
@@ -4,7 +4,7 @@
 
 """AppSec smoke tests at the agent interface level"""
 
-from utils import interfaces, remote_config as rc, weblog
+from utils import context, interfaces, remote_config as rc, weblog
 from utils.dd_types import is_same_boolean
 from utils._weblog import HttpResponse
 
@@ -322,7 +322,9 @@ class BaseUserEventsSmokeTests:
     """Verify user login events are tracked in standalone mode."""
 
     def setup_login_success_smoke(self) -> None:
-        self.r = weblog.post("/login?auth=local", data={"username": "test", "password": "1234"})
+        username_key = "user[username]" if "rails" in context.weblog_variant else "username"
+        password_key = "user[password]" if "rails" in context.weblog_variant else "password"
+        self.r = weblog.post("/login?auth=local", data={username_key: "test", password_key: "1234"})
 
     def test_login_success_smoke(self) -> None:
         for _, span in interfaces.agent.get_spans(self.r):

--- a/tests/appsec/smoke_tests/utils.py
+++ b/tests/appsec/smoke_tests/utils.py
@@ -10,6 +10,7 @@ from utils._weblog import HttpResponse
 
 SMOKE_RC_RULE_ID = "smoke-rc-0001"
 SMOKE_RC_RASP_RULE_ID = "rasp-930-100"
+SMOKE_RC_IP_BLOCK_RULE_ID = "blk-001-001"
 SMOKE_RC_RULE_FILE: tuple[str, dict[str, object]] = (
     "datadog/2/ASM_DD/rules/config",
     {
@@ -60,6 +61,25 @@ SMOKE_RC_RULE_FILE: tuple[str, dict[str, object]] = (
                             ],
                         },
                         "operator": "lfi_detector",
+                    }
+                ],
+                "transformers": [],
+                "on_match": ["block"],
+            },
+            {
+                "id": SMOKE_RC_IP_BLOCK_RULE_ID,
+                "name": "Block IP Addresses",
+                "tags": {
+                    "type": "block_ip",
+                    "category": "security_response",
+                },
+                "conditions": [
+                    {
+                        "parameters": {
+                            "inputs": [{"address": "http.client_ip"}],
+                            "data": "blocked_ips",
+                        },
+                        "operator": "ip_match",
                     }
                 ],
                 "transformers": [],
@@ -232,6 +252,7 @@ class BaseRemoteConfigSmokeTests:
     def setup_remote_config_smoke(self) -> None:
         self.config_state = rc.tracer_rc_state.reset().set_config(*SMOKE_RC_RULE_FILE).apply().state
         self.r = weblog.get("/waf", headers={"X-Smoke-Test": "rc-smoke"})
+        rc.tracer_rc_state.reset().apply()
 
     def test_remote_config_smoke(self) -> None:
         assert self.config_state == rc.ApplyState.ACKNOWLEDGED, (
@@ -250,6 +271,7 @@ class BaseRemoteConfigSmokeTests:
         """Push RASP LFI blocking rule via RC, then trigger the attack."""
         rc.tracer_rc_state.reset().set_config(*SMOKE_RC_RULE_FILE).apply()
         self.r = weblog.get("/rasp/lfi", params={"file": "../etc/passwd"})
+        rc.tracer_rc_state.reset().apply()
 
     def test_rasp_blocking_smoke(self) -> None:
         assert self.r.status_code == 403
@@ -260,12 +282,15 @@ class BaseRemoteConfigSmokeTests:
                 {
                     "id": "blocked_ips",
                     "type": "ip_with_expiration",
-                    "data": [{"value": "10.10.10.1", "expiration": 9999999999}],
+                    "data": [{"value": "1.2.3.4", "expiration": 9999999999}],
                 }
             ]
         }
-        rc.tracer_rc_state.reset().set_config("datadog/2/ASM_DATA/blocked_ips/config", config).apply()
-        self.r = weblog.get("/waf", headers={"X-Forwarded-For": "10.10.10.1"})
+        rc.tracer_rc_state.reset().set_config(*SMOKE_RC_RULE_FILE).set_config(
+            "datadog/2/ASM_DATA/blocked_ips/config", config
+        ).apply()
+        self.r = weblog.get("/waf", headers={"X-Forwarded-For": "1.2.3.4"})
+        rc.tracer_rc_state.reset().apply()
 
     def test_ip_blocking_smoke(self) -> None:
         assert self.r.status_code == 403


### PR DESCRIPTION
## Motivation

Re-enable AppSec APM Standalone system tests for Ruby after they were (correctly) disabled in https://github.com/DataDog/system-tests/pull/6768.

APM Standalone is expected to not interfere with AppSec so the declarations should be reasonably the same as for other tests.

## Changes

This PR includes a few adjustments:
- correctly reset RC state after each test
- include blocking rule in IP blocking test, to ensure that the test is self sufficient
- change test ip for blocking to a public IP
- add a missing assertion in BaseRemoteConfigAPMStandalone::test_rasp_blocking_smoke

I have checked that the test pass in the pipeline this time:  https://github.com/DataDog/system-tests/actions/runs/24665371877/job/72122459383?pr=6771#step:14:1

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
