### PR TITLE
Enable client-side-stats system tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1038,24 +1038,42 @@ manifest:
         uds: '>=3.36.0'
         poc: '>=3.36.0'
   tests/stats/test_stats.py::Test_Client_Stats::test_grpc_status_code: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats::test_is_trace_root:  # Created by easy win activation script
+  tests/stats/test_stats.py::Test_Client_Stats::test_is_trace_root:
     - weblog_declaration:
-        uds: missing_feature
-        poc: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service: missing_feature (.NET sets Service per-bucket via StatsAggregationKey, not at payload level)
-  tests/stats/test_stats.py::Test_Peer_Tags:  # Created by easy win activation script
+        uds: '>=3.43.0'
+        poc: '>=3.43.0'
+  tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service:
     - weblog_declaration:
-        uds: missing_feature
-        poc: missing_feature
-  tests/stats/test_stats.py::Test_Stats_Service_Source: v3.42.0
+        uds: '>=3.43.0'
+        poc: '>=3.43.0'
+  tests/stats/test_stats.py::Test_Stats_Service_Source:
+    - weblog_declaration:
+        uds: '>=3.42.0'
+        poc: '>=3.42.0'
+  tests/stats/test_stats.py::Test_Agent_Info_Endpoint:
+    - weblog_declaration:
+        uds: '>=3.43.0'
+        poc: '>=3.43.0'
+  tests/stats/test_stats.py::Test_Peer_Tags:
+    - weblog_declaration:
+        uds: '>=3.43.0'
+        poc: '>=3.43.0'
+  tests/stats/test_stats.py::Test_Transport_Headers:
+    - weblog_declaration:
+        uds: '>=3.43.0'
+        poc: '>=3.43.0'
+  tests/stats/test_stats.py::Test_Client_Drop_P0s:
+    - weblog_declaration:
+        uds: '>=3.43.0'
+        poc: '>=3.43.0'
   tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats:  # Created by easy win activation script
     - weblog_declaration:
-        uds: missing_feature
-        poc: missing_feature
-  tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats_bucket_alignment:  # Created by easy win activation script
+        uds: '>=3.43.0'
+        poc: '>=3.43.0'
+  tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats_bucket_alignment:
     - weblog_declaration:
-        uds: missing_feature
-        poc: missing_feature
+        uds: '>=3.43.0'
+        poc: '>=3.43.0'
   tests/test_baggage.py::Test_Baggage_Headers_Api_Datadog: v3.6.0
   tests/test_baggage.py::Test_Baggage_Headers_Api_OTel: bug (APMAPI-1849)
   tests/test_baggage.py::Test_Baggage_Headers_Basic: v3.6.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -856,28 +856,28 @@ manifest:
       component_version: <2.51.0
   ? tests/parametric/test_headers_tracestate_dd.py::Test_Headers_Tracestate_DD::test_headers_tracestate_dd_evicts_32_or_greater_list_members
   : bug (APMAPI-914)
-  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_distinct_aggregationkeys_TS003:  # Easy win for all weblogs and version 3.36.0
+  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_distinct_aggregationkeys_TS003:
     - declaration: missing_feature
-      component_version: '>=3.19.0'
-  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_measured_spans_TS004:  # Easy win for all weblogs and version 3.36.0
+      component_version: '<3.43.0'
+  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_measured_spans_TS004:
     - declaration: missing_feature
-      component_version: '>=3.19.0'
-  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_metrics_computed_after_span_finsh_TS009:  # Easy win for all weblogs and version 3.36.0
+      component_version: '<3.43.0'
+  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_metrics_computed_after_span_finsh_TS009:
     - declaration: missing_feature
-      component_version: '>=3.19.0'
-  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_metrics_msgpack_serialization_TS001:  # Easy win for all weblogs and version 3.36.0
+      component_version: '<3.43.0'
+  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_metrics_msgpack_serialization_TS001:
     - declaration: missing_feature
-      component_version: '>=3.19.0'
+      component_version: '<3.43.0'
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_relative_error_TS008: missing_feature (relative error test is broken)
-  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_sample_rate_0_TS007:  # Easy win for all weblogs and version 3.36.0
+  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_sample_rate_0_TS007:
     - declaration: missing_feature
-      component_version: '>=3.19.0'
-  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_successes_errors_recorded_separately_TS006:  # Easy win for all weblogs and version 3.36.0
+      component_version: '<3.43.0'
+  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_successes_errors_recorded_separately_TS006:
     - declaration: missing_feature
-      component_version: '>=3.19.0'
-  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_top_level_TS005:  # Easy win for all weblogs and version 3.36.0
+      component_version: '<3.43.0'
+  tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_top_level_TS005:
     - declaration: missing_feature
-      component_version: '>=3.19.0'
+      component_version: '<3.43.0'
   tests/parametric/test_llm_observability/: irrelevant (library does not implement LLM Observability)
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v2.53.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1037,6 +1037,14 @@ manifest:
         '*': missing_feature
         uds: '>=3.36.0'
         poc: '>=3.36.0'
+  tests/stats/test_stats.py::Test_Agent_Info_Endpoint:
+    - weblog_declaration:
+        uds: '>=3.43.0'
+        poc: '>=3.43.0'
+  tests/stats/test_stats.py::Test_Client_Drop_P0s:
+    - weblog_declaration:
+        uds: '>=3.43.0'
+        poc: '>=3.43.0'
   tests/stats/test_stats.py::Test_Client_Stats::test_grpc_status_code: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats::test_is_trace_root:
     - weblog_declaration:
@@ -1046,31 +1054,23 @@ manifest:
     - weblog_declaration:
         uds: '>=3.43.0'
         poc: '>=3.43.0'
-  tests/stats/test_stats.py::Test_Stats_Service_Source:
-    - weblog_declaration:
-        uds: '>=3.42.0'
-        poc: '>=3.42.0'
-  tests/stats/test_stats.py::Test_Agent_Info_Endpoint:
-    - weblog_declaration:
-        uds: '>=3.43.0'
-        poc: '>=3.43.0'
   tests/stats/test_stats.py::Test_Peer_Tags:
     - weblog_declaration:
         uds: '>=3.43.0'
         poc: '>=3.43.0'
-  tests/stats/test_stats.py::Test_Transport_Headers:
+  tests/stats/test_stats.py::Test_Stats_Service_Source:
     - weblog_declaration:
-        uds: '>=3.43.0'
-        poc: '>=3.43.0'
-  tests/stats/test_stats.py::Test_Client_Drop_P0s:
-    - weblog_declaration:
-        uds: '>=3.43.0'
-        poc: '>=3.43.0'
+        uds: '>=3.42.0'
+        poc: '>=3.42.0'
   tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats:  # Created by easy win activation script
     - weblog_declaration:
         uds: '>=3.43.0'
         poc: '>=3.43.0'
   tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats_bucket_alignment:
+    - weblog_declaration:
+        uds: '>=3.43.0'
+        poc: '>=3.43.0'
+  tests/stats/test_stats.py::Test_Transport_Headers:
     - weblog_declaration:
         uds: '>=3.43.0'
         poc: '>=3.43.0'


### PR DESCRIPTION
## Motivation

The .NET Client-Side-Stats implementation now follows the 1.2.0 spec, so we should enable the system tests

## Changes

Enable the client side stats system tests and parametric tests

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
