### PR TITLE
Add parametric coverage for the Org Propagation Guard (OPG) RFC

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -126,6 +126,12 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_specific_keys: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_datadog.py::Test_Headers_Datadog: ">1.0.0"
   tests/parametric/test_headers_none.py::Test_Headers_None: ">1.0.0"
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
   tests/parametric/test_headers_precedence.py::Test_Headers_Precedence: ">1.0.0"
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Implemented in 0.1.12)

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -126,12 +126,7 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_specific_keys: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_datadog.py::Test_Headers_Datadog: ">1.0.0"
   tests/parametric/test_headers_none.py::Test_Headers_None: ">1.0.0"
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py: missing_feature (Org Propagation Guard RFC not yet implemented)
   tests/parametric/test_headers_precedence.py::Test_Headers_Precedence: ">1.0.0"
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Implemented in 0.1.12)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -838,6 +838,12 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_default: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_key_with_asterisk: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_specific_keys: missing_feature  # Created by easy win activation script
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Default value was updated in 2.48.0)
       component_version: <2.48.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -838,12 +838,7 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_default: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_key_with_asterisk: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_specific_keys: missing_feature  # Created by easy win activation script
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Default value was updated in 2.48.0)
       component_version: <2.48.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1113,12 +1113,7 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_default: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_key_with_asterisk: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_specific_keys: missing_feature  # Created by easy win activation script
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Default value was updated in v1.62.0 (w3c phase 2))
       component_version: <1.62.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1113,6 +1113,12 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_default: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_key_with_asterisk: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_specific_keys: missing_feature  # Created by easy win activation script
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Default value was updated in v1.62.0 (w3c phase 2))
       component_version: <1.62.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3659,7 +3659,7 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_headers_baggage_default_D001: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_headers_baggage_only_D002: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags: v1.54.0-SNAPSHOT+c2aec92b86
-  tests/parametric/test_headers_opm.py: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py: v1.64.0-SNAPSHOT
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Implemented from 1.24.0)
       component_version: <1.24.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3659,12 +3659,7 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_headers_baggage_default_D001: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_headers_baggage_only_D002: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags: v1.54.0-SNAPSHOT+c2aec92b86
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Implemented from 1.24.0)
       component_version: <1.24.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3659,6 +3659,12 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_headers_baggage_default_D001: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_headers_baggage_only_D002: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags: v1.54.0-SNAPSHOT+c2aec92b86
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Implemented from 1.24.0)
       component_version: <1.24.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2034,12 +2034,7 @@ manifest:
   tests/parametric/test_headers_b3.py::Test_Headers_B3::test_headers_b3_migrated_single_key_propagate_valid: missing_feature (Need to remove b3=b3multi alias)
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage: irrelevant (uses weblog tests)
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags: *ref_5_54_0
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Implemented in 4.20.0 (and 3.41.0))
       component_version: <4.20.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2034,6 +2034,12 @@ manifest:
   tests/parametric/test_headers_b3.py::Test_Headers_B3::test_headers_b3_migrated_single_key_propagate_valid: missing_feature (Need to remove b3=b3multi alias)
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage: irrelevant (uses weblog tests)
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags: *ref_5_54_0
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Implemented in 4.20.0 (and 3.41.0))
       component_version: <4.20.0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -759,6 +759,12 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_baggageheader_maxitems_inject_D016: missing_feature
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_headers_baggage_only_D002: missing_feature
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags: v1.13.0+4663b2fa7c20c6920f347d059b57dc2a419cb7f7
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Default value was updated in v0.98.0 (w3c phase 2))
       component_version: <0.98.0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -759,12 +759,7 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_baggageheader_maxitems_inject_D016: missing_feature
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_headers_baggage_only_D002: missing_feature
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags: v1.13.0+4663b2fa7c20c6920f347d059b57dc2a419cb7f7
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Default value was updated in v0.98.0 (w3c phase 2))
       component_version: <0.98.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1809,12 +1809,7 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags: v3.7.0
   tests/parametric/test_headers_datadog.py::Test_Headers_Datadog: v2.8.0
   tests/parametric/test_headers_none.py::Test_Headers_None: v2.8.0
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py: missing_feature (Org Propagation Guard RFC not yet implemented)
   tests/parametric/test_headers_precedence.py::Test_Headers_Precedence: v2.8.0
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Default value was switched to datadog,tracecontext)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1809,6 +1809,12 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags: v3.7.0
   tests/parametric/test_headers_datadog.py::Test_Headers_Datadog: v2.8.0
   tests/parametric/test_headers_none.py::Test_Headers_None: v2.8.0
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
   tests/parametric/test_headers_precedence.py::Test_Headers_Precedence: v2.8.0
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Default value was switched to datadog,tracecontext)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2143,6 +2143,12 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_baggageheader_maxitems_inject_D016: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_headers_baggage_only_D002: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags: v2.22.1-dev
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Implemented from 1.17.0)
       component_version: <1.17.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2143,12 +2143,7 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_baggageheader_maxitems_inject_D016: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage::test_headers_baggage_only_D002: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags: v2.22.1-dev
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py: missing_feature (Org Propagation Guard RFC not yet implemented)
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_datadog_tracecontext
   : - declaration: missing_feature (Implemented from 1.17.0)
       component_version: <1.17.0

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -145,12 +145,7 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_specific_keys: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_datadog.py::Test_Headers_Datadog: v0.0.1
   tests/parametric/test_headers_none.py::Test_Headers_None: v0.0.1
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
-  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py: missing_feature (Org Propagation Guard RFC not yet implemented)
   tests/parametric/test_headers_precedence.py::Test_Headers_Precedence: v0.0.1
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_tracecontext_datadog
   : 'irrelevant (Issue: tracecontext,Datadog was never the default configuration)'

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -145,6 +145,12 @@ manifest:
   tests/parametric/test_headers_baggage.py::Test_Headers_Baggage_Span_Tags::test_baggage_span_tags_specific_keys: missing_feature  # Created by easy win activation script
   tests/parametric/test_headers_datadog.py::Test_Headers_Datadog: v0.0.1
   tests/parametric/test_headers_none.py::Test_Headers_None: v0.0.1
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_AgentInfo: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractDefault: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_ExtractEnabled: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Injection: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_Strict: missing_feature (Org Propagation Guard RFC not yet implemented)
+  tests/parametric/test_headers_opm.py::Test_HeadersOPM_TrustedOpms: missing_feature (Org Propagation Guard RFC not yet implemented)
   tests/parametric/test_headers_precedence.py::Test_Headers_Precedence: v0.0.1
   ? tests/parametric/test_headers_precedence.py::Test_Headers_Precedence::test_headers_precedence_propagationstyle_default_tracecontext_datadog
   : 'irrelevant (Issue: tracecontext,Datadog was never the default configuration)'

