### PR TITLE
[rust] update rust version to 1.87 to support new MSRV

### DIFF
--- a/utils/build/docker/rust/parametric/Cargo.toml
+++ b/utils/build/docker/rust/parametric/Cargo.toml
@@ -8,7 +8,7 @@ readme        = "README.md"
 publish       = false
 
 resolver      = "3"
-rust-version  = "1.85.1" # should match Dockerfile rustc version
+rust-version  = "1.87" # should match Dockerfile rustc version
 
 [[bin]]
 name = "ddtrace-rs-client"

--- a/utils/build/docker/rust/parametric/Dockerfile
+++ b/utils/build/docker/rust/parametric/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85.1-slim-bookworm AS builder
+FROM rust:1.87-slim-bookworm AS builder
 WORKDIR /usr/app
 COPY utils/build/docker/rust/parametric .
 COPY utils/build/docker/rust/parametric/../install_ddtrace.sh ./binaries/ /binaries/


### PR DESCRIPTION
## Motivation

The Minimum Supported Rust Version of `dd-trace-rs` has been increased here https://github.com/DataDog/dd-trace-rs/pull/232

## Changes

Update the MSRV so that `dd-trace-rs` compiles.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
