### PR TITLE
[docker_ssi] activate test_injection_metadata

### DIFF
--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -7,7 +7,6 @@ from utils import (
     context,
     irrelevant,
     bug,
-    missing_feature,
     interfaces,
     weblog,
     logger,
@@ -164,7 +163,6 @@ class TestDockerSSIFeatures:
         self._setup_all()
 
     @features.ssi_injection_metadata
-    @missing_feature(reason="auto_inject#1075 adds early 'starting' injection-metadata event; not yet released")
     @irrelevant(context.library == "python" and context.installed_language_runtime < "3.8.0")
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.1")


### PR DESCRIPTION
## Motivation

The `@missing_feature` guard on `test_injection_metadata` was added while waiting for [auto_inject#1075](https://github.com/DataDog/auto_inject/pull/1075), which introduces the early `"starting"` injection-metadata event emitted by the injector. That change has since shipped, so the test now has the behavior it asserts against and the marker is no longer needed.

## Changes

- Remove the `@missing_feature(reason="auto_inject#1075 adds early 'starting' injection-metadata event; not yet released")` decorator from `TestDockerSSIFeatures.test_injection_metadata` in `tests/docker_ssi/test_docker_ssi.py`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)