### PR TITLE
remove the need to sleep in remote config

### DIFF
--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -3,6 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import base64
+import contextlib
 import hashlib
 import json
 import re
@@ -84,10 +85,8 @@ def send_state(
     # Collect runtime_ids of all processes currently polling RC so we can wait for each one to acknowledge.
     known_runtime_ids: set[str] = set()
     for _d in library.get_data(path_filters="/v0.7/config"):
-        try:
+        with contextlib.suppress(KeyError, TypeError):
             known_runtime_ids.add(_d["request"]["content"]["client"]["client_tracer"]["runtime_id"])
-        except (KeyError, TypeError):
-            pass
 
     if target == "backend":
         assert backend_enabled, f"Remote config backend is not enabled on {context.scenario}"

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -6,7 +6,6 @@ import base64
 import hashlib
 import json
 import re
-import time
 import uuid
 from typing import Any, Literal
 from collections.abc import Mapping
@@ -82,6 +81,14 @@ def send_state(
 
     assert api_enabled, f"Remote config API is not enabled on {context.scenario}"
 
+    # Collect runtime_ids of all processes currently polling RC so we can wait for each one to acknowledge.
+    known_runtime_ids: set[str] = set()
+    for _d in library.get_data(path_filters="/v0.7/config"):
+        try:
+            known_runtime_ids.add(_d["request"]["content"]["client"]["client_tracer"]["runtime_id"])
+        except (KeyError, TypeError):
+            pass
+
     if target == "backend":
         assert backend_enabled, f"Remote config backend is not enabled on {context.scenario}"
         # Build protobuf on test runner side, send bytes to proxy
@@ -107,41 +114,56 @@ def send_state(
             "apply_error": "<No known response from the library>",
         }
 
-    state = {}
+    acknowledged_runtime_ids: set[str] = set()
+
+    def _all_processes_acknowledged() -> bool:
+        return not known_runtime_ids or acknowledged_runtime_ids >= known_runtime_ids
 
     def remote_config_applied(data: dict) -> bool:
-        nonlocal state
         if data["path"] != "/v0.7/config":
             return False
 
-        state = data.get("request", {}).get("content", {}).get("client", {}).get("state", {})
-        if len(client_configs) == 0:
-            found = state["targets_version"] == state_version and state.get("config_states", []) == []
-            if found:
-                current_states.state = ApplyState.ACKNOWLEDGED
-            return found
+        client_state = data.get("request", {}).get("content", {}).get("client", {}).get("state", {})
 
-        if state["targets_version"] != version:
+        try:
+            rid = data["request"]["content"]["client"]["client_tracer"]["runtime_id"]
+        except (KeyError, TypeError):
+            rid = None
+
+        if len(client_configs) == 0:
+            found = client_state.get("targets_version") == state_version and client_state.get("config_states", []) == []
+            if found:
+                if rid:
+                    acknowledged_runtime_ids.add(rid)
+                if _all_processes_acknowledged():
+                    current_states.state = ApplyState.ACKNOWLEDGED
+                    return True
             return False
 
-        config_states = state.get("config_states", [])
-        for state in config_states:
-            config_state = current_states.configs.get(state["id"])
-            if config_state and state["product"] == config_state["product"]:
-                logger.debug(f"Remote config state: {state}")
-                config_state.update(state)
+        if client_state.get("targets_version") != version:
+            return False
+
+        for cs in client_state.get("config_states", []):
+            config_state = current_states.configs.get(cs["id"])
+            if config_state and cs["product"] == config_state["product"]:
+                logger.debug(f"Remote config state: {cs}")
+                config_state.update(cs)
 
         if wait_for_acknowledged_status:
-            for state in current_states.configs.values():
-                if state["apply_state"] == ApplyState.UNKNOWN:
+            for config_state in current_states.configs.values():
+                if config_state["apply_state"] == ApplyState.UNKNOWN:
                     return False
 
-        current_states.state = ApplyState.ACKNOWLEDGED
-        return True
+        if rid:
+            acknowledged_runtime_ids.add(rid)
+
+        if _all_processes_acknowledged():
+            current_states.state = ApplyState.ACKNOWLEDGED
+            return True
+
+        return False
 
     library.wait_for(remote_config_applied, timeout=30)
-    # ensure the library has enough time to apply the config to all subprocesses
-    time.sleep(2)
 
     return current_states
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Using sleep is always bad and is flaky by design.

## Changes

<!-- A brief description of the change being made with this pull request. -->

From Claude:

**Before**: After the library acknowledged the config, `time.sleep(2)` was used as a blunt delay to give subprocesses (e.g., gunicorn workers) time to also apply it.

**After**: Before sending the config, we snapshot all runtime_ids already seen in `/v0.7/config` requests — one per process/worker polling RC. The `remote_config_applied` closure now only returns True once every known `runtime_id` has sent a request acknowledging the new config version. This is deterministic: on a single-process app it returns immediately after the first ACK (same as before minus the sleep), and on a multi-worker app it waits for every worker to confirm without sleeping at all.

The variable-shadowing bug in the original (for state in `config_states` overwrote the nonlocal state) was also fixed — loop variables are now `cs` and `config_state`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
