### PR TITLE
Update Java exception replay `v1` approvals and ignore generated received artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ node_modules/
 
 # debugger
 /tests/debugger/approvals/**/*received*
+/tests/debugger/utils/approvals/**/*received*
 .aider*
 
 # version check

--- a/tests/debugger/utils/approvals/java/1.5.0/exception_replay_async_spans_expected_v1.json
+++ b/tests/debugger/utils/approvals/java/1.5.0/exception_replay_async_spans_expected_v1.json
@@ -17,6 +17,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",

--- a/tests/debugger/utils/approvals/java/1.5.0/exception_replay_inner_spans_expected_v1.json
+++ b/tests/debugger/utils/approvals/java/1.5.0/exception_replay_inner_spans_expected_v1.json
@@ -17,6 +17,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",

--- a/tests/debugger/utils/approvals/java/1.5.0/exception_replay_multiframe_spans_expected_v1.json
+++ b/tests/debugger/utils/approvals/java/1.5.0/exception_replay_multiframe_spans_expected_v1.json
@@ -20,6 +20,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -59,6 +61,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -98,6 +102,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -137,6 +143,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",

--- a/tests/debugger/utils/approvals/java/1.5.0/exception_replay_recursion_3_spans_expected_v1.json
+++ b/tests/debugger/utils/approvals/java/1.5.0/exception_replay_recursion_3_spans_expected_v1.json
@@ -21,6 +21,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -61,6 +63,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -101,6 +105,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -141,6 +147,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -181,6 +189,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",

--- a/tests/debugger/utils/approvals/java/1.5.0/exception_replay_recursion_5_spans_expected_v1.json
+++ b/tests/debugger/utils/approvals/java/1.5.0/exception_replay_recursion_5_spans_expected_v1.json
@@ -23,6 +23,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -65,6 +67,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -107,6 +111,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -149,6 +155,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -191,6 +199,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -233,6 +243,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -275,6 +287,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",

--- a/tests/debugger/utils/approvals/java/1.5.0/exception_replay_rockpaperscissors_spans_expected_v1.json
+++ b/tests/debugger/utils/approvals/java/1.5.0/exception_replay_rockpaperscissors_spans_expected_v1.json
@@ -17,6 +17,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -53,6 +55,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",
@@ -89,6 +93,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",

--- a/tests/debugger/utils/approvals/java/1.5.0/exception_replay_simple_spans_expected_v1.json
+++ b/tests/debugger/utils/approvals/java/1.5.0/exception_replay_simple_spans_expected_v1.json
@@ -17,6 +17,8 @@
         "key2": "val2",
         "language": "jvm",
         "span.kind": "server",
+        "thread.id": "<scrubbed>",
+        "thread.name": "<scrubbed>",
         "version": "<scrubbed>"
       },
       "componentRef": "spring-web-controller",


### PR DESCRIPTION
## Motivation

Changed expected JSON files to correctly process thread attributes.
Also update `.gitignore` to avoid  not accidental commit of generated files.

## Changes

The Java tracer already emits these thread tags. With the legacy/v0.4 shape, `thread.name` is visible in `meta`, while `thread.id` is inside `metrics`, which these tests scrub as a whole. With the efficient trace payload format, meta and metrics are represented together under `attributes`, so both thread tags become visible in the approval surface.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
