### PR TITLE
make pulling images faster by removing files more efficiently (inline)

### DIFF
--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -22,6 +22,48 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Free Disk Space
+      shell: bash
+      run: |
+        arch="$(uname -m)"
+        case "${arch}" in
+          x86_64|amd64) asset="x86_64-unknown-linux-gnu-rmz" ;;
+          aarch64|arm64) asset="aarch64-unknown-linux-gnu-rmz" ;;
+          *) echo "Unsupported arch: ${arch}"; exit 1 ;;
+        esac
+        tmpfile=$(mktemp)
+        curl -fsSL -o "${tmpfile}" "https://github.com/SUPERCILEX/fuc/releases/download/3.1.1/${asset}"
+        sudo install -m 0755 "${tmpfile}" /usr/local/bin/rmz
+        rm -f "${tmpfile}"
+        free_mb() { df -B1 / | awk 'NR==2 {printf "%.2f", $4/1024/1024}'; }
+        total_recovered=0
+        paths=(
+          /usr/share/dotnet          # .NET runtime
+          /usr/share/doc/dotnet-*    # .NET documentation
+          /opt/ghc                   # GHC (Haskell compiler)
+          /usr/local/.ghcup          # GHCup (Haskell toolchain manager)
+          /opt/cabal                 # Cabal (Haskell build tool)
+          /home/runner/.ghcup        # GHCup user data
+          /home/runner/.cabal        # Cabal user data
+          /usr/share/swift           # Swift toolchain
+          /usr/local/share/chromium  # Chromium browser
+          /usr/share/az*             # Azure CLI
+        )
+        for path in "${paths[@]}"; do
+          [ -e "${path}" ] || continue
+          echo "Removing ${path}"
+          before=$(free_mb)
+          ts_before=$(date +%s)
+          sudo rmz "${path}" || true
+          after=$(free_mb)
+          elapsed=$(( $(date +%s) - ts_before ))
+          freed=$(awk "BEGIN {printf \"%.2f\", ${after} - ${before}}")
+          echo "FreeUp Space: ${freed} MB"
+          echo "Time Elapsed: ${elapsed} seconds"
+          total_recovered=$(awk "BEGIN {printf \"%.2f\", ${total_recovered} + ${freed}}")
+        done
+        echo "Total Recovered Space: ${total_recovered} MB"
+
     - name: Get image list
       shell: bash
       run: |
@@ -37,10 +79,6 @@ runs:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_token }}
 
-    - name: clean-up
-      shell: bash
-      run: sudo rm -rf /usr/local/lib/android
-
 #retry
     - name: Pull
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
@@ -50,7 +88,3 @@ runs:
         timeout_minutes: 15
         retry_wait_seconds: 10
         max_attempts: 3
-
-    - name: Disk space usage
-      shell: bash
-      run: df -h

--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -27,14 +27,21 @@ runs:
       run: |
         arch="$(uname -m)"
         case "${arch}" in
-          x86_64|amd64) asset="x86_64-unknown-linux-gnu-rmz" ;;
-          aarch64|arm64) asset="aarch64-unknown-linux-gnu-rmz" ;;
+          x86_64|amd64)
+            asset="x86_64-unknown-linux-gnu-rmz"
+            checksum="9017131f24a6a619568316d3cf1aabbf4fb8297d8082b11fd2b6817436876a3b"
+            ;;
+          aarch64|arm64)
+            asset="aarch64-unknown-linux-gnu-rmz"
+            checksum="1ac8e83a0242938b10bd6a37ebd1b96d92896f84547aead32f3608c3e5ff733d"
+            ;;
           *) echo "Unsupported arch: ${arch}"; exit 1 ;;
         esac
         # rmz deletes files in parallel using multiple threads, making it significantly
         # faster than rm for large directories.
         tmpfile=$(mktemp)
         curl -fsSL -o "${tmpfile}" "https://github.com/SUPERCILEX/fuc/releases/download/3.1.1/${asset}"
+        echo "${checksum}  ${tmpfile}" | sha256sum -c
         sudo install -m 0755 "${tmpfile}" /usr/local/bin/rmz
         rm -f "${tmpfile}"
         free_mb() { df -B1 / | awk 'NR==2 {printf "%.2f", $4/1024/1024}'; }

--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -31,6 +31,8 @@ runs:
           aarch64|arm64) asset="aarch64-unknown-linux-gnu-rmz" ;;
           *) echo "Unsupported arch: ${arch}"; exit 1 ;;
         esac
+        # rmz deletes files in parallel using multiple threads, making it significantly
+        # faster than rm for large directories.
         tmpfile=$(mktemp)
         curl -fsSL -o "${tmpfile}" "https://github.com/SUPERCILEX/fuc/releases/download/3.1.1/${asset}"
         sudo install -m 0755 "${tmpfile}" /usr/local/bin/rmz


### PR DESCRIPTION
## Summary

This is a re-implementation of #6809 that inlines the disk cleanup logic directly instead of using the `endersonmenezes/free-disk-space` third-party action.

**Why the change:** The third-party action in #6809 triggers the unapproved actions check for external consumers of the reusable workflow, since only actions from the `DataDog` org (and a small allowlist) are permitted.

**What it does (same as #6809):**
- Installs [`rmz`](https://github.com/SUPERCILEX/fuc) v3.1.1 for fast parallel file deletion
- Removes large, unused toolchains: .NET, Haskell/GHC, Swift, Chromium, Azure CLI
- Logs freed space and elapsed time per path, plus a total at the end
- Removes the old slow `clean-up` step (`sudo rm -rf /usr/local/lib/android`) and the `Disk space usage` diagnostic step

## Test plan

- [ ] Verify the Free Disk Space step completes in under 10 seconds
- [ ] Verify `docker compose pull` succeeds with the freed space

🤖 Generated with [Claude Code](https://claude.com/claude-code)