### PR TITLE
Check that declared version are not ahead of tested version in dev mode

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -101,6 +101,11 @@ on:
         default: "datadoghq.com"
         required: false
         type: string
+      _system_tests_dev_mode:
+        description: "Shall we run system tests in dev mode (library and agent dev binary)"
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   main:
@@ -111,6 +116,7 @@ jobs:
       SYSTEM_TESTS_REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       SYSTEM_TESTS_SKIP_EMPTY_SCENARIO: ${{ inputs.skip_empty_scenarios }}
       SYSTEM_TESTS_FORCE_EXECUTE: ${{ inputs.force_execute }}
+      SYSTEM_TESTS_DEV_MODE: ${{ inputs._system_tests_dev_mode }}
     steps:
     - name: Compute ref
       id: compute_ref

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -285,6 +285,7 @@ jobs:
       _build_proxy_image: ${{ inputs._build_proxy_image }}
       _build_lambda_proxy_image: ${{ inputs._build_lambda_proxy_image }}
       _enable_replay_scenarios: ${{ inputs._enable_replay_scenarios }}
+      _system_tests_dev_mode: ${{ inputs._system_tests_dev_mode }}
 
   display_summary:
     name: Report failures

--- a/conftest.py
+++ b/conftest.py
@@ -233,7 +233,7 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     if not session.config.option.collectonly:
         context.scenario.pytest_sessionstart(session)
 
-    # The canonical way o adding Junit properties to testsuite is not working with xdist
+    # The canonical way of adding Junit properties to testsuite is not working with xdist
     # Workaround to tackle this issue
     # https://github.com/pytest-dev/pytest/issues/7767#issuecomment-698560400
     xml = session.config._store.get(xml_key, None)  # noqa: SLF001
@@ -246,6 +246,19 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         logger.terminal.write("\n ********************************************************** \n")
         logger.terminal.write(" *** .:: Sleep mode activated. Press Ctrl+C to exit ::. *** ")
         logger.terminal.write("\n ********************************************************** \n\n")
+
+    if os.environ.get("SYSTEM_TESTS_DEV_MODE", "").lower() == "true":
+        manifest_components: dict[str, Version] = {
+            name: version for name, version in context.scenario.components.items() if isinstance(version, Version)
+        }
+        manifest = Manifest(manifest_components, context.weblog_variant)
+
+        logger.info("Checking that no version is ahead of main branch")
+        errors = assert_versions_not_ahead_of_current(manifest.data, manifest_components)
+        if errors:
+            message = "Dev mode check: manifest declares versions ahead of the current tested version:\n"
+            message += "\n".join(f"  - {e}" for e in errors)
+            pytest.exit(message, 1)
 
 
 # called when each test item is collected
@@ -294,13 +307,6 @@ def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config
         name: version for name, version in context.scenario.components.items() if isinstance(version, Version)
     }
     manifest = Manifest(manifest_components, context.weblog_variant)
-
-    if os.environ.get("SYSTEM_TESTS_DEV_MODE", "").lower() == "true":
-        version_errors = assert_versions_not_ahead_of_current(manifest.data, manifest_components)
-        if version_errors:
-            message = "Dev mode check: manifest declares versions ahead of the current tested version:\n"
-            message += "\n".join(f"  - {e}" for e in version_errors)
-            pytest.exit(message, 1)
 
     for item in items:
         assert isinstance(item, pytest.Function)
@@ -407,6 +413,8 @@ def _item_is_skipped(item: pytest.Item):
 
 
 def pytest_collection_finish(session: pytest.Session) -> None:
+    logger.debug("pytest_collection_finish")
+
     if session.config.option.collectonly:
         return
 

--- a/conftest.py
+++ b/conftest.py
@@ -27,6 +27,7 @@ from utils._decorators import configure as configure_decorators
 from utils._features import NOT_REPORTED_ID as NOT_REPORTED_FEATURE_ID
 from utils._logger import logger
 from utils.manifest import Manifest
+from utils.manifest._internal.validate import assert_versions_not_ahead_of_current
 from utils.properties_serialization import SetupProperties
 
 # Monkey patch JSON-report plugin to avoid noise in report
@@ -294,6 +295,14 @@ def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config
         name: version for name, version in context.scenario.components.items() if isinstance(version, Version)
     }
     manifest = Manifest(manifest_components, context.weblog_variant)
+
+    if os.environ.get("SYSTEM_TESTS_DEV_MODE", "").lower() == "true":
+        version_errors = assert_versions_not_ahead_of_current(manifest.data, manifest_components)
+        if version_errors:
+            message = "Dev mode check: manifest declares versions ahead of the current tested version:\n"
+            message += "\n".join(f"  - {e}" for e in version_errors)
+            pytest.exit(message, 1)
+
     for item in items:
         assert isinstance(item, pytest.Function)
         declarations = manifest.get_declarations(item.nodeid)

