### PR TITLE
Add FFE first remote config request test

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -700,6 +700,7 @@ manifest:
   tests/docker_ssi/test_docker_ssi_appsec.py::TestDockerSSIAppsecFeatures::test_telemetry_source_ssi: v3.36.0
   tests/ffe/test_dynamic_evaluation.py: v3.36.0
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Flag_Parse_Error_Isolation: bug (FFL-2184)
+  tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Down_Then_Up: bug (FFL-2339)
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Unknown_Operator_Tolerance: bug (FFL-2184)
   tests/ffe/test_exposures.py: v3.36.0
   tests/ffe/test_flag_eval_metrics.py: missing_feature (FFL-2257 - Requires Datadog.FeatureFlags.OpenFeature 2.3.0 NuGet package to be published)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3154,7 +3154,9 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         spring-boot: v1.56.0
+  tests/ffe/test_dynamic_evaluation.py::Test_FFE_First_Remote_Config_Request: v1.63.0-SNAPSHOT
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Flag_Parse_Error_Isolation::test_valid_flag_unaffected: bug (FFL-2184)
+  tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Down_Then_Up: v1.63.0-SNAPSHOT
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Unknown_Operator_Tolerance: bug (FFL-2184)
   tests/ffe/test_exposures.py:
     - weblog_declaration:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1273,7 +1273,7 @@ manifest:
   tests/docker_ssi/test_docker_ssi_crash.py::TestDockerSSICrash::test_crash:
     - declaration: bug (INPLAT-603)
       component_version: '>=3.0.0-dev'
-  tests/ffe/test_dynamic_evaluation.py::Test_FFE_First_Remote_Config_Request: v4.11.0-dev
+  tests/ffe/test_dynamic_evaluation.py::Test_FFE_First_Remote_Config_Request: bug (FFL-2339)
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Down_From_Start: v4.0.0
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Down_Then_Up: v4.11.0-dev
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Unavailable: flaky (FFL-1622)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1274,6 +1274,8 @@ manifest:
     - declaration: bug (INPLAT-603)
       component_version: '>=3.0.0-dev'
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Down_From_Start: v4.0.0
+  tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Down_Then_Up: v4.11.0-dev
+  tests/ffe/test_dynamic_evaluation.py::Test_FFE_First_Remote_Config_Request: v4.11.0-dev
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Unavailable: flaky (FFL-1622)
   tests/ffe/test_exposures.py: v4.2.0-dev
   tests/ffe/test_flag_eval_metrics.py: v4.8.0-dev

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1273,9 +1273,9 @@ manifest:
   tests/docker_ssi/test_docker_ssi_crash.py::TestDockerSSICrash::test_crash:
     - declaration: bug (INPLAT-603)
       component_version: '>=3.0.0-dev'
+  tests/ffe/test_dynamic_evaluation.py::Test_FFE_First_Remote_Config_Request: v4.11.0-dev
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Down_From_Start: v4.0.0
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Down_Then_Up: v4.11.0-dev
-  tests/ffe/test_dynamic_evaluation.py::Test_FFE_First_Remote_Config_Request: v4.11.0-dev
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Unavailable: flaky (FFL-1622)
   tests/ffe/test_exposures.py: v4.2.0-dev
   tests/ffe/test_flag_eval_metrics.py: v4.8.0-dev

--- a/tests/ffe/test_dynamic_evaluation.py
+++ b/tests/ffe/test_dynamic_evaluation.py
@@ -83,6 +83,82 @@ class Test_FFE_First_Remote_Config_Request:
 
 @scenarios.feature_flagging_and_experimentation
 @features.feature_flags_dynamic_evaluation
