### PR TITLE
Add PHP apache base images

### DIFF
--- a/utils/build/docker/php/apache-mod-7.0-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.0-zts.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=7.0
-ARG VARIANT=release-zts
+FROM datadog/system-tests:apache-mod-7.0-zts.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=7.0
+ENV VARIANT=release-zts
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-7.0.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.0.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=7.0
-ARG VARIANT=release
+FROM datadog/system-tests:apache-mod-7.0.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=7.0
+ENV VARIANT=release
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-7.1-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.1-zts.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=7.1
-ARG VARIANT=release-zts
+FROM datadog/system-tests:apache-mod-7.1-zts.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=7.1
+ENV VARIANT=release-zts
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-7.1.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.1.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=7.1
-ARG VARIANT=release
+FROM datadog/system-tests:apache-mod-7.1.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=7.1
+ENV VARIANT=release
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-7.2-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.2-zts.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=7.2
-ARG VARIANT=release-zts
+FROM datadog/system-tests:apache-mod-7.2-zts.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=7.2
+ENV VARIANT=release-zts
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-7.2.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.2.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=7.2
-ARG VARIANT=release
+FROM datadog/system-tests:apache-mod-7.2.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=7.2
+ENV VARIANT=release
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-7.3-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.3-zts.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=7.3
-ARG VARIANT=release-zts
+FROM datadog/system-tests:apache-mod-7.3-zts.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=7.3
+ENV VARIANT=release-zts
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-7.3.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.3.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=7.3
-ARG VARIANT=release
+FROM datadog/system-tests:apache-mod-7.3.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=7.3
+ENV VARIANT=release
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-7.4-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.4-zts.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=7.4
-ARG VARIANT=release-zts
+FROM datadog/system-tests:apache-mod-7.4-zts.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=7.4
+ENV VARIANT=release-zts
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-7.4.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.4.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=7.4
-ARG VARIANT=release
+FROM datadog/system-tests:apache-mod-7.4.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=7.4
+ENV VARIANT=release
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-8.0-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.0-zts.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=8.0
-ARG VARIANT=release-zts
+FROM datadog/system-tests:apache-mod-8.0-zts.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=8.0
+ENV VARIANT=release-zts
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-8.0.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.0.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=8.0
-ARG VARIANT=release
+FROM datadog/system-tests:apache-mod-8.0.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=8.0
+ENV VARIANT=release
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-8.1-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.1-zts.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=8.1
-ARG VARIANT=release-zts
+FROM datadog/system-tests:apache-mod-8.1-zts.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=8.1
+ENV VARIANT=release-zts
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-8.1.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.1.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=8.1
-ARG VARIANT=release
+FROM datadog/system-tests:apache-mod-8.1.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=8.1
+ENV VARIANT=release
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-8.2-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.2-zts.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=8.2
-ARG VARIANT=release-zts
+FROM datadog/system-tests:apache-mod-8.2-zts.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=8.2
+ENV VARIANT=release-zts
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod-8.2.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.2.Dockerfile
@@ -1,25 +1,12 @@
-ARG PHP_VERSION=8.2
-ARG VARIANT=release
+FROM datadog/system-tests:apache-mod-8.2.base-v1
 
-FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+ENV PHP_VERSION=8.2
+ENV VARIANT=release
 
-ENV DD_TRACE_ENABLED=1
-ENV DD_TRACE_GENERATE_ROOT_SPAN=1
-ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
-ENV DD_TRACE_HEADER_TAGS=user-agent
+ADD utils/build/docker/php/apache-mod/php.conf /etc/apache2/mods-available/apache-mod/php.conf
+ADD utils/build/docker/php/apache-mod/php.load /etc/apache2/mods-available/apache-mod/php.load
+ADD utils/build/docker/php/common /var/www/html
+ADD utils/build/docker/php/common/php.ini /etc/php/php.ini
+ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
-EXPOSE 7777/tcp
-
-ADD binaries* /binaries/
-ADD utils/build/docker/php /tmp/php
-
-RUN chmod +x /tmp/php/apache-mod/build.sh
-RUN /tmp/php/apache-mod/build.sh
-RUN rm -rf /tmp/php/
-
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /
-WORKDIR /binaries
-ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+RUN /install_ddtrace.sh 1