--- a/conftest.py
+++ b/conftest.py
@@ -20,13 +20,13 @@ from pytest_jsonreport.plugin import JSONReport
 
 from utils import context
 from utils._context._scenarios import Scenario, scenarios
-from utils._context.component_version import ComponentVersion, Version
+from utils._context.component_version import ComponentVersion
 from utils.const import COMPONENT_GROUPS
 from utils._decorators import add_pytest_marker
 from utils._decorators import configure as configure_decorators
 from utils._features import NOT_REPORTED_ID as NOT_REPORTED_FEATURE_ID
 from utils._logger import logger
-from utils.manifest import Manifest, assert_versions_not_ahead_of_current
+from utils.manifest import Manifest
 from utils.properties_serialization import SetupProperties
 
 # Monkey patch JSON-report plugin to avoid noise in report
@@ -248,13 +248,9 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         logger.terminal.write("\n ********************************************************** \n\n")
 
     if os.environ.get("SYSTEM_TESTS_DEV_MODE", "").lower() == "true":
-        manifest_components: dict[str, Version] = {
-            name: version for name, version in context.scenario.components.items() if isinstance(version, Version)
-        }
-        manifest = Manifest(manifest_components, context.weblog_variant)
-
         logger.info("Checking that no version is ahead of main branch")
-        errors = assert_versions_not_ahead_of_current(manifest.data, manifest_components)
+        manifest = Manifest(context.scenario.components, context.weblog_variant)
+        errors = manifest.assert_versions_not_ahead_of_current()
         if errors:
             message = "Dev mode check: manifest declares versions ahead of the current tested version:\n"
             message += "\n".join(f"  - {e}" for e in errors)
@@ -303,10 +299,7 @@ def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config
     """Unselect items that were deactivated in the manifests or that are not included in the current scenario"""
 
     logger.debug("pytest_collection_modifyitems")
-    manifest_components: dict[str, Version] = {
-        name: version for name, version in context.scenario.components.items() if isinstance(version, Version)
-    }
-    manifest = Manifest(manifest_components, context.weblog_variant)
+    manifest = Manifest(context.scenario.components, context.weblog_variant)
 
     for item in items:
         assert isinstance(item, pytest.Function)

--- a/conftest.py
+++ b/conftest.py
@@ -26,8 +26,7 @@ from utils._decorators import add_pytest_marker
 from utils._decorators import configure as configure_decorators
 from utils._features import NOT_REPORTED_ID as NOT_REPORTED_FEATURE_ID
 from utils._logger import logger
-from utils.manifest import Manifest
-from utils.manifest._internal.validate import assert_versions_not_ahead_of_current
+from utils.manifest import Manifest, assert_versions_not_ahead_of_current
 from utils.properties_serialization import SetupProperties
 
 # Monkey patch JSON-report plugin to avoid noise in report

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1946,7 +1946,7 @@ manifest:
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_Tags_Feb2024_Revision::test_metric_mismatch_non_integer: bug (APMAPI-1689)
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_With_W3C: v2.8.0
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: v4.7.0
-  tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName::test_process_tag_svc_auto: v4.8.0
+  tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName::test_process_tag_svc_auto: v4.8.0-dev
   tests/parametric/test_tracer.py::Test_Tracer: v2.8.0
   tests/parametric/test_tracer.py::Test_TracerSCITagging: v1.12.0
   tests/parametric/test_tracer.py::Test_TracerServiceNameSource: irrelevant

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1539,7 +1539,7 @@ manifest:
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span_default: missing_feature  # Created by easy win activation script
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery: v2.18.0
   tests/parametric/test_sampling_delegation.py::Test_Decisionless_Extraction: v2.4.0
-  tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: '>=2.31.0'
+  tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: v2.31.0-dev
   tests/parametric/test_sampling_span_tags.py::Test_Sampling_Span_Tags::test_tags_appsec_enabled_sst011: bug (APMAPI-737)
   tests/parametric/test_sampling_span_tags.py::Test_Sampling_Span_Tags::test_tags_child_dropped_sst001: bug (APMAPI-737)
   tests/parametric/test_sampling_span_tags.py::Test_Sampling_Span_Tags::test_tags_child_kept_sst007: bug (APMAPI-737)

--- a/tests/test_the_test/test_manifest.py
+++ b/tests/test_the_test/test_manifest.py
@@ -5,19 +5,26 @@ import textwrap
 import pytest
 from utils import scenarios
 from utils._context.component_version import Version
