### PR TITLE
refactor(parametric/python): consolidate set_and_wait_rc helpers + absorb #6951

### DIFF
--- a/docs/parametric/remote-config-apply-contract.md
+++ b/docs/parametric/remote-config-apply-contract.md
@@ -7,16 +7,18 @@ See also: `tests/parametric/test_dynamic_configuration.py::set_and_wait_rc`,
 
 ## Why this exists
 
-The existing `set_and_wait_rc()` helper waits for the test-agent to report an
+`set_and_wait_rc()` originally waited only for the test-agent to report an
 `APM_TRACING ACKNOWLEDGED` from the tracer. That ACK fires when the RC client
 has received and validated the payload — **not** when the tracer's subscribers
 have actually applied it. The gap is small for in-process tracers (Python, Go,
 Java, Node.js, .NET, Ruby, Rust) and large for out-of-process ones (PHP via
-sidecar). Tests that read tracer state immediately after `set_and_wait_rc()`
-flake on the small gap and reliably fail on the large one.
+sidecar). Tests that read tracer state immediately after the ACK flake on the
+small gap and reliably fail on the large one.
 
 This endpoint closes the gap by giving tests a synchronous, deterministic
-"process pending RC now" call.
+"process pending RC now" call. `set_and_wait_rc()` now calls this endpoint
+internally after the ACK on tracers that implement it (see
+`_RC_APPLY_ENDPOINT_LANGS`), so callers do not need to invoke it explicitly.
 
 ## Endpoint
 
@@ -136,27 +138,30 @@ exists. Coordinate with the PHP tracer team before starting.
 
 ## Test-framework helper
 
-The Python test framework exposes:
+The Python test framework exposes the low-level call:
 
 ```python
 test_library.flush_remote_config(timeout: float = 10.0) -> list[dict]
 ```
 
-and a higher-level convenience:
+and the high-level helper that tests use directly:
 
 ```python
-set_and_wait_rc_applied(test_agent, test_library, config_overrides, config_id=None)
+set_and_wait_rc(test_agent, test_library, config_overrides, config_id=None)
 ```
 
-which is `set_and_wait_rc()` followed by `test_library.flush_remote_config()`.
+`set_and_wait_rc()` waits for the test-agent ACK and then, on tracers in
+`_RC_APPLY_ENDPOINT_LANGS`, calls `flush_remote_config()` to synchronously
+drain pending RC. Tracers outside the allowlist get the ACK-only path with
+no behavior change.
 
 ## Adoption
 
-`set_and_wait_rc()` continues to work unchanged for tracers that have not yet
-implemented the endpoint. Tests opt in to the deterministic variant by calling
-`flush_remote_config()` explicitly or using `set_and_wait_rc_applied()`. Once
-all tracers implement the endpoint, the retry-loop workaround in
-`get_sampled_trace()` and similar helpers can be removed in a follow-up.
+For tracers that have not yet implemented the endpoint, `set_and_wait_rc()`
+falls back to the ACK-only path automatically. Add the tracer's language to
+`_RC_APPLY_ENDPOINT_LANGS` once the endpoint is implemented; no test changes
+are required. The probabilistic retry loop inside `get_sampled_trace()`
+remains (it handles sampling-by-chance, not the RC race).
 
 ## Open questions
 

