### PR TITLE
Use exec to ensure weblogs get SIGTERM on stop

### DIFF
--- a/lib-injection/build/docker/python/dd-lib-python-init-test-django-27/Dockerfile
+++ b/lib-injection/build/docker/python/dd-lib-python-init-test-django-27/Dockerfile
@@ -9,4 +9,4 @@ EXPOSE 18080
 
 # Many users run a non-root user, ensure this is supported by the injection mechanism
 USER 1000
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/lib-injection/build/docker/python/dd-lib-python-init-test-django-gunicorn-alpine/Dockerfile
+++ b/lib-injection/build/docker/python/dd-lib-python-init-test-django-gunicorn-alpine/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django gunicorn
 EXPOSE 18080
-CMD gunicorn --bind :18080 django_app:application
+CMD ["gunicorn", "--bind", ":18080", "django_app:application"]

--- a/lib-injection/build/docker/python/dd-lib-python-init-test-django-gunicorn/Dockerfile
+++ b/lib-injection/build/docker/python/dd-lib-python-init-test-django-gunicorn/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django gunicorn
 EXPOSE 18080
-CMD gunicorn --bind :18080 django_app:application
+CMD ["gunicorn", "--bind", ":18080", "django_app:application"]

--- a/lib-injection/build/docker/python/dd-lib-python-init-test-django-preinstalled/Dockerfile
+++ b/lib-injection/build/docker/python/dd-lib-python-init-test-django-preinstalled/Dockerfile
@@ -11,4 +11,4 @@ EXPOSE 18080
 
 # Many users run a non-root user, ensure this is supported by the injection mechanism
 USER 1000
-CMD ddtrace-run python -m django runserver 0.0.0.0:18080
+CMD ["ddtrace-run", "python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/lib-injection/build/docker/python/dd-lib-python-init-test-django-unsupported-package-force/Dockerfile
+++ b/lib-injection/build/docker/python/dd-lib-python-init-test-django-unsupported-package-force/Dockerfile
@@ -8,4 +8,4 @@ ADD . /src
 RUN pip install django structlog==16.0.0
 
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/lib-injection/build/docker/python/dd-lib-python-init-test-django-uvicorn/Dockerfile
+++ b/lib-injection/build/docker/python/dd-lib-python-init-test-django-uvicorn/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django uvicorn
 EXPOSE 18080
-CMD uvicorn --host 0.0.0.0 --port 18080 django_app:application
+CMD ["uvicorn", "--host", "0.0.0.0", "--port", "18080", "django_app:application"]

--- a/lib-injection/build/docker/python/dd-lib-python-init-test-django/Dockerfile
+++ b/lib-injection/build/docker/python/dd-lib-python-init-test-django/Dockerfile
@@ -9,4 +9,4 @@ EXPOSE 18080
 
 # Many users run a non-root user, ensure this is supported by the injection mechanism
 USER 1000
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/tests/appsec/waf/test_telemetry.py
+++ b/tests/appsec/waf/test_telemetry.py
@@ -59,8 +59,11 @@ class Test_TelemetryMetrics:
             "helper_runtime",
         }
         series = self._find_series(TELEMETRY_REQUEST_TYPE_GENERATE_METRICS, "appsec", expected_metric_name)
-        # Gunicorn creates 2 process (main gunicorn process + X child workers). It may generates two init (but not always as initialization is now lazy)
-        if context.library == "python" and context.weblog_variant not in ("fastapi", "uwsgi-poc"):
+        # Python: Gunicorn creates 2 process (main gunicorn process + X child workers). It may generates two init (but not always as initialization is now lazy)
+        # Java: OpenLiberty follows a similar pattern.
+        if (context.library == "python" and context.weblog_variant not in ("fastapi", "uwsgi-poc")) or (
+            context.library == "java" and context.weblog_variant == "spring-boot-openliberty"
+        ):
             assert len(series) in (1, 2)
         else:
             assert len(series) == 1

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -325,7 +325,10 @@ class EndToEndScenario(DockerScenario):
                 # SIGTERM handling. This affects at least REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING.
                 self.library_interface_timeout = 10
             elif library in ("nodejs"):
-                self.library_interface_timeout = 0
+                if self.weblog_variant == "nextjs":
+                    self.library_interface_timeout = 10
+                else:
+                    self.library_interface_timeout = 0
             elif library in ("php",):
                 # possibly something weird on obfuscator, let increase the delay for now
                 self.library_interface_timeout = 10

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -320,7 +320,11 @@ class EndToEndScenario(DockerScenario):
                 self.library_interface_timeout = 25
             elif library in ("golang",):
                 self.library_interface_timeout = 10
