### PR TITLE
[ruby] Normalize dev version suffixes in process discovery test

### DIFF
--- a/tests/parametric/test_process_discovery.py
+++ b/tests/parametric/test_process_discovery.py
@@ -55,8 +55,13 @@ def assert_v1(tracer_metadata: dict, test_library: APMLibrary, library_env: dict
 
     raw_version = context.library.raw_version
     if context.library.name == "ruby":
-        # weblog may adds tailing -dev
-        raw_version = raw_version.removesuffix("-dev")
+        # The Ruby tracer reports its version in SemVer-2 form ("X.Y.Z-dev"), while
+        # raw_version may be in gem prerelease form ("X.Y.Z.dev") from the gemspec
+        # or have a "-dev" suffix appended by the weblog. Strip both possibilities
+        # from raw_version and the SemVer-2 suffix from tracer_version so we compare
+        # base versions.
+        raw_version = raw_version.removesuffix("-dev").removesuffix(".dev")
+        tracer_metadata["tracer_version"] = tracer_metadata["tracer_version"].removesuffix("-dev")
     elif context.library.name == "golang":
         # for which reason ?
         raw_version = raw_version.removeprefix("v")


### PR DESCRIPTION
## Motivation

Follow-up to #6340. With dd-trace-rb [PR #5108](https://github.com/DataDog/dd-trace-rb/pull/5108), master will carry a `.dev` suffix in `lib/datadog/version.rb` (e.g. `2.34.0.dev`). The Ruby tracer converts this to SemVer-2 form (`2.34.0-dev`) when reporting `tracer_version` via process discovery. The existing test only normalized the `-dev` suffix on `raw_version`, so the comparison `tracer_metadata["tracer_version"] == raw_version` fails as `"2.34.0-dev" == "2.34.0.dev"`.

## Changes

In `assert_v1` (`tests/parametric/test_process_discovery.py`), for the Ruby branch:

- Strip both `-dev` and `.dev` suffixes from `raw_version` (covers gemspec prerelease form and weblog-appended suffix).
- Strip `-dev` from `tracer_metadata["tracer_version"]` (the tracer's SemVer-2 suffix).

Both sides reduce to the base version, matching across the four possible combinations (released gemspec with/without weblog `-dev`; prerelease gemspec with/without weblog `-dev`).

## Related PRs

- [DataDog/dd-trace-rb#5108](https://github.com/DataDog/dd-trace-rb/pull/5108) — adds `.dev` to dd-trace-rb master gemspec; the change this PR unblocks in CI.
- [DataDog/dd-trace-rb#5755](https://github.com/DataDog/dd-trace-rb/pull/5755) — documents the two coexisting Ruby version conventions on the tracer side.
- #6924 — broader cleanup that removes the `-dev` append from all 12 Ruby weblog/parametric probes. Complementary to this PR: even after #6924, the SemVer-2 (`-dev`) vs gemspec (`.dev`) split persists on the wire, so the test-side strip here is still required.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
