### PR TITLE
[nodejs] fix remote config polling slowing down multiple tests

### DIFF
--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -26,28 +26,32 @@ class Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation(debugger.BaseDe
     """
 
     def setup_inproduct_enablement_di(self):
-        def _send_config(*, enabled: bool | None = None, reset: bool = True):
+        def _configure(*, enabled: bool | None = None, reset: bool = True):
             probe = json.loads(self._probe_template)
             probe["id"] = debugger.generate_probe_id("log")
             self.set_probes([probe])
-
             self.send_rc_apm_tracing_and_probes(dynamic_instrumentation_enabled=enabled, reset=reset)
-            self.send_weblog_request("/debugger/log")
 
         self.initialize_weblog_remote_config()
         self.weblog_responses = []
         self.rc_states = []
 
-        _send_config()
+        _configure()
+        self.send_weblog_request("/debugger/log")
         self.di_initial_disabled = not self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
-        _send_config(enabled=True, reset=False)
+        _configure(enabled=True, reset=False)
+        self.wait_for_all_probes(statuses=["INSTALLED"], timeout=TIMEOUT)
+        self.send_weblog_request("/debugger/log")
         self.di_explicit_enabled = self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
-        _send_config(reset=False)
+        _configure(reset=False)
+        self.wait_for_all_probes(statuses=["INSTALLED"], timeout=TIMEOUT)
+        self.send_weblog_request("/debugger/log")
         self.di_empty_config = self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
-        _send_config(enabled=False, reset=False)
+        _configure(enabled=False, reset=False)
+        self.send_weblog_request("/debugger/log")
         self.di_explicit_disabled = not self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
     def test_inproduct_enablement_di(self):

--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -26,32 +26,29 @@ class Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation(debugger.BaseDe
     """
 
     def setup_inproduct_enablement_di(self):
-        def _configure(*, enabled: bool | None = None, reset: bool = True):
+        def _send_config(*, enabled: bool | None = None, reset: bool = True, wait_installed: bool = False):
             probe = json.loads(self._probe_template)
             probe["id"] = debugger.generate_probe_id("log")
             self.set_probes([probe])
             self.send_rc_apm_tracing_and_probes(dynamic_instrumentation_enabled=enabled, reset=reset)
+            if wait_installed:
+                self.wait_for_all_probes(statuses=["INSTALLED"], timeout=TIMEOUT)
+            self.send_weblog_request("/debugger/log")
 
         self.initialize_weblog_remote_config()
         self.weblog_responses = []
         self.rc_states = []
 
-        _configure()
-        self.send_weblog_request("/debugger/log")
+        _send_config()
         self.di_initial_disabled = not self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
-        _configure(enabled=True, reset=False)
-        self.wait_for_all_probes(statuses=["INSTALLED"], timeout=TIMEOUT)
-        self.send_weblog_request("/debugger/log")
+        _send_config(enabled=True, reset=False, wait_installed=context.library == "nodejs")
         self.di_explicit_enabled = self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
-        _configure(reset=False)
-        self.wait_for_all_probes(statuses=["INSTALLED"], timeout=TIMEOUT)
-        self.send_weblog_request("/debugger/log")
+        _send_config(reset=False, wait_installed=context.library == "nodejs")
         self.di_empty_config = self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
-        _configure(enabled=False, reset=False)
-        self.send_weblog_request("/debugger/log")
+        _send_config(enabled=False, reset=False)
         self.di_explicit_disabled = not self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
 
     def test_inproduct_enablement_di(self):

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -300,7 +300,7 @@ class _Scenarios:
     appsec_blocking_full_denylist = EndToEndScenario(
         "APPSEC_BLOCKING_FULL_DENYLIST",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None},
+        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5"},
         doc="""
             The spec says that if  DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
             In this scenario, we use remote config. By the spec, when remote config is available, rules file
@@ -453,6 +453,7 @@ class _Scenarios:
             "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": "2.0",
             "DD_API_SECURITY_REQUEST_SAMPLE_RATE": "1.0",
             "DD_API_SECURITY_SAMPLE_DELAY": "0.0",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         agent_env={
             "DD_INFRASTRUCTURE_MODE": "none",
@@ -470,6 +471,7 @@ class _Scenarios:
             "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": "2.0",
             "DD_API_SECURITY_REQUEST_SAMPLE_RATE": "1.0",
             "DD_API_SECURITY_SAMPLE_DELAY": "0.0",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         agent_env={
             "DD_INFRASTRUCTURE_MODE": "none",
@@ -549,7 +551,7 @@ class _Scenarios:
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES",
         rc_api_enabled=True,
         appsec_enabled=False,
-        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true"},
+        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5"},
         doc="",
         scenario_groups=[scenario_groups.appsec, scenario_groups.remote_config, scenario_groups.essentials],
     )
@@ -562,6 +564,7 @@ class _Scenarios:
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "1000",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         doc="",
         scenario_groups=[scenario_groups.remote_config, scenario_groups.essentials],
@@ -570,7 +573,7 @@ class _Scenarios:
     remote_config_mocked_backend_asm_dd = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None},
+        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5"},
         doc="""
             The spec says that if DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
             In this scenario, we use remote config. By the spec, when remote config is available, rules file
@@ -605,7 +608,11 @@ class _Scenarios:
     remote_config_mocked_backend_asm_features_nocache = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_ENABLED": "false", "DD_REMOTE_CONFIGURATION_ENABLED": "true"},
+        weblog_env={
+            "DD_APPSEC_ENABLED": "false",
+            "DD_REMOTE_CONFIGURATION_ENABLED": "true",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
+        },
         doc="",
         scenario_groups=[scenario_groups.appsec, scenario_groups.remote_config],
     )
