### PR TITLE
[java] Fix test_log_generation_enabled for vertx3/vertx4 after AIDM-583 fix

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4395,6 +4395,8 @@ manifest:
         jersey-grizzly2: missing_feature
         spring-boot-3-native: missing_feature
         ratpack: missing_feature
+        vertx3: missing_feature
+        vertx4: missing_feature
   tests/test_telemetry.py::Test_MessageBatch:
     - weblog_declaration:
         "*": v1.23.0

--- a/tests/test_library_logs.py
+++ b/tests/test_library_logs.py
@@ -91,13 +91,6 @@ class Test_NoExceptions:
         if context.weblog_variant == "spring-boot-wildfly":
             # APPSEC-56111:
             allowed_patterns.append(re.escape("Failed to determine dependency for uri {}"))
-        if context.weblog_variant in ("vertx3", "vertx4"):
-            # AIDM-583:
-            allowed_patterns.append(
-                re.escape(
-                    "Failed to handle exception in instrumentation for io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder"
-                )
-            )
         compiled_paterns = [re.compile(p, re.MULTILINE | re.DOTALL) for p in allowed_patterns]
         data = interfaces.library.get_telemetry_data()
         data = [d["request"]["content"] for d in data]

--- a/tests/test_library_logs.py
+++ b/tests/test_library_logs.py
@@ -91,6 +91,13 @@ class Test_NoExceptions:
         if context.weblog_variant == "spring-boot-wildfly":
             # APPSEC-56111:
             allowed_patterns.append(re.escape("Failed to determine dependency for uri {}"))
+        if context.weblog_variant in ("vertx3", "vertx4"):
+            # AIDM-583: fixed in dd-trace-java#11268, remove this once that PR is merged
+            allowed_patterns.append(
+                re.escape(
+                    "Failed to handle exception in instrumentation for io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder"
+                )
+            )
         compiled_paterns = [re.compile(p, re.MULTILINE | re.DOTALL) for p in allowed_patterns]
         data = interfaces.library.get_telemetry_data()
         data = [d["request"]["content"] for d in data]

--- a/utils/build/docker/java/vertx3/pom.xml
+++ b/utils/build/docker/java/vertx3/pom.xml
@@ -71,6 +71,16 @@
             <version>1.1.1</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>3.0.0</version>

--- a/utils/build/docker/java/vertx3/pom.xml
+++ b/utils/build/docker/java/vertx3/pom.xml
@@ -71,16 +71,6 @@
             <version>1.1.1</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.36</version>
-        </dependency>
-        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>3.0.0</version>


### PR DESCRIPTION
## Why

`test_log_generation_enabled[vertx3]` fails in dd-trace-java CI for PR #11268, which fixes AIDM-583.

### The full chain

AIDM-583 is a bug where `NettyMultipartHelper.collectBodyData()` calls `NettyFileUpload.getHttpDataType()`, which throws `UnsupportedOperationException` because Vert.x's `NettyFileUpload` doesn't implement that method. When AppSec tests in the DEFAULT scenario send multipart requests to the vertx3 `/waf` endpoint, Netty's `HttpPostMultipartRequestDecoder` encounters these objects, and the exception escapes to ByteBuddy's `suppress = Throwable.class` handler, which logs:

> `"Failed to handle exception in instrumentation for io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder"`

`DDTelemetryLogger` collects any agent log that carries a `Throwable`, so this debug-level log becomes a telemetry `logs` payload. This was:
- the **only** source of telemetry logs for vertx3/vertx4 in the DEFAULT scenario
- already tracked as AIDM-583 and explicitly **allowed** in `test_java_telemetry_logs`
- accidentally making `test_log_generation_enabled` pass

After DataDog/dd-trace-java#11268 adds `catch (UnsupportedOperationException ignored)` in `collectBodyData()`, the exception is silenced before reaching the advice handler. No more telemetry logs from this path.

### What this PR does

- `manifests/java.yml`: mark `test_log_generation_enabled` as `missing_feature` for vertx3 and vertx4, matching the behavior of `play`, `akka-http`, `jersey-grizzly2`, etc.
- `tests/test_library_logs.py`: keeps the AIDM-583 workaround with a note — it will be removed once DataDog/dd-trace-java#11268 is merged to prod.

## Testing

Verified locally by building the vertx3 weblog with the dd-trace-java#11268 agent jar and running:
```
TEST_LIBRARY=java ./run.sh tests/test_telemetry.py::Test_Log_Generation::test_log_generation_enabled
```
Result: `1 xfailed` (test correctly skipped as missing_feature for vertx3).