### PR TITLE
fix: remove tests checking telemetry otlp configs which can be sensitive

### DIFF
--- a/tests/parametric/test_otel_logs.py
+++ b/tests/parametric/test_otel_logs.py
@@ -653,7 +653,7 @@ class Test_FR11_Telemetry:
     """Test OTLP Logs generated via OpenTelemetry API generate telemetry configurations and metrics."""
 
     @pytest.mark.parametrize(
-        ("library_env", "test_agent_otlp_http_port"),
+        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
         [
             (
                 {
@@ -664,12 +664,14 @@ class Test_FR11_Telemetry:
                     "OTEL_EXPORTER_OTLP_HEADERS": "api-key=key,other-config-value=value",
                     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
                 },
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
                 4320,
             ),
         ],
     )
     def test_telemetry_exporter_configurations(
         self,
+        otlp_endpoint_library_env: dict[str, str],  # noqa: ARG002
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):
@@ -704,7 +706,7 @@ class Test_FR11_Telemetry:
             )
 
     @pytest.mark.parametrize(
-        ("library_env", "test_agent_otlp_http_port"),
+        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
         [
             (
                 {
@@ -715,12 +717,14 @@ class Test_FR11_Telemetry:
                     "OTEL_EXPORTER_OTLP_LOGS_HEADERS": "api-key=key,other-config-value=value",
                     "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": "http/protobuf",
                 },
+                "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
                 4325,
             ),
         ],
     )
     def test_telemetry_exporter_logs_configurations(
         self,
+        otlp_endpoint_library_env: dict[str, str],  # noqa: ARG002
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):

