### PR TITLE
[Debugger] Test SymDB upload event JSON and attachment metadata

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -674,6 +674,8 @@ manifest:
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_windows_path: bug (DEBUG-5108)
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Method_Probe_Statuses: v2.53.0
   tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb: v2.53.0
+  # TODO(andrei): un-skip when v3.44.0 is released
+  tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb::test_event_metadata: missing_feature (extended event schema not yet shipped)
   tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb::test_symdb_upload:  # Modified by easy win activation script
     - declaration: bug (DEBUG-3298)
       component_version: <3.36.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -865,6 +865,8 @@ manifest:
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Method_Probe_Statuses::test_span_decoration_method_status: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Method_Probe_Statuses::test_span_method_status: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb: v2.2.3
+  # TODO(andrei): un-skip when datadog-agent v7.79.0 is released (Go's symdb upload comes from the agent, not from dd-trace-go)
+  tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb::test_event_metadata: missing_feature (extended event schema not yet shipped)
   tests/debugger/test_debugger_telemetry.py::Test_Debugger_Telemetry: missing_feature
   tests/docker_ssi/test_docker_ssi_appsec.py::TestDockerSSIAppsecFeatures::test_telemetry_source_ssi: v2.0.0
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Flag_Parse_Error_Isolation::test_valid_flag_unaffected: bug (FFL-2184)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3120,6 +3120,8 @@ manifest:
         spring-boot-openliberty: v1.38.0
         spring-boot-undertow: v1.38.0
         uds-spring-boot: v1.38.0
+  # TODO(andrei): un-skip when v1.63.0 is released
+  tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb::test_event_metadata: missing_feature (extended event schema not yet shipped)
   tests/debugger/test_debugger_telemetry.py::Test_Debugger_Telemetry:
     - weblog_declaration:
         "*": missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1240,6 +1240,8 @@ manifest:
     - weblog_declaration:
         "*": missing_feature
         *flask: v2.11.0
+  # TODO(andrei): un-skip when v4.10.0 is released
+  tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb::test_event_metadata: missing_feature (extended event schema not yet shipped)
   tests/debugger/test_debugger_telemetry.py::Test_Debugger_Telemetry: v2.11.0
   tests/debugger/test_debugger_telemetry.py::Test_Debugger_Telemetry::test_telemetry_co:  # Modified by easy win activation script
     - declaration: missing_feature (DEBUG-3550)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1145,6 +1145,8 @@ manifest:
         rails72: missing_feature (feature not implemented)
         rails80: missing_feature (feature not implemented)
         uds-rails: missing_feature (feature not implemented)
+  # TODO(andrei): un-skip when v2.34.0 is released
+  tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb::test_event_metadata: missing_feature (extended event schema not yet shipped)
   tests/debugger/test_debugger_telemetry.py::Test_Debugger_Telemetry:
     - weblog_declaration:
         "*": irrelevant

--- a/tests/debugger/test_debugger_symdb.py
+++ b/tests/debugger/test_debugger_symdb.py
@@ -82,9 +82,87 @@ class Test_Debugger_SymDb(debugger.BaseDebuggerTest):
             "No scope containing debugger controller with scope_type CLASS or MODULE was found in the symbols"
         )
 
