### PR TITLE
Fix _get_ci_repo_name for azure

### DIFF
--- a/utils/_features.py
+++ b/utils/_features.py
@@ -18,7 +18,7 @@ def _get_ci_repo_name() -> str | None:
         return repo
     # Azure Pipelines
     if repo := os.environ.get("BUILD_REPOSITORY_NAME"):
-        return repo
+        return repo.split("/")[-1]
     return None
 
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

Fixed. BUILD_REPOSITORY_NAME on Azure Pipelines for GitHub-connected repos returns owner/repo, so it now gets the same .split("/")[-1] treatment as GITHUB_REPOSITORY, allowing repo_overrides lookups to
  match correctly.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
