### PR TITLE
SSI: collect dd-agent diagnostics on provision failure

### DIFF
--- a/docs/understand/scenarios/onboarding.md
+++ b/docs/understand/scenarios/onboarding.md
@@ -820,7 +820,7 @@ Located in: **var/log/datadog_weblog/**
 * **docker_proccess.log:** Docker process information.
 * **journalctl_docker.log:** Systemd journal logs related to Docker.
 * **system.timers.log:** System timer logs.
-* **dd-agent-diagnostics.log:** Datadog Agent container diagnostics collected by `create_and_run_app_container.sh` (agent compose status, container health, `docker logs dd-agent`, and `docker-compose logs datadog`). Generated on every run and again on failure (e.g. when the agent is unhealthy or the `docker-compose --wait` health check times out). Only present in container-based scenarios that start the agent via `docker-compose-agent-prod.yml`.
+* **dd-agent-diagnostics.log:** Datadog Agent container diagnostics. Only present in container-based scenarios that start the agent via `docker-compose-agent-prod.yml`.
 
 ## How to read VM log markers (`[vm_name].log`)
 

--- a/docs/understand/scenarios/onboarding.md
+++ b/docs/understand/scenarios/onboarding.md
@@ -820,6 +820,7 @@ Located in: **var/log/datadog_weblog/**
 * **docker_proccess.log:** Docker process information.
 * **journalctl_docker.log:** Systemd journal logs related to Docker.
 * **system.timers.log:** System timer logs.
+* **dd-agent-diagnostics.log:** Datadog Agent container diagnostics collected by `create_and_run_app_container.sh` (agent compose status, container health, `docker logs dd-agent`, and `docker-compose logs datadog`). Generated on every run and again on failure (e.g. when the agent is unhealthy or the `docker-compose --wait` health check times out). Only present in container-based scenarios that start the agent via `docker-compose-agent-prod.yml`.
 
 ## How to read VM log markers (`[vm_name].log`)
 

--- a/utils/build/virtual_machine/weblogs/common/create_and_run_app_container.sh
+++ b/utils/build/virtual_machine/weblogs/common/create_and_run_app_container.sh
@@ -60,6 +60,15 @@ dump_dd_agent_diagnostics() {
     sync 2>/dev/null || true
 }
 
+# Dump agent diagnostics on failure, then propagate the original exit status.
+_on_exit() {
+    local status=$?
+    if [ "$status" -ne 0 ]; then
+        dump_dd_agent_diagnostics
+    fi
+    exit "$status"
+}
+
 # ---------------------------------------------------------------------------
 # Steps
 # ---------------------------------------------------------------------------
@@ -145,7 +154,7 @@ print_services_output() {
 # ---------------------------------------------------------------------------
 main() {
     # Always dump agent diagnostics on failure too (trap is deduplicated against the success dump).
-    trap 'status=$?; if [ "$status" -ne 0 ]; then dump_dd_agent_diagnostics; fi; exit "$status"' EXIT
+    trap _on_exit EXIT
 
     echo "..:: ${SCRIPT_MARKER} ::.."
 

--- a/utils/build/virtual_machine/weblogs/common/create_and_run_app_container.sh
+++ b/utils/build/virtual_machine/weblogs/common/create_and_run_app_container.sh
@@ -23,7 +23,7 @@ agent_is_enabled() {
 }
 
 # ---------------------------------------------------------------------------
-# Diagnostics (collected on failure to help debugging in CI)
+# Diagnostics (collected on every run, and on failure, to help debugging in CI)
 # ---------------------------------------------------------------------------
 _dd_agent_diagnostics_dumped=0
 
@@ -144,7 +144,7 @@ print_services_output() {
 # Main
 # ---------------------------------------------------------------------------
 main() {
-    # Dump agent diagnostics on any failure (deduplicated if already printed).
+    # Always dump agent diagnostics on failure too (trap is deduplicated against the success dump).
     trap 'status=$?; if [ "$status" -ne 0 ]; then dump_dd_agent_diagnostics; fi; exit "$status"' EXIT
 
     echo "..:: ${SCRIPT_MARKER} ::.."
@@ -156,6 +156,9 @@ main() {
     configure_scenario_env
     start_test_app
     print_services_output
+
+    # Capture diagnostics on success as well (no-op when the agent isn't part of the scenario).
+    dump_dd_agent_diagnostics
 }
 
 main "$@"

--- a/utils/build/virtual_machine/weblogs/common/create_and_run_app_container.sh
+++ b/utils/build/virtual_machine/weblogs/common/create_and_run_app_container.sh
@@ -1,61 +1,161 @@
 #!/bin/bash
 # shellcheck disable=SC2015
 
+# Provision runs "sh create_and_run_app_container.sh" — re-exec with bash for traps/functions.
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec /bin/bash "$0" "$@"
+fi
+
 set -e
 
-# shellcheck disable=SC2035
-sudo chmod -R 755 *
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+readonly DIAGNOSTICS_LOG="${HOME}/dd-agent-diagnostics.log"
+readonly SCRIPT_MARKER="create_and_run_app_container.sh diagnostics-v3"
+readonly AGENT_COMPOSE="docker-compose-agent-prod.yml"
+readonly WEBLOG_LOG_DIR="/var/log/datadog_weblog"
+readonly DOCKER_BUILD_MAX_RETRIES=3
 
-rm -rf Dockerfile || true
-cp Dockerfile.template Dockerfile || true
+# True when the Datadog Agent is installed via its own compose file.
+agent_is_enabled() {
+    [ -f "${AGENT_COMPOSE}" ]
+}
 
-sudo systemctl start docker # Start docker service if it's not started
+# ---------------------------------------------------------------------------
+# Diagnostics (collected on failure to help debugging in CI)
+# ---------------------------------------------------------------------------
+_dd_agent_diagnostics_dumped=0
 
-#workaround. Remove the system-tests cloned folder. The sources are copied to current home folder
-#if we don't remove it, the dotnet restore will try to restore the system-tests folder
-sudo rm -rf system-tests || true
-
-#The parameter RUNTIME is used only for dotnet
-# Retry docker build up to 3 times
-retry_count=0
-max_retries=3
-while [ $retry_count -lt $max_retries ]; do
-    if sudo docker build --no-cache --build-arg RUNTIME="bullseye-slim" -t system-tests/local .; then
-        echo "Docker build succeeded on attempt $((retry_count + 1))"
-        break
-    else
-        retry_count=$((retry_count + 1))
-        if [ $retry_count -lt $max_retries ]; then
-            echo "Docker build failed on attempt $retry_count, retrying... ($retry_count/$max_retries)"
-            sleep 5  # Wait 5 seconds before retrying
-        else
-            echo "Docker build failed after $max_retries attempts"
-            exit 1
-        fi
+dump_dd_agent_diagnostics() {
+    # Only dump once, and only when the agent is part of this scenario.
+    if [ "$_dd_agent_diagnostics_dumped" -eq 1 ] || ! agent_is_enabled; then
+        return 0
     fi
-done
+    _dd_agent_diagnostics_dumped=1
 
-if [ -f docker-compose-agent-prod.yml ]; then
-    # Agent may be installed in a different way
+    {
+        echo "..:: DD-AGENT DIAGNOSTICS (${SCRIPT_MARKER}) ::.."
+        date -u '+%Y-%m-%dT%H:%M:%SZ'
+        sudo docker-compose -f "${AGENT_COMPOSE}" ps 2>&1 || true
+        if sudo docker inspect dd-agent >/dev/null 2>&1; then
+            echo "..:: DD-AGENT HEALTH ::.."
+            sudo docker inspect dd-agent --format '{{json .State.Health}}' 2>&1 || true
+            echo "..:: DD-AGENT LOGS (docker logs) ::.."
+            sudo docker logs dd-agent 2>&1 | tail -300 || true
+        else
+            echo "..:: dd-agent container not found ::.."
+            sudo docker ps -a 2>&1 || true
+        fi
+        echo "..:: DD-AGENT LOGS (docker-compose logs) ::.."
+        sudo docker-compose -f "${AGENT_COMPOSE}" logs --no-color datadog 2>&1 || true
+    } 2>&1 | tee -a "${DIAGNOSTICS_LOG}"
+
+    # Mirror diagnostics into the log folder downloaded by the test harness.
+    sudo mkdir -p "${WEBLOG_LOG_DIR}" 2>/dev/null || true
+    if [ -d "${WEBLOG_LOG_DIR}" ]; then
+        sudo cp "${DIAGNOSTICS_LOG}" "${WEBLOG_LOG_DIR}/dd-agent-diagnostics.log" 2>/dev/null || true
+        sudo chmod 644 "${WEBLOG_LOG_DIR}/dd-agent-diagnostics.log" 2>/dev/null || true
+    fi
+    sync 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Steps
+# ---------------------------------------------------------------------------
+
+# Make the weblog log folder writable even if provisioning fails before the
+# vm_logs step, so logs can still be downloaded.
+prepare_log_folder() {
+    sudo mkdir -p "${WEBLOG_LOG_DIR}" 2>/dev/null || true
+    sudo chmod 777 "${WEBLOG_LOG_DIR}" 2>/dev/null || true
+}
+
+prepare_sources() {
+    # shellcheck disable=SC2035
+    sudo chmod -R 755 *
+
+    rm -rf Dockerfile || true
+    cp Dockerfile.template Dockerfile || true
+
+    sudo systemctl start docker # Start docker service if it's not started
+
+    # Remove the cloned system-tests folder: sources are copied to the home
+    # folder, and leaving it here makes "dotnet restore" try to restore it too.
+    sudo rm -rf system-tests || true
+}
+
+# Build the weblog image, retrying on transient failures.
+# RUNTIME build-arg is only used by dotnet.
+build_weblog_image() {
+    local attempt=1
+    while [ "$attempt" -le "${DOCKER_BUILD_MAX_RETRIES}" ]; do
+        if sudo docker build --no-cache --build-arg RUNTIME="bullseye-slim" -t system-tests/local .; then
+            echo "Docker build succeeded on attempt ${attempt}"
+            return 0
+        fi
+        echo "Docker build failed on attempt ${attempt}/${DOCKER_BUILD_MAX_RETRIES}"
+        attempt=$((attempt + 1))
+        [ "$attempt" -le "${DOCKER_BUILD_MAX_RETRIES}" ] && sleep 5
+    done
+    echo "Docker build failed after ${DOCKER_BUILD_MAX_RETRIES} attempts"
+    exit 1
+}
+
+start_agent() {
+    agent_is_enabled || return 0
+
     echo "DD_API_KEY=${DD_API_KEY}" > .env
-    sudo -E docker-compose -f docker-compose-agent-prod.yml up -d --remove-orphans datadog --wait --wait-timeout 120
-fi
-#Env variables set on the scenario definition. Write to file and load  
-if [ ! -f scenario_app.env ]
-then
-   SCENARIO_APP_ENV="${DD_APP_ENV:-''}"
-    echo "$SCENARIO_APP_ENV" | tr '[:space:]' '\n' > scenario_app.env
+    if ! sudo -E docker-compose -f "${AGENT_COMPOSE}" up -d --remove-orphans datadog --wait --wait-timeout 120; then
+        echo "..:: COMPOSE_WAIT_FAILED (dd-agent unhealthy or timeout) ::.." | tee -a "${DIAGNOSTICS_LOG}" >&2
+        dump_dd_agent_diagnostics
+        echo "..:: Diagnostics written to ${DIAGNOSTICS_LOG} ::.." >&2
+        exit 1
+    fi
+}
+
+# Write the scenario-provided env variables to a file the app reads.
+configure_scenario_env() {
+    [ -f scenario_app.env ] && return 0
+
+    local scenario_app_env="${DD_APP_ENV:-''}"
+    echo "$scenario_app_env" | tr '[:space:]' '\n' > scenario_app.env
     echo "APP VARIABLES CONFIGURED FROM THE SCENARIO:"
     cat scenario_app.env
-fi
-sudo -E docker-compose -f docker-compose.yml up -d test-app
+}
 
-echo "..:: RUNNING DOCKER SERVICES ::.." 
-sudo docker-compose ps
-if [ -f docker-compose-agent-prod.yml ]; then
-    echo "..:: DATADOG AGENT OUTPUT ::.."
-    sudo docker-compose -f docker-compose-agent-prod.yml logs datadog
-fi
-echo "..:: WEBLOG APP OUTPUT ::.."
-sudo docker-compose logs
-echo "RUN DONE"
+start_test_app() {
+    sudo -E docker-compose -f docker-compose.yml up -d test-app
+}
+
+print_services_output() {
+    echo "..:: RUNNING DOCKER SERVICES ::.."
+    sudo docker-compose ps
+    if agent_is_enabled; then
+        echo "..:: DATADOG AGENT OUTPUT ::.."
+        sudo docker-compose -f "${AGENT_COMPOSE}" logs datadog
+    fi
+    echo "..:: WEBLOG APP OUTPUT ::.."
+    sudo docker-compose logs
+    echo "RUN DONE"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    # Dump agent diagnostics on any failure (deduplicated if already printed).
+    trap 'status=$?; if [ "$status" -ne 0 ]; then dump_dd_agent_diagnostics; fi; exit "$status"' EXIT
+
+    echo "..:: ${SCRIPT_MARKER} ::.."
+
+    prepare_log_folder
+    prepare_sources
+    build_weblog_image
+    start_agent
+    configure_scenario_env
+    start_test_app
+    print_services_output
+}
+
+main "$@"

--- a/utils/onboarding/debug_vm.py
+++ b/utils/onboarding/debug_vm.py
@@ -1,101 +1,130 @@
 from pathlib import Path
 import stat
+from paramiko.client import SSHClient
 from paramiko.sftp_client import SFTPClient
 from utils._logger import logger
 from utils.virtual_machine.virtual_machines import _VirtualMachine
 
+# Preserve the dd-agent diagnostics into /var/log/datadog_weblog (runs from VM user home).
+# create_and_run_app_container.sh dumps diagnostics to $HOME/dd-agent-diagnostics.log when it fails;
+# here we only copy that failure-time snapshot so it gets downloaded with the rest of the VM logs.
+_COLLECT_DD_AGENT_DIAGNOSTICS_CMD = r"""bash -lc '
+sudo mkdir -p /var/log/datadog_weblog && sudo chmod 777 /var/log/datadog_weblog;
+cd ~;
+if [ -f "$HOME/dd-agent-diagnostics.log" ]; then
+  sudo cp "$HOME/dd-agent-diagnostics.log" /var/log/datadog_weblog/dd-agent-diagnostics.log 2>/dev/null || true;
+fi'"""
 
-def download_vm_logs(vm: _VirtualMachine, remote_folder_paths: list[str], local_base_logs_folder: str):
-    """Using SSH/SFTP connects to VM and downloads one or more folders from the remote machine
+# Remote commands that collect host/docker/agent logs into /var/log/datadog_weblog before download.
+# Mirrors utils/build/virtual_machine/provisions/auto-inject/auto-inject-vm_logs.yml.
+_LOG_COLLECTION_COMMANDS = [
+    "sudo mkdir -p /var/log/datadog_weblog || true",
+    "sudo chmod 777 /var/log/datadog_weblog || true",
+    _COLLECT_DD_AGENT_DIAGNOSTICS_CMD,
+    "bash -lc 'cd ~ && sudo docker-compose ps > /var/log/datadog_weblog/docker_proccess.log 2>&1 || true'",
+    "bash -lc 'cd ~ && sudo docker-compose logs > /var/log/datadog_weblog/docker_logs.log 2>&1 || true'",
+    "sudo journalctl -xeu docker > /var/log/datadog_weblog/journalctl_docker.log 2>&1 || true",
+    "sudo cp /etc/datadog-agent/application_monitoring.yaml /var/log/datadog_weblog/application_monitoring.yaml 2>&1 || true",
+    "sudo cat /var/log/cloud-init.log > /var/log/datadog_weblog/cloud-init.log 2>&1 || true",
+    "sudo cat /var/log/syslog > /var/log/datadog_weblog/syslog.log 2>&1 || true",
+    "sudo dmesg > /var/log/datadog_weblog/dmesg.log 2>&1 || true",
+    "sudo systemctl list-dependencies docker.service > /var/log/datadog_weblog/docker_list_dependencies.log 2>&1 || true",
+    "sudo systemctl list-timers --all > /var/log/datadog_weblog/system.timers.log 2>&1 || true",
+    "sudo crontab -l > /var/log/datadog_weblog/crontab.log 2>&1 || true",
+    "sudo cat /var/log/apt/history.log > /var/log/datadog_weblog/apt.log 2>&1 || true",
+    "sudo cat /var/log/yum.log > /var/log/datadog_weblog/yum.log 2>&1 || true",
+]
 
-    Args:
-        vm: Virtual machine object
-        remote_folder_paths: Single path (str) or list of paths (list[str]) to download
-        local_base_logs_folder: Base folder where logs will be stored locally
 
+def download_vm_logs(vm: _VirtualMachine, remote_folder_paths: list[str], local_base_logs_folder: str) -> bool:
+    """Connect over SSH/SFTP and download folders from the remote machine.
+
+    Works even when provisioning failed (uses get_ssh_connection_for_log_download).
+
+    Returns True if at least one folder was downloaded successfully.
     """
-    # Handle both single path and list of paths for backward compatibility
     if isinstance(remote_folder_paths, str):
         remote_folder_paths = [remote_folder_paths]
 
+    if not vm.ssh_config.hostname:
+        logger.warning(
+            "Skipping VM log download for %s: no IP/hostname (VM may not have been created)",
+            vm.name,
+        )
+        return False
+
+    downloaded_any = False
     try:
-        logger.info(f"Downloading folders from machine {vm.get_ip()}")
-        logger.info(f"Remote folders: {remote_folder_paths}")
+        logger.info(
+            "Downloading folders from machine %s (%s) provision_error=%s",
+            vm.name,
+            vm.ssh_config.hostname,
+            vm.provision_install_error is not None,
+        )
+        logger.info("Remote folders: %s", remote_folder_paths)
 
-        # Use the VM's get_ssh_connection method instead of creating our own
-        c = vm.get_ssh_connection()
-        logger.info(f"Connected [{vm.get_ip()}]")
+        connection = vm.get_ssh_connection_for_log_download()
+        logger.info("Connected [%s]", vm.ssh_config.hostname)
 
-        # Execute remote commands to collect logs prior to download
-        commands_to_run = [
-            "sudo mkdir -p /var/log/datadog_weblog || true",
-            # Docker and systemd related logs (mirrors utils/build/virtual_machine/provisions/auto-inject/auto-inject-vm_logs.yml)
-            "sudo docker-compose ps > /var/log/datadog_weblog/docker_proccess.log 2>&1 || true",
-            "sudo docker-compose logs > /var/log/datadog_weblog/docker_logs.log 2>&1 || true",
-            "sudo journalctl -xeu docker > /var/log/datadog_weblog/journalctl_docker.log 2>&1 || true",
-            # Copy Datadog Agent configuration files
-            "sudo cp /etc/datadog-agent/application_monitoring.yaml /var/log/datadog_weblog/application_monitoring.yaml 2>&1 || true",
-            # Additional logs requested
-            "sudo cat /var/log/cloud-init.log > /var/log/datadog_weblog/cloud-init.log 2>&1 || true",
-            "sudo cat /var/log/syslog > /var/log/datadog_weblog/syslog.log 2>&1 || true",
-            "sudo dmesg > /var/log/datadog_weblog/dmesg.log 2>&1 || true",
-            "sudo systemctl list-dependencies docker.service > /var/log/datadog_weblog/docker_list_dependencies.log 2>&1 || true",
-            "sudo systemctl list-timers --all > /var/log/datadog_weblog/system.timers.log 2>&1 || true",
-            "sudo crontab -l > /var/log/datadog_weblog/crontab.log 2>&1 || true",
-            "sudo cat /var/log/apt/history.log  > /var/log/datadog_weblog/apt.log 2>&1 || true",
-            "sudo cat /var/log/yum.log  > /var/log/datadog_weblog/yum.log 2>&1 || true",
-        ]
+        _run_log_collection_commands(connection, vm)
 
-        for cmd in commands_to_run:
-            try:
-                logger.info(f"Executing remote command: {cmd}")
-                _stdin, stdout, _stderr = c.exec_command(cmd)
-                exit_status = stdout.channel.recv_exit_status()
-                logger.info(f"Remote command exit status: {exit_status}")
-            except Exception as exec_err:
-                logger.warning(f"Failed executing command on {vm.get_ip()}: {cmd}")
-                logger.exception(exec_err)
-
-        # Create SFTP client
-        sftp = c.open_sftp()
-
-        # Download each folder
+        sftp = connection.open_sftp()
         for remote_folder_path in remote_folder_paths:
             local_folder_path = f"{local_base_logs_folder}/{remote_folder_path}"
-            logger.info(f"Downloading: {remote_folder_path} -> {local_folder_path}")
+            logger.info("Downloading: %s -> %s", remote_folder_path, local_folder_path)
 
-            # Create local directory if it doesn't exist
-            local_path = Path(local_folder_path)
-            local_path.mkdir(parents=True, exist_ok=True)
-
-            # Download the folder recursively
-            _download_folder_recursive(sftp, remote_folder_path, local_folder_path)
+            Path(local_folder_path).mkdir(parents=True, exist_ok=True)
+            if _download_folder_recursive(sftp, remote_folder_path, local_folder_path):
+                downloaded_any = True
 
         sftp.close()
-        c.close()
-        logger.info(f"Successfully downloaded all folders from {vm.get_ip()}")
+        connection.close()
+
+        if downloaded_any:
+            logger.info(
+                "Successfully downloaded VM logs from %s into %s", vm.ssh_config.hostname, local_base_logs_folder
+            )
+        else:
+            logger.warning("No files downloaded from %s", vm.ssh_config.hostname)
 
     except Exception:
-        logger.error("Cannot download folders from remote machine")
+        logger.exception("Cannot download folders from remote machine %s", vm.name)
+
+    return downloaded_any
 
 
-def _download_folder_recursive(sftp: SFTPClient, remote_dir: str, local_dir: str):
-    """Recursively download a folder using SFTP"""
+def _run_log_collection_commands(connection: SSHClient, vm: _VirtualMachine) -> None:
+    """Execute the remote log-collection commands, tolerating individual failures."""
+    for cmd in _LOG_COLLECTION_COMMANDS:
+        try:
+            logger.info("Executing remote command: %s", cmd)
+            _stdin, stdout, _stderr = connection.exec_command(cmd)
+            exit_status = stdout.channel.recv_exit_status()
+            logger.info("Remote command exit status: %s", exit_status)
+        except Exception as exec_err:
+            logger.warning("Failed executing command on %s: %s", vm.ssh_config.hostname, cmd)
+            logger.exception(exec_err)
+
+
+def _download_folder_recursive(sftp: SFTPClient, remote_dir: str, local_dir: str) -> bool:
+    """Recursively download a folder using SFTP. Returns True if at least one file was downloaded."""
+    downloaded_any = False
     try:
-        # List contents of remote directory
         for item in sftp.listdir_attr(remote_dir):
             remote_path = f"{remote_dir}/{item.filename}"
             local_path = Path(local_dir) / item.filename
 
             if stat.S_ISDIR(item.st_mode):
-                # Create local directory and recursively download
                 local_path.mkdir(exist_ok=True)
-                logger.info(f"Created directory: {local_path}")
-                _download_folder_recursive(sftp, remote_path, str(local_path))
+                logger.info("Created directory: %s", local_path)
+                if _download_folder_recursive(sftp, remote_path, str(local_path)):
+                    downloaded_any = True
             else:
-                # Download file
-                logger.info(f"Downloading file: {remote_path} -> {local_path}")
+                logger.info("Downloading file: %s -> %s", remote_path, local_path)
                 sftp.get(remote_path, str(local_path))
+                downloaded_any = True
 
     except Exception:
-        logger.error(f"Error downloading from {remote_dir}")
+        logger.exception("Error downloading from %s", remote_dir)
+
+    return downloaded_any

--- a/utils/onboarding/debug_vm.py
+++ b/utils/onboarding/debug_vm.py
@@ -6,8 +6,8 @@ from utils._logger import logger
 from utils.virtual_machine.virtual_machines import _VirtualMachine
 
 # Preserve the dd-agent diagnostics into /var/log/datadog_weblog (runs from VM user home).
-# create_and_run_app_container.sh dumps diagnostics to $HOME/dd-agent-diagnostics.log when it fails;
-# here we only copy that failure-time snapshot so it gets downloaded with the rest of the VM logs.
+# create_and_run_app_container.sh writes diagnostics to $HOME/dd-agent-diagnostics.log on every run
+# (and on failure); here we only copy that snapshot so it gets downloaded with the rest of the VM logs.
 _COLLECT_DD_AGENT_DIAGNOSTICS_CMD = r"""bash -lc '
 sudo mkdir -p /var/log/datadog_weblog && sudo chmod 777 /var/log/datadog_weblog;
 cd ~;

--- a/utils/virtual_machine/aws_provider.py
+++ b/utils/virtual_machine/aws_provider.py
@@ -22,10 +22,13 @@ from utils._logger import logger
 from utils import context
 from utils.virtual_machine.vm_logger import vm_logger
 
+from utils.onboarding.debug_vm import download_vm_logs
 from utils.virtual_machine.virtual_machine_provider import VmProvider, Commander
 from utils.virtual_machine.virtual_machines import _VirtualMachine
 
 import pytest
+
+_VM_LOG_REMOTE_PATHS = ["/var/log/datadog", "/var/log/datadog_weblog", "/tmp/datadog/java"]  # noqa: S108
 
 
 class AWSPulumiProvider(VmProvider):
@@ -133,10 +136,27 @@ class AWSPulumiProvider(VmProvider):
                 pytest.exit(f"Known infraestructure exception:: {known_message}", returncode=3)
         # If the exception is not known, we will store it in the vm object and error event to dd
         self.vm.provision_install_error = exception
+        self._download_vm_logs_after_provision_failure()
         self.datadog_event_sender.sendEventToDatadog(
             f"[E2E] Stack {self.stack_name} : error on Pulumi stack up",
             repr(exception),
             ["operation:up", "result:fail", f"stack:{self.stack_name}"],
+        )
+
+    def _download_vm_logs_after_provision_failure(self) -> None:
+        """Pull /var/log from the VM while it is still up (provision may have failed mid-way)."""
+        if not self.vm.ssh_config.hostname:
+            logger.warning("Cannot download VM logs: VM has no IP yet")
+            return
+        log_folder = context.scenario.host_log_folder
+        logger.stdout(
+            f"Downloading VM logs after provision failure into {log_folder} "
+            "(including var/log/datadog_weblog/dd-agent-diagnostics.log if present)"
+        )
+        download_vm_logs(
+            vm=self.vm,
+            remote_folder_paths=_VM_LOG_REMOTE_PATHS,
+            local_base_logs_folder=log_folder,
         )
 
     def _start_vm(self, vm: _VirtualMachine):
@@ -422,18 +442,27 @@ class AWSCommander(Commander):
                 lambda outputlog: vm_logger(context.scenario.host_log_folder, logger_name).info(outputlog)
             )
         else:
-            # If there isn't logger name specified, we will use the host/ip name to store all the logs of the
-            # same remote machine in the same log file
-            # If there is a failure (exit != 0) this trace will not be stored in the log file (why?)
+            # No logger name specified: group all logs of the same remote machine by host/ip name.
             header = "\n *****************************************************************"
             header2 = "\n -----------------------------------------------------------------"
+
+            def _log_remote_command_output(args: list[object]) -> None:
+                vm_name = str(args[0])
+                step_id = str(args[1])
+                command = str(args[2])
+                stdout = str(args[3] or "")
+                stderr = str(args[4] or "")
+                failed = "Process exited with status" in stderr or "error:" in stderr.lower()
+                status = "❌ FAILED" if failed else "✅ SUCCESS"
+                vm_logger(context.scenario.host_log_folder, vm_name).info(
+                    f"{header} \n   🚀 Provision step: {step_id} 🚀 \n      Status: {status} \n {header} \n"
+                    f" {command} \n\n {header2} \n 📤 Provision step output ({step_id}) 📤  \n {header2} \n"
+                    f" {stdout} \n\n {header2} \n 🚨 error output ({step_id}) 🚨 \n {header2} \n {stderr}"
+                )
+
             Output.all(
                 vm.name, installation_id, remote_command, cmd_exec_install.stdout, cmd_exec_install.stderr
-            ).apply(
-                lambda args: vm_logger(context.scenario.host_log_folder, args[0]).info(
-                    f"{header} \n   🚀 Provision step: {args[1]} 🚀 \n      Status: ✅ SUCCESS \n {header} \n {args[2]} \n\n {header2} \n 📤 Provision step output ({args[1]}) 📤  \n {header2} \n {args[3]} \n\n {header2} \n 🚨 error output ({args[1]}) 🚨 \n {header2} \n {args[4]}"
-                )
-            )
+            ).apply(_log_remote_command_output)
         if output_callback:
             Output.all(vm, cmd_exec_install.stdout).apply(output_callback)
 

--- a/utils/virtual_machine/virtual_machines.py
+++ b/utils/virtual_machine/virtual_machines.py
@@ -141,6 +141,12 @@ class _VirtualMachine:
         self._check_provsion_install_error()
         return self.ssh_config.get_ssh_connection()
 
+    def get_ssh_connection_for_log_download(self):
+        """SSH for log extraction after a failed provision (skips provision_install_error guard)."""
+        if not self.ssh_config.hostname:
+            raise Exception("IP not found - cannot download logs from VM")
+        return self.ssh_config.get_ssh_connection()
+
     def get_ip(self):
         self._check_provsion_install_error()
         if not self.ssh_config.hostname:


### PR DESCRIPTION
## Summary

Capture Datadog Agent diagnostics when EC2 onboarding/SSI provisioning fails, so the relevant logs are downloaded and available for debugging in CI. Adapted from #6999, cleaned up for readability and to avoid duplicated diagnostic logic.

- **`create_and_run_app_container.sh`**: dumps dd-agent container status, health and logs on any failure (EXIT trap + `docker-compose --wait` failure) into `$HOME/dd-agent-diagnostics.log`, mirrored to `/var/log/datadog_weblog`. Refactored into small, named functions with a clear `main` flow.
- **`debug_vm.py`**: `download_vm_logs()` now works after a failed provision (dedicated SSH connection), returns whether anything was downloaded, uses lazy logging, and **preserves** the script-produced `dd-agent-diagnostics.log` rather than regenerating it (no duplicate dump logic).
- **`virtual_machines.py`**: adds `get_ssh_connection_for_log_download()` that skips the `provision_install_error` guard for post-failure log extraction.
- **`aws_provider.py`**: pulls `/var/log` from the VM on provision failure and logs real SUCCESS/FAILED status for remote provision steps.

## Test plan

- [ ] Run an SSI/onboarding scenario and confirm `dd-agent-diagnostics.log` and `/var/log/datadog_weblog` contents are downloaded into the host log folder on success.
- [ ] Force a provision failure (e.g. unhealthy agent) and confirm diagnostics are captured and downloaded.
- [ ] `ruff check` passes on the modified Python files.

Made with [Cursor](https://cursor.com)