### PR TITLE
Do not trigger system tests for nix workflow changes

### DIFF
--- a/tests/test_the_test/test_compute_libraries_and_scenarios.py
+++ b/tests/test_the_test/test_compute_libraries_and_scenarios.py
@@ -362,6 +362,19 @@ class Test_ComputeLibrariesAndScenarios:
             "",
         )
 
+    def test_nix_workflow(self):
+        inputs = build_inputs([".github/workflows/nix.yml"])
+
+        assert_github_processor(
+            inputs,
+            [],
+            [],
+            3600,
+            "false",
+            "DEFAULT",
+            "",
+        )
+
     @set_env("GITLAB_CI", "true")
     @set_env("CI_PIPELINE_SOURCE", "pull_request")
     @set_env("CI_COMMIT_REF_NAME", "")

--- a/utils/scripts/libraries_and_scenarios_rules.yml
+++ b/utils/scripts/libraries_and_scenarios_rules.yml
@@ -180,6 +180,9 @@ patterns:
     .github/workflows/nightly.yml:
         scenario_groups: null
         libraries: null
+    .github/workflows/nix.yml:
+        scenario_groups: null
+        libraries: null
     .github/workflows/run-docker-ssi.yml:
         scenario_groups: docker_ssi
     .github/workflows/run-end-to-end.yml:


### PR DESCRIPTION
## Motivation

Noticed changes to `nix.yml` will trigger system test execution jobs, but it should not as it does not affect them.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
