### PR TITLE
Add system-tests for API Security Testing - Headers collection RFC

### DIFF
--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -49,6 +49,7 @@ manifest:
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_Body_env_var: missing_feature (APPSEC_API_SECURITY_NO_RESPONSE_BODY not supported)
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_Headers: v1.8.0
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_on_Block: v1.8.0
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: irrelevant (not applicable to proxies)
   tests/appsec/iast/sink/: irrelevant (ASM is not implemented in C++)
   tests/appsec/iast/source/: irrelevant (ASM is not implemented in C++)
   tests/appsec/iast/source/test_parameter_value.py::TestParameterValue::test_source_reported: irrelevant

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -62,6 +62,7 @@ manifest:
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_Body_env_var: missing_feature
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_Headers: v2.46.0
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_on_Block: v3.26.3
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection_ExtendedLocation: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection_StackTrace: missing_feature

--- a/manifests/envoy.yml
+++ b/manifests/envoy.yml
@@ -2,6 +2,7 @@
 ---
 manifest:
   tests/appsec/api_security/test_endpoints.py: irrelevant (language not implementing this feature)
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: irrelevant (not applicable to proxies)
   tests/appsec/test_alpha.py: v1.72.0
   tests/appsec/test_blocking_addresses.py: v1.72.0
   tests/appsec/test_blocking_addresses.py::Test_BlockingGraphqlResolvers: irrelevant

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -83,6 +83,7 @@ manifest:
         gin: v2.1.0-dev  # Using response helper functions
         net-http: v2.1.0-dev  # Using SDK-style
         uds-echo: v2.5.0  # Modified by easy win activation script
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection_ExtendedLocation: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection_StackTrace: missing_feature

--- a/manifests/haproxy.yml
+++ b/manifests/haproxy.yml
@@ -2,6 +2,7 @@
 ---
 manifest:
   tests/appsec/api_security/test_endpoints.py: irrelevant (language not implementing this feature)
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: irrelevant (not applicable to proxies)
   tests/appsec/test_alpha.py: v2.4.0
   tests/appsec/test_blocking_addresses.py: v2.4.0
   tests/appsec/test_blocking_addresses.py::Test_BlockingGraphqlResolvers: irrelevant

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -283,6 +283,7 @@ manifest:
         akka-http: bug (APPSEC-56888)
         spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         vertx3: missing_feature
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection_ExtendedLocation: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection_StackTrace: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -224,6 +224,7 @@ manifest:
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_Body_env_var: missing_feature
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_Headers: *ref_4_21_0
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_on_Block: missing_feature
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection:
     - weblog_declaration:
         "*": *ref_5_20_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -96,6 +96,7 @@ manifest:
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_Body_env_var: v1.6.2
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_Headers: v0.94.0
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_on_Block: v1.11.0-dev
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection_ExtendedLocation: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection_StackTrace: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -134,6 +134,7 @@ manifest:
         "*": v2.1.0
         fastapi: v2.5.0
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_on_Block: v3.10.0.dev
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: missing_feature
   tests/appsec/iast:
     - weblog_declaration:
         tornado: v4.3.1  # Modified by easy win activation script

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -134,7 +134,7 @@ manifest:
         "*": v2.1.0
         fastapi: v2.5.0
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_on_Block: v3.10.0.dev
-  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: missing_feature
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: v4.9.0-rc2
   tests/appsec/iast:
     - weblog_declaration:
         tornado: v4.3.1  # Modified by easy win activation script

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -171,6 +171,7 @@ manifest:
         "*": v2.20.0-dev
         graphql23: missing_feature (no way to separate request paths)
         rack: missing_feature (performance impact of JSON parsing)
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection_ExtendedLocation: missing_feature
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection_StackTrace: missing_feature

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -5,6 +5,7 @@ refs:
 manifest:
   tests/appsec/api_security/test_endpoint_fallback.py: missing_feature
   tests/appsec/api_security/test_endpoints.py: irrelevant (language not implementing this feature)
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: missing_feature
   tests/appsec/iast/source/test_parameter_value.py::TestParameterValue::test_source_reported: irrelevant
   tests/appsec/test_only_python.py::Test_ImportError: irrelevant (specific tests for python tracer)
   tests/appsec/test_traces.py::Test_AppSecEventSpanTags::test_header_collection: irrelevant (test)

