### PR TITLE
test(debugger): budget limit for capture expressions

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3045,6 +3045,7 @@ manifest:
         spring-boot-undertow: v1.38.0
         spring-boot-wildfly: v1.38.0
         uds-spring-boot: v1.38.0
+  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets: bug (DEBUG-5730)
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_span_probe_expression_budgets: bug (DEBUG-3797)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots:
     - weblog_declaration:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3045,16 +3045,7 @@ manifest:
         spring-boot-undertow: v1.38.0
         spring-boot-wildfly: v1.38.0
         uds-spring-boot: v1.38.0
-  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets:
-    - weblog_declaration:
-        "*": missing_feature
-        spring-boot: v1.64.0
-        spring-boot-jetty: v1.64.0
-        spring-boot-openliberty: v1.64.0
-        spring-boot-payara: v1.64.0
-        spring-boot-undertow: v1.64.0
-        spring-boot-wildfly: v1.64.0
-        uds-spring-boot: v1.64.0
+  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets: bug (DEBUG-5730)
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_span_probe_expression_budgets: bug (DEBUG-3797)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots:
     - weblog_declaration:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3045,7 +3045,16 @@ manifest:
         spring-boot-undertow: v1.38.0
         spring-boot-wildfly: v1.38.0
         uds-spring-boot: v1.38.0
-  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets: bug (DEBUG-5730)
+  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets:
+    - weblog_declaration:
+        "*": missing_feature
+        spring-boot: v1.64.0
+        spring-boot-jetty: v1.64.0
+        spring-boot-openliberty: v1.64.0
+        spring-boot-payara: v1.64.0
+        spring-boot-undertow: v1.64.0
+        spring-boot-wildfly: v1.64.0
+        uds-spring-boot: v1.64.0
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_span_probe_expression_budgets: bug (DEBUG-3797)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots:
     - weblog_declaration:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -575,6 +575,7 @@ manifest:
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction::test_pii_redaction_method_full: v1.19.0
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers: missing_feature (DD_DYNAMIC_INSTRUMENTATION_REDACTION_EXCLUDED_IDENTIFIERS config key not implemented; only REDACTED_IDENTIFIERS exists which adds names, not removes them from the built-in list)
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets: v1.13.0+4663b2fa7c20c6920f347d059b57dc2a419cb7f7
+  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets: missing_feature
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_span_probe_expression_budgets: irrelevant
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots: missing_feature
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot: missing_feature (Not yet implemented)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1240,6 +1240,7 @@ manifest:
     - weblog_declaration:
         "*": missing_feature
         *flask: v2.11.0
+  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets: bug (DEBUG-5730)
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_span_probe_expression_budgets: irrelevant (Python emits evaluation errors as span tags, not error snapshots to the debugger endpoint)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots:
     - weblog_declaration:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1240,7 +1240,7 @@ manifest:
     - weblog_declaration:
         "*": missing_feature
         *flask: v2.11.0
-  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets: bug (DEBUG-5730)
+  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets: bug (DEBUG-5743)
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_span_probe_expression_budgets: irrelevant (Python emits evaluation errors as span tags, not error snapshots to the debugger endpoint)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots:
     - weblog_declaration:

--- a/tests/debugger/test_debugger_probe_budgets.py
+++ b/tests/debugger/test_debugger_probe_budgets.py
@@ -89,6 +89,41 @@ class Test_Debugger_Probe_Budgets(debugger.BaseDebuggerTest):
                 f"Expected 1-20 snapshot with captures, got {snapshots_with_captures} in {self.total_request_time} seconds"
             )
 
+    def setup_log_line_capture_expression_budgets(self):
+        self._setup(
+            "probe_capture_expressions_budgets",
+            "/debugger/budgets/150",
+            lines=self.method_and_language_to_line_number("Budgets", self.get_tracer()["language"]),
+        )
+
+    def test_log_line_capture_expression_budgets(self):
+        self._assert()
+        self._validate_snapshots()
+
+        snapshots_with_captures = 0
+        for _id in self.probe_ids:
+            for span in self.probe_snapshots[_id]:
+                captures = span.get("debugger", {}).get("snapshot", {}).get("captures", None)
+                if captures is None:
+                    continue
+
+                # Capture expressions live under captures.lines.{line}.captureExpressions for line probes.
+                has_capture_expressions = any(
+                    isinstance(line_data, dict) and "captureExpressions" in line_data
+                    for line_data in captures.get("lines", {}).values()
+                )
+                if not has_capture_expressions:
+                    continue
+
+                snapshots_with_captures += 1
+
+            # Probe budgets aren't exact and can take time to be applied, so we allow a range of 1-20 snapshots with
+            # capture expressions for 150 requests, matching the 1/s snapshot limit.
+            assert 1 <= snapshots_with_captures <= 20, (
+                f"Expected 1-20 snapshots with capture expressions, got {snapshots_with_captures} in "
+                f"{self.total_request_time} seconds"
+            )
+
     def setup_span_probe_expression_budgets(self):
         self.initialize_weblog_remote_config()
 

--- a/tests/debugger/utils/probes/probe_capture_expressions_budgets.json
+++ b/tests/debugger/utils/probes/probe_capture_expressions_budgets.json
@@ -1,0 +1,31 @@
+[
+    {
+        "language": "",
+        "type": "",
+        "id": "",
+        "version": 0,
+        "where": {
+            "typeName": null,
+            "sourceFile": "ACTUAL_SOURCE_FILE",
+            "lines": [
+                "141"
+            ]
+        },
+        "captureSnapshot": false,
+        "capture": {
+            "maxReferenceDepth": 3
+        },
+        "captureExpressions": [
+            {
+                "name": "loops",
+                "expr": {
+                    "dsl": "loops",
+                    "json": {"ref": "loops"}
+                },
+                "capture": {
+                    "maxReferenceDepth": 1
+                }
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## Motivation

Extends the Live Debugger budget tests to ensure that probes configured with **capture expressions** respect the 1 snapshot per second limit, the same budget already enforced for full-snapshot log probes.

## Changes

- New probe fixture `probe_capture_expressions_budgets.json`: a line probe on the `Budgets` method with `captureSnapshot: false` and a `captureExpressions` entry on the `loops` parameter.
- New test `Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets`: fires 150 requests and asserts that only 1-20 snapshots carrying capture expressions are emitted (matching the existing `test_log_line_budgets` tolerance for the ~1/s budget).
- Marked the test as a known bug for Java (`DEBUG-5730`) in `manifests/java.yml`: capture-expression probes currently emit on every invocation (150/150) and are not yet rate limited.

## Testing

Ran `DEBUGGER_PROBES_SNAPSHOT` locally for Java:
- Without the manifest entry, the test correctly fails (`got 150 ... should be 1-20`), confirming the budget is bypassed.
- With the `DEBUG-5730` bug declaration, the test is skipped as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)