### PR TITLE
Enable service override and process tags tests for ruby

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1969,7 +1969,12 @@ manifest:
         rails52: v2.33.0  # TODO: a lower version might be supported
   tests/integrations/test_mongo.py::Test_Mongo: missing_feature (Endpoint is not implemented on weblog)
   tests/integrations/test_otel_drop_in.py::Test_Otel_Drop_In: missing_feature
-  tests/integrations/test_service_overrides.py::Test_SqlServiceNameSource: irrelevant (Only implemented for Java)
+  tests/integrations/test_service_overrides.py::Test_SqlServiceNameSource:
+    - weblog_declaration:
+        "*": v2.35.0-dev
+        rack: irrelevant (endpoint not available)
+        sinatra14: irrelevant (endpoint not available)
+        sinatra22: irrelevant (endpoint not available)
   tests/integrations/test_sql.py::Test_Sql: missing_feature (Endpoint is not implemented on weblog)
   tests/k8s_lib_injection/test_k8s_lib_injection_appsec.py::TestK8sLibInjectionAppsecClusterEnabled: v2.0.0
   tests/k8s_lib_injection/test_k8s_lib_injection_appsec.py::TestK8sLibInjectionAppsecDisabledByDefault: v2.0.0
@@ -2277,13 +2282,11 @@ manifest:
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_Tags_Feb2024_Revision: v2.4.0
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_With_W3C: v2.4.0
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_With_W3C::test_distributed_headers_synthetics_sampling_decision: bug (APMAPI-1563)
-  tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature
-  tests/parametric/test_tracer.py::Test_TracerBaseService:  # TODO: a lower version might be supported
-    - declaration: missing_feature (_dd.base_service is not implemented)
-      component_version: <2.33.0
-  tests/parametric/test_tracer.py::Test_TracerBaseService::test_base_service_set_when_service_overridden: missing_feature (_dd.base_service is not implemented)
+  tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: v2.34.0
+  tests/parametric/test_tracer.py::Test_TracerBaseService: v2.34.0
   tests/parametric/test_tracer.py::Test_TracerSCITagging: v1.21.0
-  tests/parametric/test_tracer.py::Test_TracerServiceNameSource: irrelevant
+  tests/parametric/test_tracer.py::Test_TracerServiceNameSource: v2.35.0-dev
+  tests/parametric/test_tracer.py::Test_TracerServiceNameSource::test_tracer_srv_src_inherited_on_child_span: irrelevant (Ruby does not have service inheritance)
   tests/parametric/test_tracer.py::Test_TracerUniversalServiceTagging::test_tracer_service_name_environment_variable: "missing_feature (FIXME: library test client sets empty string as the service name)"
   tests/parametric/test_tracer_flare.py::TestTracerFlareV1: '>=2.27.0'  # Modified by easy win activation script
   tests/parametric/test_tracer_flare.py::TestTracerFlareV1::test_flare_log_level_order: missing_feature  # Created by easy win activation script

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1972,9 +1972,13 @@ manifest:
   tests/integrations/test_service_overrides.py::Test_SqlServiceNameSource:
     - weblog_declaration:
         "*": v2.35.0-dev
+        graphql23: irrelevant (endpoint not available)
         rack: irrelevant (endpoint not available)
         sinatra14: irrelevant (endpoint not available)
         sinatra22: irrelevant (endpoint not available)
+        sinatra32: irrelevant (endpoint not available)
+        sinatra41: irrelevant (endpoint not available)
+        uds-sinatra: irrelevant (endpoint not available)
   tests/integrations/test_sql.py::Test_Sql: missing_feature (Endpoint is not implemented on weblog)
   tests/k8s_lib_injection/test_k8s_lib_injection_appsec.py::TestK8sLibInjectionAppsecClusterEnabled: v2.0.0
   tests/k8s_lib_injection/test_k8s_lib_injection_appsec.py::TestK8sLibInjectionAppsecDisabledByDefault: v2.0.0


### PR DESCRIPTION
## Motivation

Enables test linked to service naming process tags and service source in tracing for ruby


## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