--- a/tests/parametric/test_otel_logs.py
+++ b/tests/parametric/test_otel_logs.py
@@ -653,7 +653,7 @@ class Test_FR11_Telemetry:
     """Test OTLP Logs generated via OpenTelemetry API generate telemetry configurations and metrics."""
 
     @pytest.mark.parametrize(
-        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
+        ("library_env", "test_agent_otlp_http_port"),
         [
             (
                 {
@@ -664,15 +664,12 @@ class Test_FR11_Telemetry:
                     "OTEL_EXPORTER_OTLP_HEADERS": "api-key=key,other-config-value=value",
                     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
                 },
-                "OTEL_EXPORTER_OTLP_ENDPOINT",
                 4320,
             ),
         ],
     )
     def test_telemetry_exporter_configurations(
         self,
-        library_env: dict[str, str],
-        otlp_endpoint_library_env: dict[str, str],  # noqa: ARG002
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):
@@ -688,9 +685,11 @@ class Test_FR11_Telemetry:
 
         for expected_env, expected_value in [
             ("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"),
-            ("OTEL_EXPORTER_OTLP_HEADERS", "api-key=key,other-config-value=value"),
+            # TODO: uncomment when redaction is implemented everywhere
+            # ("OTEL_EXPORTER_OTLP_HEADERS", "<redacted>"),
             ("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
-            ("OTEL_EXPORTER_OTLP_ENDPOINT", library_env["OTEL_EXPORTER_OTLP_ENDPOINT"]),
+            # TODO: uncomment when redaction is implemented everywhere
+            # ("OTEL_EXPORTER_OTLP_ENDPOINT",  "<redacted>"),
         ]:
             # Find configuration with env_var origin (since these are set via environment variables)
             config = test_agent.get_telemetry_config_by_origin(
@@ -705,7 +704,7 @@ class Test_FR11_Telemetry:
             )
 
     @pytest.mark.parametrize(
-        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
+        ("library_env", "test_agent_otlp_http_port"),
         [
             (
                 {
@@ -716,15 +715,12 @@ class Test_FR11_Telemetry:
                     "OTEL_EXPORTER_OTLP_LOGS_HEADERS": "api-key=key,other-config-value=value",
                     "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": "http/protobuf",
                 },
-                "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
                 4325,
             ),
         ],
     )
     def test_telemetry_exporter_logs_configurations(
         self,
-        library_env: dict[str, str],
-        otlp_endpoint_library_env: dict[str, str],  # noqa: ARG002
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):
@@ -747,9 +743,11 @@ class Test_FR11_Telemetry:
 
         for expected_env, expected_value in [
             ("OTEL_EXPORTER_OTLP_LOGS_TIMEOUT", "30000"),
-            ("OTEL_EXPORTER_OTLP_LOGS_HEADERS", "api-key=key,other-config-value=value"),
+            # TODO: uncomment when redaction is implemented everywhere
+            # ("OTEL_EXPORTER_OTLP_LOGS_HEADERS", "<redacted>"),
             ("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "http/protobuf"),
-            ("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", library_env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"]),
+            # TODO: uncomment when redaction is implemented everywhere
+            # ("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "<redacted>"),
         ]:
             # Find configuration with env_var origin (since these are set via environment variables)
             config = test_agent.get_telemetry_config_by_origin(

--- a/tests/parametric/test_otel_metrics.py
+++ b/tests/parametric/test_otel_metrics.py
@@ -1862,7 +1862,7 @@ class Test_Otel_Metrics_Telemetry:
             )
 
     @pytest.mark.parametrize(
-        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
+        ("library_env", "test_agent_otlp_http_port"),
         [
             (
                 {
@@ -1874,15 +1874,12 @@ class Test_Otel_Metrics_Telemetry:
                     "OTEL_METRIC_EXPORT_INTERVAL": "5000",
                     "OTEL_METRIC_EXPORT_TIMEOUT": "5000",
                 },
-                "OTEL_EXPORTER_OTLP_ENDPOINT",
                 4320,
             ),
         ],
     )
     def test_telemetry_exporter_configurations(
         self,
-        library_env: dict[str, str],
-        otlp_metrics_endpoint_library_env: dict[str, str],  # noqa: ARG002
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):
@@ -1900,9 +1897,11 @@ class Test_Otel_Metrics_Telemetry:
 
         for expected_env, expected_value in [
             ("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"),
-            ("OTEL_EXPORTER_OTLP_HEADERS", "api-key=key,other-config-value=value"),
+            # TODO: uncomment when redaction is implemented everywhere
+            # ("OTEL_EXPORTER_OTLP_HEADERS", "<redacted>"),
             ("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
-            ("OTEL_EXPORTER_OTLP_ENDPOINT", library_env["OTEL_EXPORTER_OTLP_ENDPOINT"]),
+            # TODO: uncomment when redaction is implemented everywhere
+            # ("OTEL_EXPORTER_OTLP_ENDPOINT", "<redacted>"),
             ("OTEL_METRIC_EXPORT_INTERVAL", "5000"),
             ("OTEL_METRIC_EXPORT_TIMEOUT", "5000"),
         ]:
@@ -1917,7 +1916,7 @@ class Test_Otel_Metrics_Telemetry:
             )
 
     @pytest.mark.parametrize(
-        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
+        ("library_env", "test_agent_otlp_http_port"),
         [
             (
                 {
@@ -1927,15 +1926,12 @@ class Test_Otel_Metrics_Telemetry:
                     "OTEL_EXPORTER_OTLP_METRICS_HEADERS": "api-key=key,other-config-value=value",
                     "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf",
                 },
-                "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
                 4325,
             ),
         ],
     )
     def test_telemetry_exporter_metrics_configurations(
         self,
-        library_env: dict[str, str],
-        otlp_metrics_endpoint_library_env: dict[str, str],  # noqa: ARG002
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):
@@ -1953,9 +1949,11 @@ class Test_Otel_Metrics_Telemetry:
 
         for expected_env, expected_value in [
             ("OTEL_EXPORTER_OTLP_METRICS_TIMEOUT", "30000"),
-            ("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "api-key=key,other-config-value=value"),
+            # TODO: uncomment when redaction is implemented everywhere
+            # ("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "<redacted>"),
             ("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "http/protobuf"),
-            ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", library_env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"]),
+            # TODO: uncomment when redaction is implemented everywhere
+            # ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "<redacted>"),
         ]:
             # Find configuration with env_var origin (since these are set via environment variables)
             config = test_agent.get_telemetry_config_by_origin(

--- a/tests/parametric/test_otel_metrics.py
+++ b/tests/parametric/test_otel_metrics.py
@@ -1862,7 +1862,7 @@ class Test_Otel_Metrics_Telemetry:
             )
 
     @pytest.mark.parametrize(
-        ("library_env", "test_agent_otlp_http_port"),
+        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
         [
             (
                 {
@@ -1874,12 +1874,14 @@ class Test_Otel_Metrics_Telemetry:
                     "OTEL_METRIC_EXPORT_INTERVAL": "5000",
                     "OTEL_METRIC_EXPORT_TIMEOUT": "5000",
                 },
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
                 4320,
             ),
         ],
     )
     def test_telemetry_exporter_configurations(
         self,
+        otlp_metrics_endpoint_library_env: dict[str, str],  # noqa: ARG002
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):
@@ -1916,7 +1918,7 @@ class Test_Otel_Metrics_Telemetry:
             )
 
     @pytest.mark.parametrize(
-        ("library_env", "test_agent_otlp_http_port"),
+        ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
         [
             (
                 {
@@ -1926,12 +1928,14 @@ class Test_Otel_Metrics_Telemetry:
                     "OTEL_EXPORTER_OTLP_METRICS_HEADERS": "api-key=key,other-config-value=value",
                     "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf",
                 },
+                "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
                 4325,
             ),
         ],
     )
     def test_telemetry_exporter_metrics_configurations(
         self,
+        otlp_metrics_endpoint_library_env: dict[str, str],  # noqa: ARG002
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):


### PR DESCRIPTION
# Motivation

We want to redact these values in libraries. These tests prevent these changes, but changing them outright will break libraries that haven't done the change

