### PR TITLE
Fixed v1 DBM boolean tag assertion.

### DIFF
--- a/tests/integrations/test_dbm.py
+++ b/tests/integrations/test_dbm.py
@@ -8,7 +8,7 @@ import re
 
 from utils import weblog, interfaces, context, scenarios, features, logger
 from utils._weblog import HttpResponse
-from utils.dd_types import DataDogLibrarySpan
+from utils.dd_types import DataDogLibrarySpan, is_same_boolean
 
 
 def remove_traceparent(s: str) -> str:
@@ -103,7 +103,7 @@ class Test_Dbm:
         meta = span.get("meta", {})
         assert self.META_TAG in meta, f"{self.META_TAG} not found in span meta: {json.dumps(span.raw_span, indent=2)}"
         tag_value = meta.get(self.META_TAG)
-        assert tag_value == "true", f"{self.META_TAG} value is not `true`."
+        assert is_same_boolean(actual=tag_value, expected="true"), f"{self.META_TAG} value is not `true`."
 
     # Setup Methods
     setup_trace_payload_disabled = weblog_trace_payload


### PR DESCRIPTION
## Motivation
Fixed v1 DBM boolean tag assertion.

## Changes

Used `is_same_boolean` for safe comparison with `true` as in `v1` `dd-trace-java` can now return real `Boolean`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