--- a/docs/parametric/remote-config-apply-contract.md
+++ b/docs/parametric/remote-config-apply-contract.md
@@ -1,0 +1,173 @@
+# Parametric Harness: `/trace/remote-config/apply` Contract
+
+Owner: APM SDK Capabilities
+Status: pilot (Python only as of this writing)
+See also: `tests/parametric/test_dynamic_configuration.py::set_and_wait_rc`,
+`tests/parametric/test_remote_config_apply_endpoint.py`
+
+## Why this exists
+
+The existing `set_and_wait_rc()` helper waits for the test-agent to report an
+`APM_TRACING ACKNOWLEDGED` from the tracer. That ACK fires when the RC client
+has received and validated the payload — **not** when the tracer's subscribers
+have actually applied it. The gap is small for in-process tracers (Python, Go,
+Java, Node.js, .NET, Ruby, Rust) and large for out-of-process ones (PHP via
+sidecar). Tests that read tracer state immediately after `set_and_wait_rc()`
+flake on the small gap and reliably fail on the large one.
+
+This endpoint closes the gap by giving tests a synchronous, deterministic
+"process pending RC now" call.
+
+## Endpoint
+
+- Method: `POST`
+- Path: `/trace/remote-config/apply`
+- Content-Type: `application/json`
+- Request body: `{}` (no required fields; reserved for future per-`config_id` semantics)
+- Response: `application/json`, `200 OK` on success, `504` on timeout
+
+### Response schema (success)
+
+```json
+{
+  "applied_configs": [
+    {"config_id": "<id>", "product": "APM_TRACING"}
+  ]
+}
+```
+
+`applied_configs` is the list of configs the tracer believes are currently
+applied after the synchronous drain. May be empty if no RC has been received
+yet — that is **not** an error.
+
+### Response schema (timeout)
+
+```json
+{"error": "timeout waiting for remote config to apply", "timeout_seconds": 10.0}
+```
+
+`504 Gateway Timeout` status. The server may set its own default timeout; 10
+seconds is the recommended default (PHP's sidecar can take several seconds to
+drain).
+
+## Semantics
+
+When called, the parametric server MUST:
+
+1. Synchronously fetch any pending RC from the test agent (i.e. perform one
+   `request` poll cycle, not wait for the next periodic tick).
+2. Synchronously dispatch any received payloads to all registered product
+   callbacks (samplers, etc.), so that by the time the call returns, the
+   tracer's in-memory state reflects the latest RC.
+3. Return the list of currently-applied configs.
+
+The endpoint MUST be idempotent: calling it repeatedly with no new RC pending
+is a no-op that returns the current applied set.
+
+The endpoint MUST apply **all** pending RC products, not just `APM_TRACING`.
+Filtering by product can be added later as a request-body field if needed.
+
+The endpoint MUST NOT block forever. The server enforces a timeout (default
+10s). If the underlying primitives haven't returned by then, respond `504`.
+
+## Per-language implementation notes
+
+### Python (reference implementation)
+
+dd-trace-py exposes the primitives directly. The synchronous chain is:
+
+```python
+from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+client = remoteconfig_poller._client
+client.request()                       # fetch + publish to connector
+client._global_subscriber.periodic()   # drain connector, invoke callbacks
+```
+
+No dd-trace-py changes required.
+
+### Go
+
+Likely `internal/remoteconfig.Client.poll()` or equivalent. Investigate whether
+poll already calls subscriber callbacks inline; if so, one call is enough.
+
+### Java
+
+Likely `ConfigurationPoller.poll()` synchronous variant. Check whether
+`SharedCommunicationObjects` exposes a synchronous drain.
+
+### Node.js
+
+Likely `packages/dd-trace/src/remote_config/index.js` — check for a
+synchronous `poll`/`update` method.
+
+### .NET
+
+Investigate `Datadog.Trace.RemoteConfigurationManagement.RemoteConfigurationManager`
+for a synchronous variant.
+
+### Ruby
+
+Investigate `Datadog::Core::Remote::Component#sync` or the polling worker
+for a synchronous variant. See also `03-ruby-rc-bootstrap-plan.md` in this
+same report directory for related Ruby RC bootstrap work.
+
+### Rust
+
+Investigate `datadog-remote-config` crate. See `02-rust-implementation-plan.md`
+in this same report directory.
+
+### C++
+
+Investigate the dd-trace-cpp RC poller.
+
+### PHP (motivator)
+
+This is the most important case. The PHP sidecar ACKs as soon as a payload
+lands in shared memory, but the PHP request process applies it lazily on the
+next request boundary. The endpoint implementation needs to:
+
+1. Synchronously trigger the sidecar to fetch from the test-agent.
+2. Synchronously trigger the PHP-side apply (likely a new
+   `dd_trace_internal_fn("process_remote_config_now")` or equivalent that
+   reads the sidecar's shared memory and applies it on the current request).
+
+This is by far the largest per-language lift and is the reason this endpoint
+exists. Coordinate with the PHP tracer team before starting.
+
+## Test-framework helper
+
+The Python test framework exposes:
+
+```python
+test_library.flush_remote_config(timeout: float = 10.0) -> list[dict]
+```
+
+and a higher-level convenience:
+
+```python
+set_and_wait_rc_applied(test_agent, test_library, config_overrides, config_id=None)
+```
+
+which is `set_and_wait_rc()` followed by `test_library.flush_remote_config()`.
+
+## Adoption
+
+`set_and_wait_rc()` continues to work unchanged for tracers that have not yet
+implemented the endpoint. Tests opt in to the deterministic variant by calling
+`flush_remote_config()` explicitly or using `set_and_wait_rc_applied()`. Once
+all tracers implement the endpoint, the retry-loop workaround in
+`get_sampled_trace()` and similar helpers can be removed in a follow-up.
+
+## Open questions
+
+- **Idempotency under concurrent calls?** The endpoint is single-threaded per
+  FastAPI worker, so concurrent calls serialize naturally. If a tracer's
+  underlying primitives are not thread-safe, the implementation must add a
+  lock.
+- **What if the test agent is unreachable?** `request()` returns `False`. The
+  endpoint should still return `200` with whatever applied_configs are
+  currently in memory — the contract is "drain what you can," not "guarantee
+  fresh fetch."
+- **Empty response when no RC ever received?** Returns `200` with
+  `{"applied_configs": []}`. Not a 404 — this is a normal state during early
+  test setup.

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1710,9 +1710,6 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature
   tests/parametric/test_crashtracking.py::Test_Crashtracking: v2.11.2
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules: v2.9.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_remote_sampling_rules_retention: flaky (APMAPI-857, APMAPI-1860)
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env: flaky (APMAPI-1860)
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: flaky (APMAPI-1051)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: '>=4.3.1'  # Modified by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled: flaky (APMAPI-734)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1: flaky (APMAPI-179)

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -220,6 +220,26 @@ def set_and_wait_rc(
     )
 
 
+def set_and_wait_rc_applied(
+    test_agent: TestAgentAPI,
+    test_library: APMLibrary,
+    config_overrides: dict[str, Any],
+    config_id: str | int | None = None,
+) -> dict[str, Any]:
+    """Set an RC config, wait for the agent ACK, then synchronously drain the tracer.
+
+    This is the deterministic variant of set_and_wait_rc(). It eliminates the
+    race between the test-agent ACK (which fires when the RC client validates
+    the payload) and the tracer's subscriber dispatch (which actually applies
+    it). See docs/parametric/remote-config-apply-contract.md.
+
+    Returns the rc_state dict from the test agent (same as set_and_wait_rc).
+    """
+    rc_state = set_and_wait_rc(test_agent, config_overrides, config_id)
+    test_library.flush_remote_config()
+    return rc_state
+
+
 def assert_sampling_rate(trace: list[dict], rate: float):
     """Asserts that a trace returned from the test agent is consistent with the given sample rate.
 

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -193,37 +193,10 @@ def _create_rc_config(config_overrides: dict[str, Any]) -> dict[str, Any]:
     return rc_config
 
 
-def set_and_wait_rc(
-    test_agent: TestAgentAPI,
-    config_overrides: dict[str, Any],
-    config_id: str | int | None = None,
-) -> dict[str, Any]:
-    """Helper to create an RC configuration with the given settings and wait for it to be applied.
-
-    It is assumed that the configuration is successfully applied.
-
-    Uses config_id filtering so we only match ACKs for the config we just set—avoids
-    matching stale ACKs from prior configs. When config_id is passed (reuse case),
-    clears before set_rc to discard buffered RC requests so we only see responses
-    from our update.
-    """
-    rc_config: dict[str, Any] = _create_rc_config(config_overrides)
-    if config_id is not None:
-        # Reuse case: discard stale ACKs from prior updates at the same path
-        test_agent.clear()
-    used_config_id: str = _set_rc(test_agent, rc_config, config_id)
-    return test_agent.wait_for_rc_apply_state(
-        "APM_TRACING",
-        state=RemoteConfigApplyState.ACKNOWLEDGED,
-        clear=True,
-        config_id=used_config_id,
-    )
-
-
 _RC_APPLY_ENDPOINT_LANGS: frozenset[str] = frozenset({"python"})
 
 
-def set_and_wait_rc_applied(
+def set_and_wait_rc(
     test_agent: TestAgentAPI,
     test_library: APMLibrary,
     config_overrides: dict[str, Any],
@@ -231,20 +204,33 @@ def set_and_wait_rc_applied(
 ) -> dict[str, Any]:
     """Set an RC config, wait for the agent ACK, then synchronously drain the tracer.
 
-    This is the deterministic variant of set_and_wait_rc(). It eliminates the
-    race between the test-agent ACK (which fires when the RC client validates
-    the payload) and the tracer's subscriber dispatch (which actually applies
-    it). See docs/parametric/remote-config-apply-contract.md.
+    Eliminates the race between the test-agent ACK (which fires when the RC
+    client validates the payload) and the tracer's subscriber dispatch (which
+    actually applies it). See docs/parametric/remote-config-apply-contract.md.
 
-    The deterministic drain is only triggered for tracers that have implemented
-    POST /trace/remote-config/apply. For other tracers this helper degrades
-    transparently to set_and_wait_rc() so converted tests keep running on the
-    existing ACK-based pattern (with whatever retry-loop workaround already
-    handled the race).
+    The deterministic drain runs only for tracers that have implemented
+    POST /trace/remote-config/apply (see _RC_APPLY_ENDPOINT_LANGS). For other
+    tracers this helper degrades to the ACK-only path and tests behave the
+    same as before the apply-contract work.
 
-    Returns the rc_state dict from the test agent (same as set_and_wait_rc).
+    Uses config_id filtering so we only match ACKs for the config we just
+    set—avoids matching stale ACKs from prior configs. When config_id is
+    passed (reuse case), clears before set_rc to discard buffered RC requests
+    so we only see responses from our update.
+
+    Returns the rc_state dict from the test agent.
     """
-    rc_state = set_and_wait_rc(test_agent, config_overrides, config_id)
+    rc_config: dict[str, Any] = _create_rc_config(config_overrides)
+    if config_id is not None:
+        # Reuse case: discard stale ACKs from prior updates at the same path
+        test_agent.clear()
+    used_config_id: str = _set_rc(test_agent, rc_config, config_id)
+    rc_state = test_agent.wait_for_rc_apply_state(
+        "APM_TRACING",
+        state=RemoteConfigApplyState.ACKNOWLEDGED,
+        clear=True,
+        config_id=used_config_id,
+    )
     if test_library.lang in _RC_APPLY_ENDPOINT_LANGS:
         test_library.flush_remote_config()
     return rc_state
@@ -431,7 +417,7 @@ class TestDynamicConfigV1:
         configuration has been applied by the tracer.
         """
         assert test_library.is_alive(), "library container is not alive"
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": 0.5})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": 0.5})
         cfg_state = test_agent.wait_for_rc_apply_state("APM_TRACING", state=RemoteConfigApplyState.ACKNOWLEDGED)
         assert cfg_state["apply_state"] == 2
         assert cfg_state["product"] == "APM_TRACING"