--- a/tests/appsec/api_security_testing/test_headers_collection.py
+++ b/tests/appsec/api_security_testing/test_headers_collection.py
@@ -1,0 +1,102 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026 Datadog, Inc.
+
+import json
+
+from utils import interfaces, rfc, weblog, features, scenarios
+from utils._weblog import HttpResponse
+
+
+@rfc("https://docs.google.com/document/d/1uR4QQvU8pItEV2zFqr3-L6jO2jxzmvLrFTX_yyvqIOA")
+@features.api_security_testing_headers_collection
+@scenarios.default
+@scenarios.everything_disabled
+@scenarios.library_conf_custom_header_tags
+class Test_SecurityTestingHeaders:
+    """Tracers tag the x-datadog-endpoint-scan and x-datadog-security-test request headers
+    on service entry spans as http.request.headers.<name> unconditionally (regardless of
+    DD_TRACE_HEADER_TAGS or AppSec being enabled) and do not propagate them downstream.
+
+    Stacking three scenarios covers the unconditional contract:
+      - @scenarios.default: AppSec on
+      - @scenarios.everything_disabled: AppSec off
+      - @scenarios.library_conf_custom_header_tags: AppSec on, DD_TRACE_HEADER_TAGS set to
+        unrelated header configs (header1..header6) so a tracer that only honors these
+        markers when DD_TRACE_HEADER_TAGS is unset still has to pass.
+    """
+
+    SCAN_VALUE = "scan-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    TEST_VALUE = "test-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    HEADERS = {
+        "x-datadog-endpoint-scan": SCAN_VALUE,
+        "x-datadog-security-test": TEST_VALUE,
+    }
+
+    @staticmethod
+    def _assert_collected(response: HttpResponse) -> None:
+        # Positive check used by every test so the whole class fails when a tracer has
+        # not implemented the RFC, instead of an absence/non-propagation test silently passing.
+        assert response.status_code == 200
+        span = interfaces.library.get_root_span(request=response)
+        meta = span.get("meta", {}) or {}
+        assert meta.get("http.request.headers.x-datadog-endpoint-scan") == Test_SecurityTestingHeaders.SCAN_VALUE, (
+            "http.request.headers.x-datadog-endpoint-scan not collected on entry span"
+        )
+        assert meta.get("http.request.headers.x-datadog-security-test") == Test_SecurityTestingHeaders.TEST_VALUE, (
+            "http.request.headers.x-datadog-security-test not collected on entry span"
+        )
+
+    @staticmethod
+    def _outgoing_header_keys(request_headers: dict | list) -> set[str]:
+        # /make_distant_call returns the outbound request headers either as a dict or as a list
+        # of {key, value} objects depending on the weblog implementation (see extract_baggage_value
+        # in tests/test_baggage.py for the same dual-shape pattern). Returns lowercased keys.
+        if isinstance(request_headers, dict):
+            return {k.lower() for k in request_headers}
+        return {h.get("key", "").lower() for h in request_headers}
+
+    def setup_collected_when_present(self):
+        self.r_collected = weblog.get("/waf", headers=self.HEADERS)
+
+    def test_collected_when_present(self):
+        """Both headers are tagged on the entry span as http.request.headers.<name>."""
+        self._assert_collected(self.r_collected)
+
+    def setup_absent_when_not_in_request(self):
+        self.r_collected = weblog.get("/waf", headers=self.HEADERS)
+        self.r_without_headers = weblog.get("/waf")
+
+    def test_absent_when_not_in_request(self):
+        """No security testing tag is set when the headers are not in the request."""
+        self._assert_collected(self.r_collected)
+        assert self.r_without_headers.status_code == 200
+        span = interfaces.library.get_root_span(request=self.r_without_headers)
+        meta = span.get("meta", {}) or {}
+        assert meta.get("http.request.headers.x-datadog-endpoint-scan") is None
+        assert meta.get("http.request.headers.x-datadog-security-test") is None
+
+    def setup_not_propagated_downstream(self):
+        self.r_distant = weblog.get(
+            "/make_distant_call",
+            params={"url": "http://weblog:7777/"},
+            headers=self.HEADERS,
+        )
+
+    def test_not_propagated_downstream(self):
+        """The security testing headers must not be propagated to downstream services.
+
+        Asserts directly on the outbound request headers reported back by /make_distant_call,
+        rather than counting tagged spans across the distributed trace -- the latter false-passes
+        when the inner request ends up in a separate trace. The positive collection check is also
+        done on this request so an endpoint-specific regression on /make_distant_call (tagging on
+        /waf but not here) is caught.
+        """
+        self._assert_collected(self.r_distant)
+        outgoing = self._outgoing_header_keys(json.loads(self.r_distant.text).get("request_headers") or {})
+        assert "x-datadog-endpoint-scan" not in outgoing, (
+            f"x-datadog-endpoint-scan was propagated to downstream request: {outgoing}"
+        )
+        assert "x-datadog-security-test" not in outgoing, (
+            f"x-datadog-security-test was propagated to downstream request: {outgoing}"
+        )

