### PR TITLE
K8s Lib Injeciton: Format code v3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,13 +239,6 @@ ignore = [
 ]
 "utils/build/*"  = ["ALL"]  # mostly python weblog code. it may be a good idea to enable rules here
 
-"utils/{k8s_lib_injection/*,_context/_scenarios/k8s_lib_injection.py}" = [
-    "SLF001",   # private-member-access: TODO
-    "TRY002",   # raise-vanilla-class: TODO
-    "TRY201",   # verbose-raise: TODO
-    "TRY301",   # raise-within-try: TODO
-    "UP031",    # printf-string-formatting: TODO
-]
 "utils/onboarding/*" = [
     "ANN201",  # missing-return-type-undocumented-public-function: TODO
     "DTZ005",  # call-datetime-now-without-tzinfo: TODO

--- a/utils/k8s_lib_injection/k8s_cluster_provider.py
+++ b/utils/k8s_lib_injection/k8s_cluster_provider.py
@@ -8,7 +8,7 @@ import base64
 import time
 from pathlib import Path
 from utils._logger import logger
-from utils.k8s_lib_injection.k8s_command_utils import execute_command
+from utils.k8s_lib_injection.k8s_command_utils import K8sLibInjectionError, execute_command
 from kubernetes import client, config
 
 
@@ -414,7 +414,7 @@ class K8sKindClusterProvider(K8sClusterProvider):
             "--format '{{.NetworkSettings.Networks.bridge.IPAddress}}'"
         ).strip()
         if not correct_control_plane_ip:
-            raise Exception("Unable to find correct control plane IP")
+            raise K8sLibInjectionError("Unable to find correct control plane IP")
         logger.debug(f"[setup_kind_in_gitlab] correct_control_plane_ip: {correct_control_plane_ip}")
 
         control_plane_address_in_config = execute_command(
@@ -423,7 +423,7 @@ class K8sKindClusterProvider(K8sClusterProvider):
             ':{{index .NetworkSettings.Ports "6443/tcp" 0 "HostPort"}}\''
         ).strip()
         if not control_plane_address_in_config:
-            raise Exception("Unable to find control plane address from config")
+            raise K8sLibInjectionError("Unable to find control plane address from config")
         logger.debug(f"[setup_kind_in_gitlab] control_plane_address_in_config: {control_plane_address_in_config}")
 
         # Replace server config with dns name + internal port

--- a/utils/k8s_lib_injection/k8s_command_utils.py
+++ b/utils/k8s_lib_injection/k8s_command_utils.py
@@ -9,6 +9,10 @@ if TYPE_CHECKING:
     from utils.k8s_lib_injection.k8s_cluster_provider import K8sClusterInfo
 
 