+    def _assert_event_metadata(self):
+        """Assert each /symdb/v1/input upload has the expected metadata fields
+        in BOTH the event JSON and the gzipped attachment, and that they agree.
+
+        Each request is a multipart with two parts: a gzipped attachment
+        ("file") and a small JSON metadata blob ("event"). The event uses
+        camelCase keys (uploadId/batchNum/attachmentSize) to match the rest
+        of the EvP event schema; the attachment uses snake_case
+        (upload_id/batch_num/final) to match the rest of the attachment
+        scope schema (scope_type/source_file/...). The (uploadId, batchNum)
+        in the event must equal (upload_id, batch_num) in the attachment.
+
+        BaseDebuggerTest._collect_symdb_upload_events() and
+        BaseDebuggerTest._collect_symbols() walk the same captured requests
+        in the same order, so events[i] pairs with the attachment in
+        symbols[i].
+        """
+        events = self.symdb_upload_events
+        attachments = self.symbols
+        assert events, "No event multipart parts were captured"
+        assert attachments, "No attachment multipart parts were captured"
+        assert len(events) == len(attachments), (
+            f"event count ({len(events)}) does not match attachment count ({len(attachments)})"
+        )
+
+        required_event_fields = (
+            "ddsource",
+            "service",
+            "version",
+            "language",
+            "runtimeId",
+            "type",
+            "uploadId",
+            "batchNum",
+            "final",
+            "attachmentSize",
+        )
+        required_attachment_fields = ("upload_id", "batch_num", "final")
+
+        for event, attachment_part in zip(events, attachments, strict=True):
+            missing = [f for f in required_event_fields if f not in event]
+            assert not missing, f"event missing fields {missing}: {event!r}"
+
+            assert event["type"] == "symdb", f"type is not 'symdb': {event['type']!r}"
+            assert isinstance(event["batchNum"], int), f"batchNum is not an integer: {event['batchNum']!r}"
+            assert event["batchNum"] >= 1, f"batchNum is not >= 1: {event['batchNum']!r}"
+            assert isinstance(event["final"], bool), f"final is not a boolean: {event['final']!r}"
+            assert isinstance(event["attachmentSize"], int), (
+                f"attachmentSize is not an integer: {event['attachmentSize']!r}"
+            )
+            assert event["attachmentSize"] > 0, f"attachmentSize is not > 0: {event['attachmentSize']!r}"
+            assert "debugger" not in event, f"event must not nest fields under 'debugger': {event['debugger']!r}"
+
+            # The attachment body must carry the same upload metadata at the
+            # root, in snake_case to match the rest of the attachment schema.
+            attachment = attachment_part.get("content", {})
+            assert isinstance(attachment, dict), f"attachment is not a JSON object: {attachment!r}"
+            missing_att = [f for f in required_attachment_fields if f not in attachment]
+            assert not missing_att, f"attachment missing fields {missing_att}: keys={list(attachment.keys())}"
+
+            assert attachment["upload_id"] == event["uploadId"], (
+                f"attachment upload_id ({attachment['upload_id']!r}) "
+                f"does not match event uploadId ({event['uploadId']!r})"
+            )
+            assert attachment["batch_num"] == event["batchNum"], (
+                f"attachment batch_num ({attachment['batch_num']!r}) "
+                f"does not match event batchNum ({event['batchNum']!r})"
+            )
+            assert isinstance(attachment["final"], bool), f"attachment final is not a boolean: {attachment['final']!r}"
+
     ############ test ############
     def setup_symdb_upload(self):
         self._setup()
 
     def test_symdb_upload(self):
         self._assert()
+
+    def setup_event_metadata(self):
+        self._setup()
+
+    def test_event_metadata(self):
+        self.collect()
+        self.assert_rc_state_not_error()
+        self._assert_event_metadata()

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -125,6 +125,11 @@ class BaseDebuggerTest:
     probe_spans: dict[str, list[DataDogAgentSpan]] = {}
     all_spans: list[DataDogAgentSpan] = []
     symbols: list[dict[str, Any]] = []
+    # symdb_upload_events holds the parsed JSON metadata blobs from each
+    # /symdb/v1/input upload (the "event" multipart part, alongside the
+    # gzipped symbols attachment). Each entry is the deserialized event
+    # JSON (e.g. {"ddsource": ..., "service": ..., "type": "symdb", ...}).
+    symdb_upload_events: list[dict[str, Any]] = []
 
     start_time: int | None = None
 
@@ -688,6 +693,7 @@ class BaseDebuggerTest:
         self._collect_snapshots()
         self._collect_spans()
         self._collect_symbols()
+        self._collect_symdb_upload_events()
 
     def _collect_probe_diagnostics(self):
         def _read_data():
@@ -895,6 +901,31 @@ class BaseDebuggerTest:
             return result
 
         self.symbols = _get_symbols()