--- a/tests/appsec/api_security_testing/test_headers_collection.py
+++ b/tests/appsec/api_security_testing/test_headers_collection.py
@@ -93,7 +93,15 @@ class Test_SecurityTestingHeaders:
         /waf but not here) is caught.
         """
         self._assert_collected(self.r_distant)
-        outgoing = self._outgoing_header_keys(json.loads(self.r_distant.text).get("request_headers") or {})
+        data = json.loads(self.r_distant.text)
+        # Require evidence of a successful inner request before asserting absence.
+        # Some weblogs serialize request_headers as null on client errors, in which case
+        # an "empty headers" assertion would trivially pass without ever observing the
+        # outbound request -- defeating the purpose of the propagation check.
+        assert data.get("status_code") == 200, f"inner /make_distant_call request did not succeed: {data}"
+        request_headers = data.get("request_headers")
+        assert request_headers is not None, f"weblog did not report outbound request_headers: {data}"
+        outgoing = self._outgoing_header_keys(request_headers)
         assert "x-datadog-endpoint-scan" not in outgoing, (
             f"x-datadog-endpoint-scan was propagated to downstream request: {outgoing}"
         )

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -2917,5 +2917,16 @@ class _Features:
         """
         return _mark_test_object(test_object, feature_id=554, owner=_Owner.ml_observability)
 
+    @staticmethod
+    def api_security_testing_headers_collection(test_object):
+        """API Security Testing - Headers collection: tracers unconditionally tag the
+        x-datadog-endpoint-scan and x-datadog-security-test request headers on service
+        entry spans as http.request.headers.<name>, regardless of DD_TRACE_HEADER_TAGS
+        or AppSec being enabled. These markers are not propagated downstream.
+
+        https://feature-parity.us1.prod.dog/#/?feature=556
+        """
+        return _mark_test_object(test_object, feature_id=556, owner=_Owner.asm)
+
 
 features = _Features()


### PR DESCRIPTION
APPSEC-63235

## Summary

System-tests for the [API Security Testing — Headers collection RFC](https://docs.google.com/document/d/1uR4QQvU8pItEV2zFqr3-L6jO2jxzmvLrFTX_yyvqIOA). Tracers must tag the `x-datadog-endpoint-scan` and `x-datadog-security-test` request headers on service entry spans as `http.request.headers.<name>` **unconditionally** (regardless of `DD_TRACE_HEADER_TAGS` or AppSec being enabled), and must **not** propagate them to downstream services.

Reference tracer implementation (Python): [DataDog/dd-trace-py#18049](https://github.com/DataDog/dd-trace-py/pull/18049).

## Tests added

`tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders`, three test methods:

- `test_collected_when_present` — both headers tagged on the entry span.
- `test_absent_when_not_in_request` — no tags set when the headers are not in the request.
- `test_not_propagated_downstream` — `/make_distant_call` is used to assert the headers do not appear in the outbound request (inspects the `request_headers` returned in the JSON response).

Every test starts with a positive-collection check on the request under test, so the class fails entirely when a tracer has not implemented the RFC (no absence/non-propagation test silently passing).

## Scenarios

The class is stacked on three scenarios to cover the unconditional contract on three orthogonal axes:

- `@scenarios.default` — AppSec on.
- `@scenarios.everything_disabled` — AppSec off.
- `@scenarios.library_conf_custom_header_tags` — AppSec on, `DD_TRACE_HEADER_TAGS` set to unrelated headers.

## Other changes

- New `@features.api_security_testing_headers_collection` decorator (feature-parity id `556`, owner `asm`).
- `missing_feature` manifest entries added for `java`, `python`, `nodejs`, `php`, `golang`, `ruby`, `dotnet`, `rust`. `cpp.yml` is intentionally skipped (only parametric tests run there per its own header comment); proxy/lambda/otel manifests are not in scope (the test runs only in the three scenarios above).
