### PR TITLE
iast: fix test_secure failure when run in isolation

### DIFF
--- a/tests/appsec/iast/utils.py
+++ b/tests/appsec/iast/utils.py
@@ -124,10 +124,9 @@ class BaseSinkTestWithoutTelemetry:
     def expected_evidence(self) -> str | None:
         return _get_expectation(self.evidence_map)
 
-    def setup_insecure(self) -> None:
+    def _setup_insecure_request(self) -> None:
         # optimize by attaching requests to the class object, to avoid calling it several times. We can't attach them
         # to self, and we need to attach the request on class object, as there are one class instance by test case
-
         if not hasattr(self.__class__, "insecure_request"):
             assert self.insecure_endpoint is not None, f"{self}.insecure_endpoint must not be None"
 
@@ -140,6 +139,9 @@ class BaseSinkTestWithoutTelemetry:
             )
 
         self.insecure_request = self.__class__.insecure_request
+
+    def setup_insecure(self) -> None:
+        self._setup_insecure_request()
 
     def test_insecure(self) -> None:
         assert_iast_vulnerability(
@@ -157,9 +159,12 @@ class BaseSinkTestWithoutTelemetry:
         self.test_insecure()
 
     def setup_secure(self) -> None:
+        # test_secure verifies the insecure endpoint IS vulnerable before asserting the secure one isn't,
+        # to avoid a false PASS from tracers that don't implement the detection at all
+        self._setup_insecure_request()
+
         # optimize by attaching requests to the class object, to avoid calling it several times. We can't attach them
         # to self, and we need to attach the request on class object, as there are one class instance by test case
-
         if not hasattr(self.__class__, "secure_request"):
             assert self.secure_endpoint is not None, f"Please set {self}.secure_endpoint"
             assert isinstance(self.secure_endpoint, str), f"Please set {self}.secure_endpoint"
@@ -384,7 +389,7 @@ def get_hardcoded_vulnerabilities(vulnerability_type: str, request: HttpResponse
 
 class BaseSinkTest(BaseSinkTestWithoutTelemetry):
     def setup_telemetry_metric_instrumented_sink(self) -> None:
-        self.setup_insecure()
+        self._setup_insecure_request()
 
     def test_telemetry_metric_instrumented_sink(self) -> None:
         self.check_test_insecure()
@@ -415,7 +420,7 @@ class BaseSinkTest(BaseSinkTestWithoutTelemetry):
             assert p[1] >= 1
 
     def setup_telemetry_metric_executed_sink(self) -> None:
-        self.setup_insecure()
+        self._setup_insecure_request()
 
     def test_telemetry_metric_executed_sink(self) -> None:
         self.check_test_insecure()


### PR DESCRIPTION


## Motivation

Running `test_secure` tests, and some related tests, in IAST, if run in isolation, always fail. They rely on asserting data that is produced by setup phase of `test_insecure`.

## Changes

Extract insecure request setup into _setup_insecure_request() and call it from setup_secure() (and setup_telemetry_metric_* setups), so that self.insecure_request is available even when test_secure runs without test_insecure having run first. test_secure requires the insecure endpoint to be vulnerable before asserting the secure one is safe, to avoid a false PASS from tracers that don't implement the detection.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