+
+    def _collect_symdb_upload_events(self):
+        """Collect the JSON event metadata from each /symdb/v1/input upload.
+
+        Each request to /symdb/v1/input is a multipart with two parts: the
+        gzipped symbols attachment (collected by _collect_symbols) and a
+        small JSON blob describing the upload (the "event" part). This
+        populates self.symdb_upload_events with the parsed event JSON for
+        every captured upload, matched by Content-Disposition name="event".
+        """
+        events: list[dict[str, Any]] = []
+        raw_data = list(interfaces.library.get_data(_SYMBOLS_PATH))
+        for data in raw_data:
+            if not isinstance(data, dict) or "request" not in data:
+                continue
+            for part in data["request"].get("content", []) or []:
+                if not isinstance(part, dict):
+                    continue
+                disposition = part.get("headers", {}).get("content-disposition", "")
+                if 'name="event"' not in disposition:
+                    continue
+                content = part.get("content")
+                if isinstance(content, dict):
+                    events.append(content)
+        self.symdb_upload_events = events
 
     def get_tracer(self) -> dict[str, str]:
         if not BaseDebuggerTest.tracer:

--- a/tests/schemas/utils/library/symdb/v1/input-request.json
+++ b/tests/schemas/utils/library/symdb/v1/input-request.json
@@ -44,12 +44,21 @@
       }
     },
     "json_content": {
+      "$comment": "Loose: only the fields old tracers always sent are required. New fields (type, version, language, uploadId, batchNum, final, attachmentSize) are type-validated if present, but presence is enforced separately by Test_Debugger_SymDb.test_event_metadata, which is gated per tracer version via the manifests.",
       "type": "object",
       "required": ["ddsource", "service", "runtimeId"],
       "properties": {
         "ddsource": { "type": "string" },
         "service": { "type": "string" },
-        "runtimeId": { "type": "string" }
+        "version": { "type": "string" },
+        "language": { "type": "string" },
+        "runtimeId": { "type": "string" },
+        "parentId": { "type": ["string", "null"] },
+        "type": { "type": "string" },
+        "uploadId": { "type": "string" },
+        "batchNum": { "type": "integer", "minimum": 1 },
+        "final": { "type": "boolean" },
+        "attachmentSize": { "type": "integer", "minimum": 1 }
       }
     },
     "gzip_content": {

--- a/tests/test_the_test/scenarios.json
+++ b/tests/test_the_test/scenarios.json
@@ -3321,6 +3321,9 @@
   "tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_span_decoration_line_status": [
     "DEBUGGER_PROBES_STATUS"
   ],
+  "tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb::test_event_metadata": [
+    "DEBUGGER_SYMDB"
+  ],
   "tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb::test_symdb_upload": [
     "DEBUGGER_SYMDB"
   ],


### PR DESCRIPTION
Test the upcoming extended schema of the EvP events associated to
symdb uploads and the matching fields in the gzipped attachment body.
The new test is initially "missing_feature" for every tracer; once the
different tracers are released, the manifest entries can be moved off
"missing_feature" to a version cap.

The event JSON gets the following fields at the root, in camelCase to
match the rest of the EvP event schema:

- "ddsource"      (was already required)
- "service"       (was already required)
- "version"
- "language"
- "runtimeId"     (was already required)
- "type": "symdb"
- "uploadId"
- "batchNum"      (1-indexed integer)
- "final"         (boolean)
- "attachmentSize" (positive integer)

The attachment body gets the matching upload metadata at the root, in
snake_case to match the rest of the attachment scope schema
(scope_type, source_file, ...):

- "upload_id"
- "batch_num"
- "final"

The test also cross-checks per upload that uploadId/batchNum in the
event equal upload_id/batch_num in the attachment.

The schema (utils/interfaces/schemas/library/symdb/v1/input-request.json)
keeps the original "ddsource"/"service"/"runtimeId" as required and
type-checks the new fields if present, so existing tracer versions are
not regressed by the schema. The strict presence check lives in the new
test_event_metadata method, which is gated per tracer/agent version via
the manifests.

Test harness changes:
- BaseDebuggerTest gains a `symdb_upload_events` list field.
- A new `_collect_symdb_upload_events()` walks every captured
  /symdb/v1/input request, picks the multipart parts whose
  Content-Disposition has name="event", and stores the parsed JSON.
- collect() invokes it alongside _collect_symbols().


🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
