### PR TITLE
Enable PHP FFE exposure system tests

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -606,7 +606,7 @@ manifest:
   tests/docker_ssi/test_docker_ssi_appsec.py::TestDockerSSIAppsecFeatures::test_telemetry_source_ssi: v1.8.3
   tests/docker_ssi/test_docker_ssi_crash.py::TestDockerSSICrash::test_crash: missing_feature (No implemented the endpoint /crashme)
   tests/ffe/test_dynamic_evaluation.py: v1.21.0-dev
-  tests/ffe/test_exposures.py: missing_feature
+  tests/ffe/test_exposures.py: v1.21.0-dev
   tests/ffe/test_flag_eval_metrics.py: missing_feature
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_kafka.py::Test_Kafka: missing_feature


### PR DESCRIPTION
## Motivation

PHP FFE exposure logging now lives in the native dd-trace-php/runtime path and needs the shared FFE exposure system tests enabled so regressions are caught outside local dogfooding.

Planning/reference doc: https://docs.google.com/document/d/1NvMfTpZWLBlFmEFNjdnlMyeVpy5l7KD8qujGFco6w2w/edit?tab=t.0

## Changes

This PR enables `tests/ffe/test_exposures.py` for PHP at `v1.21.0-dev`.

DataDog/system-tests#7003 has already merged to `main`, so this PR is now intentionally just one manifest activation on top of `main`. It does not enable FFE evaluation-metric tests; those belong to the separate metrics validation stack for DataDog/dd-trace-php#3911 and DataDog/system-tests#7033.

## Decisions

The scope is deliberately one manifest activation. The shared exposure tests already cover the required product behavior: event generation, multiple RC files, malformed/empty RC handling, same-subject deduplication, different-subject emission, allocation/variant changes, `doLog=false`, missing flags, and empty targeting keys.

The PHP behavior being validated here is implemented in DataDog/dd-trace-php#3910 and the sidecar delivery/cache support is implemented in DataDog/libdatadog#2026.

## Related PRs

- PHP runtime evaluation base: DataDog/dd-trace-php#3906
- PHP exposure implementation: DataDog/dd-trace-php#3910
- System-tests PHP FFE scaffold/evaluations base: DataDog/system-tests#7003
- Sidecar delivery/cache: DataDog/libdatadog#2026

## Validation

Current branch state after rebase onto `main`:

```text
$ PATH=/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH ./format.sh
All good, the system-tests CI will be happy!
```

Current PR diff is one file, enabling only `tests/ffe/test_exposures.py` for PHP at `v1.21.0-dev`.

Earlier local behavior validation for this activation used a matched PHP 8.2 NTS artifact and the `php-fpm-8.2` weblog:

```sh
TEST_LIBRARY=php \
WEBLOG_VARIANT=php-fpm-8.2 \
./run.sh +l php FEATURE_FLAGGING_AND_EXPERIMENTATION tests/ffe/test_exposures.py
```

Result: `11 passed in 78.22s`.