-            elif library in ("nodejs", "ruby"):
+            elif library in ("ruby",):
+                # There is an issue with ruby not flushing all data appropriately, neither with the /flush endpoint or
+                # SIGTERM handling. This affects at least REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING.
+                self.library_interface_timeout = 10
+            elif library in ("nodejs"):
                 self.library_interface_timeout = 0
             elif library in ("php",):
                 # possibly something weird on obfuscator, let increase the delay for now

--- a/utils/build/docker/cpp_httpd/httpd.Dockerfile
+++ b/utils/build/docker/cpp_httpd/httpd.Dockerfile
@@ -29,4 +29,4 @@ RUN chmod +x app.sh
 
 EXPOSE 7777
 
-CMD ./app.sh
+CMD ["./app.sh"]

--- a/utils/build/docker/cpp_httpd/httpd.Dockerfile
+++ b/utils/build/docker/cpp_httpd/httpd.Dockerfile
@@ -24,7 +24,7 @@ RUN a2enmod datadog
 # Create C++ application
 RUN echo "Hello world\n" > /app/index.html
 WORKDIR /app
-RUN echo "#!/bin/bash\napachectl -D FOREGROUND" > app.sh
+RUN echo "#!/bin/bash\nexec apachectl -D FOREGROUND" > app.sh
 RUN chmod +x app.sh
 
 EXPOSE 7777

--- a/utils/build/docker/java/spring-boot-openliberty.Dockerfile
+++ b/utils/build/docker/java/spring-boot-openliberty.Dockerfile
@@ -28,6 +28,6 @@ ENV DD_TRACE_HEADER_TAGS='user-agent:http.request.headers.user-agent'
 
 ENV JVM_ARGS='-javaagent:/app/dd-java-agent.jar'
 
-RUN echo "#!/bin/bash\njava -Xmx362m -jar /app/app.jar" > app.sh
+RUN echo "#!/bin/bash\nexec java -Xmx362m -jar /app/app.jar" > app.sh
 RUN chmod +x app.sh
 CMD [ "/app/app.sh" ]

--- a/utils/build/docker/java/spring-boot/app.sh
+++ b/utils/build/docker/java/spring-boot/app.sh
@@ -4,7 +4,7 @@ if [ ${UDS_WEBLOG:-} = "1" ]; then
     ./set-uds-transport.sh
 fi
 
-java \
+exec java \
     -Xmx362m \
     -XX:ErrorFile=/var/log/system-tests/hs_err_%p_%t_%u.log \
     -javaagent:/app/dd-java-agent.jar \

--- a/utils/build/docker/java_otel/spring-boot-native.Dockerfile
+++ b/utils/build/docker/java_otel/spring-boot-native.Dockerfile
@@ -17,6 +17,6 @@ RUN mvn clean package
 # Set up required args
 RUN echo $OTEL_VERSION > SYSTEM_TESTS_LIBRARY_VERSION
 
-RUN echo "#!/bin/bash\njava -jar target/myproject-3.0.0-SNAPSHOT.jar --server.port=7777" > app.sh
+RUN echo "#!/bin/bash\nexec java -jar target/myproject-3.0.0-SNAPSHOT.jar --server.port=7777" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/java_otel/spring-boot/app.sh
+++ b/utils/build/docker/java_otel/spring-boot/app.sh
@@ -4,4 +4,4 @@ if [ ${UDS_WEBLOG:-} = "1" ]; then
     ./set-uds-transport.sh
 fi
 
-java -Xmx362m -javaagent:/app/dd-java-agent.jar -jar /app/myproject-0.0.1-SNAPSHOT.jar --server.port=7777
+exec java -Xmx362m -javaagent:/app/dd-java-agent.jar -jar /app/myproject-0.0.1-SNAPSHOT.jar --server.port=7777

--- a/utils/build/docker/nodejs/anthropic-js.Dockerfile
+++ b/utils/build/docker/nodejs/anthropic-js.Dockerfile
@@ -25,4 +25,4 @@ RUN /binaries/install_ddtrace.sh
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN printf 'node app.js' >> app.sh
-CMD ./app.sh
+CMD ["./app.sh"]

