### PR TITLE
[ruby] Activate API10 easy wins for RASP trace tagging tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -284,7 +284,10 @@ manifest:
   tests/appsec/iast/test_sampling_by_route_method_count.py::TestSamplingByRouteMethodCount: missing_feature
   tests/appsec/iast/test_security_controls.py::TestSecurityControls: missing_feature
   tests/appsec/iast/test_vulnerability_schema.py::TestIastVulnerabilitySchema: v2.22.1-dev
-  tests/appsec/rasp/test_api10.py::Test_API10_all: missing_feature
+  tests/appsec/rasp/test_api10.py::Test_API10_all:
+    - weblog_declaration:
+        "*": v2.29.0
+        "graphql23": irrelevant
   tests/appsec/rasp/test_api10.py::Test_API10_downstream_request_tag:
     - weblog_declaration:
         "*": v2.27.0-dev
@@ -301,7 +304,10 @@ manifest:
     - weblog_declaration:
         "*": v2.29.0-dev
         "graphql23": irrelevant
-  tests/appsec/rasp/test_api10.py::Test_API10_request_body: missing_feature
+  tests/appsec/rasp/test_api10.py::Test_API10_request_body:
+    - weblog_declaration:
+        "*": v2.29.0
+        "graphql23": irrelevant
   tests/appsec/rasp/test_api10.py::Test_API10_request_headers:
     - weblog_declaration:
         "*": v2.27.0-dev
@@ -310,7 +316,10 @@ manifest:
     - weblog_declaration:
         "*": v2.27.0-dev
         "graphql23": irrelevant
-  tests/appsec/rasp/test_api10.py::Test_API10_response_body: missing_feature
+  tests/appsec/rasp/test_api10.py::Test_API10_response_body:
+    - weblog_declaration:
+        "*": v2.29.0
+        "graphql23": irrelevant
   tests/appsec/rasp/test_api10.py::Test_API10_response_headers:
     - weblog_declaration:
         "*": v2.27.0-dev


### PR DESCRIPTION
## Summary
- Activate 3 API10 RASP trace tagging tests that pass across all 12 Ruby weblog variants in nightly runs
- `Test_API10_all`, `Test_API10_request_body`, `Test_API10_response_body` — changed from `missing_feature` to `v2.29.0`

## Tests activated
- `tests/appsec/rasp/test_api10.py::Test_API10_all`
- `tests/appsec/rasp/test_api10.py::Test_API10_request_body`
- `tests/appsec/rasp/test_api10.py::Test_API10_response_body`

## Evidence
- Nightly run: https://github.com/DataDog/system-tests-dashboard/actions/runs/25357184651

## Test plan
- [ ] CI passes on all Ruby weblog variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)