### PR TITLE
Fix helm install hang on large --debug output, idempotent retries

### DIFF
--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -15,12 +15,10 @@ def execute_command(
     *,
     quiet: bool = False,
 ) -> str | None:
-    """Call shell-command and either return its output or kill it
-    if it doesn't normally exit within timeout seconds and return None.
+    """Run a shell command with a timeout.
 
-    Uses subprocess.run with capture_output to drain stdout/stderr concurrently,
-    avoiding pipe-buffer deadlocks on commands that emit a lot of output
-    (e.g. `helm install --debug` on large charts).
+    Drains stdout/stderr concurrently to avoid pipe-buffer deadlocks on
+    verbose commands (e.g. `helm install --debug` on large charts).
     """
     applied_timeout = 90 if timeout is None else timeout
 
@@ -30,25 +28,22 @@ def execute_command(
         subprocess_env = os.environ.copy()
 
     output = ""
-    log_file_handle = None
     try:
         if logfile:
-            log_file_handle = open(logfile, "w")
-            try:
-                subprocess.run(
-                    shlex.split(command),
-                    stdout=log_file_handle,
-                    stderr=log_file_handle,
-                    env=subprocess_env,
-                    timeout=applied_timeout,
-                    check=False,
-                )
-            except subprocess.TimeoutExpired:
-                if timeout is None:
-                    # If when we call this method we don't specify a timeout, we return None
-                    return None
-                # if we specify a timeout, we raise an exception
-                raise Exception(f"Command: {command} timed out after {applied_timeout} seconds") from None
+            with open(logfile, "w") as log_file_handle:
+                try:
+                    subprocess.run(
+                        shlex.split(command),
+                        stdout=log_file_handle,
+                        stderr=log_file_handle,
+                        env=subprocess_env,
+                        timeout=applied_timeout,
+                        check=False,
+                    )
+                except subprocess.TimeoutExpired:
+                    if timeout is None:
+                        return None
+                    raise Exception(f"Command: {command} timed out after {applied_timeout} seconds") from None
             return output
 
         try:
@@ -76,10 +71,7 @@ def execute_command(
 
     except Exception as ex:
         logger.error(f"Error executing command: {command} \n {ex}")
-        raise ex
-    finally:
-        if log_file_handle is not None:
-            log_file_handle.close()
+        raise
 
     return output
 
@@ -101,8 +93,8 @@ def helm_install_chart(
     set_dict: dict[str, str] = {},
     value_file: str | None = None,
     *,
-    upgrade: bool = False,  # noqa: ARG001  # kept for backward compatibility; `helm upgrade --install` is now always used
-    timeout: int = 90,
+    upgrade: bool = False,  # noqa: ARG001  # unused; retained for call-site compatibility
+    timeout: int | None = 90,
     namespace: str = "datadog",
     chart_version: str | None = None,
 ) -> None:

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -32,7 +32,7 @@ def execute_command(
         if logfile:
             with open(logfile, "w") as log_file_handle:
                 try:
-                    subprocess.run(
+                    file_result = subprocess.run(
                         shlex.split(command),
                         stdout=log_file_handle,
                         stderr=log_file_handle,
@@ -44,6 +44,8 @@ def execute_command(
                     if timeout is None:
                         return None
                     raise Exception(f"Command: {command} timed out after {applied_timeout} seconds") from None
+            if file_result.returncode != 0:
+                logger.error(f"Command exited {file_result.returncode}: {command} (output in {logfile})")
             return output
 
         try:
@@ -126,9 +128,12 @@ def helm_install_chart(
     # Always use `helm upgrade --install` so that retries are idempotent: if a previous
     # attempt left a release record (e.g. timed out after creating resources), the next
     # attempt upgrades it instead of failing with "cannot re-use a name that is still in use".
+    # `--wait` is intentionally omitted in the custom-values branch: callers (e.g. cluster
+    # agent install) own their own readiness wait afterwards, and a 90s Python-side timeout
+    # would race helm's 5m default `--timeout` and kill it before pods are ready.
     if custom_value_file:
         command = (
-            f"helm upgrade {name} --install {wait} {set_str} --debug -f {custom_value_file} "
+            f"helm upgrade {name} --install {set_str} --debug -f {custom_value_file} "
             f"{chart}{version_str} --namespace={namespace}"
         )
     else:

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -1,4 +1,4 @@
-import subprocess, datetime, os, time, signal, shlex
+import subprocess, os, shlex
 from typing import TYPE_CHECKING
 from utils._logger import logger
 from retry import retry
@@ -16,55 +16,70 @@ def execute_command(
     quiet: bool = False,
 ) -> str | None:
     """Call shell-command and either return its output or kill it
