### PR TITLE
[rust] unflag adaptive sampling override-env test

### DIFF
--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -86,6 +86,7 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature  # Created by easy win activation script
   tests/parametric/test_crashtracking.py: missing_feature
   tests/parametric/test_dynamic_configuration.py: '>=0.2.1'  # Modified by easy win activation script
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env: '>=0.3.3'
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_capability_tracing_enabled: missing_feature  # Created by easy win activation script

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -86,7 +86,6 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature  # Created by easy win activation script
   tests/parametric/test_crashtracking.py: missing_feature
   tests/parametric/test_dynamic_configuration.py: '>=0.2.1'  # Modified by easy win activation script
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_capability_tracing_enabled: missing_feature  # Created by easy win activation script


### PR DESCRIPTION
## Motivation

`TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env` was marked as `missing_feature` for Rust, but it now passes against dd-trace-rs `main` (release `0.3.3`). Verified locally with `system-tests-local`. The test passes after removing the marker.


## Changes

Remove the stale `missing_feature` entry for `test_trace_sampling_rules_override_env` from `manifests/rust.yml`.

The other two entries in the same class (`test_trace_sampling_rules_override_rate` and `test_trace_sampling_rules_with_tags`) stay marked `missing_feature`. Those have real tracer-side gaps and will be unflagged once the dd-trace-rs fixes land.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from R&P team

🛟 #apm-shared-testing 🛟

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? Only `manifests/rust.yml` modified.
* [x] A docker base image is modified? No.
* [x] A scenario is added, removed or renamed? No.