### PR TITLE
Disable sending slack notif

### DIFF
--- a/.github/workflows/changelog-slack.yml
+++ b/.github/workflows/changelog-slack.yml
@@ -1,11 +1,12 @@
 name: Changelog Slack Notification
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'CHANGELOG.md'
+  workflow_dispatch:
+#   push:
+#     branches:
+#       - main
+#     paths:
+#       - 'CHANGELOG.md'
 
 jobs:
   notify-slack:


### PR DESCRIPTION
## Motivation

github is going crazy, and fires this action for no reason : https://github.com/DataDog/system-tests/actions/workflows/changelog-slack.yml

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
