### PR TITLE
ci: add workflow to mirror MCR images to GHCR

### DIFF
--- a/.github/workflows/mirror-image.yml
+++ b/.github/workflows/mirror-image.yml
@@ -1,0 +1,44 @@
+name: Mirror image to GHCR
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Source image to mirror (e.g. mcr.microsoft.com/dotnet/sdk)"
+        required: true
+        type: string
+      tag:
+        description: "Image tag to mirror (e.g. 8.0, 8.0-alpine)"
+        required: true
+        type: string
+
+permissions:
+  packages: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve GHCR target
+        env:
+          IMAGE: ${{ inputs.image }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          GHCR_TARGET="$(echo "ghcr.io/${REPOSITORY}/${IMAGE}" | tr '[:upper:]' '[:lower:]')"
+          echo "GHCR_TARGET=${GHCR_TARGET}" >> $GITHUB_ENV
+
+      - name: Mirror manifest to GHCR
+        env:
+          SOURCE: ${{ inputs.image }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${GHCR_TARGET}:${TAG}" \
+            "${SOURCE}:${TAG}"


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` workflow to mirror container images from external registries (e.g. `mcr.microsoft.com`) to GHCR
- Mirrors images under `ghcr.io/datadog/system-tests/{source-image}:{tag}`
- Modelled after the same workflow in dd-trace-js

## Usage

Trigger manually with:
- **image**: source image (e.g. `mcr.microsoft.com/dotnet/sdk`)
- **tag**: image tag (e.g. `8.0`)

## Test plan

- [ ] Trigger the workflow manually with a .NET image and verify it appears in GHCR

## Human notes

Basically the same as https://github.com/DataDog/dd-trace-js/pull/8165. Images will then be available in [Packages](https://github.com/DataDog/system-tests/packages). Example in dd-trace-js: https://github.com/Datadog/dd-trace-js/packages

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)