### PR TITLE
Bump testagent version to unblock LLMObs - APM convergence

### DIFF
--- a/utils/_context/_scenarios/integration_frameworks.py
+++ b/utils/_context/_scenarios/integration_frameworks.py
@@ -30,7 +30,7 @@ class IntegrationFrameworksScenario(DockerFixturesScenario):
             name,
             doc=doc,
             github_workflow="endtoend",
-            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.42.0",
+            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:dev-llmobs-meta-struct",
             scenario_groups=(groups.integration_frameworks,),
         )
 

--- a/utils/_context/_scenarios/integration_frameworks.py
+++ b/utils/_context/_scenarios/integration_frameworks.py
@@ -30,7 +30,7 @@ class IntegrationFrameworksScenario(DockerFixturesScenario):
             name,
             doc=doc,
             github_workflow="endtoend",
-            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:dev-llmobs-meta-struct",
+            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.59.0",
             scenario_groups=(groups.integration_frameworks,),
         )
 

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -63,7 +63,7 @@ class ParametricScenario(DockerFixturesScenario):
             name,
             doc=doc,
             github_workflow="parametric",
-            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:dev-llmobs-meta-struct",
+            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.59.0",
         )
         self._parametric_tests_confs = ParametricScenario.PersistentParametricTestConf(self)
 

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -63,7 +63,7 @@ class ParametricScenario(DockerFixturesScenario):
             name,
             doc=doc,
             github_workflow="parametric",
-            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.42.0",
+            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:dev-llmobs-meta-struct",
         )
         self._parametric_tests_confs = ParametricScenario.PersistentParametricTestConf(self)
 

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1490,7 +1490,7 @@ class VCRCassettesContainer(TestedContainer):
 
     def __init__(self, vcr_port: int = ContainerPorts.vcr_cassettes) -> None:
         super().__init__(
-            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.39.0",
+            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:dev-llmobs-meta-struct",
             name="vcr_cassettes",
             environment={
                 "PORT": str(vcr_port),

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1490,7 +1490,7 @@ class VCRCassettesContainer(TestedContainer):
 
     def __init__(self, vcr_port: int = ContainerPorts.vcr_cassettes) -> None:
         super().__init__(
-            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:dev-llmobs-meta-struct",
+            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.59.0",
             name="vcr_cassettes",
             environment={
                 "PORT": str(vcr_port),


### PR DESCRIPTION
## Summary

* **dd-trace-py PR [[#18254](https://github.com/DataDog/dd-trace-py/pull/18254)](https://github.com/DataDog/dd-trace-py/pull/18254)** (`munir/agentbased-llmo`, commit `0829a33`) — agent-based LLMObs export, where LLMObs payloads ride APM traces via `meta_struct["_llmobs"]` for kept traces.
* **dd-apm-test-agent `1.59.0`** — includes support for extracting/synthesizing EVP LLMObs requests from `meta_struct`, which unblocks validation of the dd-trace-py PR.

## Changes

Bump the test agent version to **`1.59.0`** across all LLM-adjacent surfaces:

* `INTEGRATION_FRAMEWORKS` — anthropic / openai / google_genai LLMObs tests.
* `PARAMETRIC` — covers `tests/parametric/test_llm_observability/`.
* `VCRCassettesContainer` — backs `INTEGRATION_FRAMEWORKS`, `AI_GUARD`, and `AI_GUARD_TELEMETRY`.

Other scenarios remain unchanged.

## Why this is needed

dd-trace-py PR [[#18254](https://github.com/DataDog/dd-trace-py/pull/18254)](https://github.com/DataDog/dd-trace-py/pull/18254) sends LLMObs payloads through APM traces using `meta_struct["_llmobs"]` for kept traces. System-tests needs a test agent version that understands this payload shape and can synthesize the corresponding EVP LLMObs requests.

Bumping the test agent to **`1.59.0`** provides that support and unblocks the dd-trace-py PR.

## Test plan

* [x] `INTEGRATION_FRAMEWORKS` LLMObs suites pass in CI against the tracer commit + test agent `1.59.0`
* [x] `PARAMETRIC` LLMObs tests pass
* [x] `AI_GUARD` / `AI_GUARD_TELEMETRY` pass
* [x] No unexpected regressions in other scenarios