### PR TITLE
[ruby] Drop -dev probe append and normalize prerelease comparison

### DIFF
--- a/tests/parametric/test_process_discovery.py
+++ b/tests/parametric/test_process_discovery.py
@@ -55,8 +55,12 @@ def assert_v1(tracer_metadata: dict, test_library: APMLibrary, library_env: dict
 
     raw_version = context.library.raw_version
     if context.library.name == "ruby":
-        # weblog may adds tailing -dev
-        raw_version = raw_version.removesuffix("-dev")
+        # Ruby has two valid notations for a prerelease version: RubyGems-style
+        # ("X.Y.Z.dev", what the gemspec carries) and SemVer-2 ("X.Y.Z-dev", what
+        # the tracer emits via Identity.gem_datadog_version_semver2). Both denote
+        # the same version. Normalize raw_version to SemVer-2 so it compares equal
+        # to the tracer's report without conflating a prerelease with its release.
+        raw_version = re.sub(r"^(\d+\.\d+\.\d+)\.(\D[^.]*)$", r"\1-\2", raw_version)
     elif context.library.name == "golang":
         # for which reason ?
         raw_version = raw_version.removeprefix("v")

--- a/utils/build/docker/ruby/graphql23/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/graphql23/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/parametric/system_tests_library_version.sh
+++ b/utils/build/docker/ruby/parametric/system_tests_library_version.sh
@@ -2,10 +2,5 @@
 
 ruby -rbundler/setup <<EOF
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
-    version = gemspec.version.to_s
-    # Only append -dev if not from RubyGems AND version doesn't already have a prerelease component
-    if !gemspec.source.is_a?(Bundler::Source::Rubygems) && !gemspec.version.prerelease?
-      version = "#{version}-dev"
-    end
-    puts version
+    puts gemspec.version.to_s
 EOF

--- a/utils/build/docker/ruby/rack/config.ru
+++ b/utils/build/docker/ruby/rack/config.ru
@@ -71,7 +71,6 @@ module Healthcheck
   def run
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
     response = {
       status: 'ok',
       library: {

--- a/utils/build/docker/ruby/rails42/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/rails52/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/rails61/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/rails72/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/rails80/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/rails80/app/controllers/internal_controller.rb
@@ -4,7 +4,6 @@ class InternalController < ApplicationController
   def healthcheck
     gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
     version = gemspec.version.to_s
-    version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
 
     render json: {status: 'ok', library: {name: 'ruby', version: version}}
   end

--- a/utils/build/docker/ruby/sinatra14/app.rb
+++ b/utils/build/docker/ruby/sinatra14/app.rb
@@ -39,7 +39,6 @@ get '/healthcheck' do
 
   gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
   version = gemspec.version.to_s
-  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {

--- a/utils/build/docker/ruby/sinatra22/app.rb
+++ b/utils/build/docker/ruby/sinatra22/app.rb
@@ -41,7 +41,6 @@ get '/healthcheck' do
 
   gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
   version = gemspec.version.to_s
-  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {

--- a/utils/build/docker/ruby/sinatra32/app.rb
+++ b/utils/build/docker/ruby/sinatra32/app.rb
@@ -41,7 +41,6 @@ get '/healthcheck' do
 
   gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
   version = gemspec.version.to_s
-  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {

--- a/utils/build/docker/ruby/sinatra41/app.rb
+++ b/utils/build/docker/ruby/sinatra41/app.rb
@@ -44,7 +44,6 @@ get '/healthcheck' do
 
   gemspec = Gem.loaded_specs['datadog'] || Gem.loaded_specs['ddtrace']
   version = gemspec.version.to_s
-  version = "#{version}-dev" unless gemspec.source.is_a?(Bundler::Source::Rubygems)
   {
     status: 'ok',
     library: {


### PR DESCRIPTION
## Motivation

The Ruby weblog and parametric library probes in `utils/build/docker/ruby/**` historically appended `-dev` to the gemspec version when the gem was source-built. The rationale was that dd-trace-rb's master `lib/datadog/version.rb` had `PRE = nil`, so the gemspec read `2.34.0` even when the source was pre-2.34.0 — the `-dev` suffix compensated for that.

The compensation introduced two problems:

1. The `-dev` marker conflated "source build" with "prerelease version" — distinct concepts that the gemspec's own `prerelease?` should answer.
2. To make the assertion in `tests/parametric/test_process_discovery.py::assert_v1` pass, the test stripped `-dev` from `raw_version`. That strip silently equated a prerelease with its release (`"2.34.0-dev"` was compared as equal to `"2.34.0"`), defeating the assertion's intent.

[DataDog/dd-trace-rb#5108](https://github.com/DataDog/dd-trace-rb/pull/5108) puts `.dev` in `lib/datadog/version.rb` so the gemspec is authoritative. Once it lands, the probe's compensation logic is obsolete, and the test's strip is wrong in a new way: post-#5108 the tracer emits SemVer-2 form (`2.34.0-dev`) while the gemspec stays in RubyGems form (`2.34.0.dev`), and the old strip doesn't bridge them.

This PR removes the compensation and replaces the test's strip with a canonical-form comparison, in one atomic change that works against both pre-#5108 and post-#5108 dd-trace-rb.

## Changes

**Probe cleanup (12 files):**

- `utils/build/docker/ruby/parametric/system_tests_library_version.sh` — remove the prerelease-guarded `-dev` append (added in #6340 as a transitional fix).
- `utils/build/docker/ruby/rack/config.ru`
- `utils/build/docker/ruby/rails42/52/61/72/80/app/controllers/internal_controller.rb`
- `utils/build/docker/ruby/graphql23/app/controllers/internal_controller.rb`
- `utils/build/docker/ruby/sinatra14/22/32/41/app.rb`

Each probe now reports `gemspec.version.to_s` verbatim.

**Test normalization (`tests/parametric/test_process_discovery.py`):**

Replace `raw_version = raw_version.removesuffix("-dev")` with a regex that converts RubyGems prerelease form `X.Y.Z.suffix` to SemVer-2 form `X.Y.Z-suffix`. The tracer's `tracer_version` field is already SemVer-2, so the comparison now equates two notations of the same prerelease — and correctly distinguishes a prerelease from its release.

## Behavior across dd-trace-rb states

| Install path | gemspec | Probe output | Tracer output | Comparison |
|---|---|---|---|---|
| Pre-#5108, RubyGems install | `2.34.0` | `2.34.0` | `2.34.0` | ✅ |
| Pre-#5108, source build | `2.34.0` | `2.34.0` | `2.34.0` | ✅ |
| Post-#5108 master, source build | `2.34.0.dev` | `2.34.0.dev` | `2.34.0-dev` | ✅ (normalize matches) |
| Post-release source build | `2.34.0` | `2.34.0` | `2.34.0` | ✅ |
| Hypothetical bug: tracer says release, probe says prerelease | `2.34.0.dev` | `2.34.0.dev` | `2.34.0` | ❌ (correctly flagged) |

The last row is the protection the previous suffix-strip silently removed.

## Related PRs

- [DataDog/dd-trace-rb#5108](https://github.com/DataDog/dd-trace-rb/pull/5108) — adds `.dev` to dd-trace-rb master gemspec; this PR is the system-tests-side change that lets #5108 land cleanly.
- [DataDog/dd-trace-rb#5755](https://github.com/DataDog/dd-trace-rb/pull/5755) — documents the SemVer-2 conversion in the dd-trace-rb tracer.
- #6340 — the previous parametric-only fix that this PR supersedes.
- #6923 — superseded by this PR (test-side suffix strip only; left the semantic anti-pattern in place).
- #6924 — superseded by this PR (probe cleanup only; left the gemspec-vs-tracer notation gap unhandled).

## Workflow

1. ⚠️ Created as draft ⚠️
2. Will work on this PR until CI passes
3. Will mark ready for review then

🤖 Generated with [Claude Code](https://claude.com/claude-code)