### PR TITLE
chore: scenario.components values are strictly versions

### DIFF
--- a/tests/test_the_test/test_json_report.py
+++ b/tests/test_the_test/test_json_report.py
@@ -73,7 +73,7 @@ class Test_Json_Report:
         # Check custom components ( set on TestTheTest scenario)
         assert "testedDependencies" in self.report
         assert self.report["testedDependencies"][0]["name"] == "mock_comp1"
-        assert self.report["testedDependencies"][0]["version"] == "mock_comp1_value"
+        assert self.report["testedDependencies"][0]["version"] == "0.0.1"
 
     def test_feature_id(self):
         test = self.get_test_fp("Test_Mock::test_mock")

--- a/tests/test_the_test/test_manifest.py
+++ b/tests/test_the_test/test_manifest.py
@@ -13,7 +13,7 @@ from utils.scripts.activate_easy_wins._internal.types import Context
 
 
 def manifest_init(
-    components: dict[str, Version | str],
+    components: dict[str, Version],
     weblog: str = "some_variant",
     path: Path = Path("tests/test_the_test/manifests/manifests_parser_test/"),
     manifest_data: dict[str, list[Condition]] | None = None,
@@ -412,7 +412,7 @@ class Test_ManifestEditor_WriteNewRules:
             assert "excluded_component_version" not in first_entry
 
 
-def _get_manifest_errors(component: str, *, declared_version: str, components: dict[str, Version | str]) -> list[str]:
+def _get_manifest_errors(component: str, *, declared_version: str, components: dict[str, Version]) -> list[str]:
     manifest = manifest_init(
         components,
         manifest_data={

--- a/utils/_context/_scenarios/core.py
+++ b/utils/_context/_scenarios/core.py
@@ -114,7 +114,7 @@ class Scenario:
         self.scenario_groups = list(set(self.scenario_groups))  # removes duplicates
 
         # key value pair of what is actually tested
-        self.components: dict[str, Version | str] = {}
+        self.components: dict[str, Version] = {}
 
         # if xdist is used, this property will be set to false for sub workers
         self.is_main_worker: bool = True

--- a/utils/_context/_scenarios/otel_collector.py
+++ b/utils/_context/_scenarios/otel_collector.py
@@ -77,8 +77,9 @@ class OtelCollectorScenario(DockerScenario):
         self.components["otel_collector"] = self.otel_collector_version
         # Extract version from image name
         image_name = self.postgres_container.image.name
-        postgres_version = image_name.split(":", 1)[1] if ":" in image_name else "unknown"
-        self.components["postgresql"] = postgres_version
+        if ":" in image_name:
+            postgres_version = image_name.split(":", 1)[1]
+            self.components["postgresql"] = Version(postgres_version)
 
         self.warmups.append(self._print_otel_collector_version)
 

--- a/utils/_context/_scenarios/otel_collector.py
+++ b/utils/_context/_scenarios/otel_collector.py
@@ -75,11 +75,6 @@ class OtelCollectorScenario(DockerScenario):
         self.otel_collector_version = Version(self.collector_container.image.labels["org.opencontainers.image.version"])
 
         self.components["otel_collector"] = self.otel_collector_version
-        # Extract version from image name
-        image_name = self.postgres_container.image.name
-        if ":" in image_name:
-            postgres_version = image_name.split(":", 1)[1]
-            self.components["postgresql"] = Version(postgres_version)
 
         self.warmups.append(self._print_otel_collector_version)
 

--- a/utils/_context/_scenarios/test_the_test.py
+++ b/utils/_context/_scenarios/test_the_test.py
@@ -1,5 +1,5 @@
 import pytest
-from utils._context.component_version import ComponentVersion
+from utils._context.component_version import ComponentVersion, Version
 from .core import Scenario
 
 
@@ -9,7 +9,7 @@ class TestTheTestScenario(Scenario):
 
     def __init__(self, name: str, doc: str) -> None:
         super().__init__(name, doc=doc, github_workflow="testthetest")
-        self.components["mock_comp1"] = "mock_comp1_value"
+        self.components["mock_comp1"] = Version("0.0.1")
 
     @property
     def parametrized_tests_metadata(self):

--- a/utils/_context/core.py
+++ b/utils/_context/core.py
@@ -80,7 +80,7 @@ class _Context:
         return self._get_scenario_property("k8s_cluster_agent_version", "")
 
     @property
-    def components(self) -> dict[str, Version | str]:
+    def components(self) -> dict[str, Version]:
         assert self.scenario is not None
         return self.scenario.components
 

--- a/utils/manifest/_internal/core.py
+++ b/utils/manifest/_internal/core.py
@@ -23,7 +23,7 @@ class Manifest:
 
     def __init__(
         self,
-        components: dict[str, Version | str] | None = None,  # TODO : remove str versions from scenario.components
+        components: dict[str, Version] | None = None,
         weblog: str | None = None,
         path: Path = default_manifests_path,
     ):
@@ -33,9 +33,7 @@ class Manifest:
         self.data = load(path)
         self.rules = None
         if components is not None:
-            self._components: dict[str, Version] = {
-                name: version for name, version in components.items() if isinstance(version, Version)
-            }
+            self._components: dict[str, Version] = components
             self.update_rules(self._components, weblog)
 
     def update_rules(


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
