### PR TITLE
Disable CSS in sampling test

### DIFF
--- a/tests/parametric/test_sampling_span_tags.py
+++ b/tests/parametric/test_sampling_span_tags.py
@@ -175,7 +175,14 @@ class Test_Sampling_Span_Tags:
         )
 
     @pytest.mark.parametrize(
-        "library_env", [{"DD_TRACE_SAMPLE_RATE": 1, "DD_TRACE_SAMPLING_RULES": json.dumps([{"sample_rate": 0}])}]
+        "library_env",
+        [
+            {
+                "DD_TRACE_SAMPLE_RATE": 1,
+                "DD_TRACE_SAMPLING_RULES": json.dumps([{"sample_rate": 0}]),
+                "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
+            }
+        ],
     )
     def test_tags_defaults_rate_1_and_rule_0_sst006(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         parent_span, child_span, first_span = _get_spans(test_agent, test_library)


### PR DESCRIPTION
## Motivation

Test checking for p0 spans fails when tracer enables client-side stats by default.

## Changes

Force `test_tags_defaults_rate_1_and_rule_0_sst006` to run with client-side stats disabled

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
