### PR TITLE
feat(features): resolve test owner to per-repo sub-team in CI

### DIFF
--- a/utils/_features.py
+++ b/utils/_features.py
@@ -41,6 +41,7 @@ class _OwnerDef:
 
 
 class _Owner(Enum):
+    # fmt: off
     agent_apm            = _OwnerDef("@DataDog/agent-apm")
     apm_serverless       = _OwnerDef("@DataDog/apm-serverless")
     asm                  = _OwnerDef("@DataDog/asm-libraries")
@@ -66,6 +67,7 @@ class _Owner(Enum):
     remote_config        = _OwnerDef("@DataDog/remote-config")
     rp                   = _OwnerDef("@DataDog/apm-reliability-and-performance")
     sdk_capabilities     = _OwnerDef("@DataDog/apm-sdk-capabilities")
+    # fmt: on
 
 
 def _mark_test_object(test_object, feature_id: int, owner: _Owner):

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -1,36 +1,77 @@
-from enum import StrEnum
+from dataclasses import dataclass, field
+from enum import Enum
+import functools
+import os
 import pytest
 
 NOT_REPORTED_ID = -1
 
 
-class _Owner(StrEnum):
-    # the value of each member must be a valid github team
+@functools.cache
+def _get_ci_repo_name() -> str | None:
+    """Returns the repository name when running in CI (GHA, GitLab, Azure), or None."""
+    # GitHub Actions: GITHUB_REPOSITORY is "owner/repo"
+    if repo := os.environ.get("GITHUB_REPOSITORY"):
+        return repo.split("/")[-1]
+    # GitLab CI
+    if repo := os.environ.get("CI_PROJECT_NAME"):
+        return repo
+    # Azure Pipelines
+    if repo := os.environ.get("BUILD_REPOSITORY_NAME"):
+        return repo
+    return None
 
-    agent_apm = "@DataDog/agent-apm"
-    apm_serverless = "@DataDog/apm-serverless"
-    asm = "@DataDog/asm-libraries"  # application security monitoring
-    auto_instrumentation = "@DataDog/unified-instrumentation-setup"
-    data_pipeline = "@DataDog/libdatadog-apm"  # or agent-apm? TODO @ekump
-    debugger = "@DataDog/debugger"
-    djm = "@DataDog/data-jobs-monitoring"
-    dsm = "@DataDog/data-streams-monitoring"
-    idm = "@DataDog/apm-idm"
-    injection_platform = "@DataDog/injection-platform"
-    language_platform = "@DataDog/apm-lang-platform"
-    ml_observability = "@DataDog/ml-observability"
-    profiler = "@DataDog/profiling"  # it does not exists
-    remote_config = "@DataDog/remote-config"
-    rp = "@DataDog/apm-reliability-and-performance"  # reliability & performance
-    sdk_capabilities = "@DataDog/apm-sdk-capabilities"
-    ffe = "@DataDog/feature-flagging-and-experimentation-sdk"  # Feature Flagging & Experimentation
+
+@dataclass
+class _OwnerDef:
+    """A GitHub team, with optional per-repo sub-team overrides.
+
+    When tests run in CI, if the repo name matches a key in repo_overrides,
+    that sub-team is used instead of the default.
+    """
+
+    default: str
+    repo_overrides: dict[str, str] = field(default_factory=dict)
+
+    def resolve(self) -> str:
+        repo_name = _get_ci_repo_name()
+        if repo_name:
+            return self.repo_overrides.get(repo_name, self.default)
+        return self.default
+
+
+class _Owner(Enum):
+    agent_apm            = _OwnerDef("@DataDog/agent-apm")
+    apm_serverless       = _OwnerDef("@DataDog/apm-serverless")
+    asm                  = _OwnerDef("@DataDog/asm-libraries")
+    auto_instrumentation = _OwnerDef("@DataDog/unified-instrumentation-setup")
+    data_pipeline        = _OwnerDef("@DataDog/libdatadog-apm")  # or agent-apm? TODO @ekump
+    debugger             = _OwnerDef("@DataDog/debugger")
+    djm                  = _OwnerDef("@DataDog/data-jobs-monitoring")
+    dsm                  = _OwnerDef("@DataDog/data-streams-monitoring")
+    ffe                  = _OwnerDef("@DataDog/feature-flagging-and-experimentation-sdk")
+    idm                  = _OwnerDef("@DataDog/apm-idm")
+    injection_platform   = _OwnerDef("@DataDog/injection-platform")
+    language_platform    = _OwnerDef("@DataDog/apm-lang-platform", repo_overrides={
+                               "dd-trace-dotnet": "@DataDog/apm-lang-platform-dotnet",
+                               "dd-trace-go":     "@DataDog/lang-platform-go",
+                               "dd-trace-java":   "@DataDog/apm-lang-platform-java",
+                               "dd-trace-js":     "@DataDog/lang-platform-js",
+                               "dd-trace-php":    "@DataDog/apm-lang-platform-php",
+                               "dd-trace-py":     "@DataDog/lang-platform-python",
+                               "dd-trace-ruby":   "@DataDog/lang-platform-ruby",
+                           })
+    ml_observability     = _OwnerDef("@DataDog/ml-observability")
+    profiler             = _OwnerDef("@DataDog/profiling")  # it does not exist
+    remote_config        = _OwnerDef("@DataDog/remote-config")
+    rp                   = _OwnerDef("@DataDog/apm-reliability-and-performance")
+    sdk_capabilities     = _OwnerDef("@DataDog/apm-sdk-capabilities")
 
 
 def _mark_test_object(test_object, feature_id: int, owner: _Owner):
     """Mark the test object with a feature ID"""
     pytest.mark.features(feature_id=feature_id)(test_object)
-    pytest.mark.owners(owner=owner.value)(test_object)
-
+    pytest.mark.owners(owner=owner.value.resolve())(test_object)
     return test_object
 
 


### PR DESCRIPTION
## Motivation

When system-tests run from a tracer library repo (e.g. dd-trace-py, dd-trace-java), the `@owners` pytest mark now resolves to the language-specific sub-team rather than the generic team. This makes test failure attribution more precise in Test Optimization. 

## Changes

Allow to precise the real owner when the process is ran from a CI. Set accordingly for LP.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
