### PR TITLE
[debugger] Add compliance tests for probe `when` condition errors

### DIFF
--- a/manifests/agent.yml
+++ b/manifests/agent.yml
@@ -7,6 +7,24 @@ manifest:
   tests/appsec/smoke_tests/test_apm_standalone.py:
     - component_version: "<7.77.0-0"
       declaration: irrelevant (APM Standalone option was added in 7.77.0)
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL:
+    - component_version: "<7.77.1"
+      weblog_declaration:
+        chi: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
+        echo: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
+        gin: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
+        net-http: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
+        net-http-orchestrion: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
+        uds-echo: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error:
+    - component_version: "<7.77.1"
+      weblog_declaration:
+        chi: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
+        echo: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
+        gin: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
+        net-http: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
+        net-http-orchestrion: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
+        uds-echo: irrelevant (Go DI requires datadog-agent >= 7.77.1 for the `when` clause)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot:
     - component_version: ">=7.79.0-devel"
       weblog_declaration:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -598,6 +598,12 @@ manifest:
       weblog: [uds, poc]
     - declaration: missing_feature (Not yet implemented)
       excluded_weblog: [uds, poc]
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL::test_invalid_condition_dsl_probe_rejected: missing_feature (Dotnet compiles probe conditions lazily on first evaluation, so there is no install-time validation step to reject the probe.)
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error: v2.53.0
+  ? tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error::test_runtime_condition_error_emits_error_only_snapshot
+  : bug (DEBUG-5699)
+  ? tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error::test_runtime_condition_error_rate_limited
+  : bug (DEBUG-5703)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay:
     - weblog_declaration:
         "*": v2.50.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -823,6 +823,12 @@ manifest:
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions: v2.2.3
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions::test_complex_capture_expressions: missing_feature (index expression not yet supported in Go system-probe)
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins: missing_feature (feature not implemented)
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL: v2.2.3
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error: v2.2.3
+  ? tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error::test_runtime_condition_error_emits_error_only_snapshot
+  : bug (DEBUG-5700)
+  ? tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error::test_runtime_condition_error_probe_installs
+  : bug (DEBUG-5710)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay: missing_feature (feature not implemented)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_firsthit: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_outofmemory: missing_feature (Implemented only for dotnet)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2893,6 +2893,28 @@ manifest:
     - weblog_declaration:
         "*": missing_feature (Implemented for spring-mvc)
         spring-boot: v0.0.0
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL:
+    - weblog_declaration:
+        "*": missing_feature
+        spring-boot: v1.38.0
+        spring-boot-jetty: v1.38.0
+        spring-boot-openliberty: v1.38.0
+        spring-boot-payara: v1.38.0
+        spring-boot-undertow: v1.38.0
+        spring-boot-wildfly: v1.38.0
+        uds-spring-boot: v1.38.0
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error:
+    - weblog_declaration:
+        "*": missing_feature
+        spring-boot: v1.38.0
+        spring-boot-jetty: v1.38.0
+        spring-boot-openliberty: v1.38.0
+        spring-boot-payara: v1.38.0
+        spring-boot-undertow: v1.38.0
+        spring-boot-wildfly: v1.38.0
+        uds-spring-boot: v1.38.0
+  ? tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error::test_runtime_condition_error_rate_limited
+  : bug (DEBUG-5704)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay:
     - weblog_declaration:
         "*": missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1549,6 +1549,18 @@ manifest:
         fastify: *ref_5_24_0
         nextjs: missing_feature
         uds-express4: *ref_5_54_0
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL:
+    - weblog_declaration:
+        "*": *ref_5_46_0
+        nextjs: irrelevant
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error:
+    - weblog_declaration:
+        "*": *ref_5_46_0
+        nextjs: irrelevant
+  ? tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error::test_runtime_condition_error_emits_error_only_snapshot
+  : bug (DEBUG-5701)
+  ? tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error::test_runtime_condition_error_rate_limited
+  : bug (DEBUG-5705)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay: missing_feature
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_firsthit: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_outofmemory: missing_feature (Implemented only for dotnet)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -547,6 +547,17 @@ manifest:
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Line_Capture_Expressions: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions: v1.19.0
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins::test_code_origin_entry_present: irrelevant (HTTP entry spans in PHP-FPM/Apache are C-level; execute stack is empty at span close time so no user frames are captured)
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL:
+    - weblog_declaration:
+        "*": missing_feature
+        apache-mod-8.0: v1.13.0+4663b2fa7c20c6920f347d059b57dc2a419cb7f7
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL::test_invalid_condition_dsl_probe_rejected: bug (DEBUG-5708)
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error:
+    - weblog_declaration:
+        "*": missing_feature
+        apache-mod-8.0: v1.13.0+4663b2fa7c20c6920f347d059b57dc2a419cb7f7
+  ? tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error::test_runtime_condition_error_rate_limited
+  : bug (DEBUG-5706)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay: v1.19.0
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_firsthit: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_outofmemory: missing_feature (Implemented only for dotnet)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1142,6 +1142,15 @@ manifest:
     - weblog_declaration:
         "*": missing_feature
         *flask: v2.11.0
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL:
+    - weblog_declaration:
+        "*": missing_feature
+        *flask: v2.11.0
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL::test_invalid_condition_dsl_probe_rejected: bug (DEBUG-5709)
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error:
+    - weblog_declaration:
+        "*": missing_feature
+        *flask: v2.11.0
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay:
     - weblog_declaration:
         "*": missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1639,6 +1639,22 @@ manifest:
         rails80: missing_feature (feature not implemented)
         uds-rails: missing_feature (feature not implemented)
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins::test_code_origin_entry_present: missing_feature (Not yet implemented)
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL:
+    - weblog_declaration:
+        "*": irrelevant
+        rails72: v2.22.0
+        rails80: v2.22.0
+        uds-rails: v2.22.0
+  tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error:
+    - weblog_declaration:
+        "*": irrelevant
+        rails72: v2.22.0
+        rails80: v2.22.0
+        uds-rails: v2.22.0
+  ? tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error::test_runtime_condition_error_emits_error_only_snapshot
+  : bug (DEBUG-5702)
+  ? tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error::test_runtime_condition_error_rate_limited
+  : bug (DEBUG-5707)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay: missing_feature (feature not implemented)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_firsthit: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_outofmemory: missing_feature (Implemented only for dotnet)

