### PR TITLE
[php] simplify dumb-init setup

### DIFF
--- a/utils/build/docker/php/apache-mod-7.0-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.0-zts.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-7.0-zts.base-v1
+FROM datadog/system-tests:apache-mod-7.0-zts.base-v2
 
 ENV PHP_VERSION=7.0
 ENV VARIANT=release-zts
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.0.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-7.0.base-v1
+FROM datadog/system-tests:apache-mod-7.0.base-v2
 
 ENV PHP_VERSION=7.0
 ENV VARIANT=release
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.1-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.1-zts.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-7.1-zts.base-v1
+FROM datadog/system-tests:apache-mod-7.1-zts.base-v2
 
 ENV PHP_VERSION=7.1
 ENV VARIANT=release-zts
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.1.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.1.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-7.1.base-v1
+FROM datadog/system-tests:apache-mod-7.1.base-v2
 
 ENV PHP_VERSION=7.1
 ENV VARIANT=release
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.2-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.2-zts.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-7.2-zts.base-v1
+FROM datadog/system-tests:apache-mod-7.2-zts.base-v2
 
 ENV PHP_VERSION=7.2
 ENV VARIANT=release-zts
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.2.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.2.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-7.2.base-v1
+FROM datadog/system-tests:apache-mod-7.2.base-v2
 
 ENV PHP_VERSION=7.2
 ENV VARIANT=release
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.3-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.3-zts.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-7.3-zts.base-v1
+FROM datadog/system-tests:apache-mod-7.3-zts.base-v2
 
 ENV PHP_VERSION=7.3
 ENV VARIANT=release-zts
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.3.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.3.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-7.3.base-v1
+FROM datadog/system-tests:apache-mod-7.3.base-v2
 
 ENV PHP_VERSION=7.3
 ENV VARIANT=release
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.4-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.4-zts.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-7.4-zts.base-v1
+FROM datadog/system-tests:apache-mod-7.4-zts.base-v2
 
 ENV PHP_VERSION=7.4
 ENV VARIANT=release-zts
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-7.4.Dockerfile
+++ b/utils/build/docker/php/apache-mod-7.4.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-7.4.base-v1
+FROM datadog/system-tests:apache-mod-7.4.base-v2
 
 ENV PHP_VERSION=7.4
 ENV VARIANT=release
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.0-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.0-zts.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-8.0-zts.base-v1
+FROM datadog/system-tests:apache-mod-8.0-zts.base-v2
 
 ENV PHP_VERSION=8.0
 ENV VARIANT=release-zts
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.0.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-8.0.base-v1
+FROM datadog/system-tests:apache-mod-8.0.base-v2
 
 ENV PHP_VERSION=8.0
 ENV VARIANT=release
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.1-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.1-zts.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-8.1-zts.base-v1
+FROM datadog/system-tests:apache-mod-8.1-zts.base-v2
 
 ENV PHP_VERSION=8.1
 ENV VARIANT=release-zts
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.1.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.1.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-8.1.base-v1
+FROM datadog/system-tests:apache-mod-8.1.base-v2
 
 ENV PHP_VERSION=8.1
 ENV VARIANT=release
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.2-zts.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.2-zts.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-8.2-zts.base-v1
+FROM datadog/system-tests:apache-mod-8.2-zts.base-v2
 
 ENV PHP_VERSION=8.2
 ENV VARIANT=release-zts
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod-8.2.Dockerfile
+++ b/utils/build/docker/php/apache-mod-8.2.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:apache-mod-8.2.base-v1
+FROM datadog/system-tests:apache-mod-8.2.base-v2
 
 ENV PHP_VERSION=8.2
 ENV VARIANT=release
@@ -11,3 +11,6 @@ ADD utils/build/docker/php/common/install_ddtrace.sh /install_ddtrace.sh
 
 ADD binaries* /binaries/
 RUN /install_ddtrace.sh 1
