### PR TITLE
Add coverage for DBM dynamic_service mode

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -226,6 +226,9 @@ jobs:
     - name: Run INTEGRATIONS_AWS scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"INTEGRATIONS_AWS"')
       run: ./run.sh INTEGRATIONS_AWS
+    - name: Run DBM_DYNAMIC_SERVICE scenario
+      if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"DBM_DYNAMIC_SERVICE"')
+      run: ./run.sh DBM_DYNAMIC_SERVICE
     - name: Run APM_TRACING_E2E_OTEL scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"APM_TRACING_E2E_OTEL"')
       run: |

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -43,6 +43,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: irrelevant
   tests/integrations/test_dsm.py::Test_DsmKafka::test_dsm_kafka_without_cluster_id: irrelevant
   tests/integrations/test_dsm.py::Test_DsmRabbitmq::test_dsm_rabbitmq_dotnet_legacy: irrelevant (legacy dotnet behavior)
   tests/integrations/test_mongo.py::Test_Mongo: missing_feature (Endpoint is not implemented on weblog)

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -301,6 +301,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: irrelevant
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64: missing_feature
   tests/integrations/test_dsm.py::Test_DsmContext_Injection_Base64: missing_feature
   tests/integrations/test_dsm.py::Test_DsmHttp: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -743,6 +743,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: irrelevant
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64: missing_feature
   tests/integrations/test_dsm.py::Test_DsmContext_Injection_Base64: missing_feature
   tests/integrations/test_dsm.py::Test_DsmHttp: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -961,6 +961,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: irrelevant
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3503,6 +3503,10 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres:
+    - weblog_declaration:
+        "*": irrelevant
+        spring-boot: missing_feature
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3507,7 +3507,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres:
     - weblog_declaration:
         "*": irrelevant
-        spring-boot: missing_feature
+        spring-boot: v1.63.0-SNAPSHOT
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/java_otel.yml
+++ b/manifests/java_otel.yml
@@ -34,6 +34,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: irrelevant
   tests/integrations/test_dsm.py::Test_DsmKafka::test_dsm_kafka_without_cluster_id: irrelevant
   tests/integrations/test_dsm.py::Test_DsmRabbitmq::test_dsm_rabbitmq_dotnet_legacy: irrelevant (legacy dotnet behavior)
   tests/integrations/test_mongo.py::Test_Mongo: missing_feature (Endpoint is not implemented on weblog)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1823,7 +1823,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
-  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: missing_feature
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: v0.0.1
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1823,7 +1823,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
-  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: v0.0.1
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: v6.0.0-pre
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1823,7 +1823,13 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
-  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: v6.0.0-pre
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres:
+    - weblog_declaration:
+        "*": missing_feature (Missing on weblog)
+        express4: v6.0.0-pre
+        express5: v6.0.0-pre
+        fastify: v6.0.0-pre
+        uds-express4: v6.0.0-pre
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1823,6 +1823,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: missing_feature
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/nodejs_otel.yml
+++ b/manifests/nodejs_otel.yml
@@ -33,6 +33,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: irrelevant
   tests/integrations/test_dsm.py::Test_DsmKafka::test_dsm_kafka_without_cluster_id: irrelevant
   tests/integrations/test_dsm.py::Test_DsmRabbitmq::test_dsm_rabbitmq_dotnet_legacy: irrelevant (legacy dotnet behavior)
   tests/integrations/test_mongo.py::Test_Mongo: missing_feature (Endpoint is not implemented on weblog)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -661,6 +661,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: missing_feature
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64: missing_feature
   tests/integrations/test_dsm.py::Test_DsmContext_Injection_Base64: missing_feature
   tests/integrations/test_dsm.py::Test_DsmHttp: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1605,6 +1605,7 @@ manifest:
     - weblog_declaration:
         flask-poc: bug (APMAPI-1058)
         uds-flask: bug (APMAPI-1058)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: missing_feature
   tests/integrations/test_dbm.py::_BaseDbmComment::test_dbm_comment:
     - weblog_declaration:
         flask-poc: bug (APMAPI-1058)

--- a/manifests/python_otel.yml
+++ b/manifests/python_otel.yml
@@ -33,6 +33,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: irrelevant
   tests/integrations/test_dsm.py::Test_DsmKafka::test_dsm_kafka_without_cluster_id: irrelevant
   tests/integrations/test_dsm.py::Test_DsmRabbitmq::test_dsm_rabbitmq_dotnet_legacy: irrelevant (legacy dotnet behavior)
   tests/integrations/test_mongo.py::Test_Mongo: missing_feature (Endpoint is not implemented on weblog)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1899,6 +1899,13 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres:
