### PR TITLE
fix: free disk space without downloading external binaries

### DIFF
--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -10,6 +10,9 @@ inputs:
   scenarios:
     description: "JSON array, or comma separated list of scenarios that will be executed"
     required: true
+  github_token:
+    description: "GitHub token to avoid rate limits when downloading release assets"
+    required: true
   dockerhub_username:
     description: "To prevent reaching docker hub API limits, provide a username and token to login to docker hub"
     required: false
@@ -24,6 +27,8 @@ runs:
   steps:
     - name: Free Disk Space
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
       run: |
         arch="$(uname -m)"
         case "${arch}" in
@@ -40,7 +45,8 @@ runs:
         # rmz deletes files in parallel using multiple threads, making it significantly
         # faster than rm for large directories.
         tmpfile=$(mktemp)
-        curl -fsSL -o "${tmpfile}" "https://github.com/SUPERCILEX/fuc/releases/download/3.1.1/${asset}"
+        curl -fsSL -H "Authorization: token ${GH_TOKEN}" \
+          -o "${tmpfile}" "https://github.com/SUPERCILEX/fuc/releases/download/3.1.1/${asset}"
         echo "${checksum}  ${tmpfile}" | sha256sum -c
         sudo install -m 0755 "${tmpfile}" /usr/local/bin/rmz
         rm -f "${tmpfile}"

--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -10,9 +10,6 @@ inputs:
   scenarios:
     description: "JSON array, or comma separated list of scenarios that will be executed"
     required: true
-  github_token:
-    description: "GitHub token to avoid rate limits when downloading release assets"
-    required: true
   dockerhub_username:
     description: "To prevent reaching docker hub API limits, provide a username and token to login to docker hub"
     required: false
@@ -25,77 +22,33 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Restore rmz cache
-      id: cache-rmz
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-      with:
-        path: ~/.cache/rmz
-        key: rmz-3.1.1-${{ runner.arch }}
-
-    - name: Download rmz
-      if: steps.cache-rmz.outputs.cache-hit != 'true'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
-      run: |
-        arch="$(uname -m)"
-        case "${arch}" in
-          x86_64|amd64)
-            asset="x86_64-unknown-linux-gnu-rmz"
-            checksum="9017131f24a6a619568316d3cf1aabbf4fb8297d8082b11fd2b6817436876a3b"
-            ;;
-          aarch64|arm64)
-            asset="aarch64-unknown-linux-gnu-rmz"
-            checksum="1ac8e83a0242938b10bd6a37ebd1b96d92896f84547aead32f3608c3e5ff733d"
-            ;;
-          *) echo "Unsupported arch: ${arch}"; exit 1 ;;
-        esac
-        mkdir -p ~/.cache/rmz
-        curl -fsSL -H "Authorization: token ${GH_TOKEN}" \
-          -o ~/.cache/rmz/rmz \
-          "https://github.com/SUPERCILEX/fuc/releases/download/3.1.1/${asset}"
-        echo "${checksum}  ${HOME}/.cache/rmz/rmz" | sha256sum -c
-        chmod +x ~/.cache/rmz/rmz
-
-    - name: Save rmz cache
-      if: steps.cache-rmz.outputs.cache-hit != 'true'
-      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-      with:
-        path: ~/.cache/rmz
-        key: rmz-3.1.1-${{ runner.arch }}
-
     - name: Free Disk Space
       shell: bash
       run: |
