### PR TITLE
Add llm cost_tags field to share tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3669,6 +3669,7 @@ manifest:
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_sample_rate_0_TS007:  # Modified by easy win activation script
     - declaration: 'missing_feature (FIXME: Undefined behavior according the java tracer core team)'
       component_version: <1.58.2+06122213c8
+  tests/parametric/test_llm_observability/test_llm_observability.py::Test_CostTags: missing_feature (cost_tags not yet supported in Java LLMObs SDK)
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts::test_prompt_annotation: missing_feature (prompt annotation not supported in Java LLMObs SDK)
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts::test_prompt_annotation_default_id: missing_feature (prompt annotation not supported in Java LLMObs SDK)
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts::test_prompt_annotation_in_annotation_context: missing_feature (prompt annotation not supported in Java LLMObs SDK)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2019,6 +2019,7 @@ manifest:
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_sample_rate_0_TS007: missing_feature (nodejs has not implemented stats computation yet)
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_successes_errors_recorded_separately_TS006: missing_feature (nodejs has not implemented stats computation yet)
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_top_level_TS005: missing_feature (nodejs has not implemented stats computation yet)
+  tests/parametric/test_llm_observability/test_llm_observability.py::Test_CostTags: missing_feature (cost_tags not yet supported in Node.js LLMObs SDK)
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement: *ref_5_66_0
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: *ref_5_83_0
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1794,6 +1794,7 @@ manifest:
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_sample_rate_0_TS007: missing_feature (failure 2.8.0)  # Created by easy win activation script
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_successes_errors_recorded_separately_TS006: missing_feature (failure 2.8.0)  # Created by easy win activation script
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_top_level_TS005: missing_feature (failure 2.8.0)  # Created by easy win activation script
+  tests/parametric/test_llm_observability/test_llm_observability.py::Test_CostTags: v4.10.0
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement: v3.14.0
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: v3.15.0
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset: v4.2.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1794,7 +1794,7 @@ manifest:
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_sample_rate_0_TS007: missing_feature (failure 2.8.0)  # Created by easy win activation script
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_successes_errors_recorded_separately_TS006: missing_feature (failure 2.8.0)  # Created by easy win activation script
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_top_level_TS005: missing_feature (failure 2.8.0)  # Created by easy win activation script
-  tests/parametric/test_llm_observability/test_llm_observability.py::Test_CostTags: v4.10.0
+  tests/parametric/test_llm_observability/test_llm_observability.py::Test_CostTags: missing_feature (cost_tags merged in dd-trace-py#17628, not yet in a released version — bump to the version once released)
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement: v3.14.0
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: v3.15.0
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset: v4.2.0

--- a/tests/parametric/test_llm_observability/test_llm_observability.py
+++ b/tests/parametric/test_llm_observability/test_llm_observability.py
@@ -374,8 +374,9 @@ class Test_CostTags:
     def test_annotation_context_cost_tags_not_retained_for_tags_added_later(
         self, test_agent: TestAgentAPI, test_library: APMLibrary
     ):
-        """Regression: annotation_context cost_tags only see tag keys present at span start.
-        Keys added via a later annotate() are not retained — see dd-trace-py #17628.
+        """Known limitation: annotation_context.cost_tags only sees tag keys
+        present at span start. Tags added via a later annotate() on the same span are not
+        retroactively included.
         """
         llmobs_request = LlmObsAnnotationContextRequest(
             cost_tags=["feature"],

--- a/tests/parametric/test_llm_observability/test_llm_observability.py
+++ b/tests/parametric/test_llm_observability/test_llm_observability.py
@@ -277,7 +277,7 @@ def _get_cost_tags(span_event: dict) -> list[str] | None:
     return span_event.get("meta", {}).get("metadata", {}).get("_dd", {}).get("cost_tags")
 
 
-@features.llm_observability_sdk_enablement
+@features.llm_observability_cost_tags
 @scenarios.parametric
 class Test_CostTags:
     """Cost tags propagate user-selected span tags to LLMObs cost/token metrics.
@@ -359,17 +359,18 @@ class Test_CostTags:
         assert _get_cost_tags(span_events[0]) == ["team"]
 
     def test_cost_tags_in_annotation_context(self, test_agent: TestAgentAPI, test_library: APMLibrary):
-        """cost_tags supplied to annotation_context are applied to child spans started within the context."""
+        """cost_tags supplied to annotation_context are applied to every child span started within the context."""
         llmobs_request = LlmObsAnnotationContextRequest(
             tags={"team": "ml", "feature": "chatbot"},
             cost_tags=["team", "feature"],
-            children=[LlmObsSpanRequest(kind="llm")],
+            children=[LlmObsSpanRequest(kind="llm"), LlmObsSpanRequest(kind="llm")],
         )
         test_library.llmobs_trace(llmobs_request)
 
         span_events = test_agent.wait_for_llmobs_requests(num=1)
-        assert len(span_events) == 1
+        assert len(span_events) == 2
         assert _get_cost_tags(span_events[0]) == ["team", "feature"]
+        assert _get_cost_tags(span_events[1]) == ["team", "feature"]
 
     def test_annotation_context_cost_tags_not_retained_for_tags_added_later(
         self, test_agent: TestAgentAPI, test_library: APMLibrary

--- a/tests/parametric/test_llm_observability/test_llm_observability.py
+++ b/tests/parametric/test_llm_observability/test_llm_observability.py
@@ -271,3 +271,123 @@ class Test_Prompts:
         assert prompt["version"] == "1"
         assert prompt["variables"] == {"query": "test query"}
         assert prompt["tags"] == {"foo": "bar"}
+
+
+def _get_cost_tags(span_event: dict) -> list[str] | None:
+    return span_event.get("meta", {}).get("metadata", {}).get("_dd", {}).get("cost_tags")
+
+
+@features.llm_observability_sdk_enablement
+@scenarios.parametric
+class Test_CostTags:
+    """Cost tags propagate user-selected span tags to LLMObs cost/token metrics.
+
+    Storage location is the internal contract `meta.metadata._dd.cost_tags`,
+    consumed by the LLMObs events-updater.
+    """
+
+    def test_cost_tags_annotated_to_llm_span(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+        llmobs_span_request = LlmObsSpanRequest(
+            kind="llm",
+            annotations=[
+                LlmObsAnnotationRequest(
+                    tags={"team": "ml", "feature": "chatbot", "debug_id": "abc"},
+                    cost_tags=["team", "feature"],
+                ),
+            ],
+        )
+        test_library.llmobs_trace(llmobs_span_request)
+
+        span_events = test_agent.wait_for_llmobs_requests(num=1)
+        assert len(span_events) == 1
+        assert _get_cost_tags(span_events[0]) == ["team", "feature"]
+
+    def test_cost_tags_dedupes_across_annotations(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+        llmobs_span_request = LlmObsSpanRequest(
+            kind="llm",
+            annotations=[
+                LlmObsAnnotationRequest(tags={"team": "ml", "feature": "chatbot"}, cost_tags=["team", "feature"]),
+                LlmObsAnnotationRequest(tags={"project": "alpha"}, cost_tags=["feature", "project"]),
+            ],
+        )
+        test_library.llmobs_trace(llmobs_span_request)
+
+        span_events = test_agent.wait_for_llmobs_requests(num=1)
+        assert len(span_events) == 1
+        assert _get_cost_tags(span_events[0]) == ["team", "feature", "project"]
+
+    def test_cost_tags_invalid_entries_are_skipped(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+        """Non-string entries and entries that don't match an existing span tag are silently dropped."""
+        llmobs_span_request = LlmObsSpanRequest(
+            kind="llm",
+            annotations=[
+                LlmObsAnnotationRequest(tags={"team": "ml"}, cost_tags=["team", "missing", 123]),
+            ],
+        )
+        test_library.llmobs_trace(llmobs_span_request)
+
+        span_events = test_agent.wait_for_llmobs_requests(num=1)
+        assert len(span_events) == 1
+        assert _get_cost_tags(span_events[0]) == ["team"]
+
+    def test_cost_tags_empty_list_is_ignored(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+        llmobs_span_request = LlmObsSpanRequest(
+            kind="llm",
+            annotations=[
+                LlmObsAnnotationRequest(tags={"team": "ml"}, cost_tags=[]),
+            ],
+        )
+        test_library.llmobs_trace(llmobs_span_request)
+
+        span_events = test_agent.wait_for_llmobs_requests(num=1)
+        assert len(span_events) == 1
+        assert _get_cost_tags(span_events[0]) is None
+
+    def test_cost_tags_references_existing_span_tags(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+        """A later annotate() can reference tags set by an earlier annotate() on the same span."""
+        llmobs_span_request = LlmObsSpanRequest(
+            kind="llm",
+            annotations=[
+                LlmObsAnnotationRequest(tags={"team": "ml"}),
+                LlmObsAnnotationRequest(cost_tags=["team"]),
+            ],
+        )
+        test_library.llmobs_trace(llmobs_span_request)
+
+        span_events = test_agent.wait_for_llmobs_requests(num=1)
+        assert len(span_events) == 1
+        assert _get_cost_tags(span_events[0]) == ["team"]
+
+    def test_cost_tags_in_annotation_context(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+        """cost_tags supplied to annotation_context are applied to child spans started within the context."""
+        llmobs_request = LlmObsAnnotationContextRequest(
+            tags={"team": "ml", "feature": "chatbot"},
+            cost_tags=["team", "feature"],
+            children=[LlmObsSpanRequest(kind="llm")],
+        )
+        test_library.llmobs_trace(llmobs_request)
+
+        span_events = test_agent.wait_for_llmobs_requests(num=1)
+        assert len(span_events) == 1
+        assert _get_cost_tags(span_events[0]) == ["team", "feature"]
+
+    def test_annotation_context_cost_tags_not_retained_for_tags_added_later(
+        self, test_agent: TestAgentAPI, test_library: APMLibrary
+    ):
+        """Regression: annotation_context cost_tags only see tag keys present at span start.
+        Keys added via a later annotate() are not retained — see dd-trace-py #17628.
+        """
+        llmobs_request = LlmObsAnnotationContextRequest(
+            cost_tags=["feature"],
+            children=[
+                LlmObsSpanRequest(
+                    kind="llm",
+                    annotations=[LlmObsAnnotationRequest(tags={"feature": "chatbot"})],
+                )
+            ],
+        )
+        test_library.llmobs_trace(llmobs_request)
+
+        span_events = test_agent.wait_for_llmobs_requests(num=1)
+        assert len(span_events) == 1
+        assert _get_cost_tags(span_events[0]) is None

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2905,5 +2905,13 @@ class _Features:
         """
         return _mark_test_object(test_object, feature_id=553, owner=_Owner.asm)
 
+    @staticmethod
+    def llm_observability_cost_tags(test_object):
+        """LLM Observability supports cost_tags annotation for propagating user-selected
+        span tags to LLM cost and token metrics.
+
+        https://feature-parity.us1.prod.dog/#/?feature=554
+        """
+        return _mark_test_object(test_object, feature_id=554, owner=_Owner.ml_observability)
 
 features = _Features()

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2914,4 +2914,5 @@ class _Features:
         """
         return _mark_test_object(test_object, feature_id=554, owner=_Owner.ml_observability)
 
+
 features = _Features()

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/LlmObsController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/LlmObsController.java
@@ -159,6 +159,10 @@ public class LlmObsController {
       if (tags != null) {
         span.setTags(tags);
       }
+
+      // TODO: forward `cost_tags` once the Java LLMObs SDK exposes a setCostTags() method
+      // (tracked under the cost_tags feature; see system-tests Test_CostTags). The annotation
+      // payload already carries `cost_tags` from the shared spec for cross-language symmetry.
     }
   }
 

--- a/utils/build/docker/nodejs/parametric/llmobs.js
+++ b/utils/build/docker/nodejs/parametric/llmobs.js
@@ -28,11 +28,12 @@ function addRoutes (app) {
 function createTrace (traceStructure) {
   const type = traceStructure.type;
   if (type === 'annotation_context') {
-    const { prompt, name, tags, children } = traceStructure;
+    const { prompt, name, tags, cost_tags: costTags, children } = traceStructure;
     const options = {};
     if (prompt) options.prompt = normalizePromptArgument(prompt);
     if (name) options.name = name;
     if (tags) options.tags = tags;
+    if (costTags != null) options.costTags = costTags;
     return llmobs.annotationContext(options, () => {
       let exportedSpanCtx;
       if (!Array.isArray(children)) return;
@@ -109,6 +110,7 @@ function applyAnnotations (span, annotations, annotateAfter = false) {
     const metadata = annotation.metadata;
     const metrics = annotation.metrics;
     const tags = annotation.tags;
+    const costTags = annotation.cost_tags;
     const prompt = normalizePromptArgument(annotation.prompt);
 
     const args = [];
@@ -117,7 +119,7 @@ function applyAnnotations (span, annotations, annotateAfter = false) {
       args.push(span);
     }
 
-    args.push({ inputData, outputData, metadata, metrics, tags, prompt });
+    args.push({ inputData, outputData, metadata, metrics, tags, prompt, ...(costTags != null && { costTags }) });
 
     llmobs.annotate(...args);
   }

--- a/utils/build/docker/nodejs/parametric/llmobs.js
+++ b/utils/build/docker/nodejs/parametric/llmobs.js
@@ -119,7 +119,7 @@ function applyAnnotations (span, annotations, annotateAfter = false) {
       args.push(span);
     }
 
-    args.push({ inputData, outputData, metadata, metrics, tags, prompt, ...(costTags != null && { costTags }) });
+    args.push({ inputData, outputData, metadata, metrics, tags, prompt, costTags });
 
     llmobs.annotate(...args);
   }

--- a/utils/build/docker/python/parametric/apm_test_client/llmobs.py
+++ b/utils/build/docker/python/parametric/apm_test_client/llmobs.py
@@ -162,6 +162,11 @@ def apply_annotations(span, annotations: list[LlmObsAnnotationRequest], annotate
             for field_name in annotation.__dataclass_fields__
             if field_name != "explicit_span"
         }
+        # cost_tags was added in dd-trace-py#17628; older releases (e.g. the prod tracer
+        # image) reject the kwarg. Drop it when unset so unrelated annotate-using tests
+        # (Test_Enablement, Test_Prompts, ...) keep working on those versions.
+        if options.get("cost_tags") is None:
+            options.pop("cost_tags", None)
         if annotation.explicit_span or annotate_after:
             options["span"] = span
         LLMObs.annotate(**options)

--- a/utils/build/docker/python/parametric/apm_test_client/llmobs.py
+++ b/utils/build/docker/python/parametric/apm_test_client/llmobs.py
@@ -162,10 +162,6 @@ def apply_annotations(span, annotations: list[LlmObsAnnotationRequest], annotate
             for field_name in annotation.__dataclass_fields__
             if field_name != "explicit_span"
         }
-        # cost_tags was added later — only forward when set so older SDK versions
-        # without the kwarg don't break unrelated tests in the same weblog.
-        if options.get("cost_tags") is None:
-            options.pop("cost_tags", None)
         if annotation.explicit_span or annotate_after:
             options["span"] = span
         LLMObs.annotate(**options)

--- a/utils/build/docker/python/parametric/apm_test_client/llmobs.py
+++ b/utils/build/docker/python/parametric/apm_test_client/llmobs.py
@@ -49,6 +49,7 @@ class LlmObsAnnotationRequest:
     metadata: dict | None = None
     metrics: dict | None = None
     tags: dict | None = None
+    cost_tags: list | None = None
     prompt: dict | None = None
 
     explicit_span: bool | None = False
@@ -59,6 +60,7 @@ class LlmObsAnnotationContextRequest:
     prompt: dict | None = None
     name: str | None = None
     tags: dict | None = None
+    cost_tags: list | None = None
 
     children: list[LlmObsAnnotationContextRequest | LlmObsSpanRequest] | None = None
     type: Literal["annotation_context"] = "annotation_context"
@@ -84,6 +86,8 @@ def create_trace(trace_structure_request: SpanRequest | LlmObsAnnotationContextR
             options["name"] = trace_structure_request.name
         if trace_structure_request.tags:
             options["tags"] = trace_structure_request.tags
+        if trace_structure_request.cost_tags is not None:
+            options["cost_tags"] = trace_structure_request.cost_tags
 
         with LLMObs.annotation_context(**options):
             children = trace_structure_request.children
@@ -158,6 +162,10 @@ def apply_annotations(span, annotations: list[LlmObsAnnotationRequest], annotate
             for field_name in annotation.__dataclass_fields__
             if field_name != "explicit_span"
         }
+        # cost_tags was added later — only forward when set so older SDK versions
+        # without the kwarg don't break unrelated tests in the same weblog.
+        if options.get("cost_tags") is None:
+            options.pop("cost_tags", None)
         if annotation.explicit_span or annotate_after:
             options["span"] = span
         LLMObs.annotate(**options)

--- a/utils/docker_fixtures/spec/llm_observability.py
+++ b/utils/docker_fixtures/spec/llm_observability.py
@@ -40,6 +40,7 @@ class LlmObsAnnotationRequest:
     metadata: dict | None = None
     metrics: dict | None = None
     tags: dict | None = None
+    cost_tags: list | None = None
     prompt: dict | None = None
 
     explicit_span: bool | None = False
@@ -50,6 +51,7 @@ class LlmObsAnnotationContextRequest:
     prompt: dict | None = None
     name: str | None = None
     tags: dict | None = None
+    cost_tags: list | None = None
 
     children: list[LlmObsAnnotationContextRequest | LlmObsSpanRequest] | None = None
     type: Literal["annotation_context"] = "annotation_context"


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Add system tests for parameter `cost_tags`. 
- dd-trace-py: [PR](https://github.com/DataDog/dd-trace-py/pull/17628) is merged, likely included in v4.9
- dd-trace-js: [PR](https://github.com/DataDog/dd-trace-js/pull/8175) is open, need to merge this first to pass the tests.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