--- a/utils/build/docker/nodejs/anthropic-js.Dockerfile
+++ b/utils/build/docker/nodejs/anthropic-js.Dockerfile
@@ -24,5 +24,5 @@ RUN /binaries/install_ddtrace.sh
 
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
-RUN printf 'node app.js' >> app.sh
+RUN printf 'exec node app.js' >> app.sh
 CMD ["./app.sh"]

--- a/utils/build/docker/nodejs/express4-typescript.Dockerfile
+++ b/utils/build/docker/nodejs/express4-typescript.Dockerfile
@@ -29,7 +29,7 @@ RUN npm run build
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN printf 'node dist/app.js' >> app.sh
-CMD ./app.sh
+CMD ["./app.sh"]
 ENV DD_TRACE_HEADER_TAGS=user-agent
 
 # docker build -f utils/build/docker/nodejs.datadog.Dockerfile -t test .

--- a/utils/build/docker/nodejs/express4-typescript.Dockerfile
+++ b/utils/build/docker/nodejs/express4-typescript.Dockerfile
@@ -28,7 +28,7 @@ RUN npm run build
 
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
-RUN printf 'node dist/app.js' >> app.sh
+RUN printf 'exec node dist/app.js' >> app.sh
 CMD ["./app.sh"]
 ENV DD_TRACE_HEADER_TAGS=user-agent
 

--- a/utils/build/docker/nodejs/express4.Dockerfile
+++ b/utils/build/docker/nodejs/express4.Dockerfile
@@ -29,7 +29,7 @@ ENV DD_DATA_STREAMS_ENABLED=true
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN chmod +x app.sh
 RUN printf 'node app.js' >> app.sh
-CMD ./app.sh
+CMD ["./app.sh"]
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh

--- a/utils/build/docker/nodejs/express4.Dockerfile
+++ b/utils/build/docker/nodejs/express4.Dockerfile
@@ -28,7 +28,7 @@ ENV DD_DATA_STREAMS_ENABLED=true
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN chmod +x app.sh
-RUN printf 'node app.js' >> app.sh
+RUN printf 'exec node app.js' >> app.sh
 CMD ["./app.sh"]
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/

--- a/utils/build/docker/nodejs/express5.Dockerfile
+++ b/utils/build/docker/nodejs/express5.Dockerfile
@@ -29,7 +29,7 @@ ENV DD_DATA_STREAMS_ENABLED=true
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN chmod +x app.sh
 RUN printf 'node app.js' >> app.sh
-CMD ./app.sh
+CMD ["./app.sh"]
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh

--- a/utils/build/docker/nodejs/express5.Dockerfile
+++ b/utils/build/docker/nodejs/express5.Dockerfile
@@ -28,7 +28,7 @@ ENV DD_DATA_STREAMS_ENABLED=true
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN chmod +x app.sh
-RUN printf 'node app.js' >> app.sh
+RUN printf 'exec node app.js' >> app.sh
 CMD ["./app.sh"]
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/

--- a/utils/build/docker/nodejs/fastify.Dockerfile
+++ b/utils/build/docker/nodejs/fastify.Dockerfile
@@ -28,7 +28,7 @@ ENV DD_DATA_STREAMS_ENABLED=true
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN chmod +x app.sh
 RUN printf 'node app.js' >> app.sh
-CMD ./app.sh
+CMD ["./app.sh"]
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh

--- a/utils/build/docker/nodejs/fastify.Dockerfile
+++ b/utils/build/docker/nodejs/fastify.Dockerfile
@@ -27,7 +27,7 @@ ENV DD_DATA_STREAMS_ENABLED=true
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN chmod +x app.sh
-RUN printf 'node app.js' >> app.sh
+RUN printf 'exec node app.js' >> app.sh
 CMD ["./app.sh"]
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/

--- a/utils/build/docker/nodejs/google_genai-js.Dockerfile
+++ b/utils/build/docker/nodejs/google_genai-js.Dockerfile
@@ -25,4 +25,4 @@ RUN /binaries/install_ddtrace.sh
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN printf 'node app.js' >> app.sh
-CMD ./app.sh
+CMD ["./app.sh"]

--- a/utils/build/docker/nodejs/google_genai-js.Dockerfile
+++ b/utils/build/docker/nodejs/google_genai-js.Dockerfile
@@ -24,5 +24,5 @@ RUN /binaries/install_ddtrace.sh
 
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
-RUN printf 'node app.js' >> app.sh
+RUN printf 'exec node app.js' >> app.sh
 CMD ["./app.sh"]

