### PR TITLE
Removes legacy secrets

### DIFF
--- a/.github/actions/push_to_test_optim/action.yml
+++ b/.github/actions/push_to_test_optim/action.yml
@@ -4,8 +4,6 @@ inputs:
   datadog_site:
     description: Which DataDog site shoud be used
     default: datadoghq.com
-  datadog_api_key:
-    description: "A valid DD_API_KEY"
   ci_environment:
     description: "CI environment running the tests (dev/prod/custom), used for Test Optimization tagging"
     default: ""
@@ -51,5 +49,5 @@ runs:
           --xpath-tag "test.codeowners=/testcase/properties/property[@name='test.codeowners']"
       env:
         DATADOG_SITE: ${{ inputs.datadog_site }}
-        DATADOG_API_KEY:  ${{ inputs.datadog_api_key != '' && inputs.datadog_api_key || steps.dd-sts.outputs.api_key }}
+        DATADOG_API_KEY:  ${{ steps.dd-sts.outputs.api_key }}
         DD_TAGS: ${{ inputs.ci_environment != '' && format('test.configuration.ci_environment:{0}', inputs.ci_environment) || '' }}

--- a/.github/workflows/compute-workflow-parameters.yml
+++ b/.github/workflows/compute-workflow-parameters.yml
@@ -186,7 +186,6 @@ jobs:
       env:
         LIBRARY_TARGET_BRANCH: "${{ steps.extract_branch.outputs.library_branch }}"
         AGENT_TARGET_BRANCH: "${{ steps.extract_branch.outputs.agent_branch }}"
-        CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload artifact

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -558,6 +558,5 @@ jobs:
       if: steps.build.outcome == 'success' && inputs.push_to_test_optimization && !cancelled()
       uses: ./.github/actions/push_to_test_optim
       with:
-        datadog_api_key: ${{ secrets.TEST_OPTIMIZATION_API_KEY }}
         datadog_site: ${{ inputs.test_optimization_datadog_site }}
         ci_environment: ${{ inputs.ci_environment }}

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -76,10 +76,6 @@ on:
         default: "datadoghq.com"
         required: false
         type: string
-    secrets:
-      TEST_OPTIMIZATION_API_KEY:
-        description: "API key for pushing test results to DataDog Test Optimization"
-        required: false
 
 env:
   REGISTRY: ghcr.io
@@ -163,6 +159,5 @@ jobs:
         if: inputs.push_to_test_optimization && !cancelled()
         uses: ./.github/actions/push_to_test_optim
         with:
-          datadog_api_key: ${{ secrets.TEST_OPTIMIZATION_API_KEY }}
           datadog_site: ${{ inputs.test_optimization_datadog_site }}
           ci_environment: ${{ inputs.ci_environment }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -115,7 +115,7 @@ on:
         required: false
         type: number
       push_to_test_optimization:
-        description: "Push test result to DataDog Test Optimization, require TEST_OPTIMIZATION_API_KEY secret"
+        description: "Push test result to DataDog Test Optimization"
         default: false
         required: false
         type: boolean
@@ -134,10 +134,6 @@ on:
       DOCKERHUB_USERNAME:
         required: false
       DOCKERHUB_TOKEN:
-        required: false
-      TEST_OPTIMIZATION_API_KEY:
-        required: false
-      CIRCLECI_TOKEN:
         required: false
       DD_API_KEY:
         required: false

--- a/docs/CI/github-actions.md
+++ b/docs/CI/github-actions.md
@@ -52,12 +52,15 @@ jobs:
 | `force_execute`                  | Comma-separated list of tests to run even if they are skipped by manifest or decorators         | string  | false    | *empty*       |
 | `library`                        | Library to test                                                                                 | string  | true     | —             |
 | `parametric_job_count`           | How many jobs should be used to run PARAMETRIC scenario                                         | number  | false    | 1             |
-| `push_to_test_optimization`      | Push tests results to DataDog Test Optimization. Uses `TEST_OPTIMIZATION_API_KEY` secret if set, otherwise fetches credentials automatically via dd-sts (recommended) | boolean | false    | false         |
+| `push_to_test_optimization`      | Push tests results to DataDog Test Optimization. Fetches credentials automatically via dd-sts   | boolean | false    | false         |
 | `test_optimization_datadog_site` | DataDog site to use for test optimization                                                       | string  | false    | datadoghq.com |
 | `ref`                            | system-tests ref to run the tests on (can be any valid branch, tag or SHA in system-tests repo) | string  | false    | main          |
 | `scenarios`                      | Comma-separated list scenarios to run                                                           | string  | false    | DEFAULT       |
 | `scenarios_groups`               | Comma-separated list of scenarios groups to run                                                 | string  | false    | *empty*       |
 | `skip_empty_scenarios`           | Skip scenarios that contain only xfail or irrelevant tests                                      | boolean | false    | false         |
+
+
+Note: if `test_optimization_datadog_site` is set to `true`, then the calling repo must be referenced in [dd-sts](https://github.com/DataDog/dd-source/blob/main/domains/seceng/sit/apps/apis/dd-sts/config/policies/us1.ddbuild.io/system-tests.yaml).
 
 ## Permissions
 
@@ -74,7 +77,6 @@ For some purposes, secrets are used in the workflow:
 
 | Name                                   | Description
 | -------------------------------------- | ----------------------------------------------------------------------------------
-| CIRCLECI_TOKEN                         | Only used with `_system_tests_dev_mode`
 | DD_API_KEY                             | Some scenarios requires valid API and APP keys
 | DD_APPLICATION_KEY                     |
 | DD_API_KEY_2                           |
@@ -82,7 +84,6 @@ For some purposes, secrets are used in the workflow:
 | DD_API_KEY_3                           |
 | DD_APP_KEY_3                           |
 | DOCKERHUB_USERNAME and DOCKERHUB_TOKEN | If both are set, all docker pull are authenticated, which offer higher rate limit
-| TEST_OPTIMIZATION_API_KEY              | The DD_API_KEY to use to push tests runs to DataDog Test Optimization. **Deprecated**: prefer not setting this and letting dd-sts fetch credentials automatically
 
 
 You can sends them ,either by using `secrets: inherit` ([doc](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idsecretsinherit)), or [use explicit secret ids](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idsecretssecret_id)


### PR DESCRIPTION
## Motivation

Cleanup legacy stuff

## Changes

* Remove `CIRCLECI_TOKEN` secrets, it's not used anymore
* Remove `TEST_OPTIMIZATION_API_KEY` : this secret must not be stored anymore in repo secrets, official system-tests workflow ship a dd-sts mechanism to retrieve it.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
