### PR TITLE
Fix flaky DEBUGGER_PII_REDACTION test on .NET

### DIFF
--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -135,6 +135,11 @@ class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
 
         if not snapshot_found:
             self.setup_failures.append("Snapshot was not received")
+        else:
+            # The EMITTING diagnostic can arrive after the snapshot itself
+            # (notably on .NET where it is reported asynchronously), so wait
+            # for it explicitly before the assertion runs.
+            self.wait_for_all_probes(statuses=["EMITTING"])
 
     ############ assert ############
     def _assert(self, excluded_identifiers: list[str] | None = None, *, line_probe: bool = False):


### PR DESCRIPTION
<!-- dd-meta {"pullId":"798a63bd-3d48-437a-8165-45aaafd6f54c","source":"chat","resourceId":"0b949963-1697-4c8c-97ed-fe66b1a6b8b5","workflowId":"74fb89ae-09b6-46a1-8131-2ff49be30041","codeChangeId":"74fb89ae-09b6-46a1-8131-2ff49be30041","sourceType":"slack"} -->
## Motivation

The `Test_Debugger_PII_Redaction.test_pii_redaction_method_full` test failed on .NET with:

```
AssertionError: The following probes are not emitting: {'log170aa-acda-4453-9111-1478a6method': 'INSTALLED'}
```

PR #6434 (fix flaky snapshot and PII tests) replaced the `wait_for_all_probes(statuses=["EMITTING"])` call in the PII setup with a retry loop that only waits for snapshots. However, on .NET the `EMITTING` probe diagnostic is reported asynchronously, separately from the snapshot upload itself. The snapshot can therefore arrive before the diagnostic does. When the setup exits the snapshot-found loop and `_assert()` immediately runs `collect()`, the probe status is still `INSTALLED` and `assert_all_probes_are_emitting()` fails. The sibling `tests/debugger/test_debugger_probe_snapshot.py` setup still has this wait, which is why it does not exhibit the same flake.

## Changes

- `tests/debugger/test_debugger_pii.py`: after the snapshot retry loop succeeds, wait for all probes to reach `EMITTING` status (with the default 30s timeout) before returning from `_setup`. This matches the wait already present in `tests/debugger/test_debugger_probe_snapshot.py` and lets the asynchronous `EMITTING` diagnostic settle before the assertion runs.

## Testing

- Syntactic and lint checks: `python -m py_compile` and `ruff check` on `tests/debugger/test_debugger_pii.py` both pass.
- The change is a pure test-side wait/timing fix: it keeps the existing retry logic and snapshot wait, and only adds an additional `wait_for_all_probes(statuses=["EMITTING"])` after a snapshot is observed. If `EMITTING` arrives quickly (the common case) the wait is essentially a no-op; if it arrives slightly after the snapshot, the assertion now sees the up-to-date status. End-to-end DEBUGGER_PII_REDACTION runs require the dotnet weblog container and cannot be executed in this sandbox.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/0b949963-1697-4c8c-97ed-fe66b1a6b8b5)

Comment @datadog to request changes