### PR TITLE
SSI: Git Checkout step only for ruby

### DIFF
--- a/utils/virtual_machine/virtual_machine_provider.py
+++ b/utils/virtual_machine/virtual_machine_provider.py
@@ -114,7 +114,8 @@ class VmProvider:
         # We commit the branch reference of the CI_COMMIT_BRANCH env variable only if the gitlab project is system-tests
         # Proabably we need to change this in the future, and translate this logic to the pipelines or another class
         # Not for windows, because we don't have git installed on windows
-        if vm.os_type != "windows":
+        # Only applied for ruby provisions (other languages don't need this checkout step, because they are handling less number of files)
+        if vm.os_type != "windows" and context.library.name == "ruby":
             ci_commit_branch = os.getenv("GITLAB_CI")
             if ci_commit_branch:
                 ci_commit_branch = (


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
GitHub is not always very stable. In some pipelines, cloning repositories is causing flakiness in our tests.
We need to copy the files to the remote machine using git clone because copy the files using SSH connection is slow and it can cause problems related to the connection stability
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
