### PR TITLE
[dotnet] Raise ThreadPool min threads to avoid Kestrel stalls

### DIFF
--- a/utils/build/docker/dotnet/poc.Dockerfile
+++ b/utils/build/docker/dotnet/poc.Dockerfile
@@ -45,7 +45,7 @@ ENV COMPlus_DbgEnableMiniDump=1
 # - MiniDumpWithPrivateReadWriteMemory is 2
 ENV COMPlus_DbgMiniDumpType=2
 ENV DOTNET_ThreadPool_ForceMinWorkerThreads=32
-ENV DOTNET_ThreadPool_ForceMinIoCompletionThreads=32
+ENV DOTNET_ThreadPool_ForceMinIOCompletionThreads=32
 
 # copy the dotnet app (built above)
 COPY --from=build-app /app/out .

--- a/utils/build/docker/dotnet/poc.Dockerfile
+++ b/utils/build/docker/dotnet/poc.Dockerfile
@@ -44,6 +44,8 @@ ENV ASPNETCORE_hostBuilder__reloadConfigOnChange=false
 ENV COMPlus_DbgEnableMiniDump=1
 # - MiniDumpWithPrivateReadWriteMemory is 2
 ENV COMPlus_DbgMiniDumpType=2
+ENV DOTNET_ThreadPool_ForceMinWorkerThreads=32
+ENV DOTNET_ThreadPool_ForceMinIoCompletionThreads=32
 
 # copy the dotnet app (built above)
 COPY --from=build-app /app/out .

--- a/utils/build/docker/dotnet/uds.Dockerfile
+++ b/utils/build/docker/dotnet/uds.Dockerfile
@@ -38,6 +38,8 @@ ENV ASPNETCORE_hostBuilder__reloadConfigOnChange=false
 ENV COMPlus_DbgEnableMiniDump=1
 # - MiniDumpWithPrivateReadWriteMemory is 2
 ENV COMPlus_DbgMiniDumpType=2
+ENV DOTNET_ThreadPool_ForceMinWorkerThreads=32
+ENV DOTNET_ThreadPool_ForceMinIoCompletionThreads=32
 
 # copy the dotnet app (built above)
 COPY --from=build-app /app/out .

--- a/utils/build/docker/dotnet/uds.Dockerfile
+++ b/utils/build/docker/dotnet/uds.Dockerfile
@@ -39,7 +39,7 @@ ENV COMPlus_DbgEnableMiniDump=1
 # - MiniDumpWithPrivateReadWriteMemory is 2
 ENV COMPlus_DbgMiniDumpType=2
 ENV DOTNET_ThreadPool_ForceMinWorkerThreads=32
-ENV DOTNET_ThreadPool_ForceMinIoCompletionThreads=32
+ENV DOTNET_ThreadPool_ForceMinIOCompletionThreads=32
 
 # copy the dotnet app (built above)
 COPY --from=build-app /app/out .


### PR DESCRIPTION
## Motivation

`Test_SqlServiceNameSource` intermittently fails in `INTEGRATIONS` (~2% of runs in `dd-trace-dotnet` master). Root cause: Kestrel response-flush stalls for ~5 s while the .NET ThreadPool grows — the request completes server-side in ~12 ms, but bytes don't reach the client until after the test's 5 s read timeout.

The ThreadPool defaults its minimum to `Environment.ProcessorCount` for both worker and IOCP threads (so 2–4 on `ubuntu-latest`), and grows by 1 thread every ~500 ms. Under cumulative tracer + AppSec + IAST background load in this scenario, Kestrel's I/O queues behind tracer activity until the pool grows — long enough to trip the client timeout.

## Changes

Set `DOTNET_ThreadPool_ForceMinWorkerThreads=32` and `DOTNET_ThreadPool_ForceMinIoCompletionThreads=32` in `poc.Dockerfile` and `uds.Dockerfile`. 32 is a comfortable floor above the burst; idle threads cost ~1 MB each, and on hosts with ≥32 vCPU the env vars are a no-op.

## Verification

2 CI runs × 50 INTEGRATIONS attempts = 100 fresh scenario runs, 0 stalls (prior baseline ≈ 2 / 100). Diagnostic branch `diag/dotnet-rasp-sqli-stall` kept in case the flake reappears.
