### PR TITLE
[nodejs] Handle Next.js weblog shutdown telemetry

### DIFF
--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -24,6 +24,6 @@ ENV DD_DATA_STREAMS_ENABLED=true
 ENV PORT=7777
 ENV HOSTNAME=0.0.0.0
 COPY utils/build/docker/nodejs/app.sh app.sh
-RUN printf './node_modules/.bin/next start' >> app.sh
 ENV NODE_OPTIONS="--import dd-trace/initialize.mjs"
-CMD ./app.sh
+RUN printf 'exec ./node_modules/.bin/next start' >> app.sh
+CMD ["./app.sh"]

--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -21,6 +21,11 @@ ENV DD_TRACE_HEADER_TAGS=user-agent
 
 # docker startup
 ENV DD_DATA_STREAMS_ENABLED=true
+# Let src/instrumentation.js handle Next.js shutdown signals manually, as documented in:
+# https://nextjs.org/docs/pages/guides/self-hosting#manual-graceful-shutdowns
+# Support was added in https://github.com/vercel/next.js/pull/59117; this
+# weblog is pinned to Next.js >=14.0.4 to support NEXT_MANUAL_SIG_HANDLE.
+ENV NEXT_MANUAL_SIG_HANDLE=true
 ENV PORT=7777
 ENV HOSTNAME=0.0.0.0
 COPY utils/build/docker/nodejs/app.sh app.sh

--- a/utils/build/docker/nodejs/nextjs/next.config.js
+++ b/utils/build/docker/nodejs/nextjs/next.config.js
@@ -3,7 +3,11 @@ const nextConfig = {
   // Disabled because standalone mode does not support using modules directly
   // from node_modules which is necessary when using `npm link dd-trace`.
   // output: 'standalone'
-  outputFileTracing: false
+  outputFileTracing: false,
+  experimental: {
+    // Run out src/instrumentation.js hooks
+    instrumentationHook: true
+  }
 }
 
 module.exports = nextConfig

--- a/utils/build/docker/nodejs/nextjs/src/instrumentation.js
+++ b/utils/build/docker/nodejs/nextjs/src/instrumentation.js
@@ -1,0 +1,33 @@
+'use strict'
+
+// Time to wait after invoking dd-trace's beforeExit handlers before forcing
+// the process to exit. The handlers are fire-and-forget (no Promise, no
+// awaitable signal) and initiate asynchronous HTTP exports for telemetry,
+// traces, remote config, AppSec metrics, dogstatsd, etc., so we need a grace
+// window for those in-flight requests to drain. Same as docker stop's default
+// 10s SIGKILL timeout.
+const SHUTDOWN_GRACE_MS = 10000
+
+function shutdown () {
+  const ddTrace = globalThis[Symbol.for('dd-trace')]
+
+  if (ddTrace?.beforeExitHandlers) {
+    for (const handler of ddTrace.beforeExitHandlers) {
+      try {
+        handler()
+      } catch (err) {
+        // Best-effort: keep running other handlers even if one throws.
+        console.error('dd-trace beforeExit handler threw', err)
+      }
+    }
+  }
+
+  setTimeout(() => process.exit(0), SHUTDOWN_GRACE_MS).unref()
+}
+
+export function register () {
+  if (!process.env.NEXT_MANUAL_SIG_HANDLE || process.env.NEXT_RUNTIME === 'edge') return
+
+  process.once('SIGINT', shutdown)
+  process.once('SIGTERM', shutdown)
+}


### PR DESCRIPTION
## Motivation

While fixing SIGTERM dispatch to weblogs (see https://github.com/DataDog/system-tests/pull/6804) I noticed the Next.js weblog does not exit gracefully on SIGTERM. Its signal handler calls `process.exit`, which does not run any beforeExit hook in dd-trace-js.

## Changes

- Register signal handlers to call exit hooks from dd-trace-js. These signal handlers are the recommended way to implement graceful shutdown in Next.js, see https://nextjs.org/docs/pages/guides/self-hosting#manual-graceful-shutdowns
  - Adds a grace period of 10s to allow flush actions to finish. A fixed timeout is not ideal, but still better than the undocumented 10s docker stop timeout.
- If a later version of dd-trace-js implements a publich shutdown/flush method, that might be used here instead of the current hack.
- Change Dockerfile and app.sh to use `exec` to run nextjs, so that signals to the container on docker stop are properly dispatched to the Node app.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
