### PR TITLE
[nodejs] activate Test_SecurityTestingHeaders from v5.104.0

### DIFF
--- a/.cursor/rules/test-activation.mdc
+++ b/.cursor/rules/test-activation.mdc
@@ -81,17 +81,13 @@ tests/path/test.py::TestClass:
     component_version: '<5.0.0'
 ```
 
-### Inferring the Next Release Version (nodejs only)
+### Inferring the Next Release Version (specific to dd-trace-js, do not apply to other tracers)
 
-When activating a test in `manifests/nodejs.yml` after a `dd-trace-js` PR has merged,
-do NOT infer the next release version from `vX.Y.Z-proposal` branches in the
-`dd-trace-js` repo. Those branches are cut early in the release cycle, and PRs
-merged to `master` afterwards still ship in that same version — not the next one.
-
-If the upcoming version is unclear, ask the user instead of guessing.
-
-This rule is specific to `dd-trace-js`. Other tracers may follow different release
-conventions — check with the user before applying similar logic to other manifests.
+Don't try to predict the next `dd-trace-js` minimum version yourself.
+`vX.Y.Z-proposal` branches are mutable — PRs continue to be merged into them
+until the release is cut, so a PR landing on `master` after a proposal branch
+exists may still ship in that same version. When activating a test, ask the user
+which version contains the change.
 
 ### After Modifying Manifests
 

--- a/.cursor/rules/test-activation.mdc
+++ b/.cursor/rules/test-activation.mdc
@@ -81,6 +81,18 @@ tests/path/test.py::TestClass:
     component_version: '<5.0.0'
 ```
 
+### Inferring the Next Release Version (nodejs only)
+
+When activating a test in `manifests/nodejs.yml` after a `dd-trace-js` PR has merged,
+do NOT infer the next release version from `vX.Y.Z-proposal` branches in the
+`dd-trace-js` repo. Those branches are cut early in the release cycle, and PRs
+merged to `master` afterwards still ship in that same version — not the next one.
+
+If the upcoming version is unclear, ask the user instead of guessing.
+
+This rule is specific to `dd-trace-js`. Other tracers may follow different release
+conventions — check with the user before applying similar logic to other manifests.
+
 ### After Modifying Manifests
 
 **ALWAYS run `./format.sh` after any manifest modification.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,7 @@ All coding agents MUST read and follow all rules from these files:
 
 ## Always Applied Rules
 
-These rules apply in EVERY interaction. The `@`-imports below inline each file at
-session start so the rules are loaded automatically (Cursor reads them via its own
-`alwaysApply: true` frontmatter).
+These rules apply in EVERY interaction.
 
 - @.cursor/rules/general-behavior.mdc — Communication style, documentation references, Slack support
 - @.cursor/rules/system-tests-overview.mdc — Project overview, main concepts, terminology

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,20 +10,22 @@ All coding agents MUST read and follow all rules from these files:
 
 ## Always Applied Rules
 
-Read and follow these rules in EVERY interaction:
+These rules apply in EVERY interaction. The `@`-imports below inline each file at
+session start so the rules are loaded automatically (Cursor reads them via its own
+`alwaysApply: true` frontmatter).
 
-1. **`.cursor/rules/general-behavior.mdc`** - Communication style, documentation references, Slack support
-2. **`.cursor/rules/system-tests-overview.mdc`** - Project overview, main concepts, terminology
-3. **`.cursor/rules/repository-structure.mdc`** - Repository structure, test class conventions
-4. **`.cursor/rules/fine-tuning-guidance.mdc`** - Documentation navigation, scenario discovery
-5. **`.cursor/rules/code-format-standards.mdc`** - Code formatting requirements (shellcheck, mypy, YAML)
-6. **`.cursor/rules/aws-ssi-testing.mdc`** - AWS SSI testing guidelines
-7. **`.cursor/rules/end-to-end-testing.mdc`** - End-to-end testing guidelines
-8. **`.cursor/rules/parametric-testing.mdc`** - Parametric scenario testing; use `--skip-parametric-build` when re-running parametric tests without image changes
-9. **`.cursor/rules/k8s-ssi.mdc`** - Kubernetes library injection testing
-10. **`.cursor/rules/test-activation.mdc`** - Test activation/deactivation rules
-11. **`.cursor/rules/doc.mdc`** - Rules for editing the documentation
-12. **`.cursor/rules/devtools.mdc`** - Developer tools: MCP, GitHub (gh), GitLab (glab) usage
+- @.cursor/rules/general-behavior.mdc — Communication style, documentation references, Slack support
+- @.cursor/rules/system-tests-overview.mdc — Project overview, main concepts, terminology
+- @.cursor/rules/repository-structure.mdc — Repository structure, test class conventions
+- @.cursor/rules/fine-tuning-guidance.mdc — Documentation navigation, scenario discovery
+- @.cursor/rules/code-format-standards.mdc — Code formatting requirements (shellcheck, mypy, YAML)
+- @.cursor/rules/aws-ssi-testing.mdc — AWS SSI testing guidelines
+- @.cursor/rules/end-to-end-testing.mdc — End-to-end testing guidelines
+- @.cursor/rules/parametric-testing.mdc — Parametric scenario testing; use `--skip-parametric-build` when re-running parametric tests without image changes
+- @.cursor/rules/k8s-ssi.mdc — Kubernetes library injection testing
+- @.cursor/rules/test-activation.mdc — Test activation/deactivation rules
+- @.cursor/rules/doc.mdc — Rules for editing the documentation
+- @.cursor/rules/devtools.mdc — Developer tools: MCP, GitHub (gh), GitLab (glab) usage
 
 ## Manual Rules (Apply Only When Explicitly Requested)
 

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -93,6 +93,7 @@ refs:
   - &ref_5_98_0 '>=5.98.0'
   - &ref_5_99_0 '>=5.99.0'
   - &ref_5_103_0 '>=5.103.0'
+  - &ref_5_104_0 '>=5.104.0'
   - &ref_6_0_0 '>=6.0.0-pre'
 manifest:
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardEvent_Tag: missing_feature (APPSEC-62217)
@@ -226,7 +227,7 @@ manifest:
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_Body_env_var: missing_feature
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_Headers: *ref_4_21_0
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_on_Block: missing_feature
-  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: missing_feature
+  tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: *ref_5_104_0
   tests/appsec/iast/sink/test_code_injection.py::TestCodeInjection:
     - weblog_declaration:
         "*": *ref_5_20_0


### PR DESCRIPTION
## Summary

- Activates `tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders` for the Node.js tracer from v5.104.0, following the merge of [DataDog/dd-trace-js#8463](https://github.com/DataDog/dd-trace-js/pull/8463).
- Inlines the always-applied `.cursor/rules/*.mdc` files in `AGENTS.md` via `@`-imports so Claude Code actually loads them at session start (Cursor was already covered by its own `alwaysApply: true` frontmatter).
- Adds a nodejs-only note in `.cursor/rules/test-activation.mdc` warning against inferring the next dd-trace-js release version from `vX.Y.Z-proposal` branches.

## Test plan

- [ ] CI green on the Node.js end-to-end scenarios that stack the test class (`default`, `everything_disabled`, `library_conf_custom_header_tags`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)