### PR TITLE
SSI: Only ruby uses git checkout to get the app source file in the EC2

### DIFF
--- a/utils/virtual_machine/virtual_machine_provisioner.py
+++ b/utils/virtual_machine/virtual_machine_provisioner.py
@@ -173,6 +173,8 @@ class VirtualMachineProvisioner:
         installations = weblog["install"]
         # Use GIT does not work for windows machines
         ci_commit_branch = os.getenv("GITLAB_CI") if os_type != "windows" else None
+        # Only ruby uses git, because other languages don't need this checkout step,
+        # because they are handling less number of files
         installation = self._get_installation(
             env,
             library_name,
@@ -181,7 +183,7 @@ class VirtualMachineProvisioner:
             os_branch,
             os_cpu,
             installations,
-            use_git=ci_commit_branch is not None,
+            use_git=ci_commit_branch is not None and library_name == "ruby",
         )
         installation.id = weblog["name"]
         installation.nginx_config = weblog.get("nginx_config", None)


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Fix. Only Ruby uses git to upload the app source files to the ec2 machine

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