--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -24,6 +24,6 @@ ENV DD_DATA_STREAMS_ENABLED=true
 ENV PORT=7777
 ENV HOSTNAME=0.0.0.0
 COPY utils/build/docker/nodejs/app.sh app.sh
-RUN printf './node_modules/.bin/next start' >> app.sh
 ENV NODE_OPTIONS="--import dd-trace/initialize.mjs"
+RUN printf 'exec ./node_modules/.bin/next start' >> app.sh
 CMD ["./app.sh"]

--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -26,4 +26,4 @@ ENV HOSTNAME=0.0.0.0
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN printf './node_modules/.bin/next start' >> app.sh
 ENV NODE_OPTIONS="--import dd-trace/initialize.mjs"
-CMD ./app.sh
+CMD ["./app.sh"]

--- a/utils/build/docker/nodejs/openai-js.Dockerfile
+++ b/utils/build/docker/nodejs/openai-js.Dockerfile
@@ -25,4 +25,4 @@ RUN /binaries/install_ddtrace.sh
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN printf 'node app.js' >> app.sh
-CMD ./app.sh
+CMD ["./app.sh"]

--- a/utils/build/docker/nodejs/openai-js.Dockerfile
+++ b/utils/build/docker/nodejs/openai-js.Dockerfile
@@ -24,5 +24,5 @@ RUN /binaries/install_ddtrace.sh
 
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
-RUN printf 'node app.js' >> app.sh
+RUN printf 'exec node app.js' >> app.sh
 CMD ["./app.sh"]

--- a/utils/build/docker/nodejs/parametric/Dockerfile
+++ b/utils/build/docker/nodejs/parametric/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM node:18.10-slim
-RUN apt-get update && apt-get -y install bash curl git jq \
-  || sleep 60 && apt-get update && apt-get -y install bash curl git jq
+RUN apt-get update && apt-get -y install bash curl git jq dumb-init \
+  || sleep 60 && apt-get update && apt-get -y install bash curl git jq dumb-init
 WORKDIR /usr/app
 COPY utils/build/docker/nodejs/parametric/package.json /usr/app/
 COPY utils/build/docker/nodejs/parametric/package-lock.json /usr/app/

--- a/utils/build/docker/nodejs/parametric/app.sh
+++ b/utils/build/docker/nodejs/parametric/app.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/dumb-init /bin/sh
+# shellcheck shell=sh
 
 if [ "${UDS_WEBLOG:-}" = "1" ]; then
     ./set-uds-transport.sh

--- a/utils/build/docker/nodejs/parametric/app.sh
+++ b/utils/build/docker/nodejs/parametric/app.sh
@@ -13,4 +13,4 @@ if [ -e /volumes/dd-trace-js ]; then
 fi
 
 # shellcheck disable=SC2086
-node server.js ${SYSTEM_TESTS_EXTRA_COMMAND_ARGUMENTS:-}
+exec node server.js ${SYSTEM_TESTS_EXTRA_COMMAND_ARGUMENTS:-}

--- a/utils/build/docker/nodejs/uds-express4.Dockerfile
+++ b/utils/build/docker/nodejs/uds-express4.Dockerfile
@@ -32,7 +32,7 @@ ENV DD_DATA_STREAMS_ENABLED=true
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN printf 'node app.js' >> app.sh
 COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh
-CMD ./app.sh
+CMD ["./app.sh"]
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh

--- a/utils/build/docker/nodejs/uds-express4.Dockerfile
+++ b/utils/build/docker/nodejs/uds-express4.Dockerfile
@@ -30,8 +30,8 @@ ENV DD_DATA_STREAMS_ENABLED=true
 
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
-RUN printf 'node app.js' >> app.sh
 COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh
+RUN printf 'exec node app.js' >> app.sh
 CMD ["./app.sh"]
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/

--- a/utils/build/docker/nodejs_otel/express4-otel.Dockerfile
+++ b/utils/build/docker/nodejs_otel/express4-otel.Dockerfile
@@ -31,4 +31,4 @@ ENV OTEL_BSP_SCHEDULE_DELAY=200
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN printf 'node --require @opentelemetry/auto-instrumentations-node/register app.js' >> app.sh
-CMD ./app.sh
+CMD ["./app.sh"]