-from utils.manifest import Manifest, SkipDeclaration, TestDeclaration, assert_versions_not_ahead_of_current
-from utils.manifest._internal.types import ManifestData, SemverRange as CustomSpec
+from utils.manifest import Manifest, SkipDeclaration, TestDeclaration
+from utils.manifest._internal.types import ManifestData, SemverRange as CustomSpec, Condition
 from utils.manifest._internal.validate import assert_nodeids_exist
 from utils.scripts.activate_easy_wins._internal.manifest_editor import ManifestEditor
 from utils.scripts.activate_easy_wins._internal.types import Context
 
 
 def manifest_init(
-    components: dict[str, Version],
+    components: dict[str, Version | str],
     weblog: str = "some_variant",
     path: Path = Path("tests/test_the_test/manifests/manifests_parser_test/"),
-):
-    return Manifest(components, weblog, path)
+    manifest_data: dict[str, list[Condition]] | None = None,
+) -> Manifest:
+    result = Manifest(components, weblog, path)
+    if manifest_data:
+        result.data = ManifestData()
+        for key, value in manifest_data.items():
+            result.data[key] = value
+
+    return result
 
 
 @scenarios.test_the_test
@@ -405,50 +412,59 @@ class Test_ManifestEditor_WriteNewRules:
             assert "excluded_component_version" not in first_entry
 
 
-def _make_manifest(component: str, *, declared_version: str) -> ManifestData:
-    data = ManifestData()
-    data["tests/foo.py::TestFoo"] = [
-        {
-            "component": component,
-            "component_version": CustomSpec(declared_version),
-            "excluded_component_version": CustomSpec(declared_version),
-            "declaration": SkipDeclaration("missing_feature"),
-        }
-    ]
-    return data
+def _get_manifest_errors(component: str, *, declared_version: str, components: dict[str, Version | str]) -> list[str]:
+    manifest = manifest_init(
+        components,
+        manifest_data={
+            "tests/foo.py::TestFoo": [
+                {
+                    "component": component,
+                    "component_version": CustomSpec(declared_version),
+                    "excluded_component_version": CustomSpec(declared_version),
+                    "declaration": SkipDeclaration("missing_feature"),
+                }
+            ]
+        },
+    )
+
+    return manifest.assert_versions_not_ahead_of_current()
 
 
 @scenarios.test_the_test
 class Test_VersionsNotAheadOfCurrent:
     def test_declared_version_below_current_is_ok(self):
         """A declared version lower than the current version produces no errors."""