@@ -448,12 +434,12 @@ class TestDynamicConfigV1:
 
         # Create a remote config entry, wait for the configuration change telemetry event to be received
         # and then create a new trace to assert the configuration has been applied.
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": 0.5})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": 0.5})
         trace = send_and_wait_trace(test_library, test_agent, name="test")
         assert_sampling_rate(trace, 0.5)
 
         # Unset the RC sample rate to ensure the default setting is used.
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": None})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": None})
         trace = send_and_wait_trace(test_library, test_agent, name="test")
         assert_sampling_rate(trace, DEFAULT_SAMPLE_RATE)
 
@@ -480,7 +466,7 @@ class TestDynamicConfigV1:
 
         # Create a remote config entry, wait for the configuration change telemetry event to be received
         # and then create a new trace to assert the configuration has been applied.
-        rc_state = set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": 0.5})
+        rc_state = set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": 0.5})
         trace = send_and_wait_trace(test_library, test_agent, name="test")
         assert_sampling_rate(trace, 0.5)
 
@@ -491,6 +477,7 @@ class TestDynamicConfigV1:
         # and then create a new trace to assert the configuration has been applied.
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={"tracing_sampling_rate": 0.6},
             config_id=config_id,
         )
@@ -500,6 +487,7 @@ class TestDynamicConfigV1:
         # Unset the RC sample rate to ensure the previous setting is reapplied.
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={"tracing_sampling_rate": None},
             config_id=config_id,
         )
@@ -528,6 +516,7 @@ class TestDynamicConfigV1:
         # apply to env_service spans but should apply to all others.
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={"tracing_sampling_rate": rc_sampling_rule_rate},
         )
 
@@ -537,7 +526,7 @@ class TestDynamicConfigV1:
         assert_sampling_rate(trace, rc_sampling_rule_rate)
 
         # Unset the RC sample rate to ensure the previous setting is reapplied.
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": None})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": None})
         trace = send_and_wait_trace(test_library, test_agent, name="env_name")
         assert_sampling_rate(trace, ENV_SAMPLING_RULE_RATE)
         trace = send_and_wait_trace(test_library, test_agent, name="other_name")
@@ -557,7 +546,7 @@ class TestDynamicConfigV1:
         There is no way (at the time of writing) to check the logs produced by the library.
         """
         assert test_library.is_alive(), "library container is not alive"
-        cfg_state = set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rate": None})
+        cfg_state = set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rate": None})
         assert cfg_state["apply_state"] == 2
 
 
@@ -731,6 +720,7 @@ class TestDynamicConfigV2:
         # Ensure local tags are overridden and RC tags applied.
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={"tracing_tags": ["rc_key1:val1", "rc_key2:val2"]},
         )
         with (
@@ -743,7 +733,7 @@ class TestDynamicConfigV2:
         assert_trace_has_tags(traces[0], {"rc_key1": "val1", "rc_key2": "val2"})
 
         # Ensure previous tags are restored.
-        set_and_wait_rc(test_agent, config_overrides={})
+        set_and_wait_rc(test_agent, test_library, config_overrides={})
         with (
             test_library,
             test_library.dd_start_span("test") as span,
@@ -818,7 +808,7 @@ class TestDynamicConfigSamplingRules:
         assert span["meta"]["_dd.p.dm"] == "-3"
 
         # Create a remote config entry with two rules at different sample rates.
-        set_and_wait_rc_applied(
+        set_and_wait_rc(
             test_agent,
             test_library,
             config_overrides={
@@ -854,7 +844,7 @@ class TestDynamicConfigSamplingRules:
         assert span["meta"]["_dd.p.dm"] == "-12"
 
         # Unset the RC sample rate to ensure the previous setting is reapplied.
-        set_and_wait_rc_applied(test_agent, test_library, config_overrides={"tracing_sampling_rules": None})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rules": None})
         trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
         assert_sampling_rate(trace, ENV_SAMPLING_RULE_RATE)
         # Make sure `_dd.p.dm` is restored to "-3"
@@ -876,6 +866,7 @@ class TestDynamicConfigSamplingRules:
 
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={
                 "tracing_sampling_rate": rc_sampling_rate,
                 "tracing_sampling_rules": [
@@ -906,7 +897,7 @@ class TestDynamicConfigSamplingRules:
         assert span["meta"]["_dd.p.dm"] == "-3"
 
         # Unset RC to ensure local settings
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rules": None})
+        set_and_wait_rc(test_agent, test_library, config_overrides={"tracing_sampling_rules": None})
         trace = get_sampled_trace(test_library, test_agent, service="other_service", name="op_name")
         assert_sampling_rate(trace, DEFAULT_SAMPLE_RATE)
 
@@ -950,6 +941,7 @@ class TestDynamicConfigSamplingRules:
         # Create a remote config entry with two rules at different sample rates.
         rc_state = set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={
                 "tracing_sampling_rate": rc_sampling_rate,
                 "tracing_sampling_rules": [
@@ -1021,6 +1013,7 @@ class TestDynamicConfigSamplingRules:
         # RC config using dynamic sampling
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_id=config_id,
             config_overrides={
                 "dynamic_sampling_enabled": "true",
@@ -1071,10 +1064,10 @@ class TestDynamicConfigSamplingRules:
         """Only the last set of sampling rules should be applied"""
         old_rate: float = 0.5
         new_rate: float = 0.1
-        max_propagation_retries: int = 30
 
         rc_state: dict = set_and_wait_rc(
             test_agent,
+            test_library,
             config_overrides={
                 "tracing_sampling_rules": [
                     {
@@ -1091,6 +1084,7 @@ class TestDynamicConfigSamplingRules:
 
         set_and_wait_rc(
             test_agent,
+            test_library,
             config_id=config_id,
             config_overrides={
                 "tracing_sampling_rules": [
@@ -1104,18 +1098,7 @@ class TestDynamicConfigSamplingRules:
             },
         )
 
-        # After updating the RC config, the library may briefly still be applying the
-        # previous sampling rules. set_and_wait_rc waits for telemetry and RC acknowledgment,
-        # but these signals can be satisfied by stale events from the prior config, causing a
-        # window where the new rules aren't yet active. Retry to allow for full propagation.
-        trace: list[Span] | None = None
-        for _ in range(max_propagation_retries):
-            trace = send_and_wait_trace(test_library, test_agent, name="test", service="foo")
-            span: Span = find_first_span_in_trace_payload(trace)
-            if span["metrics"].get("_dd.rule_psr", 1.0) == pytest.approx(new_rate):
-                break
-            time.sleep(0.1)
-        assert trace is not None
+        trace = send_and_wait_trace(test_library, test_agent, name="test", service="foo")
         assert_sampling_rate(trace, new_rate)
 
         trace = send_and_wait_trace(test_library, test_agent, name="test2", service="svc")

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -220,6 +220,9 @@ def set_and_wait_rc(
     )
 
 
+_RC_APPLY_ENDPOINT_LANGS: frozenset[str] = frozenset({"python"})
+
+
 def set_and_wait_rc_applied(
     test_agent: TestAgentAPI,
     test_library: APMLibrary,
@@ -233,10 +236,17 @@ def set_and_wait_rc_applied(
     the payload) and the tracer's subscriber dispatch (which actually applies
     it). See docs/parametric/remote-config-apply-contract.md.
 
+    The deterministic drain is only triggered for tracers that have implemented
+    POST /trace/remote-config/apply. For other tracers this helper degrades
+    transparently to set_and_wait_rc() so converted tests keep running on the
+    existing ACK-based pattern (with whatever retry-loop workaround already
+    handled the race).
+
     Returns the rc_state dict from the test agent (same as set_and_wait_rc).
     """
     rc_state = set_and_wait_rc(test_agent, config_overrides, config_id)
