### PR TITLE
Re-enable test_client_stats for PHP

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -931,9 +931,6 @@ manifest:
   tests/serverless/span_pointers/aws/test_s3_span_pointers.py::Test_MultipartUpload: missing_feature
   tests/serverless/span_pointers/aws/test_s3_span_pointers.py::Test_PutObject: missing_feature
   tests/stats/test_stats.py: v1.19.0
-  tests/stats/test_stats.py::Test_Client_Stats::test_client_stats:
-    - component_version: ">=1.19.0"
-      declaration: bug (APMLP-1311)
   tests/stats/test_stats.py::Test_Client_Stats::test_disable: v1.17.0
   tests/stats/test_stats.py::Test_Client_Stats::test_grpc_status_code: missing_feature (PHP does not support gRPC)
   tests/stats/test_stats.py::Test_Client_Stats::test_obfuscation: missing_feature


### PR DESCRIPTION
I think we fixed it in dd-trace-php - running CI to verify.