### PR TITLE
fix(parametric): retry loop for flaky Python adaptive sampling tests

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1710,9 +1710,6 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature
   tests/parametric/test_crashtracking.py::Test_Crashtracking: v2.11.2
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules: v2.9.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_remote_sampling_rules_retention: flaky (APMAPI-857, APMAPI-1860)
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env: flaky (APMAPI-1860)
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: flaky (APMAPI-1051)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: '>=4.3.1'  # Modified by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled: flaky (APMAPI-734)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1: flaky (APMAPI-179)

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -835,7 +835,7 @@ class TestDynamicConfigSamplingRules:
         # Unset the RC sample rate to ensure the previous setting is reapplied.
         set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rules": None})
         # Retry: RC ACK can precede full application of the unset (same as test_remote_sampling_rules_retention).
-        trace = None
+        trace: list[Span] | None = None
         for _ in range(max_propagation_retries):
             trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
             if find_first_span_in_trace_payload(trace)["metrics"].get("_dd.rule_psr", 1.0) == pytest.approx(
@@ -906,7 +906,7 @@ class TestDynamicConfigSamplingRules:
         # Unset RC to ensure local settings
         set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rules": None})
         # Retry: RC ACK can precede full application of the unset (same as test_remote_sampling_rules_retention).
-        trace = None
+        trace: list[Span] | None = None
         for _ in range(max_propagation_retries):
             trace = get_sampled_trace(test_library, test_agent, service="other_service", name="op_name")
             if find_first_span_in_trace_payload(trace)["metrics"].get("_dd.rule_psr", 1.0) == pytest.approx(

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -774,6 +774,7 @@ class TestDynamicConfigSamplingRules:
         """
         rc_sampling_rule_rate_customer = 0.8
         rc_sampling_rule_rate_dynamic = 0.4
+        max_propagation_retries: int = 30
         assert rc_sampling_rule_rate_customer != ENV_SAMPLING_RULE_RATE
         assert rc_sampling_rule_rate_dynamic != ENV_SAMPLING_RULE_RATE
         assert rc_sampling_rule_rate_customer != DEFAULT_SAMPLE_RATE
@@ -808,7 +809,16 @@ class TestDynamicConfigSamplingRules:
             },
         )
 
-        trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
+        # Retry: RC ACK can precede full application of new rules (same as test_remote_sampling_rules_retention).
+        trace: list[Span] | None = None
+        for _ in range(max_propagation_retries):
+            trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
+            if find_first_span_in_trace_payload(trace)["metrics"].get("_dd.rule_psr", 1.0) == pytest.approx(
+                rc_sampling_rule_rate_customer
+            ):
+                break
+            time.sleep(0.1)
+        assert trace is not None
         assert_sampling_rate(trace, rc_sampling_rule_rate_customer)
         # Make sure `_dd.p.dm` is set to "-11" (i.e., remote user rule)
         span = find_first_span_in_trace_payload(trace)
@@ -824,7 +834,16 @@ class TestDynamicConfigSamplingRules:
 
         # Unset the RC sample rate to ensure the previous setting is reapplied.
         set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rules": None})
-        trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
+        # Retry: RC ACK can precede full application of the unset (same as test_remote_sampling_rules_retention).
+        trace = None
+        for _ in range(max_propagation_retries):
+            trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
+            if find_first_span_in_trace_payload(trace)["metrics"].get("_dd.rule_psr", 1.0) == pytest.approx(
+                ENV_SAMPLING_RULE_RATE
+            ):
+                break
+            time.sleep(0.1)
+        assert trace is not None
         assert_sampling_rate(trace, ENV_SAMPLING_RULE_RATE)
         # Make sure `_dd.p.dm` is restored to "-3"
         span = find_first_span_in_trace_payload(trace)
@@ -836,6 +855,7 @@ class TestDynamicConfigSamplingRules:
         """The RC sampling rules should override the RC sampling rate."""
         rc_sampling_rule_rate_customer = 0.8
         rc_sampling_rate = 0.9
+        max_propagation_retries: int = 30
         assert rc_sampling_rule_rate_customer != DEFAULT_SAMPLE_RATE
         assert rc_sampling_rate != DEFAULT_SAMPLE_RATE
 
@@ -859,7 +879,16 @@ class TestDynamicConfigSamplingRules:
         )
 
         # trace/span matching the rule gets applied the rule's rate
-        trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
+        # Retry: RC ACK can precede full application of new rules (same as test_remote_sampling_rules_retention).
+        trace: list[Span] | None = None
+        for _ in range(max_propagation_retries):
+            trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
+            if find_first_span_in_trace_payload(trace)["metrics"].get("_dd.rule_psr", 1.0) == pytest.approx(
+                rc_sampling_rule_rate_customer
+            ):
+                break
+            time.sleep(0.1)
+        assert trace is not None
         assert_sampling_rate(trace, rc_sampling_rule_rate_customer)
         # Make sure `_dd.p.dm` is set to "-11" (i.e., remote user rule)
         span = find_first_span_in_trace_payload(trace)
@@ -876,7 +905,16 @@ class TestDynamicConfigSamplingRules:
 
         # Unset RC to ensure local settings
         set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rules": None})
-        trace = get_sampled_trace(test_library, test_agent, service="other_service", name="op_name")
+        # Retry: RC ACK can precede full application of the unset (same as test_remote_sampling_rules_retention).
+        trace = None
+        for _ in range(max_propagation_retries):
+            trace = get_sampled_trace(test_library, test_agent, service="other_service", name="op_name")
+            if find_first_span_in_trace_payload(trace)["metrics"].get("_dd.rule_psr", 1.0) == pytest.approx(
+                DEFAULT_SAMPLE_RATE
+            ):
+                break
+            time.sleep(0.1)
+        assert trace is not None
         assert_sampling_rate(trace, DEFAULT_SAMPLE_RATE)
 
     @parametrize(


### PR DESCRIPTION
## Motivation

Three Python `TestDynamicConfigSamplingRules` tests have been flagged as flaky for months ([APMAPI-857](https://datadoghq.atlassian.net/browse/APMAPI-857), [APMAPI-1051](https://datadoghq.atlassian.net/browse/APMAPI-1051), [APMAPI-1860](https://datadoghq.atlassian.net/browse/APMAPI-1860)). Vlad Scherbich diagnosed the race in early 2026: `set_and_wait_rc` ACKs new RC config before the tracer's `apm-tracing.rc` event has propagated to the sampler, so the next span assertion can race against stale rules.

Vlad's commits [`5d9142e51`](https://github.com/DataDog/system-tests/commit/5d9142e51) and [`7932d7c2f`](https://github.com/DataDog/system-tests/commit/7932d7c2f) fixed two of these tests (`test_remote_sampling_rules_retention` and `test_trace_sampling_rules_with_tags`) by adding a retry loop that polls `_dd.rule_psr` until it matches the expected rate. This PR applies the same pattern to the two remaining flaky tests and unflags the third (already covered by Vlad's earlier fix).

Cross-language context: this is the Python piece of a multi-tracer adaptive-sampling investigation tracked locally at `~/dd/polyglot-tracer-reports/adaptive-sampling/01-investigation.md`.

## Changes

`tests/parametric/test_dynamic_configuration.py` — wrap four post-`set_and_wait_rc` assertion blocks in retry loops:
- `test_trace_sampling_rules_override_env` (2 assertion blocks)
- `test_trace_sampling_rules_override_rate` (2 assertion blocks)

Each loop matches Vlad's pattern: `max_propagation_retries = 30`, `time.sleep(0.1)` per iteration, breaks on rate match, asserts as before.

`manifests/python.yml` — removes three `flaky` entries now resolved:
- `test_remote_sampling_rules_retention: flaky (APMAPI-857, APMAPI-1860)` (already fixed by Vlad)
- `test_trace_sampling_rules_override_env: flaky (APMAPI-1860)`
- `test_trace_sampling_rules_override_rate: flaky (APMAPI-1051)`

## Workflow

1. Draft until CI passes
2. Mark ready once green

## Reviewer checklist

- [ ] No code or scenario changes — test + manifest only
- [ ] No docker base image changes
- [ ] No scenario added, removed, or renamed

[APMAPI-857]: https://datadoghq.atlassian.net/browse/APMAPI-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMAPI-1051]: https://datadoghq.atlassian.net/browse/APMAPI-1051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMAPI-1860]: https://datadoghq.atlassian.net/browse/APMAPI-1860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