--- a/utils/build/docker/nodejs_otel/express4-otel.Dockerfile
+++ b/utils/build/docker/nodejs_otel/express4-otel.Dockerfile
@@ -30,5 +30,5 @@ ENV OTEL_BSP_SCHEDULE_DELAY=200
 
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
-RUN printf 'node --require @opentelemetry/auto-instrumentations-node/register app.js' >> app.sh
+RUN printf 'exec node --require @opentelemetry/auto-instrumentations-node/register app.js' >> app.sh
 CMD ["./app.sh"]

--- a/utils/build/docker/php/apache-mod-7.0-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.0-zts.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.0.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.0.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.1-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.1-zts.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.1.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.1.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.2-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.2-zts.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.2.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.2.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.3-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.3-zts.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.3.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.3.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.4-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.4-zts.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.4.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.4.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.0-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.0-zts.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.0.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.0.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.1-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.1-zts.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.1.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.1.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.2-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.2-zts.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.2.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.2.Dockerfile
@@ -11,3 +11,10 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/app.sh
+++ b/utils/build/docker/php/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-#Nothing to do here. This file is to allow --sleep execution
+exec dumb-init /entrypoint.sh

--- a/utils/build/docker/php/php-fpm-7.0.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.0.Dockerfile
@@ -27,6 +27,6 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/php/php-fpm-7.1.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.1.Dockerfile
@@ -27,6 +27,6 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/php/php-fpm-7.2.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.2.Dockerfile
@@ -27,6 +27,6 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/php/php-fpm-7.3.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.3.Dockerfile
@@ -27,6 +27,6 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/php/php-fpm-7.4.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.4.Dockerfile
@@ -27,6 +27,6 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/php/php-fpm-8.0.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.0.Dockerfile
@@ -27,6 +27,6 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/php/php-fpm-8.1.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.1.Dockerfile
@@ -27,6 +27,6 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/php/php-fpm-8.2.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.2.Dockerfile
@@ -27,6 +27,6 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/php/php-fpm-8.5.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.5.Dockerfile
@@ -29,6 +29,6 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
+RUN echo "#!/bin/bash\nexec dumb-init /entrypoint.sh" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/proxy.Dockerfile
+++ b/utils/build/docker/proxy.Dockerfile
@@ -7,4 +7,4 @@ RUN pip install requests-toolbelt==1.0.0 grpcio-tools==1.56.0 opentelemetry-prot
 
 COPY utils/proxy /app/utils/proxy
 
-CMD python utils/proxy/core.py
+CMD ["python", "utils/proxy/core.py"]

--- a/utils/build/docker/python/django-poc.Dockerfile
+++ b/utils/build/docker/python/django-poc.Dockerfile
@@ -24,7 +24,7 @@ ENV DD_REMOTECONFIG_POLL_SECONDS=1
 ENV _DD_APPSEC_DEDUPLICATION_ENABLED=false
 
 # docker startup
-CMD ./app.sh
+CMD ["./app.sh"]
 
 # docker build -f utils/build/docker/python/django-poc.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test

--- a/utils/build/docker/python/django-py3.13.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.Dockerfile
@@ -21,7 +21,7 @@ ENV DD_REMOTECONFIG_POLL_SECONDS=1
 ENV _DD_APPSEC_DEDUPLICATION_ENABLED=false
 
 # docker startup
-CMD ./app.sh
+CMD ["./app.sh"]
 
 # docker build -f utils/build/docker/python/django-py3.13.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test

--- a/utils/build/docker/python/fastapi.Dockerfile
+++ b/utils/build/docker/python/fastapi.Dockerfile
@@ -19,7 +19,7 @@ ENV _DD_APPSEC_DEDUPLICATION_ENABLED=false
 ENV DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
 
 # docker startup
-CMD ./app.sh
+CMD ["./app.sh"]
 
 # docker build -f utils/build/docker/python/fastapi.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test

--- a/utils/build/docker/python/flask-poc.Dockerfile
+++ b/utils/build/docker/python/flask-poc.Dockerfile
@@ -25,7 +25,7 @@ ENV LOG_LEVEL='DEBUG'
 # FIXME: Ensure gevent patching occurs before ddtrace
 
 ENV FLASK_APP=app.py
-CMD ./app.sh
+CMD ["./app.sh"]
 
 # docker build -f utils/build/docker/python/flask-poc.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test

