### PR TITLE
feat(parametric): add synchronous /trace/remote-config/apply endpoint

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -199,6 +199,7 @@ manifest:
   tests/parametric/test_otel_span_with_baggage.py::Test_Otel_Span_With_Baggage: missing_feature
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer::test_otel_force_flush: irrelevant (library does not implement OpenTelemetry)
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer::test_otel_simple_trace: irrelevant (library does not implement OpenTelemetry)
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: missing_feature (add_link is not supported)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Set_Error: bug (APMAPI-778)  # The expected error status is not set
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Set_Metric: missing_feature (Tracer does not provide a public method for directly setting a span metric)

--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -84,6 +84,7 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -332,6 +332,7 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -961,6 +961,7 @@ manifest:
       component_version: <=2.41.0
   tests/parametric/test_otel_span_with_baggage.py::Test_Otel_Span_With_Baggage: missing_feature
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer: v2.8.0
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: incomplete_test_app (add_link parametric endpoint is not implemented)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource parametric endpoint is not implemented)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage: incomplete_test_app (baggage endpoints are not implemented)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1205,6 +1205,7 @@ manifest:
   ? tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_span_strict_reserved_attributes_overrides_analytics_event
   : "irrelevant (\"Go tracer decided to always set _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0\")"
   tests/parametric/test_otel_span_with_baggage.py::Test_Otel_Span_With_Baggage: missing_feature
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: missing_feature (add_link endpoint is not implemented)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Set_Resource: missing_feature (does not support setting a resource name after span creation)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage: missing_feature (baggage endpoints are not implemented)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3794,6 +3794,7 @@ manifest:
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer::test_otel_force_flush:
     - declaration: missing_feature (OTel resource naming implemented in 1.24.0)
       component_version: <=1.23.0
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: incomplete_test_app (add_link endpoint is not implemented)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage:  # Modified by easy win activation script
     - declaration: incomplete_test_app (baggage endpoints are not implemented)

--- a/manifests/java_otel.yml
+++ b/manifests/java_otel.yml
@@ -52,6 +52,7 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2158,6 +2158,7 @@ manifest:
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_start_span: missing_feature (New operation name mapping not yet implemented)
   tests/parametric/test_otel_span_with_baggage.py::Test_Otel_Span_With_Baggage: *ref_5_32_0
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer::test_otel_force_flush: missing_feature (Not implemented)
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not implemented)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Start: bug (APMAPI-778)  # The resource name of the child span is overidden by the parent span.
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage: incomplete_test_app (baggage endpoints are not implemented)

--- a/manifests/nodejs_otel.yml
+++ b/manifests/nodejs_otel.yml
@@ -69,6 +69,7 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -866,6 +866,7 @@ manifest:
       component_version: <=0.95.0
   tests/parametric/test_otel_span_with_baggage.py::Test_Otel_Span_With_Baggage: missing_feature
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer: v0.94.0
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: v1.13.0+4663b2fa7c20c6920f347d059b57dc2a419cb7f7
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Start: v1.13.0+4663b2fa7c20c6920f347d059b57dc2a419cb7f7
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage: missing_feature (baggage is not supported)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1762,9 +1762,6 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature
   tests/parametric/test_crashtracking.py::Test_Crashtracking: v2.11.2
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules: v2.9.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_remote_sampling_rules_retention: flaky (APMAPI-857, APMAPI-1860)
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env: flaky (APMAPI-1860)
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: flaky (APMAPI-1051)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: '>=4.3.1'  # Modified by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled: flaky (APMAPI-734)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1: flaky (APMAPI-179)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2263,6 +2263,7 @@ manifest:
   ? tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_span_strict_reserved_attributes_overrides_analytics_event
   : "irrelevant (\"Ruby tracer decided to always set _dd1.sr.eausr: 1 for truthy analytics.event inputs, else 0\")"
   tests/parametric/test_otel_span_with_baggage.py::Test_Otel_Span_With_Baggage: missing_feature
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not supported)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage: missing_feature (baggage is not supported)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Current_Span: incomplete_test_app (current span endpoint is not supported)

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -212,6 +212,7 @@ manifest:
   : missing_feature (Not implemented)
   tests/parametric/test_otel_span_with_baggage.py::Test_Otel_Span_With_Baggage: missing_feature
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer: v0.0.1
+  tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: missing_feature
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Finish: v0.0.1
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Set_Error: missing_feature

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -195,29 +195,29 @@ def _create_rc_config(config_overrides: dict[str, Any]) -> dict[str, Any]:
 
 def set_and_wait_rc(
     test_agent: TestAgentAPI,
+    test_library: APMLibrary,
     config_overrides: dict[str, Any],
     config_id: str | int | None = None,
 ) -> dict[str, Any]:
