### PR TITLE
Affect LP as owner of implementation of some data pipeline feature

### DIFF
--- a/utils/_features.py
+++ b/utils/_features.py
@@ -57,7 +57,6 @@ class _Owner(Enum):
                                 "nginx-datadog":    "@DataDog/asm-cpp",
                             })
     auto_instrumentation = _OwnerDef("@DataDog/unified-instrumentation-setup")
-    data_pipeline        = _OwnerDef("@DataDog/libdatadog-apm")  # or agent-apm? TODO @ekump
     debugger             = _OwnerDef("@DataDog/debugger", repo_overrides={
                                 "dd-trace-dotnet":  "@DataDog/debugger-dotnet",
                                 "dd-trace-go":      "@DataDog/debugger-go",
@@ -182,7 +181,7 @@ class _Features:
         https://feature-parity.us1.prod.dog/#/?feature=6
         """
 
-        return _mark_test_object(test_object, feature_id=6, owner=_Owner.data_pipeline)
+        return _mark_test_object(test_object, feature_id=6, owner=_Owner.language_platform)
 
     @staticmethod
     def unix_domain_sockets_automatic_detection(test_object):
@@ -190,7 +189,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=7
         """
-        return _mark_test_object(test_object, feature_id=7, owner=_Owner.data_pipeline)
+        return _mark_test_object(test_object, feature_id=7, owner=_Owner.language_platform)
 
     @staticmethod
     def twl_customer_controls_ingestion_dd_trace_sampling_rules(test_object):
@@ -250,7 +249,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=14
         """
-        return _mark_test_object(test_object, feature_id=14, owner=_Owner.data_pipeline)
+        return _mark_test_object(test_object, feature_id=14, owner=_Owner.language_platform)
 
     # @staticmethod
     # def support_ddmeasured(test_object):
@@ -326,7 +325,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=23
         """
-        return _mark_test_object(test_object, feature_id=23, owner=_Owner.data_pipeline)
+        return _mark_test_object(test_object, feature_id=23, owner=_Owner.language_platform)
 
     @staticmethod
     def partial_flush_on_by_default(test_object):
@@ -334,7 +333,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=24
         """
-        return _mark_test_object(test_object, feature_id=24, owner=_Owner.data_pipeline)
+        return _mark_test_object(test_object, feature_id=24, owner=_Owner.language_platform)
 
     @staticmethod
     def automatic_trace_id_injection_into_logs(test_object):
@@ -486,7 +485,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=45
         """
-        return _mark_test_object(test_object, feature_id=45, owner=_Owner.data_pipeline)
+        return _mark_test_object(test_object, feature_id=45, owner=_Owner.language_platform)
 
     # @staticmethod
     # def setting_to_rename_service_by_tag_split_by_tag(test_object):
@@ -554,7 +553,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=53
         """
-        return _mark_test_object(test_object, feature_id=53, owner=_Owner.data_pipeline)
+        return _mark_test_object(test_object, feature_id=53, owner=_Owner.language_platform)
 
     @staticmethod
     def aws_sdk_integration_tags(test_object):
@@ -602,7 +601,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=60
         """
-        return _mark_test_object(test_object, feature_id=60, owner=_Owner.data_pipeline)
+        return _mark_test_object(test_object, feature_id=60, owner=_Owner.language_platform)
 
     @staticmethod
     def creation_and_propagation_of_ddpdm(test_object):
@@ -618,7 +617,7 @@ class _Features:
 
         https://feature-parity.us1.prod.dog/#/?feature=62
         """
-        return _mark_test_object(test_object, feature_id=62, owner=_Owner.data_pipeline)
+        return _mark_test_object(test_object, feature_id=62, owner=_Owner.language_platform)
 
     # @staticmethod
     # def client_side_stats_on_by_default(test_object):


### PR DESCRIPTION
## Motivation

Discussed on slack : data pipeline is owner of the feature iteself, but implemetation on libraries belongs to LP. As system-tests mostly tests implementation, we change the ownership to LP for those features.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
