### PR TITLE
Add Attributes to OTLP Metrics Test

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4260,7 +4260,10 @@ manifest:
         play: irrelevant (integration injects Date header after bytecode injection occurs)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)
   tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_dd_metrics_are_absent: bug (APMAPI-1952)
-  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_otel_metrics_are_present_and_attributed: v1.63.0-SNAPSHOT
+  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_otel_metrics_are_present_and_attributed:
+    - weblog_declaration:
+        "*": v1.63.0-SNAPSHOT
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
   tests/test_profiling.py::Test_Profile:
     - weblog_declaration:
         akka-http: v1.22.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4260,7 +4260,7 @@ manifest:
         play: irrelevant (integration injects Date header after bytecode injection occurs)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)
   tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_dd_metrics_are_absent: bug (APMAPI-1952)
-  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_otel_metrics_are_present_and_attributed: v1.63.0
+  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_otel_metrics_are_present_and_attributed: v1.63.0-SNAPSHOT
   tests/test_profiling.py::Test_Profile:
     - weblog_declaration:
         akka-http: v1.22.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4260,7 +4260,7 @@ manifest:
         play: irrelevant (integration injects Date header after bytecode injection occurs)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)
   tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_dd_metrics_are_absent: bug (APMAPI-1952)
-  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_otel_metrics_are_present: missing_feature
+  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics::test_otel_metrics_are_present_and_attributed: v1.63.0
   tests/test_profiling.py::Test_Profile:
     - weblog_declaration:
         akka-http: v1.22.0

--- a/tests/test_otlp_runtime_metrics.py
+++ b/tests/test_otlp_runtime_metrics.py
@@ -9,76 +9,177 @@ runtime.go.*, runtime.node.*, etc.).
 from utils import context, features, interfaces, scenarios, weblog
 
 
