### PR TITLE
Fix build.sh for local run for cpp library

### DIFF
--- a/utils/build/build.sh
+++ b/utils/build/build.sh
@@ -402,18 +402,22 @@ BINARY_PATH="${BINARY_PATH:-}"
 BINARY_URL="${BINARY_URL:-}"
 GITHUB_TOKEN_FILE="${GITHUB_TOKEN_FILE:-}"
 
-if [[ "${BUILD_IMAGES}" =~ /weblog/ && ! -d "${SCRIPT_DIR}/docker/${TEST_LIBRARY}" ]]; then
-    echo "Library ${TEST_LIBRARY} not found"
-    echo "Available libraries: $(echo $(list-libraries))"
-    exit 1
-fi
+# When building the weblog image, check the library and weblog variant exist.
+# Some libraries (e.g. cpp) have no default weblog variant.
+if [[ ",${BUILD_IMAGES}," == *",weblog,"* ]]; then
+    if [[ ! -d "${SCRIPT_DIR}/docker/${TEST_LIBRARY}" ]]; then
+        echo "Library ${TEST_LIBRARY} not found"
+        echo "Available libraries: $(echo $(list-libraries))"
+        exit 1
+    fi
 
-WEBLOG_VARIANT="${WEBLOG_VARIANT:-$(default-weblog)}"
+    WEBLOG_VARIANT="${WEBLOG_VARIANT:-$(default-weblog)}"
 
-if [[ "${BUILD_IMAGES}" =~ /weblog/ && (-n "$WEBLOG_VARIANT") && (! -f "${SCRIPT_DIR}/docker/${TEST_LIBRARY}/${WEBLOG_VARIANT}.Dockerfile") ]]; then
-    echo "Variant ${WEBLOG_VARIANT} for library ${TEST_LIBRARY} not found"
-    echo "Available weblog variants for ${TEST_LIBRARY}: $(echo $(list-weblogs))"
-    exit 1
+    if [[ (-n "$WEBLOG_VARIANT") && (! -f "${SCRIPT_DIR}/docker/${TEST_LIBRARY}/${WEBLOG_VARIANT}.Dockerfile") ]]; then
+        echo "Variant ${WEBLOG_VARIANT} for library ${TEST_LIBRARY} not found"
+        echo "Available weblog variants for ${TEST_LIBRARY}: $(echo $(list-weblogs))"
+        exit 1
+    fi
 fi
 
 "${COMMAND}"


### PR DESCRIPTION
## Motivation

Because `build.sh` assumed that all libraries have a default weblog, it was not possible to run locally system tests for the `cpp` library (C++ Tracer, `dd-trace-cpp`).

Before:
```
./run.sh PARAMETRIC +l cpp
45d44
< types-paramiko==4.0.0.20250822
== Run build script (attempt 1 on 1) with timeout 600s ==
ERROR: This script should not be run for the cpp library because it has no default weblog.
❌ Attempt 1 failed with exit code 1
Build step failed after 1 attempts
```

Now it works fine.

More precisely, `build.sh` resolved the default weblog variant unconditionally, even when the weblog image wasn't being built. This blocked `./run.sh PARAMETRIC +l cpp` whenever a stale `venv` triggered a runner rebuild.

## Changes

- Run weblog validation and default-variant resolution only when `weblog` is in `BUILD_IMAGES`
- Also fixed the guard condition:  `=~ /weblog/` never matched the comma-separated list because the `/` were literal, not delimiters (the regex syntax in `bash` is not the same as the one in `sed`).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [x] A docker base image is modified?
    * [x] the relevant `build-XXX-image` label is present
* [x] A scenario is added, removed or renamed?
    * [x] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