-    if it doesn't normally exit within timeout seconds and return None
+    if it doesn't normally exit within timeout seconds and return None.
+
+    Uses subprocess.run with capture_output to drain stdout/stderr concurrently,
+    avoiding pipe-buffer deadlocks on commands that emit a lot of output
+    (e.g. `helm install --debug` on large charts).
     """
-    applied_timeout = 90
-    if timeout is not None:
-        applied_timeout = timeout
+    applied_timeout = 90 if timeout is None else timeout
 
     logger.debug(f"Launching Command: {command} ")
-    command_out_redirect = subprocess.PIPE
-    if logfile:
-        command_out_redirect = open(logfile, "w")
 
     if not subprocess_env:
         subprocess_env = os.environ.copy()
 
     output = ""
+    log_file_handle = None
     try:
-        start = datetime.datetime.now()
-        process = subprocess.Popen(
-            shlex.split(command), stdout=command_out_redirect, stderr=command_out_redirect, env=subprocess_env
-        )
-
-        while process.poll() is None:
-            time.sleep(0.1)
-            now = datetime.datetime.now()
-            if (now - start).seconds > applied_timeout:
-                os.kill(process.pid, signal.SIGKILL)
-                os.waitpid(-1, os.WNOHANG)
+        if logfile:
+            log_file_handle = open(logfile, "w")
+            try:
+                subprocess.run(
+                    shlex.split(command),
+                    stdout=log_file_handle,
+                    stderr=log_file_handle,
+                    env=subprocess_env,
+                    timeout=applied_timeout,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired:
                 if timeout is None:
                     # If when we call this method we don't specify a timeout, we return None
                     return None
-                else:
-                    # if we specify a timeout, we raise an exception
-                    raise Exception(f"Command: {command} timed out after {applied_timeout} seconds")
-        if not logfile:
-            output = process.stdout.read()
-            output = str(output, "utf-8")
-            if not quiet:
-                logger.debug(f"Command: {command} \n {output}")
-            else:
-                logger.info(f"Command: {command}")
-            if process.returncode != 0:
-                output_error = process.stderr.read()
-                output_error_str = str(output_error, "utf-8")
-                logger.debug(f"Command: {command} \n {output_error_str}")
-                raise Exception(f"Error executing command: {command} \nStdout: {output}\nStderr: {output_error_str}")
+                # if we specify a timeout, we raise an exception
+                raise Exception(f"Command: {command} timed out after {applied_timeout} seconds") from None
+            return output
+
+        try:
+            result = subprocess.run(
+                shlex.split(command),
+                capture_output=True,
+                env=subprocess_env,
+                timeout=applied_timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            if timeout is None:
+                return None
+            raise Exception(f"Command: {command} timed out after {applied_timeout} seconds") from None
+
+        output = result.stdout.decode("utf-8", errors="replace")
+        if not quiet:
+            logger.debug(f"Command: {command} \n {output}")
+        else:
+            logger.info(f"Command: {command}")
+        if result.returncode != 0:
+            output_error_str = result.stderr.decode("utf-8", errors="replace")
+            logger.debug(f"Command: {command} \n {output_error_str}")
+            raise Exception(f"Error executing command: {command} \nStdout: {output}\nStderr: {output_error_str}")
 
     except Exception as ex:
         logger.error(f"Error executing command: {command} \n {ex}")
         raise ex
+    finally:
+        if log_file_handle is not None:
+            log_file_handle.close()
 
     return output
 
@@ -86,7 +101,7 @@ def helm_install_chart(
     set_dict: dict[str, str] = {},
     value_file: str | None = None,
     *,
-    upgrade: bool = False,
+    upgrade: bool = False,  # noqa: ARG001  # kept for backward compatibility; `helm upgrade --install` is now always used
     timeout: int = 90,
     namespace: str = "datadog",
     chart_version: str | None = None,
@@ -116,14 +131,15 @@ def helm_install_chart(
 
     version_str = f" --version {chart_version}" if chart_version else ""
 
-    command = f"helm install {name} --debug {wait} {set_str} {chart}{version_str} --namespace={namespace}"
-    if upgrade:
-        command = f"helm upgrade {name} --debug --install {wait} {set_str} {chart}{version_str} --namespace={namespace}"
+    # Always use `helm upgrade --install` so that retries are idempotent: if a previous
+    # attempt left a release record (e.g. timed out after creating resources), the next
+    # attempt upgrades it instead of failing with "cannot re-use a name that is still in use".
     if custom_value_file:
         command = (
-            f"helm install {name} {set_str} --debug -f {custom_value_file} {chart}{version_str} --namespace={namespace}"
+            f"helm upgrade {name} --install {wait} {set_str} --debug -f {custom_value_file} "
+            f"{chart}{version_str} --namespace={namespace}"
         )
-        if upgrade:
-            command = f"helm upgrade {name} {set_str} --debug --install -f {custom_value_file} {chart}{version_str} --namespace={namespace}"
+    else:
+        command = f"helm upgrade {name} --install --debug {wait} {set_str} {chart}{version_str} --namespace={namespace}"
     execute_command("kubectl config current-context")
     execute_command(command, timeout=timeout, quiet=True)  # Too many traces to show in the logs

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -95,7 +95,6 @@ def helm_install_chart(
     set_dict: dict[str, str] = {},
     value_file: str | None = None,
     *,
-    upgrade: bool = False,  # noqa: ARG001  # unused; retained for call-site compatibility
     timeout: int | None = 90,
     namespace: str = "datadog",
     chart_version: str | None = None,
@@ -112,7 +111,6 @@ def helm_install_chart(
 
         with open(custom_value_file, "w") as fp:
             fp.write(value_data)
-            fp.seek(0)
 
     set_str = ""
     if set_dict:


### PR DESCRIPTION
## Summary

- Replace `Popen`+poll loop in `execute_command` with `subprocess.run(capture_output=True, timeout=...)` so stdout/stderr are drained concurrently — fixes the pipe-buffer deadlock that hung `helm install --debug` on the larger datadog helm chart 3.213.3.
- Switch `helm_install_chart` to always use `helm upgrade --install` so that `@retry(tries=5)` retries are idempotent and never trip "cannot re-use a name that is still in use" after a timed-out attempt.

## Why

All K8S_LIB_INJECTION_* jobs on #6958 (auto-bump of chart `3.205.0` → `3.213.3`) failed at warmup with:

```
Exception: Error executing command: helm install datadog ... --version 3.213.3 ...
Error: INSTALLATION FAILED: cannot re-use a name that is still in use
```

Example: https://gitlab.ddbuild.io/DataDog/system-tests/-/jobs/1688489008

The chart actually installs successfully (the cluster-agent pod is visible in the job artifacts and starts cleanly). The Python wrapper times out because `helm install --debug` emits enough output on the new chart to overflow the 64 KB OS pipe buffer; `Popen.poll()` only reads the pipes _after_ the process exits, so helm blocks on `write()` and is killed at 90 s. The `@retry` decorator then re-runs `helm install`, but the release already exists — hence the name-collision error.

`subprocess.run(capture_output=True, timeout=...)` reads stdout/stderr concurrently through internal threads, so large debug output no longer deadlocks. `helm upgrade --install` makes the operation idempotent so a partial install followed by a retry just upgrades the existing release.

## Test plan

- [ ] K8S_LIB_INJECTION_* jobs pass on this PR.
- [ ] After this lands, rebase #6958 (chart 3.213.3 bump) and confirm its K8S_LIB_INJECTION_* jobs pass.