### PR TITLE
[python] disable TestUnvalidatedHeader::test_secure (APPSEC-62470)

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -377,6 +377,9 @@ manifest:
   tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedHeader:  # Easy win for django-poc, django-py3.13, fastapi, flask-poc, python3.12, uds-flask, uwsgi-poc and version 4.6.4
     - weblog_declaration:
         "*": v4.7.0-rc1 (implemented in v3.9.0.dev, but there was the APPSEC-57817 and APPSEC-61861 bugs)
+  tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedHeader::test_secure:
+    - weblog_declaration:
+        "*": bug (APPSEC-62470)
   tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedHeader_ExtendedLocation:  # Easy win for django-poc, django-py3.13, fastapi, flask-poc, python3.12, uds-flask, uwsgi-poc and version 4.6.4
     - weblog_declaration:
         "*": bug (APPSEC-62470)


### PR DESCRIPTION
Disable `TestUnvalidatedHeader::test_secure` for all weblogs in python with a `bug` status, reusing ticket APPSEC-62470 already used for sibling tests in the same file.