-    """Helper to create an RC configuration with the given settings and wait for it to be applied.
+    """Set an RC config, wait for the agent ACK, then drain the tracer.
 
-    It is assumed that the configuration is successfully applied.
-
-    Uses config_id filtering so we only match ACKs for the config we just set—avoids
-    matching stale ACKs from prior configs. When config_id is passed (reuse case),
-    clears before set_rc to discard buffered RC requests so we only see responses
-    from our update.
+    The drain closes the race between the agent ACK and the tracer applying the
+    config. config_id filtering matches only the ACK we just triggered.
     """
     rc_config: dict[str, Any] = _create_rc_config(config_overrides)
     if config_id is not None:
         # Reuse case: discard stale ACKs from prior updates at the same path
         test_agent.clear()
     used_config_id: str = _set_rc(test_agent, rc_config, config_id)
-    return test_agent.wait_for_rc_apply_state(
+    rc_state = test_agent.wait_for_rc_apply_state(
         "APM_TRACING",
         state=RemoteConfigApplyState.ACKNOWLEDGED,
         clear=True,
         config_id=used_config_id,
     )
+    # No-op (returns None) on tracers without the apply endpoint yet.
+    test_library.flush_remote_config()
+    return rc_state
 
 
 def assert_sampling_rate(trace: list[dict], rate: float):
@@ -401,7 +401,7 @@ class TestDynamicConfigV1:
         configuration has been applied by the tracer.
         """
         assert test_library.is_alive(), "library container is not alive"
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": 0.5})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": 0.5})
         cfg_state = test_agent.wait_for_rc_apply_state("APM_TRACING", state=RemoteConfigApplyState.ACKNOWLEDGED)
         assert cfg_state["apply_state"] == 2
         assert cfg_state["product"] == "APM_TRACING"
@@ -418,12 +418,12 @@ class TestDynamicConfigV1:
 
         # Create a remote config entry, wait for the configuration change telemetry event to be received
         # and then create a new trace to assert the configuration has been applied.
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": 0.5})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": 0.5})
         trace = send_and_wait_trace(test_library, test_agent, name="test")
         assert_sampling_rate(trace, 0.5)
 
         # Unset the RC sample rate to ensure the default setting is used.
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": None})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": None})
         trace = send_and_wait_trace(test_library, test_agent, name="test")
         assert_sampling_rate(trace, DEFAULT_SAMPLE_RATE)
 
@@ -450,7 +450,7 @@ class TestDynamicConfigV1:
 
         # Create a remote config entry, wait for the configuration change telemetry event to be received
         # and then create a new trace to assert the configuration has been applied.
-        rc_state = set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": 0.5})
+        rc_state = set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": 0.5})
         trace = send_and_wait_trace(test_library, test_agent, name="test")
         assert_sampling_rate(trace, 0.5)
 
@@ -461,6 +461,7 @@ class TestDynamicConfigV1:
         # and then create a new trace to assert the configuration has been applied.
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={"tracing_sampling_rate": 0.6},
             config_id=config_id,
         )
