### PR TITLE
Only run test_activation on schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    if: success() || failure()
+    if: (success() || failure()) && github.event_name == 'schedule'
     needs:
       - nightly
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,6 @@ name: Nightly
 
 on:
   workflow_dispatch: {}
-  pull_request:
   push:
     branches:
       - "main"
@@ -41,8 +40,7 @@ jobs:
       contents: read
       id-token: write
     with:
-      # scenarios_groups: tracer_release
-      scenarios: DEFAULT
+      scenarios_groups: tracer_release
       library: ${{ matrix.library }}
       parametric_job_count: 8
       _system_tests_dev_mode: ${{ matrix.version == 'dev' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,7 +81,7 @@ jobs:
   test_activation:
     name: Test activation
     runs-on: ubuntu-latest
-    if: success() || failure()
+    if: (success() || failure()) && github.event_name == 'schedule'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,7 @@ name: Nightly
 
 on:
   workflow_dispatch: {}
+  pull_request:
   push:
     branches:
       - "main"
@@ -40,7 +41,8 @@ jobs:
       contents: read
       id-token: write
     with:
-      scenarios_groups: tracer_release
+      # scenarios_groups: tracer_release
+      scenarios: DEFAULT
       library: ${{ matrix.library }}
       parametric_job_count: 8
       _system_tests_dev_mode: ${{ matrix.version == 'dev' }}


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
