### PR TITLE
enable client ip tests for python

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2287,7 +2287,7 @@ manifest:
         uwsgi-poc: v4.3.1  # Modified by easy win activation script
   tests/test_standard_tags.py::Test_StandardTagsClientIp: v2.7.0
   tests/test_standard_tags.py::Test_StandardTagsMethod: v1.2.1
-  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp: bug (APPSEC-62204)
+  tests/test_standard_tags.py::Test_StandardTagsNetworkClientIp: v4.12.0-rc1
   tests/test_standard_tags.py::Test_StandardTagsReferrerHostname: v3.4.0
   tests/test_standard_tags.py::Test_StandardTagsRoute:
     - weblog_declaration:


### PR DESCRIPTION
APPSEC-62204

Following fix in https://github.com/DataDog/dd-trace-py/pull/17433, enable network client ip tests again.