### PR TITLE
[python] enable global variable in span decoration probe (DEBUG-2708)

### DIFF
--- a/utils/build/docker/python/flask/debugger/debugger_controller.py
+++ b/utils/build/docker/python/flask/debugger/debugger_controller.py
@@ -39,7 +39,7 @@ def span_probe():
 # dummy line
 @debugger_blueprint.route("/span-decoration/<string:arg>/<int:intArg>", methods=["GET"])
 def span_decoration_probe(arg, intArg):
-    # global intLocal # fails on evaluation
+    global intLocal
     intLocal = intArg * len(arg)
     return f"Span Decoration Probe {intLocal}"
 


### PR DESCRIPTION
## Motivation

DEBUG-2708 has been addressed and the system tests can be fixed to cover the failing case.

## Changes

Un-comment `global intLocal` in the flask weblog span decoration endpoint. The underlying tracer bug has been fixed, and both method and line span decoration tests now pass with the global variable in use.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
