### PR TITLE
APPSEC-68195: re-enable Test_RemoteConfigurationExtraServices on uwsgi-poc for python

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2045,7 +2045,6 @@ manifest:
     - weblog_declaration:
         "*": v2.1.1
         django-py3.13: v3.15.0.dev (v2.1.1 but fixed incompatibility issue with gevent 25.8.2)
-        uwsgi-poc: flaky (APPSEC-68195)
   tests/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceASMDD: v2.9.0
   tests/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceASMDDNoCache: missing_feature
   tests/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceFeatures: v1.7.4


### PR DESCRIPTION
APPSEC-68195

the bug causing `Test_RemoteConfigurationExtraServices` to be flaky on the `uwsgi-poc` weblog for Python has been fixed.

## Changes

- Remove `uwsgi-poc: flaky (APPSEC-68195)` from `manifests/python.yml` so the test runs again on that weblog variant.