### PR TITLE
[ruby] Stop appending '-dev' suffix in weblog/parametric library probes

### DIFF
--- a/utils/build/docker/ruby/graphql23/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/graphql23/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/parametric/system_tests_library_version.sh
+++ b/utils/build/docker/ruby/parametric/system_tests_library_version.sh
@@ -2,10 +2,5 @@
 
 ruby -rbundler/setup <<EOF
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
-    version = gemspec.version.to_s
-    # Only append -dev if not from RubyGems AND version doesn't already have a prerelease component
-    if !gemspec.source.is_a?(Bundler::Source::Rubygems) && !gemspec.version.prerelease?
-      version = "#{version}-dev"
-    end
-    puts version
+    puts gemspec.version.to_s
 EOF

--- a/utils/build/docker/ruby/rack/config.ru
+++ b/utils/build/docker/ruby/rack/config.ru
@@ -71,7 +71,6 @@ module Healthcheck
   def run
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     response = {
       status: 'ok',
       library: {

--- a/utils/build/docker/ruby/rails42/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/rails52/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/rails61/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/rails72/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/rails80/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/rails80/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/sinatra14/app.rb
+++ b/utils/build/docker/ruby/sinatra14/app.rb
@@ -39,7 +39,6 @@ get '/healthcheck' do
 
   gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
   version = gemspec.version.to_s
-  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {

--- a/utils/build/docker/ruby/sinatra22/app.rb
+++ b/utils/build/docker/ruby/sinatra22/app.rb
@@ -41,7 +41,6 @@ get '/healthcheck' do
 
   gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
   version = gemspec.version.to_s
-  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {

--- a/utils/build/docker/ruby/sinatra32/app.rb
+++ b/utils/build/docker/ruby/sinatra32/app.rb
@@ -41,7 +41,6 @@ get '/healthcheck' do
 
   gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
   version = gemspec.version.to_s
-  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {

--- a/utils/build/docker/ruby/sinatra41/app.rb
+++ b/utils/build/docker/ruby/sinatra41/app.rb
@@ -44,7 +44,6 @@ get '/healthcheck' do
 
   gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
   version = gemspec.version.to_s
-  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {


### PR DESCRIPTION
## Motivation

The Ruby weblog and parametric library probes in `utils/build/docker/ruby/**` historically appended `-dev` to the gemspec version when the gem was source-built (not installed from RubyGems). The rationale was that dd-trace-rb's master `lib/datadog/version.rb` had `PRE = nil`, so the gemspec reported the *next* release version (e.g. `2.34.0`) even when the source was pre-release — the `-dev` suffix patched that lie.

With [DataDog/dd-trace-rb#5108](https://github.com/DataDog/dd-trace-rb/pull/5108), the gemspec carries `.dev` natively on master, so the probe no longer needs to compensate.

## Changes

For all 12 Ruby probes:

- `utils/build/docker/ruby/parametric/system_tests_library_version.sh` — drop the conditional `-dev` append introduced in #6340 (now vacuous; the prerelease guard exists *because* the gemspec is now authoritative).
- `utils/build/docker/ruby/rack/config.ru`
- `utils/build/docker/ruby/rails42/52/61/72/80/app/controllers/internal_controller.rb`
- `utils/build/docker/ruby/graphql23/app/controllers/internal_controller.rb`
- `utils/build/docker/ruby/sinatra14/22/32/41/app.rb`

Each probe now reports `gemspec.version.to_s` verbatim.

## Compatibility with existing released dd-trace-rb versions

Verified by grep: no consumer of `context.library.raw_version` outside `tests/parametric/test_process_discovery.py` depends on the `-dev` suffix. Manifest declarations (`manifests/ruby.yml`) compare via `ComponentVersion(...).version` (parsed) rather than `.raw_version`, and `component_version.py:88-93` normalizes `.dev` and `-dev` forms to the same `Version` object.

| Install path | Before this PR | After this PR |
|---|---|---|
| RubyGems install, any release | `X.Y.Z` | `X.Y.Z` |
| Source build of release tag | `X.Y.Z-dev` (wrong) | `X.Y.Z` (correct) |
| Source build of old master (pre-#5108) | `X.Y.Z-dev` | `X.Y.Z` |
| Source build of post-#5108 master | `X.Y.Z.dev` (parametric) / `X.Y.Z.dev-dev` (other) | `X.Y.Z.dev` |

## Related PRs

- [DataDog/dd-trace-rb#5108](https://github.com/DataDog/dd-trace-rb/pull/5108) — adds `.dev` to dd-trace-rb master gemspec; the change that motivates this cleanup.
- [DataDog/dd-trace-rb#5755](https://github.com/DataDog/dd-trace-rb/pull/5755) — expands the comment on `Identity.gem_datadog_version_semver2` documenting the two coexisting Ruby version conventions.
- [DataDog/system-tests#6923](https://github.com/DataDog/system-tests/pull/6923) — minimal test-side normalization in `test_process_discovery.py` that unblocks dd-trace-rb#5108 CI. This PR is a broader cleanup; #6923 is the targeted fix.
- [DataDog/system-tests#6340](https://github.com/DataDog/system-tests/pull/6340) — the prior fix (parametric only) that this PR generalizes and supersedes.

## Workflow

1. ⚠️ Created as draft ⚠️
2. Will work on this PR until CI passes
3. Will mark as ready for review then

🤖 Generated with [Claude Code](https://claude.com/claude-code)