### PR TITLE
Disable stats computation in sampling test

### DIFF
--- a/tests/parametric/test_span_sampling.py
+++ b/tests/parametric/test_span_sampling.py
@@ -838,6 +838,7 @@ class Test_Span_Sampling:
                 "DD_TRACE_PROPAGATION_STYLE": "datadog",
                 "DD_SPAN_SAMPLING_RULES": json.dumps([{"name": "web.request", "sample_rate": 0.0}]),
                 "DD_TRACE_SAMPLING_RULES": json.dumps([{"name": "web.request", "sample_rate": 0.0}]),
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",  # Disable stats computation to send P0s
             }
         ],
     )
@@ -876,9 +877,7 @@ class Test_Span_Sampling:
 
         test_library.dd_flush()
 
-        tracer_sends_p0 = context.library.name != "java" or context.library.version <= "1.54"
-
-        traces = test_agent.wait_for_num_traces(2 if tracer_sends_p0 else 1)
+        traces = test_agent.wait_for_num_traces(2)
 
         case1 = find_span_in_traces(traces, s1.trace_id, s1.span_id)
         # Assert the RUM origin is set
@@ -893,16 +892,15 @@ class Test_Span_Sampling:
         assert SINGLE_SPAN_SAMPLING_RATE not in case1["metrics"]
         assert SINGLE_SPAN_SAMPLING_MAX_PER_SEC not in case1["metrics"]
 
-        if tracer_sends_p0:
-            case2 = find_span_in_traces(traces, s2.trace_id, s2.span_id)
-            # Assert the RUM origin is set
-            assert case2["meta"]["_dd.origin"] == "rum"
-            # Assert the propagated sampling priority is unaffected
-            assert case2["metrics"].get(SAMPLING_PRIORITY_KEY) == 0
-            # Assert that there is no trace sampling happening
-            assert "_dd.p.dm" not in case2["meta"]
-            assert "_dd.rule_psr" not in case2["meta"]
-            # Assert that there is no single span sampling happening
-            assert SINGLE_SPAN_SAMPLING_MECHANISM not in case1["metrics"]
-            assert SINGLE_SPAN_SAMPLING_RATE not in case1["metrics"]
-            assert SINGLE_SPAN_SAMPLING_MAX_PER_SEC not in case1["metrics"]
+        case2 = find_span_in_traces(traces, s2.trace_id, s2.span_id)
+        # Assert the RUM origin is set
+        assert case2["meta"]["_dd.origin"] == "rum"
+        # Assert the propagated sampling priority is unaffected
+        assert case2["metrics"].get(SAMPLING_PRIORITY_KEY) == 0
+        # Assert that there is no trace sampling happening
+        assert "_dd.p.dm" not in case2["meta"]
+        assert "_dd.rule_psr" not in case2["meta"]
+        # Assert that there is no single span sampling happening
+        assert SINGLE_SPAN_SAMPLING_MECHANISM not in case1["metrics"]
+        assert SINGLE_SPAN_SAMPLING_RATE not in case1["metrics"]
+        assert SINGLE_SPAN_SAMPLING_MAX_PER_SEC not in case1["metrics"]


### PR DESCRIPTION
## Motivation

Sampling tests matching on output spans break when CSS is enabled because P0 spans are no longer sent. It makes more sense to disabled it for affected tests since CSS is going to be enabled by default in most tracers.

## Changes

Disable stats computation in sampling test

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
