### PR TITLE
APPSEC-65478 Enable Test_NormalizedRoute for django, flask and tornado in python

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -148,7 +148,10 @@ manifest:
   tests/appsec/api_security_testing/test_normalized_route.py::Test_NormalizedRoute:
     - weblog_declaration:
         "*": missing_feature
+        *django: v4.11.0-rc1
         fastapi: v4.11.0-rc1
+        *flask: v4.11.0-rc1
+        tornado: v4.12.0-rc1
   tests/appsec/iast:
     - weblog_declaration:
         tornado: v4.3.1  # Modified by easy win activation script


### PR DESCRIPTION
## Summary

- Enables `Test_NormalizedRoute` for django and flask weblogs at `v4.11.0-rc1` (using `*django` and `*flask` YAML anchors)
- Enables `Test_NormalizedRoute` for tornado at `v4.12.0-rc1`
- fastapi was already enabled at `v4.11.0-rc1`

## Test plan

- [ ] CI passes for the affected python weblogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)