### PR TITLE
mirror_images: introduce dd-repo-tools wrapper and seed config

### DIFF
--- a/mirror_images.yaml
+++ b/mirror_images.yaml
@@ -1,0 +1,67 @@
+# Images to mirror into registry.ddbuild.io.
+# See: https://github.com/DataDog/dd-repo-tools/blob/main/shared/mirror-images/mirror_images.md
+#
+# Targets default to `registry.ddbuild.io/ci/system-tests/mirror/<source>`.
+# To mirror the same source list into ghcr.io (for GitHub-hosted CI), run:
+#
+#   MIRROR_DEST_REGISTRY=ghcr.io/datadog/system-tests \
+#     utils/mirror_images.sh lock -o mirror_images.ghcr.lock.yaml
+#   MIRROR_DEST_REGISTRY=ghcr.io/datadog/system-tests \
+#     utils/mirror_images.sh mirror --lock-yaml mirror_images.ghcr.lock.yaml
+
+images:
+  # Bare-name & docker.io images
+  - amazonlinux:2023
+  - apache/spark:3.4.4
+  - datadog/dd-trace-ci:php-8.2_bookworm-6
+  - debian:bookworm-slim
+  - docker.io/datadog/dd-lib-ruby-init:latest
+  - golang:1.25
+  - maven:3-eclipse-temurin-21
+  - node:13
+  - node:18.10-slim
+  - openjdk:7-alpine
+  - python:2.7
+  - python:3.11-slim
+  - ruby:3.1.3
+  - rust:1.87-slim-bookworm
+  - ubuntu:22.04
+
+  # gcr.io
+  - gcr.io/datadoghq/agent:7.78.4
+
+  # ghcr.io
+  - ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:latest_snapshot
+
+  # mcr.microsoft.com (.NET)
+  - mcr.microsoft.com/dotnet/aspnet:2.1-stretch-slim
+  - mcr.microsoft.com/dotnet/aspnet:6.0
+  - mcr.microsoft.com/dotnet/aspnet:6.0-alpine
+  - mcr.microsoft.com/dotnet/aspnet:8.0
+  - mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+  - mcr.microsoft.com/dotnet/sdk:6.0-alpine
+  - mcr.microsoft.com/dotnet/sdk:7.0
+  - mcr.microsoft.com/dotnet/sdk:7.0.100
+  - mcr.microsoft.com/dotnet/sdk:7.0.100-preview.2
+  - mcr.microsoft.com/dotnet/sdk:8.0
+  - mcr.microsoft.com/dotnet/sdk:8.0-alpine
+
+  # internal Datadog ECR (legacy PHP CI image)
+  - 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/php:5.6-cli
+
+ignore:
+  images:
+    # Multi-stage Dockerfile stage names (not registry refs).
+    - "base"
+    - "build"
+    - "dd-lib-init_.+"
+    # docker-compose local `build:` targets (no registry).
+    - "reverseproxy:latest"
+    - "system-tests/.+:latest"
+    # Dockerfile ARG-substituted refs — resolved at build time, can't be
+    # lint-validated as static images.
+    - ".*\\$\\{?RUNTIME\\}?.*"
+    - ".*\\$\\{?TARGETARCH\\}?.*"
+    # public.ecr.aws is AWS's public mirror of Docker Hub — treated as a
+    # trusted upstream that does not need to be re-mirrored.
+    - "public\\.ecr\\.aws/.*"

--- a/utils/mirror_images.sh
+++ b/utils/mirror_images.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec uv run --no-config --script \
+    https://binaries.ddbuild.io/dd-repo-tools/default/ca/fb4f39a542e4dd42b646c300b539c7a9f4201531/mirror_images.py \
+    "$@"


### PR DESCRIPTION
## Summary

- Add `utils/mirror_images.sh` — thin wrapper around the shared `dd-repo-tools/mirror_images.py` (pinned to commit `fb4f39a5`).
- Seed `mirror_images.yaml` with the 29 real public images this repo's Dockerfiles/docker-compose files reference, plus ignore patterns that suppress 161 false-positive lint hits.

## What's covered

**Mirrored** (→ `registry.ddbuild.io/ci/system-tests/mirror/...` by default):
- `mcr.microsoft.com/dotnet/{aspnet,sdk}:*` — multiple versions
- Docker Hub bare-name images: `golang:1.25`, `maven:3-eclipse-temurin-21`, `node:13`, `node:18.10-slim`, `python:2.7`, `python:3.11-slim`, `ruby:3.1.3`, `rust:1.87-slim-bookworm`, `ubuntu:22.04`, `openjdk:7-alpine`, `debian:bookworm-slim`, `amazonlinux:2023`, `apache/spark:3.4.4`, `datadog/dd-trace-ci:php-8.2_bookworm-6`, `docker.io/datadog/dd-lib-ruby-init:latest`
- `gcr.io/datadoghq/agent:7.78.4`
- `ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:latest_snapshot`
- `669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/php:5.6-cli`

**Ignored** (regex patterns in `ignore.images`):
- Dockerfile stage names: `base`, `build`, `dd-lib-init_.+`
- docker-compose local build targets: `reverseproxy:latest`, `system-tests/.+:latest`
- Build-time ARG-substituted refs: `.*\${?RUNTIME}?.*`, `.*\${?TARGETARCH}?.*`
- `public\.ecr\.aws/.*` — AWS's trusted public Docker Hub mirror, no re-mirroring needed

## Mirroring to both registries

Same `mirror_images.yaml` feeds both destinations via env var (documented in the header):

```bash
# GitLab CI (default)
utils/mirror_images.sh lock && utils/mirror_images.sh mirror

# GitHub-hosted CI
MIRROR_DEST_REGISTRY=ghcr.io/datadog/system-tests \
  utils/mirror_images.sh lock -o mirror_images.ghcr.lock.yaml
MIRROR_DEST_REGISTRY=ghcr.io/datadog/system-tests \
  utils/mirror_images.sh mirror --lock-yaml mirror_images.ghcr.lock.yaml
```

## Follow-up

`utils/mirror_images.sh lint` still reports 40 refs in 29 unique images — these are the actual Dockerfile `FROM` / docker-compose `image:` lines that need to be rewritten to use `registry.ddbuild.io/ci/system-tests/mirror/...`. That's a much larger refactor and is intentionally out of scope here.

## Test plan

- [ ] `utils/mirror_images.sh lint` runs and only flags the expected 29 unmirrored sources (no `base`/`build`/`system-tests/*` noise).
- [ ] `utils/mirror_images.sh lock` resolves digests for all declared images.
- [ ] `utils/mirror_images.sh mirror --dry-run` shows the expected copy plan.
- [ ] Dry-run with `MIRROR_DEST_REGISTRY=ghcr.io/datadog/system-tests` targets ghcr.io paths.