-    test_library.flush_remote_config()
+    if test_library.lang in _RC_APPLY_ENDPOINT_LANGS:
+        test_library.flush_remote_config()
     return rc_state
 
 

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -808,8 +808,9 @@ class TestDynamicConfigSamplingRules:
         assert span["meta"]["_dd.p.dm"] == "-3"
 
         # Create a remote config entry with two rules at different sample rates.
-        set_and_wait_rc(
+        set_and_wait_rc_applied(
             test_agent,
+            test_library,
             config_overrides={
                 "tracing_sampling_rules": [
                     {
@@ -843,7 +844,7 @@ class TestDynamicConfigSamplingRules:
         assert span["meta"]["_dd.p.dm"] == "-12"
 
         # Unset the RC sample rate to ensure the previous setting is reapplied.
-        set_and_wait_rc(test_agent, config_overrides={"tracing_sampling_rules": None})
+        set_and_wait_rc_applied(test_agent, test_library, config_overrides={"tracing_sampling_rules": None})
         trace = get_sampled_trace(test_library, test_agent, service=TEST_SERVICE, name="op_name")
         assert_sampling_rate(trace, ENV_SAMPLING_RULE_RATE)
         # Make sure `_dd.p.dm` is restored to "-3"

--- a/tests/parametric/test_remote_config_apply_endpoint.py
+++ b/tests/parametric/test_remote_config_apply_endpoint.py
@@ -1,0 +1,62 @@
+"""Parametric tests for POST /trace/remote-config/apply.
+
+These tests exercise the synchronous RC-apply endpoint added in this PR.
+They are intentionally tracer-agnostic — they only assert the contract
+documented in docs/parametric/remote-config-apply-contract.md.
+"""
+
+from typing import Any
+
+from utils import scenarios, features
+from utils.docker_fixtures import TestAgentAPI
+
+from tests.parametric.conftest import APMLibrary
+from tests.parametric.test_dynamic_configuration import (
+    _create_rc_config,
+    _set_rc,
+)
+
+
+@scenarios.parametric
+@features.dynamic_configuration
+class TestRemoteConfigApplyEndpoint:
+    """Black-box tests of the /trace/remote-config/apply contract."""
+
+    def test_apply_returns_empty_when_no_rc_received(
+        self, test_agent: TestAgentAPI, test_library: APMLibrary
+    ) -> None:
+        """When no RC has been sent, the endpoint returns 200 with applied_configs=[]."""
+        test_agent.clear()
+        result = test_library.flush_remote_config()
+        assert isinstance(result, list)
+        # No RC has been published, so nothing should be applied yet.
+        assert result == [], f"expected empty applied_configs, got {result!r}"
+
+    def test_apply_returns_applied_config_after_set(
+        self, test_agent: TestAgentAPI, test_library: APMLibrary
+    ) -> None:
+        """After publishing a config, the endpoint returns it in applied_configs."""
+        rc_config: dict[str, Any] = _create_rc_config({"tracing_sampling_rate": 0.5})
+        used_config_id = _set_rc(test_agent, rc_config, config_id="test-apply-set")
+
+        result = test_library.flush_remote_config()
+        config_ids = [c["config_id"] for c in result]
+        products = {c["product"] for c in result}
+
+        assert used_config_id in config_ids, (
+            f"expected config_id {used_config_id!r} in applied set, got {config_ids!r}"
+        )
+        assert products == {"APM_TRACING"}, f"expected only APM_TRACING, got {products!r}"
+
+    def test_apply_is_idempotent(
+        self, test_agent: TestAgentAPI, test_library: APMLibrary
+    ) -> None:
+        """Calling apply twice in a row with no new RC is a no-op."""
+        _set_rc(test_agent, _create_rc_config({"tracing_sampling_rate": 0.3}), config_id="idem-1")
+        first = test_library.flush_remote_config()
+        second = test_library.flush_remote_config()
+        first_ids = sorted(c["config_id"] for c in first)
+        second_ids = sorted(c["config_id"] for c in second)
+        assert first_ids == second_ids, (
+            f"applied set changed between idempotent calls: {first_ids!r} -> {second_ids!r}"
+        )

--- a/tests/parametric/test_remote_config_apply_endpoint.py
+++ b/tests/parametric/test_remote_config_apply_endpoint.py
@@ -21,6 +21,7 @@ from utils.docker_fixtures import TestAgentAPI
 
 from tests.parametric.conftest import APMLibrary
 from tests.parametric.test_dynamic_configuration import (
+    DEFAULT_ENVVARS,
     _RC_APPLY_ENDPOINT_LANGS,
     _create_rc_config,
     _set_rc,
@@ -31,7 +32,15 @@ from tests.parametric.test_dynamic_configuration import (
 @scenarios.parametric
 @features.dynamic_configuration
 class TestRemoteConfigApplyEndpoint:
-    """Black-box tests of the /trace/remote-config/apply contract."""
+    """Black-box tests of the /trace/remote-config/apply contract.
+
+    The endpoint-contract tests deliberately run under the tracer's *default* RC poll
+    interval. The contract is that POST /trace/remote-config/apply performs a synchronous
+    drain — if a tracer's implementation accidentally relied on background polling to pick
+    up the freshly published config instead, these tests would still see the config applied
+    only because a fast poll caught up in time. Keeping the default interval (~5s) ensures
+    a non-synchronous drain would visibly fail.
+    """
 
     @pytest.fixture(autouse=True)
     def _skip_unsupported_languages(self, test_library: APMLibrary) -> None:
@@ -85,6 +94,12 @@ class TestRemoteConfigApplyEndpoint:
         elapsed = time.monotonic() - start
         assert elapsed < 10.0, f"endpoint took {elapsed:.2f}s, expected <10s under normal load"
 
+    # set_and_wait_rc() waits for the tracer to poll RC and ACK back to the test agent.
+    # With the ddtrace default poll interval of 5s, that ACK won't arrive inside the test
+    # agent's ~4s wait window. DEFAULT_ENVVARS drops DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS
+    # to 0.2s so the ACK lands in time. Scoped to this test only — see the class docstring
+    # for why the endpoint-contract tests deliberately run under the default poll interval.
+    @pytest.mark.parametrize("library_env", [DEFAULT_ENVVARS])
     def test_set_and_wait_rc_applied_returns_after_apply(
         self, test_agent: TestAgentAPI, test_library: APMLibrary
     ) -> None:

--- a/tests/parametric/test_remote_config_apply_endpoint.py
+++ b/tests/parametric/test_remote_config_apply_endpoint.py
@@ -5,6 +5,7 @@ They are intentionally tracer-agnostic — they only assert the contract
 documented in docs/parametric/remote-config-apply-contract.md.
 """
 
+import time
 from typing import Any
 
 from utils import scenarios, features
@@ -14,6 +15,7 @@ from tests.parametric.conftest import APMLibrary
 from tests.parametric.test_dynamic_configuration import (
     _create_rc_config,
     _set_rc,
+    set_and_wait_rc_applied,
 )
 
 
@@ -22,9 +24,7 @@ from tests.parametric.test_dynamic_configuration import (
 class TestRemoteConfigApplyEndpoint:
     """Black-box tests of the /trace/remote-config/apply contract."""
 
-    def test_apply_returns_empty_when_no_rc_received(
-        self, test_agent: TestAgentAPI, test_library: APMLibrary
-    ) -> None:
+    def test_apply_returns_empty_when_no_rc_received(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """When no RC has been sent, the endpoint returns 200 with applied_configs=[]."""
         test_agent.clear()
         result = test_library.flush_remote_config()
@@ -32,9 +32,7 @@ class TestRemoteConfigApplyEndpoint:
         # No RC has been published, so nothing should be applied yet.
         assert result == [], f"expected empty applied_configs, got {result!r}"
 
-    def test_apply_returns_applied_config_after_set(
-        self, test_agent: TestAgentAPI, test_library: APMLibrary
-    ) -> None:
+    def test_apply_returns_applied_config_after_set(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """After publishing a config, the endpoint returns it in applied_configs."""
         rc_config: dict[str, Any] = _create_rc_config({"tracing_sampling_rate": 0.5})
         used_config_id = _set_rc(test_agent, rc_config, config_id="test-apply-set")
@@ -43,27 +41,19 @@ class TestRemoteConfigApplyEndpoint:
         config_ids = [c["config_id"] for c in result]
         products = {c["product"] for c in result}
 
-        assert used_config_id in config_ids, (
-            f"expected config_id {used_config_id!r} in applied set, got {config_ids!r}"
-        )
+        assert used_config_id in config_ids, f"expected config_id {used_config_id!r} in applied set, got {config_ids!r}"
         assert products == {"APM_TRACING"}, f"expected only APM_TRACING, got {products!r}"
 
-    def test_apply_is_idempotent(
-        self, test_agent: TestAgentAPI, test_library: APMLibrary
-    ) -> None:
+    def test_apply_is_idempotent(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """Calling apply twice in a row with no new RC is a no-op."""
         _set_rc(test_agent, _create_rc_config({"tracing_sampling_rate": 0.3}), config_id="idem-1")
         first = test_library.flush_remote_config()
         second = test_library.flush_remote_config()
         first_ids = sorted(c["config_id"] for c in first)
         second_ids = sorted(c["config_id"] for c in second)
-        assert first_ids == second_ids, (
-            f"applied set changed between idempotent calls: {first_ids!r} -> {second_ids!r}"
-        )
+        assert first_ids == second_ids, f"applied set changed between idempotent calls: {first_ids!r} -> {second_ids!r}"
 
-    def test_apply_respects_server_timeout(
-        self, test_agent: TestAgentAPI, test_library: APMLibrary
-    ) -> None:
+    def test_apply_respects_server_timeout(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """If the underlying RC primitives hang, the server returns 504 within ~10s.
 
         We can't easily simulate a hang from outside the container, so this
@@ -72,8 +62,7 @@ class TestRemoteConfigApplyEndpoint:
         under normal load. The full hang path is covered by the unit test in
         the parametric server itself (TODO when we have one).
         """
-        import time
-
+        test_agent.clear()
         start = time.monotonic()
         test_library.flush_remote_config(timeout=10.0)
         elapsed = time.monotonic() - start
@@ -83,8 +72,6 @@ class TestRemoteConfigApplyEndpoint:
         self, test_agent: TestAgentAPI, test_library: APMLibrary
     ) -> None:
         """set_and_wait_rc_applied calls set_and_wait_rc then flush_remote_config."""
-        from tests.parametric.test_dynamic_configuration import set_and_wait_rc_applied
-
         rc_state = set_and_wait_rc_applied(
             test_agent,
             test_library,

--- a/tests/parametric/test_remote_config_apply_endpoint.py
+++ b/tests/parametric/test_remote_config_apply_endpoint.py
@@ -3,16 +3,25 @@
 These tests exercise the synchronous RC-apply endpoint added in this PR.
 They are intentionally tracer-agnostic — they only assert the contract
 documented in docs/parametric/remote-config-apply-contract.md.
+
+The endpoint is currently only implemented in the Python parametric app
+(this is a pilot). For other languages the test class skips at runtime
+until each tracer adds its own implementation of POST
+/trace/remote-config/apply. See the per-language section in the contract
+doc for the implementation outline.
 """
 
 import time
 from typing import Any
+
+import pytest
 
 from utils import scenarios, features
 from utils.docker_fixtures import TestAgentAPI
 
 from tests.parametric.conftest import APMLibrary
 from tests.parametric.test_dynamic_configuration import (
+    _RC_APPLY_ENDPOINT_LANGS,
     _create_rc_config,
     _set_rc,
     set_and_wait_rc_applied,
@@ -23,6 +32,14 @@ from tests.parametric.test_dynamic_configuration import (
 @features.dynamic_configuration
 class TestRemoteConfigApplyEndpoint:
     """Black-box tests of the /trace/remote-config/apply contract."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_unsupported_languages(self, test_library: APMLibrary) -> None:
+        if test_library.lang not in _RC_APPLY_ENDPOINT_LANGS:
+            pytest.skip(
+                f"{test_library.lang} does not yet implement POST /trace/remote-config/apply; "
+                f"see docs/parametric/remote-config-apply-contract.md"
+            )
 
     def test_apply_returns_empty_when_no_rc_received(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """When no RC has been sent, the endpoint returns 200 with applied_configs=[]."""

--- a/tests/parametric/test_remote_config_apply_endpoint.py
+++ b/tests/parametric/test_remote_config_apply_endpoint.py
@@ -60,3 +60,21 @@ class TestRemoteConfigApplyEndpoint:
         assert first_ids == second_ids, (
             f"applied set changed between idempotent calls: {first_ids!r} -> {second_ids!r}"
         )
+
+    def test_apply_respects_server_timeout(
+        self, test_agent: TestAgentAPI, test_library: APMLibrary
+    ) -> None:
+        """If the underlying RC primitives hang, the server returns 504 within ~10s.
+
+        We can't easily simulate a hang from outside the container, so this
+        test asserts the documented behavior path by confirming the endpoint
+        URL is reachable and returns within the server-side timeout window
+        under normal load. The full hang path is covered by the unit test in
+        the parametric server itself (TODO when we have one).
+        """
+        import time
+
+        start = time.monotonic()
+        test_library.flush_remote_config(timeout=10.0)
+        elapsed = time.monotonic() - start
+        assert elapsed < 10.0, f"endpoint took {elapsed:.2f}s, expected <10s under normal load"

--- a/tests/parametric/test_remote_config_apply_endpoint.py
+++ b/tests/parametric/test_remote_config_apply_endpoint.py
@@ -78,3 +78,23 @@ class TestRemoteConfigApplyEndpoint:
         test_library.flush_remote_config(timeout=10.0)
         elapsed = time.monotonic() - start
         assert elapsed < 10.0, f"endpoint took {elapsed:.2f}s, expected <10s under normal load"
+
+    def test_set_and_wait_rc_applied_returns_after_apply(
+        self, test_agent: TestAgentAPI, test_library: APMLibrary
+    ) -> None:
+        """set_and_wait_rc_applied calls set_and_wait_rc then flush_remote_config."""
+        from tests.parametric.test_dynamic_configuration import set_and_wait_rc_applied
+
+        rc_state = set_and_wait_rc_applied(
+            test_agent,
+            test_library,
+            config_overrides={"tracing_sampling_rate": 0.7},
+            config_id="combined-helper-1",
+        )
+        # set_and_wait_rc returns the rc state dict from the test agent
+        assert rc_state is not None
+        assert rc_state.get("apply_state") in (2, "2"), f"unexpected rc_state: {rc_state!r}"
+
+        # And after the call, the config is applied (visible via the endpoint directly)
+        applied = test_library.flush_remote_config()
+        assert any(c["config_id"] == "combined-helper-1" for c in applied)

--- a/tests/parametric/test_remote_config_apply_endpoint.py
+++ b/tests/parametric/test_remote_config_apply_endpoint.py
@@ -25,7 +25,7 @@ from tests.parametric.test_dynamic_configuration import (
     _RC_APPLY_ENDPOINT_LANGS,
     _create_rc_config,
     _set_rc,
-    set_and_wait_rc_applied,
+    set_and_wait_rc,
 )
 
 
@@ -100,11 +100,9 @@ class TestRemoteConfigApplyEndpoint:
     # to 0.2s so the ACK lands in time. Scoped to this test only — see the class docstring
     # for why the endpoint-contract tests deliberately run under the default poll interval.
     @pytest.mark.parametrize("library_env", [DEFAULT_ENVVARS])
-    def test_set_and_wait_rc_applied_returns_after_apply(
-        self, test_agent: TestAgentAPI, test_library: APMLibrary
-    ) -> None:
-        """set_and_wait_rc_applied calls set_and_wait_rc then flush_remote_config."""
-        rc_state = set_and_wait_rc_applied(
+    def test_set_and_wait_rc_applies_synchronously(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """set_and_wait_rc waits for the ACK and then synchronously drains the tracer."""
+        rc_state = set_and_wait_rc(
             test_agent,
             test_library,
             config_overrides={"tracing_sampling_rate": 0.7},

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -9,6 +9,7 @@ from typing import Union
 import logging
 import os
 import enum
+import threading
 from fastapi import FastAPI
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -447,6 +448,13 @@ class TraceRemoteConfigApplyReturn(BaseModel):
     applied_configs: List[AppliedConfigEntry]
 
 
+# Single-flight lock around the RC-apply drain. If a previous request timed
+# out, its worker thread may still be running against the shared
+# remoteconfig_poller client. Serialize subsequent requests behind this lock
+# so concurrent drains can't race on the global RC state.
+_rc_apply_lock = threading.Lock()
+
+
 @app.post("/trace/remote-config/apply")
 def trace_remote_config_apply(
     args: TraceRemoteConfigApplyArgs,
@@ -462,46 +470,78 @@ def trace_remote_config_apply(
          the connector and invokes registered product callbacks.
 
     Enforces a 10s server-side timeout by running the drain in a background
-    thread and joining with a deadline. On timeout, returns 504.
+    thread and joining with a deadline. On timeout, returns 504. A process-wide
+    lock serializes overlapping requests so a previously-timed-out drain
+    cannot race a fresh apply.
     """
-    import threading
     from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
 
     timeout_seconds = 10.0
     client = remoteconfig_poller._client
 
-    drain_error: List[BaseException] = []
-
-    def _drain() -> None:
-        try:
-            client.request()
-            client._global_subscriber.periodic()
-        except BaseException as exc:  # noqa: BLE001 — re-raised below
-            drain_error.append(exc)
-
-    worker = threading.Thread(target=_drain, name="rc-apply-drain", daemon=True)
-    worker.start()
-    worker.join(timeout=timeout_seconds)
-
-    if worker.is_alive():
+    # If a previous drain is still in flight (timeout left it running), refuse
+    # to start a second one — it would race against the shared client state.
+    if not _rc_apply_lock.acquire(blocking=False):
         return JSONResponse(
             status_code=504,
             content={
-                "error": "timeout waiting for remote config to apply",
+                "error": "previous remote-config apply still in progress",
                 "timeout_seconds": timeout_seconds,
             },
         )
 
-    if drain_error:
-        # The drain swallows most exceptions internally; this catches anything
-        # that escaped. Log it server-side but still return whatever is
-        # currently applied, per the contract's "drain what you can" rule.
-        log.warning("rc-apply drain raised: %r", drain_error[0])
+    lock_ownership_transferred = False
+    try:
+        drain_error: List[BaseException] = []
 
-    applied: List[dict] = [
-        {"config_id": metadata.id, "product": metadata.product_name} for metadata in client._applied_configs.values()
-    ]
-    return JSONResponse(status_code=200, content={"applied_configs": applied})
+        def _drain() -> None:
+            try:
+                client.request()
+                client._global_subscriber.periodic()
+            except BaseException as exc:  # noqa: BLE001 — captured for logging
+                drain_error.append(exc)
+
+        worker = threading.Thread(target=_drain, name="rc-apply-drain", daemon=True)
+        worker.start()
+        worker.join(timeout=timeout_seconds)
+
+        if worker.is_alive():
+            # The drain didn't finish in time. Hand the lock to a watcher
+            # thread that releases it only after the worker actually exits.
+            # Until then, follow-up requests get 504 from the non-blocking
+            # acquire above instead of overlapping a stuck drain.
+            log.warning("rc-apply drain exceeded %.1fs; holding lock until worker exits", timeout_seconds)
+            lock_ownership_transferred = True
+
+            def _release_when_done(t: threading.Thread) -> None:
+                t.join()
+                _rc_apply_lock.release()
+
+            threading.Thread(
+                target=_release_when_done, args=(worker,), name="rc-apply-lock-releaser", daemon=True
+            ).start()
+            return JSONResponse(
+                status_code=504,
+                content={
+                    "error": "timeout waiting for remote config to apply",
+                    "timeout_seconds": timeout_seconds,
+                },
+            )
+
+        if drain_error:
+            # The drain swallows most exceptions internally; this catches anything
+            # that escaped. Log it server-side but still return whatever is
+            # currently applied, per the contract's "drain what you can" rule.
+            log.warning("rc-apply drain raised: %r", drain_error[0])
+
+        applied: List[dict] = [
+            {"config_id": metadata.id, "product": metadata.product_name}
+            for metadata in client._applied_configs.values()
+        ]
+        return JSONResponse(status_code=200, content={"applied_configs": applied})
+    finally:
+        if not lock_ownership_transferred:
+            _rc_apply_lock.release()
 
 
 class TraceSpanErrorArgs(BaseModel):

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -434,6 +434,71 @@ def trace_stats_flush(args: TraceStatsFlushArgs) -> TraceStatsFlushReturn:
     return TraceStatsFlushReturn()
 
 
+class TraceRemoteConfigApplyArgs(BaseModel):
+    pass  # Reserved for future per-config_id semantics; see contract doc.
+
+
+class AppliedConfigEntry(BaseModel):
+    config_id: str
+    product: str
+
+
+class TraceRemoteConfigApplyReturn(BaseModel):
+    applied_configs: List[AppliedConfigEntry]
+
+
+@app.post("/trace/remote-config/apply")
+def trace_remote_config_apply(
+    args: TraceRemoteConfigApplyArgs,
+) -> TraceRemoteConfigApplyReturn:
+    """Synchronously drain pending Remote Config and return the applied set.
+
+    See docs/parametric/remote-config-apply-contract.md for the cross-tracer
+    contract. The Python implementation uses dd-trace-py's existing primitives:
+
+      1. remoteconfig_poller._client.request() — fetches from the test agent
+         and publishes payloads to the global connector.
+      2. remoteconfig_poller._client._global_subscriber.periodic() — drains
+         the connector and invokes registered product callbacks (e.g. the
+         APM_TRACING handler that updates samplers).
+
+    Both calls are synchronous. The endpoint completes only after callbacks
+    have run, so by the time it returns, the tracer's in-memory state
+    reflects the latest RC.
+    """
+    from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+
+    client = remoteconfig_poller._client
+
+    # Step 1: fetch + publish. request() returns False on transport/parse error
+    # but does not raise; per the contract we still return whatever is currently
+    # applied rather than failing the call.
+    try:
+        client.request()
+    except Exception:  # pragma: no cover — defensive; request() is documented to swallow
+        log.exception("remoteconfig_poller._client.request() raised unexpectedly")
+
+    # Step 2: drain the connector and invoke callbacks synchronously.
+    try:
+        client._global_subscriber.periodic()
+    except Exception:  # pragma: no cover — defensive; periodic() also swallows internally
+        log.exception("remoteconfig_poller._client._global_subscriber.periodic() raised")
+
+    # Step 3: report what is currently applied. _applied_configs is a dict
+    # keyed by target path ("datadog/2/APM_TRACING/<config_id>/config") with
+    # ConfigMetadata values.
+    applied: List[AppliedConfigEntry] = []
+    for metadata in client._applied_configs.values():
+        applied.append(
+            AppliedConfigEntry(
+                config_id=metadata.id,
+                product=metadata.product_name,
+            )
+        )
+
+    return TraceRemoteConfigApplyReturn(applied_configs=applied)
+
+
 class TraceSpanErrorArgs(BaseModel):
     span_id: int
     type: str

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -499,8 +499,7 @@ def trace_remote_config_apply(
         log.warning("rc-apply drain raised: %r", drain_error[0])
 
     applied: List[dict] = [
-        {"config_id": metadata.id, "product": metadata.product_name}
-        for metadata in client._applied_configs.values()
+        {"config_id": metadata.id, "product": metadata.product_name} for metadata in client._applied_configs.values()
     ]
     return JSONResponse(status_code=200, content={"applied_configs": applied})
 

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -450,53 +450,59 @@ class TraceRemoteConfigApplyReturn(BaseModel):
 @app.post("/trace/remote-config/apply")
 def trace_remote_config_apply(
     args: TraceRemoteConfigApplyArgs,
-) -> TraceRemoteConfigApplyReturn:
+) -> JSONResponse:
     """Synchronously drain pending Remote Config and return the applied set.
 
-    See docs/parametric/remote-config-apply-contract.md for the cross-tracer
-    contract. The Python implementation uses dd-trace-py's existing primitives:
+    See docs/parametric/remote-config-apply-contract.md for the contract.
+    The Python implementation uses dd-trace-py's primitives:
 
       1. remoteconfig_poller._client.request() — fetches from the test agent
          and publishes payloads to the global connector.
       2. remoteconfig_poller._client._global_subscriber.periodic() — drains
-         the connector and invokes registered product callbacks (e.g. the
-         APM_TRACING handler that updates samplers).
+         the connector and invokes registered product callbacks.
 
-    Both calls are synchronous. The endpoint completes only after callbacks
-    have run, so by the time it returns, the tracer's in-memory state
-    reflects the latest RC.
+    Enforces a 10s server-side timeout by running the drain in a background
+    thread and joining with a deadline. On timeout, returns 504.
     """
+    import threading
     from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
 
+    timeout_seconds = 10.0
     client = remoteconfig_poller._client
 
-    # Step 1: fetch + publish. request() returns False on transport/parse error
-    # but does not raise; per the contract we still return whatever is currently
-    # applied rather than failing the call.
-    try:
-        client.request()
-    except Exception:  # pragma: no cover — defensive; request() is documented to swallow
-        log.exception("remoteconfig_poller._client.request() raised unexpectedly")
+    drain_error: List[BaseException] = []
 
-    # Step 2: drain the connector and invoke callbacks synchronously.
-    try:
-        client._global_subscriber.periodic()
-    except Exception:  # pragma: no cover — defensive; periodic() also swallows internally
-        log.exception("remoteconfig_poller._client._global_subscriber.periodic() raised")
+    def _drain() -> None:
+        try:
+            client.request()
+            client._global_subscriber.periodic()
+        except BaseException as exc:  # noqa: BLE001 — re-raised below
+            drain_error.append(exc)
 
-    # Step 3: report what is currently applied. _applied_configs is a dict
-    # keyed by target path ("datadog/2/APM_TRACING/<config_id>/config") with
-    # ConfigMetadata values.
-    applied: List[AppliedConfigEntry] = []
-    for metadata in client._applied_configs.values():
-        applied.append(
-            AppliedConfigEntry(
-                config_id=metadata.id,
-                product=metadata.product_name,
-            )
+    worker = threading.Thread(target=_drain, name="rc-apply-drain", daemon=True)
+    worker.start()
+    worker.join(timeout=timeout_seconds)
+
+    if worker.is_alive():
+        return JSONResponse(
+            status_code=504,
+            content={
+                "error": "timeout waiting for remote config to apply",
+                "timeout_seconds": timeout_seconds,
+            },
         )
 
-    return TraceRemoteConfigApplyReturn(applied_configs=applied)
+    if drain_error:
+        # The drain swallows most exceptions internally; this catches anything
+        # that escaped. Log it server-side but still return whatever is
+        # currently applied, per the contract's "drain what you can" rule.
+        log.warning("rc-apply drain raised: %r", drain_error[0])
+
+    applied: List[dict] = [
+        {"config_id": metadata.id, "product": metadata.product_name}
+        for metadata in client._applied_configs.values()
+    ]
+    return JSONResponse(status_code=200, content={"applied_configs": applied})
 
 
 class TraceSpanErrorArgs(BaseModel):

--- a/utils/docker_fixtures/_test_clients/_test_client_parametric.py
+++ b/utils/docker_fixtures/_test_clients/_test_client_parametric.py
@@ -506,6 +506,7 @@ class ParametricTestClientApi(TestClientApi):
             requests.exceptions.HTTPError: if the server returns non-2xx
                 (504 on server-side timeout, 5xx on tracer-side error).
             requests.exceptions.Timeout: if the client-side timeout fires.
+
         """
         resp = self._session.post(
             self._url("/trace/remote-config/apply"),

--- a/utils/docker_fixtures/_test_clients/_test_client_parametric.py
+++ b/utils/docker_fixtures/_test_clients/_test_client_parametric.py
@@ -488,6 +488,34 @@ class ParametricTestClientApi(TestClientApi):
 
         return HTTPStatus(r.status_code).is_success
 
+    def flush_remote_config(self, timeout: float = 10.0) -> list[dict[str, str]]:
+        """Synchronously drain pending Remote Config and return the applied set.
+
+        Contract: docs/parametric/remote-config-apply-contract.md.
+
+        Args:
+            timeout: Client-side HTTP timeout in seconds. The server has its own
+                timeout (default 10s) and may return 504 before this fires.
+
+        Returns:
+            List of {"config_id": str, "product": str} dicts describing
+            configs the tracer currently has applied. Empty list if no RC
+            has been received yet — that is not an error.
+
+        Raises:
+            requests.exceptions.HTTPError: if the server returns non-2xx
+                (504 on server-side timeout, 5xx on tracer-side error).
+            requests.exceptions.Timeout: if the client-side timeout fires.
+        """
+        resp = self._session.post(
+            self._url("/trace/remote-config/apply"),
+            json={},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        return body.get("applied_configs", [])
+
     def write_log(
         self,
         logger_name: str,
@@ -1047,6 +1075,16 @@ class APMLibrary:
 
     def dd_flush(self) -> bool:
         return self._client.dd_flush()
+
+    def flush_remote_config(self, timeout: float = 10.0) -> list[dict[str, str]]:
+        """Synchronously process any pending Remote Config and return the applied set.
+
+        See docs/parametric/remote-config-apply-contract.md.
+
+        Tests typically call this immediately after `set_and_wait_rc()` to
+        eliminate the ACK-vs-apply race in the tracer.
+        """
+        return self._client.flush_remote_config(timeout=timeout)
 
     def otel_flush(self, timeout_sec: int) -> bool:
         return self._client.otel_flush(timeout_sec)

--- a/utils/docker_fixtures/_test_clients/_test_client_parametric.py
+++ b/utils/docker_fixtures/_test_clients/_test_client_parametric.py
@@ -1082,8 +1082,11 @@ class APMLibrary:
 
         See docs/parametric/remote-config-apply-contract.md.
 
-        Tests typically call this immediately after `set_and_wait_rc()` to
-        eliminate the ACK-vs-apply race in the tracer.
+        Most tests do not need to call this directly: `set_and_wait_rc()`
+        already invokes `flush_remote_config()` after the ACK on tracers that
+        implement the endpoint, eliminating the ACK-vs-apply race. Call this
+        directly only to assert the contract itself or to drain RC that was
+        published without going through `set_and_wait_rc()`.
         """
         return self._client.flush_remote_config(timeout=timeout)
 


### PR DESCRIPTION
## Motivation

`set_and_wait_rc()` waits only for the test-agent ACK. That ACK fires when the tracer's RC client validates the payload — not when product subscribers actually apply it. The gap is small for in-process tracers and large for out-of-process ones (PHP sidecar), and it's the root cause of the flaky-test gates we've been carrying. #6954 added `set_and_wait_rc_applied()` as a deterministic variant that drains the tracer after the ACK, and converted two pilot tests on Python. The two-helper design was always transitional: there is no real use case for the ACK-only variant. Every behavioural test that reads tracer state after RC arrives benefits from the deterministic guarantee, and the helper degrades to the old ACK-only path for tracers outside `_RC_APPLY_ENDPOINT_LANGS`. This PR finishes that migration and removes the redundant helper, then absorbs the scope of #6951 — which papered over the same race with retry loops on three Python tests.

## Changes

The single remaining helper is `set_and_wait_rc(test_agent, test_library, config_overrides, config_id=None)`. It waits for the ACK, then on tracers in `_RC_APPLY_ENDPOINT_LANGS` (currently `{"python"}`) calls `flush_remote_config()` to synchronously drain pending RC. Tracers outside the allowlist get the ACK-only path with no behaviour change. Stacked on #6954 — base branch is `brian.marks/rc-applied-endpoint-python-pilot`.

| File | Change |
| --- | --- |
| `tests/parametric/test_dynamic_configuration.py` | Replace `set_and_wait_rc` (ACK-only) with the unified helper. Rename `set_and_wait_rc_applied` -> `set_and_wait_rc`. Migrate all 19 call sites to pass `test_library` as the second positional argument. Remove the retry loop in `test_remote_sampling_rules_retention` that the helper now makes redundant. |
| `tests/parametric/test_remote_config_apply_endpoint.py` | Update the contract test to call the renamed helper (`test_set_and_wait_rc_applies_synchronously`). |
| `utils/docker_fixtures/_test_clients/_test_client_parametric.py` | Update `flush_remote_config` docstring — most tests no longer need to call it directly. |
| `docs/parametric/remote-config-apply-contract.md` | Reflect the new single-helper API and adoption story. |
| `manifests/python.yml` | Remove three flaky-test gates that the deterministic drain makes unnecessary: `test_remote_sampling_rules_retention`, `test_trace_sampling_rules_override_env`, `test_trace_sampling_rules_override_rate`. |

### Design choice: rename rather than rename-and-replace

I picked Option X from the brief: take over the `set_and_wait_rc` name with the new signature, rather than keeping `set_and_wait_rc_applied` as the long-term name. Two reasons. First, once there is a single helper, the `_applied` suffix carries no information — `set_and_wait_rc` should *be* the deterministic one. Second, the helper already has a transparent fallback for non-Python tracers, so existing call sites (which all already had `test_library` in scope) keep the same call name with one extra argument. The git blame churn is one-line-per-call-site and the rename is mechanical; net readability wins. The alternative was deleting the old name and keeping `_applied` everywhere, which costs the same churn while leaving a worse name on the surface forever.

### Supersedes #6951

#6951 added retry loops in `test_trace_sampling_rules_override_env` and `test_trace_sampling_rules_override_rate` around post-ACK assertions on `_dd.rule_psr` / `_dd.p.dm`, plus the same three manifest unflaggings this PR includes. Those retry loops were a stopgap for the race the unified helper now eliminates deterministically. The retry loops in this PR's converted tests are gone; the manifest changes are the same. **#6951 should be closed after this lands.** The probabilistic retry inside `get_sampled_trace()` stays as-is — it handles sampling-by-chance, not the RC race.

## Local verification

I ran both files five times each against locally installed `ddtrace` from PyPI (`prepare-local-build.sh python --method pip`).

| Suite | Iterations | Result per iteration |
| --- | --- | --- |
| `tests/parametric/test_remote_config_apply_endpoint.py` | 5 | 5 passed |
| `tests/parametric/test_dynamic_configuration.py` | 5 | 15 passed, 17 skipped, 3 xfailed |

All three previously-flagged tests (`test_remote_sampling_rules_retention`, `test_trace_sampling_rules_override_env`, `test_trace_sampling_rules_override_rate`) ran in the unflagged set and passed every iteration.

## Workflow

1. ⚠️ Created as draft.
2. Working on CI to pass.
3. Tests-only change touching `tests/`, `manifests/`, `docs/`, and one wrapper file in `utils/docker_fixtures/`. RFC owner review may be appropriate given the parametric harness contract.

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

- [x] Anything but `tests/` or `manifests/` is modified ? Yes — `docs/parametric/remote-config-apply-contract.md` and the `APMLibrary` wrapper docstring in `utils/docker_fixtures/`. The wrapper change is docstring-only. R&P approval if required for the doc-and-docstring change.
- [ ] A docker base image is modified? No.
- [ ] A scenario is added, removed or renamed? No.