### PR TITLE
Add parametric tests for DD_PROCESS_TAGS_MAPPING (APMSP-2804)

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -229,6 +229,7 @@ manifest:
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery::test_metadata_content_without_process_tags:  # Easy win for all weblogs and version 2.0.0
     - declaration: bug (APMAPI-1772)
       component_version: '>=2.0.0'
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_sampling_delegation.py::Test_Decisionless_Extraction: ">1.0.0"
   tests/parametric/test_sampling_manual.py::Test_Manual_Sampling: bug (APMAPI-1720)  # Manual keep did not override the upstream drop decision
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: '>=2.1.0'

--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -86,6 +86,7 @@ manifest:
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -329,6 +329,7 @@ manifest:
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -978,6 +978,7 @@ manifest:
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span_default: missing_feature (partial flushing not enabled by default)
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery: '>=3.36.0'  # Modified by easy win activation script
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery::test_metadata_content_with_process_tags: missing_feature  # Created by easy win activation script
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: '>=3.41.0'
   tests/parametric/test_sampling_span_tags.py::Test_Sampling_Span_Tags::test_tags_appsec_enabled_sst011: bug (APMAPI-737)
   tests/parametric/test_sampling_span_tags.py::Test_Sampling_Span_Tags::test_tags_child_dropped_sst001: bug (APMAPI-737)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1206,6 +1206,7 @@ manifest:
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span_default: missing_feature (partial flushing not enabled by default)
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery: v2.2.3
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: '>=2.8.0'
   tests/parametric/test_sampling_span_tags.py::Test_Sampling_Span_Tags::test_tags_appsec_enabled_sst011: bug (APMAPI-737)
   tests/parametric/test_sampling_span_tags.py::Test_Sampling_Span_Tags::test_tags_child_dropped_sst001: bug (APMAPI-737)

--- a/manifests/java_otel.yml
+++ b/manifests/java_otel.yml
@@ -51,6 +51,7 @@ manifest:
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2122,6 +2122,7 @@ manifest:
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log: *ref_5_72_0
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing: bug (APMLP-270)
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery: v5.93.0
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_sampling_manual.py::Test_Manual_Sampling: bug (APMAPI-1720)  # Manual keep did not override the upstream drop decision
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: '>=5.93.0'
   tests/parametric/test_sampling_span_tags.py::Test_Sampling_Span_Tags::test_tags_appsec_enabled_sst011: bug (APMAPI-737)

--- a/manifests/nodejs_otel.yml
+++ b/manifests/nodejs_otel.yml
@@ -68,6 +68,7 @@ manifest:
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -856,6 +856,7 @@ manifest:
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_disabled: '>=1.16.0'
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_under_limit_one_payload: '>=1.16.0'
   tests/parametric/test_process_discovery.py: missing_feature
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_sampling_delegation.py::Test_Decisionless_Extraction: v1.13.0+4663b2fa7c20c6920f347d059b57dc2a419cb7f7
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: '>=1.18.0'
   ? tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate::test_sampling_extract_knuth_sample_rate_distributed_tracing_datadog

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1896,6 +1896,7 @@ manifest:
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Otel_Baggage: v2.16.0
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing: flaky (APMAPI-734)
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery: v3.15.0+dev36.gb57f15308
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_sampling_delegation.py::Test_Decisionless_Extraction: v2.8.0
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: v4.7.0
   tests/parametric/test_sampling_span_tags.py::Test_Sampling_Span_Tags: v2.8.0

--- a/manifests/python_lambda.yml
+++ b/manifests/python_lambda.yml
@@ -317,6 +317,7 @@ manifest:
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature

--- a/manifests/python_otel.yml
+++ b/manifests/python_otel.yml
@@ -61,6 +61,7 @@ manifest:
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1607,6 +1607,7 @@ manifest:
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span: missing_feature  # Created by easy win activation script
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span_default: missing_feature  # Created by easy win activation script
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery: v2.18.0
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_sampling_delegation.py::Test_Decisionless_Extraction: v2.4.0
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: v2.31.0-dev
   tests/parametric/test_sampling_span_tags.py::Test_Sampling_Span_Tags::test_tags_appsec_enabled_sst011: bug (APMAPI-737)

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -236,6 +236,7 @@ manifest:
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span: missing_feature  # Created by easy win activation script
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span_default: missing_feature  # Created by easy win activation script
   tests/parametric/test_process_discovery.py: missing_feature