@@ -663,6 +670,7 @@ class _Scenarios:
         "LIBRARY_CONF_CUSTOM_HEADER_TAGS",
         additional_trace_header_tags=(VALID_CONFIGS),
         rc_api_enabled=True,
+        weblog_env={"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5"},
         doc="Scenario with custom headers to be used with DD_TRACE_HEADER_TAGS",
     )
     library_conf_custom_header_tags_invalid = EndToEndScenario(
@@ -696,6 +704,7 @@ class _Scenarios:
             "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "datadog,tracecontext,b3multi,baggage",
             "DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT": "restart",
             "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": "true",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         appsec_enabled=False,  # disable ASM to test non asm client ip tagging
         iast_enabled=False,
@@ -752,6 +761,7 @@ class _Scenarios:
             "DD_LOGS_INJECTION": "true",
             "DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED": "false",
             "DD_TRACE_OTEL_ENABLED": "true",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         doc="",
         rc_api_enabled=True,
@@ -851,6 +861,7 @@ class _Scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_EXCEPTION_REPLAY_ENABLED": "1",
             "DD_SYMBOL_DATABASE_UPLOAD_ENABLED": "1",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         library_interface_timeout=5,
         doc="Test scenario for checking debugger telemetry.",

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -317,7 +317,11 @@ class _Scenarios:
         rc_api_enabled=True,
         appsec_enabled=False,
         iast_enabled=False,
-        weblog_env={"DD_APPSEC_WAF_TIMEOUT": "10000000", "DD_APPSEC_TRACE_RATE_LIMIT": "10000"},  # 10 seconds
+        weblog_env={
+            "DD_APPSEC_WAF_TIMEOUT": "10000000",  # 10 seconds
+            "DD_APPSEC_TRACE_RATE_LIMIT": "10000",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
+        },
         doc="",
         scenario_groups=[scenario_groups.appsec, scenario_groups.appsec_rasp],
     )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -300,7 +300,7 @@ class _Scenarios:
     appsec_blocking_full_denylist = EndToEndScenario(
         "APPSEC_BLOCKING_FULL_DENYLIST",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5"},
+        weblog_env={"DD_APPSEC_RULES": None},
         doc="""
             The spec says that if  DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
             In this scenario, we use remote config. By the spec, when remote config is available, rules file
@@ -320,8 +320,6 @@ class _Scenarios:
         weblog_env={
             "DD_APPSEC_WAF_TIMEOUT": "10000000",  # 10 seconds
             "DD_APPSEC_TRACE_RATE_LIMIT": "10000",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
-            "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": "2.0",
         },
         doc="",
         scenario_groups=[scenario_groups.appsec, scenario_groups.appsec_rasp],
@@ -355,7 +353,6 @@ class _Scenarios:
             "DD_API_SECURITY_SAMPLE_DELAY": "0.0",
             "DD_APPSEC_WAF_TIMEOUT": "10000000",
             "DD_APPSEC_TRACE_RATE_LIMIT": "10000",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         rc_api_enabled=True,
         doc="""
@@ -454,7 +451,6 @@ class _Scenarios:
             "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": "2.0",
             "DD_API_SECURITY_REQUEST_SAMPLE_RATE": "1.0",
             "DD_API_SECURITY_SAMPLE_DELAY": "0.0",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         agent_env={
             "DD_INFRASTRUCTURE_MODE": "none",
@@ -472,7 +468,6 @@ class _Scenarios:
             "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": "2.0",
             "DD_API_SECURITY_REQUEST_SAMPLE_RATE": "1.0",
             "DD_API_SECURITY_SAMPLE_DELAY": "0.0",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         agent_env={
             "DD_INFRASTRUCTURE_MODE": "none",
@@ -552,7 +547,7 @@ class _Scenarios:
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES",
         rc_api_enabled=True,
         appsec_enabled=False,
-        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true", "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5"},
+        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true"},
         doc="",
         scenario_groups=[scenario_groups.appsec, scenario_groups.remote_config, scenario_groups.essentials],
     )
@@ -565,7 +560,6 @@ class _Scenarios:
             "DD_DEBUGGER_ENABLED": "1",
             "DD_REMOTE_CONFIG_ENABLED": "true",
             "DD_INTERNAL_RCM_POLL_INTERVAL": "1000",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         doc="",
         scenario_groups=[scenario_groups.remote_config, scenario_groups.essentials],
@@ -574,7 +568,7 @@ class _Scenarios:
     remote_config_mocked_backend_asm_dd = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD",
         rc_api_enabled=True,
-        weblog_env={"DD_APPSEC_RULES": None, "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5"},
+        weblog_env={"DD_APPSEC_RULES": None},
         doc="""
             The spec says that if DD_APPSEC_RULES is defined, then rules won't be loaded from remote config.
             In this scenario, we use remote config. By the spec, when remote config is available, rules file
@@ -612,7 +606,6 @@ class _Scenarios:
         weblog_env={
             "DD_APPSEC_ENABLED": "false",
             "DD_REMOTE_CONFIGURATION_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         doc="",
         scenario_groups=[scenario_groups.appsec, scenario_groups.remote_config],
@@ -671,7 +664,6 @@ class _Scenarios:
         "LIBRARY_CONF_CUSTOM_HEADER_TAGS",
         additional_trace_header_tags=(VALID_CONFIGS),
         rc_api_enabled=True,
-        weblog_env={"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5"},
         doc="Scenario with custom headers to be used with DD_TRACE_HEADER_TAGS",
     )
     library_conf_custom_header_tags_invalid = EndToEndScenario(
@@ -705,7 +697,6 @@ class _Scenarios:
             "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "datadog,tracecontext,b3multi,baggage",
             "DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT": "restart",
             "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         appsec_enabled=False,  # disable ASM to test non asm client ip tagging
         iast_enabled=False,
@@ -762,7 +753,6 @@ class _Scenarios:
             "DD_LOGS_INJECTION": "true",
             "DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED": "false",
             "DD_TRACE_OTEL_ENABLED": "true",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         doc="",
         rc_api_enabled=True,
@@ -862,7 +852,6 @@ class _Scenarios:
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "1",
             "DD_EXCEPTION_REPLAY_ENABLED": "1",
             "DD_SYMBOL_DATABASE_UPLOAD_ENABLED": "1",
-            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         library_interface_timeout=5,
         doc="Test scenario for checking debugger telemetry.",

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -354,6 +354,7 @@ class _Scenarios:
             "DD_API_SECURITY_SAMPLE_DELAY": "0.0",
             "DD_APPSEC_WAF_TIMEOUT": "10000000",
             "DD_APPSEC_TRACE_RATE_LIMIT": "10000",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
         },
         rc_api_enabled=True,
         doc="""

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -321,6 +321,7 @@ class _Scenarios:
             "DD_APPSEC_WAF_TIMEOUT": "10000000",  # 10 seconds
             "DD_APPSEC_TRACE_RATE_LIMIT": "10000",
             "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.5",
+            "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": "2.0",
         },
         doc="",
         scenario_groups=[scenario_groups.appsec, scenario_groups.appsec_rasp],

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -317,10 +317,7 @@ class _Scenarios:
         rc_api_enabled=True,
         appsec_enabled=False,
         iast_enabled=False,
-        weblog_env={
-            "DD_APPSEC_WAF_TIMEOUT": "10000000",  # 10 seconds
-            "DD_APPSEC_TRACE_RATE_LIMIT": "10000",
-        },
+        weblog_env={"DD_APPSEC_WAF_TIMEOUT": "10000000", "DD_APPSEC_TRACE_RATE_LIMIT": "10000"},  # 10 seconds
         doc="",
         scenario_groups=[scenario_groups.appsec, scenario_groups.appsec_rasp],
     )
