### PR TITLE
Use verbose build.sh logs in CI

### DIFF
--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -115,9 +115,16 @@ default-weblog() {
 run_build_command() {
     local log_file
     local exit_code
-    log_file=$(mktemp)
-
     echo "Running command: $*"
+    # During development, we prefer non-verbose output in the absence of errors. This adds less clutter
+    # in terminals, and saves a significant amount of useless tokens for coding agents.
+    # In CI, however, we keep full logs that sometimes help troubleshooting build times.
+    if [[ ${CI:-} = true ]]; then
+	    "$@"
+	    exit_code=$?
+	    return $exit_code
+    fi
+    log_file=$(mktemp /tmp/system-tests-build-XXXXXXX.log)
     echo "Build log file: ${log_file}"
 
     set +e
@@ -131,7 +138,6 @@ run_build_command() {
     fi
     echo "Build command failed: $*" >&2
     cat "${log_file}" >&2
-    rm -f "${log_file}"
     return "${exit_code}"
 }
 


### PR DESCRIPTION
## Motivation

Some folks use build logs in CI, even in the absence of errors, to debug build times.

## Changes

- Disable redirection of build logs to tmp files in CI. An alternative was attaching them as build artifacts, but that'd contribute to CI flakiness.
- Make the log paths more identifiable (include `system-tests-build` in the log name.
- Do not remove log file after the build finishes.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
