### PR TITLE
Automatically close stale PRs

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,35 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  stale:
+    name: Mark and close stale PRs
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          # Only touch PRs, not issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # Mark a PR stale after 1 year of no activity
+          days-before-pr-stale: 365
+          # Close it 2 weeks after the stale warning, if still no activity
+          days-before-pr-close: 14
+
+          stale-pr-label: stale
+          stale-pr-message: >
+            This PR has had no activity for over a year. It will be closed in 2 weeks
+            unless there is new activity or the `stale` label is removed.
+          close-pr-message: >
+            Closing this PR due to inactivity. Feel free to reopen if the work is still relevant.
+
+          # Exempt PRs whose authors are members or collaborators
+          exempt-pr-labels: 'do-not-close,pinned'

--- a/utils/scripts/libraries_and_scenarios_rules.yml
+++ b/utils/scripts/libraries_and_scenarios_rules.yml
@@ -192,6 +192,9 @@ patterns:
         scenarios: PARAMETRIC
     .github/workflows/run-exotics.yml:
         scenario_groups: exotics
+    .github/workflows/stale-prs.yml:
+        scenario_groups: null
+        libraries: null
     .github/*:
         scenario_groups: null
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
