### PR TITLE
perf(build): use zstd instead of gzip for weblog image compression

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -958,7 +958,7 @@ class WeblogContainer(TestedContainer):
         """Returns images needed to build the weblog"""
 
         # If an image is saved as a file in binaries, we don't need any image
-        filename = f"binaries/{library}-{weblog}-weblog.tar.gz"
+        filename = f"binaries/{library}-{weblog}-weblog.tar.zst"
         if Path(filename).is_file():
             return []
 

--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -72,7 +72,7 @@ print_usage() {
     echo -e "  ${CYAN}--default-weblog${NC}             Prints the name of the default weblog for a given library and exits."
     echo -e "  ${CYAN}--binary-path${NC}                Optional. Path of a directory binaries will be copied from. Should be used for local development only."
     echo -e "  ${CYAN}--binary-url${NC}                 Optional. Url of the client library redistributable. Should be used for local development only."
-    echo -e "  ${CYAN}--save-to-binaries${NC}           Optional. Save image in binaries folder as a tar.gz file."
+    echo -e "  ${CYAN}--save-to-binaries${NC}           Optional. Save image in binaries folder as a tar.zst file."
     echo -e "  ${CYAN}--help${NC}                       Prints this message and exits."
     echo
     echo -e "${WHITE_BOLD}EXAMPLES${NC}"
@@ -257,11 +257,11 @@ build() {
             fi
 
             # keep this name consistent with WeblogContainer.get_image_list()
-            BINARIES_FILENAME=binaries/${TEST_LIBRARY}-${WEBLOG_VARIANT}-weblog.tar.gz
+            BINARIES_FILENAME=binaries/${TEST_LIBRARY}-${WEBLOG_VARIANT}-weblog.tar.zst
 
-            if [ -f $BINARIES_FILENAME ]; then
+            if [ -f "$BINARIES_FILENAME" ]; then
                 echo "Loading image from $BINARIES_FILENAME"
-                docker load --input $BINARIES_FILENAME
+                zstd -d -c "$BINARIES_FILENAME" | docker load
             else
 
                 if [[ $TEST_LIBRARY == python ]]; then
@@ -339,7 +339,7 @@ build() {
 
                 if [[ $SAVE_TO_BINARIES == 1 ]]; then
                     echo "Saving image to $BINARIES_FILENAME"
-                    docker save system_tests/weblog | gzip > $BINARIES_FILENAME
+                    docker save system_tests/weblog | zstd > "$BINARIES_FILENAME"
                 fi
             fi
         elif [[ $IMAGE_NAME == lambda-proxy ]]; then


### PR DESCRIPTION
## Summary

- Replaces `gzip` with `zstd` for saving and loading weblog image artifacts in `build.sh`
- Updates the artifact filename extension from `.tar.gz` to `.tar.zst`
- Fixes unquoted `$BINARIES_FILENAME` variable references

## Dependencies

None — this PR is independent and can be merged in any order.

## Test plan

- [ ] Run a weblog build with `--save-to-binaries` and verify the `.tar.zst` artifact is created
- [ ] Verify the artifact can be loaded back correctly in a subsequent run

🤖 Generated with [Claude Code](https://claude.com/claude-code)