--- a/tests/parametric/test_headers_opm.py
+++ b/tests/parametric/test_headers_opm.py
@@ -1,0 +1,414 @@
+"""Parametric coverage for the Org Propagation Guard (OPG) RFC.
+
+The Org Propagation Marker (OPM) is a stable, ~10-char base64url marker derived
+from `Trunc60(SHA-256(org_uuid))`. The trace intake produces it, the agent
+surfaces it under `org_prop_marker` in `/info`, and tracers inject/extract it
+via:
+
+- `_dd.p.opm=<OPM>` inside `x-datadog-tags` (Datadog style)
+- `t.opm=<OPM>` inside the `dd=` segment of `tracestate` (W3C style)
+
+When `DD_TRACE_ORG_GUARD_ENABLED=true`, a tracer that knows its local OPM and
+sees a different inbound OPM strips the dd part of the inbound trace context
+(sampling, origin, propagated tags) while keeping `trace_id`, `parent_id`, and
+baggage intact for cyclic-call resilience.
+
+The local OPM is provided to the tracer via the agent /info endpoint. The
+parametric harness pins `ddapm-test-agent` >= v1.54.1, which reads the
+`ORG_PROP_MARKER` env var and surfaces its value as `org_prop_marker` in /info.
+
+RFC: https://docs.google.com/document/d/1SzZWivVWT79lJe80ZulEra6AARszjEYVEwWJ7IhJ6Xo/edit?tab=t.0
+"""
+
+import pytest
+
+from utils import features, scenarios, rfc
+from utils.docker_fixtures import TestAgentAPI
+
+from .conftest import APMLibrary
+
+
+parametrize = pytest.mark.parametrize
+
+
+LOCAL_OPM = "AaBbCcDdEeFf"
+FOREIGN_OPM = "Zz1122334455"
+TRUSTED_OPM = "Tt9988776655"
+
+INBOUND_TRACE_ID = 123456789
+INBOUND_PARENT_ID = 987654321
+INBOUND_TID = "1111111111111111"  # _dd.p.tid value (128-bit trace ID high bits)
+
+
+def _local_opm_agent_env() -> pytest.MarkDecorator:
+    # ddapm-test-agent v1.54.1+ reads ORG_PROP_MARKER and surfaces it
+    # as `org_prop_marker` in /info.
+    return parametrize("agent_env", [{"ORG_PROP_MARKER": LOCAL_OPM}])
+
+
+def _enable_guard(extra: dict[str, str] | None = None) -> pytest.MarkDecorator:
+    env: dict[str, str] = {"DD_TRACE_ORG_GUARD_ENABLED": "true"}
+    if extra:
+        env.update(extra)
+    return parametrize("library_env", [env])
+
+
+def _both_styles() -> pytest.MarkDecorator:
+    return parametrize(
+        "library_env",
+        [
+            {
+                "DD_TRACE_PROPAGATION_STYLE_INJECT": "datadog,tracecontext",
+                "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "datadog,tracecontext",
+            }
+        ],
+    )
+
+
+def _inbound(*extra: tuple[str, str]) -> list[tuple[str, str]]:
+    """Datadog-style inbound headers with the standard trace/parent ids and an
+    explicit USER_KEEP sampling priority. Pass extras to add `_dd.p.opm`,
+    `_dd.p.dm`, origin, baggage, etc.
+    """
+    return [
+        ("x-datadog-trace-id", str(INBOUND_TRACE_ID)),
+        ("x-datadog-parent-id", str(INBOUND_PARENT_ID)),
+        ("x-datadog-sampling-priority", "2"),
+        *extra,
+    ]
+
+
+def _x_dd_tags(headers: dict[str, str]) -> str:
+    return headers.get("x-datadog-tags", "")
+
+
+def _tracestate(headers: dict[str, str]) -> str:
+    return headers.get("tracestate", "")
+
+
+def _dd_segment(tracestate: str) -> str | None:
+    """Return the `dd=...` member of a tracestate, or None if absent."""
+    for raw_member in tracestate.split(","):
+        member = raw_member.strip()
+        if member.startswith("dd="):
+            return member[len("dd=") :]
+    return None
+
+
+@rfc("https://docs.google.com/document/d/1SzZWivVWT79lJe80ZulEra6AARszjEYVEwWJ7IhJ6Xo/edit?tab=t.0")
+@features.org_propagation_guard
+@scenarios.parametric
+class Test_HeadersOPM_Injection:
+    """OPM injection behavior depending on whether the tracer knows a local OPM."""
+
+    def test_no_local_opm_no_inbound_opm_does_not_inject(self, test_library: APMLibrary) -> None:
+        """No local OPM, no inbound OPM -> outbound headers carry no _dd.p.opm / t.opm."""
+        with test_library:
+            headers = test_library.dd_make_child_span_and_get_headers(_inbound())
+
+        assert "_dd.p.opm=" not in _x_dd_tags(headers)
+        assert "t.opm:" not in _tracestate(headers)
+
+    def test_no_local_opm_propagates_inbound_opm(self, test_library: APMLibrary) -> None:
+        """No local OPM but inbound OPM present -> propagate inbound OPM as-is (passthrough rule)."""
+        with test_library:
+            headers = test_library.dd_make_child_span_and_get_headers(
+                _inbound(("x-datadog-tags", f"_dd.p.opm={FOREIGN_OPM}"))
+            )
+
+        assert f"_dd.p.opm={FOREIGN_OPM}" in _x_dd_tags(headers)
+
+    @_local_opm_agent_env()
+    def test_local_opm_overrides_inbound_opm(self, test_library: APMLibrary) -> None:
+        """Local OPM known -> inject local OPM regardless of any inbound OPM."""
+        with test_library:
+            headers = test_library.dd_make_child_span_and_get_headers(
+                _inbound(("x-datadog-tags", f"_dd.p.opm={FOREIGN_OPM}"))
+            )
+
+        x_dd_tags = _x_dd_tags(headers)
+        assert f"_dd.p.opm={LOCAL_OPM}" in x_dd_tags
+        assert f"_dd.p.opm={FOREIGN_OPM}" not in x_dd_tags
+
+    @_local_opm_agent_env()
+    @_both_styles()
+    def test_opm_injected_in_both_styles(self, test_library: APMLibrary) -> None:
+        """When both datadog & tracecontext styles inject, OPM appears in both header families."""
+        with test_library:
+            headers = test_library.dd_make_child_span_and_get_headers(_inbound())
+
+        assert f"_dd.p.opm={LOCAL_OPM}" in _x_dd_tags(headers)
+        dd_member = _dd_segment(_tracestate(headers))
+        assert dd_member is not None
+        assert f"t.opm:{LOCAL_OPM}" in dd_member
+
+
+@rfc("https://docs.google.com/document/d/1SzZWivVWT79lJe80ZulEra6AARszjEYVEwWJ7IhJ6Xo/edit?tab=t.0")
+@features.org_propagation_guard
+@scenarios.parametric
+class Test_HeadersOPM_ExtractDefault:
+    """Guard disabled (default): an inbound `_dd.p.opm` tag must not break extraction."""
+
+    def test_mismatch_does_not_enforce(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        with (
+            test_library,
+            test_library.dd_extract_headers_and_make_child_span(
+                "guard_disabled_mismatch",
+                _inbound(
+                    ("x-datadog-origin", "rum"),
+                    ("x-datadog-tags", f"_dd.p.dm=-4,_dd.p.opm={FOREIGN_OPM}"),
+                ),
+            ),
+        ):
+            pass
+
+        traces = test_agent.wait_for_num_traces(1)
+        assert len(traces) == 1
+        span = traces[0][0]
+        assert span.get("trace_id") == INBOUND_TRACE_ID
+        assert span.get("parent_id") == INBOUND_PARENT_ID
+        assert span["meta"].get("_dd.p.dm") == "-4"
+        assert span["meta"].get("_dd.origin") == "rum"
+
+
+@rfc("https://docs.google.com/document/d/1SzZWivVWT79lJe80ZulEra6AARszjEYVEwWJ7IhJ6Xo/edit?tab=t.0")
+@features.org_propagation_guard
+@scenarios.parametric
+class Test_HeadersOPM_ExtractEnabled:
+    """Guard enabled: matching OPM continues, mismatching OPM enforces."""
+
+    @_local_opm_agent_env()
+    @_enable_guard()
+    def test_match_continues_trace(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """Inbound OPM == local OPM -> sampling / origin / propagated tags preserved."""
+        with (
+            test_library,
+            test_library.dd_extract_headers_and_make_child_span(
+                "guard_match",
+                _inbound(
+                    ("x-datadog-origin", "rum"),
+                    ("x-datadog-tags", f"_dd.p.tid={INBOUND_TID},_dd.p.dm=-4,_dd.p.opm={LOCAL_OPM}"),
+                ),
+            ),
+        ):
+            pass
+
+        span = test_agent.wait_for_num_traces(1)[0][0]
+        assert span.get("trace_id") == INBOUND_TRACE_ID
+        assert span.get("parent_id") == INBOUND_PARENT_ID
+        # Propagated tags survive on match: dm, tid, origin.
+        assert span["meta"].get("_dd.p.dm") == "-4"
+        assert span["meta"].get("_dd.p.tid") == INBOUND_TID
+        assert span["meta"].get("_dd.origin") == "rum"
+
+    @_local_opm_agent_env()
+    @_enable_guard()
+    def test_match_continues_trace_w3c(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """Same match-path semantics when OPM arrives only via the W3C carrier."""
+        with (
+            test_library,
+            test_library.dd_extract_headers_and_make_child_span(
+                "guard_match_w3c",
+                [
+                    ("traceparent", "00-11111111111111110000000000000001-0000000000000001-01"),
+                    ("tracestate", f"dd=s:2;t.dm:-4;t.opm:{LOCAL_OPM},foo=1"),
+                ],
+            ),
+        ):
+            pass
+
+        span = test_agent.wait_for_num_traces(1)[0][0]
+        # Inbound dm survives (would be stripped on mismatch).
+        assert span["meta"].get("_dd.p.dm") == "-4"
+
+    @_local_opm_agent_env()
+    @_enable_guard()
+    def test_mismatch_strips_dd_state(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """Inbound OPM != local OPM -> drop sampling, origin, propagated _dd.p.* tags."""
+        with (
+            test_library,
+            test_library.dd_extract_headers_and_make_child_span(
+                "guard_mismatch",
+                _inbound(
+                    ("x-datadog-origin", "rum"),
+                    ("x-datadog-tags", f"_dd.p.tid={INBOUND_TID},_dd.p.dm=-4,_dd.p.opm={FOREIGN_OPM}"),
+                ),
+            ),
+        ):
+            pass
+
+        span = test_agent.wait_for_num_traces(1)[0][0]
+        # Parent linkage is preserved (cyclic-call guarantee from RFC).
+        assert span.get("trace_id") == INBOUND_TRACE_ID
+        assert span.get("parent_id") == INBOUND_PARENT_ID
+        # dd-controlled *decisions* are dropped:
+        # `_dd.p.dm` is propagation-only on the wire but the local sampler
+        # restamps it on the new child span, so we only assert the inbound
+        # value didn't survive (rather than is None).
+        assert span["meta"].get("_dd.p.dm") != "-4"
+        assert span["meta"].get("_dd.origin") is None
+        # Trace identity is preserved (cyclic-call guarantee). `_dd.p.tid`
+        # carries the high 64 bits of the 128-bit trace_id, so dropping it
+        # would corrupt trace_id — it must survive enforcement.
+        assert span["meta"].get("_dd.p.tid") == INBOUND_TID
+
+    @_local_opm_agent_env()
+    @_enable_guard()
+    def test_mismatch_strips_dd_tracestate_member(self, test_library: APMLibrary) -> None:
+        """On mismatch, outbound tracestate must not carry the inbound dd state, but foreign vendors survive."""
+        with test_library:
+            headers = test_library.dd_make_child_span_and_get_headers(
+                [
+                    ("traceparent", "00-11111111111111110000000000000001-0000000000000001-01"),
+                    ("tracestate", f"dd=s:2;t.dm:-4;t.opm:{FOREIGN_OPM},foo=1"),
+                ]
+            )
+
+        ts = _tracestate(headers)
+        # The outbound tracestate may contain a *new* dd= segment created locally,
+        # but it must not carry the inbound foreign OPM, dm, or sampling decision.
+        assert f"t.opm:{FOREIGN_OPM}" not in ts
+        assert "t.dm:-4" not in ts
+        assert "foo=1" in ts
+
+    @_local_opm_agent_env()
+    @_enable_guard({"DD_TRACE_PROPAGATION_STYLE": "datadog,tracecontext,baggage"})
+    def test_mismatch_preserves_baggage(self, test_library: APMLibrary) -> None:
+        """Baggage is general and must survive enforcement untouched.
+
+        `baggage` is included explicitly in DD_TRACE_PROPAGATION_STYLE so the
+        propagator actually injects it; otherwise the assertion would conflate
+        "guard dropped baggage" with "baggage was never an active propagator".
+        """
+        with test_library:
+            headers = test_library.dd_make_child_span_and_get_headers(
+                _inbound(
+                    ("x-datadog-tags", f"_dd.p.opm={FOREIGN_OPM}"),
+                    ("baggage", "key1=value1"),
+                )
+            )
+
+        assert "key1=value1" in headers.get("baggage", "")
+
+    @_local_opm_agent_env()
+    @_enable_guard()
+    def test_missing_inbound_opm_does_not_enforce(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """Non-strict default: missing inbound OPM does not trigger enforcement.
+
+        Two sides of the same real-world scenario (a request from outside the org):
+        - Extraction: the inbound trace continues, propagated tags survive.
+        - Injection: the outbound carries the local OPM so the next hop sees it.
+        """
+        with test_library:
+            headers = test_library.dd_make_child_span_and_get_headers(_inbound(("x-datadog-tags", "_dd.p.dm=-4")))
+
+        # Extraction side: trace continued, propagated tags preserved
+        span = test_agent.wait_for_num_traces(1)[0][0]
+        assert span.get("trace_id") == INBOUND_TRACE_ID
+        assert span["meta"].get("_dd.p.dm") == "-4"
+
+        # Injection side: outbound carries the local OPM
+        assert f"_dd.p.opm={LOCAL_OPM}" in _x_dd_tags(headers)
+
+
+@rfc("https://docs.google.com/document/d/1SzZWivVWT79lJe80ZulEra6AARszjEYVEwWJ7IhJ6Xo/edit?tab=t.0")
+@features.org_propagation_guard
+@scenarios.parametric
+class Test_HeadersOPM_TrustedOpms:
+    """`DD_TRACE_ORG_GUARD_TRUSTED_OPMS` allowlist bypasses enforcement."""
+
+    @_local_opm_agent_env()
+    @_enable_guard({"DD_TRACE_ORG_GUARD_TRUSTED_OPMS": f"{TRUSTED_OPM},{FOREIGN_OPM}"})
+    def test_trusted_inbound_opm_passes_through(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        with (
+            test_library,
+            test_library.dd_extract_headers_and_make_child_span(
+                "guard_trusted",
+                _inbound(("x-datadog-tags", f"_dd.p.dm=-4,_dd.p.opm={TRUSTED_OPM}")),
+            ),
+        ):
+            pass
+
+        span = test_agent.wait_for_num_traces(1)[0][0]
+        assert span["meta"].get("_dd.p.dm") == "-4"
+
+    @_local_opm_agent_env()
+    @_enable_guard({"DD_TRACE_ORG_GUARD_TRUSTED_OPMS": TRUSTED_OPM})
+    def test_untrusted_inbound_opm_is_enforced(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        with (
+            test_library,
+            test_library.dd_extract_headers_and_make_child_span(
+                "guard_untrusted",
+                _inbound(("x-datadog-tags", f"_dd.p.dm=-4,_dd.p.opm={FOREIGN_OPM}")),
+            ),
+        ):
+            pass
+
+        span = test_agent.wait_for_num_traces(1)[0][0]
+        assert span.get("parent_id") == INBOUND_PARENT_ID
+        assert span["meta"].get("_dd.p.dm") != "-4"
+
+
+@rfc("https://docs.google.com/document/d/1SzZWivVWT79lJe80ZulEra6AARszjEYVEwWJ7IhJ6Xo/edit?tab=t.0")
+@features.org_propagation_guard
+@scenarios.parametric
+class Test_HeadersOPM_Strict:
+    """Strict mode enforces even when the inbound OPM is missing."""
+
+    @_local_opm_agent_env()
+    @_enable_guard({"DD_TRACE_ORG_GUARD_STRICT": "true"})
+    def test_strict_missing_inbound_enforces(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        with (
+            test_library,
+            test_library.dd_extract_headers_and_make_child_span(
+                "guard_strict_missing",
+                _inbound(
+                    ("x-datadog-origin", "rum"),
+                    ("x-datadog-tags", "_dd.p.dm=-4"),
+                ),
+            ),
+        ):
+            pass
+
+        span = test_agent.wait_for_num_traces(1)[0][0]
+        assert span.get("parent_id") == INBOUND_PARENT_ID
+        assert span["meta"].get("_dd.p.dm") != "-4"
+        assert span["meta"].get("_dd.origin") is None
+
+    @_local_opm_agent_env()
+    @_enable_guard({"DD_TRACE_ORG_GUARD_STRICT": "true"})
+    def test_strict_match_continues(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        with (
+            test_library,
+            test_library.dd_extract_headers_and_make_child_span(
+                "guard_strict_match",
+                _inbound(("x-datadog-tags", f"_dd.p.dm=-4,_dd.p.opm={LOCAL_OPM}")),
+            ),
+        ):
+            pass
+
+        span = test_agent.wait_for_num_traces(1)[0][0]
+        assert span["meta"].get("_dd.p.dm") == "-4"
+
+
+@rfc("https://docs.google.com/document/d/1SzZWivVWT79lJe80ZulEra6AARszjEYVEwWJ7IhJ6Xo/edit?tab=t.0")
+@features.org_propagation_guard
+@scenarios.parametric
+class Test_HeadersOPM_AgentInfo:
+    """Agent /info exposes `org_prop_marker`, and the tracer consumes it."""
+
+    @_local_opm_agent_env()
+    def test_info_endpoint_exposes_opm(self, test_agent: TestAgentAPI) -> None:
+        info = test_agent.info()
+        assert info.get("org_prop_marker") == LOCAL_OPM
+
+    @_local_opm_agent_env()
+    def test_tracer_consumes_info_opm(self, test_library: APMLibrary) -> None:
+        """Once the tracer has fetched /info, outbound headers carry the local OPM."""
+        with test_library:
+            # Warm up: a first span so the tracer has time to poll /info before injecting.
+            with test_library.dd_start_span(name="warmup"):
+                pass
+            headers = test_library.dd_make_child_span_and_get_headers(_inbound())
+
+        assert f"_dd.p.opm={LOCAL_OPM}" in _x_dd_tags(headers)

--- a/tests/parametric/test_headers_opm.py
+++ b/tests/parametric/test_headers_opm.py
@@ -53,18 +53,6 @@ def _enable_guard(extra: dict[str, str] | None = None) -> pytest.MarkDecorator:
     return parametrize("library_env", [env])
 
 
-def _both_styles() -> pytest.MarkDecorator:
-    return parametrize(
-        "library_env",
-        [
-            {
-                "DD_TRACE_PROPAGATION_STYLE_INJECT": "datadog,tracecontext",
-                "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "datadog,tracecontext",
-            }
-        ],
-    )
-
-
 def _inbound(*extra: tuple[str, str]) -> list[tuple[str, str]]:
     """Datadog-style inbound headers with the standard trace/parent ids and an
     explicit USER_KEEP sampling priority. Pass extras to add `_dd.p.opm`,
@@ -119,6 +107,20 @@ class Test_HeadersOPM_Injection:
         assert f"_dd.p.opm={FOREIGN_OPM}" in _x_dd_tags(headers)
 
     @_local_opm_agent_env()
+    def test_guard_disabled_propagates_inbound_opm(self, test_library: APMLibrary) -> None:
+        """Guard disabled: local OPM is not injected, inbound OPM propagates as-is."""
+        with test_library:
+            test_library.ensure_agent_info()
+            headers = test_library.dd_make_child_span_and_get_headers(
+                _inbound(("x-datadog-tags", f"_dd.p.opm={FOREIGN_OPM}"))
+            )
+
+        x_dd_tags = _x_dd_tags(headers)
+        assert f"_dd.p.opm={FOREIGN_OPM}" in x_dd_tags
+        assert f"_dd.p.opm={LOCAL_OPM}" not in x_dd_tags
+
+    @_local_opm_agent_env()
+    @_enable_guard()
     def test_local_opm_overrides_inbound_opm(self, test_library: APMLibrary) -> None:
         """Local OPM known -> inject local OPM regardless of any inbound OPM."""
         with test_library:
@@ -132,7 +134,16 @@ class Test_HeadersOPM_Injection:
         assert f"_dd.p.opm={FOREIGN_OPM}" not in x_dd_tags
 
     @_local_opm_agent_env()
-    @_both_styles()
+    @parametrize(
+        "library_env",
+        [
+            {
+                "DD_TRACE_ORG_GUARD_ENABLED": "true",
+                "DD_TRACE_PROPAGATION_STYLE_INJECT": "datadog,tracecontext",
+                "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "datadog,tracecontext",
+            }
+        ],
+    )
     def test_opm_injected_in_both_styles(self, test_library: APMLibrary) -> None:
         """When both datadog & tracecontext styles inject, OPM appears in both header families."""
         with test_library:
@@ -425,6 +436,7 @@ class Test_HeadersOPM_AgentInfo:
         assert info.get("org_prop_marker") == LOCAL_OPM
 
     @_local_opm_agent_env()
+    @_enable_guard()
     def test_tracer_consumes_info_opm(self, test_library: APMLibrary) -> None:
         """Once the tracer has fetched /info, outbound headers carry the local OPM."""
         with test_library:

--- a/tests/parametric/test_headers_opm.py
+++ b/tests/parametric/test_headers_opm.py
@@ -122,6 +122,7 @@ class Test_HeadersOPM_Injection:
     def test_local_opm_overrides_inbound_opm(self, test_library: APMLibrary) -> None:
         """Local OPM known -> inject local OPM regardless of any inbound OPM."""
         with test_library:
+            test_library.ensure_agent_info()
             headers = test_library.dd_make_child_span_and_get_headers(
                 _inbound(("x-datadog-tags", f"_dd.p.opm={FOREIGN_OPM}"))
             )
@@ -135,6 +136,7 @@ class Test_HeadersOPM_Injection:
     def test_opm_injected_in_both_styles(self, test_library: APMLibrary) -> None:
         """When both datadog & tracecontext styles inject, OPM appears in both header families."""
         with test_library:
+            test_library.ensure_agent_info()
             headers = test_library.dd_make_child_span_and_get_headers(_inbound())
 
         assert f"_dd.p.opm={LOCAL_OPM}" in _x_dd_tags(headers)
@@ -181,6 +183,7 @@ class Test_HeadersOPM_ExtractEnabled:
     @_enable_guard()
     def test_match_continues_trace(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """Inbound OPM == local OPM -> sampling / origin / propagated tags preserved."""
+        test_library.ensure_agent_info()
         with (
             test_library,
             test_library.dd_extract_headers_and_make_child_span(
@@ -205,6 +208,7 @@ class Test_HeadersOPM_ExtractEnabled:
     @_enable_guard()
     def test_match_continues_trace_w3c(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """Same match-path semantics when OPM arrives only via the W3C carrier."""
+        test_library.ensure_agent_info()
         with (
             test_library,
             test_library.dd_extract_headers_and_make_child_span(
@@ -225,6 +229,7 @@ class Test_HeadersOPM_ExtractEnabled:
     @_enable_guard()
     def test_mismatch_strips_dd_state(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """Inbound OPM != local OPM -> drop sampling, origin, propagated _dd.p.* tags."""
+        test_library.ensure_agent_info()
         with (
             test_library,
             test_library.dd_extract_headers_and_make_child_span(
@@ -254,19 +259,30 @@ class Test_HeadersOPM_ExtractEnabled:
 
     @_local_opm_agent_env()
     @_enable_guard()
-    def test_mismatch_strips_dd_tracestate_member(self, test_library: APMLibrary) -> None:
-        """On mismatch, outbound tracestate must not carry the inbound dd state, but foreign vendors survive."""
+    def test_mismatch_strips_dd_tracestate_member(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """On mismatch, outbound tracestate must not carry the inbound dd state, but foreign vendors survive.
+        The trace_id and parent_id from traceparent must be preserved on the span (RFC cyclic-call guarantee).
+        traceparent: trace-id low-64 = 0x0000000000000001 = 1, parent-id = 0x0000000000000001 = 1
+        """
         with test_library:
-            headers = test_library.dd_make_child_span_and_get_headers(
+            test_library.ensure_agent_info()
+            with test_library.dd_extract_headers_and_make_child_span(
+                "guard_mismatch_tracestate",
                 [
                     ("traceparent", "00-11111111111111110000000000000001-0000000000000001-01"),
                     ("tracestate", f"dd=s:2;t.dm:-4;t.opm:{FOREIGN_OPM},foo=1"),
-                ]
-            )
+                ],
+            ) as span:
+                outbound = dict(test_library.dd_inject_headers(span.span_id))
 
-        ts = _tracestate(headers)
-        # The outbound tracestate may contain a *new* dd= segment created locally,
-        # but it must not carry the inbound foreign OPM, dm, or sampling decision.
+        # Parent linkage from traceparent is preserved even on enforcement
+        # traceparent trace-id low-64 = 0x0000000000000001 = 1, parent-id = 0x0000000000000001 = 1
+        recorded_span = test_agent.wait_for_num_traces(1)[0][0]
+        assert recorded_span.get("trace_id") == 1
+        assert recorded_span.get("parent_id") == 1
+
+        ts = outbound.get("tracestate", "")
+        # The outbound tracestate must not carry the inbound foreign OPM, dm, or sampling decision.
         assert f"t.opm:{FOREIGN_OPM}" not in ts
         assert "t.dm:-4" not in ts
         assert "foo=1" in ts
@@ -281,6 +297,7 @@ class Test_HeadersOPM_ExtractEnabled:
         "guard dropped baggage" with "baggage was never an active propagator".
         """
         with test_library:
+            test_library.ensure_agent_info()
             headers = test_library.dd_make_child_span_and_get_headers(
                 _inbound(
                     ("x-datadog-tags", f"_dd.p.opm={FOREIGN_OPM}"),
@@ -300,6 +317,7 @@ class Test_HeadersOPM_ExtractEnabled:
         - Injection: the outbound carries the local OPM so the next hop sees it.
         """
         with test_library:
+            test_library.ensure_agent_info()
             headers = test_library.dd_make_child_span_and_get_headers(_inbound(("x-datadog-tags", "_dd.p.dm=-4")))
 
         # Extraction side: trace continued, propagated tags preserved
@@ -320,6 +338,7 @@ class Test_HeadersOPM_TrustedOpms:
     @_local_opm_agent_env()
     @_enable_guard({"DD_TRACE_ORG_GUARD_TRUSTED_OPMS": f"{TRUSTED_OPM},{FOREIGN_OPM}"})
     def test_trusted_inbound_opm_passes_through(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        test_library.ensure_agent_info()
         with (
             test_library,
             test_library.dd_extract_headers_and_make_child_span(
@@ -335,6 +354,7 @@ class Test_HeadersOPM_TrustedOpms:
     @_local_opm_agent_env()
     @_enable_guard({"DD_TRACE_ORG_GUARD_TRUSTED_OPMS": TRUSTED_OPM})
     def test_untrusted_inbound_opm_is_enforced(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        test_library.ensure_agent_info()
         with (
             test_library,
             test_library.dd_extract_headers_and_make_child_span(
@@ -358,6 +378,7 @@ class Test_HeadersOPM_Strict:
     @_local_opm_agent_env()
     @_enable_guard({"DD_TRACE_ORG_GUARD_STRICT": "true"})
     def test_strict_missing_inbound_enforces(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        test_library.ensure_agent_info()
         with (
             test_library,
             test_library.dd_extract_headers_and_make_child_span(
@@ -378,6 +399,7 @@ class Test_HeadersOPM_Strict:
     @_local_opm_agent_env()
     @_enable_guard({"DD_TRACE_ORG_GUARD_STRICT": "true"})
     def test_strict_match_continues(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        test_library.ensure_agent_info()
         with (
             test_library,
             test_library.dd_extract_headers_and_make_child_span(
@@ -406,9 +428,7 @@ class Test_HeadersOPM_AgentInfo:
     def test_tracer_consumes_info_opm(self, test_library: APMLibrary) -> None:
         """Once the tracer has fetched /info, outbound headers carry the local OPM."""
         with test_library:
-            # Warm up: a first span so the tracer has time to poll /info before injecting.
-            with test_library.dd_start_span(name="warmup"):
-                pass
+            test_library.ensure_agent_info()
             headers = test_library.dd_make_child_span_and_get_headers(_inbound())
 
         assert f"_dd.p.opm={LOCAL_OPM}" in _x_dd_tags(headers)

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2283,6 +2283,14 @@ class _Features:
         return _mark_test_object(test_object, feature_id=353, owner=_Owner.sdk_capabilities)
 
     @staticmethod
+    def org_propagation_guard(test_object):
+        """Org Propagation Guard: Org Propagation Marker (OPM) gates trace context continuation across orgs
+
+        https://feature-parity.us1.prod.dog/#/?feature=555
+        """
+        return _mark_test_object(test_object, feature_id=555, owner=_Owner.sdk_capabilities)
+
+    @staticmethod
     def iast_sink_email_html_injection(test_object):
         """IAST Sink: Email HTML injection
 

--- a/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
+++ b/utils/build/docker/dotnet/parametric/Endpoints/ApmTestApi.cs
@@ -15,6 +15,7 @@ public abstract class ApmTestApi
         // By instantiating the Tracer first, that faulty getter code path will not be invoked
         _ = Tracer.Instance;
 
+        app.MapGet("/trace/agent/ensure_agent_info", () => Results.Ok(new { ready = true }));
         app.MapGet("/trace/crash", Crash);
         app.MapGet("/trace/config", GetTracerConfig);
         app.MapPost("/trace/tracer/stop", StopTracer);

--- a/utils/build/docker/golang/parametric/datadog.go
+++ b/utils/build/docker/golang/parametric/datadog.go
@@ -392,3 +392,9 @@ func (s *apmClientServer) getTraceConfigHandler(w http.ResponseWriter, r *http.R
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(response)
 }
+
+func (s *apmClientServer) ensureAgentInfoHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]bool{"ready": true})
+}

--- a/utils/build/docker/golang/parametric/main.go
+++ b/utils/build/docker/golang/parametric/main.go
@@ -96,6 +96,7 @@ func main() {
 	http.HandleFunc("/trace/span/extract_headers", s.extractHeadersHandler)
 	http.HandleFunc("/trace/span/error", s.spanSetErrorHandler)
 	http.HandleFunc("/trace/config", s.getTraceConfigHandler)
+	http.HandleFunc("/trace/agent/ensure_agent_info", s.ensureAgentInfoHandler)
 	http.HandleFunc("/trace/span/manual_keep", s.spanManualKeepHandler)
 	http.HandleFunc("/trace/span/manual_drop", s.spanManualDropHandler)
 

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/TraceController.java
@@ -60,6 +60,11 @@ public class TraceController {
     }
   }
 
+  @GetMapping("agent/ensure_agent_info")
+  public Map<String, Object> ensureAgentInfo() {
+    return Map.of("ready", true);
+  }
+
   @GetMapping("crash")
   public void crash() {
     LOGGER.info("Crashing client app");

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentracing/controller/OpenTracingController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentracing/controller/OpenTracingController.java
@@ -45,10 +45,21 @@ public class OpenTracingController implements Closeable {
 
   /** The extracted span contexts, indexed by span identifier. */
   private final Map<Long, SpanContext> extractedSpanContexts;
+  /**
+   * Raw inbound {@code baggage} header value, indexed by trace identifier.
+   *
+   * <p>Captured on extract because the dd-trace-ot bridge drops the W3C baggage
+   * entry when converting the internal Context to {@link io.opentracing.SpanContext},
+   * so it never reaches inject through the OT API. Keyed by trace_id (not span_id)
+   * because baggage is trace-scoped and child spans built via {@code asChildOf}
+   * share the inbound trace_id.
+   */
+  private final Map<Long, String> extractedBaggageHeaders;
 
   public OpenTracingController() {
     this.tracer = GlobalTracer.get();
     this.extractedSpanContexts = new HashMap<>();
+    this.extractedBaggageHeaders = new ConcurrentHashMap<>();
   }
 
   @PostMapping("start")
@@ -175,6 +186,16 @@ public class OpenTracingController implements Closeable {
       // Get context from span and inject it to carrier
       TextMapAdapter carrier = TextMapAdapter.empty();
       this.tracer.inject(span.context(), TEXT_MAP, carrier);
+      // Re-attach the inbound baggage header captured on extract — the OT bridge
+      // strips it when building the OT SpanContext, so tracer.inject would not
+      // emit it on its own.
+      String traceIdStr = span.context().toTraceId();
+      if (traceIdStr != null && !traceIdStr.isEmpty()) {
+        String baggage = this.extractedBaggageHeaders.get(DDTraceId.from(traceIdStr).toLong());
+        if (baggage != null) {
+          carrier.put("baggage", baggage);
+        }
+      }
       return new SpanInjectHeadersResult(carrier.toHeaders());
     }
     return new SpanInjectHeadersResult(emptyList());
@@ -189,6 +210,17 @@ public class OpenTracingController implements Closeable {
     }
     long spanId = DDSpanId.from(context.toSpanId());
     this.extractedSpanContexts.put(spanId, context);
+
+    // OT extract drops the W3C baggage entry; capture the raw header so we
+    // can re-emit it on the matching inject_headers call.
+    String baggage = args.headers().stream()
+        .filter(h -> "baggage".equalsIgnoreCase(h.key()))
+        .map(KeyValue::value)
+        .findFirst()
+        .orElse(null);
+    if (baggage != null && !context.toTraceId().isEmpty()) {
+      this.extractedBaggageHeaders.put(DDTraceId.from(context.toTraceId()).toLong(), baggage);
+    }
     return new SpanExtractHeadersResult(spanId);
   }
 
@@ -202,6 +234,7 @@ public class OpenTracingController implements Closeable {
       }
       spans.clear();
       this.extractedSpanContexts.clear();
+      this.extractedBaggageHeaders.clear();
     } catch (Throwable t) {
       LOGGER.error("Uncaught throwable", t);
     }

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentracing/controller/OpenTracingController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentracing/controller/OpenTracingController.java
@@ -218,8 +218,13 @@ public class OpenTracingController implements Closeable {
         .map(KeyValue::value)
         .findFirst()
         .orElse(null);
-    if (baggage != null && !context.toTraceId().isEmpty()) {
-      this.extractedBaggageHeaders.put(DDTraceId.from(context.toTraceId()).toLong(), baggage);
+    if (!context.toTraceId().isEmpty()) {
+      long traceKey = DDTraceId.from(context.toTraceId()).toLong();
+      if (baggage != null) {
+        this.extractedBaggageHeaders.put(traceKey, baggage);
+      } else {
+        this.extractedBaggageHeaders.remove(traceKey);
+      }
     }
     return new SpanExtractHeadersResult(spanId);
   }

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -113,6 +113,10 @@ app.post('/trace/span/extract_headers', (req, res) => {
   res.json({ span_id: extractedSpanID });
 });
 
+app.get('/trace/agent/ensure_agent_info', (req, res) => {
+  res.json({ ready: true })
+})
+
 app.get('/trace/crash', (req, res) => {
   process.kill(process.pid, 'SIGSEGV');
   res.json({});

--- a/utils/build/docker/php/parametric/server.php
+++ b/utils/build/docker/php/parametric/server.php
@@ -454,6 +454,10 @@ $router->addRoute('POST', '/trace/stats/flush', new ClosureRequestHandler(functi
     # NOP: php doesn't expose an API to flush trace stats
     return jsonResponse([]);
 }));
+$router->addRoute('GET', '/trace/agent/ensure_agent_info', new ClosureRequestHandler(function () {
+    $ready = dd_trace_internal_fn('await_agent_info');
+    return jsonResponse(['ready' => $ready]);
+}));
 $router->addRoute('GET', '/trace/span/current', new ClosureRequestHandler(function () use (&$spans, &$activeSpan) {
     $span = $activeSpan;
 

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -172,6 +172,11 @@ class TraceConfigReturn(BaseModel):
     config: dict[str, Optional[str]]
 
 
+@app.get("/trace/agent/ensure_agent_info")
+def trace_ensure_agent_info():
+    return {"ready": True}
+
+
 @app.get("/trace/config")
 def trace_config() -> TraceConfigReturn:
     return TraceConfigReturn(

--- a/utils/build/docker/ruby/parametric/server.rb
+++ b/utils/build/docker/ruby/parametric/server.rb
@@ -960,6 +960,8 @@ class MyApp
       handle_trace_span_finish(req, res)
     when '/trace/span/set_meta'
       handle_trace_span_set_meta(req, res)
+    when '/trace/agent/ensure_agent_info'
+      res.write({ ready: true }.to_json)
     when '/trace/config'
       handle_trace_config(req, res)
     when '/trace/span/set_metric'

--- a/utils/build/docker/rust/parametric/src/datadog/mod.rs
+++ b/utils/build/docker/rust/parametric/src/datadog/mod.rs
@@ -33,11 +33,16 @@ pub fn app() -> Router<AppState> {
         .route("/span/flush", post(flush_spans))
         .route("/stats/flush", post(flush_stats))
         .route("/config", get(config))
+        .route("/agent/ensure_agent_info", get(ensure_agent_info))
     // .route("/span/set_baggage", post(set_baggage))
     // .route("/span/get_baggage", get(get_baggage))
     // .route("/span/get_all_baggage", get(get_all_baggage))
     // .route("/span/remove_baggage", post(remove_baggage))
     // .route("/span/remove_all_baggage", post(remove_all_baggage))
+}
+
+async fn ensure_agent_info() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "ready": true }))
 }
 
 // Handler implementations

--- a/utils/docker_fixtures/_test_clients/_test_client_parametric.py
+++ b/utils/docker_fixtures/_test_clients/_test_client_parametric.py
@@ -722,6 +722,10 @@ class ParametricTestClientApi(TestClientApi):
         data = resp.json()
         return data["value"]
 
+    def ensure_agent_info(self) -> bool:
+        r = self._session.get(self._url("/trace/agent/ensure_agent_info"))
+        return HTTPStatus(r.status_code).is_success
+
     def config(self) -> dict[str, str | None]:
         resp = self._session.get(self._url("/trace/config")).json()
         config_dict = resp["config"]
@@ -1078,6 +1082,9 @@ class APMLibrary:
             end_on_exit=end_on_exit,
         ) as span:
             yield span
+
+    def ensure_agent_info(self) -> bool:
+        return self._client.ensure_agent_info()
 
     def dd_flush(self) -> bool:
         return self._client.dd_flush()

--- a/utils/docker_fixtures/_test_clients/_test_client_parametric.py
+++ b/utils/docker_fixtures/_test_clients/_test_client_parametric.py
@@ -724,7 +724,9 @@ class ParametricTestClientApi(TestClientApi):
 
     def ensure_agent_info(self) -> bool:
         r = self._session.get(self._url("/trace/agent/ensure_agent_info"))
-        return HTTPStatus(r.status_code).is_success
+        if not HTTPStatus(r.status_code).is_success:
+            return False
+        return r.json().get("ready", True)
 
     def config(self) -> dict[str, str | None]:
         resp = self._session.get(self._url("/trace/config")).json()


### PR DESCRIPTION
## Motivation

Adds parametric system-tests coverage for the **Org Propagation Guard** RFC 

The tests relies on a new test-agent that is able to inject a customizable `org_propagation_guard` field in the info endpoint. Without it, testing this feature is not possible.

Note: the java opentracing controller has been modified here since was not taking into account the baggage correctly. It can be moved in another PR if needed (i.e. the one that will activate java tests).


## Changes

- **`tests/parametric/test_headers_opm.py`** *(new, 17 tests)* — covers injection passthrough/override rules, both Datadog and W3C carrier styles, default-off (no regression), match path, mismatch enforcement, trusted-OPM allowlist, strict mode, and the agent → /info → tracer pipeline.
- **`utils/_features.py`** — adds `@features.org_propagation_guard` decorator (feature_id 555, owner `sdk_capabilities`).
- **`utils/_context/_scenarios/parametric.py`** — bumps `ddapm-test-agent` from `v1.42.0` to `v1.54.1`. v1.54.1 reads `ORG_PROP_MARKER` env var and surfaces it as `org_prop_marker` in `/info`, which is what lets tests configure the tracer's local OPM. Other test-agent pins (used by unrelated scenarios) are intentionally left at their existing versions.
- **`utils/build/docker/java/parametric/.../OpenTracingController.java`** — pre-existing harness limitation: dd-trace-ot drops the W3C `baggage` entry when converting `Context` → `io.opentracing.SpanContext`, so neither extract nor inject sees baggage through the OT API. The patch side-channels the raw inbound `baggage` header, keyed by `trace_id` so it survives the extract → make-child-span → inject flow used by `dd_make_child_span_and_get_headers`. Only affects the parametric Java test client; the dd-java-tracer's actual OPG enforcer correctly preserves `ctx.getBaggage()`.



## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
