### PR TITLE
remote_config: enable verbose tracer logs for ASM_FEATURES scenario

### DIFF
--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -556,6 +556,7 @@ class _Scenarios:
         appsec_enabled=False,
         weblog_env={
             "DD_REMOTE_CONFIGURATION_ENABLED": "true",
+            # configs below will used to debug connection failures in ddtrace-py
             "DD_TRACE_LOGGING_RATE": "0",
             "DD_TRACE_DEBUG": "true",
         },

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -554,7 +554,11 @@ class _Scenarios:
         "REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES",
         rc_api_enabled=True,
         appsec_enabled=False,
-        weblog_env={"DD_REMOTE_CONFIGURATION_ENABLED": "true"},
+        weblog_env={
+            "DD_REMOTE_CONFIGURATION_ENABLED": "true",
+            "DD_TRACE_LOGGING_RATE": "0",
+            "DD_TRACE_DEBUG": "true",
+        },
         doc="",
         scenario_groups=[scenario_groups.appsec, scenario_groups.remote_config, scenario_groups.essentials],
     )


### PR DESCRIPTION
## Summary

Temporary diagnostic enablement for the intermittent CI failure of `Test_RemoteConfigurationExtraServices::test_tracer_extra_services` (`AssertionError: no extra_services contains extraVegetables`) in the `REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES` scenario. The fix and new log checkpoints land in DataDog/dd-trace-py#18223; this PR turns them on in CI so the next failure is diagnosable. Revert once the flake is resolved.

[Flake dashboard](https://app.datadoghq.com/dashboard/eit-h7i-h4q?currentTab=overview&fromUser=false&refresh_mode=sliding&tpl_var_codeowner%5B0%5D=%40DataDog%2Fapm-sdk-capabilities-python&tpl_var_repo%5B0%5D=github.com%2Fdatadog%2Fdd-trace-py&from_ts=1778793883059&to_ts=1779398683059&live=true)

## Change

Adds two env vars to the scenario's `weblog_env`:

- `DD_TRACE_LOGGING_RATE=0` — disables Python `DDLogger`'s 60 s rate limiter so repeated warnings are not collapsed into `[N skipped]`. Ignored by non-Python tracers.
- `DD_TRACE_DEBUG=true` — exposes the producer (`_add_extra_service: queued '<name>'`) and consumer (`_get_extra_services: merged N new entries`) checkpoints from dd-trace-py#18223.

## Blast radius

`DD_TRACE_DEBUG=true` is honoured by **every** Datadog tracer (Java, .NET, Node, Ruby, PHP, Go), so every weblog variant in this scenario will emit verbose stderr while this PR is in place. `Test_RemoteConfigurationUpdateSequenceFeatures` (the other test in the scenario) is not behaviourally affected.

## Failure modes the new logs distinguish

| Captured log signal | Diagnosis |
| --- | --- |
| No `_add_extra_service: queued '<name>'` debug line | `Pin.override` never ran |
| `_add_extra_service: failed to enqueue '<name>'` warning | Silent `SharedStringFile.put` drop (fixed in dd-trace-py#18223) |
| `SharedStringFile.put: ... file full (size=..., attempted=..., max=8192)` warning | 8 KiB queue overflow |
| `SharedStringFile.put ... failed` warning | I/O exception (full traceback) |
| Producer line present, no consumer line | RC poller dead or did not survive fork |

## Test plan

- [ ] `Test_RemoteConfigurationExtraServices::test_tracer_extra_services` still passes on `fastapi` and `uwsgi-poc` in this scenario.
- [ ] CI runs `REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES` green across all supported tracer languages.
