### PR TITLE
reduce build noise by capturing command logs

### DIFF
--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -112,6 +112,29 @@ default-weblog() {
     echo -n "${!var}"
 }
 
+run_build_command() {
+    local log_file
+    local exit_code
+    log_file=$(mktemp)
+
+    echo "Running command: $*"
+    echo "Build log file: ${log_file}"
+
+    set +e
+    "$@" >"${log_file}" 2>&1
+    exit_code=$?
+    set -e
+
+    if [ "${exit_code}" -eq 0 ]; then
+        rm -f "${log_file}"
+        return 0
+    fi
+    echo "Build command failed: $*" >&2
+    cat "${log_file}" >&2
+    rm -f "${log_file}"
+    return "${exit_code}"
+}
+
 build() {
     CACHE_TO=
     CACHE_FROM=
@@ -176,16 +199,16 @@ build() {
                     fi
                 fi
                 source venv/bin/activate
-                python -m pip install --upgrade pip setuptools==75.8.0
+                run_build_command python -m pip install --upgrade pip setuptools==75.8.0
             fi
-            python -m pip install -e .
+            run_build_command python -m pip install -e .
             if [[ -d "venv/" ]]; then
                 cp requirements.txt venv/requirements.txt
             fi
 
 
         elif [[ $IMAGE_NAME == runner ]] && [[ $DOCKER_MODE == 1 ]]; then
-            docker buildx build \
+            run_build_command docker buildx build \
                 --build-arg BUILDKIT_INLINE_CACHE=1 \
                 --load \
                 --progress=plain \
@@ -195,7 +218,7 @@ build() {
                 .
 
         elif [[ $IMAGE_NAME == proxy ]]; then
-            docker buildx build \
+            run_build_command docker buildx build \
                 --build-arg BUILDKIT_INLINE_CACHE=1 \
                 --load \
                 --progress=plain \
@@ -263,7 +286,7 @@ build() {
                     esac
 
                     echo "Using Python version: $PYTHON_VERSION"
-                    docker run ${DOCKER_PLATFORM_ARGS} -v ./binaries/:/app -w /app ghcr.io/datadog/dd-trace-py/testrunner bash -c "pyenv global $PYTHON_VERSION; pip wheel --no-deps -w . /app/dd-trace-py"
+                    run_build_command docker run ${DOCKER_PLATFORM_ARGS} -v ./binaries/:/app -w /app ghcr.io/datadog/dd-trace-py/testrunner bash -c "pyenv global $PYTHON_VERSION; pip wheel --no-deps -w . /app/dd-trace-py"
                 fi
 
                 DOCKERFILE=utils/build/docker/${TEST_LIBRARY}/${WEBLOG_VARIANT}.Dockerfile
@@ -280,7 +303,7 @@ build() {
                     GITHUB_TOKEN_SECRET_ARG="--secret id=github_token,src=$GITHUB_TOKEN_FILE"
                 fi
 
-                docker buildx build \
+                run_build_command docker buildx build \
                     --build-arg BUILDKIT_INLINE_CACHE=1 \
                     --load \
                     --progress=plain \
@@ -297,7 +320,7 @@ build() {
 
                 if test -f "binaries/waf_rule_set.json"; then
 
-                    docker buildx build \
+                    run_build_command docker buildx build \
                         --build-arg BUILDKIT_INLINE_CACHE=1 \
                         --load \
                         --progress=plain \
@@ -314,7 +337,7 @@ build() {
                 fi
             fi
         elif [[ $IMAGE_NAME == lambda-proxy ]]; then
-            docker buildx build \
+            run_build_command docker buildx build \
                 --build-arg BUILDKIT_INLINE_CACHE=1 \
                 --load \
                 --progress=plain \


### PR DESCRIPTION


## Motivation

`./build.sh` is too verbose on the happy path, both in CI and locally. This is inefficient for coding agents, that have to shift through too many useless tokens for any task involving build.sh (most of them). Output build command logs only on failures.

## Changes

Wrap docker build/run and pip install commands in a helper that writes output to a temp file and only prints logs when the command fails, while still showing the command and log path up front. After this PR:

```
❯ ./build.sh
== Run build script (attempt 1 on 1) with timeout 600s ==
==================================
build images for system tests

TEST_LIBRARY:      nodejs
WEBLOG_VARIANT:    express4
BUILD_IMAGES:      weblog,runner
EXTRA_DOCKER_ARGS:

-----------------------
Build weblog
Running command: docker buildx build --build-arg BUILDKIT_INLINE_CACHE=1 --load --progress=plain --platform linux/amd64 -f utils/build/docker/nodejs/express4.Dockerfile --label system-tests-library=nodejs --label system-tests-weblog-variant=express4 -t system_tests/weblog .
Build log file: /tmp/tmp.YMxEQLRJgk
-----------------------
Build runner
Running command: python -m pip install --upgrade pip setuptools==75.8.0
Build log file: /tmp/tmp.hE4UJ6R91g
Running command: python -m pip install -e .
Build log file: /tmp/tmp.FXr1YAlZeu
```

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