--- a/utils/build/docker/php/apache-mod.base.Dockerfile
+++ b/utils/build/docker/php/apache-mod.base.Dockerfile
@@ -1,0 +1,25 @@
+ARG PHP_VERSION=8.0
+ARG VARIANT=release
+
+FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
+
+ENV DD_TRACE_ENABLED=1
+ENV DD_TRACE_GENERATE_ROOT_SPAN=1
+ENV DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=0
+ENV DD_TRACE_HEADER_TAGS=user-agent
+
+EXPOSE 7777/tcp
+
+ADD binaries* /binaries/
+ADD utils/build/docker/php /tmp/php
+
+RUN chmod +x /tmp/php/apache-mod/build.sh
+RUN /tmp/php/apache-mod/build.sh
+RUN rm -rf /tmp/php/
+
+ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
+WORKDIR /binaries
+ENTRYPOINT []
+RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
+RUN chmod +x app.sh
+CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod/build.sh
+++ b/utils/build/docker/php/apache-mod/build.sh
@@ -14,7 +14,6 @@ mkdir -p /etc/apache2/mods-available/ /var/www/html/rasp /etc/php/
 cp -rf /tmp/php/apache-mod/php.conf /etc/apache2/mods-available/
 cp -rf /tmp/php/apache-mod/php.load /etc/apache2/mods-available/
 cp -rf /tmp/php/common/* /var/www/html/
-cp -rf /tmp/php/common/install_ddtrace.sh /
 cp -rf /tmp/php/common/php.ini /etc/php/
 
 # Install required packages and PHP extensions
@@ -76,9 +75,3 @@ fi
 # Set proper permissions
 chmod -R 755 /var/www/html/vendor
 find /var/www/html/vendor -type f -exec chmod 644 {} \;
-
-/install_ddtrace.sh 1
-
-if [[ -f "/etc/php/98-ddtrace.ini" ]]; then
-    grep -E 'datadog.trace.request_init_hook|datadog.trace.sources_path' /etc/php/98-ddtrace.ini >> /etc/php/php.ini
-fi

--- a/utils/build/docker/php/common/install_ddtrace.sh
+++ b/utils/build/docker/php/common/install_ddtrace.sh
@@ -156,3 +156,9 @@ mkdir -p /etc/dd-appsec
 find /opt -name recommended.json -exec ln -s '{}' /etc/dd-appsec/ \;
 
 rm -rf /tmp/{dd-library-php-setup.php,dd-library,dd-appsec}
+
+if [[ $IS_APACHE -eq 1 ]]; then
+  if [[ -f "/etc/php/98-ddtrace.ini" ]]; then
+      grep -E 'datadog.trace.request_init_hook|datadog.trace.sources_path' /etc/php/98-ddtrace.ini >> /etc/php/php.ini
+  fi
+fi

--- a/utils/build/docker/php/docker-bake.hcl
+++ b/utils/build/docker/php/docker-bake.hcl
@@ -11,7 +11,121 @@ group "default" {
     "php-fpm-8_1",
     "php-fpm-8_2",
     "php-fpm-8_5",
+
+    "apache-mod-7_0",
+    "apache-mod-7_1",
+    "apache-mod-7_2",
+    "apache-mod-7_3",
+    "apache-mod-7_4",
+    "apache-mod-8_0",
+    "apache-mod-8_1",
+    "apache-mod-8_2",
+
+    "apache-mod-7_0-zts",
+    "apache-mod-7_1-zts",
+    "apache-mod-7_2-zts",
+    "apache-mod-7_3-zts",
+    "apache-mod-7_4-zts",
+    "apache-mod-8_0-zts",
+    "apache-mod-8_1-zts",
+    "apache-mod-8_2-zts",
   ]
+}
+
+target "apache-mod-7_0" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "7.0", VARIANT = "release" }
+  tags       = ["datadog/system-tests:apache-mod-7.0.base-v1"]
+}
+
+target "apache-mod-7_1" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "7.1", VARIANT = "release" }
+  tags       = ["datadog/system-tests:apache-mod-7.1.base-v1"]
+}
+
+target "apache-mod-7_2" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "7.2", VARIANT = "release" }
+  tags       = ["datadog/system-tests:apache-mod-7.2.base-v1"]
+}
+
+target "apache-mod-7_3" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "7.3", VARIANT = "release" }
+  tags       = ["datadog/system-tests:apache-mod-7.3.base-v1"]
+}
+
+target "apache-mod-7_4" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "7.4", VARIANT = "release" }
+  tags       = ["datadog/system-tests:apache-mod-7.4.base-v1"]
+}
+
+target "apache-mod-8_0" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "8.0", VARIANT = "release" }
+  tags       = ["datadog/system-tests:apache-mod-8.0.base-v1"]
+}
+
+target "apache-mod-8_1" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "8.1", VARIANT = "release" }
+  tags       = ["datadog/system-tests:apache-mod-8.1.base-v1"]
+}
+
+target "apache-mod-8_2" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "8.2", VARIANT = "release" }
+  tags       = ["datadog/system-tests:apache-mod-8.2.base-v1"]
+}
+
+target "apache-mod-7_0-zts" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "7.0", VARIANT = "release-zts" }
+  tags       = ["datadog/system-tests:apache-mod-7.0-zts.base-v1"]
+}
+
+target "apache-mod-7_1-zts" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "7.1", VARIANT = "release-zts" }
+  tags       = ["datadog/system-tests:apache-mod-7.1-zts.base-v1"]
+}
+
+target "apache-mod-7_2-zts" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "7.2", VARIANT = "release-zts" }
+  tags       = ["datadog/system-tests:apache-mod-7.2-zts.base-v1"]
+}
+
+target "apache-mod-7_3-zts" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "7.3", VARIANT = "release-zts" }
+  tags       = ["datadog/system-tests:apache-mod-7.3-zts.base-v1"]
+}
+
+target "apache-mod-7_4-zts" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "7.4", VARIANT = "release-zts" }
+  tags       = ["datadog/system-tests:apache-mod-7.4-zts.base-v1"]
+}
+
+target "apache-mod-8_0-zts" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "8.0", VARIANT = "release-zts" }
+  tags       = ["datadog/system-tests:apache-mod-8.0-zts.base-v1"]
+}
+
+target "apache-mod-8_1-zts" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "8.1", VARIANT = "release-zts" }
+  tags       = ["datadog/system-tests:apache-mod-8.1-zts.base-v1"]
+}
+
+target "apache-mod-8_2-zts" {
+  dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
+  args       = { PHP_VERSION = "8.2", VARIANT = "release-zts" }
+  tags       = ["datadog/system-tests:apache-mod-8.2-zts.base-v1"]
 }
 
 target "php-fpm-7_0" {


### PR DESCRIPTION
## Motivation

Same as #6861 : php builds relies on many third parties with a questionnable stability. by pre-baking base images, the only third party we'll depend on will be docker hub

## Changes

Introduce PHP base images for php apache.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
