### PR TITLE
Implement `/otel/logger/` endpoint for Java

### DIFF
--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryLogsController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryLogsController.java
@@ -1,0 +1,80 @@
+package com.datadoghq.trace.opentelemetry.controller;
+
+import static com.datadoghq.ApmTestClient.LOGGER;
+import static com.datadoghq.trace.opentelemetry.controller.OpenTelemetryTraceController.getSpan;
+
+import com.datadoghq.trace.opentelemetry.dto.*;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.logs.*;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OpenTelemetryLogsController {
+  private final LoggerProvider loggerProvider = GlobalOpenTelemetry.get().getLogsBridge();
+
+  /** Known loggers, populated via createLogger requests. */
+  private final Map<String, Logger> loggers = new ConcurrentHashMap<>();
+
+  @PostMapping("/otel/logger/create")
+  public void createLogger(@RequestBody CreateLoggerArgs args) {
+    LOGGER.info("Creating OTel logger: {}", args);
+    String loggerName = args.name();
+    if (!loggers.containsKey(loggerName)) {
+      loggers.put(
+          loggerName,
+          loggerProvider
+              .loggerBuilder(loggerName)
+              .setInstrumentationVersion(args.version())
+              .setSchemaUrl(args.schemaUrl())
+              .build());
+      }
+  }
+
+  @PostMapping("/otel/logger/write")
+  public void writeLog(@RequestBody WriteLogArgs args) {
+    LOGGER.info("Writing OTel log: {}", args);
+    String loggerName = args.loggerName();
+    Logger logger = loggers.get(loggerName);
+    if (logger == null) {
+      throw new IllegalStateException(
+          "Logger " + loggerName + " not found in registered loggers " + loggers.keySet());
+    }
+    Scope scope = null;
+    if (args.spanId() != 0) {
+      Span span = getSpan(args.spanId());
+      if (span == null) {
+        throw new IllegalStateException("Span not found for span_id: " + args.spanId());
+      }
+      scope = span.makeCurrent();
+    }
+    try {
+      logger.logRecordBuilder()
+          .setSeverity(Severity.valueOf(args.level().toUpperCase(Locale.ROOT)))
+          .setBody(args.message())
+          .emit();
+    } finally {
+      if (scope != null) {
+        scope.close();
+      }
+    }
+  }
+
+  @PostMapping("/log/otel/flush")
+  public FlushResult flushLogs(@RequestBody FlushArgs args) {
+    LOGGER.info("Flushing OTel logs: {}", args);
+    try {
+      // TODO: call internal hook to flush logs
+      return new FlushResult(true);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to flush OTel logs", e);
+      return new FlushResult(false);
+    }
+  }
+}

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryTraceController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryTraceController.java
@@ -18,6 +18,7 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,13 +30,13 @@ import java.util.Map;
 @RestController
 @RequestMapping(value = "/trace/otel")
 public class OpenTelemetryTraceController {
+  private static final Map<Long, Span> spans = new ConcurrentHashMap<>();
+
   private final Tracer tracer;
-  private final Map<Long, Span> spans;
   private Baggage baggage;
 
   public OpenTelemetryTraceController() {
     this.tracer = GlobalOpenTelemetry.getTracer("java-client");
-    this.spans = new HashMap<>();
     this.baggage = Baggage.empty();
   }
 
@@ -78,7 +79,7 @@ public class OpenTelemetryTraceController {
     // Store span
     long traceId = DDTraceId.fromHex(span.getSpanContext().getTraceId()).toLong();
     long spanId = DDSpanId.fromHex(span.getSpanContext().getSpanId());
-    this.spans.put(spanId, span);
+    spans.put(spanId, span);
     // Return result
     return new StartSpanResult(spanId, traceId);
   }
@@ -191,7 +192,7 @@ public class OpenTelemetryTraceController {
       if (GlobalTracer.get() instanceof InternalTracer internalTracer) {
           internalTracer.flush();
       }
-      this.spans.clear();
+      spans.clear();
       return new FlushResult(true);
     } catch (Exception e) {
       LOGGER.warn("Failed to flush OTel spans", e);
@@ -238,8 +239,8 @@ public class OpenTelemetryTraceController {
     this.baggage = Baggage.empty();
   }
 
-  private Span getSpan(long spanId) {
-    Span span = this.spans.get(spanId);
+  static Span getSpan(long spanId) {
+    Span span = spans.get(spanId);
     if (span == null) {
       LOGGER.warn("OTel span {} does not exist.", spanId);
     }

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/dto/CreateLoggerArgs.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/dto/CreateLoggerArgs.java
@@ -1,0 +1,11 @@
+package com.datadoghq.trace.opentelemetry.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+public record CreateLoggerArgs(
+    String name,
+    String level,
+    String version,
+    @JsonProperty("schema_url") String schemaUrl,
+    Map<String, String> attributes) {}

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/dto/WriteLogArgs.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/dto/WriteLogArgs.java
@@ -1,0 +1,10 @@
+package com.datadoghq.trace.opentelemetry.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+public record WriteLogArgs(
+    @JsonProperty("logger_name") String loggerName,
+    String level,
+    String message,
+    @JsonProperty("span_id") long spanId) {}


### PR DESCRIPTION
## Motivation

Update weblog to support testing OTel logs support on Java

## Changes

Implemented `/otel/logger` endpoint, using similar approach as `utils/build/docker/python/parametric/apm_test_client/server.py`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
