### PR TITLE
Revert "perf(ffe): set OTEL_METRIC_EXPORT_INTERVAL=1s to eliminate 30s agent wait"

### DIFF
--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -601,8 +601,8 @@ class _Scenarios:
             "DD_METRICS_OTEL_ENABLED": "true",
             "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf",
             "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://agent:4318/v1/metrics",
-            "OTEL_METRIC_EXPORT_INTERVAL": "1000",
         },
+        agent_interface_timeout=30,
         doc="",
         scenario_groups=[scenario_groups.ffe],
     )


### PR DESCRIPTION
Reverts DataDog/system-tests#6904

pythen/dev seems to not support this : https://github.com/DataDog/system-tests/actions/runs/25883774130/job/76070851737?pr=6925#step:47:83