### PR TITLE
[debugger] add v2 schema coverage

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -83,6 +83,7 @@ refs:
   - &ref_5_80_0 '>=5.80.0'
   - &ref_5_81_0 '>=5.81.0'
   - &ref_5_83_0 '>=5.83.0'
+  - &ref_5_85_0 '>=5.85.0'
   - &ref_5_87_0 '>=5.87.0'  # Debugger: Capture expressions support
   - &ref_5_88_0 '>=5.88.0'
   - &ref_5_89_0 '>=5.89.0'
@@ -1572,8 +1573,14 @@ manifest:
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_default_max_length: bug (DEBUG-4611)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_default_max_reference_depth: bug (DEBUG-4611)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot: bug (DEBUG-4611)
-  tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_debug_track: missing_feature (DEBUG-4345)
-  tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_new_destination: missing_feature (DEBUG-4345)
+  tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_debug_track:
+    - weblog_declaration:
+        "*": *ref_5_85_0
+        nextjs: irrelevant
+  tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_new_destination:
+    - weblog_declaration:
+        "*": *ref_5_85_0
+        nextjs: irrelevant
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot_svc: missing_feature
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_span_decoration_line_snapshot: missing_feature (Not yet implemented)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1058,8 +1058,6 @@ manifest:
     - declaration: bug (DEBUG-3747)
       component_version: <2.28.0
       weblog: [rails72, uds-rails, rails80]
-    - declaration: bug (DEBUG-3747)
-      excluded_weblog: [rails72, uds-rails, rails80]
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets:
     - weblog_declaration:
         "*": irrelevant
@@ -1074,18 +1072,14 @@ manifest:
         rails80: v2.8.0
         uds-rails: v2.12.0
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_default_max_reference_depth: bug (DEBUG-4675)
-  tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_debug_track:  # Modified by easy win activation script
+  tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_debug_track:
     - declaration: missing_feature (DEBUG-4343)
-      component_version: <2.27.0
+      component_version: <2.24.0
       weblog: [rails80, rails72, uds-rails]
+  tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_new_destination:
     - declaration: missing_feature (DEBUG-4343)
-      excluded_weblog: [rails80, rails72, uds-rails]
-  tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_new_destination:  # Modified by easy win activation script
-    - declaration: missing_feature (DEBUG-4343)
-      component_version: <2.27.0
+      component_version: <2.24.0
       weblog: [rails80, rails72, uds-rails]
-    - declaration: missing_feature (DEBUG-4343)
-      excluded_weblog: [rails80, rails72, uds-rails]
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot_svc: missing_feature
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_span_decoration_line_snapshot: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots_With_SCM:

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -69,6 +69,12 @@ class Test_DdtraceSchemas:
                 ticket="DEBUG-3734",
             ),
             SchemaBug(
+                endpoint="/debugger/v2/input",
+                data_path="$[].debugger.snapshot.probe.location.method",
+                condition=context.library == "dotnet",
+                ticket="DEBUG-3734",
+            ),
+            SchemaBug(
                 endpoint="/symdb/v1/input",
                 data_path=None,
                 condition=context.library == "dotnet" and context.scenario is scenarios.debugger_symdb,

--- a/tests/schemas/utils/library/debugger/v2/input-request.json
+++ b/tests/schemas/utils/library/debugger/v2/input-request.json
@@ -1,0 +1,4 @@
+{
+  "$id": "/library/debugger/v2/input-request.json",
+  "$ref": "/library/debugger/v1/input-request.json"
+}


### PR DESCRIPTION
## Motivation

Add schema coverage for debugger snapshot payloads sent to `/debugger/v2/input`.

## Changes

- add a `/library/debugger/v2/input-request.json` schema that reuses the existing debugger v1 input schema
- enable the nodejs debugger snapshot destination tests starting from the tracer versions that introduced debugger track and `/debugger/v2/input` support
- lower the ruby version gate for the debugger snapshot destination tests to the first tracer version that added the new endpoint support
- simplify the ruby manifest entries by removing redundant weblog exclusions and keeping only the Rails-specific version gating

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
