### PR TITLE
Enriching & Enabling OTLP Runtime Metrics for JS

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2408,7 +2408,7 @@ manifest:
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)
   tests/test_library_logs.py::Test_NoExceptions::test_java_logs: irrelevant (only for Java)
   tests/test_library_logs.py::Test_NoExceptions::test_java_telemetry_logs: irrelevant (only for Java)
-  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics: missing_feature
+  tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics: v5.107.0-pre
   tests/test_profiling.py::Test_Profile: *ref_5_16_0
   tests/test_profiling.py::Test_Profile::test_process_tags: missing_feature
   tests/test_profiling.py::Test_Profile::test_process_tags_svc: missing_feature

--- a/tests/test_otlp_runtime_metrics.py
+++ b/tests/test_otlp_runtime_metrics.py
@@ -57,13 +57,22 @@ EXPECTED_METRICS: dict[str, dict[str, dict[str, list[str]]]] = {
         "nodejs.eventloop.delay.p50": {"all": []},
         "nodejs.eventloop.delay.p90": {"all": []},
         "nodejs.eventloop.delay.p99": {"all": []},
+        "nodejs.eventloop.delay.stddev": {"all": []},
+        "nodejs.eventloop.time": {"all": ["nodejs.eventloop.state"]},
         "nodejs.eventloop.utilization": {"all": []},
-        "process.cpu.utilization": {"all": []},
-        "process.memory.usage": {"all": []},
+        # v8js.gc.duration is a histogram; the agent surfaces it as .count/.sum/.min/.max series.
+        "v8js.gc.duration.count": {"all": ["v8js.gc.type"]},
+        "v8js.gc.duration.max": {"all": ["v8js.gc.type"]},
+        "v8js.gc.duration.min": {"all": ["v8js.gc.type"]},
+        "v8js.gc.duration.sum": {"all": ["v8js.gc.type"]},
+        # v8js.memory.heap.limit emits a single aggregate point (heap_size_limit) without a space tag;
+        # all other heap instruments emit per-space points carrying v8js.heap.space.name.
         "v8js.memory.heap.limit": {"all": []},
-        "v8js.memory.heap.space.available_size": {"all": []},
-        "v8js.memory.heap.space.physical_size": {"all": []},
-        "v8js.memory.heap.used": {"all": []},
+        "v8js.memory.heap.space.available_size": {"all": ["v8js.heap.space.name"]},
+        "v8js.memory.heap.space.physical_size": {"all": ["v8js.heap.space.name"]},
+        "v8js.memory.heap.space.size": {"all": ["v8js.heap.space.name"]},
+        "v8js.memory.heap.used": {"all": ["v8js.heap.space.name"]},
+        "v8js.resource.active": {"all": ["v8js.resource.type"]},
     },
     "java": {
         "jvm.buffer.count": {"all": ["jvm.buffer.pool.name"]},
@@ -97,10 +106,61 @@ EXPECTED_METRICS: dict[str, dict[str, dict[str, list[str]]]] = {
     },
 }
 
-# Valid value domains for attributes. For closed enums (jvm.memory.type, jvm.thread.*) these are
-# exhaustive. For open-ended attributes (pool names, GC names) these are supersets covering all
-# known JVM/GC implementations — the assertion is that observed values fall within the known universe.
+# Valid value domains for attributes. For closed enums (jvm.memory.type, jvm.thread.*,
+# nodejs.eventloop.state, v8js.gc.type) these are exhaustive. For open-ended attributes
+# (pool names, GC names, V8 heap space names, libuv resource types) these are supersets
+# covering all known implementations — the assertion is that observed values fall within
+# the known universe.
 EXPECTED_METRIC_ATTRIBUTE_VALUES: dict[str, dict[str, frozenset[str]]] = {
+    "nodejs": {
+        # Closed enum: performance.eventLoopUtilization() exposes idle and active only.
+        "nodejs.eventloop.state": frozenset({"active", "idle"}),
+        # Closed enum: dd-trace-js maps perf_hooks GC kinds to these four OTel values.
+        # Kind 2 (V8 MinorMarkSweep on Node 20+) is mapped to "minor" upstream.
+        "v8js.gc.type": frozenset({"minor", "major", "incremental", "weakcb"}),
+        # V8 heap space names: OTel well-known set plus additional spaces V8 exposes in
+        # Node 18+ (read_only, *_large_object) and Node 20+ multi-isolate/sandbox spaces.
+        "v8js.heap.space.name": frozenset(
+            {
+                "new_space",
+                "old_space",
+                "code_space",
+                "large_object_space",
+                "map_space",
+                "read_only_space",
+                "new_large_object_space",
+                "code_large_object_space",
+                "shared_space",
+                "shared_large_object_space",
+                "trusted_space",
+                "trusted_large_object_space",
+                "shared_trusted_space",
+                "shared_trusted_large_object_space",
+            }
+        ),
+        # libuv handle types reported by process.getActiveResourcesInfo(); superset across Node 18+.
+        "v8js.resource.type": frozenset(
+            {
+                "Immediate",
+                "Timeout",
+                "TCPServerWrap",
+                "TCPWrap",
+                "TTYWrap",
+                "PipeWrap",
+                "UDPWrap",
+                "TLSWrap",
+                "FSReqCallback",
+                "MessagePort",
+                "DNSChannel",
+                "FSEvent",
+                "SignalWrap",
+                "StatWatcher",
+                "HTTPClientRequest",
+                "HTTPParser",
+                "Microtask",
+            }
+        ),
+    },
     "java": {
         "jvm.memory.type": frozenset({"heap", "non_heap"}),
         "jvm.thread.daemon": frozenset({"true", "false"}),


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
So that we can test that the work is done correctly when collecting and sending OTLP Runtime Metrics using the DD SDK.

## Changes

Added attributes to the test assertions, removed unexpected metrics and enabled it.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
