### PR TITLE
Revert "Exclude FEATURE_FLAGGING_AND_EXPERIMENTATION from dev (#6968)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       library: ${{ matrix.library }}
       scenarios: ${{ needs.compute_libraries_and_scenarios.outputs.scenarios }}
       scenarios_groups: ${{ needs.compute_libraries_and_scenarios.outputs.scenarios_groups }}
-      excluded_scenarios: OTEL_COLLECTOR_E2E${{ matrix.version == 'dev' && matrix.library == 'python' && ',FEATURE_FLAGGING_AND_EXPERIMENTATION' || '' }}  # rely on real backend
+      excluded_scenarios: OTEL_COLLECTOR_E2E  # rely on real backend
       parametric_job_count: ${{ matrix.version == 'dev' && 2 || 1 }}  # test both use cases
       skip_empty_scenarios: true
       display_summary: true


### PR DESCRIPTION
## Motivation

Revert #6968 so Python `dev` runs no longer exclude `FEATURE_FLAGGING_AND_EXPERIMENTATION` from the shared system-tests CI workflow.

## Changes

This reverts merge commit `ce3eccc13ca9134c81905812af7d5b6f4938703b` and restores `excluded_scenarios` to only `OTEL_COLLECTOR_E2E`.

## Decisions

Keep this as a direct Git revert so the rollback is easy to audit and can land independently while the dd-trace-py recovery is being prepared.
