### PR TITLE
ruby parametric: drop linux/amd64 platform pin

### DIFF
--- a/utils/build/docker/ruby/parametric/Dockerfile
+++ b/utils/build/docker/ruby/parametric/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ruby:3.2.1-bullseye
+FROM ruby:3.2.1-bullseye
 
 WORKDIR /app
 COPY utils/build/docker/ruby/parametric .


### PR DESCRIPTION
## Motivation

The Ruby parametric Dockerfile is the only one in `utils/build/docker/` with a `--platform=linux/amd64` pin on its `FROM` line. Under Colima/Apple Silicon, the pin forces QEMU emulation, and `gcc` segfaults compiling the `msgpack` native gem during `bundle install` — blocking local parametric runs against `dd-trace-rb` on arm64.

## Changes

Drop `--platform=linux/amd64` from `utils/build/docker/ruby/parametric/Dockerfile`. The `ruby:3.2.1-bullseye` base image is multi-arch on Docker Hub, so this:

- remains amd64 on CI (`ubuntu-latest` is amd64), and
- becomes arm64 on Apple Silicon dev machines — matching the host-arch default already used by every other parametric Dockerfile (cpp, dotnet, golang, java, nodejs, php, python, rust).

This was found while verifying a new laptop could run the full system-tests local-build flow for all nine tracer languages. Ruby was the only one that failed under Colima/arm64; with this change, `TEST_LIBRARY=ruby ./run.sh PARAMETRIC -k "test_start_span"` passes against the local `dd-trace-rb` checkout in ~26s.

### Note on host-arch divergence

A reviewer pointed out that this makes the Ruby parametric image's architecture depend on the build host — amd64 in CI, arm64 on Apple Silicon. That property already applies to every other parametric Dockerfile (none of them pin a platform), so this PR aligns Ruby with the existing convention rather than introducing new divergence. A separate, larger refactor would be needed to add explicit platform control to the parametric build path (see `utils/docker_fixtures/_test_clients/_core.py`) — out of scope here.

## Workflow

1. ⚠️ Created as draft ⚠️
2. CI to confirm green
3. Mark ready for review after CI passes

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified — touches `utils/build/docker/ruby/parametric/Dockerfile`, will need R&P approval
* [x] A docker base image is modified — `build-ruby-image` label is set
* [ ] A scenario is added, removed or renamed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)