### PR TITLE
(java) don't use private API on weblogs

### DIFF
--- a/utils/build/docker/java/openai_app/build.gradle
+++ b/utils/build/docker/java/openai_app/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'com.anthropic:anthropic-java:2.4.0'
 
     compileOnly files('/dd-tracer/dd-java-agent.jar')
+    implementation 'io.opentracing:opentracing-api:0.33.0'
+    implementation 'io.opentracing:opentracing-util:0.33.0'
 }
 
 application {

--- a/utils/build/docker/java/openai_app/src/main/java/SingleFileServer.java
+++ b/utils/build/docker/java/openai_app/src/main/java/SingleFileServer.java
@@ -13,10 +13,10 @@ import java.util.List;
 
 import datadog.trace.api.llmobs.LLMObs;
 import datadog.trace.api.llmobs.LLMObsSpan;
-import datadog.trace.api.GlobalTracer;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
 
 // OpenAI imports
 import com.openai.client.OpenAIClient;
@@ -389,7 +389,7 @@ public class SingleFileServer {
   }
 
   private static String doGetSDKInfo (Context ctx) {
-    Package tracerPackage = GlobalTracer.class.getPackage();
+    Package tracerPackage = datadog.trace.api.GlobalTracer.class.getPackage();
     String version = tracerPackage.getImplementationVersion();
 
     Map<String, String> responseMap = Map.of(
@@ -428,20 +428,14 @@ public class SingleFileServer {
         span.finish();
       }
     } else {
-      AgentSpan span = AgentTracer
-          .get()
-          .buildSpan(name)
-          .start();
-
-      AgentScope scope = AgentTracer
-        .get()
-        .activateSpan(span);
-
-      JSONArray children = traceStructure.optJSONArray("children");
-      doTraceChildren(children);
-
-      span.finish();
-      scope.close();
+      Tracer tracer = GlobalTracer.get();
+      Span span = tracer.buildSpan(name).start();
+      try (Scope scope = tracer.activateSpan(span)) {
+        JSONArray children = traceStructure.optJSONArray("children");
+        doTraceChildren(children);
+      } finally {
+        span.finish();
+      }
     }
 
     return toJson(


### PR DESCRIPTION
## Motivation

Internal API should not be used in weblogs (`AgentTracer` is for not a public API) and the used APIs are gonna be removed

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