-        sudo install -m 0755 ~/.cache/rmz/rmz /usr/local/bin/rmz
-        free_mb() { df -B1 / | awk 'NR==2 {printf "%.2f", $4/1024/1024}'; }
-        total_recovered=0
+        before=$(df -B1 / | awk 'NR==2 {printf "%.2f", $4/1024/1024}')
         paths=(
-          /usr/share/dotnet          # .NET runtime
-          /usr/share/doc/dotnet-*    # .NET documentation
-          /opt/ghc                   # GHC (Haskell compiler)
-          /usr/local/.ghcup          # GHCup (Haskell toolchain manager)
-          /opt/cabal                 # Cabal (Haskell build tool)
-          /home/runner/.ghcup        # GHCup user data
-          /home/runner/.cabal        # Cabal user data
-          /usr/share/swift           # Swift toolchain
-          /usr/local/share/chromium  # Chromium browser
-          /usr/share/az*             # Azure CLI
+          /usr/share/dotnet
+          /usr/share/doc/dotnet-*
+          /opt/ghc
+          /usr/local/.ghcup
+          /opt/cabal
+          /home/runner/.ghcup
+          /home/runner/.cabal
+          /usr/share/swift
+          /usr/local/share/chromium
+          /usr/share/az*
         )
+        pids=()
         for path in "${paths[@]}"; do
           [ -e "${path}" ] || continue
           echo "Removing ${path}"
-          before=$(free_mb)
-          ts_before=$(date +%s)
-          sudo rmz "${path}" || true
-          after=$(free_mb)
-          elapsed=$(( $(date +%s) - ts_before ))
-          freed=$(awk "BEGIN {printf \"%.2f\", ${after} - ${before}}")
-          echo "FreeUp Space: ${freed} MB"
-          echo "Time Elapsed: ${elapsed} seconds"
-          total_recovered=$(awk "BEGIN {printf \"%.2f\", ${total_recovered} + ${freed}}")
+          sudo rm -rf "${path}" &
+          pids+=($!)
         done
-        echo "Total Recovered Space: ${total_recovered} MB"
+        for pid in "${pids[@]}"; do wait "$pid" || true; done
+        after=$(df -B1 / | awk 'NR==2 {printf "%.2f", $4/1024/1024}')
+        freed=$(awk "BEGIN {printf \"%.2f\", ${after} - ${before}}")
+        echo "Total Recovered Space: ${freed} MB"
 
     - name: Get image list
       shell: bash

--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -25,7 +25,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Free Disk Space
+    - name: Restore rmz cache
+      id: cache-rmz
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.cache/rmz
+        key: rmz-3.1.1-${{ runner.arch }}
+
+    - name: Download rmz
+      if: steps.cache-rmz.outputs.cache-hit != 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
@@ -42,14 +50,24 @@ runs:
             ;;
           *) echo "Unsupported arch: ${arch}"; exit 1 ;;
         esac
-        # rmz deletes files in parallel using multiple threads, making it significantly
-        # faster than rm for large directories.
-        tmpfile=$(mktemp)
+        mkdir -p ~/.cache/rmz
         curl -fsSL -H "Authorization: token ${GH_TOKEN}" \
