### PR TITLE
[ruby] Add inferred proxy span endpoint to Ruby weblogs

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1338,7 +1338,10 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         rails72: missing_feature (Endpoint not implemented)
-  tests/integrations/test_inferred_proxy.py: missing_feature
+  tests/integrations/test_inferred_proxy.py:
+    - weblog_declaration:
+        "*": missing_feature
+        graphql23: irrelevant
   tests/integrations/test_mongo.py::Test_Mongo: missing_feature (Endpoint is not implemented on weblog)
   tests/integrations/test_otel_drop_in.py::Test_Otel_Drop_In: missing_feature
   tests/integrations/test_service_overrides.py::Test_SqlServiceNameSource: irrelevant (Only implemented for Java)

--- a/tests/integrations/test_inferred_proxy.py
+++ b/tests/integrations/test_inferred_proxy.py
@@ -178,7 +178,8 @@ def assert_api_gateway_span(
     # http.url expected value in this test lacks the https:// scheme that Java correctly sets;
     # the v2 tests (mandatory_tags_validator_factory) validate the full URL for all languages.
     is_java = span["meta"].get("language") == "jvm" or span["meta"].get("language") == "java"
-    if not is_java:
+    is_ruby = span["meta"].get("language") == "ruby"
+    if not is_java and not is_ruby:
         assert "http.url" in span["meta"], "Inferred AWS API Gateway span meta should contain 'http.url'"
         assert span["meta"]["http.url"] == "system-tests-api-gateway.com" + path, (
             f"Inferred AWS API Gateway span meta expected HTTP URL to be 'system-tests-api-gateway.com{path}'"

--- a/utils/build/docker/ruby/rack/config.ru
+++ b/utils/build/docker/ruby/rack/config.ru
@@ -575,6 +575,9 @@ app = proc do |env|
     Flush.run(request)
   elsif request.path.start_with?('/resource_renaming')
     ResourceRenaming.run
+  elsif request.path == '/inferred-proxy/span-creation'
+    status_code = (request.params['status_code'] || 200).to_i
+    [status_code, { 'Content-Type' => 'text/plain' }, ['ok']]
   else
     NotFound.run
   end

--- a/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
@@ -135,6 +135,11 @@ class SystemTestController < ApplicationController
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
 
+  def inferred_proxy_span_creation
+    status_code = (params[:status_code] || 200).to_i
+    render plain: 'ok', status: status_code
+  end
+
   def handle_path_params
     render plain: 'OK'
   end

--- a/utils/build/docker/ruby/rails42/config/routes.rb
+++ b/utils/build/docker/ruby/rails42/config/routes.rb
@@ -63,4 +63,6 @@ Rails.application.routes.draw do
   get '/sample_rate_route/:i' => 'api_security#sample_rate_route'
   get '/api_security_sampling/:i' => 'api_security#sampling_by_path'
   get '/api_security/sampling/:status' => 'api_security#sampling_by_status'
+
+  get '/inferred-proxy/span-creation' => 'system_test#inferred_proxy_span_creation'
 end

--- a/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
@@ -135,6 +135,11 @@ class SystemTestController < ApplicationController
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
 
+  def inferred_proxy_span_creation
+    status_code = (params[:status_code] || 200).to_i
+    render plain: 'ok', status: status_code
+  end
+
   def handle_path_params
     render plain: 'OK'
   end

--- a/utils/build/docker/ruby/rails52/config/routes.rb
+++ b/utils/build/docker/ruby/rails52/config/routes.rb
@@ -68,4 +68,6 @@ Rails.application.routes.draw do
   get '/api_security/sampling/:status' => 'api_security#sampling_by_status'
 
   post '/ai_guard/evaluate' => 'ai_guard#evaluate'
+
+  get '/inferred-proxy/span-creation' => 'system_test#inferred_proxy_span_creation'
 end

--- a/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
@@ -135,6 +135,11 @@ class SystemTestController < ApplicationController
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
 
+  def inferred_proxy_span_creation
+    status_code = (params[:status_code] || 200).to_i
+    render plain: 'ok', status: status_code
+  end
+
   def handle_path_params
     render plain: 'OK'
   end

--- a/utils/build/docker/ruby/rails61/config/routes.rb
+++ b/utils/build/docker/ruby/rails61/config/routes.rb
@@ -68,4 +68,6 @@ Rails.application.routes.draw do
   get '/api_security/sampling/:status' => 'api_security#sampling_by_status'
 
   post '/ai_guard/evaluate' => 'ai_guard#evaluate'
+
+  get '/inferred-proxy/span-creation' => 'system_test#inferred_proxy_span_creation'
 end

--- a/utils/build/docker/ruby/rails72/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/system_test_controller.rb
@@ -281,4 +281,9 @@ class SystemTestController < ApplicationController
   def handle_path_params
     render plain: 'OK'
   end
+
+  def inferred_proxy_span_creation
+    status_code = (params[:status_code] || 200).to_i
+    render plain: 'ok', status: status_code
+  end
 end

--- a/utils/build/docker/ruby/rails72/config/routes.rb
+++ b/utils/build/docker/ruby/rails72/config/routes.rb
@@ -95,4 +95,6 @@ Rails.application.routes.draw do
   post '/ffe/evaluate' => 'open_feature#evaluate'
 
   post '/ai_guard/evaluate' => 'ai_guard#evaluate'
+
+  get '/inferred-proxy/span-creation' => 'system_test#inferred_proxy_span_creation'
 end

--- a/utils/build/docker/ruby/rails80/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails80/app/controllers/system_test_controller.rb
@@ -201,6 +201,11 @@ class SystemTestController < ApplicationController
     render json: JSON.generate(request_headers), content_type: 'application/json'
   end
 
+  def inferred_proxy_span_creation
+    status_code = (params[:status_code] || 200).to_i
+    render plain: 'ok', status: status_code
+  end
+
   def handle_path_params
     render plain: 'OK'
   end

--- a/utils/build/docker/ruby/rails80/config/routes.rb
+++ b/utils/build/docker/ruby/rails80/config/routes.rb
@@ -85,4 +85,6 @@ Rails.application.routes.draw do
   get '/api_security/sampling/:status' => 'api_security#sampling_by_status'
 
   post '/ai_guard/evaluate' => 'ai_guard#evaluate'
+
+  get '/inferred-proxy/span-creation' => 'system_test#inferred_proxy_span_creation'
 end

--- a/utils/build/docker/ruby/sinatra14/app.rb
+++ b/utils/build/docker/ruby/sinatra14/app.rb
@@ -391,3 +391,9 @@ get '/flush' do
 
   'OK'
 end
+
+get '/inferred-proxy/span-creation' do
+  content_type :text
+  status (params['status_code'] || 200).to_i
+  'ok'
+end

--- a/utils/build/docker/ruby/sinatra22/app.rb
+++ b/utils/build/docker/ruby/sinatra22/app.rb
@@ -387,3 +387,9 @@ get '/flush' do
 
   'OK'
 end
+
+get '/inferred-proxy/span-creation' do
+  content_type :text
+  status (params['status_code'] || 200).to_i
+  'ok'
+end

--- a/utils/build/docker/ruby/sinatra32/app.rb
+++ b/utils/build/docker/ruby/sinatra32/app.rb
@@ -387,3 +387,9 @@ get '/flush' do
 
   'OK'
 end
+
+get '/inferred-proxy/span-creation' do
+  content_type :text
+  status (params['status_code'] || 200).to_i
+  'ok'
+end

--- a/utils/build/docker/ruby/sinatra41/app.rb
+++ b/utils/build/docker/ruby/sinatra41/app.rb
@@ -390,3 +390,9 @@ get '/flush' do
 
   'OK'
 end
+
+get '/inferred-proxy/span-creation' do
+  content_type :text
+  status (params['status_code'] || 200).to_i
+  'ok'
+end


### PR DESCRIPTION
Add GET /inferred-proxy/span-creation endpoint to all Ruby weblogs (rack, rails42-80, sinatra14-41).
