### PR TITLE
[dotnet] Enable DBM dynamic_service tests

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -742,7 +742,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
-  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: irrelevant
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: v3.45.0
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64: missing_feature
   tests/integrations/test_dsm.py::Test_DsmContext_Injection_Base64: missing_feature
   tests/integrations/test_dsm.py::Test_DsmHttp: missing_feature

--- a/tests/integrations/test_dbm.py
+++ b/tests/integrations/test_dbm.py
@@ -465,6 +465,7 @@ class Test_Dbm_DynamicService_Postgres(_BaseDbmDynamicService):
         "java": "postgresql",
         "ruby": "pg",
         "php": "pdo-pgsql",
+        "dotnet": "npgsql",
     }
 
     @property

--- a/utils/build/docker/dotnet/weblog/Endpoints/StubDbmEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/StubDbmEndpoint.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Npgsql;
+
+namespace weblog
+{
+    public class StubDbmEndpoint : ISystemTestEndpoint
+    {
+        public void Register(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder routeBuilder)
+        {
+            routeBuilder.MapGet("/stub_dbm", async context =>
+            {
+                var integration = context.Request.Query["integration"].ToString();
+
+                if (integration == "npgsql")
+                {
+                    await using var connection = new NpgsqlConnection(Constants.NpgSqlConnectionString);
+                    await connection.OpenAsync();
+                    var command = new NpgsqlCommand("SELECT version()", connection);
+                    await command.ExecuteNonQueryAsync();
+                    // After execution the tracer has prepended the DBM comment into CommandText
+                    var injectedSql = command.CommandText;
+                    await connection.CloseAsync();
+
+                    context.Response.ContentType = "application/json";
+                    await context.Response.WriteAsync(
+                        JsonSerializer.Serialize(new { status = "ok", dbm_comment = injectedSql }));
+                }
+                else
+                {
+                    context.Response.StatusCode = 406;
+                    await context.Response.WriteAsync($"Unexpected Integration Name: {integration}");
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Adds a /stub_dbm endpoint to the dotnet weblog that executes an Npgsql query and returns the DBM-injected SQL comment as JSON as the other languages are doing. The tracer prepends the comment directly into command.CommandText, so reading it after execution is enough to capture the injected value.

Also enable the tests for the DBM dynamic mode. Please note that since the stub_dbm is not implemented we can follow up this PR by enabling also tests for the full mode (that looks uncovered)

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
