### PR TITLE
parametric: bump library client SIGTERM grace to drain gRPC/OTLP threads

### DIFF
--- a/utils/docker_fixtures/_core.py
+++ b/utils/docker_fixtures/_core.py
@@ -49,7 +49,17 @@ def docker_run(
     ports: dict[str, int],
     log_file: TextIO,
     command: list[str] | None = None,
+    stop_timeout: int = 1,
 ) -> Generator[Container, None, None]:
+    """Run a docker container in detached mode and stop it on teardown.
+
+    ``stop_timeout`` is the SIGTERM grace period (seconds) before SIGKILL. The default of 1s
+    keeps cheap shutdown for fixtures that hold no state (e.g. the test agent). Containers that
+    run user code with background threads holding host ports (e.g. parametric library clients
+    with gRPC/OTLP exporters) should pass a larger value so those threads can drain cleanly;
+    SIGKILLing mid-shutdown can leave host ports in TIME_WAIT and cause rare startup flakes for
+    the next test on the same xdist worker.
+    """
     logger.info(f"Run container {name} from image {image} with ports {ports}")
 
     try:
@@ -75,7 +85,7 @@ def docker_run(
         yield container
     finally:
         logger.info(f"Stopping {name}")
-        container.stop(timeout=1)
+        container.stop(timeout=stop_timeout)
         logs = container.logs()
         log_file.write(logs.decode("utf-8"))
         log_file.flush()

--- a/utils/docker_fixtures/_test_clients/_test_client_parametric.py
+++ b/utils/docker_fixtures/_test_clients/_test_client_parametric.py
@@ -88,6 +88,10 @@ class ParametricTestClientFactory(TestClientFactory):
                 volumes=self.container_volumes,
                 log_file=log_file,
                 network=test_agent.network,
+                # Give ddtrace/OTLP/gRPC background threads time to drain on SIGTERM before
+                # the next test on this xdist worker reuses the same host port. SIGKILLing
+                # mid-shutdown was the most likely cause of rare container-exit flakes.
+                stop_timeout=5,
             ) as container,
         ):
             test_server_timeout = 60


### PR DESCRIPTION
## Problem

Rare (~1/1000) parametric flake where a test client container (e.g. `python-test-client-*`) starts successfully then exits ~0.6s later. The failure surfaces as `Timeout of 60 seconds exceeded waiting for HTTP server to start` because the framework's poll loop treats `status == exited` the same as "not ready yet" and keeps retrying. The flake is most often observed in OTel logs/metrics tests, which is where `ddtrace`'s `grpc` integration patch and the OTLP exporter background threads are most active.

Example: [dd-trace-py run 26044048099, job 76563345401](https://github.com/DataDog/dd-trace-py/actions/runs/26044048099/job/76563345401).

## Cause

`docker_run` was calling `container.stop(timeout=1)` for every container. 1s is enough for the test agent (no state to drain) but not for parametric library clients: `ddtrace` + OTLP exporter + gRPC patch hold background threads that bind host ports. SIGKILLing them mid-shutdown leaves those host ports in `TIME_WAIT`, which collides with the next test on the same xdist worker (which reuses the port allocation `4500 + worker_id`).

## Fix

Parameterise `docker_run` with a `stop_timeout` argument (default 1s — keeps existing behaviour for the test agent and any other zero-state fixtures) and pass `stop_timeout=5` from the parametric library client only.

```python
# utils/docker_fixtures/_core.py
def docker_run(..., stop_timeout: int = 1) -> ...:
    ...
    container.stop(timeout=stop_timeout)

# utils/docker_fixtures/_test_clients/_test_client_parametric.py
docker_run(..., stop_timeout=5)
```

## Test plan

- [x] 5 sequential local runs of the target test: `passed in 6.21s / 6.19s / 6.22s / 6.39s / 6.28s` — within the prior baseline of ~6.5s. The new 5s cap only activates when the client actually fails to drain on SIGTERM.
- [x] Verified via `tests.log`: healthy `python-test-client-*` stop took ~454ms; `ddapm-test-agent-*` stop took ~1.5s. No regression on the happy path.
- [x] `./format.sh` clean (mypy, ruff, yamllint, shellcheck).