--- a/utils/build/docker/python/python3.12.Dockerfile
+++ b/utils/build/docker/python/python3.12.Dockerfile
@@ -21,7 +21,7 @@ ENV DD_REMOTECONFIG_POLL_SECONDS=1
 ENV _DD_APPSEC_DEDUPLICATION_ENABLED=false
 
 # docker startup
-CMD ./app.sh
+CMD ["./app.sh"]
 
 # docker build -f utils/build/docker/python/django-poc.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test

--- a/utils/build/docker/python/tornado.Dockerfile
+++ b/utils/build/docker/python/tornado.Dockerfile
@@ -16,7 +16,7 @@ COPY utils/build/docker/python/tornado/main.py /app/main.py
 COPY utils/build/docker/python/iast.py /app/iast.py
 
 # docker startup
-CMD ./app.sh
+CMD ["./app.sh"]
 
 # docker build -f utils/build/docker/python/tornado.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test

--- a/utils/build/docker/python/uds-flask.Dockerfile
+++ b/utils/build/docker/python/uds-flask.Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install socat -y
 ENV UDS_WEBLOG=1
 COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh
 
-CMD ./app.sh
+CMD ["./app.sh"]
 
 # docker build -f utils/build/docker/python.flask-poc.Dockerfile -t test .
 # docker run -ti -p 7777:7777 test

--- a/utils/build/docker/python_otel/flask-poc-otel.Dockerfile
+++ b/utils/build/docker/python_otel/flask-poc-otel.Dockerfile
@@ -21,5 +21,5 @@ RUN pip freeze | grep opentelemetry
 
 ENV OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
 ENV FLASK_APP=app.py
-CMD ./app.sh
+CMD ["./app.sh"]
 

--- a/utils/build/docker/python_otel/flask-poc-otel/app.sh
+++ b/utils/build/docker/python_otel/flask-poc-otel/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-opentelemetry-instrument gunicorn -w 1 -b 0.0.0.0:7777 --access-logfile - app:app -k gevent
+exec opentelemetry-instrument gunicorn -w 1 -b 0.0.0.0:7777 --access-logfile - app:app -k gevent

--- a/utils/build/docker/ruby/graphql23/app.sh
+++ b/utils/build/docker/ruby/graphql23/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1
+exec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1

--- a/utils/build/docker/ruby/rack/app.sh
+++ b/utils/build/docker/ruby/rack/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1
+exec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1

--- a/utils/build/docker/ruby/rails42/app.sh
+++ b/utils/build/docker/ruby/rails42/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1
+exec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1

--- a/utils/build/docker/ruby/rails52/app.sh
+++ b/utils/build/docker/ruby/rails52/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1
+exec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1

--- a/utils/build/docker/ruby/rails61/app.sh
+++ b/utils/build/docker/ruby/rails61/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1
+exec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1

--- a/utils/build/docker/ruby/rails72/app.sh
+++ b/utils/build/docker/ruby/rails72/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1
+exec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1

--- a/utils/build/docker/ruby/rails80/app.sh
+++ b/utils/build/docker/ruby/rails80/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1
+exec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1

--- a/utils/build/docker/ruby/sinatra14/app.sh
+++ b/utils/build/docker/ruby/sinatra14/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1
+exec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1

--- a/utils/build/docker/ruby/sinatra22/app.sh
+++ b/utils/build/docker/ruby/sinatra22/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1
+exec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1

--- a/utils/build/docker/ruby/sinatra32/app.sh
+++ b/utils/build/docker/ruby/sinatra32/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1
+exec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1

--- a/utils/build/docker/ruby/sinatra41/app.sh
+++ b/utils/build/docker/ruby/sinatra41/app.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1
+exec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1

--- a/utils/build/docker/ruby/uds-rails.Dockerfile
+++ b/utils/build/docker/ruby/uds-rails.Dockerfile
@@ -21,7 +21,7 @@ RUN bundle exec rails db:prepare
 
 COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh
 
-RUN echo "#!/bin/bash\n./set-uds-transport.sh\nbundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1" > app.sh
+RUN echo "#!/bin/bash\n./set-uds-transport.sh\nexec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1" > app.sh
 RUN chmod +x app.sh
 
 CMD [ "./app.sh" ]

--- a/utils/build/docker/ruby/uds-sinatra.Dockerfile
+++ b/utils/build/docker/ruby/uds-sinatra.Dockerfile
@@ -16,6 +16,6 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 ENV DD_APM_RECEIVER_SOCKET=/var/run/datadog/apm.socket
 
 COPY utils/build/docker/set-uds-transport.sh set-uds-transport.sh
