### PR TITLE
Use Datadog registry in injector dev defaults

### DIFF
--- a/utils/_context/_scenarios/k8s_injector_dev.py
+++ b/utils/_context/_scenarios/k8s_injector_dev.py
@@ -58,7 +58,9 @@ class K8sInjectorDevScenario(Scenario):
         )
 
         self.k8s_injector_img = K8sComponentImage(
-            config.option.k8s_injector_img if config.option.k8s_injector_img else "gcr.io/datadoghq/apm-inject:latest",
+            config.option.k8s_injector_img
+            if config.option.k8s_injector_img
+            else "registry.datadoghq.com/apm-inject:latest",
             extract_injector_version,
             self.ssi_registry_base,
         )

--- a/utils/build/virtual_machine/provisions/auto-inject/docker/docker-compose-agent-prod.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/docker/docker-compose-agent-prod.yml
@@ -2,7 +2,7 @@ services:
   datadog:
     container_name: dd-agent
     # Pin to 7.78.4 agent release. APMSP-3059
-    image: gcr.io/datadoghq/agent:7.78.4
+    image: registry.datadoghq.com/agent:7.78.4
     environment:
       - DD_API_KEY=${DD_API_KEY}
       - DD_SITE=datadoghq.com

--- a/utils/k8s/k8s_component_image.py
+++ b/utils/k8s/k8s_component_image.py
@@ -28,7 +28,7 @@ class K8sComponentImage:
         """Initialize a K8sComponentImage instance.
 
         Args:
-            registry_url: The full Docker image URL (e.g. 'gcr.io/datadoghq/apm-inject:latest')
+            registry_url: The full Docker image URL (e.g. 'registry.datadoghq.com/apm-inject:latest')
             version_extractor: A function that takes a registry URL and returns the extracted version
             ssi_registry_base: Optional base registry URL to prepend to the registry_url
 

--- a/utils/scripts/ssi_wizards/k8s_injector_dev_wizard.sh
+++ b/utils/scripts/ssi_wizards/k8s_injector_dev_wizard.sh
@@ -357,12 +357,12 @@ migrate_images_to_private_registry() {
     esac
 
     # Migrate lib-init image
-    local lib_init_source="gcr.io/datadoghq/${lib_init_name}:latest"
+    local lib_init_source="registry.datadoghq.com/${lib_init_name}:latest"
     pull_and_push_image "$lib_init_source" "$lib_init_name" "latest"
 
     # Migrate apm-injector and cluster-agent
-    pull_and_push_image "gcr.io/datadoghq/apm-inject:latest" "apm-inject" "latest"
-    pull_and_push_image "gcr.io/datadoghq/cluster-agent:latest" "cluster-agent" "latest"
+    pull_and_push_image "registry.datadoghq.com/apm-inject:latest" "apm-inject" "latest"
+    pull_and_push_image "registry.datadoghq.com/cluster-agent:latest" "cluster-agent" "latest"
 
     echo -e "${GREEN}✅ Image migration completed${NC}"
 }


### PR DESCRIPTION
## Summary
- Change K8s injector-dev defaults from `gcr.io/datadoghq` to `registry.datadoghq.com` for `apm-inject`, lib-init images, and cluster-agent migration helpers.
- Change the auto-inject VM Agent compose fixture to pull the pinned Agent image from `registry.datadoghq.com`.
- Update the component-image docstring example to match the new default registry.

## Why
The container registry guidance recommends `registry.datadoghq.com` for simple Datadog image pulls while keeping GCR as an explicit Google registry option. These defaults are used by local/dev test flows, so this keeps system-tests aligned with the current registry guidance.

## Validation
- `crane manifest registry.datadoghq.com/apm-inject:latest`
- `crane manifest registry.datadoghq.com/agent:7.78.4`
- `python3 -m py_compile utils/_context/_scenarios/k8s_injector_dev.py utils/k8s/k8s_component_image.py`
- `bash -n utils/scripts/ssi_wizards/k8s_injector_dev_wizard.sh`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' utils/build/virtual_machine/provisions/auto-inject/docker/docker-compose-agent-prod.yml`
- `git diff --check`

`./format.sh` did not complete locally because this machine does not have `python3.12`, and the script stops while building the runner environment before formatting.
