### PR TITLE
chore: dump Library metadata from /binaries/metadata.txt if available

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1114,9 +1114,10 @@ class WeblogContainer(TestedContainer):
 
         logger.stdout(f"Library: {self.library}")
 
-        exit_code, output = self.exec_run("cat /binaries/metadata.txt")
-        if exit_code == 0 and output:
-            logger.stdout(f"Library metadata:\n{output.decode('utf-8', errors='replace').strip()}")
+        if self._container is not None:
+            exit_code, output = self.exec_run("cat /binaries/metadata.txt")
+            if exit_code == 0 and output:
+                logger.stdout(f"Library metadata:\n{output.decode('utf-8', errors='replace').strip()}")
 
         if self.appsec_rules_file:
             logger.stdout("Using a custom appsec rules file")

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1114,6 +1114,10 @@ class WeblogContainer(TestedContainer):
 
         logger.stdout(f"Library: {self.library}")
 
+        exit_code, output = self.exec_run("cat /binaries/metadata.txt")
+        if exit_code == 0 and output:
+            logger.stdout(f"Library metadata:\n{output.decode('utf-8', errors='replace').strip()}")
+
         if self.appsec_rules_file:
             logger.stdout("Using a custom appsec rules file")
 

--- a/utils/build/docker/python/install_ddtrace.sh
+++ b/utils/build/docker/python/install_ddtrace.sh
@@ -20,7 +20,7 @@ elif [ $(ls python-load-from-s3 | wc -l) = 1 ]; then
     echo "Install ddtrace from S3, git ref: ${GIT_REF}"
     # Try to fetch `metadata.txt` and save it so test output can display it, but don't fail if we cannot
     # This includes commit sha, pipeline id, etc that was used to build the artifact
-    curl -s https://dd-trace-py-builds.s3.amazonaws.com/${GIT_REF}/metadata.txt > metadata.txt || true
+    curl -sf https://dd-trace-py-builds.s3.amazonaws.com/${GIT_REF}/metadata.txt > metadata.txt || true
     if [ -s metadata.txt ]; then
         cat metadata.txt
     fi

--- a/utils/build/docker/python/install_ddtrace.sh
+++ b/utils/build/docker/python/install_ddtrace.sh
@@ -18,9 +18,12 @@ elif [ "$(ls *.whl | wc -l)" = "1" ]; then
 elif [ $(ls python-load-from-s3 | wc -l) = 1 ]; then
     GIT_REF=$(cat python-load-from-s3)
     echo "Install ddtrace from S3, git ref: ${GIT_REF}"
-    # Try to fetch `metadata.txt` to display, but don't fail if we cannot
+    # Try to fetch `metadata.txt` and save it so test output can display it, but don't fail if we cannot
     # This includes commit sha, pipeline id, etc that was used to build the artifact
-    curl -s https://dd-trace-py-builds.s3.amazonaws.com/${GIT_REF}/metadata.txt || true
+    curl -s https://dd-trace-py-builds.s3.amazonaws.com/${GIT_REF}/metadata.txt > metadata.txt || true
+    if [ -s metadata.txt ]; then
+        cat metadata.txt
+    fi
     # Install from S3 bucket
     # NOTE: Artifacts age out after 2 weeks, if this fails then you need to first run the dd-trace-py GitLab CI for the desired commit again
     # NOTE: Must have `--no-index` otherwise `pip` will look for the highest available version between S3 and PyPI

--- a/utils/build/docker/python/install_ddtrace.sh
+++ b/utils/build/docker/python/install_ddtrace.sh
@@ -18,6 +18,9 @@ elif [ "$(ls *.whl | wc -l)" = "1" ]; then
 elif [ $(ls python-load-from-s3 | wc -l) = 1 ]; then
     GIT_REF=$(cat python-load-from-s3)
     echo "Install ddtrace from S3, git ref: ${GIT_REF}"
+    # Try to fetch `metadata.txt` to display, but don't fail if we cannot
+    # This includes commit sha, pipeline id, etc that was used to build the artifact
+    curl -s https://dd-trace-py-builds.s3.amazonaws.com/${GIT_REF}/metadata.txt || true
     # Install from S3 bucket
     # NOTE: Artifacts age out after 2 weeks, if this fails then you need to first run the dd-trace-py GitLab CI for the desired commit again
     # NOTE: Must have `--no-index` otherwise `pip` will look for the highest available version between S3 and PyPI


### PR DESCRIPTION
## Motivation

When running CI against a GIT_REF like `main` for dd-trace-py it can be hard to know exactly which artifact was used for the tests.

This change will look for a possible `/metadata.txt` file if it exists in S3 and supports dumping the metadata both in `install_ddtrace.sh`, and when dumping container metadata when running tests.

Example PR/test run where it is difficult to understand the artifact:

https://github.com/DataDog/system-tests/actions/runs/24707739878/job/72305061453?pr=6721#step:34:22

This change will add dumping:

```
Library metadata:
commit_sha=dc5f4286e2de5be4c8ee74bba6523649b2690f74
commit_short_sha=dc5f4286
ref_name=brettlangdon/s3.metadata
pipeline_id=109300625
package_version=4.8.0rc5
created_at=2026-04-23T13:58:51Z
```

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
