### PR TITLE
ci(security): add dd-octo-sts policy for Node.js base image publishing

### DIFF
--- a/.github/chainguard/self.publish-nodejs-base-images.sts.yaml
+++ b/.github/chainguard/self.publish-nodejs-base-images.sts.yaml
@@ -1,0 +1,12 @@
+# Docs: https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/system-tests:ref:refs/heads/main
+claim_pattern:
+  event_name: push
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/system-tests/\.github/workflows/publish-nodejs-base-images\.yml@refs/heads/main
+
+permissions:
+  packages: write


### PR DESCRIPTION
## Summary

Adds a `dd-octo-sts` policy that restricts GHCR package writes to pushes on `main` via the dedicated `publish-nodejs-base-images` reusable workflow.

This is a prerequisite for #6903, which will switch from using `GITHUB_TOKEN` with `packages: write` to using a scoped `dd-octo-sts` token — preventing PR branches from pushing arbitrary image tags.

The claim is not wired up in #6903 yet; this policy just needs to be merged first so the token can be requested once #6903 is ready to switch over.

> 🤖 Generated with [Claude Code](https://claude.ai/claude-code)