### PR TITLE
fix: test_minimal_number_of_scenarios compare agent_envs too

### DIFF
--- a/tests/test_the_test/test_minimal_number_of_scenarios.py
+++ b/tests/test_the_test/test_minimal_number_of_scenarios.py
@@ -135,8 +135,9 @@ def test_minimal_number_of_scenarios():
         )
 
         # 2. LEVEL 1 + LEVEL 3: equivalent configs AND one can be included in the other (REPORT ONLY)
+        # Only check subset when agent envs are identical — different agent_env means scenarios can't be merged
         # python trickery to get if a dict is a sub set of another
-        if small_scenario.weblog_container.environment.items() <= large_scenario.weblog_container.environment.items():
+        if agent_envs_match and small_scenario.weblog_container.environment.items() <= large_scenario.weblog_container.environment.items():
             logger.error(f"Small scenario: {small_scenario.name}")
             logger.error(f"Large scenario: {large_scenario.name}")
 

--- a/tests/test_the_test/test_minimal_number_of_scenarios.py
+++ b/tests/test_the_test/test_minimal_number_of_scenarios.py
@@ -137,7 +137,11 @@ def test_minimal_number_of_scenarios():
         # 2. LEVEL 1 + LEVEL 3: equivalent configs AND one can be included in the other (REPORT ONLY)
         # Only check subset when agent envs are identical — different agent_env means scenarios can't be merged
         # python trickery to get if a dict is a sub set of another
-        if agent_envs_match and small_scenario.weblog_container.environment.items() <= large_scenario.weblog_container.environment.items():
+        if (
+            agent_envs_match
+            and small_scenario.weblog_container.environment.items()
+            <= large_scenario.weblog_container.environment.items()
+        ):
             logger.error(f"Small scenario: {small_scenario.name}")
             logger.error(f"Large scenario: {large_scenario.name}")
 


### PR DESCRIPTION
## Motivation
This test was failing in CI when adding new scenarios with differences only in `agent_env`. Example here: https://github.com/DataDog/system-tests/actions/runs/26833318814/job/79120434759?pr=6648

## Changes
Checks that `agent_env` are also equivalent before failing.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
