### PR TITLE
[php] Re-enable Test_ExtendedHeartbeat for PHP with SchemaBug for null dependency versions

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1119,7 +1119,7 @@ manifest:
       component_version: '>=0.93.0'
   tests/test_standard_tags.py::Test_StandardTagsUserAgent: v0.75.0
   tests/test_telemetry.py::Test_DependencyEnable: missing_feature
-  tests/test_telemetry.py::Test_ExtendedHeartbeat: '>=1.20.0'
+  tests/test_telemetry.py::Test_ExtendedHeartbeat: v1.20.0
   tests/test_telemetry.py::Test_Log_Generation:  # TODO: a lower version might be supported
     - weblog_declaration:
         '*': missing_feature

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1119,7 +1119,7 @@ manifest:
       component_version: '>=0.93.0'
   tests/test_standard_tags.py::Test_StandardTagsUserAgent: v0.75.0
   tests/test_telemetry.py::Test_DependencyEnable: missing_feature
-  tests/test_telemetry.py::Test_ExtendedHeartbeat: missing_feature (PHP v1.20.0 emits null for dependencies[].version in app-extended-heartbeat, failing schema validation)
+  tests/test_telemetry.py::Test_ExtendedHeartbeat: '>=1.20.0'
   tests/test_telemetry.py::Test_Log_Generation:  # TODO: a lower version might be supported
     - weblog_declaration:
         '*': missing_feature

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -84,7 +84,7 @@ class Test_DdtraceSchemas:
                 endpoint="/telemetry/proxy/api/v2/apmtelemetry",
                 data_path="$.payload.dependencies[].version",
                 condition=context.library == "php",
-                ticket="PHP-XXXX",  # TODO: file ticket — dd-trace-php emits null version for some dependencies in app-extended-heartbeat
+                ticket="APMAPI-1938",
             ),
             SchemaBug(
                 endpoint="/debugger/v1/diagnostics",
@@ -168,7 +168,7 @@ class Test_DdtraceSchemas:
                 endpoint="/api/v2/apmtelemetry",
                 data_path="$.payload.dependencies[].version",
                 condition=context.library == "php",
-                ticket="PHP-XXXX",  # TODO: file ticket — dd-trace-php emits null version for some dependencies in app-extended-heartbeat
+                ticket="APMAPI-1938",
             ),
             SchemaBug(
                 endpoint="/api/v2/debugger",

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -83,7 +83,7 @@ class Test_DdtraceSchemas:
             SchemaBug(
                 endpoint="/telemetry/proxy/api/v2/apmtelemetry",
                 data_path="$.payload.dependencies[].version",
-                condition=context.library == "php",
+                condition=context.library == "php" and context.scenario is scenarios.telemetry_extended_heartbeat,
                 ticket="APMAPI-1938",
             ),
             SchemaBug(
@@ -167,7 +167,7 @@ class Test_DdtraceSchemas:
             SchemaBug(
                 endpoint="/api/v2/apmtelemetry",
                 data_path="$.payload.dependencies[].version",
-                condition=context.library == "php",
+                condition=context.library == "php" and context.scenario is scenarios.telemetry_extended_heartbeat,
                 ticket="APMAPI-1938",
             ),
             SchemaBug(

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -81,6 +81,12 @@ class Test_DdtraceSchemas:
                 ticket="APMAPI-1270",
             ),
             SchemaBug(
+                endpoint="/telemetry/proxy/api/v2/apmtelemetry",
+                data_path="$.payload.dependencies[].version",
+                condition=context.library == "php",
+                ticket="PHP-XXXX",  # TODO: file ticket — dd-trace-php emits null version for some dependencies in app-extended-heartbeat
+            ),
+            SchemaBug(
                 endpoint="/debugger/v1/diagnostics",
                 data_path="$[]",
                 condition=context.library >= "php@1.8.3",
@@ -157,6 +163,12 @@ class Test_DdtraceSchemas:
                 data_path="$.payload",
                 condition=context.library > "php@1.7.3",
                 ticket="XXX-1234",
+            ),
+            SchemaBug(
+                endpoint="/api/v2/apmtelemetry",
+                data_path="$.payload.dependencies[].version",
+                condition=context.library == "php",
+                ticket="PHP-XXXX",  # TODO: file ticket — dd-trace-php emits null version for some dependencies in app-extended-heartbeat
             ),
             SchemaBug(
                 endpoint="/api/v2/debugger",


### PR DESCRIPTION
## Summary

Re-enables `Test_ExtendedHeartbeat` for PHP at `>=1.20.0` by registering a `SchemaBug` for the known null-version-in-dependencies deviation, instead of disabling the test entirely.

Follow-up to #6338 (merged 2026-05-12) where I had to revert PHP back to `missing_feature` in commit `4aabacfb7` because `dd-trace-php` emits `null` for `dependencies[].version` in the `app-extended-heartbeat` payload, failing schema validation in `Test_DdtraceSchemas` with:

```
None is not of type 'string' on instance $.payload.dependencies[12].version
```

## Tracking ticket

**[APMAPI-1938 — PHP emits null for dependencies[].version in app-extended-heartbeat payload](https://datadoghq.atlassian.net/browse/APMAPI-1938)** — filed against APM SDK Capabilities, Bug, `system-tests` label, unassigned for apm-php triage.

## Why a SchemaBug rather than leave the test disabled?

- The libdatadog-side fixes are already shipped and present in `dd-trace-php` master via the submodule pin at `91fd13c8` (12 commits ahead of [libdatadog#1910](https://github.com/DataDog/libdatadog/pull/1910), also includes [#1962](https://github.com/DataDog/libdatadog/pull/1962) "include dependencies and integrations in app-extended-heartbeat"). The dependencies array is being populated correctly.
- The remaining bug is `dd-trace-php`'s own dependency tracker emitting `null` for the `version` field on some entries — a tracer-side fix, not a libdatadog gap. As of 2026-05-13 there's no fix on `dd-trace-php` master for this.
- Pattern parallels the previous golang `SchemaBug` for `$.payload.configuration[].value` (ticket APMS-12697), which we dropped in #6338 once the spec was relaxed in [instrumentation-telemetry-api-docs#124](https://github.com/DataDog/instrumentation-telemetry-api-docs/pull/124). Same shape: document the deviation, keep the test running for everything else.

## Changes

- **`manifests/php.yml`** — flip `Test_ExtendedHeartbeat` from `missing_feature` back to `'>=1.20.0'`.
- **`tests/schemas/test_schemas.py`** — add `SchemaBug` entries scoped to `php` AND `scenarios.telemetry_extended_heartbeat` for `$.payload.dependencies[].version` on both the library (`/telemetry/proxy/api/v2/apmtelemetry`) and agent (`/api/v2/apmtelemetry`) interfaces. Scenario scoping ensures unrelated null-version regressions in other PHP payloads (e.g. `app-dependencies-loaded` in DEFAULT) remain visible.