### PR TITLE
Enable PHP FFE evaluation metric system tests

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -607,7 +607,7 @@ manifest:
   tests/docker_ssi/test_docker_ssi_crash.py::TestDockerSSICrash::test_crash: missing_feature (No implemented the endpoint /crashme)
   tests/ffe/test_dynamic_evaluation.py: v1.21.0-dev
   tests/ffe/test_exposures.py: v1.21.0-dev
-  tests/ffe/test_flag_eval_metrics.py: missing_feature
+  tests/ffe/test_flag_eval_metrics.py: v1.21.0-dev
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_kafka.py::Test_Kafka: missing_feature
   tests/integrations/crossed_integrations/test_kinesis.py::Test_Kinesis_PROPAGATION_VIA_MESSAGE_ATTRIBUTES: missing_feature


### PR DESCRIPTION
## Motivation

PHP FFE evaluation metrics are merged in DataDog/dd-trace-php#3911, so the shared system-test coverage should be enabled for PHP.

Design doc: https://docs.google.com/document/d/1NvMfTpZWLBlFmEFNjdnlMyeVpy5l7KD8qujGFco6w2w/edit?tab=t.0

## Changes

This PR enables `tests/ffe/test_flag_eval_metrics.py` for PHP at `v1.21.0-dev` in `manifests/php.yml`.

Scope is intentionally only evaluation metrics. PHP evaluation and exposure system-test activation are already separate, so this PR stays as the metric-validation layer.

## Decisions

The PR remains a manifest-only activation. The shared metric tests already cover successful evaluations, missing flags, malformed/empty RC payloads, disabled flags, type mismatches, targeting keys, and allocation metadata.

I checked the RC readiness concern locally. `RemoteConfigState.apply()` waits for the tracer RC ACK and then sleeps briefly; that ACK is not a formal guarantee that the PHP evaluator has installed the config. I did not add a new wait helper in this PR because the current suite passed against the merged PHP implementation. If this flakes in CI, the targeted follow-up is to wait for a successful `/ffe` evaluation before asserting metrics, not to broaden this PR.

`v1.21.0-dev` is kept as the activation floor. A prior CI run used `php@1.21.0+f4ff7b4c82f6f25bf6486b700a1ba27875d48e09`, which predates DataDog/dd-trace-php#3911 and therefore failed the metrics assertions. The PHP dev S3 `latest` artifact now points at the merged commit `1.21.0+87f1683bd2365ee388396502fc9ea9cd3a5d2e2e`.

## Related PRs

- PHP runtime evaluation base: DataDog/dd-trace-php#3906
- PHP metric implementation: DataDog/dd-trace-php#3911
- PHP evaluation system tests: DataDog/system-tests#7003
- PHP exposure system tests: DataDog/system-tests#7031
- Sidecar metric delivery: DataDog/libdatadog#2052

## Validation

Current pushed head: `2957e57b5`, including a normal signed merge of latest `origin/main`.

Confirmed PHP dev S3 latest now targets the merged metrics artifact:

```sh
curl -fsSL https://s3.us-east-1.amazonaws.com/dd-trace-php-builds/latest/datadog-setup.php \
  | rg "RELEASE_VERSION"
```

Result:

```text
define('RELEASE_VERSION', urlencode('1.21.0+87f1683bd2365ee388396502fc9ea9cd3a5d2e2e'));
```

Local Apple Silicon validation used the same S3 artifact. `utils/scripts/load-binary.sh php dev` requested `arm64-linux-gnu`, but PHP publishes the local ARM Linux artifact as `aarch64-linux-gnu`, so I fetched the matching tarball manually into `binaries/` and rebuilt the weblog with no cache.

```sh
DOCKER_HOST=unix:///Users/leo.romanovsky/.colima/default/docker.sock \
DOCKER_CONFIG=/tmp/system-tests-docker-config-nocredsstore \
TEST_LIBRARY=php \
WEBLOG_VARIANT=php-fpm-8.2 \
EXTRA_DOCKER_ARGS=--no-cache \
./utils/build/build.sh --library php --weblog-variant php-fpm-8.2 --images weblog
```

Forced local run:

```sh
DOCKER_HOST=unix:///Users/leo.romanovsky/.colima/default/docker.sock \
DOCKER_CONFIG=/tmp/system-tests-docker-config-nocredsstore \
TEST_LIBRARY=php \
WEBLOG_VARIANT=php-fpm-8.2 \
./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION \
  -F tests/ffe/test_flag_eval_metrics.py \
  tests/ffe/test_flag_eval_metrics.py
```

Context:

- Agent: `7.65.0`
- Backend: `datad0g.com`
- Library: `php@1.21.0+87f1683bd2365ee388396502fc9ea9cd3a5d2e2e`
- Weblog variant: `php-fpm-8.2`
- Weblog system: Linux arm64

Result: `17 passed in 81.79s`, exit code 0.

Local run notes:

- On this Apple Silicon machine, `datadog/agent:latest` crashed before tests started, so validation pinned the local ignored `binaries/agent-image` override to `datadog/agent:7.65.0`. That override was removed after validation and is not part of this PR.
