### PR TITLE
Miscellaneous OTLP fixes on Java

### DIFF
--- a/tests/parametric/test_otel_logs.py
+++ b/tests/parametric/test_otel_logs.py
@@ -153,7 +153,7 @@ class Test_FR03_Resource_Attributes:
 
         assert attrs.get("service.name") == "service"
         assert attrs.get("service.version") == "2.0"
-        assert attrs.get("deployment.environment") == "otelenv"
+        assert attrs.get("deployment.environment") == "otelenv" or attrs.get("deployment.environment.name") == "otelenv"
 
     @pytest.mark.parametrize(
         "library_env",
@@ -180,7 +180,7 @@ class Test_FR03_Resource_Attributes:
 
         assert attrs.get("service.name") == "ddservice"
         assert attrs.get("service.version") == "ddver"
-        assert attrs.get("deployment.environment") == "ddenv"
+        assert attrs.get("deployment.environment") == "ddenv" or attrs.get("deployment.environment.name") == "ddenv"
 
 
 @features.otel_logs_enabled
@@ -553,8 +553,11 @@ class Test_FR09_Log_Injection:
         # Verify service/env/version are ONLY in resource attributes
         resource_attrs = find_attributes(resource)
         assert resource_attrs.get("service.name") == "testservice"
-        assert resource_attrs.get("deployment.environment") == "testenv"
         assert resource_attrs.get("service.version") == "1.0.0"
+        assert (
+            resource_attrs.get("deployment.environment") == "testenv"
+            or resource_attrs.get("deployment.environment.name") == "testenv"
+        )
 
         # Verify no duplication in log record attributes
         log_attrs = find_attributes(log_record)
@@ -594,8 +597,11 @@ class Test_FR09_Log_Injection:
         # Verify service/env/version are ONLY in resource attributes
         resource_attrs = find_attributes(resource)
         assert resource_attrs.get("service.name") == "testservice"
-        assert resource_attrs.get("deployment.environment") == "testenv"
         assert resource_attrs.get("service.version") == "1.0.0"
+        assert (
+            resource_attrs.get("deployment.environment") == "testenv"
+            or resource_attrs.get("deployment.environment.name") == "testenv"
+        )
 
 
 @features.otel_logs_enabled

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryLogsController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryLogsController.java
@@ -4,6 +4,8 @@ import static com.datadoghq.ApmTestClient.LOGGER;
 
 import com.datadoghq.trace.opentelemetry.dto.*;
 import com.datadoghq.trace.opentracing.controller.OpenTracingController;
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.api.internal.InternalTracer;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.logs.*;
 import io.opentelemetry.api.trace.Span;
@@ -79,7 +81,10 @@ public class OpenTelemetryLogsController {
   public FlushResult flushLogs(@RequestBody FlushArgs args) {
     LOGGER.info("Flushing OTel logs: {}", args);
     try {
-      // TODO: call internal hook to flush logs
+      if (GlobalTracer.get() instanceof InternalTracer internalTracer) {
+        //noinspection JavaReflectionMemberAccess new method not yet in a release
+        InternalTracer.class.getMethod("flushLogs").invoke(internalTracer);
+      }
       return new FlushResult(true);
     } catch (Exception e) {
       LOGGER.warn("Failed to flush OTel logs", e);

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryLogsController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryLogsController.java
@@ -1,13 +1,12 @@
 package com.datadoghq.trace.opentelemetry.controller;
 
 import static com.datadoghq.ApmTestClient.LOGGER;
-import static com.datadoghq.trace.opentelemetry.controller.OpenTelemetryTraceController.getSpan;
 
 import com.datadoghq.trace.opentelemetry.dto.*;
+import com.datadoghq.trace.opentracing.controller.OpenTracingController;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.logs.*;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Scope;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,13 +45,19 @@ public class OpenTelemetryLogsController {
       throw new IllegalStateException(
           "Logger " + loggerName + " not found in registered loggers " + loggers.keySet());
     }
-    Scope scope = null;
+    AutoCloseable scope = null;
     if (args.spanId() != 0) {
-      Span span = getSpan(args.spanId());
-      if (span == null) {
-        throw new IllegalStateException("Span not found for span_id: " + args.spanId());
+      Span span = OpenTelemetryTraceController.getSpan(args.spanId());
+      if (span != null) {
+        scope = span.makeCurrent();
+      } else {
+        io.opentracing.Span otSpan = OpenTracingController.getSpan(args.spanId());
+        if (otSpan != null) {
+          scope = io.opentracing.util.GlobalTracer.get().activateSpan(otSpan);
+        } else {
+          throw new IllegalStateException("Span not found for span_id: " + args.spanId());
+        }
       }
-      scope = span.makeCurrent();
     }
     try {
       logger.logRecordBuilder()
@@ -61,7 +66,9 @@ public class OpenTelemetryLogsController {
           .emit();
     } finally {
       if (scope != null) {
-        scope.close();
+        try {
+          scope.close();
+        } catch (Exception ignore) {}
       }
     }
   }

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryLogsController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryLogsController.java
@@ -60,8 +60,10 @@ public class OpenTelemetryLogsController {
       }
     }
     try {
+      Severity severity = Severity.valueOf(args.level().toUpperCase(Locale.ROOT));
       logger.logRecordBuilder()
-          .setSeverity(Severity.valueOf(args.level().toUpperCase(Locale.ROOT)))
+          .setSeverity(severity)
+          .setSeverityText(severity.name())
           .setBody(args.message())
           .emit();
     } finally {

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryMetricsController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryMetricsController.java
@@ -3,6 +3,8 @@ package com.datadoghq.trace.opentelemetry.controller;
 import static com.datadoghq.ApmTestClient.LOGGER;
 
 import com.datadoghq.trace.opentelemetry.dto.*;
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.api.internal.InternalTracer;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -211,7 +213,9 @@ public class OpenTelemetryMetricsController {
   public FlushResult forceFlush(@RequestBody FlushArgs args) {
     LOGGER.info("Flushing OTel metrics: {}", args);
     try {
-      // TODO: call internal hook to flush metrics
+      if (GlobalTracer.get() instanceof InternalTracer internalTracer) {
+        internalTracer.flushMetrics();
+      }
       return new FlushResult(true);
     } catch (Exception e) {
       LOGGER.warn("Failed to flush OTel metrics", e);

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryTraceController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryTraceController.java
@@ -30,6 +30,7 @@ import java.util.Map;
 @RestController
 @RequestMapping(value = "/trace/otel")
 public class OpenTelemetryTraceController {
+  /** Created spans, indexed by their identifiers .*/
   private static final Map<Long, Span> spans = new ConcurrentHashMap<>();
 
   private final Tracer tracer;
@@ -239,7 +240,7 @@ public class OpenTelemetryTraceController {
     this.baggage = Baggage.empty();
   }
 
-  static Span getSpan(long spanId) {
+  public static Span getSpan(long spanId) {
     Span span = spans.get(spanId);
     if (span == null) {
       LOGGER.warn("OTel span {} does not exist.", spanId);

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentracing/controller/OpenTracingController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentracing/controller/OpenTracingController.java
@@ -21,6 +21,7 @@ import io.opentracing.propagation.TextMap;
 import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 import jakarta.annotation.PreDestroy;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,15 +38,16 @@ import java.util.Map;
 @RestController
 @RequestMapping(value = "/trace/span")
 public class OpenTracingController implements Closeable {
-  private final Tracer tracer;
   /** Created spans, indexed by their identifiers .*/
-  private final Map<Long, Span> spans;
+  private static final Map<Long, Span> spans = new ConcurrentHashMap<>();
+
+  private final Tracer tracer;
+
   /** The extracted span contexts, indexed by span identifier. */
   private final Map<Long, SpanContext> extractedSpanContexts;
 
   public OpenTracingController() {
     this.tracer = GlobalTracer.get();
-    this.spans = new HashMap<>();
     this.extractedSpanContexts = new HashMap<>();
   }
 
@@ -79,7 +81,7 @@ public class OpenTracingController implements Closeable {
       // Store span
       long spanId = DDSpanId.from(span.context().toSpanId());
       long traceId = DDTraceId.from(span.context().toTraceId()).toLong();
-      this.spans.put(spanId, span);
+      spans.put(spanId, span);
       // Complete request
       return new StartSpanResult(spanId, traceId);
     } catch (Throwable t) {
@@ -198,7 +200,7 @@ public class OpenTracingController implements Closeable {
       if (datadog.trace.api.GlobalTracer.get() instanceof InternalTracer internalTracer) {
           internalTracer.flush();
       }
-      this.spans.clear();
+      spans.clear();
       this.extractedSpanContexts.clear();
     } catch (Throwable t) {
       LOGGER.error("Uncaught throwable", t);
@@ -260,8 +262,8 @@ public class OpenTracingController implements Closeable {
     }
   }
 
-  private Span getSpan(long spanId) {
-    Span span = this.spans.get(spanId);
+  public static Span getSpan(long spanId) {
+    Span span = spans.get(spanId);
     if (span == null) {
       LOGGER.warn("OT span {} does not exist.", spanId);
     }


### PR DESCRIPTION
## Changes

* Update OTLP logs test to check for either `deployment.environment` (Otel semantic convention pre-1.27) or `deployment.environment.name` (Otel semantic convention post-1.27)
* Support activating either OpenTelemetry or OpenTracing spans when testing OTLP logs on Java
* Set both severity and severity text when testing OTLP logs on Java
* Flush OpenTelemetry logs on request
* Flush OpenTelemetry metrics on request

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
