### PR TITLE
[ruby] DEBUG-4675: Enable test_default_max_reference_depth

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1087,7 +1087,6 @@ manifest:
         rails72: v2.8.0
         rails80: v2.8.0
         uds-rails: v2.12.0
-  tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_default_max_reference_depth: bug (DEBUG-4675)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_debug_track:
     - declaration: missing_feature (DEBUG-4343)
       component_version: <2.24.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1089,7 +1089,7 @@ manifest:
         uds-rails: v2.12.0
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_default_max_reference_depth:
     - declaration: bug (DEBUG-4675)
-      component_version: <2.34.0
+      component_version: '<2.34.0-dev'
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_debug_track:
     - declaration: missing_feature (DEBUG-4343)
       component_version: <2.24.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1087,6 +1087,9 @@ manifest:
         rails72: v2.8.0
         rails80: v2.8.0
         uds-rails: v2.12.0
+  tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_default_max_reference_depth:
+    - declaration: bug (DEBUG-4675)
+      component_version: <2.34.0
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_debug_track:
     - declaration: missing_feature (DEBUG-4343)
       component_version: <2.24.0


### PR DESCRIPTION
## Summary

Version-gates the `bug (DEBUG-4675)` marker for `tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_default_max_reference_depth` in `manifests/ruby.yml` to `'<2.34.0-dev'`.

Companion to DataDog/dd-trace-rb#5753 (merged), which fixes the off-by-one in the dd-trace-rb Dynamic Instrumentation serializer's max capture depth handling. The Ruby tracer was capturing N+1 levels for `max_capture_depth=N`; from 2.34.0-dev onward it captures N levels.

The gate uses `'<2.34.0-dev'` (not `'<2.34.0'`) so the dev tracer is *not* covered by the bug marker — `2.34.0-dev < 2.34.0` is true per semver prerelease ordering, so `'<2.34.0'` would incorrectly skip the test on the tracer that contains the fix. This matches the existing convention for prerelease-period gates in `ruby.yml` (the APMLP-1047 entries at lines 1170/1174/1178/1182/1186/1190 all use `'<X.Y.0-dev'`).

## Validation

On commit `5e3fe16fb` (this PR's tip), the `DEBUGGER_PROBES_SNAPSHOT` scenario ran `test_default_max_reference_depth` with the expected behaviour on every supported weblog:

| Weblog | dev (2.34.0-dev) | prod (2.33.0) |
|---|---|---|
| `rails72` | passed | skipped — `bug (DEBUG-4675)` |
| `rails80` | passed | skipped — `bug (DEBUG-4675)` |
| `uds-rails` | passed | skipped — `bug (DEBUG-4675)` |

Other weblogs (`rack`, `sinatra14/22/32/41`, `rails42/52/61`, `uds-sinatra`) skip via the parent class's `'*': irrelevant` declaration — unchanged by this PR.

## Test plan

- [x] dd-trace-rb fix merged to master (DataDog/dd-trace-rb#5753)
- [x] CI confirms `test_default_max_reference_depth` passes on rails72/rails80/uds-rails against the dev tracer
- [x] CI confirms the bug marker still applies on rails72/rails80/uds-rails against the latest released tracer (2.33.0)