-# All OTel semconv metric names that MUST be present per language.
-# These are the complete instrument sets from each tracer's OTLP runtime metrics implementation.
-EXPECTED_METRICS = {
-    "dotnet": [
-        "dotnet.assembly.count",
-        "dotnet.exceptions",
-        "dotnet.gc.collections",
-        "dotnet.gc.heap.total_allocated",
-        "dotnet.gc.last_collection.heap.fragmentation.size",
-        "dotnet.gc.last_collection.heap.size",
-        "dotnet.gc.last_collection.memory.committed_size",
-        "dotnet.gc.pause.time",
-        "dotnet.jit.compilation.time",
-        "dotnet.jit.compiled_il.size",
-        "dotnet.jit.compiled_methods",
-        "dotnet.monitor.lock_contentions",
-        "dotnet.process.cpu.count",
-        "dotnet.process.cpu.time",
-        "dotnet.process.memory.working_set",
-        "dotnet.thread_pool.queue.length",
-        "dotnet.thread_pool.thread.count",
-        "dotnet.thread_pool.work_item.count",
-        "dotnet.timer.count",
-    ],
-    "golang": [
-        "go.config.gogc",
-        "go.goroutine.count",
-        "go.memory.allocated",
-        "go.memory.allocations",
-        "go.memory.gc.goal",
-        "go.memory.limit",
-        "go.memory.used",
-        "go.processor.limit",
-    ],
-    "nodejs": [
-        "nodejs.eventloop.delay.max",
-        "nodejs.eventloop.delay.mean",
-        "nodejs.eventloop.delay.min",
-        "nodejs.eventloop.delay.p50",
-        "nodejs.eventloop.delay.p90",
-        "nodejs.eventloop.delay.p99",
-        "nodejs.eventloop.utilization",
-        "process.cpu.utilization",
-        "process.memory.usage",
-        "v8js.memory.heap.limit",
-        "v8js.memory.heap.space.available_size",
-        "v8js.memory.heap.space.physical_size",
-        "v8js.memory.heap.used",
-    ],
-    "java": [
-        "jvm.buffer.count",
-        "jvm.buffer.memory.limit",
-        "jvm.buffer.memory.used",
-        "jvm.class.count",
-        "jvm.class.loaded",
-        "jvm.class.unloaded",
-        "jvm.cpu.count",
-        "jvm.cpu.recent_utilization",
-        "jvm.cpu.time",
-        "jvm.memory.committed",
-        "jvm.memory.init",
-        "jvm.memory.limit",
-        "jvm.memory.used",
-        "jvm.memory.used_after_last_gc",
-        "jvm.thread.count",
-    ],
+# Maps each expected metric to its attribute constraints:
+#   "all"  — attribute keys that must appear on every emitted data point.
+#   "some" — attribute keys that must appear on at least one data point.
+#
+# Use "some" when a metric emits both per-dimension points (which carry the attribute)
+# and aggregate rollup points (which don't). For example, jvm.memory.used emits one
+# point per memory pool (with jvm.memory.pool.name) as well as heap/non-heap totals
+# (without it), so pool.name goes in "some" while jvm.memory.type, which is present
+# on every point, goes in "all".
+EXPECTED_METRICS: dict[str, dict[str, dict[str, list[str]]]] = {
+    "dotnet": {
+        "dotnet.assembly.count": {"all": []},
+        "dotnet.exceptions": {"all": []},
+        "dotnet.gc.collections": {"all": []},
+        "dotnet.gc.heap.total_allocated": {"all": []},
+        "dotnet.gc.last_collection.heap.fragmentation.size": {"all": []},
+        "dotnet.gc.last_collection.heap.size": {"all": []},
+        "dotnet.gc.last_collection.memory.committed_size": {"all": []},
+        "dotnet.gc.pause.time": {"all": []},
+        "dotnet.jit.compilation.time": {"all": []},
+        "dotnet.jit.compiled_il.size": {"all": []},
+        "dotnet.jit.compiled_methods": {"all": []},
+        "dotnet.monitor.lock_contentions": {"all": []},
+        "dotnet.process.cpu.count": {"all": []},
+        "dotnet.process.cpu.time": {"all": []},
+        "dotnet.process.memory.working_set": {"all": []},
+        "dotnet.thread_pool.queue.length": {"all": []},
+        "dotnet.thread_pool.thread.count": {"all": []},
+        "dotnet.thread_pool.work_item.count": {"all": []},
+        "dotnet.timer.count": {"all": []},
+    },
+    "golang": {
+        "go.config.gogc": {"all": []},
+        "go.goroutine.count": {"all": []},
+        "go.memory.allocated": {"all": []},
+        "go.memory.allocations": {"all": []},
+        "go.memory.gc.goal": {"all": []},
+        "go.memory.limit": {"all": []},
+        "go.memory.used": {"all": []},
+        "go.processor.limit": {"all": []},
+    },
+    "nodejs": {
+        "nodejs.eventloop.delay.max": {"all": []},
+        "nodejs.eventloop.delay.mean": {"all": []},
+        "nodejs.eventloop.delay.min": {"all": []},
+        "nodejs.eventloop.delay.p50": {"all": []},
+        "nodejs.eventloop.delay.p90": {"all": []},
+        "nodejs.eventloop.delay.p99": {"all": []},
+        "nodejs.eventloop.utilization": {"all": []},
+        "process.cpu.utilization": {"all": []},
+        "process.memory.usage": {"all": []},
+        "v8js.memory.heap.limit": {"all": []},
+        "v8js.memory.heap.space.available_size": {"all": []},
+        "v8js.memory.heap.space.physical_size": {"all": []},
+        "v8js.memory.heap.used": {"all": []},
+    },
+    "java": {
+        "jvm.buffer.count": {"all": ["jvm.buffer.pool.name"]},
+        "jvm.buffer.memory.limit": {"all": ["jvm.buffer.pool.name"]},
+        "jvm.buffer.memory.used": {"all": ["jvm.buffer.pool.name"]},
+        "jvm.class.count": {"all": []},
+        "jvm.class.loaded": {"all": []},
+        "jvm.class.unloaded": {"all": []},
+        "jvm.cpu.count": {"all": []},
+        "jvm.cpu.recent_utilization": {"all": []},
+        "jvm.cpu.time": {"all": []},
+        # jvm.gc.duration is a histogram; the agent surfaces it as .count/.sum/.min/.max series.
+        "jvm.gc.duration.count": {"all": ["jvm.gc.name", "jvm.gc.action", "jvm.gc.cause"]},
+        "jvm.gc.duration.sum": {"all": ["jvm.gc.name", "jvm.gc.action", "jvm.gc.cause"]},
+        "jvm.gc.duration.min": {"all": ["jvm.gc.name", "jvm.gc.action", "jvm.gc.cause"]},
+        "jvm.gc.duration.max": {"all": ["jvm.gc.name", "jvm.gc.action", "jvm.gc.cause"]},
+        # memory metrics emit per-pool points (with pool.name) and aggregate totals (without),
+        # so jvm.memory.type is required on all points and pool.name on at least one.
+        "jvm.memory.committed": {"all": ["jvm.memory.type"], "some": ["jvm.memory.pool.name"]},
+        "jvm.memory.init": {"all": ["jvm.memory.type"], "some": ["jvm.memory.pool.name"]},
+        "jvm.memory.limit": {"all": ["jvm.memory.type"], "some": ["jvm.memory.pool.name"]},
+        "jvm.memory.used": {"all": ["jvm.memory.type"], "some": ["jvm.memory.pool.name"]},
+        # used_after_last_gc only emits per-pool points — both attributes are always present.
+        "jvm.memory.used_after_last_gc": {"all": ["jvm.memory.pool.name", "jvm.memory.type"]},
+        "jvm.thread.count": {"all": ["jvm.thread.daemon", "jvm.thread.state"]},
+        # experimental metrics (on by default); no domain-specific attributes.
+        "jvm.system.cpu.utilization": {"all": []},
+        "jvm.system.cpu.load_1m": {"all": []},
+        "jvm.file_descriptor.count": {"all": []},
+        "jvm.file_descriptor.limit": {"all": []},
+    },
 }
 
-# DD-proprietary prefixes that should NOT appear when OTLP metrics are active
-DD_PROPRIETARY_PREFIXES = {
+# Valid value domains for attributes. For closed enums (jvm.memory.type, jvm.thread.*) these are
+# exhaustive. For open-ended attributes (pool names, GC names) these are supersets covering all
+# known JVM/GC implementations — the assertion is that observed values fall within the known universe.
+EXPECTED_METRIC_ATTRIBUTE_VALUES: dict[str, dict[str, frozenset[str]]] = {
+    "java": {
+        "jvm.memory.type": frozenset({"heap", "non_heap"}),
+        "jvm.thread.daemon": frozenset({"true", "false"}),
+        "jvm.thread.state": frozenset({"new", "runnable", "blocked", "waiting", "timed_waiting", "terminated"}),
+        # Pool names vary by GC algorithm; superset across G1GC, ZGC, Shenandoah, ParallelGC, SerialGC, CMS.
+        # Values are emitted as raw JMX strings (mixed case, spaces, quotes preserved).
+        "jvm.memory.pool.name": frozenset(
+            {
+                # G1GC
+                "G1 Eden Space",
+                "G1 Survivor Space",
+                "G1 Old Gen",
+                # ZGC
+                "ZHeap",
+                # Shenandoah
+                "Shenandoah",
+                # ParallelGC
+                "PS Eden Space",
+                "PS Survivor Space",
+                "PS Old Gen",
+                # SerialGC / CMS young
+                "Eden Space",
+                "Survivor Space",
+                # SerialGC old
+                "Tenured Gen",
+                # CMS
+                "Par Eden Space",
+                "Par Survivor Space",
+                "CMS Old Gen",
+                # Non-heap regions common across all GCs
+                "Metaspace",
+                "Compressed Class Space",
+                # Code Cache (monolithic, JDK < 9 or -XX:-SegmentedCodeCache)
+                "Code Cache",
+                # Segmented Code Cache (JDK 9+)
+                "CodeHeap 'non-nmethods'",
+                "CodeHeap 'profiled nmethods'",
+                "CodeHeap 'non-profiled nmethods'",
+            }
+        ),
+        # Buffer pool names are stable across JVM versions.
+        "jvm.buffer.pool.name": frozenset(
+            {
+                "direct",
+                "mapped",
+                "mapped - 'non-volatile memory'",  # JDK 14+ non-volatile MappedByteBuffer
+            }
+        ),
+        # GC collector names vary by algorithm.
+        "jvm.gc.name": frozenset(
+            {
+                # G1GC
+                "G1 Young Generation",
+                "G1 Old Generation",
+                "G1 Concurrent GC",
+                # ZGC
+                "ZGC",
+                "ZGC Pauses",
+                "ZGC Cycles",
+                # Shenandoah
+                "Shenandoah Cycles",
+                "Shenandoah Pauses",
+                # ParallelGC
+                "PS Scavenge",
+                "PS MarkSweep",
+                # SerialGC
+                "Copy",
+                "MarkSweepCompact",
+                # CMS (deprecated but still encountered)
+                "ParNew",
+                "ConcurrentMarkSweep",
+            }
+        ),
+        "jvm.gc.action": frozenset({"end of minor GC", "end of major GC", "end of GC cycle"}),
+    },
+}
+
+# DD-proprietary prefixes that should NOT appear when OTLP metrics are active.
+DD_PROPRIETARY_PREFIXES: dict[str, str] = {
     "dotnet": "runtime.dotnet.",
     "golang": "runtime.go.",
     "nodejs": "runtime.node.",
@@ -86,16 +187,18 @@ DD_PROPRIETARY_PREFIXES = {
 }
 
 
-def get_runtime_metric_names():
-    """Extract runtime metric names from the agent interface (agent -> backend series).
+def get_runtime_metrics_by_name() -> dict[str, list[dict[str, str]]]:
+    """Return observed runtime metrics grouped by name.
 
-    Uses interfaces.agent.get_metrics() — the same approach as
-    Test_Config_RuntimeMetrics_Enabled in test_config_consistency.py.
+    Each entry maps metric name -> list of tag dicts, one per data point.
+    Tags are parsed from "key:value" strings in the agent series.
     """
-    metric_names = set()
+    result: dict[str, list[dict[str, str]]] = {}
     for _, metric in interfaces.agent.get_metrics():
-        metric_names.add(metric["metric"])
-    return metric_names
+        name: str = metric["metric"]
+        tags: dict[str, str] = dict(tag.split(":", 1) for tag in metric.get("tags", []) if ":" in tag)
+        result.setdefault(name, []).append(tags)
+    return result
 
 
 @scenarios.otlp_runtime_metrics
@@ -103,29 +206,58 @@ def get_runtime_metric_names():
 class Test_OtlpRuntimeMetrics:
     """Verify runtime metrics are sent via OTLP with OTel names, not DD-proprietary names."""
 
-    def setup_otel_metrics_are_present(self):
+    def setup_otel_metrics_are_present_and_attributed(self) -> None:
         self.req = weblog.get("/")
 
-    def test_otel_metrics_are_present(self):
+    def test_otel_metrics_are_present_and_attributed(self) -> None:
         assert self.req.status_code == 200
 
         library = context.library.name
         if library not in EXPECTED_METRICS:
             return
 
-        metric_names = get_runtime_metric_names()
+        observed = get_runtime_metrics_by_name()
+        attribute_values = EXPECTED_METRIC_ATTRIBUTE_VALUES.get(library, {})
 
-        expected = EXPECTED_METRICS[library]
-        for expected_name in expected:
-            assert expected_name in metric_names, (
-                f"Expected OTel runtime metric '{expected_name}' not found for {library}. "
-                f"Got metrics: {sorted(metric_names)}"
+        for metric_name, constraints in EXPECTED_METRICS[library].items():
+            assert metric_name in observed, (
+                f"Expected OTel runtime metric '{metric_name}' not found for {library}. "
+                f"Got metrics: {sorted(observed.keys())}"
             )
 
-    def setup_dd_metrics_are_absent(self):
+            points = observed[metric_name]
+            all_keys = constraints.get("all", [])
+            some_keys = constraints.get("some", [])
+
+            for point_tags in points:
+                for key in all_keys:
+                    assert key in point_tags, (
+                        f"Metric '{metric_name}' data point missing required attribute '{key}' "
+                        f"for {library}. Got tags: {point_tags}"
+                    )
+                    if key in attribute_values:
+                        assert point_tags[key] in attribute_values[key], (
+                            f"Metric '{metric_name}' attribute '{key}' has invalid value "
+                            f"'{point_tags[key]}' for {library}. "
+                            f"Expected one of: {sorted(attribute_values[key])}"
+                        )
+
+            for key in some_keys:
+                assert any(key in point_tags for point_tags in points), (
+                    f"Metric '{metric_name}' has no data point with attribute '{key}' for {library}."
+                )
+                for point_tags in points:
+                    if key in point_tags and key in attribute_values:
+                        assert point_tags[key] in attribute_values[key], (
+                            f"Metric '{metric_name}' attribute '{key}' has invalid value "
+                            f"'{point_tags[key]}' for {library}. "
+                            f"Expected one of: {sorted(attribute_values[key])}"
+                        )
+
+    def setup_dd_metrics_are_absent(self) -> None:
         self.req = weblog.get("/")
 
-    def test_dd_metrics_are_absent(self):
+    def test_dd_metrics_are_absent(self) -> None:
         assert self.req.status_code == 200
 
         library = context.library.name
@@ -133,9 +265,8 @@ class Test_OtlpRuntimeMetrics:
         if not dd_prefix:
             return
 
-        metric_names = get_runtime_metric_names()
-
-        dd_named_metrics = [n for n in metric_names if n.startswith(dd_prefix)]
+        observed = get_runtime_metrics_by_name()
+        dd_named_metrics = [n for n in observed if n.startswith(dd_prefix)]
         assert len(dd_named_metrics) == 0, (
             f"Found DD-proprietary metric names for {library}: {dd_named_metrics}. Expected OTel-native names only."
         )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -1234,6 +1234,7 @@ class _Scenarios:
         "OTLP_RUNTIME_METRICS",
         weblog_env={
             "DD_METRICS_OTEL_ENABLED": "true",
+            "DD_DOGSTATSD_START_DELAY": "0",
             "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
             "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": f"http://proxy:{ProxyPorts.open_telemetry_weblog}/v1/metrics",
             "OTEL_EXPORTER_OTLP_METRICS_HEADERS": "dd-protocol=otlp,dd-otlp-path=agent",


### PR DESCRIPTION
## Motivation
This PR adds Attributes to OTLP Metrics tests. It sets the framework for metric testing w/ Attributes and implements JVM Metric Attributes. The other languages are left empty so the test result remains the same as before, and language experts can add in the correct attributes.

This PR also adds validation for extra metrics from this Java [PR](https://github.com/DataDog/dd-trace-java/pull/11411), and enables the test for the correct Java version.
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
