### PR TITLE
feat(java): move Jetty download into prebuilt base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
       _build_proxy_image: ${{ contains(github.event.pull_request.labels.*.name, 'build-proxy-image') }}
       _build_python_base_images: ${{ contains(github.event.pull_request.labels.*.name, 'build-python-base-images') }}
       _build_php_base_images: ${{ contains(github.event.pull_request.labels.*.name, 'build-php-base-images') }}
+      _build_java_base_images: ${{ contains(github.event.pull_request.labels.*.name, 'build-java-base-images') }}
       _enable_replay_scenarios: true
       _system_tests_dev_mode: ${{ matrix.version == 'dev' }}
       _system_tests_library_target_branch_map: ${{ needs.compute_libraries_and_scenarios.outputs.target-branch-map }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -54,6 +54,11 @@ on:
         default: false
         required: false
         type: boolean
+      _build_java_base_images:
+        description: "Shall we build Java base images for tests on Java tracer"
+        default: false
+        required: false
+        type: boolean
       _build_buddies_images:
         description: "Shall we build buddies images"
         default: false
@@ -236,6 +241,10 @@ jobs:
         if: inputs.library == 'php' && inputs._build_php_base_images
         run: |
           ./utils/build/build_php_base_images.sh
+      - name: Build java weblog base images
+        if: inputs.library == 'java' && inputs._build_java_base_images
+        run: |
+          ./utils/build/build_java_base_images.sh
       - name: Build weblog
         id: build
         run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh ${{ inputs.library }} -i weblog -w ${{ matrix.weblog.name }} -s --github-token-file "$RUNNER_TEMP/github_token.txt"

--- a/docs/edit/update-docker-images.md
+++ b/docs/edit/update-docker-images.md
@@ -7,4 +7,5 @@ If you need to update them, you will need to follow those
   * `build-python-base-images` for python weblogs
   * `build-php-base-images` for PHP weblogs
   * `build-proxy-image` for proxy image
+  * `build-java-base-images` for Java weblog base images
 3. just before merging your PR, ping somebody from Reliability & Performance team to push your image to hub.docker.com (`#apm-shared-testing` on slack)

--- a/docs/edit/update-docker-images.md
+++ b/docs/edit/update-docker-images.md
@@ -4,8 +4,8 @@ If you need to update them, you will need to follow those
 
 1. update the version in the tag for the image you've just modified (there should be 3 or 4 occurences in the code)
 2. create your PR, and add the relevant label to rebuild the image in the CI
+  * `build-java-base-images` for Java weblog base images
   * `build-python-base-images` for python weblogs
   * `build-php-base-images` for PHP weblogs
   * `build-proxy-image` for proxy image
-  * `build-java-base-images` for Java weblog base images
 3. just before merging your PR, ping somebody from Reliability & Performance team to push your image to hub.docker.com (`#apm-shared-testing` on slack)

--- a/utils/build/build_java_base_images.sh
+++ b/utils/build/build_java_base_images.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$1" = "--push" ]; then
+    exec docker buildx bake --progress=plain -f "utils/build/docker/java/docker-bake.hcl" "$@"
+else
+    exec docker buildx bake --progress=plain --load -f "utils/build/docker/java/docker-bake.hcl" "$@"
+fi

--- a/utils/build/docker/java/docker-bake.hcl
+++ b/utils/build/docker/java/docker-bake.hcl
@@ -7,6 +7,6 @@ group "default" {
 target "java-jetty-classpath" {
   context    = "."
   dockerfile = "utils/build/docker/java/jetty-classpath.base.Dockerfile"
-  args       = { JETTY_VERSION = "9.4.56.v20240826" }
-  tags       = ["datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1"]
+  args       = { JETTY_VERSION = "9.4.58.v20250814" }
+  tags       = ["datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1"]
 }

--- a/utils/build/docker/java/docker-bake.hcl
+++ b/utils/build/docker/java/docker-bake.hcl
@@ -1,0 +1,12 @@
+# Docker Buildx bake file for Java base images
+
+group "default" {
+  targets = ["java-jetty-classpath"]
+}
+
+target "java-jetty-classpath" {
+  context    = "."
+  dockerfile = "utils/build/docker/java/jetty-classpath.base.Dockerfile"
+  args       = { JETTY_VERSION = "9.4.56.v20240826" }
+  tags       = ["datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1"]
+}

--- a/utils/build/docker/java/jetty-classpath.base.Dockerfile
+++ b/utils/build/docker/java/jetty-classpath.base.Dockerfile
@@ -1,0 +1,22 @@
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
+
+ARG JETTY_VERSION=9.4.56.v20240826
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl findutils tar \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    JETTY_FILE="jetty-distribution-${JETTY_VERSION}.tar.gz"; \
+    JETTY_URL="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${JETTY_VERSION}/${JETTY_FILE}"; \
+    curl -fsSL \
+      --retry 5 \
+      --retry-delay 5 \
+      --retry-connrefused \
+      -o "/tmp/${JETTY_FILE}" \
+      "${JETTY_URL}"; \
+    mkdir -p /opt/jetty-classpath; \
+    tar -xzf "/tmp/${JETTY_FILE}" -C /tmp; \
+    find "/tmp/jetty-distribution-${JETTY_VERSION}/lib" -iname '*.jar' -exec cp {} /opt/jetty-classpath/ \;; \
+    rm -f /opt/jetty-classpath/jetty-jaspi*; \
+    rm -rf "/tmp/${JETTY_FILE}" "/tmp/jetty-distribution-${JETTY_VERSION}"

--- a/utils/build/docker/java/jetty-classpath.base.Dockerfile
+++ b/utils/build/docker/java/jetty-classpath.base.Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/docker/library/debian:bookworm-slim
 
-ARG JETTY_VERSION=9.4.56.v20240826
+ARG JETTY_VERSION=9.4.58.v20250814
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl findutils tar \

--- a/utils/build/ssi/java/jetty-app.Dockerfile
+++ b/utils/build/ssi/java/jetty-app.Dockerfile
@@ -1,18 +1,14 @@
 #syntax=docker/dockerfile:1.4
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
 ARG BASE_IMAGE
+
+FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
 
 FROM ${BASE_IMAGE}
 
-RUN wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.56.v20240826/jetty-distribution-9.4.56.v20240826.tar.gz
-RUN tar -xvf jetty-distribution-9.4.56.v20240826.tar.gz
-
-RUN mkdir -p jetty-classpath
-RUN find jetty-distribution-9.4.56.v20240826/lib -iname '*.jar' -exec cp \{\} jetty-classpath/ \;
-
-# Causes ClassNotFound exceptions https://github.com/jetty/jetty.project/issues/4746
-RUN rm jetty-classpath/jetty-jaspi*
+COPY --from=jetty_classpath /opt/jetty-classpath /opt/jetty-classpath
 
 COPY lib-injection/build/docker/java/jetty-app/ .
-RUN javac -cp "jetty-classpath/*" JettyServletMain.java CrashServlet.java
+RUN javac -cp "/opt/jetty-classpath/*" JettyServletMain.java CrashServlet.java
 
-CMD [ "java", "-cp", "jetty-classpath/*:.", "JettyServletMain" ]
+CMD [ "java", "-cp", "/opt/jetty-classpath/*:.", "JettyServletMain" ]

--- a/utils/build/ssi/java/jetty-app.Dockerfile
+++ b/utils/build/ssi/java/jetty-app.Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.4
-ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1
 ARG BASE_IMAGE
 
 FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-alpine.yml
@@ -43,12 +43,7 @@ weblog:
           - name: copy-java-app
             local_path: lib-injection/build/docker/java/jetty-app
 
-          - name: compile-app-script
-            local_path: utils/build/virtual_machine/weblogs/java/test-app-java/compile_app.sh
-
           - name: run-app-script
             local_path: utils/build/virtual_machine/weblogs/java/test-app-java/run_app.sh
 
-        remote-command: |
-          sh compile_app.sh 18080
-          sh create_and_run_app_container.sh
+        remote-command: sh create_and_run_app_container.sh

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-container.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-container.yml
@@ -43,12 +43,7 @@ weblog:
           - name: copy-java-app
             local_path: lib-injection/build/docker/java/jetty-app
 
-          - name: compile-app-script
-            local_path: utils/build/virtual_machine/weblogs/java/test-app-java/compile_app.sh
-
           - name: run-app-script
             local_path: utils/build/virtual_machine/weblogs/java/test-app-java/run_app.sh
 
-        remote-command: |
-          sh compile_app.sh 18080
-          sh create_and_run_app_container.sh
+        remote-command: sh create_and_run_app_container.sh

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-multialpine.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-multialpine.yml
@@ -35,8 +35,6 @@ weblog:
             local_path: utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/docker-compose.yml
           - name: copy-java-app
             local_path: lib-injection/build/docker/java/jetty-app
-          - name: compile-app-script
-            local_path: utils/build/virtual_machine/weblogs/java/test-app-java/compile_app.sh
           - name: run-app-script
             local_path: utils/build/virtual_machine/weblogs/java/test-app-java/run_app.sh
           - name: copy-jdk8-app-dockerfile
@@ -53,6 +51,4 @@ weblog:
             local_path: utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.reverseproxy
           - name: copy-reverseproxy-conf
             local_path: utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/nginx.conf
-        remote-command: |
-          sh compile_app.sh 18080
-          sh create_and_run_app_multicontainer.sh
+        remote-command: sh create_and_run_app_multicontainer.sh

--- a/utils/build/virtual_machine/weblogs/java/provision_test-app-java-multicontainer.yml
+++ b/utils/build/virtual_machine/weblogs/java/provision_test-app-java-multicontainer.yml
@@ -35,8 +35,6 @@ weblog:
             local_path: utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/docker-compose.yml
           - name: copy-java-app
             local_path: lib-injection/build/docker/java/jetty-app
-          - name: compile-app-script
-            local_path: utils/build/virtual_machine/weblogs/java/test-app-java/compile_app.sh
           - name: run-app-script
             local_path: utils/build/virtual_machine/weblogs/java/test-app-java/run_app.sh
           - name: copy-jdk8-app-dockerfile
@@ -53,6 +51,4 @@ weblog:
             local_path: utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.reverseproxy
           - name: copy-reverseproxy-conf
             local_path: utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/nginx.conf
-        remote-command: |
-          sh compile_app.sh 18080
-          sh create_and_run_app_multicontainer.sh
+        remote-command: sh create_and_run_app_multicontainer.sh

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk11-alpine
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk11-alpine
@@ -1,10 +1,15 @@
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
+
 FROM public.ecr.aws/docker/library/alpine:latest
-RUN apk --no-cache add openjdk11
+RUN apk --no-cache add openjdk11-jdk
 RUN apk add --no-cache bash curl
 
-COPY jetty-classpath/. /opt/jetty-classpath
-COPY JettyServletMain.class /usr/local/app/
-COPY CrashServlet.class /usr/local/app/
+COPY --from=jetty_classpath /opt/jetty-classpath /opt/jetty-classpath
+COPY JettyServletMain.java /usr/local/app/
+COPY CrashServlet.java /usr/local/app/
 COPY run_app.sh /usr/local/app/
 WORKDIR /usr/local/app/
+RUN javac -cp "/opt/jetty-classpath/*:." JettyServletMain.java CrashServlet.java
+
 ENTRYPOINT ["/usr/local/app/run_app.sh"]

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk11-alpine
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk11-alpine
@@ -1,4 +1,4 @@
-ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1
 FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
 
 FROM public.ecr.aws/docker/library/alpine:latest

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk15-alpine
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk15-alpine
@@ -1,4 +1,4 @@
-ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1
 FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
 
 FROM public.ecr.aws/docker/library/alpine:3.18

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk15-alpine
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk15-alpine
@@ -1,10 +1,15 @@
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
+
 FROM public.ecr.aws/docker/library/alpine:3.18
 RUN apk --no-cache add openjdk15-jdk
 RUN apk add --no-cache bash curl
 
-COPY jetty-classpath/. /opt/jetty-classpath
-COPY JettyServletMain.class /usr/local/app/
-COPY CrashServlet.class /usr/local/app/
+COPY --from=jetty_classpath /opt/jetty-classpath /opt/jetty-classpath
+COPY JettyServletMain.java /usr/local/app/
+COPY CrashServlet.java /usr/local/app/
 COPY run_app.sh /usr/local/app/
 WORKDIR /usr/local/app/
+RUN javac -cp "/opt/jetty-classpath/*:." JettyServletMain.java CrashServlet.java
+
 ENTRYPOINT ["/usr/local/app/run_app.sh"]

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk17-alpine
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk17-alpine
@@ -1,10 +1,15 @@
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
+
 FROM public.ecr.aws/docker/library/alpine:latest
-RUN apk --no-cache add openjdk17
+RUN apk --no-cache add openjdk17-jdk
 RUN apk add --no-cache bash curl
 
-COPY jetty-classpath/. /opt/jetty-classpath
-COPY JettyServletMain.class /usr/local/app/
-COPY CrashServlet.class /usr/local/app/
+COPY --from=jetty_classpath /opt/jetty-classpath /opt/jetty-classpath
+COPY JettyServletMain.java /usr/local/app/
+COPY CrashServlet.java /usr/local/app/
 COPY run_app.sh /usr/local/app/
 WORKDIR /usr/local/app/
+RUN javac -cp "/opt/jetty-classpath/*:." JettyServletMain.java CrashServlet.java
+
 ENTRYPOINT ["/usr/local/app/run_app.sh"]

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk17-alpine
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk17-alpine
@@ -1,4 +1,4 @@
-ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1
 FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
 
 FROM public.ecr.aws/docker/library/alpine:latest

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk21-alpine
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk21-alpine
@@ -1,10 +1,15 @@
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
+
 FROM public.ecr.aws/docker/library/alpine:latest
-RUN apk --no-cache add openjdk21
+RUN apk --no-cache add openjdk21-jdk
 RUN apk add --no-cache bash curl
 
-COPY jetty-classpath/. /opt/jetty-classpath
-COPY JettyServletMain.class /usr/local/app/
-COPY CrashServlet.class /usr/local/app/
+COPY --from=jetty_classpath /opt/jetty-classpath /opt/jetty-classpath
+COPY JettyServletMain.java /usr/local/app/
+COPY CrashServlet.java /usr/local/app/
 COPY run_app.sh /usr/local/app/
 WORKDIR /usr/local/app/
+RUN javac -cp "/opt/jetty-classpath/*:." JettyServletMain.java CrashServlet.java
+
 ENTRYPOINT ["/usr/local/app/run_app.sh"]

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk21-alpine
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk21-alpine
@@ -1,4 +1,4 @@
-ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1
 FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
 
 FROM public.ecr.aws/docker/library/alpine:latest

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk8-alpine
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk8-alpine
@@ -1,4 +1,4 @@
-ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1
 FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
 
 FROM public.ecr.aws/docker/library/alpine:latest

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk8-alpine
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multialpine/Dockerfile.jdk8-alpine
@@ -1,10 +1,15 @@
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
+
 FROM public.ecr.aws/docker/library/alpine:latest
 RUN apk --no-cache add openjdk8
 RUN apk add --no-cache bash curl
 
-COPY jetty-classpath/. /opt/jetty-classpath
-COPY JettyServletMain.class /usr/local/app/
-COPY CrashServlet.class /usr/local/app/
+COPY --from=jetty_classpath /opt/jetty-classpath /opt/jetty-classpath
+COPY JettyServletMain.java /usr/local/app/
+COPY CrashServlet.java /usr/local/app/
 COPY run_app.sh /usr/local/app/
 WORKDIR /usr/local/app/
+RUN javac -cp "/opt/jetty-classpath/*:." JettyServletMain.java CrashServlet.java
+
 ENTRYPOINT ["/usr/local/app/run_app.sh"]

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk11
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk11
@@ -1,8 +1,13 @@
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
+
 FROM public.ecr.aws/docker/library/openjdk:11
 
-COPY jetty-classpath/. /opt/jetty-classpath
-COPY JettyServletMain.class /usr/local/app/
-COPY CrashServlet.class /usr/local/app/
+COPY --from=jetty_classpath /opt/jetty-classpath /opt/jetty-classpath
+COPY JettyServletMain.java /usr/local/app/
+COPY CrashServlet.java /usr/local/app/
 COPY run_app.sh /usr/local/app/
 WORKDIR /usr/local/app/
+RUN javac -cp "/opt/jetty-classpath/*:." JettyServletMain.java CrashServlet.java
+
 ENTRYPOINT ["/usr/local/app/run_app.sh"]

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk11
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk11
@@ -1,4 +1,4 @@
-ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1
 FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
 
 FROM public.ecr.aws/docker/library/openjdk:11

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk15
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk15
@@ -1,8 +1,13 @@
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
+
 FROM public.ecr.aws/docker/library/openjdk:15
 
-COPY jetty-classpath/. /opt/jetty-classpath
-COPY JettyServletMain.class /usr/local/app/
-COPY CrashServlet.class /usr/local/app/
+COPY --from=jetty_classpath /opt/jetty-classpath /opt/jetty-classpath
+COPY JettyServletMain.java /usr/local/app/
+COPY CrashServlet.java /usr/local/app/
 COPY run_app.sh /usr/local/app/
 WORKDIR /usr/local/app/
+RUN javac -cp "/opt/jetty-classpath/*:." JettyServletMain.java CrashServlet.java
+
 ENTRYPOINT ["/usr/local/app/run_app.sh"]

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk15
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk15
@@ -1,4 +1,4 @@
-ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1
 FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
 
 FROM public.ecr.aws/docker/library/openjdk:15

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk17
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk17
@@ -1,4 +1,4 @@
-ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1
 FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
 
 FROM public.ecr.aws/docker/library/openjdk:17

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk17
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk17
@@ -1,8 +1,13 @@
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
+
 FROM public.ecr.aws/docker/library/openjdk:17
 
-COPY jetty-classpath/. /opt/jetty-classpath
-COPY JettyServletMain.class /usr/local/app/
-COPY CrashServlet.class /usr/local/app/
+COPY --from=jetty_classpath /opt/jetty-classpath /opt/jetty-classpath
+COPY JettyServletMain.java /usr/local/app/
+COPY CrashServlet.java /usr/local/app/
 COPY run_app.sh /usr/local/app/
 WORKDIR /usr/local/app/
+RUN javac -cp "/opt/jetty-classpath/*:." JettyServletMain.java CrashServlet.java
+
 ENTRYPOINT ["/usr/local/app/run_app.sh"]

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk21
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk21
@@ -1,8 +1,13 @@
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
+
 FROM public.ecr.aws/docker/library/openjdk:21
 
-COPY jetty-classpath/. /opt/jetty-classpath
-COPY JettyServletMain.class /usr/local/app/
-COPY CrashServlet.class /usr/local/app/
+COPY --from=jetty_classpath /opt/jetty-classpath /opt/jetty-classpath
+COPY JettyServletMain.java /usr/local/app/
+COPY CrashServlet.java /usr/local/app/
 COPY run_app.sh /usr/local/app/
 WORKDIR /usr/local/app/
+RUN javac -cp "/opt/jetty-classpath/*:." JettyServletMain.java CrashServlet.java
+
 ENTRYPOINT ["/usr/local/app/run_app.sh"]

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk21
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk21
@@ -1,4 +1,4 @@
-ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1
 FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
 
 FROM public.ecr.aws/docker/library/openjdk:21

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk8
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk8
@@ -1,4 +1,4 @@
-ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1
 FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
 
 FROM public.ecr.aws/docker/library/openjdk:8

--- a/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk8
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java-multicontainer/Dockerfile.jdk8
@@ -1,8 +1,13 @@
+ARG JETTY_CLASSPATH_IMAGE=datadog/system-tests:java-jetty-9.4.56.v20240826.base-v1
+FROM ${JETTY_CLASSPATH_IMAGE} AS jetty_classpath
+
 FROM public.ecr.aws/docker/library/openjdk:8
 
-COPY jetty-classpath/. /opt/jetty-classpath
-COPY JettyServletMain.class /usr/local/app/
-COPY CrashServlet.class /usr/local/app/
+COPY --from=jetty_classpath /opt/jetty-classpath /opt/jetty-classpath
+COPY JettyServletMain.java /usr/local/app/
+COPY CrashServlet.java /usr/local/app/
 COPY run_app.sh /usr/local/app/
 WORKDIR /usr/local/app/
+RUN javac -cp "/opt/jetty-classpath/*:." JettyServletMain.java CrashServlet.java
+
 ENTRYPOINT ["/usr/local/app/run_app.sh"]

--- a/utils/build/virtual_machine/weblogs/java/test-app-java/compile_app.sh
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java/compile_app.sh
@@ -5,7 +5,7 @@ set -e
 sudo chmod -R 755 *
 
 echo "Compiling Java app"
-JETTY_VERSION=9.4.56.v20240826
+JETTY_VERSION=9.4.58.v20250814
 JETTY_FILE="jetty-distribution-$JETTY_VERSION.tar.gz"
 PORT=$1
 if [ -f "$JETTY_FILE" ]; then

--- a/utils/build/virtual_machine/weblogs/java/test-app-java/compile_app.sh
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java/compile_app.sh
@@ -12,8 +12,24 @@ if [ -f "$JETTY_FILE" ]; then
     echo "Jetty already downloaded."
 else
     echo "Downloading Jetty runtime"
-    wget -q https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
-    sudo tar -xf jetty-distribution-$JETTY_VERSION.tar.gz -C /opt/
+    JETTY_URL="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz"
+    for attempt in 1 2 3 4 5; do
+        if command -v curl >/dev/null 2>&1; then
+            curl -fsSL -o "$JETTY_FILE" "$JETTY_URL" && break
+        else
+            wget -q -O "$JETTY_FILE" "$JETTY_URL" && break
+        fi
+
+        rm -f "$JETTY_FILE"
+        if [ "$attempt" = "5" ]; then
+            echo "Failed to download Jetty runtime after $attempt attempts"
+            exit 1
+        fi
+
+        echo "Retrying Jetty runtime download in 5 seconds... ($attempt/5)"
+        sleep 5
+    done
+    sudo tar -xf "$JETTY_FILE" -C /opt/
 fi
 
 mkdir -p jetty-classpath

--- a/utils/scripts/get_pr_merged_labels.sh
+++ b/utils/scripts/get_pr_merged_labels.sh
@@ -23,8 +23,9 @@ if [[ $CI_COMMIT_MESSAGE =~ ($PR_PATTERN) ]]; then
     is_build_buddies=$(echo "$PR_DATA" | jq -c '.[] | select(.name | contains("build-buddies-images"))');
     is_build_python_base_images=$(echo "$PR_DATA" | jq -c '.[] | select(.name | contains("build-python-base-images"))');
     is_build_php_base_images=$(echo "$PR_DATA" | jq -c '.[] | select(.name | contains("build-php-base-images"))');
+    is_build_java_base_images=$(echo "$PR_DATA" | jq -c '.[] | select(.name | contains("build-java-base-images"))');
 
-    if [ -z "$is_build_buddies" ] && [ -z "$is_build_python_base_images" ] && [ -z "$is_build_php_base_images" ]
+    if [ -z "$is_build_buddies" ] && [ -z "$is_build_python_base_images" ] && [ -z "$is_build_php_base_images" ] && [ -z "$is_build_java_base_images" ]
     then
         echo "The PR $PR_NUMBER doesn't contain any docker build label "
         exit 0
@@ -59,6 +60,16 @@ if [[ $CI_COMMIT_MESSAGE =~ ($PR_PATTERN) ]]; then
         echo "The PR $PR_NUMBER contains the 'build-php-base-images' label. Launching the images generation process "
         ./utils/build/build_php_base_images.sh --push
         echo "------------- The php base images have been built and pushed ------------- "
+    fi
+
+    #BUILD JAVA BASE IMAGES
+    if [ -z "$is_build_java_base_images" ]
+    then
+        echo "The PR $PR_NUMBER doesn't contain the 'build-java-base-images' label "
+    else
+        echo "The PR $PR_NUMBER contains the 'build-java-base-images' label. Launching the images generation process "
+        ./utils/build/build_java_base_images.sh --push
+        echo "------------- The java base images have been built and pushed ------------- "
     fi
 
 else


### PR DESCRIPTION
# What Does This Do

Moves the Jetty distribution download out of per-test image builds and into a single prebuilt, pushed base image (`datadog/system-tests:java-jetty-9.4.58.v20250814.base-v1`), mirroring the PHP approach from #6861. Also bumps Jetty to `9.4.58.v20250814` (latest 9.4.x with security fixes).

- New `jetty-classpath.base.Dockerfile` + `docker-bake.hcl` + `build_java_base_images.sh` build the classpath once (with `curl --retry`).
- Java weblog Dockerfiles (`multialpine`, `multicontainer`, SSI `jetty-app`) now `COPY --from=jetty_classpath /opt/jetty-classpath` and compile `*.java` in-image instead of downloading Jetty at build time.
- Alpine images switched from JRE-only packages to `*-jdk` (so `javac` is available); `openjdk8` already bundles `javac`.
- VM provisioning (`alpine`/`container`/`multi*`) drops the `compile_app.sh` step. The bare-VM `provision_test-app-java.yml` keeps it, now with a `curl`/`wget` retry loop.
- CI wiring for a new `build-java-base-images` label (GitHub Actions + GitLab `get_pr_merged_labels.sh`) and docs.

# Motivation

Many GitLab jobs failed because the Jetty download from Maven Central hit **`429: Too Many Requests`** (confirmed via DDCI job `1736247977`). Downloading Jetty in every weblog build multiplies requests to `repo1.maven.org`; building it once into a base image removes that load from the test path. The version bump to `9.4.58.v20250814` picks up the latest security fixes.

# Additional Notes

- Requires the `build-java-base-images` label so the base image is built and pushed to Docker Hub before tests consume it — ping Reliability & Performance to approve the push.
- Verified locally on `9.4.58.v20250814`: base image builds, `Dockerfile.jdk11` compiles and runs (**HTTP 200 on :18080**, log reports `jetty-9.4.58.v20250814`), `jdk21-alpine` (`openjdk21-jdk`) and `jdk8-alpine` (`openjdk8`) build with working `javac`. `shellcheck` passes.
- The `test-app-java-buildpack` 429 (Gradle/Spring Boot deps) is a separate path not addressed here.