+class Test_FFE_RC_Down_Then_Up:
+    """FFE must recover when RC is unavailable before the tracer receives flags.
+
+    This covers the startup race we care about: the app starts, the tracer cannot
+    get FFE config from the Agent/RC endpoint yet, and evaluations correctly use
+    defaults. Once RC becomes available and sends FFE_FLAGS, the same app must
+    start using the delivered flag value without a restart.
+    """
+
+    def setup_ffe_rc_down_then_up_recovers(self):
+        self.config_request_data = None
+        self.flag_key = "test-flag"
+        self.default_before_config = "default-before-config"
+        self.default_after_config = "default-after-config"
+
+        def wait_for_config_503(data: dict) -> bool:
+            if data["path"] == "/v0.7/config" and data["response"]["status_code"] == HTTPStatus.SERVICE_UNAVAILABLE:
+                self.config_request_data = data
+                return True
+            return False
+
+        StaticJsonMockedTracerResponse(
+            path="/v0.7/config", mocked_json={"error": "Service Unavailable"}, status_code=503
+        ).send()
+
+        interfaces.library.wait_for(wait_for_config_503, timeout=60)
+
+        self.default_eval = weblog.post(
+            "/ffe",
+            json={
+                "flag": self.flag_key,
+                "variationType": "STRING",
+                "defaultValue": self.default_before_config,
+                "targetingKey": "user-before-rc-recovery",
+                "attributes": {},
+            },
+        )
+
+        self.config_state = (
+            rc.tracer_rc_state.reset()
+            .set_config(f"{RC_PATH}/ffe-rc-down-then-up/config", UFC_FIXTURE_DATA)
+            .apply()
+        )
+
+        self.recovered_eval = weblog.post(
+            "/ffe",
+            json={
+                "flag": self.flag_key,
+                "variationType": "STRING",
+                "defaultValue": self.default_after_config,
+                "targetingKey": "user-after-rc-recovery",
+                "attributes": {},
+            },
+        )
+
+    def test_ffe_rc_down_then_up_recovers(self):
+        assert self.config_request_data is not None, "No /v0.7/config 503 response was captured"
+        assert self.config_request_data["response"]["status_code"] == HTTPStatus.SERVICE_UNAVAILABLE, (
+            f"Expected 503, got {self.config_request_data['response']['status_code']}"
+        )
+
+        assert self.default_eval.status_code == 200, f"Default evaluation failed: {self.default_eval.text}"
+        default_result = json.loads(self.default_eval.text)
+        assert default_result["value"] == self.default_before_config, (
+            f"Expected default before config recovery, got '{default_result['value']}'"
+        )
+
+        assert self.recovered_eval.status_code == 200, f"Recovered evaluation failed: {self.recovered_eval.text}"
+        recovered_result = json.loads(self.recovered_eval.text)
+        assert recovered_result["value"] == "on", (
+            f"Expected delivered flag value after config recovery, got '{recovered_result['value']}'"
+        )
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_dynamic_evaluation
 class Test_FFE_Unknown_Operator_Tolerance:
     """SDKs must ignore only the affected flag when a condition has an unknown operator.
 

--- a/tests/ffe/test_dynamic_evaluation.py
+++ b/tests/ffe/test_dynamic_evaluation.py
@@ -122,9 +122,7 @@ class Test_FFE_RC_Down_Then_Up:
         )
 
         self.config_state = (
-            rc.tracer_rc_state.reset()
-            .set_config(f"{RC_PATH}/ffe-rc-down-then-up/config", UFC_FIXTURE_DATA)
-            .apply()
+            rc.tracer_rc_state.reset().set_config(f"{RC_PATH}/ffe-rc-down-then-up/config", UFC_FIXTURE_DATA).apply()
         )
 
         self.recovered_eval = weblog.post(

--- a/tests/ffe/test_dynamic_evaluation.py
+++ b/tests/ffe/test_dynamic_evaluation.py
@@ -1,10 +1,12 @@
 """Test feature flags dynamic evaluation via Remote Config."""
 
+import base64
 import copy
 import json
 import uuid
 from http import HTTPStatus
 
+from utils.dd_constants import Capabilities
 from utils import (
     weblog,
     interfaces,
@@ -17,6 +19,11 @@ from utils.proxy.mocked_response import StaticJsonMockedTracerResponse
 
 RC_PRODUCT = "FFE_FLAGS"
 RC_PATH = f"datadog/2/{RC_PRODUCT}"
+
+
+def _decode_capabilities(capabilities: list[int] | str) -> int:
+    raw_capabilities = bytes(capabilities) if isinstance(capabilities, list) else base64.b64decode(capabilities)
+    return int.from_bytes(raw_capabilities, byteorder="big")
 
 
 # Simple UFC fixture for testing with doLog: true
@@ -41,6 +48,37 @@ UFC_FIXTURE_DATA = {
         }
     },
 }
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_dynamic_evaluation
+class Test_FFE_First_Remote_Config_Request:
+    """The tracer must subscribe to FFE on its first RC request.
+
+    This covers the warm-Agent case: the Agent can already be running without
+    any FFE cache, then a tracer starts. If the tracer only adds FFE on a later
+    RC poll, the Agent can miss the fast new-client backend fetch and the app
+    may keep default flag values during startup.
+    """
+
+    def test_first_remote_config_request_subscribes_to_ffe(self) -> None:
+        remote_config_requests = list(interfaces.library.get_data(path_filters="/v0.7/config"))
+        assert remote_config_requests, "Expected the tracer to send at least one remote config request"
+
+        first_request = remote_config_requests[0]
+        client = first_request["request"]["content"]["client"]
+        products = client.get("products", [])
+        assert RC_PRODUCT in products, (
+            f"Expected first remote config request to subscribe to {RC_PRODUCT}, got products={products}. "
+            "If FFE appears only on a later poll, an already-running Agent can miss its new-client backend fetch."
+        )
+
+        capabilities = client.get("capabilities")
+        assert capabilities is not None, "Expected first remote config request to include capabilities"
+        decoded_capabilities = _decode_capabilities(capabilities)
+        assert (decoded_capabilities >> Capabilities.FFE_FLAG_CONFIGURATION_RULES) & 1 == 1, (
+            f"Expected first remote config request to advertise {Capabilities.FFE_FLAG_CONFIGURATION_RULES.name}."
+        )
 
 
 @scenarios.feature_flagging_and_experimentation


### PR DESCRIPTION
## Motivation

Customers can have an Agent running for a long time before a tracer with Feature Flags enabled starts. In that shape, the Agent may not have an `FFE_FLAGS` cache yet. The tracer needs to advertise FFE on its first Remote Config request so the Agent can use the new-client backend fetch path immediately. If `FFE_FLAGS` only appears on a later poll, the application can keep serving default flag values during startup.

There is a second startup shape we also want covered: the app starts while the Agent/RC endpoint is unavailable, then the Agent comes online after the tracer has already made its first request. In that case the provider must recover without an app restart once `FFE_FLAGS` is delivered.

We observed different behavior and corrected the first-RC subscription path in the Java client: https://github.com/DataDog/dd-trace-java/pull/11465. This PR also exposed a Java provider readiness issue in the RC-down-then-up case; the fix is https://github.com/DataDog/dd-trace-java/pull/11474. The Go tracer is the reference shape for first-RC subscription: it subscribes FFE during tracer Remote Config startup in https://github.com/DataDog/dd-trace-go/blob/3ded6653e44aeb0d27bd5944e1e8033775473768/ddtrace/tracer/remote_config.go#L508-L512, and the OpenFeature bridge registers `FFE_FLAGS` with the FFE capability in https://github.com/DataDog/dd-trace-go/blob/3ded6653e44aeb0d27bd5944e1e8033775473768/internal/openfeature/rc_subscription.go#L42-L71.

## Changes

This adds shared FFE system-test coverage under the existing `FEATURE_FLAGGING_AND_EXPERIMENTATION` scenario.

`Test_FFE_First_Remote_Config_Request` checks the first tracer `/v0.7/config` request captured by the library interface. It requires the client product list to include `FFE_FLAGS`, and it requires the advertised capabilities to include `FFE_FLAG_CONFIGURATION_RULES`. The test intentionally has no setup call to `/ffe`, so it checks the startup Remote Config subscription, not a subscription that appears only after the first flag-evaluation endpoint is hit.

`Test_FFE_RC_Down_Then_Up` makes the recovery case obvious. The proxy first returns `503` for `/v0.7/config`; the test waits until the tracer sees that failure and verifies a flag evaluation returns the in-code default. Then the test restores Remote Config by publishing an `FFE_FLAGS` config and evaluates the same flag again. A recovered provider returns the delivered value, `on`; a provider stuck in the startup error state keeps returning the default and fails the test.

The manifests now keep the new assertions active where the behavior is implemented and mark observed gaps explicitly. Java is gated to `v1.63.0-SNAPSHOT` and depends on https://github.com/DataDog/dd-trace-java/pull/11474 for the recovery behavior. Python recovery is gated to `v4.11.0-dev`, while Python first-request subscription remains marked as `bug (FFL-2339)` until the dd-trace-py fix lands. Dotnet recovery is also marked as `bug (FFL-2339)` because the SDK currently returns `null` instead of the in-code default while RC is unavailable.

## Decisions

This is intentionally a cross-language system test, not a Java-only assertion. The bug shape is about the tracer/provider Remote Config contract: FFE must be subscribed early enough, and a provider that starts before config is available must still recover when config arrives later.

The recovery test simulates the Agent/RC outage through the system-tests proxy instead of physically stopping and starting the Agent container. That keeps the test focused on the behavior SDKs can control: first RC fetch fails, a later RC payload succeeds, and evaluations switch from defaults to the delivered flag value without restarting the app.