@@ -603,10 +600,7 @@ class _Scenarios:
     remote_config_mocked_backend_asm_features_nocache = EndToEndScenario(
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES_NOCACHE",
         rc_api_enabled=True,
-        weblog_env={
-            "DD_APPSEC_ENABLED": "false",
-            "DD_REMOTE_CONFIGURATION_ENABLED": "true",
-        },
+        weblog_env={"DD_APPSEC_ENABLED": "false", "DD_REMOTE_CONFIGURATION_ENABLED": "true"},
         doc="",
         scenario_groups=[scenario_groups.appsec, scenario_groups.remote_config],
     )

--- a/utils/_context/_scenarios/debugger.py
+++ b/utils/_context/_scenarios/debugger.py
@@ -39,6 +39,7 @@ class DebuggerScenario(EndToEndScenario):
             self.weblog_container.environment["DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL"] = "0.1"
         elif library == "nodejs":
             self.weblog_container.environment["DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS"] = "0.1"
+            self.weblog_container.environment["DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS"] = "0.2"
         elif library in ("java", "dotnet"):
             # Java and .NET use UPLOAD_FLUSH_INTERVAL in milliseconds
             self.weblog_container.environment["DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL"] = "100"

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -121,7 +121,7 @@ class DockerScenario(Scenario):
 
         # lot of issue using the default OS dependant notifiers (not working on WSL, reaching some inotify watcher
         # limits on Linux) -> using the good old bare polling system
