### PR TITLE
Revert "[python] activate capture expressions tests with version gate (DEBUG-5601)"

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1129,12 +1129,8 @@ manifest:
   tests/auto_inject/test_auto_inject_install.py::TestSimpleInstallerAutoInjectManualProfiling::test_profiling:
     - declaration: irrelevant (PROF-11296)
       component_version: <3.0.0
-  tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Line_Capture_Expressions:
-    - declaration: bug (DEBUG-5601)
-      component_version: <4.9.0
-  tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions:
-    - declaration: bug (DEBUG-5601)
-      component_version: <4.9.0
+  tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Line_Capture_Expressions: missing_feature (Not yet implemented)
+  tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins:
     - weblog_declaration:
         "*": missing_feature


### PR DESCRIPTION
Reverts DataDog/system-tests#6909

Test is failing : https://github.com/DataDog/system-tests-dashboard/actions/runs/26141234509/job/76887248295