@@ -470,6 +471,7 @@ class TestDynamicConfigV1:
         # Unset the RC sample rate to ensure the previous setting is reapplied.
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={"tracing_sampling_rate": None},
             config_id=config_id,
         )
@@ -498,6 +500,7 @@ class TestDynamicConfigV1:
         # apply to env_service spans but should apply to all others.
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={"tracing_sampling_rate": rc_sampling_rule_rate},
         )
 
@@ -507,7 +510,7 @@ class TestDynamicConfigV1:
         assert_sampling_rate(trace, rc_sampling_rule_rate)
 
         # Unset the RC sample rate to ensure the previous setting is reapplied.
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": None})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": None})
         trace = send_and_wait_trace(test_library, test_agent, name="env_name")
         assert_sampling_rate(trace, ENV_SAMPLING_RULE_RATE)
         trace = send_and_wait_trace(test_library, test_agent, name="other_name")
@@ -527,7 +530,7 @@ class TestDynamicConfigV1:
         There is no way (at the time of writing) to check the logs produced by the library.
         """
         assert test_library.is_alive(), "library container is not alive"
-        cfg_state = set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": None})
+        cfg_state = set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": None})
         assert cfg_state["apply_state"] == 2
 
 
@@ -701,6 +704,7 @@ class TestDynamicConfigV2:
         # Ensure local tags are overridden and RC tags applied.
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={"tracing_tags": ["rc_key1:val1", "rc_key2:val2"]},
         )
         with (
@@ -713,7 +717,7 @@ class TestDynamicConfigV2:
         assert_trace_has_tags(traces[0], {"rc_key1": "val1", "rc_key2": "val2"})
 
         # Ensure previous tags are restored.
-        set_and_wait_rc(test_agent, config_overrides={})
+        set_and_wait_rc(test_agent, test_library, config_overrides={})
         with (
             test_library,
             test_library.dd_start_span("test") as span,
@@ -790,6 +794,7 @@ class TestDynamicConfigSamplingRules:
         # Create a remote config entry with two rules at different sample rates.
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={
                 "tracing_sampling_rules": [
                     {
@@ -823,7 +828,7 @@ class TestDynamicConfigSamplingRules:
         assert span["meta"]["_dd.p.dm"] == "-12"
 
         # Unset the RC sample rate to ensure the previous setting is reapplied.
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rules": None})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rules": None})
         trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
         assert_sampling_rate(trace, ENV_SAMPLING_RULE_RATE)
         # Make sure `_dd.p.dm` is restored to "-3"
@@ -845,6 +850,7 @@ class TestDynamicConfigSamplingRules:
 
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={
                 "tracing_sampling_rate": rc_sampling_rate,
                 "tracing_sampling_rules": [
@@ -875,7 +881,7 @@ class TestDynamicConfigSamplingRules:
         assert span["meta"]["_dd.p.dm"] == "-3"
 
         # Unset RC to ensure local settings
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rules": None})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rules": None})
         trace = get_sampled_trace(test_library, test_agent, service="other_service", name="op_name")
         assert_sampling_rate(trace, DEFAULT_SAMPLE_RATE)
 
@@ -919,6 +925,7 @@ class TestDynamicConfigSamplingRules:
         # Create a remote config entry with two rules at different sample rates.
         rc_state = set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={
                 "tracing_sampling_rate": rc_sampling_rate,
                 "tracing_sampling_rules": [
@@ -990,6 +997,7 @@ class TestDynamicConfigSamplingRules:
         # RC config using dynamic sampling
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_id=config_id,
             config_overrides={
                 "dynamic_sampling_enabled": "true",
@@ -1044,6 +1052,7 @@ class TestDynamicConfigSamplingRules:
 
         rc_state: dict = set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={
                 "tracing_sampling_rules": [
                     {
@@ -1060,6 +1069,7 @@ class TestDynamicConfigSamplingRules:
 
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_id=config_id,
             config_overrides={
                 "tracing_sampling_rules": [
@@ -1073,10 +1083,9 @@ class TestDynamicConfigSamplingRules:
             },
         )
 
-        # After updating the RC config, the library may briefly still be applying the
-        # previous sampling rules. set_and_wait_rc waits for telemetry and RC acknowledgment,
-        # but these signals can be satisfied by stale events from the prior config, causing a
-        # window where the new rules aren't yet active. Retry to allow for full propagation.
+        # Python's set_and_wait_rc already drained RC, so the new rules are live now.
+        # Other tracers use the ACK-only path, where the ACK can precede the sampler
+        # applying the rules; retry until they implement the apply endpoint.
         trace: list[Span] | None = None
         for _ in range(max_propagation_retries):
             trace = send_and_wait_trace(test_library, test_agent, name="test", service="foo")

--- a/tests/parametric/test_parametric_endpoints.py
+++ b/tests/parametric/test_parametric_endpoints.py
@@ -6,6 +6,8 @@ When in doubt refer to the python implementation as the source of truth via
 the OpenAPI schema: https://github.com/DataDog/system-tests/blob/44281005e9d2ddec680f31b2813eb90af831c0fc/docs/understand/scenarios/parametric.md#shared-interface
 """
 
