### PR TITLE
fix: use exponential backoff when retrying docker compose pull

### DIFF
--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -76,8 +76,7 @@ runs:
     - name: Pull
       shell: bash
       run: |
-        max_attempts=3
-        retry_wait_seconds=10
+        max_attempts=5
         timeout_seconds=900
         attempt=1
         while true; do
@@ -92,6 +91,8 @@ runs:
             exit 1
           fi
 
+          # Exponential backoff: 30s, 60s, 120s, 240s
+          retry_wait_seconds=$(( 30 * (1 << (attempt - 1)) ))
           echo "docker compose pull failed (attempt ${attempt}/${max_attempts}), retrying in ${retry_wait_seconds}s..."
           sleep "${retry_wait_seconds}"
           attempt=$((attempt + 1))


### PR DESCRIPTION
## Summary

- Docker Hub's auth endpoint (`auth.docker.io`) occasionally times out from GitHub Actions runners, causing `docker compose pull` to fail
- Increases max retry attempts from 3 to 5
- Replaces flat 10s wait with exponential backoff: 30s → 60s → 120s → 240s

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Monitor for reduced Docker Hub pull failures in tracer library CI runs

---

> Generated by [Claude Code](https://claude.com/claude-code)