+  tests/parametric/test_process_tags_mapping.py::Test_ProcessTagsMapping: missing_feature
   tests/parametric/test_sampling_manual.py::Test_Manual_Sampling: missing_feature
   tests/parametric/test_sampling_span_tags.py: '>=0.2.1'  # Modified by easy win activation script
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: '>=0.4.0'

--- a/tests/parametric/test_process_tags_mapping.py
+++ b/tests/parametric/test_process_tags_mapping.py
@@ -1,0 +1,200 @@
+"""Parametric system test for DD_PROCESS_TAGS_MAPPING.
+
+Verifies the contract introduced by the RFC "Infer Process Tags from User Configuration":
+the configuration ``DD_PROCESS_TAGS_MAPPING`` accepts a comma-separated list of
+``{source}config_key:process_tag_key`` mappings and emits matching process tags
+(stored in ``_dd.tags.process``) only when the source is recognised, the key exists
+and the value is non-empty.
+
+Currently the feature is tailored to dd-trace-java; other tracers are gated as
+``missing_feature`` in their manifests until a follow-up RFC extends the contract.
+"""
+
+import pytest
+
+from utils import features, scenarios
+from utils.docker_fixtures import TestAgentAPI
+from utils.docker_fixtures.spec.trace import find_root_span, find_trace
+
+from .conftest import APMLibrary
+
+
+parametrize = pytest.mark.parametrize
+
+
+@scenarios.parametric
+@features.process_tags
+class Test_ProcessTagsMapping:
+    """End-to-end validation of DD_PROCESS_TAGS_MAPPING.
+
+    Each test sets ``DD_PROCESS_TAGS_MAPPING`` (and any backing env vars) via
+    ``library_env`` and inspects the ``_dd.tags.process`` meta field of the
+    root span emitted by the parametric library harness.
+    """
+
+    @parametrize(
+        "library_env",
+        [
+            {
+                "TEST_ENV_KEY": "test_env_value",
+                "DD_PROCESS_TAGS_MAPPING": "{env}TEST_ENV_KEY:custom_tag",
+                "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": "true",
+            }
+        ],
+    )
+    def test_env_source_emits_tag(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """A single valid ``{env}`` mapping resolves to ``process_tag_key:value``.
+
+        Covers TS-019, TS-030, TS-035 from the RFC test plan.
+        """
+        with test_library, test_library.dd_start_span("operation") as root:
+            pass
+
+        traces = test_agent.wait_for_num_traces(1, sort_by_start=False)
+        trace = find_trace(traces, root.trace_id)
+        span = find_root_span(trace)
+        assert span is not None
+        process_tags = span["meta"]["_dd.tags.process"]
+        assert "custom_tag:test_env_value" in process_tags, (
+            f"Expected mapped tag 'custom_tag:test_env_value' in process tags, got: {process_tags}"
+        )
+
+    @parametrize(
+        "library_env",
+        [
+            {
+                "DD_PROCESS_TAGS_MAPPING": "{env}NOT_SET_KEY:missing_tag",
+                "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": "true",
+            }
+        ],
+    )
+    def test_missing_key_no_emission(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """When the referenced env var does not exist, no mapped tag is emitted.
+
+        Covers TS-024, TS-032 from the RFC test plan.
+        """
+        with test_library, test_library.dd_start_span("operation") as root:
+            pass
+
+        traces = test_agent.wait_for_num_traces(1, sort_by_start=False)
+        trace = find_trace(traces, root.trace_id)
+        span = find_root_span(trace)
+        assert span is not None
+        process_tags = span["meta"].get("_dd.tags.process", "")
+        assert "missing_tag:" not in process_tags, (
+            f"Expected no 'missing_tag:' in process tags when key is unset, got: {process_tags}"
+        )
+
+    @parametrize(
+        "library_env",
+        [
+            {
+                "EMPTY_KEY": "",
+                "DD_PROCESS_TAGS_MAPPING": "{env}EMPTY_KEY:empty_tag",
+                "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": "true",
+            }
+        ],
+    )
+    def test_empty_value_no_emission(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """When the referenced env var is set but empty, no mapped tag is emitted.
+
+        Covers TS-026, TS-033 from the RFC test plan.
+        """
+        with test_library, test_library.dd_start_span("operation") as root:
+            pass
+
+        traces = test_agent.wait_for_num_traces(1, sort_by_start=False)
+        trace = find_trace(traces, root.trace_id)
+        span = find_root_span(trace)
+        assert span is not None
+        process_tags = span["meta"].get("_dd.tags.process", "")
+        assert "empty_tag:" not in process_tags, (
+            f"Expected no 'empty_tag:' in process tags when value is empty, got: {process_tags}"
+        )
+
+    @parametrize(
+        "library_env",
+        [
+            {
+                "K1": "v1",
+                "K2": "v2",
+                "DD_PROCESS_TAGS_MAPPING": "{env}K1:collision_tag,{env}K2:collision_tag",
+                "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": "true",
+            }
+        ],
+    )
+    def test_last_wins_both_valid(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """When two mappings emit the same process_tag_key, the last one wins.
+
+        Covers TS-045, TS-048 from the RFC test plan.
+        """
+        with test_library, test_library.dd_start_span("operation") as root:
+            pass
+
+        traces = test_agent.wait_for_num_traces(1, sort_by_start=False)
+        trace = find_trace(traces, root.trace_id)
+        span = find_root_span(trace)
+        assert span is not None
+        process_tags = span["meta"]["_dd.tags.process"]
+        assert "collision_tag:v2" in process_tags, (
+            f"Expected last-wins tag 'collision_tag:v2' in process tags, got: {process_tags}"
+        )
+        assert "collision_tag:v1" not in process_tags, (
+            f"Expected previous mapping value 'collision_tag:v1' to be overridden, got: {process_tags}"
+        )
+
+    @parametrize(
+        "library_env",
+        [
+            {
+                "EXPLICIT_KEY": "explicit_value",
+                "IMPLICIT_KEY": "implicit_value",
+                "DD_PROCESS_TAGS_MAPPING": "{env}EXPLICIT_KEY:explicit_tag",
+                "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": "true",
+            }
+        ],
+    )
+    def test_security_explicit_only(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """Only env vars listed in DD_PROCESS_TAGS_MAPPING are exposed as process tags.
+
+        Covers TS-056, TS-057 from the RFC test plan.
+        """
+        with test_library, test_library.dd_start_span("operation") as root:
+            pass
+
+        traces = test_agent.wait_for_num_traces(1, sort_by_start=False)
+        trace = find_trace(traces, root.trace_id)
+        span = find_root_span(trace)
+        assert span is not None
+        process_tags = span["meta"]["_dd.tags.process"]
+        assert "explicit_tag:explicit_value" in process_tags, (
+            f"Expected explicitly mapped tag in process tags, got: {process_tags}"
+        )
+        assert "implicit_value" not in process_tags, (
+            f"Expected non-listed env var value 'implicit_value' to NOT be exposed, got: {process_tags}"
+        )
+
+    @parametrize(
+        "library_env",
+        [
+            {
+                "DD_PROCESS_TAGS_MAPPING": "{invalid}SOME_KEY:bad_tag",
+                "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": "true",
+                "SOME_KEY": "some_value",
+            }
+        ],
+    )
+    def test_unrecognised_source_no_emission(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """An unrecognised source (e.g. ``{invalid}``) is rejected gracefully.
+
+        Covers TS-009, TS-031 from the RFC test plan.
+        """
+        with test_library, test_library.dd_start_span("operation") as root:
+            pass
+
+        traces = test_agent.wait_for_num_traces(1, sort_by_start=False)
+        trace = find_trace(traces, root.trace_id)
+        span = find_root_span(trace)
+        assert span is not None
+        process_tags = span["meta"].get("_dd.tags.process", "")
+        assert "bad_tag:" not in process_tags, f"Expected no 'bad_tag:' from unrecognised source, got: {process_tags}"


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Adds the system-tests parametric coverage required by the RFC
"Infer Process Tags from User Configuration" (APMSP-2804).
- New test class `Test_ProcessTagsMapping` in
  `tests/parametric/test_process_tags_mapping.py` covering 6 cases:
  env source emission, missing key, empty value, last-wins, security
  (explicit-only), and unrecognised source.
- Java-only scope per the RFC: all non-Java parametric manifests
  (python, nodejs, golang, ruby, php, dotnet, cpp, rust, *_otel,
  python_lambda, cpp_httpd, cpp_nginx) gated as `missing_feature`.
- Reuses the existing `@features.process_tags` decorator
  (FPD feature_id 475).

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
