### PR TITLE
Improve validator failure messages for observed interface data

### DIFF
--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -147,8 +147,9 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
 
         If no payload satisfies validator(), then validate_one will fail
         """
-
+        n_iters = 0
         for data in self.get_data(path_filters=path_filters):
+            n_iters += 1
             try:
                 if validator(data) is True:
                     return
@@ -163,7 +164,9 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
 
                 raise
 
-        raise ValueError(f"No data has been observed on {path_filters}")
+        if n_iters:
+            raise ValueError(f"{n_iters} observed on path filter {path_filters} but none matched the validator")
+        raise ValueError(f"No data observed on path filter {path_filters}")
 
     def validate_all(
         self,


### PR DESCRIPTION
## Motivation

The current failure message when no message passes the validator is misleading, suggesting there was no data at all.

## Changes

Use different error messages when there is no data vs when no data passes validation.


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
