### PR TITLE
[python] implement /flush endpoint in python weblogs

### DIFF
--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -314,13 +314,11 @@ class EndToEndScenario(DockerScenario):
                 self.library_interface_timeout = 25
             elif library in ("golang",):
                 self.library_interface_timeout = 10
-            elif library in ("nodejs", "ruby"):
+            elif library in ("nodejs", "python", "ruby"):
                 self.library_interface_timeout = 0
             elif library in ("php",):
                 # possibly something weird on obfuscator, let increase the delay for now
                 self.library_interface_timeout = 10
-            elif library in ("python",):
-                self.library_interface_timeout = 5
             else:
                 self.library_interface_timeout = 40
         else:

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1089,9 +1089,9 @@ class WeblogContainer(TestedContainer):
     def flush(self) -> None:
         if self.library.name not in (
             "nodejs",
+            "python",
             "ruby",
         ):
-            # only nodejs and ruby supports it
             return
 
         try:

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -5,8 +5,9 @@ import os
 import random
 import shlex
 import subprocess
-import xmltodict
 import sys
+import time
+import xmltodict
 import boto3
 import django
 import httpx
@@ -1199,6 +1200,7 @@ def flush(request):
     #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
     tracer.flush()
     telemetry.telemetry_writer.periodic(force_flush=True)
+    time.sleep(0.2)
     return HttpResponse("OK")
 
 

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -6,7 +6,6 @@ import random
 import shlex
 import subprocess
 import sys
-import time
 import xmltodict
 import boto3
 import django
@@ -1199,8 +1198,10 @@ def flush(request):
     #       this is the place to do it.
     #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
     tracer.flush()
