### PR TITLE
[ruby] unflag adaptive sampling tests for CI verification

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1399,10 +1399,6 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature
   tests/parametric/test_crashtracking.py::Test_Crashtracking: v2.3.0
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules: v2.0.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_remote_sampling_rules_retention: bug (APMAPI-867)
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env: bug (APMAPI-867)
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: bug (APMAPI-867)
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: bug (APMAPI-868)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled: '>=2.27.0'  # Modified by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_capability_tracing_enabled: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_default_capability_completeness: missing_feature  # Created by easy win activation script

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1398,7 +1398,11 @@ manifest:
       component_version: <=2.22.0
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature
   tests/parametric/test_crashtracking.py::Test_Crashtracking: v2.3.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules: v2.31.0
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules: v2.0.0
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_remote_sampling_rules_retention: v2.31.0
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env: v2.31.0
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: v2.31.0
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: v2.31.0
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled: '>=2.27.0'  # Modified by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_capability_tracing_enabled: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_default_capability_completeness: missing_feature  # Created by easy win activation script

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1399,6 +1399,18 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature
   tests/parametric/test_crashtracking.py::Test_Crashtracking: v2.3.0
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules: v2.0.0
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_remote_sampling_rules_retention:
+    - declaration: bug (APMAPI-867)
+      component_version: <2.31.0
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env:
+    - declaration: bug (APMAPI-867)
+      component_version: <2.31.0
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate:
+    - declaration: bug (APMAPI-867)
+      component_version: <2.31.0
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags:
+    - declaration: bug (APMAPI-868)
+      component_version: <2.31.0
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled: '>=2.27.0'  # Modified by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_capability_tracing_enabled: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_default_capability_completeness: missing_feature  # Created by easy win activation script

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1398,19 +1398,7 @@ manifest:
       component_version: <=2.22.0
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature
   tests/parametric/test_crashtracking.py::Test_Crashtracking: v2.3.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules: v2.0.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_remote_sampling_rules_retention:
-    - declaration: bug (APMAPI-867)
-      component_version: <2.31.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env:
-    - declaration: bug (APMAPI-867)
-      component_version: <2.31.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate:
-    - declaration: bug (APMAPI-867)
-      component_version: <2.31.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags:
-    - declaration: bug (APMAPI-868)
-      component_version: <2.31.0
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules: v2.31.0
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled: '>=2.27.0'  # Modified by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_capability_tracing_enabled: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_default_capability_completeness: missing_feature  # Created by easy win activation script


### PR DESCRIPTION
## Motivation

Both [APMAPI-867](https://datadoghq.atlassian.net/browse/APMAPI-867) and [APMAPI-868](https://datadoghq.atlassian.net/browse/APMAPI-868) are blank placeholder tickets from November 2024 — no comments, no assignee, no linked PRs. dd-trace-rb [#5421](https://github.com/DataDog/dd-trace-rb/pull/5421) (merged 2026-04-15) added the post-resource re-sampling these tests need, but nobody updated the manifest. This PR removes all four flagged entries and lets CI tell us which, if any, still fail. If anything breaks, we'll re-add targeted entries with the specific failure mode.

## Changes

Removes four entries from `manifests/ruby.yml`:

- `TestDynamicConfigSamplingRules::test_remote_sampling_rules_retention`
- `TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env`
- `TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate`
- `TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags`

## Caveat for CI interpretation

dd-trace-rb's Remote Config worker only boots via `lib/datadog/core/remote/tie.rb#boot`, called exclusively from Rack middleware in the tracer. The Ruby parametric harness (`utils/build/docker/ruby/parametric/server.rb`) uses Rack+WEBrick, so the worker should start. If any of these tests fail in CI, a span-creation path that bypasses the Rack request lifecycle is the most likely cause.

## Workflow

1. Draft until CI passes
2. Mark ready once green

## Reviewer checklist

- [ ] No code or scenario changes — manifest only
- [ ] No docker base image changes
- [ ] No scenario added, removed, or renamed

[APMAPI-867]: https://datadoghq.atlassian.net/browse/APMAPI-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMAPI-868]: https://datadoghq.atlassian.net/browse/APMAPI-868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