+    - weblog_declaration:
+        "*": irrelevant
+        sinatra14: missing_feature
+        sinatra22: missing_feature
+        sinatra32: missing_feature
+        sinatra41: missing_feature
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -46,6 +46,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: irrelevant
   tests/integrations/test_dsm.py::Test_DsmKafka::test_dsm_kafka_without_cluster_id: irrelevant
   tests/integrations/test_dsm.py::Test_DsmRabbitmq::test_dsm_rabbitmq_dotnet_legacy: irrelevant (legacy dotnet behavior)
   tests/integrations/test_mongo.py::Test_Mongo: missing_feature (Endpoint is not implemented on weblog)

--- a/tests/integrations/test_dbm.py
+++ b/tests/integrations/test_dbm.py
@@ -398,3 +398,75 @@ class Test_Dbm_Comment_Mysql(_BaseDbmComment):
     @property
     def dddbs(self):
         return self._LIBRARY_CONFIG.get(context.library.name, (None, None))[1]
+
+
+class _BaseDbmDynamicService:
+    """Verify DD_DBM_PROPAGATION_MODE=dynamic_service:
+    - injects ddsh='<hash>' into the SQL comment
+    - sets _dd.propagated_hash=<same_hash> on the SQL span
+    """
+
+    operation: str = "execute"
+
+    @property
+    def integration(self):
+        return None
+
+    def setup_dbm_dynamic_service(self):
+        self.r = weblog.get("/stub_dbm", params={"integration": self.integration, "operation": self.operation})
+
+    def test_dbm_dynamic_service(self):
+        assert self.r.status_code == 200, f"Request: {self.r.request.url} wasn't successful."
+
+        try:
+            data = json.loads(self.r.text)
+        except json.decoder.JSONDecodeError as e:
+            raise ValueError(f"Response from {self.r.request.url} should have been JSON") from e
+
+        assert data.get("status") == "ok"
+        comment = data.get("dbm_comment", "")
+        assert comment, "dbm_comment is empty"
+
+        # ddsh field is present and non-empty in the SQL comment
+        match = re.search(r"ddsh='([^']*)'", comment)
+        assert match, f"ddsh field not found in SQL comment: {comment}"
+        ddsh_value = match.group(1)
+        assert ddsh_value, "ddsh value is empty"
+
+        # SQL span carries _dd.propagated_hash equal to ddsh
+        sql_spans = [
+            span
+            for _, trace in interfaces.library.get_traces(request=self.r)
+            for span in trace
+            if span.get("type") == "sql"
+        ]
+        assert sql_spans, "No SQL span found for the /stub_dbm request"
+
+        for span in sql_spans:
+            propagated_hash = span.get("meta", {}).get("_dd.propagated_hash")
+            if propagated_hash is not None:
+                assert propagated_hash == ddsh_value, f"_dd.propagated_hash '{propagated_hash}' != ddsh '{ddsh_value}'"
+                return
+
+        raise AssertionError(
+            f"_dd.propagated_hash not found in any SQL span. "
+            f"Span meta keys: {[list(s.get('meta', {}).keys()) for s in sql_spans]}"
+        )
+
+
+@features.database_monitoring_dynamic_service
+@scenarios.dbm_dynamic_service
+class Test_Dbm_DynamicService_Postgres(_BaseDbmDynamicService):
+    """DBM dynamic_service mode — PostgreSQL integration across all languages."""
+
+    _LIBRARY_CONFIG = {
+        "python": "psycopg",
+        "nodejs": "pg",
+        "java": "postgresql",
+        "ruby": "pg",
+        "php": "pdo-pgsql",
+    }
+
+    @property
+    def integration(self):
+        return self._LIBRARY_CONFIG.get(context.library.name)

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -8,7 +8,12 @@ from .aws_lambda import LambdaScenario
 from .core import Scenario, scenario_groups
 from .default import DefaultScenario
 from .endtoend import DockerScenario, EndToEndScenario
-from .integrations import CrossedTracingLibraryScenario, IntegrationsScenario, AWSIntegrationsScenario
+from .integrations import (
+    CrossedTracingLibraryScenario,
+    DbmDynamicServiceScenario,
+    IntegrationsScenario,
+    AWSIntegrationsScenario,
+)
 from .open_telemetry import OpenTelemetryScenario
 from .otel_collector import OtelCollectorScenario
 from .parametric import ParametricScenario
@@ -55,6 +60,7 @@ class _Scenarios:
     )
     integrations = IntegrationsScenario()
     integrations_aws = AWSIntegrationsScenario("INTEGRATIONS_AWS")
