### PR TITLE
SSI: Pin agent version to 7.78.4

### DIFF
--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -247,7 +247,6 @@ class TestSimpleInstallerAutoInjectManualOriginDetection(base.AutoInjectBaseTest
     )
     @irrelevant(context.library >= "python@4.0.0.dev" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library < "python@4.0.0.dev" and context.installed_language_runtime < "3.8.0")
-    @bug(reason="APMSP-3059")
     def test_origin_detection(self):
         virtual_machine = context.virtual_machine
         logger.info(

--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -247,6 +247,7 @@ class TestSimpleInstallerAutoInjectManualOriginDetection(base.AutoInjectBaseTest
     )
     @irrelevant(context.library >= "python@4.0.0.dev" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library < "python@4.0.0.dev" and context.installed_language_runtime < "3.8.0")
+    @bug(reason="APMSP-3059")
     def test_origin_detection(self):
         virtual_machine = context.virtual_machine
         logger.info(

--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
@@ -9,6 +9,9 @@
       local_path: binaries/
 
   remote-command: |
+    # Pin to 7.78.4 agent release. APMSP-3059
+    export DD_AGENT_MAJOR_VERSION=7
+    export DD_AGENT_MINOR_VERSION=78.4
     # Check if Docker is installed and ensure it's running
     if command -v docker >/dev/null 2>&1; then
         echo "Docker is installed, ensuring service is enabled and running..."
@@ -85,8 +88,6 @@
       export DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE='installtesting.datad0g.com'
       export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT="${DD_INSTALLER_AGENT_VERSION}"
     fi
-    # Pin to 7.78.4 agent release. APMSP-3059
-    export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT="7.78.4"
 
     if [ -n "${DD_INSTALLER_INSTALLER_VERSION}" ]; then
       export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE='installtesting.datad0g.com'
@@ -190,8 +191,6 @@
       $env:DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE = "installtesting.datad0g.com";
       $env:DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT = $env:DD_INSTALLER_AGENT_VERSION;
     }
-    # Pin to 7.78.4 agent release. APMSP-3059
-    $env:DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT = "7.78.4";
 
     if ($env:DD_INSTALLER_INSTALLER_VERSION) {
       $env:DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE = "installtesting.datad0g.com";

--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject_installer_manual.yml
@@ -85,6 +85,8 @@
       export DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE='installtesting.datad0g.com'
       export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT="${DD_INSTALLER_AGENT_VERSION}"
     fi
+    # Pin to 7.78.4 agent release. APMSP-3059
+    export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT="7.78.4"
 
     if [ -n "${DD_INSTALLER_INSTALLER_VERSION}" ]; then
       export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE='installtesting.datad0g.com'
@@ -188,6 +190,8 @@
       $env:DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE = "installtesting.datad0g.com";
       $env:DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT = $env:DD_INSTALLER_AGENT_VERSION;
     }
+    # Pin to 7.78.4 agent release. APMSP-3059
+    $env:DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT = "7.78.4";
 
     if ($env:DD_INSTALLER_INSTALLER_VERSION) {
       $env:DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE = "installtesting.datad0g.com";

--- a/utils/build/virtual_machine/provisions/auto-inject/docker/docker-compose-agent-prod.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/docker/docker-compose-agent-prod.yml
@@ -1,7 +1,8 @@
 services:
   datadog:
     container_name: dd-agent
-    image: gcr.io/datadoghq/agent:7.78.0
+    # Pin to 7.78.4 agent release. APMSP-3059
+    image: gcr.io/datadoghq/agent:7.78.4
     environment:
       - DD_API_KEY=${DD_API_KEY}
       - DD_SITE=datadoghq.com

--- a/utils/build/virtual_machine/provisions/auto-inject/docker/docker-compose-agent-prod.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/docker/docker-compose-agent-prod.yml
@@ -1,7 +1,7 @@
 services:
   datadog:
     container_name: dd-agent
-    image: gcr.io/datadoghq/agent:7
+    image: gcr.io/datadoghq/agent:7.78.0
     environment:
       - DD_API_KEY=${DD_API_KEY}
       - DD_SITE=datadoghq.com


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The Agent release (7.79.0,) is introducing instability in the tests.
Pin the agent version: 7.78.4
#incident-54830

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
