### PR TITLE
fix(rust): unblock four adaptive-sampling parametric tests

### DIFF
--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -87,8 +87,6 @@ manifest:
   tests/parametric/test_crashtracking.py: missing_feature
   tests/parametric/test_dynamic_configuration.py: '>=0.2.1'  # Modified by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env: missing_feature  # Created by easy win activation script
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: missing_feature  # Created by easy win activation script
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_capability_tracing_enabled: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_default_capability_completeness: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_tracing_client_tracing_disable_one_way: missing_feature  # Created by easy win activation script
@@ -96,8 +94,6 @@ manifest:
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_apply_state: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_log_injection_enabled: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_trace_sampling_rate_override_default: missing_feature  # Created by easy win activation script
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_trace_sampling_rate_override_env: missing_feature  # Created by easy win activation script
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_trace_sampling_rate_with_sampling_rules: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1_ServiceTargets::test_not_match_service_target: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV2: missing_feature  # Created by easy win activation script
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation: missing_feature


### PR DESCRIPTION
## Motivation

Enables four parametric tests for Rust now that DataDog/dd-trace-rs#227 fixes the underlying precedence and adds `DD_TRACE_SAMPLE_RATE` support.

## What does this PR do?

Removes four `missing_feature` entries from `manifests/rust.yml`:

- `TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate`
- `TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags`
- `TestDynamicConfigV1::test_trace_sampling_rate_override_env`
- `TestDynamicConfigV1::test_trace_sampling_rate_with_sampling_rules`

## Do not merge before DataDog/dd-trace-rs#227

The parametric scenario runs against both the dd-trace-rs `main` build (`rust dev`) and the released crates.io version (`rust prod`). Both fail on these four tests until dd-trace-rs#227 lands.

Sequence:
1. Merge dd-trace-rs#227.
2. Mark this PR ready for review; re-trigger CI. `rust dev` goes green.
3. After the next dd-trace-rs release contains the fixes, `rust prod` also goes green.

## Test plan

- [ ] CI confirms the four tests pass against the dd-trace-rs `main` build after #227 merges.
- [ ] No other rust manifest entries regress.