+class K8sLibInjectionError(Exception):
+    """Raised when a k8s lib-injection helper fails (command execution, resource not ready, etc.)."""
+
+
 def execute_command(
     command: str,
     timeout: int | None = None,
@@ -45,7 +49,9 @@ def execute_command(
                 except subprocess.TimeoutExpired:
                     if timeout is None:
                         return None
-                    raise Exception(f"Command: {command} timed out after {applied_timeout} seconds") from None
+                    raise K8sLibInjectionError(
+                        f"Command: {command} timed out after {applied_timeout} seconds"
+                    ) from None
             if file_result.returncode != 0:
                 logger.error(f"Command exited {file_result.returncode}: {command} (output in {logfile})")
             return output
@@ -61,21 +67,26 @@ def execute_command(
         except subprocess.TimeoutExpired:
             if timeout is None:
                 return None
-            raise Exception(f"Command: {command} timed out after {applied_timeout} seconds") from None
+            raise K8sLibInjectionError(f"Command: {command} timed out after {applied_timeout} seconds") from None
 
         output = result.stdout.decode("utf-8", errors="replace")
         if not quiet:
             logger.debug(f"Command: {command} \n {output}")
         else:
             logger.info(f"Command: {command}")
-        if result.returncode != 0:
+        command_failed = result.returncode != 0
+        if command_failed:
             output_error_str = result.stderr.decode("utf-8", errors="replace")
             logger.debug(f"Command: {command} \n {output_error_str}")
-            raise Exception(f"Error executing command: {command} \nStdout: {output}\nStderr: {output_error_str}")
 
     except Exception as ex:
         logger.error(f"Error executing command: {command} \n {ex}")
         raise
+
+    if command_failed:
+        error_message = f"Error executing command: {command} \nStdout: {output}\nStderr: {output_error_str}"
+        logger.error(f"Error executing command: {command} \n {error_message}")
+        raise K8sLibInjectionError(error_message)
 
     return output
 

--- a/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
+++ b/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
@@ -7,6 +7,7 @@ from kubernetes import client, watch
 from kubernetes.client.rest import ApiException
 from utils._logger import logger
 from utils.k8s_lib_injection.k8s_command_utils import (
+    K8sLibInjectionError,
     helm_add_repo,
     helm_install_chart,
     execute_command,
@@ -271,8 +272,8 @@ class K8sDatadog:
             time.sleep(5)
 
         if not daemonset_created:
-            logger.info("[Test agent] Daemonset not created. Last status: %s" % daemonset_status)
-            raise Exception("Daemonset not created")
+            logger.info(f"[Test agent] Daemonset not created. Last status: {daemonset_status}")
+            raise K8sLibInjectionError("Daemonset not created")
 
         w = watch.Watch()
         for event in w.stream(
@@ -325,13 +326,13 @@ class K8sDatadog:
             time.sleep(5)
 
         if not cluster_agent_ready:
-            logger.error("Cluster agent not created. Last status: %s" % cluster_agent_status)
+            logger.error(f"Cluster agent not created. Last status: {cluster_agent_status}")
             if datadog_cluster_name:
                 cluster_agent_logs = self.k8s_cluster_info.core_v1_api().read_namespaced_pod_log(
                     name=datadog_cluster_name, namespace=namespace
                 )
                 logger.error(f"Cluster agent logs: {cluster_agent_logs}")
-            raise Exception("Cluster agent not created")
+            raise K8sLibInjectionError("Cluster agent not created")
         # At this point the cluster_agent should be ready, we are going to wait a little bit more
         # to make sure the cluster_agent is ready (some times the cluster_agent is ready but the
         # cluster agent is not ready yet)
@@ -353,7 +354,7 @@ class K8sDatadog:
         if ret is not None:
             for i in ret.items:
                 k8s_logger(self.output_folder, "get.pods").info(
-                    "%s\t%s\t%s" % (i.status.pod_ip, i.metadata.namespace, i.metadata.name)
+                    f"{i.status.pod_ip}\t{i.metadata.namespace}\t{i.metadata.name}"
                 )
                 execute_command(
                     f"kubectl get event --field-selector involvedObject.name={i.metadata.name}",

--- a/utils/k8s_lib_injection/k8s_weblog.py
+++ b/utils/k8s_lib_injection/k8s_weblog.py
@@ -1,5 +1,6 @@
 from kubernetes import client, watch
 from utils._logger import logger
+from utils.k8s_lib_injection.k8s_command_utils import K8sLibInjectionError
 from utils.k8s_lib_injection.k8s_logger import k8s_logger
 from utils.k8s_lib_injection.k8s_cluster_provider import K8sClusterInfo
 from retry import retry
@@ -56,8 +57,8 @@ class K8sWeblog:
 
         logger.info(
             "[Deploy weblog] Creating weblog pod configuration. "
-            "weblog_variant_image: [%s], library: [%s], library_init_image: [%s]"
-            % (self.app_image, self.library, self.library_init_image)
+            f"weblog_variant_image: [{self.app_image}], library: [{self.library}], "
+            f"library_init_image: [{self.library_init_image}]"
         )
         library_lib = "js" if self.library == "nodejs" else self.library
         pod_metadata = client.V1ObjectMeta(
@@ -227,10 +228,10 @@ class K8sWeblog:
             pod_status = self.k8s_cluster_info.core_v1_api().read_namespaced_pod_status(
                 name="my-app", namespace=namespace
             )
-            logger.error("[Deploy weblog] weblog not created. Last status: %s" % pod_status)
+            logger.error(f"[Deploy weblog] weblog not created. Last status: {pod_status}")
             pod_logs = self.k8s_cluster_info.core_v1_api().read_namespaced_pod_log(name="my-app", namespace=namespace)
             logger.error(f"[Deploy weblog] weblog logs: {pod_logs}")
-            raise Exception("[Deploy weblog] Weblog not created")
+            raise K8sLibInjectionError("[Deploy weblog] Weblog not created")
 
     @retry(delay=1, tries=5)
     def list_namespaced_pod(self, namespace: str, **kwargs: object) -> client.V1PodList:
@@ -246,7 +247,7 @@ class K8sWeblog:
             k8s_logger(self.output_folder, "myapp.describe").info(api_response)
         except Exception as e:
             k8s_logger(self.output_folder, "myapp.describe").info(
-                "Exception when calling CoreV1Api->read_namespaced_pod: %s\n" % e
+                f"Exception when calling CoreV1Api->read_namespaced_pod: {e}\n"
             )
 
         # check weblog logs for pod
@@ -257,7 +258,7 @@ class K8sWeblog:
             k8s_logger(self.output_folder, "myapp.logs").info(api_response)
         except Exception as e:
             k8s_logger(self.output_folder, "myapp.logs").info(
-                "Exception when calling CoreV1Api->read_namespaced_pod_log: %s\n" % e
+                f"Exception when calling CoreV1Api->read_namespaced_pod_log: {e}\n"
             )
 
         app_name = f"{self.library}-app"
@@ -277,4 +278,4 @@ class K8sWeblog:
                 )
                 k8s_logger(self.output_folder, "deployment.logs").info(api_response)
         except Exception as e:
-            k8s_logger(self.output_folder, "deployment.logs").info("Exception when calling deployment data: %s\n" % e)
+            k8s_logger(self.output_folder, "deployment.logs").info(f"Exception when calling deployment data: {e}\n")


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
 Rules fixed
| Rule | Description | Where |
|------|-------------|-------|
| `RET505` | superfluous-else-return | `k8s_cluster_provider.py` (`K8sProviderFactory.get_provider`) |
| `RET508` | superfluous-else-break | `k8s_datadog_kubernetes.py` (`wait_for_test_agent`) |
| `RUF059` | unused-unpacked-variable | `k8s_cluster_provider.py` (`arn` → `_arn`, `err` → `_err`) |
| `TRY002` | raise-vanilla-class | 8 sites across `k8s_command_utils.py`, `k8s_cluster_provider.py`, `k8s_datadog_kubernetes.py`, `k8s_weblog.py` |
| `TRY301` | raise-within-try | `k8s_command_utils.py::execute_command` — failure raise lifted out of the `try` block while preserving the same error logging |
| `UP031` | printf-string-formatting | 8 sites converted from `"… %s" % var` to f-strings in `k8s_datadog_kubernetes.py` and `k8s_weblog.py` |
`SIM108`, `SIM115`, `SLF001`, `TRY201` had no remaining violations and were dropped from the exemptions as well.


## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
