### PR TITLE
Separate OTLP Runtime Metrics Tests into 2 Tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4241,8 +4241,8 @@ manifest:
         akka-http: irrelevant (integration injects Date header after bytecode injection occurs)
         play: irrelevant (integration injects Date header after bytecode injection occurs)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)
-  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_otel_metrics_are_present: missing_feature
   tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_dd_metrics_are_absent: bug (APMAPI-1952)
+  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_otel_metrics_are_present: missing_feature
   tests/test_profiling.py::Test_Profile:
     - weblog_declaration:
         akka-http: v1.22.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4241,7 +4241,8 @@ manifest:
         akka-http: irrelevant (integration injects Date header after bytecode injection occurs)
         play: irrelevant (integration injects Date header after bytecode injection occurs)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)
-  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics: missing_feature
+  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_otel_metrics_are_present: missing_feature
+  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_dd_metrics_are_absent: bug (APMAPI-1952)
   tests/test_profiling.py::Test_Profile:
     - weblog_declaration:
         akka-http: v1.22.0

--- a/tests/test_otlp_runtime_metrics.py
+++ b/tests/test_otlp_runtime_metrics.py
@@ -82,7 +82,7 @@ DD_PROPRIETARY_PREFIXES = {
     "dotnet": "runtime.dotnet.",
     "golang": "runtime.go.",
     "nodejs": "runtime.node.",
-    "java": "jvm.heap_memory",
+    "java": "jvm.",
 }
 
 

--- a/tests/test_otlp_runtime_metrics.py
+++ b/tests/test_otlp_runtime_metrics.py
@@ -82,7 +82,7 @@ DD_PROPRIETARY_PREFIXES = {
     "dotnet": "runtime.dotnet.",
     "golang": "runtime.go.",
     "nodejs": "runtime.node.",
-    "java": "jvm.",
+    "java": "jvm.heap_memory",
 }
 
 

--- a/tests/test_otlp_runtime_metrics.py
+++ b/tests/test_otlp_runtime_metrics.py
@@ -68,14 +68,11 @@ EXPECTED_METRICS = {
         "jvm.cpu.count",
         "jvm.cpu.recent_utilization",
         "jvm.cpu.time",
-        "jvm.file_descriptor.count",
-        "jvm.file_descriptor.limit",
         "jvm.memory.committed",
         "jvm.memory.init",
         "jvm.memory.limit",
         "jvm.memory.used",
         "jvm.memory.used_after_last_gc",
-        "jvm.system.cpu.utilization",
         "jvm.thread.count",
     ],
 }
@@ -106,10 +103,10 @@ def get_runtime_metric_names():
 class Test_OtlpRuntimeMetrics:
     """Verify runtime metrics are sent via OTLP with OTel names, not DD-proprietary names."""
 
-    def setup_main(self):
+    def setup_otel_metrics_are_present(self):
         self.req = weblog.get("/")
 
-    def test_main(self):
+    def test_otel_metrics_are_present(self):
         assert self.req.status_code == 200
 
         library = context.library.name
@@ -118,7 +115,6 @@ class Test_OtlpRuntimeMetrics:
 
         metric_names = get_runtime_metric_names()
 
-        # All expected OTel-named metrics must be present
         expected = EXPECTED_METRICS[library]
         for expected_name in expected:
             assert expected_name in metric_names, (
@@ -126,10 +122,20 @@ class Test_OtlpRuntimeMetrics:
                 f"Got metrics: {sorted(metric_names)}"
             )
 
-        # DD-proprietary names must NOT be present
+    def setup_dd_metrics_are_absent(self):
+        self.req = weblog.get("/")
+
+    def test_dd_metrics_are_absent(self):
+        assert self.req.status_code == 200
+
+        library = context.library.name
         dd_prefix = DD_PROPRIETARY_PREFIXES.get(library)
-        if dd_prefix:
-            dd_named_metrics = [n for n in metric_names if n.startswith(dd_prefix)]
-            assert len(dd_named_metrics) == 0, (
-                f"Found DD-proprietary metric names for {library}: {dd_named_metrics}. Expected OTel-native names only."
-            )
+        if not dd_prefix:
+            return
+
+        metric_names = get_runtime_metric_names()
+
+        dd_named_metrics = [n for n in metric_names if n.startswith(dd_prefix)]
+        assert len(dd_named_metrics) == 0, (
+            f"Found DD-proprietary metric names for {library}: {dd_named_metrics}. Expected OTel-native names only."
+        )


### PR DESCRIPTION
## Motivation

For Java, the first half of the test (verifying OTel metrics are emitted) pass, but the second half (verifying no DD metrics are emitted) fails. This is because of logic that is in the [agent](https://github.com/DataDog/datadog-agent/blob/6fa8dd0d843d6ff3a5ea6a5d0afb729ec43ee940/pkg/opentelemetry-mapping-go/otlp/metrics/runtime_metric_mappings.go#L108) that maps OTel metrics to DD metrics. This is only an issue for Java since the mappings for other languages only map deprecated metrics.

This PR splits the original weblog test into 2 tests to clearly indicate what is working and broken. This PR also removes a few metrics that we currently choose not to emit b/c they are "developmental" in OTel.
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
