### PR TITLE
fix: stop RC tests on last expected request without requiring a trailing poll

### DIFF
--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -210,9 +210,6 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
                 return False
 
             logger.info(f"validating request number {self.request_number}")
-            if self.request_number >= len(asm_features_expected_requests):
-                return True
-
             rc_check_request(data, asm_features_expected_requests[self.request_number], caching=True)
 
             self.python_request_number += 1
@@ -226,7 +223,7 @@ class Test_RemoteConfigurationUpdateSequenceFeatures(RemoteConfigurationFieldsBa
             else:
                 self.request_number += 1
 
-            return False
+            return self.request_number >= len(asm_features_expected_requests)
 
         interfaces.library.validate_one_remote_configuration(validator=validate)
 
@@ -311,14 +308,11 @@ class Test_RemoteConfigurationUpdateSequenceLiveDebugging(RemoteConfigurationFie
 
             runtime_id = data["request"]["content"]["client"]["client_tracer"]["runtime_id"]
             logger.info(f"validating request number {request_number[runtime_id]}")
-            if request_number[runtime_id] >= len(live_debugging_expected_requests):
-                return True
-
             rc_check_request(data, live_debugging_expected_requests[request_number[runtime_id]], caching=True)
 
             request_number[runtime_id] += 1
 
-            return False
+            return request_number[runtime_id] >= len(live_debugging_expected_requests)
 
         interfaces.library.validate_one_remote_configuration(validator=validate)
 
@@ -355,15 +349,12 @@ class Test_RemoteConfigurationUpdateSequenceASMDD(RemoteConfigurationFieldsBasic
             if not self.response_has_been_overwritten(data):
                 return False
 
-            if self.request_number >= len(asm_dd_expected_requests):
-                return True
-
             logger.info(f"Validating request #{self.request_number} in {data['log_filename']}")
             rc_check_request(data, asm_dd_expected_requests[self.request_number], caching=True)
 
             self.request_number += 1
 
-            return False
+            return self.request_number >= len(asm_dd_expected_requests)
 
         interfaces.library.validate_one_remote_configuration(validator=validate)
 
@@ -403,14 +394,11 @@ class Test_RemoteConfigurationUpdateSequenceFeaturesNoCache(RemoteConfigurationF
                 return False
 
             logger.info(f"validating request number {self.request_number}")
-            if self.request_number >= len(asm_features_expected_requests):
-                return True
-
             rc_check_request(data, asm_features_expected_requests[self.request_number], caching=False)
 
             self.request_number += 1
 
-            return False
+            return self.request_number >= len(asm_features_expected_requests)
 
         interfaces.library.validate_one_remote_configuration(validator=validate)
 
@@ -448,14 +436,11 @@ class Test_RemoteConfigurationUpdateSequenceASMDDNoCache(RemoteConfigurationFiel
                 return False
 
             logger.info(f"validating request number {self.request_number}")
-            if self.request_number >= len(asm_dd_expected_requests):
-                return True
-
             rc_check_request(data, asm_dd_expected_requests[self.request_number], caching=False)
 
             self.request_number += 1
 
-            return False
+            return self.request_number >= len(asm_dd_expected_requests)
 
         interfaces.library.validate_one_remote_configuration(validator=validate)
 


### PR DESCRIPTION


## Motivation

The validate() functions in RC sequence tests used to return True only when called with a request AFTER all expected ones had been validated, requiring an extra trailing RC poll. This made them fragile when the tracer stops polling shortly after the last mocked response.

This can happen in tracers that support the `/flush` mechanism and so the setup phase exits before an additional RC poll request happening. Related to https://github.com/DataDog/system-tests/pull/6772

## Changes

Fix: return True directly after validating and incrementing on the last expected request, removing the need for any additional poll.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
