### PR TITLE
Move test logic in test methods

### DIFF
--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -173,34 +173,42 @@ class Test_Debugger_Line_Probe_Statuses(BaseDebuggerProbeStatusTest):
     def setup_probe_status_log_line_with_different_casing(self):
         self._setup("probe_status_log_line", "log", uppercase_source_files=True)
 
+    def test_probe_status_log_line_with_different_casing(self):
         # Validate that the source file was actually uppercased to ensure this test is meaningful
         for probe in self.probe_definitions:
-            source_file = probe["where"].get("sourceFile", "")
-            if source_file.islower():
-                self.setup_failures.append(
-                    f"Test expects source file to be uppercased, but got: {source_file}. "
-                    f"This suggests the uppercase transformation didn't work."
-                )
+            assert "where" in probe
+            assert "sourceFile" in probe["where"]
 
-    def test_probe_status_log_line_with_different_casing(self):
+            source_file = probe["where"]["sourceFile"]
+            assert isinstance(source_file, str)
+
+            assert not source_file.islower(), (
+                f"Test expects source file to be uppercased, but got: {source_file}. "
+                f"This suggests the uppercase transformation didn't work."
+            )
+
         self._assert()
 
     ############ log line probe with Windows path ############
     def setup_probe_status_log_line_with_windows_path(self):
         self._setup("probe_status_log_line", "log", use_backslashes=True)
 
+    def test_probe_status_log_line_with_windows_path(self):
         # Validate that the source file actually contains backslashes to ensure
         # this test is meaningful (i.e., it's actually testing Windows path handling)
         for probe in self.probe_definitions:
-            source_file = probe["where"].get("sourceFile", "")
-            if "\\" not in source_file:
-                self.setup_failures.append(
-                    f"Test expects source file to contain backslashes for Windows path testing, "
-                    f"but got: {source_file}. This suggests the tracer's source path doesn't include "
-                    f"subdirectories, making this edge case test meaningless. See DEBUG-5108 for .NET."
-                )
+            assert "where" in probe
+            assert "sourceFile" in probe["where"]
 
-    def test_probe_status_log_line_with_windows_path(self):
+            source_file = probe["where"]["sourceFile"]
+            assert isinstance(source_file, str)
+
+            assert "\\" in source_file, (
+                f"Test expects source file to contain backslashes for Windows path testing, "
+                f"but got: {source_file}. This suggests the tracer's source path doesn't include "
+                f"subdirectories, making this edge case test meaningless. See DEBUG-5108 for .NET."
+            )
+
         self._assert()
 
     ############ metric line probe ############

--- a/tests/debugger/test_debugger_probe_status.py
+++ b/tests/debugger/test_debugger_probe_status.py
@@ -182,7 +182,7 @@ class Test_Debugger_Line_Probe_Statuses(BaseDebuggerProbeStatusTest):
             source_file = probe["where"]["sourceFile"]
             assert isinstance(source_file, str)
 
-            assert not source_file.islower(), (
+            assert source_file.isupper(), (
                 f"Test expects source file to be uppercased, but got: {source_file}. "
                 f"This suggests the uppercase transformation didn't work."
             )


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
