### PR TITLE
[ruby] Activate RASP SQLI and SSRF telemetry easy wins

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -376,7 +376,10 @@ manifest:
         sinatra32: irrelevant
         sinatra41: irrelevant
         uds-sinatra: irrelevant
-  tests/appsec/rasp/test_sqli.py::Test_Sqli_Rules_Version: missing_feature (relies on Telemetry V2)
+  tests/appsec/rasp/test_sqli.py::Test_Sqli_Rules_Version:
+    - weblog_declaration:
+        "*": v2.29.0
+        "graphql23": irrelevant
   tests/appsec/rasp/test_sqli.py::Test_Sqli_StackTrace:
     - weblog_declaration:
         "*": v2.14.0
@@ -405,19 +408,28 @@ manifest:
         sinatra32: irrelevant
         sinatra41: irrelevant
         uds-sinatra: irrelevant
-  tests/appsec/rasp/test_sqli.py::Test_Sqli_Waf_Version: missing_feature (relies on Telemetry V2)
+  tests/appsec/rasp/test_sqli.py::Test_Sqli_Waf_Version:
+    - weblog_declaration:
+        "*": v2.29.0
+        "graphql23": irrelevant
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_BodyJson: v2.14.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_BodyUrlEncoded: v2.14.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_BodyXml: irrelevant  # xml body not natively supported
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Capability: v2.15.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Mandatory_SpanTags: v2.14.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Optional_SpanTags: v2.14.0
-  tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Rules_Version: missing_feature  # requires Telemetry V2
+  tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Rules_Version:
+    - weblog_declaration:
+        "*": v2.29.0
+        "graphql23": irrelevant
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_StackTrace: v2.14.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Telemetry: v2.14.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Telemetry_V2: missing_feature
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_UrlQuery: v2.14.0
-  tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: missing_feature  # requires Telemetry V2
+  tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version:
+    - weblog_declaration:
+        "*": v2.29.0
+        "graphql23": irrelevant
   tests/appsec/smoke_tests/test_apm_standalone.py: v2.30.0
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_lfi_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_shi_smoke: missing_feature


### PR DESCRIPTION
## Summary
- Activate 4 RASP easy wins for Ruby: `Test_Sqli_Rules_Version`, `Test_Sqli_Waf_Version`, `Test_Ssrf_Rules_Version`, `Test_Ssrf_Waf_Version`
- These tests check `waf.init` telemetry metrics (`event_rules_version` and `waf_version` tags)
- Feature was added in dd-trace-rb v2.29.0 (commit 756ca80c40 "Add reporting of waf.init telemetry")
- `graphql23` variant marked as irrelevant (not applicable to RASP tests)

Nightly run: https://github.com/DataDog/system-tests-dashboard/actions/runs/25416113363

## Test plan
- [ ] CI passes on all Ruby weblog variants
- [ ] Verify the 4 activated tests pass in the DEFAULT, APPSEC_RASP, and APPSEC_STANDALONE_RASP scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)