-RUN echo "#!/bin/bash\n./set-uds-transport.sh\nbundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1" > app.sh
+RUN echo "#!/bin/bash\n./set-uds-transport.sh\nexec bundle exec puma -b tcp://0.0.0.0 -p 7777 -w 1" > app.sh
 RUN chmod +x app.sh
 CMD [ "./app.sh" ]

--- a/utils/build/docker/runner.Dockerfile
+++ b/utils/build/docker/runner.Dockerfile
@@ -24,4 +24,4 @@ COPY manifests /app/manifests
 COPY conftest.py /app/
 COPY run.sh /app/
 
-CMD ./run.sh
+CMD ["./run.sh"]

--- a/utils/build/ssi/nodejs/js-app.Dockerfile
+++ b/utils/build/ssi/nodejs/js-app.Dockerfile
@@ -22,4 +22,4 @@ EXPOSE 18080
 # We need pid 1 to be bash and to properly configure nvm
 # doing this via `RUN` doesn't seem to work
 COPY utils/build/ssi/nodejs/run.sh /app/
-CMD /app/run.sh
+CMD ["/app/run.sh"]

--- a/utils/build/ssi/python/py-app.Dockerfile
+++ b/utils/build/ssi/python/py-app.Dockerfile
@@ -10,4 +10,4 @@ ENV PYENV_ROOT $HOME/.pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver --noreload 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "--noreload", "0.0.0.0:18080"]

--- a/utils/build/ssi/ruby/rails6-app-deployment-mode.Dockerfile
+++ b/utils/build/ssi/ruby/rails6-app-deployment-mode.Dockerfile
@@ -15,5 +15,5 @@ ENV RBENV_ROOT $HOME/.rbenv
 ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
 RUN env DD_APM_INSTRUMENTATION_DEBUG=false sh -c 'bundle lock --update && bundle config set --local deployment true && bundle install && rbenv rehash'
 EXPOSE 18080
-CMD bin/rails server -b 0.0.0.0 -p 18080
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "18080"]
 

--- a/utils/build/ssi/ruby/rails6-app-vendored-mode.Dockerfile
+++ b/utils/build/ssi/ruby/rails6-app-vendored-mode.Dockerfile
@@ -16,4 +16,4 @@ ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
 ENV BUNDLE_PATH=/bundle
 RUN env DD_APM_INSTRUMENTATION_DEBUG=false bundle install && rbenv rehash
 EXPOSE 18080
-CMD bin/rails server -b 0.0.0.0 -p 18080
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "18080"]

--- a/utils/build/ssi/ruby/rails6-app.Dockerfile
+++ b/utils/build/ssi/ruby/rails6-app.Dockerfile
@@ -15,4 +15,4 @@ ENV RBENV_ROOT $HOME/.rbenv
 ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
 RUN env DD_APM_INSTRUMENTATION_DEBUG=false bundle install && rbenv rehash
 EXPOSE 18080
-CMD rails server -b 0.0.0.0 -p 18080
+CMD ["rails", "server", "-b", "0.0.0.0", "-p", "18080"]

--- a/utils/build/ssi/ruby/ruby-app-deployment-mode.Dockerfile
+++ b/utils/build/ssi/ruby/ruby-app-deployment-mode.Dockerfile
@@ -15,5 +15,5 @@ ENV RBENV_ROOT $HOME/.rbenv
 ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
 RUN env DD_APM_INSTRUMENTATION_DEBUG=false sh -c 'bundle lock --update && bundle config set --local deployment true && bundle install && rbenv rehash'
 EXPOSE 18080
-CMD bin/rails server -b 0.0.0.0 -p 18080
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "18080"]
 

--- a/utils/build/ssi/ruby/ruby-app-vendored-mode.Dockerfile
+++ b/utils/build/ssi/ruby/ruby-app-vendored-mode.Dockerfile
@@ -16,4 +16,4 @@ ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
 ENV BUNDLE_PATH=/bundle
 RUN env DD_APM_INSTRUMENTATION_DEBUG=false bundle install && rbenv rehash
 EXPOSE 18080
-CMD bin/rails server -b 0.0.0.0 -p 18080
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "18080"]

