### PR TITLE
python(appsec): enable stripe tests for python

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -740,8 +740,12 @@ manifest:
         *django: v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
   tests/appsec/test_automated_login_events.py::Test_V3_Login_Events_RC: v2.11.0
   tests/appsec/test_automated_payment_events.py::Test_Automated_Payment_Events_Stripe_Custom_Rules: v4.2.0
-  tests/appsec/test_automated_payment_events.py::Test_Automated_Payment_Events_Stripe_Default_Rules: irrelevant (APPSEC-65755)
-  tests/appsec/test_automated_payment_events.py::Test_Automated_Payment_Events_Stripe_RC_disablement: irrelevant (APPSEC-65755)
+  tests/appsec/test_automated_payment_events.py::Test_Automated_Payment_Events_Stripe_Default_Rules:
+    - declaration: irrelevant (caused duplicate traces before 4.12.0-rc1)
+      component_version: '<4.12.0-rc1'
+  tests/appsec/test_automated_payment_events.py::Test_Automated_Payment_Events_Stripe_RC_disablement:
+    - declaration: irrelevant (caused duplicate traces before 4.12.0-rc1)
+      component_version: '<4.12.0-rc1'
   tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_Session_Blocking:
     - weblog_declaration:
         "*": v3.11.0.dev


### PR DESCRIPTION
## Motivation

The underlying bug preventing from enabling those tests was resolved in https://github.com/DataDog/dd-trace-py/pull/18262.

## Changes

Enable stripe in the DEFAULT and APPSEC_AUTO_EVENTS_RC  scenarios for v4.12.0-rc1 and up.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
