### PR TITLE
fix(parametric): use canonical addLink shape for dd-trace-js v6

### DIFF
--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -132,7 +132,7 @@ app.post('/trace/span/start', (req, res) => {
   });
 
   if (ddContext[request.parent_id]) {
-    for (const link of ddContext[request.parent_id]._links || []) span.addLink(link.context, link.attributes)
+    for (const link of ddContext[request.parent_id]._links || []) span.addLink(link)
   }
 
   spans[span.context().toSpanId()] = span;
@@ -143,9 +143,9 @@ app.post('/trace/span/add_link', (req, res) => {
   const request = req.body;
   const span = spans[request.span_id]
   if (spans[request.parent_id]) {
-    span.addLink(spans[request.parent_id].context(), request.attributes)
+    span.addLink({ context: spans[request.parent_id].context(), attributes: request.attributes })
   } else {
-    span.addLink(ddContext[request.parent_id], request.attributes)
+    span.addLink({ context: ddContext[request.parent_id], attributes: request.attributes })
   }
   res.json({});
 });


### PR DESCRIPTION
dd-trace-js#8319 gates off the legacy two-argument `addLink(spanContext, attributes)` overload in v6: the OpenTracing path throws TypeError, the OTel bridge silently drops the link.

Rewrite the three call sites in the parametric Node.js server to the canonical `{ context, attributes }` single-argument form, supported since dd-trace-js 5.3.0:

1. `/trace/span/start`: pass the cached link object directly, since it already has the canonical `{ context, attributes }` shape.
2. `/trace/span/add_link` spans branch: wrap the lookup result in `{ context, attributes }`.
3. `/trace/span/add_link` ddContext branch: same shape on the propagator-context fallback.

Forward-compatible on v5; unblocks dd-trace-js#8319 on v6.

Refs: https://github.com/DataDog/dd-trace-js/pull/8319