-        observer = PollingObserver(timeout=0.1)
+        observer = PollingObserver()
 
         for interface in interfaces:
             observer.schedule(Event(interface), path=interface.log_folder)
@@ -315,14 +315,14 @@ class EndToEndScenario(DockerScenario):
         if self._library_interface_timeout is None:
             if library == "java":
                 self.library_interface_timeout = 25
-            elif library == "golang":
+            elif library in ("golang",):
                 self.library_interface_timeout = 10
             elif library in ("nodejs", "ruby"):
                 self.library_interface_timeout = 0
-            elif library == "php":
+            elif library in ("php",):
                 # possibly something weird on obfuscator, let increase the delay for now
                 self.library_interface_timeout = 10
-            elif library == "python":
+            elif library in ("python",):
                 self.library_interface_timeout = 5
             else:
                 self.library_interface_timeout = 40

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -309,6 +309,11 @@ class EndToEndScenario(DockerScenario):
 
         library = self.weblog_infra.library_name
 
+        if library == "nodejs":
+            self.weblog_infra.http_container.environment.setdefault(
+                "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS", "0.5"
+            )
+
         if self._library_interface_timeout is None:
             if library == "java":
                 self.library_interface_timeout = 25

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -121,7 +121,7 @@ class DockerScenario(Scenario):
 
         # lot of issue using the default OS dependant notifiers (not working on WSL, reaching some inotify watcher
         # limits on Linux) -> using the good old bare polling system
-        observer = PollingObserver()
+        observer = PollingObserver(timeout=0.1)
 
         for interface in interfaces:
             observer.schedule(Event(interface), path=interface.log_folder)

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -310,21 +310,19 @@ class EndToEndScenario(DockerScenario):
         library = self.weblog_infra.library_name
 
         if library == "nodejs":
-            self.weblog_infra.http_container.environment.setdefault(
-                "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS", "0.5"
-            )
+            self.weblog_infra.http_container.environment.setdefault("DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS", "0.5")
 
         if self._library_interface_timeout is None:
             if library == "java":
                 self.library_interface_timeout = 25
-            elif library in ("golang",):
+            elif library == "golang":
                 self.library_interface_timeout = 10
             elif library in ("nodejs", "ruby"):
                 self.library_interface_timeout = 0
-            elif library in ("php",):
+            elif library == "php":
                 # possibly something weird on obfuscator, let increase the delay for now
                 self.library_interface_timeout = 10
