### PR TITLE
[ruby] DEBUG-5107 / DEBUG-5111: Enable probe-status path-matching edge-case tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1126,6 +1126,12 @@ manifest:
         rails80: v2.8.0
         uds-rails: v2.12.0
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_metric_line_status: missing_feature (Not yet implemented)
+  tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_different_casing:
+    - declaration: bug (DEBUG-5107)
+      component_version: '<2.34.0-dev'
+  tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_windows_path:
+    - declaration: bug (DEBUG-5111)
+      component_version: '<2.34.0-dev'
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_span_decoration_line_status: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Method_Probe_Statuses:
     - weblog_declaration:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1126,9 +1126,6 @@ manifest:
         rails80: v2.8.0
         uds-rails: v2.12.0
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_metric_line_status: missing_feature (Not yet implemented)
-  ? tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_different_casing
-  : bug (DEBUG-5107)
-  tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_windows_path: bug (DEBUG-5111)
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_span_decoration_line_status: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Method_Probe_Statuses:
     - weblog_declaration:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1127,8 +1127,7 @@ manifest:
         uds-rails: v2.12.0
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_metric_line_status: missing_feature (Not yet implemented)
   ? tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_different_casing
-  :
-    - declaration: bug (DEBUG-5107)
+  : - declaration: bug (DEBUG-5107)
       component_version: '<2.34.0-dev'
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_windows_path:
     - declaration: bug (DEBUG-5111)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1126,7 +1126,8 @@ manifest:
         rails80: v2.8.0
         uds-rails: v2.12.0
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_metric_line_status: missing_feature (Not yet implemented)
-  tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_different_casing:
+  ? tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_different_casing
+  :
     - declaration: bug (DEBUG-5107)
       component_version: '<2.34.0-dev'
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_windows_path:


### PR DESCRIPTION
## Summary

Version-gates the `bug (DEBUG-5107)` and `bug (DEBUG-5111)` markers for the two probe-status path-matching edge-case tests in `manifests/ruby.yml` to `'<2.34.0-dev'`:

- `tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_different_casing` — DEBUG-5107
- `tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_windows_path` — DEBUG-5111

Companion to DataDog/dd-trace-rb#5754 (merged), which makes `Utils.path_matches_suffix?` and `Utils.path_can_match_spec?` case-insensitive (DEBUG-5107) and tolerant of Windows-style backslash separators in user-supplied probe `sourceFile` (DEBUG-5111).

The gate uses `'<2.34.0-dev'` (not `'<2.34.0'`) so the dev tracer is *not* covered by the bug marker — per semver prerelease ordering, `2.34.0-dev < 2.34.0` is true, so `'<2.34.0'` would incorrectly skip the tests on the tracer that contains the fix. This matches the existing convention in `ruby.yml` (the DEBUG-4675 entry above and the APMLP-1047 entries around lines 1170/1174/1178/1182/1186/1190 all use `'<X.Y.0-dev'`).

## Validation

On commit `d094be361` (this PR's tip), the `DEBUGGER_PROBES_STATUS` scenario ran both tests with the expected behaviour on every supported weblog:

| Weblog | dev (2.34.0-dev) | prod (2.33.0) |
|---|---|---|
| `rails72` — different_casing | passed | xfailed — `bug (DEBUG-5107)` |
| `rails72` — windows_path | passed | xfailed — `bug (DEBUG-5111)` |
| `rails80` — different_casing | passed | xfailed — `bug (DEBUG-5107)` |
| `rails80` — windows_path | passed | xfailed — `bug (DEBUG-5111)` |
| `uds-rails` — different_casing | passed | xfailed — `bug (DEBUG-5107)` |
| `uds-rails` — windows_path | passed | xfailed — `bug (DEBUG-5111)` |

Other weblogs (`rack`, `sinatra14/22/32/41`, `rails42/52/61`, `uds-sinatra`) skip via the parent class's `'*': irrelevant` declaration — unchanged by this PR.

## Test plan

- [x] dd-trace-rb fix merged to master (DataDog/dd-trace-rb#5754)
- [x] CI confirms both tests pass on rails72/rails80/uds-rails against the dev tracer (2.34.0-dev)
- [x] CI confirms the bug markers still apply on rails72/rails80/uds-rails against the latest released tracer (2.33.0)