### PR TITLE
Enable Test_NormalizedRoute on python fastapi

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -135,7 +135,10 @@ manifest:
         fastapi: v2.5.0
   tests/appsec/api_security/test_schemas.py::Test_Schema_Response_on_Block: v3.10.0.dev
   tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders: v4.9.0-rc2
-  tests/appsec/api_security_testing/test_normalized_route.py::Test_NormalizedRoute: missing_feature
+  tests/appsec/api_security_testing/test_normalized_route.py::Test_NormalizedRoute:
+    - weblog_declaration:
+        "*": missing_feature
+        fastapi: v4.10.0-rc1
   tests/appsec/iast:
     - weblog_declaration:
         tornado: v4.3.1  # Modified by easy win activation script


### PR DESCRIPTION
APPSEC-63236

Activates `Test_NormalizedRoute` on the python `fastapi` weblog at `v4.10.0-rc1` (where the RFC-1103 implementation landed in dd-trace-py main); other python weblogs stay `missing_feature`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)