### PR TITLE
[nodejs] Response content headers always sent when Appsec is enabled

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -93,6 +93,7 @@ refs:
   - &ref_5_98_0 '>=5.98.0'
   - &ref_5_99_0 '>=5.99.0'
   - &ref_5_103_0 '>=5.103.0'
+  - &ref_5_104_0 '>=5.104.0'
   - &ref_6_0_0 '>=6.0.0-pre'
 manifest:
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardEvent_Tag: missing_feature (APPSEC-62217)
@@ -1311,7 +1312,7 @@ manifest:
   tests/appsec/test_service_activation_metric.py::TestServiceActivationRemoteConfigMetric: *ref_5_55_0_5_78_0
   tests/appsec/test_service_activation_metric.py::TestServiceActivationRemoteConfigurationConfigMetric: *ref_5_79_0
   tests/appsec/test_shell_execution.py::Test_ShellExecution: *ref_5_3_0
-  tests/appsec/test_span_tags_headers.py: bug (APPSEC-61286)
+  tests/appsec/test_span_tags_headers.py: *ref_5_104_0
   tests/appsec/test_suspicious_attacker_blocking.py::Test_Suspicious_Attacker_Blocking: *ref_5_59_0
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRules: *ref_5_60_0
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRulesRcCapability: *ref_5_60_0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1312,7 +1312,15 @@ manifest:
   tests/appsec/test_service_activation_metric.py::TestServiceActivationRemoteConfigMetric: *ref_5_55_0_5_78_0
   tests/appsec/test_service_activation_metric.py::TestServiceActivationRemoteConfigurationConfigMetric: *ref_5_79_0
   tests/appsec/test_shell_execution.py::Test_ShellExecution: *ref_5_3_0
-  tests/appsec/test_span_tags_headers.py: *ref_5_104_0
+  tests/appsec/test_span_tags_headers.py::Test_Headers_No_Event:
+    - weblog_declaration:
+        "*": *ref_5_104_0
+        nextjs: irrelevant (Next.js App Router serves / with chunked transfer encoding; response lacks Content-Length)
+  tests/appsec/test_span_tags_headers.py::Test_Headers_Event_No_Blocking:
+    - weblog_declaration:
+        "*": *ref_5_104_0
+        nextjs: irrelevant (Next.js App Router serves / with chunked transfer encoding; response lacks Content-Length)
+  tests/appsec/test_span_tags_headers.py::Test_Headers_Event_Blocking: *ref_5_104_0
   tests/appsec/test_suspicious_attacker_blocking.py::Test_Suspicious_Attacker_Blocking: *ref_5_59_0
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRules: *ref_5_60_0
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRulesRcCapability: *ref_5_60_0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1312,15 +1312,15 @@ manifest:
   tests/appsec/test_service_activation_metric.py::TestServiceActivationRemoteConfigMetric: *ref_5_55_0_5_78_0
   tests/appsec/test_service_activation_metric.py::TestServiceActivationRemoteConfigurationConfigMetric: *ref_5_79_0
   tests/appsec/test_shell_execution.py::Test_ShellExecution: *ref_5_3_0
-  tests/appsec/test_span_tags_headers.py::Test_Headers_No_Event:
-    - weblog_declaration:
-        "*": *ref_5_104_0
-        nextjs: irrelevant (Next.js App Router serves / with chunked transfer encoding; response lacks Content-Length)
+  tests/appsec/test_span_tags_headers.py::Test_Headers_Event_Blocking: *ref_5_104_0
   tests/appsec/test_span_tags_headers.py::Test_Headers_Event_No_Blocking:
     - weblog_declaration:
         "*": *ref_5_104_0
         nextjs: irrelevant (Next.js App Router serves / with chunked transfer encoding; response lacks Content-Length)
-  tests/appsec/test_span_tags_headers.py::Test_Headers_Event_Blocking: *ref_5_104_0
+  tests/appsec/test_span_tags_headers.py::Test_Headers_No_Event:
+    - weblog_declaration:
+        "*": *ref_5_104_0
+        nextjs: irrelevant (Next.js App Router serves / with chunked transfer encoding; response lacks Content-Length)
   tests/appsec/test_suspicious_attacker_blocking.py::Test_Suspicious_Attacker_Blocking: *ref_5_59_0
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRules: *ref_5_60_0
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRulesRcCapability: *ref_5_60_0


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
