### PR TITLE
Change formatter script reference in runbook.md

### DIFF
--- a/docs/edit/runbook.md
+++ b/docs/edit/runbook.md
@@ -23,7 +23,7 @@ The impact is that these **configs are not visible** in Metabase, REDAPL, or any
 1. Check the test failure to see exactly which configs are missing.
 2. Add config normalization rules [here](https://github.com/DataDog/dd-go/tree/prod/trace/apps/tracer-telemetry-intake/telemetry-payload/static/) following the existing pattern. Note that the PR should be made against the `prod` (default) branch.
    1. This can be merged with any review from [@apm-sdk](https://github.com/orgs/DataDog/teams/apm-sdk).
-   2. Bonus Points: Run the auto-formatter [_format.py](https://github.com/DataDog/dd-go/blob/prod/trace/apps/tracer-telemetry-intake/telemetry-payload/static/_format.py) from the `dd-go` root via `python ./trace/apps/tracer-telemetry-intake/telemetry-payload/static/_format.py`
+   2. Bonus Points: Run the auto-formatter [_format_json.py](https://github.com/DataDog/dd-go/blob/prod/trace/apps/tracer-telemetry-intake/_format_json.py) from the `dd-go` root via `python ./trace/apps/tracer-telemetry-intake/_format_json.py`
 3. After merging, update system-tests by running [update.sh](/utils/telemetry/intake/update.sh)
    1. This can be run from the root by running `./utils/telemetry/intake/update.sh`
       1. If this fails, try re-running with `USE_GIT_SSH=1` to force a `git@github.com:` URL


### PR DESCRIPTION
Updated the auto-formatter script reference in the runbook.

## Motivation

The link to format script is outdated.

## Changes

Updated GH url and the cmd to match current file path.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
