### PR TITLE
[rust] fix dev version rewrite when dd-trace-rs has no git repo

### DIFF
--- a/utils/build/docker/rust/install_ddtrace.sh
+++ b/utils/build/docker/rust/install_ddtrace.sh
@@ -36,7 +36,8 @@ if [ -e /binaries/dd-trace-rs ]; then
     fi
 
     echo "generating dev version $dev_version from $current_version"
-    cargo release version -p datadog-opentelemetry "$dev_version" -x --no-confirm
+    # cargo release requires a git repo; use sed to rewrite the workspace version directly
+    sed -i "s/^version = \"${current_version}\"/version = \"${dev_version}\"/" /binaries/dd-trace-rs/Cargo.toml
 
     cd /usr/app
     cargo add datadog-opentelemetry --path /binaries/dd-trace-rs/datadog-opentelemetry --features metrics-http,metrics-grpc,logs-http,logs-grpc

--- a/utils/build/docker/rust/parametric/Dockerfile
+++ b/utils/build/docker/rust/parametric/Dockerfile
@@ -7,8 +7,6 @@ COPY utils/build/docker/rust/parametric/src /usr/app/
 
 RUN apt-get update && apt-get install -y --no-install-recommends openssh-client git jq build-essential perl libssl-dev
 
-RUN cargo install cargo-release@0.25.18 --locked
-
 RUN /binaries/install_ddtrace.sh
 
 RUN \


### PR DESCRIPTION
## Motivation

`dd-trace-rs` PRs fail on system-tests right now since `cargo release version` always invokes `git2::Repository::discover()` internally, even with `-x --no-confirm`, then when `/binaries/dd-trace-rs` is a plain directory (no `.git`) — as is the case when a `dd-trace-rs` PR mounts the library directly rather than cloning it — `cargo-release` fails with `class=Repository (6); code=NotFound (-3)`.

## Changes

Replace cargo release version with a sed one-liner that rewrites the version = "..." line in the workspace Cargo.toml directly. No git history required. Also drops the cargo install cargo-release step from the Dockerfile, saving ~1 min of build time.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