--- a/tests/debugger/test_debugger_condition_errors.py
+++ b/tests/debugger/test_debugger_condition_errors.py
@@ -1,0 +1,239 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+"""Compliance tests: a probe with a broken ``when`` condition must not produce probe data."""
+
+import time
+
+import tests.debugger.utils as debugger
+from utils import context, features, scenarios
+
+
+def _capture_point_contains_data(point: object) -> bool:
+    """Return True iff a single capture point (entry / return / one line entry) contains data."""
+    if not isinstance(point, dict):
+        return False
+    for key in ("arguments", "locals", "staticFields"):
+        if point.get(key):
+            return True
+    return bool(point.get("throwable"))
+
+
+def _captures_contain_data(captures: object) -> bool:
+    """Return True iff the ``captures`` field of a snapshot contains any captured probe data.
+
+    A snapshot whose ``captures`` is missing, ``None``, or only contains empty
+    ``entry`` / ``return`` / ``lines`` sub-structures (i.e. no captured arguments,
+    locals, static fields, or throwable) returns False -- it is an empty captures
+    container and acceptable as part of an evaluation-error snapshot.
+    """
+    if not isinstance(captures, dict):
+        return False
+    for key, value in captures.items():
+        # `entry` and `return` map directly to a capture-point dict.
+        # `lines` maps line-numbers to capture-point dicts, so descend one level.
+        if key == "lines" and isinstance(value, dict):
+            if any(_capture_point_contains_data(v) for v in value.values()):
+                return True
+        elif _capture_point_contains_data(value):
+            return True
+    return False
+
+
+class _ConditionTestBase(debugger.BaseDebuggerTest):
+    """Shared base for the condition-error compliance tests."""
+
+    def _convert_to_line_probe_if_needed(self, probe: dict) -> None:
+        """In-place: rewrite a LogProbe method probe to a line probe for tracers that need it."""
+        if context.library.name != "nodejs":
+            return
+        where = probe["where"]
+        where.pop("methodName", None)
+        where["typeName"] = None
+        where["sourceFile"] = "ACTUAL_SOURCE_FILE"
+        where["lines"] = self.method_and_language_to_line_number("LogProbe", "nodejs")
+
+
+@features.debugger_expression_language
+@scenarios.debugger_probes_snapshot
+class Test_Debugger_Invalid_Condition_DSL(_ConditionTestBase):
+    """Compliance: a probe whose ``when`` condition cannot be parsed must be rejected with an ERROR diagnostic."""
+
+    def setup_invalid_condition_dsl_probe_rejected(self) -> None:
+        self.initialize_weblog_remote_config()
+
+        probes = debugger.read_probes("probe_invalid_condition_dsl")
+        for probe in probes:
+            probe["id"] = debugger.generate_probe_id("log")
+            self._convert_to_line_probe_if_needed(probe)
+
+        self.set_probes(probes)
+        self.send_rc_probes()
+        # Wait until each probe reaches a terminal state. ERROR is the conforming
+        # target (the tracer rejected the broken DSL); INSTALLED catches non-conforming
+        # tracers that wrongly install the probe -- returning on INSTALLED keeps those
+        # bug paths fast. The 15s timeout fires only for tracers that emit no diagnostic
+        # at all; those fail the diagnostic-presence assertion below.
+        self.wait_for_all_probes(statuses=["INSTALLED", "ERROR"], timeout=15)
+        # Trigger the instrumented method so any lazy-compilation paths have a chance to
+        # surface the failure. A conforming tracer must not emit a snapshot here.
+        self.send_weblog_request("/debugger/log")
+        # Drains any (non-conforming) snapshot the tracer may have emitted so the
+        # snapshot assertion below sees it. Returns immediately if none arrives.
+        self.wait_for_all_snapshots(timeout=5)
+
+    def test_invalid_condition_dsl_probe_rejected(self) -> None:
+        """A probe whose ``when`` condition cannot be parsed must be rejected by the tracer.
+
+        Concretely: the tracer must emit a status=ERROR diagnostic (so the developer who
+        configured the broken probe knows it was rejected) and must not produce any probe
+        result (snapshot).
+        """
+        self.collect()
+        self.assert_setup_ok()
+
+        # ``self.probe_diagnostics[probe_id]["status"]`` is the framework-aggregated
+        # "most-advanced" status; ERROR is only stored if it's reached from RECEIVED.
+        # An INSTALLED -> ERROR transition would be hidden (test would see INSTALLED).
+        for probe_id in self.probe_ids:
+            diag = self.probe_diagnostics.get(probe_id)
+            assert diag is not None, (
+                "The probe did not receive any diagnostic; the tracer must emit a "
+                "status=ERROR diagnostic so the developer knows the probe was rejected."
+            )
+            status = diag["status"]
+            assert status == "ERROR", (
+                f"Probe reached status {status!r}; a probe with invalid DSL must reach "
+                f"status=ERROR so the developer knows it was rejected."
+            )
+            snapshots = self.probe_snapshots.get(probe_id, [])
+            assert not snapshots, (
+                f"Probe emitted {len(snapshots)} snapshot(s); a probe with invalid DSL "
+                f"must not produce any probe result."
+            )
+
+
+@features.debugger_expression_language
+@scenarios.debugger_probes_snapshot
+class Test_Debugger_Runtime_Condition_Error(_ConditionTestBase):
+    """Compliance: a probe whose ``when`` raises at eval time must surface the error without leaking probe data."""
+
+    def _setup_runtime_condition_error(self, request_count: int = 1, spacing_s: float = 0.0) -> None:
+        self.initialize_weblog_remote_config()
+
+        probes = debugger.read_probes("probe_runtime_condition_error")
+        for probe in probes:
+            probe["id"] = debugger.generate_probe_id("log")
+            self._convert_to_line_probe_if_needed(probe)
+
+        self.set_probes(probes)
+        self.send_rc_probes()
+        if not self.wait_for_all_probes(statuses=["INSTALLED"], timeout=30):
+            self.setup_failures.append("Probes did not reach INSTALLED status within 30s")
+
+        for i in range(request_count):
+            self.send_weblog_request("/debugger/log", reset=(i == 0))
+            if spacing_s > 0 and i < request_count - 1:
+                time.sleep(spacing_s)
+
+        if spacing_s > 0:
+            # In the multi-hit case we deliberately do NOT use wait_for_all_snapshots:
+            # a non-conforming tracer emits one eval-error snapshot per hit (so two
+            # in total here). wait_for_all_snapshots returns the moment the first
+            # snapshot is on disk, which would leave the second snapshot still in
+            # flight when collect() reads disk -- a false pass. A fixed sleep gives
+            # the second snapshot enough time to land.
+            time.sleep(5)
+        else:
+            # Returns as soon as the snapshot arrives, or after the timeout for tracers
+            # that emit nothing.
+            self.wait_for_all_snapshots(timeout=5)
+
+    def setup_runtime_condition_error_probe_installs(self) -> None:
+        self._setup_runtime_condition_error()
+
+    def test_runtime_condition_error_probe_installs(self) -> None:
+        """A probe whose ``when`` is structurally valid must install successfully."""
+        self.collect()
+        self.assert_setup_ok()
+        self.assert_rc_state_not_error()
+
+        for probe_id in self.probe_ids:
+            assert probe_id in self.probe_diagnostics, "Expected a diagnostic for the probe, but none was received."
+            status = self.probe_diagnostics[probe_id]["status"]
+            assert status in ("INSTALLED", "EMITTING"), (
+                f"Expected the probe to reach INSTALLED/EMITTING status, got {status!r}."
+            )
+
+    def setup_runtime_condition_error_emits_error_only_snapshot(self) -> None:
+        self._setup_runtime_condition_error()
+
+    def test_runtime_condition_error_emits_error_only_snapshot(self) -> None:
+        """When the ``when`` raises at eval time, the tracer must emit a probe result that:
+
+        * carries a non-empty ``evaluationErrors[]`` array (so the developer is informed
+          that their condition is broken), AND
+        * does NOT include captured probe data (the condition was not successfully
+          evaluated, so the probe did not effectively fire from the user-data perspective).
+        """
+        self.collect()
+        self.assert_setup_ok()
+
+        for probe_id in self.probe_ids:
+            snapshots = self.probe_snapshots.get(probe_id, [])
+            assert snapshots, (
+                "The probe emitted no snapshot at all; a probe whose condition errors "
+                "at runtime must surface the error to the user via a probe result with "
+                "evaluationErrors[]."
+            )
+
+            envelope = snapshots[0]
+            snap = envelope.get("debugger", {}).get("snapshot") or envelope.get("debugger.snapshot") or {}
+
+            evaluation_errors = snap.get("evaluationErrors") or []
+            assert evaluation_errors, (
+                "The probe emitted a snapshot without a populated evaluationErrors[] "
+                "array; the developer must be told what failed."
+            )
+
+            # The condition in probe_runtime_condition_error.json references the unbound
+            # variable `definitelyDoesNotExist`. At least one evaluation-error entry should
+            # mention that variable name (in `expr` or `message`) so the developer can pin
+            # down which part of the condition failed.
+            mentions_var = any(
+                "definitelyDoesNotExist" in str(entry.get("expr", ""))
+                or "definitelyDoesNotExist" in str(entry.get("message", ""))
+                for entry in evaluation_errors
+            )
+            assert mentions_var, (
+                f"The probe emitted an eval-error snapshot whose evaluationErrors[] does "
+                f"not mention the failing variable name 'definitelyDoesNotExist' "
+                f"(entries: {evaluation_errors!r}); the developer must be able to pin "
+                f"down which part of the condition failed."
+            )
+
+            captures = snap.get("captures")
+            assert not _captures_contain_data(captures), (
+                f"The probe emitted a snapshot whose ``captures`` field contains captured "
+                f"data ({captures!r}); an eval-error snapshot must have empty captures "
+                f"because the condition was not successfully evaluated."
+            )
+
+    def setup_runtime_condition_error_rate_limited(self) -> None:
+        # Fire two hits >1s apart so each hit clears any general 1/s snapshot sampler;
+        # anything dropping the second snapshot must be the eval-error rate limiter.
+        self._setup_runtime_condition_error(request_count=2, spacing_s=1.5)
+
+    def test_runtime_condition_error_rate_limited(self) -> None:
+        """At most 1 eval-error snapshot per probe per 5 minutes."""
+        self.collect()
+        self.assert_setup_ok()
+
+        for probe_id in self.probe_ids:
+            snapshots = self.probe_snapshots.get(probe_id, [])
+            assert len(snapshots) <= 1, (
+                f"The probe emitted {len(snapshots)} eval-error snapshots for two hits "
+                f"spaced >1s apart. A conforming tracer must rate-limit to at most 1 "
+                f"eval-error snapshot per probe per 5 minutes."
+            )

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -159,6 +159,7 @@ class BaseDebuggerTest:
         """method_and_language_to_line_number returns the respective line number given the method and language"""
         definitions: dict[str, dict[str, list[int]]] = {
             "Budgets": {"java": [138], "dotnet": [136], "python": [142]},
+            "LogProbe": {"nodejs": [20]},
             "Expression": {"java": [71], "dotnet": [74], "python": [72], "ruby": [82], "nodejs": [82], "golang": [71]},
             # The `@exception` variable is not available in the context of line probes.
             "ExpressionException": {},

--- a/tests/debugger/utils/probes/probe_invalid_condition_dsl.json
+++ b/tests/debugger/utils/probes/probe_invalid_condition_dsl.json
@@ -1,0 +1,25 @@
+[
+    {
+        "language": "",
+        "type": "",
+        "id": "",
+        "version": 0,
+        "where": {
+            "typeName": "ACTUAL_TYPE_NAME",
+            "methodName": "LogProbe",
+            "sourceFile": null
+        },
+        "when": {
+            "dsl": "notARealOperator(foo)",
+            "json": {
+                "notARealOperator": [
+                    {"ref": "foo"}
+                ]
+            }
+        },
+        "captureSnapshot": true,
+        "segments": [
+            {"str": "invalid-condition-dsl probe fired (should never happen)"}
+        ]
+    }
+]

--- a/tests/debugger/utils/probes/probe_runtime_condition_error.json
+++ b/tests/debugger/utils/probes/probe_runtime_condition_error.json
@@ -1,0 +1,26 @@
+[
+    {
+        "language": "",
+        "type": "",
+        "id": "",
+        "version": 0,
+        "where": {
+            "typeName": "ACTUAL_TYPE_NAME",
+            "methodName": "LogProbe",
+            "sourceFile": null
+        },
+        "when": {
+            "dsl": "definitelyDoesNotExist == \"never\"",
+            "json": {
+                "eq": [
+                    {"ref": "definitelyDoesNotExist"},
+                    "never"
+                ]
+            }
+        },
+        "captureSnapshot": true,
+        "segments": [
+            {"str": "runtime-condition-error probe fired"}
+        ]
+    }
+]

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -57,6 +57,12 @@ class Test_DdtraceSchemas:
                 ticket="APMRP-360",
             ),
             SchemaBug(
+                endpoint="/debugger/v2/input",
+                data_path="$[].debugger.snapshot.stack",
+                condition=context.library == "python" and context.scenario is scenarios.debugger_probes_snapshot,
+                ticket="DEBUG-0000",
+            ),
+            SchemaBug(
                 endpoint="/debugger/v1/input",
                 data_path="$[].debugger.snapshot.probe.location.method",
                 condition=context.library == "dotnet",
@@ -157,6 +163,12 @@ class Test_DdtraceSchemas:
                 data_path="$[]",
                 condition=context.library == "dotnet" and context.scenario is scenarios.debugger_symdb,
                 ticket="DEBUG-3298",
+            ),
+            SchemaBug(
+                endpoint="/api/v2/debugger",
+                data_path="$[]",
+                condition=context.library == "python" and context.scenario is scenarios.debugger_probes_snapshot,
+                ticket="DEBUG-0000",
             ),
             SchemaBug(
                 endpoint="/api/v2/apmtelemetry",

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -60,7 +60,7 @@ class Test_DdtraceSchemas:
                 endpoint="/debugger/v2/input",
                 data_path="$[].debugger.snapshot.stack",
                 condition=context.library == "python" and context.scenario is scenarios.debugger_probes_snapshot,
-                ticket="DEBUG-0000",
+                ticket="DEBUG-5715",
             ),
             SchemaBug(
                 endpoint="/debugger/v1/input",
@@ -168,7 +168,7 @@ class Test_DdtraceSchemas:
                 endpoint="/api/v2/debugger",
                 data_path="$[]",
                 condition=context.library == "python" and context.scenario is scenarios.debugger_probes_snapshot,
-                ticket="DEBUG-0000",
+                ticket="DEBUG-5715",
             ),
             SchemaBug(
                 endpoint="/api/v2/apmtelemetry",


### PR DESCRIPTION
## Motivation

Tracers currently diverge in how they handle a probe whose `when` condition can't be evaluated - some silently drop the probe, some install it and then emit a snapshot with no eval error, some have no rate-limiting, etc.

This PR pins down the contract we want every tracer to follow and gives us a clear baseline to drive each tracer toward conformance.

There is no existing RFC for the eval-error rate-limit policy. This PR uses the system-test as the cross-tracer commitment: **at most 1 eval-error snapshot per probe per 5 minutes**. The rate matches `dd-trace-py`'s implementation; the choice is deliberate (one snapshot is enough to alert the developer that a probe is misconfigured, anything more frequent is noise). Tracers that emit more frequently are tracked as bugs and will need to either adopt this rate or push back on the test.

## Changes

Two new compliance test classes in `tests/debugger/test_debugger_condition_errors.py`:

* `Test_Debugger_Invalid_Condition_DSL` (1 test)
  * `test_invalid_condition_dsl_probe_rejected` - a probe whose `when` DSL cannot be parsed must be rejected with a `status=ERROR` diagnostic and must not emit any snapshot.
* `Test_Debugger_Runtime_Condition_Error` (3 tests)
  * `test_runtime_condition_error_probe_installs` - a structurally valid `when` must install successfully (the runtime failure happens later).
  * `test_runtime_condition_error_emits_error_only_snapshot` - when the condition raises at eval time, the tracer must emit a snapshot with `evaluationErrors[]` populated (mentioning the unbound symbol) and an empty `captures` field (no leaking of captured probe data).
  * `test_runtime_condition_error_rate_limited` - two probe hits >1s apart must produce at most 1 eval-error snapshot per probe (i.e. the 1/5min commitment). The >1s spacing ensures each hit clears any general per-second snapshot sampler, so anything dropping the second snapshot must be the eval-error-specific rate limiter doing its job.

Supporting changes:

* New probe fixtures `probe_invalid_condition_dsl.json` / `probe_runtime_condition_error.json`.
* One new entry in `method_and_language_to_line_number` (`tests/debugger/utils.py`) registering the line number for the Node.js `LogProbe` weblog method. The in-test conversion from method-probe to line-probe for Node.js is kept strictly local to this test file (with a docstring explaining why it's unsafe to generalize: method-probe -> line-probe is not a generally equivalent rewrite, and these tests only get away with it because they assert on diagnostics, not on captured data).
* Two new `SchemaBug(...)` entries in `tests/schemas/test_schemas.py` covering a pre-existing schema-compliance gap in `dd-trace-py` that this PR's new tests surfaced for the first time (Python emits `stack: null` in eval-error snapshots; the schema requires an array). The bug existed but had never been triggered because no prior system-test exercised the eval-error code path. Tracked under the Python bug ticket.

Manifest updates (compliance markers, not characterization):

* `agent.yml` - `irrelevant` for Go DI on `datadog-agent < 7.77.1` (the `when` clause requires that agent version on Go). Scoped via `weblog_declaration` to the Go weblogs only so the constraint doesn't accidentally apply to non-Go runs against an old agent (addressed in review).
* `golang.yml`, `java.yml`, `nodejs.yml`, `php.yml`, `python.yml`, `ruby.yml`, `dotnet.yml` - per-tracer `bug` or `missing_feature` markers for tests that don't yet conform. Bug tickets are placeholders to be replaced by each tracer team. Note: under the 1/5min rate-limit commitment above, all of `java`, `nodejs`, `ruby`, `php`, `dotnet` need a rate-limit `bug` marker (their current implementations are at 1/s or per-probe-configurable, not 1/5min).
* Min-version gates use the released-version baselines that the language teams have established for their other DI tests.

## Workflow

1. [x] Create your PR as draft
2. [x] Work on you PR until the CI passes
3. [ ] Mark it as ready for review
   * Test logic is modified? -> Get a review from RFC owner.
   * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
  * Note: the only `utils/`-adjacent change is a single new entry in `method_and_language_to_line_number` in `tests/debugger/utils.py` (purely test-helper code).
* [ ] A docker base image is modified?
  * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
  * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)