### PR TITLE
[python] use @value for hash iteration in EL (DEBUG-3240)

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1146,7 +1146,6 @@ manifest:
     - weblog_declaration:
         "*": missing_feature
         *flask: v2.11.0
-  tests/debugger/test_debugger_expression_language.py::Test_Debugger_Expression_Language::test_expression_language_hash_operations: missing_feature (DEBUG-3240)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin:
     - weblog_declaration:
         "*": missing_feature

--- a/tests/debugger/test_debugger_expression_language.py
+++ b/tests/debugger/test_debugger_expression_language.py
@@ -689,7 +689,7 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
         language, method = self.get_tracer()["language"], "CollectionOperations"
         if self.get_tracer()["language"] == "dotnet":
             get_hash_value = Dsl("getmember", [Dsl("ref", "@it"), "Value"])
-        elif self.get_tracer()["language"] in ["nodejs", "ruby"]:
+        elif self.get_tracer()["language"] in ["nodejs", "ruby", "python"]:
             get_hash_value = Dsl("ref", "@value")
         else:
             get_hash_value = Dsl("getmember", [Dsl("ref", "@it"), "value"])


### PR DESCRIPTION
## Motivation

For Python dicts, `@it` is the key — to access the value, `@value` must be used, consistent with Node.js and Ruby.

## Changes

Update the test and remove the missing_feature marker.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