--- a/utils/build/ssi/ruby/ruby-app.Dockerfile
+++ b/utils/build/ssi/ruby/ruby-app.Dockerfile
@@ -15,4 +15,4 @@ ENV RBENV_ROOT $HOME/.rbenv
 ENV PATH $RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH
 RUN env DD_APM_INSTRUMENTATION_DEBUG=false bundle install && rbenv rehash
 EXPOSE 18080
-CMD rails server -b 0.0.0.0 -p 18080
+CMD ["rails", "server", "-b", "0.0.0.0", "-p", "18080"]

--- a/utils/build/virtual_machine/microvm/Dockerfile.amazonlinux2023
+++ b/utils/build/virtual_machine/microvm/Dockerfile.amazonlinux2023
@@ -28,4 +28,4 @@ COPY systemctl /usr/bin/systemctl
 COPY sudo.sh /usr/bin/sudo
 RUN chmod +x /usr/bin/systemctl
 RUN chmod +x /usr/bin/sudo
-ENTRYPOINT sleep infinity
+ENTRYPOINT ["sleep", "infinity"]

--- a/utils/build/virtual_machine/microvm/Dockerfile.ubuntu22
+++ b/utils/build/virtual_machine/microvm/Dockerfile.ubuntu22
@@ -23,4 +23,4 @@ COPY systemctl /usr/bin/systemctl
 COPY sudo.sh /usr/bin/sudo
 RUN chmod +x /usr/bin/systemctl
 RUN chmod +x /usr/bin/sudo
-ENTRYPOINT sleep infinity
+ENTRYPOINT ["sleep", "infinity"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-alpine/Dockerfile.template
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-alpine/Dockerfile.template
@@ -8,4 +8,4 @@ WORKDIR /src
 ADD . /src
 RUN pip3 install django
 EXPOSE 18080
-CMD python3 -m django runserver 0.0.0.0:18080
+CMD ["python3", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-multialpine/Dockerfile.python_3_10-alpine
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-multialpine/Dockerfile.python_3_10-alpine
@@ -7,4 +7,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-multialpine/Dockerfile.python_3_11-alpine
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-multialpine/Dockerfile.python_3_11-alpine
@@ -7,4 +7,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-multialpine/Dockerfile.python_3_12-alpine
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-multialpine/Dockerfile.python_3_12-alpine
@@ -7,4 +7,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-multialpine/Dockerfile.python_3_8-alpine
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-multialpine/Dockerfile.python_3_8-alpine
@@ -7,4 +7,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-multialpine/Dockerfile.python_3_9-alpine
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-multialpine/Dockerfile.python_3_9-alpine
@@ -7,4 +7,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-multicontainer/Dockerfile.python_3_10
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-multicontainer/Dockerfile.python_3_10
@@ -6,4 +6,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-multicontainer/Dockerfile.python_3_11
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-multicontainer/Dockerfile.python_3_11
@@ -6,4 +6,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-multicontainer/Dockerfile.python_3_12
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-multicontainer/Dockerfile.python_3_12
@@ -6,4 +6,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-multicontainer/Dockerfile.python_3_8
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-multicontainer/Dockerfile.python_3_8
@@ -6,4 +6,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python-multicontainer/Dockerfile.python_3_9
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python-multicontainer/Dockerfile.python_3_9
@@ -6,4 +6,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]

--- a/utils/build/virtual_machine/weblogs/python/test-app-python37-container/Dockerfile.template
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python37-container/Dockerfile.template
@@ -6,4 +6,4 @@ WORKDIR /src
 ADD . /src
 RUN pip install django
 EXPOSE 18080
-CMD python -m django runserver 0.0.0.0:18080
+CMD ["python", "-m", "django", "runserver", "0.0.0.0:18080"]


### PR DESCRIPTION
## Motivation

Improve reliability of end of setup flushes. Most tracers try to flush data on SIGTERM, but not all weblogs are setup in a way that the app gets SIGTERM signals.

## Changes

- Ensure weblog gets SIGTERM signals from `docker stop`:
  - Use exec-form `CMD` / `ENTRYPOINT` directives in dockerfiles, to make sure a parent shell is not created.
  - Use `exec` as the last call in `app.sh` scripts.
- Add 10s timeout for Ruby, since there appears to be some issue with Remote Config requests (`REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING`) if we exit immediately. It was previously not failing because `docker stop` would give a 10s grace period before killing the container if it does not exits on its own.
- Add 10s timeout for Next.js weblog, which does not handle SIGTERM gracefully. See https://github.com/DataDog/system-tests/pull/6814

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