-          -o "${tmpfile}" "https://github.com/SUPERCILEX/fuc/releases/download/3.1.1/${asset}"
-        echo "${checksum}  ${tmpfile}" | sha256sum -c
-        sudo install -m 0755 "${tmpfile}" /usr/local/bin/rmz
-        rm -f "${tmpfile}"
+          -o ~/.cache/rmz/rmz \
+          "https://github.com/SUPERCILEX/fuc/releases/download/3.1.1/${asset}"
+        echo "${checksum}  ${HOME}/.cache/rmz/rmz" | sha256sum -c
+        chmod +x ~/.cache/rmz/rmz
+
+    - name: Save rmz cache
+      if: steps.cache-rmz.outputs.cache-hit != 'true'
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.cache/rmz
+        key: rmz-3.1.1-${{ runner.arch }}
+
+    - name: Free Disk Space
+      shell: bash
+      run: |
+        sudo install -m 0755 ~/.cache/rmz/rmz /usr/local/bin/rmz
         free_mb() { df -B1 / | awk 'NR==2 {printf "%.2f", $4/1024/1024}'; }
         total_recovered=0
         paths=(

--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -27,16 +27,16 @@ runs:
       run: |
         before=$(df -B1 / | awk 'NR==2 {printf "%.2f", $4/1024/1024}')
         paths=(
-          /usr/share/dotnet
-          /usr/share/doc/dotnet-*
-          /opt/ghc
-          /usr/local/.ghcup
-          /opt/cabal
-          /home/runner/.ghcup
-          /home/runner/.cabal
-          /usr/share/swift
-          /usr/local/share/chromium
-          /usr/share/az*
+          /usr/share/dotnet          # .NET runtime
+          /usr/share/doc/dotnet-*    # .NET documentation
+          /opt/ghc                   # GHC (Haskell compiler)
+          /usr/local/.ghcup          # GHCup (Haskell toolchain manager)
+          /opt/cabal                 # Cabal (Haskell build tool)
+          /home/runner/.ghcup        # GHCup user data
+          /home/runner/.cabal        # Cabal user data
+          /usr/share/swift           # Swift toolchain
+          /usr/local/share/chromium  # Chromium browser
+          /usr/share/az*             # Azure CLI
         )
         pids=()
         for path in "${paths[@]}"; do

--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -52,7 +52,7 @@ runs:
           pids+=($!)
         done
         for pid in "${pids[@]}"; do wait "$pid" || true; done
-        cat "${tmpdir}"/*
+        cat "${tmpdir}"/* 2>/dev/null || true
         rm -rf "${tmpdir}"
         after=$(df -B1 / | awk 'NR==2 {printf "%.2f", $4/1024/1024}')
         echo "Total Recovered Space: $(awk "BEGIN {printf \"%.2f\", ${after} - ${before}}") MB"

--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -26,6 +26,8 @@ runs:
       shell: bash
       run: |
         before=$(df -B1 / | awk 'NR==2 {printf "%.2f", $4/1024/1024}')
+        ts_total=$(date +%s)
+        tmpdir=$(mktemp -d)
         paths=(
           /usr/share/dotnet          # .NET runtime
           /usr/share/doc/dotnet-*    # .NET documentation
@@ -41,14 +43,20 @@ runs:
         pids=()
         for path in "${paths[@]}"; do
           [ -e "${path}" ] || continue
-          echo "Removing ${path}"
-          sudo rm -rf "${path}" &
+          outfile="${tmpdir}/${path//\//_}"
+          {
+            ts=$(date +%s)
+            sudo rm -rf "${path}"
+            echo "Removed ${path} in $(( $(date +%s) - ts ))s"
+          } > "${outfile}" &
           pids+=($!)
         done
         for pid in "${pids[@]}"; do wait "$pid" || true; done
+        cat "${tmpdir}"/*
+        rm -rf "${tmpdir}"
         after=$(df -B1 / | awk 'NR==2 {printf "%.2f", $4/1024/1024}')
-        freed=$(awk "BEGIN {printf \"%.2f\", ${after} - ${before}}")
-        echo "Total Recovered Space: ${freed} MB"
+        echo "Total Recovered Space: $(awk "BEGIN {printf \"%.2f\", ${after} - ${before}}") MB"
+        echo "Total Time: $(( $(date +%s) - ts_total ))s"
 
     - name: Get image list
       shell: bash

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -151,6 +151,7 @@ jobs:
         library: ${{ inputs.library }}
         weblog: ${{ inputs.weblog }}
         scenarios: ${{ inputs.scenarios }}
+        github_token: ${{ github.token }}
         dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
         dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build weblog

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -151,7 +151,6 @@ jobs:
         library: ${{ inputs.library }}
         weblog: ${{ inputs.weblog }}
         scenarios: ${{ inputs.scenarios }}
-        github_token: ${{ github.token }}
         dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
         dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build weblog


### PR DESCRIPTION
## Summary

- The `pull_images` action was downloading the `rmz` binary from GitHub releases on every job, hitting both the GitHub Releases and GitHub Cache API rate limits at scale (thousands of concurrent jobs)
- Replaced `rmz` with native parallel `rm -rf` using bash background jobs (`&` + `wait`), which has no external dependencies and no rate limit risk
- Removed the now-unnecessary `github_token` input

## Test Plan

- [ ] Verify the `Free Disk Space` step completes successfully in CI
- [ ] Check that sufficient disk space is freed for Docker image pulls

---

> Generated by [Claude Code](https://claude.ai/claude-code)