### PR TITLE
Assert OTLP header and Datadog key configs are not reported in telemetry [python@brian.marks/omit-sensitive-config-telemetry][golang@brian.marks/omit-sensitive-config-telemetry][java@brian.marks/omit-sensitive-config-telemetry][nodejs@brian.marks/omit-sensitive-config-telemetry][dotnet@brian.marks/omit-sensitive-config-telemetry][ruby@brian.marks/omit-sensitive-config-telemetry][php@brian.marks/omit-sensitive-config-telemetry][rust@brian.marks/omit-sensitive-config-telemetry]

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -277,6 +277,7 @@ manifest:
   : missing_feature (extended configs are not supported)
   ? tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_origin_extended_configs_temporary_use_case
   : missing_feature (extended configs are not supported)
+  tests/parametric/test_telemetry.py::Test_TelemetryConfigSensitive: missing_feature (Sensitive configurations not yet excluded from configuration telemetry)
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature: ">1.0.0"
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: '>=2.0.0'  # Modified by easy win activation script
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated: missing_feature  # Created by easy win activation script

--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -88,6 +88,7 @@ manifest:
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)
+  tests/parametric/test_telemetry.py::Test_TelemetryConfigSensitive: missing_feature (Sensitive configurations not yet excluded from configuration telemetry)
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature
   tests/parametric/test_tracer.py::Test_TracerBaseService: missing_feature (_dd.base_service is not implemented)

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -338,6 +338,7 @@ manifest:
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_keep_span_with_stats_computation_sss010: missing_feature (this has to be implemented by a lot of the tracers and we need to do a bit of work on the assert)
+  tests/parametric/test_telemetry.py::Test_TelemetryConfigSensitive: missing_feature (Sensitive configurations not yet excluded from configuration telemetry)
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature
   tests/parametric/test_tracer.py::Test_TracerBaseService: missing_feature (_dd.base_service is not implemented)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -913,9 +913,8 @@ manifest:
   tests/parametric/test_otel_metrics.py: v3.29.0
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Api_MeterProvider::test_otel_get_meter_by_distinct_schema_url: missing_feature (Not supported by .NET's System.Diagnostics.Metrics API)
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Host_Name::test_hostname_from_dd_hostname: missing_feature (DD_HOSTNAME to host.name resource attribute mapping not yet implemented)
-  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_exporter_configurations:  # Modified by easy win activation script
-    - declaration: missing_feature (OTel metrics telemetry metrics (otel.metrics_export_attempts) not yet fully flushed in time)
-      component_version: <3.36.0
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_exporter_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_exporter_metrics_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_metrics_grpc: missing_feature (OTel metrics telemetry metrics (otel.metrics_export_attempts) not yet fully flushed in time)
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_metrics_http_protobuf: missing_feature
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_add_event_meta_serialization: missing_feature (Newer agents/testagents enabled native span event serialization by default)
@@ -1018,6 +1017,7 @@ manifest:
   tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_config_id: missing_feature (Not implemented)
   ? tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_origin_extended_configs_temporary_use_case
   : irrelevant (temporary use case for python, ruby and nodejs)
+  tests/parametric/test_telemetry.py::Test_TelemetryConfigSensitive: missing_feature (Sensitive configurations not yet excluded from configuration telemetry)
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature: v2.45.0
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: v2.50.0
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1251,6 +1251,7 @@ manifest:
   : missing_feature (extended configs are not supported)
   ? tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_origin_extended_configs_temporary_use_case
   : missing_feature (extended configs are not supported)
+  tests/parametric/test_telemetry.py::Test_TelemetryConfigSensitive: missing_feature (Sensitive configurations not yet excluded from configuration telemetry)
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature: '>=2.5.0'  # Modified by easy win activation script
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature::test_telemetry_event_not_propagated: missing_feature  # Created by easy win activation script
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: v1.63.0-rc.1

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3859,6 +3859,7 @@ manifest:
   tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_config_id: 1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
   ? tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_origin_extended_configs_temporary_use_case
   : irrelevant (temporary use case for python, ruby and nodejs)
+  tests/parametric/test_telemetry.py::Test_TelemetryConfigSensitive: missing_feature (Sensitive configurations not yet excluded from configuration telemetry)
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature: v1.27.0
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: v1.61.0-SNAPSHOT  # Normalization of telemetry keys updated in https://github.com/DataDog/dd-trace-java/pull/10823
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2099,6 +2099,8 @@ manifest:
   tests/parametric/test_otel_logs.py::Test_FR09_Log_Injection: *ref_5_72_0
   tests/parametric/test_otel_logs.py::Test_FR10_Timeout_Configuration: *ref_5_72_0
   tests/parametric/test_otel_logs.py::Test_FR11_Telemetry: *ref_5_72_0
+  tests/parametric/test_otel_logs.py::Test_FR11_Telemetry::test_telemetry_exporter_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
+  tests/parametric/test_otel_logs.py::Test_FR11_Telemetry::test_telemetry_exporter_logs_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
   tests/parametric/test_otel_logs.py::Test_FR12_Log_Levels: *ref_5_72_0
   tests/parametric/test_otel_logs.py::Test_FR13_Scope_Fields::test_scope_attributes_field: missing_feature (dd-trace-js does not support scope attributes - hardcoded to empty array in otlp_transformer.js)
   tests/parametric/test_otel_logs.py::Test_FR13_Scope_Fields::test_scope_schema_url_field: *ref_5_72_0
@@ -2110,6 +2112,8 @@ manifest:
   ? tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Endpoint::test_otlp_metrics_custom_endpoint_grpc
   : missing_feature (Does not support grpc)
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Host_Name::test_hostname_from_dd_hostname: missing_feature (DD_HOSTNAME to host.name resource attribute mapping not yet implemented)
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_exporter_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_exporter_metrics_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_metrics_grpc: missing_feature (Does not support grpc)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_add_event_meta_serialization:
     - declaration: missing_feature (Implemented in v5.17.0 & v4.41.0)
@@ -2218,6 +2222,7 @@ manifest:
   ? tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_origin_extended_configs_temporary_use_case
   : - declaration: missing_feature (extended configs are not supported)
       component_version: <=5.75.0
+  tests/parametric/test_telemetry.py::Test_TelemetryConfigSensitive: missing_feature (Sensitive configurations not yet excluded from configuration telemetry)
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature: *ref_4_23_0
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: *ref_5_13_0
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated_specifics: irrelevant

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -925,6 +925,7 @@ manifest:
   tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin: bug (APMAPI-1898)
   ? tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_origin_extended_configs_temporary_use_case
   : irrelevant (temporary use case for python, ruby and nodejs)
+  tests/parametric/test_telemetry.py::Test_TelemetryConfigSensitive: missing_feature (Sensitive configurations not yet excluded from configuration telemetry)
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature: missing_feature
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: missing_feature
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_propagated: '>=1.16.0'

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1893,12 +1893,16 @@ manifest:
   tests/parametric/test_otel_logs.py::Test_FR09_Log_Injection: v3.13.0.dev
   tests/parametric/test_otel_logs.py::Test_FR10_Timeout_Configuration: v3.13.0.dev
   tests/parametric/test_otel_logs.py::Test_FR11_Telemetry: v3.15.0
+  tests/parametric/test_otel_logs.py::Test_FR11_Telemetry::test_telemetry_exporter_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
+  tests/parametric/test_otel_logs.py::Test_FR11_Telemetry::test_telemetry_exporter_logs_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
   tests/parametric/test_otel_logs.py::Test_FR12_Log_Levels: v3.13.0.dev
   tests/parametric/test_otel_logs.py::Test_FR13_Scope_Fields::test_scope_attributes_field: missing_feature (OpenTelemetry Python SDK bug - LoggerProvider.get_logger() caching doesn't preserve scope attributes when attributes=None)
   tests/parametric/test_otel_logs.py::Test_FR13_Scope_Fields::test_scope_schema_url_field: missing_feature
   tests/parametric/test_otel_logs.py::Test_FR13_Scope_Fields::test_scope_version_field: missing_feature
   tests/parametric/test_otel_metrics.py: v3.18.0
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Api_MeterProvider::test_otel_get_meter_by_distinct_schema_url: '>=4.3.1'  # Modified by easy win activation script
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_exporter_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_exporter_metrics_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods: v2.8.0
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_add_event_meta_serialization:
     - declaration: missing_feature (Not implemented)
@@ -2013,6 +2017,7 @@ manifest:
   tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin: v3.7.0.dev
   ? tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_origin_extended_configs_good_use_case
   : bug (APMAPI-1630)
+  tests/parametric/test_telemetry.py::Test_TelemetryConfigSensitive: missing_feature (Sensitive configurations not yet excluded from configuration telemetry)
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature: v2.5.0
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: v2.9.0
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_enabled_not_propagated:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2219,6 +2219,7 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_sdk_disabled_set: missing_feature (does not support enabling opentelemetry via DD_TRACE_OTEL_ENABLED)
   tests/parametric/test_otel_logs.py: '>=2.34.0-dev'
   tests/parametric/test_otel_logs.py::Test_FR08_Custom_Headers: missing_feature (Ruby net/http titlecases header names; test checks lowercase; fix requires overriding OTLP exporter HTTP headers)
+  tests/parametric/test_otel_logs.py::Test_FR11_Telemetry::test_telemetry_exporter_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
   tests/parametric/test_otel_logs.py::Test_FR11_Telemetry::test_telemetry_exporter_logs_configurations: missing_feature (OTEL_EXPORTER_OTLP_LOGS_ENDPOINT is not supported)
   tests/parametric/test_otel_logs.py::Test_FR13_Scope_Fields::test_scope_attributes_field: missing_feature (opentelemetry-logs-sdk >= 0.5.1 required for scope attributes; upgrade Docker image to ruby:3.3+)
   tests/parametric/test_otel_logs.py::Test_FR13_Scope_Fields::test_scope_schema_url_field: missing_feature (opentelemetry-logs-sdk >= 0.5.1 required for schema_url; upgrade Docker image to ruby:3.3+)
@@ -2241,6 +2242,8 @@ manifest:
   ? tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Configuration_OTLP_Exporter_Metrics_Endpoint::test_otlp_metrics_custom_endpoint_grpc
   : missing_feature (Does not support grpc)
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Configuration_Temporality_Preference::test_otel_aggregation_temporality: missing_feature (default Histogram bucket ranges is not up to spec)
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_exporter_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_exporter_metrics_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_metrics_grpc: missing_feature (Does not support grpc)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods: v1.17.0
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_add_event_meta_serialization: missing_feature (Newer agents/testagents enabled native span event serialization by default)
@@ -2332,6 +2335,7 @@ manifest:
   tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin: v2.31.0-dev
   ? tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin::test_stable_configuration_origin_extended_configs_good_use_case
   : bug (APMAPI-1631)
+  tests/parametric/test_telemetry.py::Test_TelemetryConfigSensitive: missing_feature (Sensitive configurations not yet excluded from configuration telemetry)
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature: '>=2.27.0'  # Modified by easy win activation script
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature::test_telemetry_event_not_propagated: missing_feature  # Created by easy win activation script
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: v2.31.0-dev

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -190,6 +190,8 @@ manifest:
     - declaration: incomplete_test_app
   tests/parametric/test_otel_logs.py: v0.3.0
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
+  tests/parametric/test_otel_logs.py::Test_FR11_Telemetry::test_telemetry_exporter_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
+  tests/parametric/test_otel_logs.py::Test_FR11_Telemetry::test_telemetry_exporter_logs_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
   tests/parametric/test_otel_logs.py::Test_FR11_Telemetry::test_telemetry_metrics: missing_feature (Rust telemetry metrics are not submitted in time to run tests against)
   tests/parametric/test_otel_logs.py::Test_FR13_Scope_Fields::test_scope_attributes_field: missing_feature (OpenTelemetry Rust SDK limitation - scope attributes not exported by opentelemetry-otlp)
   tests/parametric/test_otel_logs.py::Test_FR13_Scope_Fields::test_scope_schema_url_field: missing_feature (OpenTelemetry Rust SDK limitation - schema_url not exported by opentelemetry-otlp)
@@ -199,6 +201,8 @@ manifest:
   : missing_feature (OpenTelemetry Rust SDK does not filter negative values for Histogram.record(). This is a bug in the upstream SDK)
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Api_MeterProvider::test_otel_get_meter_by_distinct_scope_attributes: missing_feature (Rust OpenTelemetry SDK 0.31.0's meter() method does not support scope attributes parameter)
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Host_Name::test_hostname_from_dd_hostname: missing_feature
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_exporter_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
+  tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_exporter_metrics_configurations: missing_feature (OTLP header configurations not yet excluded from configuration telemetry)
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_metrics_grpc: '>=0.2.1'  # Modified by easy win activation script
   tests/parametric/test_otel_metrics.py::Test_Otel_Metrics_Telemetry::test_telemetry_metrics_http_protobuf: '>=0.2.1'  # Modified by easy win activation script
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods: v0.0.1
@@ -272,6 +276,7 @@ manifest:
   tests/parametric/test_telemetry.py::Test_Defaults: missing_feature
   tests/parametric/test_telemetry.py::Test_Environment: missing_feature
   tests/parametric/test_telemetry.py::Test_Stable_Configuration_Origin: missing_feature
+  tests/parametric/test_telemetry.py::Test_TelemetryConfigSensitive: missing_feature (Sensitive configurations not yet excluded from configuration telemetry)
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature: '>=0.2.1'  # Modified by easy win activation script
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature::test_telemetry_event_propagated: missing_feature  # Created by easy win activation script
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: '>=0.2.1'  # Modified by easy win activation script

--- a/tests/parametric/test_otel_logs.py
+++ b/tests/parametric/test_otel_logs.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 import pytest
 
 from utils import scenarios, features, logger
+from utils.telemetry_utils import OTLP_HEADER_SENTINELS, assert_no_otlp_header_value_in_telemetry
 from utils.docker_fixtures.parametric import LogLevel
 from utils.docker_fixtures import TestAgentAPI
 from utils.docker_fixtures.spec.trace import find_only_span
@@ -661,7 +662,7 @@ class Test_FR11_Telemetry:
                     "DD_TRACE_DEBUG": None,
                     "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1",
                     "OTEL_EXPORTER_OTLP_TIMEOUT": "30000",
-                    "OTEL_EXPORTER_OTLP_HEADERS": "api-key=key,other-config-value=value",
+                    "OTEL_EXPORTER_OTLP_HEADERS": f"dd-api-key={OTLP_HEADER_SENTINELS['OTEL_EXPORTER_OTLP_HEADERS']}",
                     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
                 },
                 "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -676,7 +677,11 @@ class Test_FR11_Telemetry:
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):
-        """Test configurations starting with OTEL_EXPORTER_OTLP_ are sent to the instrumentation telemetry intake."""
+        """Test non-header OTEL_EXPORTER_OTLP_ configurations are sent to the instrumentation telemetry intake.
+
+        The OTEL_EXPORTER_OTLP_HEADERS value is not reported in configuration telemetry: tracers either
+        omit the entry or redact its value, so the configured header value never appears in any reported value.
+        """
         with test_library as library:
             library.create_logger("test_logger", LogLevel.INFO)
             library.write_log("test_logger", LogLevel.INFO, "test_telemetry_exporter_configurations")
@@ -688,7 +693,6 @@ class Test_FR11_Telemetry:
 
         for expected_env, expected_value in [
             ("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"),
-            ("OTEL_EXPORTER_OTLP_HEADERS", "api-key=key,other-config-value=value"),
             ("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
             ("OTEL_EXPORTER_OTLP_ENDPOINT", library_env["OTEL_EXPORTER_OTLP_ENDPOINT"]),
         ]:
@@ -704,6 +708,8 @@ class Test_FR11_Telemetry:
                 f"Expected {expected_env} to be {expected_value}, configuration: {config}"
             )
 
+        assert_no_otlp_header_value_in_telemetry(configurations_by_name)
+
     @pytest.mark.parametrize(
         ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
         [
@@ -713,7 +719,7 @@ class Test_FR11_Telemetry:
                     "DD_TRACE_DEBUG": None,
                     "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1",
                     "OTEL_EXPORTER_OTLP_LOGS_TIMEOUT": "30000",
-                    "OTEL_EXPORTER_OTLP_LOGS_HEADERS": "api-key=key,other-config-value=value",
+                    "OTEL_EXPORTER_OTLP_LOGS_HEADERS": f"dd-api-key={OTLP_HEADER_SENTINELS['OTEL_EXPORTER_OTLP_LOGS_HEADERS']}",
                     "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": "http/protobuf",
                 },
                 "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
@@ -728,7 +734,11 @@ class Test_FR11_Telemetry:
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):
-        """Test Teleemtry configurations starting with OTEL_EXPORTER_OTLP_LOGS_ are sent to the instrumentation telemetry intake."""
+        """Test non-header OTEL_EXPORTER_OTLP_LOGS_ configurations are sent to the instrumentation telemetry intake.
+
+        The OTEL_EXPORTER_OTLP_LOGS_HEADERS value is not reported in configuration telemetry: tracers either
+        omit the entry or redact its value, so the configured header value never appears in any reported value.
+        """
         with test_library as library:
             library.create_logger("telemetry_exporter_logs_configurations", LogLevel.INFO)
             library.write_log(
@@ -747,7 +757,6 @@ class Test_FR11_Telemetry:
 
         for expected_env, expected_value in [
             ("OTEL_EXPORTER_OTLP_LOGS_TIMEOUT", "30000"),
-            ("OTEL_EXPORTER_OTLP_LOGS_HEADERS", "api-key=key,other-config-value=value"),
             ("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "http/protobuf"),
             ("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", library_env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"]),
         ]:
@@ -760,6 +769,8 @@ class Test_FR11_Telemetry:
             assert str(config.get("value")) == expected_value, (
                 f"Expected {expected_env} to be {expected_value}, configuration: {config}"
             )
+
+        assert_no_otlp_header_value_in_telemetry(configurations_by_name)
 
     @pytest.mark.parametrize(
         "library_env",

--- a/tests/parametric/test_otel_metrics.py
+++ b/tests/parametric/test_otel_metrics.py
@@ -2,6 +2,7 @@ from urllib.parse import urlparse
 import pytest
 
 from utils import features, scenarios
+from utils.telemetry_utils import OTLP_HEADER_SENTINELS, assert_no_otlp_header_value_in_telemetry
 
 from utils.docker_fixtures import TestAgentAPI
 from .conftest import APMLibrary
@@ -1869,7 +1870,7 @@ class Test_Otel_Metrics_Telemetry:
                     **DEFAULT_ENVVARS,
                     "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1",
                     "OTEL_EXPORTER_OTLP_TIMEOUT": "30000",
-                    "OTEL_EXPORTER_OTLP_HEADERS": "api-key=key,other-config-value=value",
+                    "OTEL_EXPORTER_OTLP_HEADERS": f"dd-api-key={OTLP_HEADER_SENTINELS['OTEL_EXPORTER_OTLP_HEADERS']}",
                     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
                     "OTEL_METRIC_EXPORT_INTERVAL": "5000",
                     "OTEL_METRIC_EXPORT_TIMEOUT": "5000",
@@ -1886,7 +1887,11 @@ class Test_Otel_Metrics_Telemetry:
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):
-        """Test configurations starting with OTEL_EXPORTER_OTLP_ are sent to the instrumentation telemetry intake."""
+        """Test non-header OTEL_EXPORTER_OTLP_ configurations are sent to the instrumentation telemetry intake.
+
+        The OTEL_EXPORTER_OTLP_HEADERS value is not reported in configuration telemetry: tracers either
+        omit the entry or redact its value, so the configured header value never appears in any reported value.
+        """
         name = "test_telemetry_exporter_configurations"
 
         with test_library as t:
@@ -1900,7 +1905,6 @@ class Test_Otel_Metrics_Telemetry:
 
         for expected_env, expected_value in [
             ("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"),
-            ("OTEL_EXPORTER_OTLP_HEADERS", "api-key=key,other-config-value=value"),
             ("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
             ("OTEL_EXPORTER_OTLP_ENDPOINT", library_env["OTEL_EXPORTER_OTLP_ENDPOINT"]),
             ("OTEL_METRIC_EXPORT_INTERVAL", "5000"),
@@ -1916,6 +1920,8 @@ class Test_Otel_Metrics_Telemetry:
                 f"Expected {expected_env} to be {expected_value}, configuration: {config}"
             )
 
+        assert_no_otlp_header_value_in_telemetry(configurations_by_name)
+
     @pytest.mark.parametrize(
         ("library_env", "endpoint_env", "test_agent_otlp_http_port"),
         [
@@ -1924,7 +1930,7 @@ class Test_Otel_Metrics_Telemetry:
                     "DD_METRICS_OTEL_ENABLED": "true",
                     "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1",
                     "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT": "30000",
-                    "OTEL_EXPORTER_OTLP_METRICS_HEADERS": "api-key=key,other-config-value=value",
+                    "OTEL_EXPORTER_OTLP_METRICS_HEADERS": f"dd-api-key={OTLP_HEADER_SENTINELS['OTEL_EXPORTER_OTLP_METRICS_HEADERS']}",
                     "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf",
                 },
                 "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
@@ -1939,7 +1945,11 @@ class Test_Otel_Metrics_Telemetry:
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ):
-        """Test Teleemtry configurations starting with OTEL_EXPORTER_OTLP_METRICS_ are sent to the instrumentation telemetry intake."""
+        """Test non-header OTEL_EXPORTER_OTLP_METRICS_ configurations are sent to the instrumentation telemetry intake.
+
+        The OTEL_EXPORTER_OTLP_METRICS_HEADERS value is not reported in configuration telemetry: tracers either
+        omit the entry or redact its value, so the configured header value never appears in any reported value.
+        """
         name = "test_telemetry_exporter_metrics_configurations"
 
         with test_library as t:
@@ -1953,7 +1963,6 @@ class Test_Otel_Metrics_Telemetry:
 
         for expected_env, expected_value in [
             ("OTEL_EXPORTER_OTLP_METRICS_TIMEOUT", "30000"),
-            ("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "api-key=key,other-config-value=value"),
             ("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "http/protobuf"),
             ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", library_env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"]),
         ]:
@@ -1966,6 +1975,8 @@ class Test_Otel_Metrics_Telemetry:
             assert str(config.get("value")) == expected_value, (
                 f"Expected {expected_env} to be {expected_value}, configuration: {config}"
             )
+
+        assert_no_otlp_header_value_in_telemetry(configurations_by_name)
 
     @pytest.mark.parametrize(
         "library_env",

--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -8,7 +8,12 @@ import uuid
 import pytest
 
 from .conftest import StableConfigWriter
-from utils.telemetry_utils import TelemetryUtils
+from utils.telemetry_utils import (
+    DD_KEY_SENTINELS,
+    OTLP_HEADER_SENTINELS,
+    TelemetryUtils,
+    assert_no_sensitive_value_in_telemetry,
+)
 
 from utils import context, scenarios, rfc, features, logger
 from utils.docker_fixtures import TestAgentAPI
@@ -1288,3 +1293,72 @@ class Test_TelemetrySCAEnvVar:
             assert cfg_appsec_enabled[0].get("value") is None
         else:
             assert all(config_name not in configuration_by_name for config_name in dd_appsec_sca_enabled_names)
+
+
+@rfc("https://docs.google.com/document/d/14vsrCbnAKnXmJAkacX9I6jKPGKmxsq0PKUb3dfiZpWE/edit")
+@scenarios.parametric
+@features.telemetry_app_started_event
+class Test_TelemetryConfigSensitive:
+    """Sensitive configuration values are not reported with their real value in configuration telemetry.
+
+    Covers the OTLP exporter header family and the Datadog key family. Each value is set to a distinct
+    recognizable sentinel; the configured value must not appear in any reported configuration value.
+    Tracers satisfy this by either omitting the configuration entry or by redacting its value, so a
+    single assertion (sentinel-absence) covers both idioms with no per-language carve-out.
+    """
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+                **DEFAULT_ENVVARS,
+                "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1",
+                # Each OTLP header variant carries a distinct sentinel value. A tracer that does not read
+                # a given variant simply will not report it, so the same assertion holds for every language.
+                "OTEL_EXPORTER_OTLP_HEADERS": f"dd-api-key={OTLP_HEADER_SENTINELS['OTEL_EXPORTER_OTLP_HEADERS']}",
+                "OTEL_EXPORTER_OTLP_TRACES_HEADERS": (
+                    f"dd-api-key={OTLP_HEADER_SENTINELS['OTEL_EXPORTER_OTLP_TRACES_HEADERS']}"
+                ),
+                "OTEL_EXPORTER_OTLP_METRICS_HEADERS": (
+                    f"dd-api-key={OTLP_HEADER_SENTINELS['OTEL_EXPORTER_OTLP_METRICS_HEADERS']}"
+                ),
+                "OTEL_EXPORTER_OTLP_LOGS_HEADERS": (
+                    f"dd-api-key={OTLP_HEADER_SENTINELS['OTEL_EXPORTER_OTLP_LOGS_HEADERS']}"
+                ),
+            },
+        ],
+    )
+    def test_otlp_headers_not_in_telemetry(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+        """No OTEL_EXPORTER_OTLP_*_HEADERS value appears in configuration telemetry."""
+        with test_library.dd_start_span("test"):
+            pass
+
+        configuration_by_name = test_agent.wait_for_telemetry_configurations()
+        assert configuration_by_name, "No configuration telemetry was reported"
+
+        assert_no_sensitive_value_in_telemetry(configuration_by_name, list(OTLP_HEADER_SENTINELS.values()))
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+                **DEFAULT_ENVVARS,
+                "DD_TELEMETRY_HEARTBEAT_INTERVAL": "0.1",
+                # Set the Datadog key family to recognizable sentinels. The parametric scenario points the
+                # tracer at the test agent via DD_TRACE_AGENT_URL, so configuration telemetry is still captured.
+                "DD_API_KEY": DD_KEY_SENTINELS["DD_API_KEY"],
+                "DD_APP_KEY": DD_KEY_SENTINELS["DD_APP_KEY"],
+                # A control config that is reported normally, so we can confirm configuration reporting is active.
+                "DD_SERVICE": "test_telemetry_config_sensitive",
+            },
+        ],
+    )
+    def test_dd_api_key_not_in_telemetry(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+        """No DD_API_KEY / DD_APP_KEY value appears in configuration telemetry."""
+        with test_library.dd_start_span("test"):
+            pass
+
+        configuration_by_name = test_agent.wait_for_telemetry_configurations()
+        assert configuration_by_name, "No configuration telemetry was reported"
+
+        assert_no_sensitive_value_in_telemetry(configuration_by_name, list(DD_KEY_SENTINELS.values()))

--- a/utils/telemetry_utils.py
+++ b/utils/telemetry_utils.py
@@ -1,6 +1,47 @@
 from utils._context.component_version import ComponentVersion
 
 
+# Distinct, recognizable sentinel values for each OTLP header variant. Each is set as the value of a
+# header in the corresponding OTEL_EXPORTER_OTLP_*_HEADERS environment variable. None of these values
+# may appear in any configuration telemetry value: tracers either omit the configuration entry or
+# redact its value, so the configured header value is never reported.
+OTLP_HEADER_SENTINELS: dict[str, str] = {
+    "OTEL_EXPORTER_OTLP_HEADERS": "SENTINEL_OTLP_BASE",
+    "OTEL_EXPORTER_OTLP_TRACES_HEADERS": "SENTINEL_OTLP_TRACES",
+    "OTEL_EXPORTER_OTLP_METRICS_HEADERS": "SENTINEL_OTLP_METRICS",
+    "OTEL_EXPORTER_OTLP_LOGS_HEADERS": "SENTINEL_OTLP_LOGS",
+}
+
+# Sentinel values for the Datadog key family. Set as the value of the corresponding environment
+# variable; the value must not appear in any configuration telemetry value.
+DD_KEY_SENTINELS: dict[str, str] = {
+    "DD_API_KEY": "SENTINEL_DD_API_KEY",
+    "DD_APP_KEY": "SENTINEL_DD_APP_KEY",
+}
+
+
+def assert_no_sensitive_value_in_telemetry(configurations_by_name: dict[str, list[dict]], sentinels: list[str]) -> None:
+    """Assert that no configuration telemetry entry reports any of the given sentinel values.
+
+    `configurations_by_name` is the mapping returned by TestAgentAPI.wait_for_telemetry_configurations():
+    configuration name -> list of {name, value, origin, ...} entries. A tracer satisfies the invariant
+    by either omitting an entry (its value never appears) or redacting it (e.g. `<redacted>`, `<hidden>`),
+    so this check passes for both idioms and fails only if a real configured value is reported.
+    """
+    for config_list in configurations_by_name.values():
+        for config in config_list:
+            value = str(config.get("value"))
+            for sentinel in sentinels:
+                assert sentinel not in value, (
+                    f"Sensitive value '{sentinel}' must not appear in configuration telemetry, configuration: {config}"
+                )
+
+
+def assert_no_otlp_header_value_in_telemetry(configurations_by_name: dict[str, list[dict]]) -> None:
+    """Assert that no OTLP header sentinel value appears in any configuration telemetry value."""
+    assert_no_sensitive_value_in_telemetry(configurations_by_name, list(OTLP_HEADER_SENTINELS.values()))
+
+
 class TelemetryUtils:
     test_loaded_dependencies = {
         "dotnet": {"NodaTime": False},


### PR DESCRIPTION
## Motivation

These configurations should not be reported with their value in configuration telemetry; this adds parametric coverage of that.

## Changes

Adds `Test_TelemetryConfigSensitive` (parametric), which sets each OTLP exporter header configuration and `DD_API_KEY`/`DD_APP_KEY` to a distinct sentinel value and asserts no sentinel appears in any configuration telemetry value. The new and updated assertions are gated with `missing_feature` across the language manifests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified? A shared helper in `utils/telemetry_utils.py` is added; pending R&P review.
* [ ] A docker base image is modified? No.
* [ ] A scenario is added, removed or renamed? No.
