### PR TITLE
SSI: Download jetty runtime from internal repo

### DIFF
--- a/utils/build/ssi/java/jetty-app.Dockerfile
+++ b/utils/build/ssi/java/jetty-app.Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE}
 
-RUN wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.56.v20240826/jetty-distribution-9.4.56.v20240826.tar.gz
+RUN wget https://static.datadoghq.com/assets/dd-repo-tools/mirror/02f5f9c4f6b4be0e5b2640d4b5a21e2838d68143ef96c540c2ba39885b60cb62/jetty-distribution-9.4.56.v20240826.tar.gz
 RUN tar -xvf jetty-distribution-9.4.56.v20240826.tar.gz
 
 RUN mkdir -p jetty-classpath

--- a/utils/build/virtual_machine/weblogs/java/test-app-java/compile_app.sh
+++ b/utils/build/virtual_machine/weblogs/java/test-app-java/compile_app.sh
@@ -12,7 +12,7 @@ if [ -f "$JETTY_FILE" ]; then
     echo "Jetty already downloaded."
 else
     echo "Downloading Jetty runtime"
-    wget -q https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz
+    wget -q https://static.datadoghq.com/assets/dd-repo-tools/mirror/02f5f9c4f6b4be0e5b2640d4b5a21e2838d68143ef96c540c2ba39885b60cb62/jetty-distribution-$JETTY_VERSION.tar.gz
     sudo tar -xf jetty-distribution-$JETTY_VERSION.tar.gz -C /opt/
 fi
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The Jetty runtime distribution (jetty-distribution-9.4.56.v20240826) was being downloaded directly from Maven Central (repo1.maven.org) in the AWS SSI Java weblog provision script (compile_app.sh). This external URL is not always reliably available in CI environments, causing intermittent test flakiness.

This PR migrates the download source to the internal Datadog static mirror (static.datadoghq.com), aligning it with the approach already used by the Docker SSI jetty-app.Dockerfile.

- Eliminates a source of network-related test flakiness in AWS SSI Java tests.
- Ensures consistency across all test types: Docker SSI was already using the internal mirror, AWS SSI was the only outlier.
- Reduces external dependencies in CI, improving reliability and build reproducibility.

## Changes

<!-- A brief description of the change being made with this pull request. -->
Updated utils/build/virtual_machine/weblogs/java/test-app-java/compile_app.sh to download the Jetty distribution from the Datadog internal mirror instead of Maven Central.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