+from typing import Any
+
 import pytest
 import time
 
@@ -21,6 +23,8 @@ from utils.docker_fixtures.spec.trace import retrieve_span_events
 from utils.docker_fixtures.spec.trace import find_only_span
 from utils.docker_fixtures.parametric import Link, LogLevel
 from utils.docker_fixtures import TestAgentAPI, ParametricTestClientApi as APMLibrary
+
+from tests.parametric.test_dynamic_configuration import _create_rc_config, _set_rc
 
 # this global mark applies to all tests in this file.
 #   DD_TRACE_OTEL_ENABLED=true is required in the tracers to enable OTel
@@ -804,3 +808,47 @@ class Test_Parametric_FFE_Start:
         """
         result = test_library.ffe_start()
         assert result is True
+
+
+@scenarios.parametric
+@features.parametric_endpoint_parity
+class TestRemoteConfigApplyEndpoint:
+    """Black-box tests of the synchronous POST /trace/remote-config/apply endpoint contract.
+
+    The endpoint drains pending RC synchronously regardless of the tracer's RC poll interval.
+    """
+
+    def test_apply_returns_empty_when_no_rc_received(
+        self,
+        test_agent: TestAgentAPI,  # noqa: ARG002
+        test_library: APMLibrary,
+    ) -> None:
+        """When no RC has been sent, the endpoint returns 200 with applied_configs=[]."""
+        result = test_library.flush_remote_config()
+        assert isinstance(result, list)
+        # No RC has been published, so nothing should be applied yet.
+        assert result == [], f"expected empty applied_configs, got {result!r}"
+
+    def test_apply_returns_applied_config_after_set(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """After publishing a config, the endpoint returns it in applied_configs."""
+        rc_config: dict[str, Any] = _create_rc_config({"tracing_sampling_rate": 0.5})
+        used_config_id = _set_rc(test_agent, rc_config, config_id="test-apply-set")
+
+        result = test_library.flush_remote_config()
+        assert result is not None, "endpoint should be implemented for Python"
+        config_ids = [c["config_id"] for c in result]
+        products = {c["product"] for c in result}
+
+        assert used_config_id in config_ids, f"expected config_id {used_config_id!r} in applied set, got {config_ids!r}"
+        assert products == {"APM_TRACING"}, f"expected only APM_TRACING, got {products!r}"
+
+    def test_apply_is_idempotent(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """Calling apply twice in a row with no new RC is a no-op."""
+        _set_rc(test_agent, _create_rc_config({"tracing_sampling_rate": 0.3}), config_id="idem-1")
+        first = test_library.flush_remote_config()
+        second = test_library.flush_remote_config()
+        assert first is not None, "endpoint should be implemented for Python"
+        assert second is not None, "endpoint should be implemented for Python"
+        first_ids = sorted(c["config_id"] for c in first)
+        second_ids = sorted(c["config_id"] for c in second)
+        assert first_ids == second_ids, f"applied set changed between idempotent calls: {first_ids!r} -> {second_ids!r}"

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -9,6 +9,7 @@ from typing import Union
 import logging
 import os
 import enum
+import threading
 from fastapi import FastAPI
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -432,6 +433,107 @@ def trace_stats_flush(args: TraceStatsFlushArgs) -> TraceStatsFlushReturn:
     if len(stats_proc):
         stats_proc[0].periodic()
     return TraceStatsFlushReturn()
+
+
+class TraceRemoteConfigApplyArgs(BaseModel):
+    pass  # Reserved for future per-config_id semantics; see contract doc.
+
+
+class AppliedConfigEntry(BaseModel):
+    config_id: str
+    product: str
+
+
+class TraceRemoteConfigApplyReturn(BaseModel):
+    applied_configs: List[AppliedConfigEntry]
+
+
+# Serialize overlapping /trace/remote-config/apply calls (sync handlers run in a
+# threadpool). A timed-out drain keeps the lock until its worker thread exits.
+_rc_apply_lock = threading.Lock()
+
+
+@app.post("/trace/remote-config/apply")
+def trace_remote_config_apply(
+    args: TraceRemoteConfigApplyArgs,
+) -> JSONResponse:
+    """Synchronously drain pending Remote Config and return the applied set.
+
+    Contract: docs/parametric/remote-config-apply-contract.md. The drain runs in
+    a worker thread joined with a 10s deadline (504 on timeout).
+    """
+    # Imported lazily (matches /rc/start, /rc/stop) to avoid touching RC internals at module import time.
+    from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+
+    timeout_seconds = 10.0
+    client = remoteconfig_poller._client
+
+    # A prior drain timed out and still holds the lock.
+    if not _rc_apply_lock.acquire(blocking=False):
+        return JSONResponse(
+            status_code=504,
+            content={
+                "error": "previous remote-config apply still in progress",
+                "timeout_seconds": timeout_seconds,
+            },
+        )
+
+    lock_ownership_transferred = False
+    try:
+        drain_error: List[BaseException] = []
+
+        def _drain() -> None:
+            try:
+                client.request()
+                client._global_subscriber.periodic()
+            except BaseException as exc:  # noqa: BLE001
+                drain_error.append(exc)
+
+        worker = threading.Thread(target=_drain, name="rc-apply-drain", daemon=True)
+        worker.start()
+        worker.join(timeout=timeout_seconds)
+
+        if worker.is_alive():
+            # Drain didn't finish in time; a watcher releases the lock once the
+            # worker exits, so follow-up calls get 504 instead of overlapping it.
+            log.warning("rc-apply drain exceeded %.1fs; holding lock until worker exits", timeout_seconds)
+            lock_ownership_transferred = True
+
+            def _release_when_done(t: threading.Thread) -> None:
+                t.join()
+                _rc_apply_lock.release()
+
+            threading.Thread(
+                target=_release_when_done, args=(worker,), name="rc-apply-lock-releaser", daemon=True
+            ).start()
+            return JSONResponse(
+                status_code=504,
+                content={
+                    "error": "timeout waiting for remote config to apply",
+                    "timeout_seconds": timeout_seconds,
+                },
+            )
+
+        if drain_error:
+            # Report the failure rather than an optimistic 200 (the applied-config
+            # set alone doesn't prove the product callbacks ran).
+            log.warning("rc-apply drain raised: %r", drain_error[0])
+            return JSONResponse(
+                status_code=500,
+                content={"error": f"remote config apply failed: {drain_error[0]!r}"},
+            )
+
+        success = TraceRemoteConfigApplyReturn(
+            applied_configs=[
+                AppliedConfigEntry(config_id=metadata.id, product=metadata.product_name)
+                for metadata in client._applied_configs.values()
+            ]
+        )
+        # Pydantic v1 (fastapi==0.89.1): .dict(), not v2's .model_dump().
+        return JSONResponse(status_code=200, content=success.dict())
+    finally:
+        if not lock_ownership_transferred:
+            _rc_apply_lock.release()
 
 
 class TraceSpanErrorArgs(BaseModel):

--- a/utils/docker_fixtures/_test_clients/_test_client_parametric.py
+++ b/utils/docker_fixtures/_test_clients/_test_client_parametric.py
@@ -492,6 +492,29 @@ class ParametricTestClientApi(TestClientApi):
 
         return HTTPStatus(r.status_code).is_success
 
+    def flush_remote_config(self, timeout: float = 10.0) -> list[dict[str, str]] | None:
+        """Synchronously drain pending Remote Config and return the applied set.
+
+        Contract: docs/parametric/remote-config-apply-contract.md. Returns None on
+        tracers that haven't implemented the endpoint yet (404), as distinct from
+        [] which means the endpoint ran and applied nothing. On any other non-2xx
+        response (e.g. a 504 when the server-side drain timed out), logs a WARNING
+        and returns None instead of raising: a non-2xx response can occur even when
+        the tracer applied RC correctly, so the test should assert on actual tracer
+        state rather than be killed prematurely.
+        """
+        resp = self._session.post(
+            self._url("/trace/remote-config/apply"),
+            json={},
+            timeout=timeout,
+        )
+        if resp.status_code == HTTPStatus.NOT_FOUND:
+            return None
+        if not resp.ok:
+            logger.warning("flush_remote_config got %s: %s", resp.status_code, resp.text)
+            return None
+        return resp.json().get("applied_configs", [])
+
     def write_log(
         self,
         logger_name: str,
@@ -1058,6 +1081,14 @@ class APMLibrary:
 
     def dd_flush(self) -> bool:
         return self._client.dd_flush()
+
+    def flush_remote_config(self, timeout: float = 10.0) -> list[dict[str, str]] | None:
+        """Synchronously drain pending Remote Config and return the applied set.
+
+        Returns None on tracers that haven't implemented the endpoint yet.
+        Tests rarely call this directly; set_and_wait_rc() invokes it after the ACK.
+        """
+        return self._client.flush_remote_config(timeout=timeout)
 
     def otel_flush(self, timeout_sec: int) -> bool:
         return self._client.otel_flush(timeout_sec)


### PR DESCRIPTION
## Motivation

Parametric RC tests call `set_and_wait_rc()`, which waits for the test agent's `APM_TRACING ACKNOWLEDGED`. That ACK fires when the tracer's RC client *validates* a payload, not when its subscribers have *applied* it. Reading tracer state in that gap is racy, and it is the cause of the Python flaky gates on `TestDynamicConfigSamplingRules` (APMAPI-857, APMAPI-1051, APMAPI-1860), which were previously masked with retry loops.

This closes the gap at the source: a synchronous "apply pending RC now" endpoint the test can call after the ACK, so Python reads tracer state only once the new config is live.

## Changes

- New `POST /trace/remote-config/apply` on the Python parametric `apm_test_client`: drains pending RC synchronously (10s timeout → `504`; `500` if the drain raises), plus a `flush_remote_config()` client helper. The helper returns `None` on a missing endpoint (`404`); on any other non-2xx it logs a warning and returns `None`, so a transient transport error or server-side timeout doesn't kill the test.
- `set_and_wait_rc()` calls `flush_remote_config()` unconditionally after the ACK (no per-language branching). It's a no-op on tracers that haven't implemented the endpoint yet, so they keep their existing retry loops.
- Unflags the 3 Python sampling tests that were carrying the race.
- Endpoint-parity tests live in `test_parametric_endpoints.py` (`@features.parametric_endpoint_parity`). Non-Python parametric apps don't implement the endpoint yet, so they're declared `incomplete_test_app` in their manifests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
