### PR TITLE
perf(ffe): set OTEL_METRIC_EXPORT_INTERVAL=1s to eliminate 30s agent wait

### DIFF
--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -591,8 +591,8 @@ class _Scenarios:
             "DD_METRICS_OTEL_ENABLED": "true",
             "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf",
             "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://agent:4318/v1/metrics",
+            "OTEL_METRIC_EXPORT_INTERVAL": "1000",
         },
-        agent_interface_timeout=30,
         doc="",
         scenario_groups=[scenario_groups.ffe],
     )

--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -48,6 +48,9 @@ class InterfaceValidator:
         return f"{self.name} interface"
 
 
+_QUIET_PERIOD = 0.5  # seconds of silence after last ingest before declaring done
+
+
 class ProxyBasedInterfaceValidator(InterfaceValidator):
     """Interfaces based on proxy container"""
 
@@ -60,6 +63,7 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
         self._lock = threading.RLock()
         self._data_list: list[dict] = []
         self._ingested_files: set[str] = set()
+        self._last_ingest_time: float = 0.0
 
     def configure(self, host_log_folder: str, *, replay: bool):
         super().configure(host_log_folder, replay=replay)
@@ -93,7 +97,16 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
             self._wait_for_event.set()
 
     def wait(self, timeout: int):
-        time.sleep(timeout)
+        if timeout == 0:
+            return
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            last = self._last_ingest_time
+            if last and time.monotonic() - last >= _QUIET_PERIOD:
+                logger.debug(f"{self.name} interface quiet for {_QUIET_PERIOD}s, done waiting")
+                return
+            time.sleep(0.05)
+        logger.debug(f"{self.name} interface timed out after {timeout}s")
 
     def check_deserialization_errors(self):
         """Verify that all proxy deserialization are successful"""
@@ -119,6 +132,7 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
 
     def _append_data(self, data: dict):
         self._data_list.append(data)
+        self._last_ingest_time = time.monotonic()
 
     def get_data(self, path_filters: Iterable[str] | str | None = None):
         if path_filters is not None:

--- a/utils/interfaces/_core.py
+++ b/utils/interfaces/_core.py
@@ -48,9 +48,6 @@ class InterfaceValidator:
         return f"{self.name} interface"
 
 
-_QUIET_PERIOD = 0.5  # seconds of silence after last ingest before declaring done
-
-
 class ProxyBasedInterfaceValidator(InterfaceValidator):
     """Interfaces based on proxy container"""
 
@@ -63,7 +60,6 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
         self._lock = threading.RLock()
         self._data_list: list[dict] = []
         self._ingested_files: set[str] = set()
-        self._last_ingest_time: float = 0.0
 
     def configure(self, host_log_folder: str, *, replay: bool):
         super().configure(host_log_folder, replay=replay)
@@ -97,16 +93,7 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
             self._wait_for_event.set()
 
     def wait(self, timeout: int):
-        if timeout == 0:
-            return
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            last = self._last_ingest_time
-            if last and time.monotonic() - last >= _QUIET_PERIOD:
-                logger.debug(f"{self.name} interface quiet for {_QUIET_PERIOD}s, done waiting")
-                return
-            time.sleep(0.05)
-        logger.debug(f"{self.name} interface timed out after {timeout}s")
+        time.sleep(timeout)
 
     def check_deserialization_errors(self):
         """Verify that all proxy deserialization are successful"""
@@ -132,7 +119,6 @@ class ProxyBasedInterfaceValidator(InterfaceValidator):
 
     def _append_data(self, data: dict):
         self._data_list.append(data)
-        self._last_ingest_time = time.monotonic()
 
     def get_data(self, path_filters: Iterable[str] | str | None = None):
         if path_filters is not None:


### PR DESCRIPTION
## Summary

- The `FEATURE_FLAGGING_AND_EXPERIMENTATION` scenario had `agent_interface_timeout=30` because OTel metrics were flushed on an unknown default interval (likely 10–60s depending on the tracer), so teardown had to wait up to 30s for them to arrive
- The fix: add `OTEL_METRIC_EXPORT_INTERVAL=1000` (1s) to the scenario's `weblog_env`, which bounds the flush cycle to 1 second and lets the timeout revert to the default 5s
- Net saving: up to **25 seconds** per scenario run, with deterministic behaviour — the wait is now bounded by a known flush interval rather than an arbitrary maximum

## Test plan

- [ ] Run `FEATURE_FLAGGING_AND_EXPERIMENTATION` and confirm metrics arrive within ~1s of the last test request
- [ ] Confirm teardown no longer blocks at the 30s agent wait
- [ ] Verify all FFE tests pass across all tracers (tracers that ignore `OTEL_METRIC_EXPORT_INTERVAL` may still need follow-up)

> 🤖 Generated with [Claude Code](https://claude.ai/claude-code)