### PR TITLE
Add Injection Platform Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,9 @@
 /tests/remote_config/ @DataDog/remote-config @DataDog/system-tests-core
 /tests/appsec/ @DataDog/asm-libraries @DataDog/system-tests-core
 /tests/ai_guard/ @DataDog/k9-ai-guard @DataDog/system-tests-core
+/tests/k8s_lib_injection/ @DataDog/injection-platform
+/tests/auto_inject/ @DataDog/injection-platform
+/tests/docker_ssi/ @DataDog/injection-platform
 /docs/understand/scenarios/ai_guard.md @DataDog/k9-ai-guard @DataDog/system-tests-core
 /tests/debugger/ @DataDog/debugger @DataDog/system-tests-core
 /tests/test_telemetry.py @DataDog/libdatadog-telemetry @DataDog/apm-sdk-capabilities @DataDog/system-tests-core


### PR DESCRIPTION

## Motivation

<!-- What inspired you to submit this pull request? -->

The Injection Platform team is taking ownership over our tests. See [SSI System Test Ownership](https://docs.google.com/document/d/1WqiMFcAKDHuLSoB1GcFMfch3MSrSlUm8yQ-E5Y2rhZQ/edit?usp=sharing).

## Changes

<!-- A brief description of the change being made with this pull request. -->

This commit adds the injection platform team as CODEOWNERS for the test directories we own.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
* [x] A scenario is added, removed or renamed?
    * [x] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
