### PR TITLE
add option to skip removing android

### DIFF
--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "To prevent reaching docker hub API limits, provide a username and token to login to docker hub"
     required: false
     default: ""
+  remove_android:
+    description: "Run the Android cleanup step (rm -rf /usr/local/lib/android)"
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -37,7 +41,8 @@ runs:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_token }}
 
-    - name: clean-up
+    - name: remove-android
+      if: inputs.remove_android == 'true'
       shell: bash
       run: sudo rm -rf /usr/local/lib/android
 

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -106,6 +106,11 @@ on:
         default: false
         required: false
         type: boolean
+      remove_android:
+        description: "Remove /usr/local/lib/android to free up disk space before pulling images"
+        default: true
+        required: false
+        type: boolean
 
 jobs:
   main:
@@ -162,6 +167,7 @@ jobs:
         scenarios: ${{ inputs.scenarios }}
         dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
         dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+        remove_android: ${{ inputs.remove_android }}
     - name: Build weblog
       id: build
       run: |

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -99,6 +99,11 @@ on:
         default: false
         required: false
         type: boolean
+      remove_android:
+        description: "Remove /usr/local/lib/android to free up disk space before pulling images"
+        default: true
+        required: false
+        type: boolean
       _system_tests_library_target_branch_map:
         description: "If system-tests dev mode, JSON map of library to branch (e.g. {\"java\":\"b1\",\"dotnet\":\"b2\"})"
         default: ''
@@ -288,6 +293,7 @@ jobs:
       _build_lambda_proxy_image: ${{ inputs._build_lambda_proxy_image }}
       _enable_replay_scenarios: ${{ inputs._enable_replay_scenarios }}
       _system_tests_dev_mode: ${{ inputs._system_tests_dev_mode }}
+      remove_android: ${{ inputs.remove_android }}
 
   display_summary:
     name: Report failures


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

I tried implementing an alternative clean up strategy in #6809, but it ended up being more contentious than anticipated. This PR instead simply adds an option to skip the removal instead so that we can experiment with alternative approaches only in dd-trace-js. We can then port those back to system tests once we have gained enough confidence.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Add option to skip removing android.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