-            elif library in ("python",):
+            elif library == "python":
                 self.library_interface_timeout = 5
             else:
                 self.library_interface_timeout = 40

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -133,7 +133,7 @@ def send_state(
 
         if wait_for_acknowledged_status:
             for state in current_states.configs.values():
-                if state["apply_state"] == ApplyState.UNKNOWN:
+                if state["apply_state"] != ApplyState.ACKNOWLEDGED:
                     return False
 
         current_states.state = ApplyState.ACKNOWLEDGED

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -141,7 +141,7 @@ def send_state(
 
     library.wait_for(remote_config_applied, timeout=30)
     # ensure the library has enough time to apply the config to all subprocesses
-    time.sleep(2)
+    time.sleep(0.5)
 
     return current_states
 

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -141,7 +141,7 @@ def send_state(
 
     library.wait_for(remote_config_applied, timeout=30)
     # ensure the library has enough time to apply the config to all subprocesses
-    time.sleep(1)
+    time.sleep(1 if context.library.name == "nodejs" else 2)
 
     return current_states
 

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -141,7 +141,8 @@ def send_state(
 
     library.wait_for(remote_config_applied, timeout=30)
     # ensure the library has enough time to apply the config to all subprocesses
-    time.sleep(1 if context.library.name == "nodejs" else 2)
+    if context.library.name != "nodejs":
+        time.sleep(2)
 
     return current_states
 

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -141,8 +141,7 @@ def send_state(
 
     library.wait_for(remote_config_applied, timeout=30)
     # ensure the library has enough time to apply the config to all subprocesses
-    if context.library.name != "nodejs":
-        time.sleep(2)
+    time.sleep(0.1 if context.library.name == "nodejs" else 2)
 
     return current_states
 

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -133,7 +133,7 @@ def send_state(
 
         if wait_for_acknowledged_status:
             for state in current_states.configs.values():
-                if state["apply_state"] != ApplyState.ACKNOWLEDGED:
+                if state["apply_state"] == ApplyState.UNKNOWN:
                     return False
 
         current_states.state = ApplyState.ACKNOWLEDGED
@@ -141,7 +141,7 @@ def send_state(
 
     library.wait_for(remote_config_applied, timeout=30)
     # ensure the library has enough time to apply the config to all subprocesses
-    time.sleep(0.5)
+    time.sleep(1)
 
     return current_states
 

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -141,7 +141,8 @@ def send_state(
 
     library.wait_for(remote_config_applied, timeout=30)
     # ensure the library has enough time to apply the config to all subprocesses
-    time.sleep(0.1 if context.library.name == "nodejs" else 2)
+    if context.library.name != "nodejs":
+        time.sleep(2)
 
     return current_states
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

That was slowing everything down.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Fix remote config polling slowing down multiple tests.

Explanation from Claude when I originally asked it to fix `APPSEC_RUNTIME_ACTIVATION` and `APPSEC_AUTO_EVENTS_RC` being the slowest tests:

---

Two changes made:

utils/_context/_scenarios/__init__.py — Added DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: "0.5" to APPSEC_RUNTIME_ACTIVATION. Without this, each apply() call waited for the default ~5s poll cycle before the tracer acknowledged the config. The scenario had 58 total apply() calls across its test files (34 in test_remote_config_rule_changes.py alone), making this the dominant bottleneck.

utils/_remote_config.py:144 — Reduced time.sleep(2) to time.sleep(0.5). This sleep runs after every send_state() call to give subprocesses time to catch up. With a 0.5s poll interval, 0.5s (one poll cycle) is sufficient — any worker process that hadn't applied yet will poll within that window. The old 2s value was actually already too short for scenarios using the default 5s interval, but 4× too long for scenarios using 0.5s.

Estimated speedup:

APPSEC_RUNTIME_ACTIVATION: each apply goes from ~5s + 2s = ~7s → ~0.5s + 0.5s = ~1s — roughly 7× faster
APPSEC_AUTO_EVENTS_RC: each apply goes from ~0.5s + 2s = ~2.5s → ~0.5s + 0.5s = ~1s — roughly 2.5× faster

---

I then asked it to apply the same fix to everything else and applied further suggestions. I isolated the changes to Node because system tests seem extremely flaky for other languages, so I don't know how to differentiate flakiness from actual failures caused by a change.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
