### PR TITLE
fix: switch mssql image to ghcr mirror to avoid flaky mcr registry

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1373,7 +1373,7 @@ class MsSqlServerContainer(SqlDbTestedContainer):
         }
 
         super().__init__(
-            image_name="mcr.microsoft.com/mssql/server:2022-latest",
+            image_name="ghcr.io/datadog/system-tests/mcr.microsoft.com/mssql/server:2022-latest",
             name="mssql",
             cap_add=["SYS_PTRACE"],
             user="root",


### PR DESCRIPTION
## Summary

- Replaces `mcr.microsoft.com/mssql/server:2022-latest` with the GHCR mirror `ghcr.io/datadog/system-tests/mcr.microsoft.com/mssql/server:2022-latest`
- The MCR registry has been flaky, causing intermittent test failures; the GHCR mirror follows the same convention used by the existing `mirror-image.yml` workflow

## Test plan

- [ ] Verify mssql-dependent integration tests pass in CI

> Generated by [Claude Code](https://claude.com/claude-code)