-    telemetry.telemetry_writer.periodic(force_flush=True)
-    time.sleep(0.2)
+    # app_shutdown() sends a force flush with an app-closing event so the agent
+    # finalises the telemetry batch, then disables the writer (safe: /flush is
+    # called only once, at the end of the test suite).
+    telemetry.telemetry_writer.app_shutdown()
     return HttpResponse("OK")
 
 

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -34,6 +34,7 @@ from iast import (
 import ddtrace
 
 from ddtrace.appsec import trace_utils as ato_user_sdk_v1
+from ddtrace.internal import telemetry
 
 try:
     from ddtrace.appsec import track_user_sdk
@@ -1192,6 +1193,15 @@ def stripe_webhook(request):
         return JsonResponse({"error": str(e)}, status=403)
 
 
+def flush(request):
+    # NOTE: If anything needs to be flushed here before the test suite ends,
+    #       this is the place to do it.
+    #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
+    tracer.flush()
+    telemetry.telemetry_writer.periodic(force_flush=True)
+    return HttpResponse("OK")
+
+
 urlpatterns = [
     path("", hello_world),
     path("api_security/sampling/<int:status_code>", api_security_sampling_status),
@@ -1294,4 +1304,5 @@ urlpatterns = [
     path("stripe/create_checkout_session", stripe_create_checkout_session),
     path("stripe/create_payment_intent", stripe_create_payment_intent),
     path("stripe/webhook", stripe_webhook),
+    path("flush", flush),
 ]

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -37,6 +37,7 @@ from starlette.middleware.sessions import SessionMiddleware
 
 import ddtrace
 from ddtrace.appsec import trace_utils as appsec_trace_utils
+from ddtrace.internal import telemetry
 from openfeature import api
 from ddtrace.openfeature import DataDogProvider
 from openfeature.evaluation_context import EvaluationContext
@@ -1400,3 +1401,13 @@ async def stripe_webhook(request: Request):
         return JSONResponse(event.data.object)
     except Exception as e:
         return JSONResponse({"error": str(e)}, status_code=403)
+
+
+@app.get("/flush", response_class=PlainTextResponse)
+def flush():
+    # NOTE: If anything needs to be flushed here before the test suite ends,
+    #       this is the place to do it.
+    #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
+    tracer.flush()
+    telemetry.telemetry_writer.periodic(force_flush=True)
+    return "OK"

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -6,7 +6,6 @@ import random
 import shlex
 import subprocess
 import sys
-import time
 import typing
 
 import fastapi
@@ -1410,6 +1409,8 @@ def flush():
     #       this is the place to do it.
     #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
     tracer.flush()
-    telemetry.telemetry_writer.periodic(force_flush=True)
-    time.sleep(0.2)
+    # app_shutdown() sends a force flush with an app-closing event so the agent
+    # finalises the telemetry batch, then disables the writer (safe: /flush is
+    # called only once, at the end of the test suite).
+    telemetry.telemetry_writer.app_shutdown()
     return "OK"

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -6,6 +6,7 @@ import random
 import shlex
 import subprocess
 import sys
+import time
 import typing
 
 import fastapi
@@ -1410,4 +1411,5 @@ def flush():
     #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
     tracer.flush()
     telemetry.telemetry_writer.periodic(force_flush=True)
+    time.sleep(0.2)
     return "OK"

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -19,7 +19,6 @@ import shlex
 import subprocess
 import sys
 import threading
-import time
 import urllib.request
 
 import boto3
@@ -2244,6 +2243,8 @@ def flush():
     #       this is the place to do it.
     #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
     tracer.flush()
-    telemetry.telemetry_writer.periodic(force_flush=True)
-    time.sleep(0.2)
+    # app_shutdown() sends a force flush with an app-closing event so the agent
+    # finalises the telemetry batch, then disables the writer (safe: /flush is
+    # called only once, at the end of the test suite).
+    telemetry.telemetry_writer.app_shutdown()
     return Response("OK")

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -97,6 +97,7 @@ if os.environ.get("CONFIG_CHAINING_TEST", "").lower() == "true":
     config._logs_injection = True
 
 from ddtrace.appsec import trace_utils as appsec_trace_utils
+from ddtrace.internal import telemetry
 from ddtrace.internal.datastreams import data_streams_processor
 from ddtrace.internal.datastreams.processor import DsmPathwayCodec
 from ddtrace.data_streams import set_consume_checkpoint
@@ -2234,3 +2235,13 @@ def stripe_webhook():
         return jsonify(event.data.object)
     except Exception as e:
         return jsonify({"error": str(e)}), 403
+
+
+@app.route("/flush")
+def flush():
+    # NOTE: If anything needs to be flushed here before the test suite ends,
+    #       this is the place to do it.
+    #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
+    tracer.flush()
+    telemetry.telemetry_writer.periodic(force_flush=True)
+    return Response("OK")

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -19,6 +19,7 @@ import shlex
 import subprocess
 import sys
 import threading
+import time
 import urllib.request
 
 import boto3
@@ -2244,4 +2245,5 @@ def flush():
     #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
     tracer.flush()
     telemetry.telemetry_writer.periodic(force_flush=True)
+    time.sleep(0.2)
     return Response("OK")

--- a/utils/build/docker/python/tornado/main.py
+++ b/utils/build/docker/python/tornado/main.py
@@ -7,7 +7,6 @@ import os
 import sqlite3
 import subprocess
 import sys
-import time
 from http import HTTPStatus
 from typing import Any, ClassVar
 from urllib.parse import parse_qs
@@ -875,8 +874,10 @@ class FlushHandler(BaseHandler):
         #       this is the place to do it.
         #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
         tracer.flush()
-        telemetry.telemetry_writer.periodic(force_flush=True)
-        time.sleep(0.2)
+        # app_shutdown() sends a force flush with an app-closing event so the agent
+        # finalises the telemetry batch, then disables the writer (safe: /flush is
+        # called only once, at the end of the test suite).
+        telemetry.telemetry_writer.app_shutdown()
         self.write("OK")
 
 

--- a/utils/build/docker/python/tornado/main.py
+++ b/utils/build/docker/python/tornado/main.py
@@ -21,6 +21,7 @@ from ddtrace._trace.pin import Pin
 from ddtrace.appsec import trace_utils as appsec_trace_utils
 from ddtrace.appsec import track_user_sdk
 from ddtrace.contrib.trace_utils import set_user
+from ddtrace.internal import telemetry
 from ddtrace.openfeature import DataDogProvider
 from ddtrace.trace import tracer
 from iast import (
@@ -867,6 +868,16 @@ class StripeWebhookHandler(BaseHandler):
             self.write(json.dumps({"error": str(e)}))
 
 
+class FlushHandler(BaseHandler):
+    def get(self) -> None:
+        # NOTE: If anything needs to be flushed here before the test suite ends,
+        #       this is the place to do it.
+        #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
+        tracer.flush()
+        telemetry.telemetry_writer.periodic(force_flush=True)
+        self.write("OK")
+
+
 class ExternalRequestHandler(BaseHandler):
     SUPPORTED_METHODS = ("GET", "POST", "PUT", "TRACE")
 
@@ -1115,6 +1126,8 @@ def make_app() -> Application:
             (r"/stripe/create_checkout_session", StripeCreateCheckoutSessionHandler),
             (r"/stripe/create_payment_intent", StripeCreatePaymentIntentHandler),
             (r"/stripe/webhook", StripeWebhookHandler),
+            # Flush endpoint
+            (r"/flush", FlushHandler),
         ],
         debug=False,
         cookie_secret="just_for_tests",  # noqa: S106

--- a/utils/build/docker/python/tornado/main.py
+++ b/utils/build/docker/python/tornado/main.py
@@ -7,6 +7,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+import time
 from http import HTTPStatus
 from typing import Any, ClassVar
 from urllib.parse import parse_qs
@@ -875,6 +876,7 @@ class FlushHandler(BaseHandler):
         #       See https://github.com/DataDog/system-tests/blob/main/docs/edit/flushing.md
         tracer.flush()
         telemetry.telemetry_writer.periodic(force_flush=True)
+        time.sleep(0.2)
         self.write("OK")
 
 


### PR DESCRIPTION

## Motivation

Faster run, better guarantees for telemetry arrival.

## Changes

Add GET /flush to flask, fastapi, django, and tornado weblogs. The endpoint calls tracer.flush() and telemetry_writer.periodic(force_flush=True) to force all pending data to be sent to the agent.

Enable python in the flush() call in containers.py, and set library_interface_timeout to 0 for python (alongside nodejs and ruby) now that explicit flushing is supported.


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