+
+ADD utils/build/docker/php/apache-mod/app.sh /app.sh
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/apache-mod.base.Dockerfile
+++ b/utils/build/docker/php/apache-mod.base.Dockerfile
@@ -17,9 +17,5 @@ RUN chmod +x /tmp/php/apache-mod/build.sh
 RUN /tmp/php/apache-mod/build.sh
 RUN rm -rf /tmp/php/
 
-ADD utils/build/docker/php/apache-mod/entrypoint.sh /entrypoint.sh
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]

--- a/utils/build/docker/php/apache-mod/app.sh
+++ b/utils/build/docker/php/apache-mod/app.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -e
+#!/usr/bin/dumb-init /bin/bash
+# shellcheck shell=bash
+
+set -e
 
 if [[ $# -gt 0 ]]; then
   "$@"
@@ -11,13 +14,13 @@ chmod a+rx /root
 export SYSTEM_TESTS_LOGS=/var/log/system-tests
 
 rm -f /tmp/ddappsec.lock
-LOGS_PHP=($SYSTEM_TESTS_LOGS/appsec.log $SYSTEM_TESTS_LOGS/helper.log $SYSTEM_TESTS_LOGS/php_error.log $SYSTEM_TESTS_LOGS/sidecar.log $SYSTEM_TESTS_LOGS/tracer.log)
+LOGS_PHP=("$SYSTEM_TESTS_LOGS/appsec.log" "$SYSTEM_TESTS_LOGS/helper.log" "$SYSTEM_TESTS_LOGS/php_error.log" "$SYSTEM_TESTS_LOGS/sidecar.log" "$SYSTEM_TESTS_LOGS/tracer.log")
 touch "${LOGS_PHP[@]}"
 chown www-data:www-data "${LOGS_PHP[@]}"
 
 export APACHE_LOG_DIR="$SYSTEM_TESTS_LOGS/apache2"
 mkdir -p "$APACHE_LOG_DIR"
-LOGS_APACHE=($APACHE_LOG_DIR/{access.log,error.log})
+LOGS_APACHE=("$APACHE_LOG_DIR/access.log" "$APACHE_LOG_DIR/error.log")
 touch "${LOGS_APACHE[@]}"
 chown root:adm "${LOGS_APACHE[@]}"
 

--- a/utils/build/docker/php/apache-mod/build.sh
+++ b/utils/build/docker/php/apache-mod/build.sh
@@ -20,21 +20,11 @@ cp -rf /tmp/php/common/php.ini /etc/php/
 printf '#!/bin/sh\n\nexit 101\n' > /usr/sbin/policy-rc.d && \
 	chmod +x /usr/sbin/policy-rc.d && \
 	apt-get update && apt-get install -y \
-		apache2 jq \
+		apache2 jq dumb-init \
 	&& rm -rf /var/lib/apt/lists/* && \
 	rm -rf /usr/sbin/policy-rc.d
 
 a2enmod rewrite
-
-ARCH=$(arch)
-if [[ $ARCH = aarch64 ]]; then
-  ARCH=arm64
-else
-  ARCH=amd64
-fi
-
-curl -Lf -o /tmp/dumb_init.deb https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_${ARCH}.deb && \
-	dpkg -i /tmp/dumb_init.deb && rm /tmp/dumb_init.deb
 
 if [[ "${PHP_MAJOR_VERSION}" -ge 8 ]]; then
 	sed -i "s/%PHP_MAJOR_VERSION//g" /etc/apache2/mods-available/php.{conf,load};

--- a/utils/build/docker/php/docker-bake.hcl
+++ b/utils/build/docker/php/docker-bake.hcl
@@ -35,158 +35,158 @@ group "default" {
 target "apache-mod-7_0" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "7.0", VARIANT = "release" }
-  tags       = ["datadog/system-tests:apache-mod-7.0.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-7.0.base-v2"]
 }
 
 target "apache-mod-7_1" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "7.1", VARIANT = "release" }
-  tags       = ["datadog/system-tests:apache-mod-7.1.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-7.1.base-v2"]
 }
 
 target "apache-mod-7_2" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "7.2", VARIANT = "release" }
-  tags       = ["datadog/system-tests:apache-mod-7.2.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-7.2.base-v2"]
 }
 
 target "apache-mod-7_3" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "7.3", VARIANT = "release" }
-  tags       = ["datadog/system-tests:apache-mod-7.3.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-7.3.base-v2"]
 }
 
 target "apache-mod-7_4" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "7.4", VARIANT = "release" }
-  tags       = ["datadog/system-tests:apache-mod-7.4.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-7.4.base-v2"]
 }
 
 target "apache-mod-8_0" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "8.0", VARIANT = "release" }
-  tags       = ["datadog/system-tests:apache-mod-8.0.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-8.0.base-v2"]
 }
 
 target "apache-mod-8_1" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "8.1", VARIANT = "release" }
-  tags       = ["datadog/system-tests:apache-mod-8.1.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-8.1.base-v2"]
 }
 
 target "apache-mod-8_2" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "8.2", VARIANT = "release" }
-  tags       = ["datadog/system-tests:apache-mod-8.2.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-8.2.base-v2"]
 }
 
 target "apache-mod-7_0-zts" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "7.0", VARIANT = "release-zts" }
-  tags       = ["datadog/system-tests:apache-mod-7.0-zts.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-7.0-zts.base-v2"]
 }
 
 target "apache-mod-7_1-zts" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "7.1", VARIANT = "release-zts" }
-  tags       = ["datadog/system-tests:apache-mod-7.1-zts.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-7.1-zts.base-v2"]
 }
 
 target "apache-mod-7_2-zts" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "7.2", VARIANT = "release-zts" }
-  tags       = ["datadog/system-tests:apache-mod-7.2-zts.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-7.2-zts.base-v2"]
 }
 
 target "apache-mod-7_3-zts" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "7.3", VARIANT = "release-zts" }
-  tags       = ["datadog/system-tests:apache-mod-7.3-zts.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-7.3-zts.base-v2"]
 }
 
 target "apache-mod-7_4-zts" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "7.4", VARIANT = "release-zts" }
-  tags       = ["datadog/system-tests:apache-mod-7.4-zts.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-7.4-zts.base-v2"]
 }
 
 target "apache-mod-8_0-zts" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "8.0", VARIANT = "release-zts" }
-  tags       = ["datadog/system-tests:apache-mod-8.0-zts.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-8.0-zts.base-v2"]
 }
 
 target "apache-mod-8_1-zts" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "8.1", VARIANT = "release-zts" }
-  tags       = ["datadog/system-tests:apache-mod-8.1-zts.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-8.1-zts.base-v2"]
 }
 
 target "apache-mod-8_2-zts" {
   dockerfile = "utils/build/docker/php/apache-mod.base.Dockerfile"
   args       = { PHP_VERSION = "8.2", VARIANT = "release-zts" }
-  tags       = ["datadog/system-tests:apache-mod-8.2-zts.base-v1"]
+  tags       = ["datadog/system-tests:apache-mod-8.2-zts.base-v2"]
 }
 
 target "php-fpm-7_0" {
   context    = "utils/build/docker/php/"
   dockerfile = "php-fpm.base.Dockerfile"
   args       = { PHP_VERSION = "7.0" }
-  tags       = ["datadog/system-tests:php-fpm-7.0.base-v1"]
+  tags       = ["datadog/system-tests:php-fpm-7.0.base-v2"]
 }
 
 target "php-fpm-7_1" {
   context    = "utils/build/docker/php"
   dockerfile = "php-fpm.base.Dockerfile"
   args       = { PHP_VERSION = "7.1" }
-  tags       = ["datadog/system-tests:php-fpm-7.1.base-v1"]
+  tags       = ["datadog/system-tests:php-fpm-7.1.base-v2"]
 }
 
 target "php-fpm-7_2" {
   context    = "utils/build/docker/php"
   dockerfile = "php-fpm.base.Dockerfile"
   args       = { PHP_VERSION = "7.2" }
-  tags       = ["datadog/system-tests:php-fpm-7.2.base-v1"]
+  tags       = ["datadog/system-tests:php-fpm-7.2.base-v2"]
 }
 
 target "php-fpm-7_3" {
   context    = "utils/build/docker/php"
   dockerfile = "php-fpm.base.Dockerfile"
   args       = { PHP_VERSION = "7.3" }
-  tags       = ["datadog/system-tests:php-fpm-7.3.base-v1"]
+  tags       = ["datadog/system-tests:php-fpm-7.3.base-v2"]
 }
 
 target "php-fpm-7_4" {
   context    = "utils/build/docker/php"
   dockerfile = "php-fpm.base.Dockerfile"
   args       = { PHP_VERSION = "7.4" }
-  tags       = ["datadog/system-tests:php-fpm-7.4.base-v1"]
+  tags       = ["datadog/system-tests:php-fpm-7.4.base-v2"]
 }
 
 target "php-fpm-8_0" {
   context    = "utils/build/docker/php"
   dockerfile = "php-fpm.base.Dockerfile"
   args       = { PHP_VERSION = "8.0" }
-  tags       = ["datadog/system-tests:php-fpm-8.0.base-v1"]
+  tags       = ["datadog/system-tests:php-fpm-8.0.base-v2"]
 }
 
 target "php-fpm-8_1" {
   context    = "utils/build/docker/php"
   dockerfile = "php-fpm.base.Dockerfile"
   args       = { PHP_VERSION = "8.1" }
-  tags       = ["datadog/system-tests:php-fpm-8.1.base-v1"]
+  tags       = ["datadog/system-tests:php-fpm-8.1.base-v2"]
 }
 
 target "php-fpm-8_2" {
   context    = "utils/build/docker/php"
   dockerfile = "php-fpm.base.Dockerfile"
   args       = { PHP_VERSION = "8.2" }
-  tags       = ["datadog/system-tests:php-fpm-8.2.base-v1"]
+  tags       = ["datadog/system-tests:php-fpm-8.2.base-v2"]
 }
 
 target "php-fpm-8_5" {
   context    = "utils/build/docker/php"
   dockerfile = "php-fpm.base.Dockerfile"
   args       = { PHP_VERSION = "8.5" }
-  tags       = ["datadog/system-tests:php-fpm-8.5.base-v1"]
+  tags       = ["datadog/system-tests:php-fpm-8.5.base-v2"]
 }

--- a/utils/build/docker/php/php-fpm-7.0.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.0.Dockerfile
@@ -1,13 +1,13 @@
 
-FROM datadog/system-tests:php-fpm-7.0.base-v1
+FROM datadog/system-tests:php-fpm-7.0.base-v2
 
 ARG PHP_VERSION=7.0
 
 ADD utils/build/docker/php/common/ /var/www/html/
 ADD utils/build/docker/php/common/php.ini /etc/php/$PHP_VERSION/fpm/php.ini
 ADD utils/build/docker/php/php-fpm/php-fpm.conf /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
-ADD utils/build/docker/php/php-fpm/entrypoint.sh /entrypoint.sh
-RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /entrypoint.sh
+ADD utils/build/docker/php/php-fpm/app.sh /app.sh
+RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /app.sh
 RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 RUN sed -i s/PHP_MAJOR_VERSION/$PHP_MAJOR_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 
@@ -27,6 +27,4 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/php-fpm-7.1.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.1.Dockerfile
@@ -1,13 +1,13 @@
 
-FROM datadog/system-tests:php-fpm-7.1.base-v1
+FROM datadog/system-tests:php-fpm-7.1.base-v2
 
 ARG PHP_VERSION=7.1
 
 ADD utils/build/docker/php/common/ /var/www/html/
 ADD utils/build/docker/php/common/php.ini /etc/php/$PHP_VERSION/fpm/php.ini
 ADD utils/build/docker/php/php-fpm/php-fpm.conf /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
-ADD utils/build/docker/php/php-fpm/entrypoint.sh /entrypoint.sh
-RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /entrypoint.sh
+ADD utils/build/docker/php/php-fpm/app.sh /app.sh
+RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /app.sh
 RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 RUN sed -i s/PHP_MAJOR_VERSION/$PHP_MAJOR_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 
@@ -27,6 +27,4 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/php-fpm-7.2.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.2.Dockerfile
@@ -1,13 +1,13 @@
 
-FROM datadog/system-tests:php-fpm-7.2.base-v1
+FROM datadog/system-tests:php-fpm-7.2.base-v2
 
 ARG PHP_VERSION=7.2
 
 ADD utils/build/docker/php/common/ /var/www/html/
 ADD utils/build/docker/php/common/php.ini /etc/php/$PHP_VERSION/fpm/php.ini
 ADD utils/build/docker/php/php-fpm/php-fpm.conf /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
-ADD utils/build/docker/php/php-fpm/entrypoint.sh /entrypoint.sh
-RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /entrypoint.sh
+ADD utils/build/docker/php/php-fpm/app.sh /app.sh
+RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /app.sh
 RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 RUN sed -i s/PHP_MAJOR_VERSION/$PHP_MAJOR_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 
@@ -27,6 +27,4 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/php-fpm-7.3.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.3.Dockerfile
@@ -1,13 +1,13 @@
 
-FROM datadog/system-tests:php-fpm-7.3.base-v1
+FROM datadog/system-tests:php-fpm-7.3.base-v2
 
 ARG PHP_VERSION=7.3
 
 ADD utils/build/docker/php/common/ /var/www/html/
 ADD utils/build/docker/php/common/php.ini /etc/php/$PHP_VERSION/fpm/php.ini
 ADD utils/build/docker/php/php-fpm/php-fpm.conf /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
-ADD utils/build/docker/php/php-fpm/entrypoint.sh /entrypoint.sh
-RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /entrypoint.sh
+ADD utils/build/docker/php/php-fpm/app.sh /app.sh
+RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /app.sh
 RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 RUN sed -i s/PHP_MAJOR_VERSION/$PHP_MAJOR_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 
@@ -27,6 +27,4 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/php-fpm-7.4.Dockerfile
+++ b/utils/build/docker/php/php-fpm-7.4.Dockerfile
@@ -1,13 +1,13 @@
 
-FROM datadog/system-tests:php-fpm-7.4.base-v1
+FROM datadog/system-tests:php-fpm-7.4.base-v2
 
 ARG PHP_VERSION=7.4
 
 ADD utils/build/docker/php/common/ /var/www/html/
 ADD utils/build/docker/php/common/php.ini /etc/php/$PHP_VERSION/fpm/php.ini
 ADD utils/build/docker/php/php-fpm/php-fpm.conf /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
-ADD utils/build/docker/php/php-fpm/entrypoint.sh /entrypoint.sh
-RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /entrypoint.sh
+ADD utils/build/docker/php/php-fpm/app.sh /app.sh
+RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /app.sh
 RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 RUN sed -i s/PHP_MAJOR_VERSION/$PHP_MAJOR_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 
@@ -27,6 +27,4 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/php-fpm-8.0.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.0.Dockerfile
@@ -1,13 +1,13 @@
 
-FROM datadog/system-tests:php-fpm-8.0.base-v1
+FROM datadog/system-tests:php-fpm-8.0.base-v2
 
 ARG PHP_VERSION=8.0
 
 ADD utils/build/docker/php/common/ /var/www/html/
 ADD utils/build/docker/php/common/php.ini /etc/php/$PHP_VERSION/fpm/php.ini
 ADD utils/build/docker/php/php-fpm/php-fpm.conf /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
-ADD utils/build/docker/php/php-fpm/entrypoint.sh /entrypoint.sh
-RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /entrypoint.sh
+ADD utils/build/docker/php/php-fpm/app.sh /app.sh
+RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /app.sh
 RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 RUN sed -i s/PHP_MAJOR_VERSION/$PHP_MAJOR_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 
@@ -27,6 +27,4 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/php-fpm-8.1.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.1.Dockerfile
@@ -1,13 +1,13 @@
 
-FROM datadog/system-tests:php-fpm-8.1.base-v1
+FROM datadog/system-tests:php-fpm-8.1.base-v2
 
 ARG PHP_VERSION=8.1
 
 ADD utils/build/docker/php/common/ /var/www/html/
 ADD utils/build/docker/php/common/php.ini /etc/php/$PHP_VERSION/fpm/php.ini
 ADD utils/build/docker/php/php-fpm/php-fpm.conf /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
-ADD utils/build/docker/php/php-fpm/entrypoint.sh /entrypoint.sh
-RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /entrypoint.sh
+ADD utils/build/docker/php/php-fpm/app.sh /app.sh
+RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /app.sh
 RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 RUN sed -i s/PHP_MAJOR_VERSION/$PHP_MAJOR_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 
@@ -27,6 +27,4 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/php-fpm-8.2.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.2.Dockerfile
@@ -1,13 +1,13 @@
 
-FROM datadog/system-tests:php-fpm-8.2.base-v1
+FROM datadog/system-tests:php-fpm-8.2.base-v2
 
 ARG PHP_VERSION=8.2
 
 ADD utils/build/docker/php/common/ /var/www/html/
 ADD utils/build/docker/php/common/php.ini /etc/php/$PHP_VERSION/fpm/php.ini
 ADD utils/build/docker/php/php-fpm/php-fpm.conf /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
-ADD utils/build/docker/php/php-fpm/entrypoint.sh /entrypoint.sh
-RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /entrypoint.sh
+ADD utils/build/docker/php/php-fpm/app.sh /app.sh
+RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /app.sh
 RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 RUN sed -i s/PHP_MAJOR_VERSION/$PHP_MAJOR_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 
@@ -27,6 +27,4 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/php-fpm-8.5.Dockerfile
+++ b/utils/build/docker/php/php-fpm-8.5.Dockerfile
@@ -1,13 +1,13 @@
 
-FROM datadog/system-tests:php-fpm-8.5.base-v1
+FROM datadog/system-tests:php-fpm-8.5.base-v2
 
 ARG PHP_VERSION=8.5
 
 ADD utils/build/docker/php/common/ /var/www/html/
 ADD utils/build/docker/php/common/php.ini /etc/php/$PHP_VERSION/fpm/php.ini
 ADD utils/build/docker/php/php-fpm/php-fpm.conf /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
-ADD utils/build/docker/php/php-fpm/entrypoint.sh /entrypoint.sh
-RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /entrypoint.sh
+ADD utils/build/docker/php/php-fpm/app.sh /app.sh
+RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /app.sh
 RUN sed -i s/PHP_VERSION/$PHP_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 RUN sed -i s/PHP_MAJOR_VERSION/$PHP_MAJOR_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 
@@ -29,6 +29,4 @@ EXPOSE 7777/tcp
 
 WORKDIR /binaries
 ENTRYPOINT []
-RUN echo "#!/bin/bash\ndumb-init /entrypoint.sh" > app.sh
-RUN chmod +x app.sh
-CMD [ "./app.sh" ]
+CMD [ "/app.sh" ]

--- a/utils/build/docker/php/php-fpm/app.sh
+++ b/utils/build/docker/php/php-fpm/app.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -e
+#!/usr/bin/dumb-init /bin/bash
+# shellcheck shell=bash
+
+set -e
 
 if [[ $# -gt 0 ]]; then
   "$@"

--- a/utils/build/docker/php/php-fpm/build.sh
+++ b/utils/build/docker/php/php-fpm/build.sh
@@ -31,7 +31,7 @@ nala update
 printf '#!/bin/sh\n\nexit 101\n' > /usr/sbin/policy-rc.d
 chmod +x /usr/sbin/policy-rc.d
 
-nala install -y --no-install-recommends tzdata publicsuffix curl apache2 libapache2-mod-fcgid jq ca-certificates git php$PHP_VERSION-fpm php$PHP_VERSION-curl apache2 php$PHP_VERSION-mysql php$PHP_VERSION-pgsql php$PHP_VERSION-xml php$PHP_VERSION-mongodb
+nala install -y --no-install-recommends tzdata publicsuffix curl apache2 libapache2-mod-fcgid jq ca-certificates git dumb-init php$PHP_VERSION-fpm php$PHP_VERSION-curl apache2 php$PHP_VERSION-mysql php$PHP_VERSION-pgsql php$PHP_VERSION-xml php$PHP_VERSION-mongodb
 
 rm -rf /usr/sbin/policy-rc.d
 rm -rf /var/lib/apt/lists/*
@@ -42,7 +42,7 @@ mkdir -p /var/www/html/rasp
 cp -rf /tmp/php/common/* /var/www/html/
 cp /tmp/php/php-fpm/php-fpm.conf /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 cp /tmp/php/common/php.ini /etc/php/$PHP_VERSION/fpm/php.ini
-cp /tmp/php/php-fpm/entrypoint.sh /
+cp /tmp/php/php-fpm/app.sh /
 
 chmod 644 /var/www/html/*.php
 
@@ -52,18 +52,8 @@ a2enconf php$PHP_VERSION-fpm
 a2enmod proxy
 a2enmod proxy_fcgi
 
-ARCH=$(arch)
-if [[ $ARCH = aarch64 ]]; then
-  ARCH=arm64
-else
-  ARCH=amd64
-fi
-
-curl -Lf -o /tmp/dumb_init.deb https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_${ARCH}.deb && \
-	dpkg -i /tmp/dumb_init.deb && rm /tmp/dumb_init.deb
-
 sed -i s/80/7777/ /etc/apache2/ports.conf
-sed -i s/PHP_VERSION/$PHP_VERSION/ /entrypoint.sh
+sed -i s/PHP_VERSION/$PHP_VERSION/ /app.sh
 sed -i s/PHP_VERSION/$PHP_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 sed -i s/PHP_MAJOR_VERSION/$PHP_MAJOR_VERSION/ /etc/apache2/conf-available/php$PHP_VERSION-fpm.conf
 


### PR DESCRIPTION
## Motivation

Preparing to extend dumb-init usage across the board. Simplifying php usage of it first.

## Changes

- install `dumb-init` from apt repositories instead of fetching the release `.deb` over HTTPS during the base image build.
- use the dumb-init shebang on the app entrypoint (as recommended by the dumb-init docs), so it acts as PID 1 directly.
- rename `apache-mod/entrypoint.sh` and `php-fpm/entrypoint.sh` to `app.sh`, and drop the trivial `RUN echo "...\nexec /entrypoint.sh"
  > app.sh` wrapper that only existed to invoke dumb-init.
- move the `ADD app.sh` and `CMD` lines out of `apache-mod.base.Dockerfile` into each per-version `apache-mod-*.Dockerfile`, so updates to the app entrypoint don't require rebuilding the base image.
- bump apache-mod and php-fpm base image tags from `base-v1` to `base-v2` (the `apt install dumb-init` change in the build scripts is baked into the base).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
