### PR TITLE
Enable OTLP metrics system tests on Java

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3709,18 +3709,18 @@ manifest:
   tests/parametric/test_otel_logs.py::Test_FR11_Telemetry: missing_feature  # Created by easy win activation script
   tests/parametric/test_otel_logs.py::Test_FR12_Log_Levels: missing_feature  # Created by easy win activation script
   tests/parametric/test_otel_logs.py::Test_FR13_Scope_Fields: missing_feature  # Created by easy win activation script
-  tests/parametric/test_otel_metrics.py: '>=1.58.2+06122213c8'  # Modified by easy win activation script
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Api_Instrument: missing_feature  # Created by easy win activation script
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Api_Meter: missing_feature  # Created by easy win activation script
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Api_MeterProvider: missing_feature  # Created by easy win activation script
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Configuration_Enabled::test_otlp_metrics_enabled: missing_feature  # Created by easy win activation script
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Endpoint: missing_feature  # Created by easy win activation script
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Headers: missing_feature  # Created by easy win activation script
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Protocol: missing_feature  # Created by easy win activation script
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Configuration_Temporality_Preference: missing_feature  # Created by easy win activation script
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Host_Name: missing_feature  # Created by easy win activation script
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Resource_Attributes: missing_feature  # Created by easy win activation script
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry: missing_feature  # Created by easy win activation script
+  tests/parametric/test_otel_metrics.py: '>=1.62.0'
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Api_Meter::test_otel_create_instruments_by_distinct:
+    - declaration: bug (APMAPI-1937)
+      component_version: <1.63.0
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Api_MeterProvider::test_otel_get_meter_by_distinct_scope_attributes: irrelevant (OTel API does not support scope attributes on Java)
+  ? tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Endpoint::test_otlp_custom_endpoint_grpc
+  : incomplete_test_app (GPRC fails for system-test but works with real collector)
+  ? tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Endpoint::test_otlp_metrics_custom_endpoint_grpc
+  : incomplete_test_app (GPRC fails for system-test but works with real collector)
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Protocol::test_otlp_protocol_grpc: incomplete_test_app (GPRC fails for system-test but works with real collector)
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry: missing_feature (not yet implemented)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_add_event_meta_serialization:
     - declaration: missing_feature (Not implemented)
       component_version: <1.40.0

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/metrics/controller/MetricsController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/metrics/controller/MetricsController.java
@@ -11,8 +11,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(value = "/trace/stats")
 public class MetricsController {
+
+  private static boolean skipNextFlush;
+
+  /** Skip the next request to flush metrics. */
+  public static void skipNextFlush() {
+    skipNextFlush = true;
+  }
+
   @PostMapping("flush")
   public void flush() {
+    if (skipNextFlush) {
+      LOGGER.info("Skipping request to flush metrics");
+      skipNextFlush = false;
+      return;
+    }
     LOGGER.info("Flushing metrics");
     try {
       // Only flush trace stats when tracing was enabled

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryMetricsController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/opentelemetry/controller/OpenTelemetryMetricsController.java
@@ -2,6 +2,7 @@ package com.datadoghq.trace.opentelemetry.controller;
 
 import static com.datadoghq.ApmTestClient.LOGGER;
 
+import com.datadoghq.trace.metrics.controller.MetricsController;
 import com.datadoghq.trace.opentelemetry.dto.*;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.internal.InternalTracer;
@@ -215,6 +216,11 @@ public class OpenTelemetryMetricsController {
     try {
       if (GlobalTracer.get() instanceof InternalTracer internalTracer) {
         internalTracer.flushMetrics();
+        // skip the next general metrics flush, as it's covered by the same call
+        // (this avoids an issue where OTel metrics tests end up flushing twice:
+        // one explicit flush call and another when 'with test_library' exits,
+        // which disrupts certain assertions that assume only one flush event)
+        MetricsController.skipNextFlush();
       }
       return new FlushResult(true);
     } catch (Exception e) {


### PR DESCRIPTION
## Motivation

Support for OTLP metrics initially shipped in dd-trace-java v1.61.0 with subsequent fixes in v1.62.0

## Changes

Enable OTLP metrics system tests on Java for 1.62.0 and later.

One test involving async counters will be fixed in 1.63.0 by https://github.com/DataDog/dd-trace-java/pull/11332

Note I had to add code to the Java weblog app to temporarily suppress flushing of metrics triggered by exiting the `with test_library` block during the OTel metrics tests. This is because the Java tracer flushes both general and OTel metrics using the same `flushMetrics` method, and the OTel metrics tests expect one single explicit flush. The extra implicit metrics flush when exiting the `with test_library` block was disrupting assumptions about what metrics data would be captured just before the test assertions.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
