### PR TITLE
fix: allow empty string in RC apply_error

### DIFF
--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -34,8 +34,8 @@ class Test_NoError:
             )
 
             for state in config_states:
-                error = state.get("apply_error", None)
-                if error is not None:
+                error = state.get("apply_error", "") # Allow unset or empty string
+                if error is not "":
                     raise Exception(f"Error in remote config application: {error}")
 
         interfaces.library.validate_all_remote_configuration(no_error, allow_no_data=True)

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -34,7 +34,7 @@ class Test_NoError:
             )
 
             for state in config_states:
-                error = state.get("apply_error", "") # Allow unset or empty string
+                error = state.get("apply_error", "")  # Allow unset or empty string
                 if error is not "":
                     raise Exception(f"Error in remote config application: {error}")
 

--- a/tests/remote_config/test_remote_configuration.py
+++ b/tests/remote_config/test_remote_configuration.py
@@ -35,7 +35,7 @@ class Test_NoError:
 
             for state in config_states:
                 error = state.get("apply_error", "")  # Allow unset or empty string
-                if error is not "":
+                if error != "":
                     raise Exception(f"Error in remote config application: {error}")
 
         interfaces.library.validate_all_remote_configuration(no_error, allow_no_data=True)


### PR DESCRIPTION
## Motivation

According to RFC `RCTE2 - Configuration apply status` which defines the individual RC configs error states, the `apply_error` field explicitly consider empty string to be a nominal case: 
> MUST contain an associated error message if apply_state is ERROR.
MUST NOT be set OR empty string if apply_state is anything else.

## Changes

Allow `apply_error` to be either unset or empty string to be considered nominal.