+    dbm_dynamic_service = DbmDynamicServiceScenario()
     crossed_tracing_libraries = CrossedTracingLibraryScenario()
 
     otel_integrations = OpenTelemetryScenario(

--- a/utils/_context/_scenarios/integrations.py
+++ b/utils/_context/_scenarios/integrations.py
@@ -75,6 +75,22 @@ class IntegrationsScenario(EndToEndScenario):
         self.unique_id = _get_unique_id(self.host_log_folder, replay=self.replay)
 
 
+class DbmDynamicServiceScenario(EndToEndScenario):
+    def __init__(self) -> None:
+        super().__init__(
+            "DBM_DYNAMIC_SERVICE",
+            weblog_env={
+                "DD_DBM_PROPAGATION_MODE": "dynamic_service",
+            },
+            other_weblog_containers=(PostgresContainer,),
+            doc=(
+                "Verifies DD_DBM_PROPAGATION_MODE=dynamic_service injects ddsh into SQL comments "
+                "and sets _dd.propagated_hash on SQL spans with the same value."
+            ),
+            scenario_groups=[scenario_groups.integrations],
+        )
+
+
 class AWSIntegrationsScenario(EndToEndScenario):
     unique_id: str = ""
 

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -1921,6 +1921,14 @@ class _Features:
         )  # tracing/context-propagation, apm/dbm, idm-sugar
 
     @staticmethod
+    def database_monitoring_dynamic_service(test_object):
+        """DBM: dynamic_service propagation mode — injects ddsh into SQL comments and _dd.propagated_hash onto spans
+
+        https://docs.google.com/document/d/1v-NuhF_0LNCY3zkSQlL6nPxrvlKfvm9LDkeZlEOyO3w/edit?tab=t.0
+        """
+        return _mark_test_object(test_object, feature_id=558, owner=_Owner.idm)
+
+    @staticmethod
     def rasp_stack_trace(test_object):
         """Appsec RASP: Stack Trace
 

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -1924,6 +1924,7 @@ class _Features:
     def database_monitoring_dynamic_service(test_object):
         """DBM: dynamic_service propagation mode — injects ddsh into SQL comments and _dd.propagated_hash onto spans
 
+        https://feature-parity.us1.prod.dog/#/?feature=558
         https://docs.google.com/document/d/1v-NuhF_0LNCY3zkSQlL6nPxrvlKfvm9LDkeZlEOyO3w/edit?tab=t.0
         """
         return _mark_test_object(test_object, feature_id=558, owner=_Owner.idm)

--- a/utils/build/docker/nodejs/express/app.js
+++ b/utils/build/docker/nodejs/express/app.js
@@ -296,15 +296,12 @@ app.get('/stub_dbm', async (req, res) => {
   const operation = req.query.operation
 
   if (integration === 'pg') {
-    tracer.use(integration, { dbmPropagationMode: 'full' })
     const dbmComment = await pgsql.doOperation(operation)
     res.send({ status: 'ok', dbm_comment: dbmComment })
   } else if (integration === 'mysql2') {
-    tracer.use(integration, { dbmPropagationMode: 'full' })
     const result = await mysql.doOperation(operation)
     res.send({ status: 'ok', dbm_comment: result })
   } else if (integration === 'mssql') {
-    tracer.use(integration, { dbmPropagationMode: 'full' })
     res.send(await mssql.doOperation(operation))
   }
 })

--- a/utils/build/docker/nodejs/fastify/app.js
+++ b/utils/build/docker/nodejs/fastify/app.js
@@ -319,15 +319,12 @@ fastify.get('/stub_dbm', async (request, reply) => {
   const operation = request.query.operation
 
   if (integration === 'pg') {
-    tracer.use(integration, { dbmPropagationMode: 'full' })
     const dbmComment = await pgsql.doOperation(operation)
     return { status: 'ok', dbm_comment: dbmComment }
   } else if (integration === 'mysql2') {
-    tracer.use(integration, { dbmPropagationMode: 'full' })
     const result = await mysql.doOperation(operation)
     return { status: 'ok', dbm_comment: result }
   } else if (integration === 'mssql') {
-    tracer.use(integration, { dbmPropagationMode: 'full' })
     return await mssql.doOperation(operation)
   }
 })


### PR DESCRIPTION
## Motivation

Add coverage for the new DD_DBM_PROPAGATION_MODE=dynamic_service value that combines service mode behaviour with automatic SQL base hash injection, without requiring users to separately set DD_DBM_INJECT_SQL_BASEHASH=true.

Setting dynamic_service is equivalent to:

DD_DBM_PROPAGATION_MODE=service
DD_DBM_INJECT_SQL_BASEHASH=true

The test checks that the basehash is the same in both the `ddsh` comment field and the related span meta `_dd. propagated_hash`

Note: already tested working locally with the in progress java implementation: https://github.com/DataDog/dd-trace-java/pull/11432

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