-        errors = assert_versions_not_ahead_of_current(
-            _make_manifest("nodejs", declared_version=">=5.0.0"),
-            {"nodejs": Version("5.2.0")},
+        errors = _get_manifest_errors(
+            "nodejs",
+            declared_version=">=5.0.0",
+            components={"nodejs": Version("5.2.0")},
         )
         assert errors == []
 
     def test_declared_version_equals_current_is_ok(self):
         """A declared version equal to the current version produces no errors."""
-        errors = assert_versions_not_ahead_of_current(
-            _make_manifest("nodejs", declared_version=">=5.2.0"),
-            {"nodejs": Version("5.2.0")},
+        errors = _get_manifest_errors(
+            "nodejs",
+            declared_version=">=5.2.0",
+            components={"nodejs": Version("5.2.0")},
         )
         assert errors == []
 
     def test_declared_version_with_prerelease(self):
         """Declaring v5.2.0 while testing 5.2.0-dev is not allowed."""
-        errors = assert_versions_not_ahead_of_current(
-            _make_manifest("nodejs", declared_version=">=5.2.0"),
-            {"nodejs": Version("5.2.0-dev")},
+        errors = _get_manifest_errors(
+            "nodejs",
+            declared_version=">=5.2.0",
+            components={"nodejs": Version("5.2.0-dev")},
         )
         assert len(errors) == 2
 
     def test_declared_version_above_current_is_an_error(self):
         """A declared version higher than the current version produces an error per field."""
-        errors = assert_versions_not_ahead_of_current(
-            _make_manifest("nodejs", declared_version=">=6.0.0"),
-            {"nodejs": Version("5.2.0-dev")},
+        errors = _get_manifest_errors(
+            "nodejs",
+            declared_version=">=6.0.0",
+            components={"nodejs": Version("5.2.0-dev")},
         )
         assert len(errors) == 2
         assert all("nodejs" in e for e in errors)
@@ -457,51 +473,63 @@ class Test_VersionsNotAheadOfCurrent:
 
     def test_caret_notation_above_current_is_an_error(self):
         """^X.Y.Z is treated as a lower bound; flagged for each field when it exceeds current version."""
-        errors = assert_versions_not_ahead_of_current(
-            _make_manifest("nodejs", declared_version="^6.0.0"),
-            {"nodejs": Version("5.2.0")},
+        errors = _get_manifest_errors(
+            "nodejs",
+            declared_version="^6.0.0",
+            components={"nodejs": Version("5.2.0")},
         )
         assert len(errors) == 2
 
     def test_or_expression_is_treated(self):
         """Multi-branch OR expressions are not ignored."""
-        errors = assert_versions_not_ahead_of_current(
-            _make_manifest("nodejs", declared_version=">=6.0.0 || ^3.0.0"),
-            {"nodejs": Version("5.2.0-dev")},
+        errors = _get_manifest_errors(
+            "nodejs",
+            declared_version=">=6.0.0 || ^3.0.0",
+            components={"nodejs": Version("5.2.0-dev")},
         )
         assert len(errors) == 2
 
     def test_no_excluded_component_version_is_ok(self):
         """Conditions without excluded_component_version (plain skip declarations) are ignored."""
-        data = ManifestData()
-        data["tests/foo.py::TestFoo"] = [{"component": "nodejs", "declaration": SkipDeclaration("missing_feature")}]
-        errors = assert_versions_not_ahead_of_current(data, {"nodejs": Version("5.2.0")})
+        manifest = manifest_init(
+            components={"nodejs": Version("5.2.0")},
+            manifest_data={
+                "tests/foo.py::TestFoo": [{"component": "nodejs", "declaration": SkipDeclaration("missing_feature")}]
+            },
+        )
+
+        errors = manifest.assert_versions_not_ahead_of_current()
         assert errors == []
 
     def test_unknown_component_is_skipped(self):
         """Conditions for components not in the tested set are ignored."""
-        errors = assert_versions_not_ahead_of_current(
-            _make_manifest("java", declared_version=">=6.0.0"),
-            {"nodejs": Version("5.2.0")},
+        errors = _get_manifest_errors(
+            "java",
+            declared_version=">=6.0.0",
+            components={"nodejs": Version("5.2.0")},
         )
         assert errors == []
 
     def test_multiple_violations_are_all_reported(self):
         """Every offending condition is reported, not just the first."""
-        data = ManifestData()
-        data["tests/foo.py::TestFoo"] = [
-            {
-                "component": "nodejs",
-                "excluded_component_version": CustomSpec(">=6.0.0"),
-                "declaration": SkipDeclaration("missing_feature"),
-            }
-        ]
-        data["tests/bar.py::TestBar"] = [
-            {
-                "component": "nodejs",
-                "component_version": CustomSpec(">=7.0.0"),
-                "declaration": SkipDeclaration("missing_feature"),
-            }
-        ]
-        errors = assert_versions_not_ahead_of_current(data, {"nodejs": Version("5.2.0")})
+        manifest = manifest_init(
+            components={"nodejs": Version("5.2.0")},
+            manifest_data={
+                "tests/foo.py::TestFoo": [
+                    {
+                        "component": "nodejs",
+                        "excluded_component_version": CustomSpec(">=6.0.0"),
+                        "declaration": SkipDeclaration("missing_feature"),
+                    }
+                ],
+                "tests/bar.py::TestBar": [
+                    {
+                        "component": "nodejs",
+                        "component_version": CustomSpec(">=7.0.0"),
+                        "declaration": SkipDeclaration("missing_feature"),
+                    }
+                ],
+            },
+        )
+        errors = manifest.assert_versions_not_ahead_of_current()
         assert len(errors) == 2

--- a/tests/test_the_test/test_manifest.py
+++ b/tests/test_the_test/test_manifest.py
@@ -6,8 +6,8 @@ import pytest
 from utils import scenarios
 from utils._context.component_version import Version
 from utils.manifest import Manifest, SkipDeclaration, TestDeclaration
-from utils.manifest._internal.types import SemverRange as CustomSpec
-from utils.manifest._internal.validate import assert_nodeids_exist
+from utils.manifest._internal.types import ManifestData, SemverRange as CustomSpec
+from utils.manifest._internal.validate import assert_nodeids_exist, assert_versions_not_ahead_of_current
 from utils.scripts.activate_easy_wins._internal.manifest_editor import ManifestEditor
 from utils.scripts.activate_easy_wins._internal.types import Context
 
@@ -403,3 +403,107 @@ class Test_ManifestEditor_WriteNewRules:
             first_entry = python_manifest_rule[0]
             assert first_entry == {"declaration": "bug (TICKET-123)"}
             assert "excluded_component_version" not in first_entry
+
+
+def _make_manifest(component: str, *, declared_version: str) -> ManifestData:
+    data = ManifestData()
+    data["tests/foo.py::TestFoo"] = [
+        {
+            "component": component,
+            "component_version": CustomSpec(declared_version),
+            "excluded_component_version": CustomSpec(declared_version),
+            "declaration": SkipDeclaration("missing_feature"),
+        }
+    ]
+    return data
+
+
+@scenarios.test_the_test
+class Test_VersionsNotAheadOfCurrent:
+    def test_declared_version_below_current_is_ok(self):
+        """A declared version lower than the current version produces no errors."""
+        errors = assert_versions_not_ahead_of_current(
+            _make_manifest("nodejs", declared_version=">=5.0.0"),
+            {"nodejs": Version("5.2.0")},
+        )
+        assert errors == []
+
+    def test_declared_version_equals_current_is_ok(self):
+        """A declared version equal to the current version produces no errors."""
+        errors = assert_versions_not_ahead_of_current(
+            _make_manifest("nodejs", declared_version=">=5.2.0"),
+            {"nodejs": Version("5.2.0")},
+        )
+        assert errors == []
+
+    def test_declared_version_with_prerelease(self):
+        """Declaring v5.2.0 while testing 5.2.0-dev is not allowed."""
+        errors = assert_versions_not_ahead_of_current(
+            _make_manifest("nodejs", declared_version=">=5.2.0"),
+            {"nodejs": Version("5.2.0-dev")},
+        )
+        assert len(errors) == 2
+
+    def test_declared_version_above_current_is_an_error(self):
+        """A declared version higher than the current version produces an error per field."""
+        errors = assert_versions_not_ahead_of_current(
+            _make_manifest("nodejs", declared_version=">=6.0.0"),
+            {"nodejs": Version("5.2.0-dev")},
+        )
+        assert len(errors) == 2
+        assert all("nodejs" in e for e in errors)
+        assert all("6.0.0" in e for e in errors)
+        assert all("5.2.0" in e for e in errors)
+
+    def test_caret_notation_above_current_is_an_error(self):
+        """^X.Y.Z is treated as a lower bound; flagged for each field when it exceeds current version."""
+        errors = assert_versions_not_ahead_of_current(
+            _make_manifest("nodejs", declared_version="^6.0.0"),
+            {"nodejs": Version("5.2.0")},
+        )
+        assert len(errors) == 2
+
+    def test_or_expression_is_treated(self):
+        """Multi-branch OR expressions are not ignored."""
+        errors = assert_versions_not_ahead_of_current(
+            _make_manifest("nodejs", declared_version=">=6.0.0 || ^3.0.0"),
+            {"nodejs": Version("5.2.0-dev")},
+        )
+        assert len(errors) == 2
+
+    def test_no_excluded_component_version_is_ok(self):
+        """Conditions without excluded_component_version (plain skip declarations) are ignored."""
+        data = ManifestData()
+        data["tests/foo.py::TestFoo"] = [
+            {"component": "nodejs", "declaration": SkipDeclaration("missing_feature")}
+        ]
+        errors = assert_versions_not_ahead_of_current(data, {"nodejs": Version("5.2.0")})
+        assert errors == []
+
+    def test_unknown_component_is_skipped(self):
+        """Conditions for components not in the tested set are ignored."""
+        errors = assert_versions_not_ahead_of_current(
+            _make_manifest("java", declared_version=">=6.0.0"),
+            {"nodejs": Version("5.2.0")},
+        )
+        assert errors == []
+
+    def test_multiple_violations_are_all_reported(self):
+        """Every offending condition is reported, not just the first."""
+        data = ManifestData()
+        data["tests/foo.py::TestFoo"] = [
+            {
+                "component": "nodejs",
+                "excluded_component_version": CustomSpec(">=6.0.0"),
+                "declaration": SkipDeclaration("missing_feature"),
+            }
+        ]
+        data["tests/bar.py::TestBar"] = [
+            {
+                "component": "nodejs",
+                "component_version": CustomSpec(">=7.0.0"),
+                "declaration": SkipDeclaration("missing_feature"),
+            }
+        ]
+        errors = assert_versions_not_ahead_of_current(data, {"nodejs": Version("5.2.0")})
+        assert len(errors) == 2

--- a/tests/test_the_test/test_manifest.py
+++ b/tests/test_the_test/test_manifest.py
@@ -5,9 +5,9 @@ import textwrap
 import pytest
 from utils import scenarios
 from utils._context.component_version import Version
-from utils.manifest import Manifest, SkipDeclaration, TestDeclaration
+from utils.manifest import Manifest, SkipDeclaration, TestDeclaration, assert_versions_not_ahead_of_current
 from utils.manifest._internal.types import ManifestData, SemverRange as CustomSpec
-from utils.manifest._internal.validate import assert_nodeids_exist, assert_versions_not_ahead_of_current
+from utils.manifest._internal.validate import assert_nodeids_exist
 from utils.scripts.activate_easy_wins._internal.manifest_editor import ManifestEditor
 from utils.scripts.activate_easy_wins._internal.types import Context
 
@@ -474,9 +474,7 @@ class Test_VersionsNotAheadOfCurrent:
     def test_no_excluded_component_version_is_ok(self):
         """Conditions without excluded_component_version (plain skip declarations) are ignored."""
         data = ManifestData()
-        data["tests/foo.py::TestFoo"] = [
-            {"component": "nodejs", "declaration": SkipDeclaration("missing_feature")}
-        ]
+        data["tests/foo.py::TestFoo"] = [{"component": "nodejs", "declaration": SkipDeclaration("missing_feature")}]
         errors = assert_versions_not_ahead_of_current(data, {"nodejs": Version("5.2.0")})
         assert errors == []
 

--- a/utils/manifest/__init__.py
+++ b/utils/manifest/__init__.py
@@ -1,6 +1,5 @@
 from ._internal import Manifest
 from ._internal import SkipDeclaration, Condition, ManifestData, TestDeclaration
-from ._internal import assert_versions_not_ahead_of_current
 
 __all__ = [
     "Condition",
@@ -8,5 +7,4 @@ __all__ = [
     "ManifestData",
     "SkipDeclaration",
     "TestDeclaration",
-    "assert_versions_not_ahead_of_current",
 ]

--- a/utils/manifest/__init__.py
+++ b/utils/manifest/__init__.py
@@ -1,4 +1,12 @@
 from ._internal import Manifest
 from ._internal import SkipDeclaration, Condition, ManifestData, TestDeclaration
+from ._internal import assert_versions_not_ahead_of_current
 
-__all__ = ["Condition", "Manifest", "ManifestData", "SkipDeclaration", "TestDeclaration"]
+__all__ = [
+    "Condition",
+    "Manifest",
+    "ManifestData",
+    "SkipDeclaration",
+    "TestDeclaration",
+    "assert_versions_not_ahead_of_current",
+]

--- a/utils/manifest/_internal/__init__.py
+++ b/utils/manifest/_internal/__init__.py
@@ -1,5 +1,12 @@
 from .const import TestDeclaration
-from .core import Manifest
+from .core import Manifest, assert_versions_not_ahead_of_current
 from .types import SkipDeclaration, Condition, ManifestData
 
-__all__ = ["Condition", "Manifest", "ManifestData", "SkipDeclaration", "TestDeclaration"]
+__all__ = [
+    "Condition",
+    "Manifest",
+    "ManifestData",
+    "SkipDeclaration",
+    "TestDeclaration",
+    "assert_versions_not_ahead_of_current",
+]

--- a/utils/manifest/_internal/__init__.py
+++ b/utils/manifest/_internal/__init__.py
@@ -1,5 +1,5 @@
 from .const import TestDeclaration
-from .core import Manifest, assert_versions_not_ahead_of_current
+from .core import Manifest
 from .types import SkipDeclaration, Condition, ManifestData
 
 __all__ = [
@@ -8,5 +8,4 @@ __all__ = [
     "ManifestData",
     "SkipDeclaration",
     "TestDeclaration",
-    "assert_versions_not_ahead_of_current",
 ]

--- a/utils/manifest/_internal/core.py
+++ b/utils/manifest/_internal/core.py
@@ -122,8 +122,8 @@ def assert_versions_not_ahead_of_current(
             current_version = components[component]
 
             semver_ranges = (
-                condition["component_version"],
-                condition["excluded_component_version"],
+                condition.get("component_version"),
+                condition.get("excluded_component_version"),
             )
 
             for sem_range in semver_ranges:

--- a/utils/manifest/_internal/core.py
+++ b/utils/manifest/_internal/core.py
@@ -11,6 +11,9 @@ from .const import default_manifests_path
 from .format import yml_sort
 
 
+_LOWER_BOUND_RE = re.compile(r"(?:>=?|\^)(\d+\.\d+(?:\.\d+)?[.\w+-]*)")
+
+
 class Manifest:
     """Provides a simple way to get information from the manifests"""
 
@@ -20,7 +23,7 @@ class Manifest:
 
     def __init__(
         self,
-        components: dict[str, Version] | None = None,
+        components: dict[str, Version | str] | None = None,  # TODO : remove str versions from scenario.components
         weblog: str | None = None,
         path: Path = default_manifests_path,
     ):
@@ -29,9 +32,12 @@ class Manifest:
         """
         self.data = load(path)
         self.rules = None
-        self._components = components
-        if components is not None:
-            self.update_rules(components, weblog)
+        components = components or {}
+        self._components: dict[str, Version] = {
+            name: version for name, version in components.items() if isinstance(version, Version)
+        }
+        if self._components:
+            self.update_rules(self._components, weblog)
 
     def update_rules(
         self,
@@ -97,49 +103,42 @@ class Manifest:
         """
         yml_sort(path)
 
+    def assert_versions_not_ahead_of_current(self) -> list[str]:
+        """Check that no manifest condition declares a version higher than the current component version.
 
-_LOWER_BOUND_RE = re.compile(r"(?:>=?|\^)(\d+\.\d+(?:\.\d+)?[.\w+-]*)")
+        In dev mode, any version boundary declared in the manifest must not exceed the version currently being tested.
+        Both component_version and excluded_component_version fields are checked. Prerelease versions of the current
+        version are not treated as equivalent to the release: 5.2.0-dev is strictly below 5.2.0.
+        """
+        errors = []
 
-
-def assert_versions_not_ahead_of_current(
-    manifest_data: ManifestData,
-    components: dict[str, Version],
-) -> list[str]:
-    """Check that no manifest condition declares a version higher than the current component version.
-
-    In dev mode, any version boundary declared in the manifest must not exceed the version currently being tested.
-    Both component_version and excluded_component_version fields are checked. Prerelease versions of the current
-    version are not treated as equivalent to the release: 5.2.0-dev is strictly below 5.2.0.
-    """
-    errors = []
-
-    for nodeid, conditions in manifest_data.items():
-        for condition in conditions:
-            component = condition["component"]
-            if component not in components:
-                continue
-
-            current_version = components[component]
-
-            semver_ranges = (
-                condition.get("component_version"),
-                condition.get("excluded_component_version"),
-            )
-
-            for sem_range in semver_ranges:
-                if sem_range is None:
+        for nodeid, conditions in self.data.items():
+            for condition in conditions:
+                component = condition["component"]
+                if component not in self._components:
                     continue
 
-                for match in _LOWER_BOUND_RE.finditer(sem_range.expression):
-                    try:
-                        declared = Version(match.group(1))
-                    except (ValueError, TypeError):
+                current_version = self._components[component]
+
+                semver_ranges = (
+                    condition.get("component_version"),
+                    condition.get("excluded_component_version"),
+                )
+
+                for sem_range in semver_ranges:
+                    if sem_range is None:
                         continue
 
-                    if declared > current_version:
-                        errors.append(
-                            f"{nodeid} [{component}]: declared version {declared}"
-                            f" exceeds current version {current_version}"
-                        )
+                    for match in _LOWER_BOUND_RE.finditer(sem_range.expression):
+                        try:
+                            declared = Version(match.group(1))
+                        except (ValueError, TypeError):
+                            continue
 
-    return errors
+                        if declared > current_version:
+                            errors.append(
+                                f"{nodeid} [{component}]: declared version {declared}"
+                                f" exceeds current version {current_version}"
+                            )
+
+        return errors

--- a/utils/manifest/_internal/core.py
+++ b/utils/manifest/_internal/core.py
@@ -32,11 +32,10 @@ class Manifest:
         """
         self.data = load(path)
         self.rules = None
-        components = components or {}
-        self._components: dict[str, Version] = {
-            name: version for name, version in components.items() if isinstance(version, Version)
-        }
-        if self._components:
+        if components is not None:
+            self._components: dict[str, Version] = {
+                name: version for name, version in components.items() if isinstance(version, Version)
+            }
             self.update_rules(self._components, weblog)
 
     def update_rules(

--- a/utils/manifest/_internal/core.py
+++ b/utils/manifest/_internal/core.py
@@ -1,6 +1,9 @@
 from pathlib import Path
-from .parser import load
+import re
+
 from utils._context.component_version import Version
+
+from .parser import load
 from .rule import get_rules, match_rule
 from .types import ManifestData, SkipDeclaration
 from .validate import validate_manifest_files as validate
@@ -26,6 +29,7 @@ class Manifest:
         """
         self.data = load(path)
         self.rules = None
+        self._components = components
         if components is not None:
             self.update_rules(components, weblog)
 
@@ -92,3 +96,50 @@ class Manifest:
 
         """
         yml_sort(path)
+
+
+_LOWER_BOUND_RE = re.compile(r"(?:>=?|\^)(\d+\.\d+(?:\.\d+)?[.\w+-]*)")
+
+
+def assert_versions_not_ahead_of_current(
+    manifest_data: ManifestData,
+    components: dict[str, Version],
+) -> list[str]:
+    """Check that no manifest condition declares a version higher than the current component version.
+
+    In dev mode, any version boundary declared in the manifest must not exceed the version currently being tested.
+    Both component_version and excluded_component_version fields are checked. Prerelease versions of the current
+    version are not treated as equivalent to the release: 5.2.0-dev is strictly below 5.2.0.
+    """
+    errors = []
+
+    for nodeid, conditions in manifest_data.items():
+        for condition in conditions:
+            component = condition["component"]
+            if component not in components:
+                continue
+
+            current_version = components[component]
+
+            semver_ranges = (
+                condition["component_version"],
+                condition["excluded_component_version"],
+            )
+
+            for sem_range in semver_ranges:
+                if sem_range is None:
+                    continue
+
+                for match in _LOWER_BOUND_RE.finditer(sem_range.expression):
+                    try:
+                        declared = Version(match.group(1))
+                    except (ValueError, TypeError):
+                        continue
+
+                    if declared > current_version:
+                        errors.append(
+                            f"{nodeid} [{component}]: declared version {declared}"
+                            f" exceeds current version {current_version}"
+                        )
+
+    return errors

--- a/utils/manifest/_internal/validate.py
+++ b/utils/manifest/_internal/validate.py
@@ -2,7 +2,6 @@ import ast
 import importlib.util
 import inspect
 import json
-import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -10,11 +9,9 @@ from typing import TYPE_CHECKING
 import yaml
 from jsonschema import validate
 
-from utils._context.component_version import Version
 from utils._context.core import context
 
 from .parser import _load_file
-from .types import ManifestData
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -223,51 +220,6 @@ def assert_nodeids_exist(obj: dict) -> list[str]:
 #         stack.append((key, val))
 #
 #     return errors
-
-
-_LOWER_BOUND_RE = re.compile(r"(?:>=?|\^)(\d+\.\d+(?:\.\d+)?[.\w+-]*)")
-
-_VERSION_FIELDS = ("component_version", "excluded_component_version")
-
-
-def assert_versions_not_ahead_of_current(
-    manifest_data: ManifestData,
-    components: dict[str, Version],
-) -> list[str]:
-    """Check that no manifest condition declares a version higher than the current component version.
-
-    In dev mode, any version boundary declared in the manifest must not exceed the version currently being tested.
-    Both component_version and excluded_component_version fields are checked. Prerelease versions of the current
-    version are not treated as equivalent to the release: 5.2.0-dev is strictly below 5.2.0.
-    """
-    errors = []
-
-    for nodeid, conditions in manifest_data.items():
-        for condition in conditions:
-            component = condition["component"]
-            if component not in components:
-                continue
-
-            current_version = components[component]
-
-            for field in _VERSION_FIELDS:
-                sem_range = condition.get(field)
-                if sem_range is None:
-                    continue
-
-                for match in _LOWER_BOUND_RE.finditer(sem_range.expression):
-                    try:
-                        declared = Version(match.group(1))
-                    except (ValueError, TypeError):
-                        continue
-
-                    if declared > current_version:
-                        errors.append(
-                            f"{nodeid} [{component}]: declared version {declared}"
-                            f" exceeds current version {current_version}"
-                        )
-
-    return errors
 
 
 def pretty(name: str, errors: dict[str, list]) -> str:

--- a/utils/manifest/_internal/validate.py
+++ b/utils/manifest/_internal/validate.py
@@ -2,6 +2,7 @@ import ast
 import importlib.util
 import inspect
 import json
+import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -9,9 +10,11 @@ from typing import TYPE_CHECKING
 import yaml
 from jsonschema import validate
 
+from utils._context.component_version import Version
 from utils._context.core import context
 
 from .parser import _load_file
+from .types import ManifestData
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -220,6 +223,51 @@ def assert_nodeids_exist(obj: dict) -> list[str]:
 #         stack.append((key, val))
 #
 #     return errors
+
+
+_LOWER_BOUND_RE = re.compile(r"(?:>=?|\^)(\d+\.\d+(?:\.\d+)?[.\w+-]*)")
+
+_VERSION_FIELDS = ("component_version", "excluded_component_version")
+
+
+def assert_versions_not_ahead_of_current(
+    manifest_data: ManifestData,
+    components: dict[str, Version],
+) -> list[str]:
+    """Check that no manifest condition declares a version higher than the current component version.
+
+    In dev mode, any version boundary declared in the manifest must not exceed the version currently being tested.
+    Both component_version and excluded_component_version fields are checked. Prerelease versions of the current
+    version are not treated as equivalent to the release: 5.2.0-dev is strictly below 5.2.0.
+    """
+    errors = []
+
+    for nodeid, conditions in manifest_data.items():
+        for condition in conditions:
+            component = condition["component"]
+            if component not in components:
+                continue
+
+            current_version = components[component]
+
+            for field in _VERSION_FIELDS:
+                sem_range = condition.get(field)
+                if sem_range is None:
+                    continue
+
+                for match in _LOWER_BOUND_RE.finditer(sem_range.expression):
+                    try:
+                        declared = Version(match.group(1))
+                    except (ValueError, TypeError):
+                        continue
+
+                    if declared > current_version:
+                        errors.append(
+                            f"{nodeid} [{component}]: declared version {declared}"
+                            f" exceeds current version {current_version}"
+                        )
+
+    return errors
 
 
 def pretty(name: str, errors: dict[str, list]) -> str:


### PR DESCRIPTION
## Motivation

It's very easy to set by error a version ahead of `main` in manifest. When it happens, tests are not activated, so there is no way to realize the error.

## Changes

On `dev` mode, no version can be higher than the tested version (since here, we're picking last commit on main of all components).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
