### PR TITLE
Mark Java alpine SSI install/appsec tests as bug on CentOS 7 & RedHat…

### DIFF
--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -189,6 +189,10 @@ class TestInstallerAutoInjectManual(base.AutoInjectBaseTest):
     # the uninstall test today
 
     @irrelevant(condition=context.weblog_variant == "test-app-dotnet-iis")
+    @bug(
+        context.vm_name in ["CentOS_7_amd64", "RedHat_7_9_amd64"] and context.weblog_variant == "test-app-java-alpine",
+        reason="APMSP-3489",
+    )
     def test_install_uninstall(self):
         virtual_machine = context.virtual_machine
         logger.info(f"Launching test_install_uninstall for : [{virtual_machine.name}]...")
@@ -261,6 +265,10 @@ class TestSimpleInstallerAutoInjectManualOriginDetection(base.AutoInjectBaseTest
 @features.auto_instrumentation_appsec
 @scenarios.simple_auto_injection_appsec
 class TestSimpleInstallerAutoInjectManualAppsec(base.AutoInjectBaseTest):
+    @bug(
+        context.vm_name in ["CentOS_7_amd64", "RedHat_7_9_amd64"] and context.weblog_variant == "test-app-java-alpine",
+        reason="APMSP-3489",
+    )
     def test_appsec(self):
         logger.info(f"Launching test_appsec for : [{context.vm_name}]...")
         self._test_install(context.virtual_machine, appsec=True)

--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -93,6 +93,10 @@ class TestContainerAutoInjectInstallScript(base.AutoInjectBaseTest):
         "Ubuntu_25_04_arm64",
     ]
 
+    @bug(
+        context.vm_name in ["CentOS_7_amd64", "RedHat_7_9_amd64"] and context.weblog_variant == "test-app-java-alpine",
+        reason="APMSP-3489",
+    )
     def test_install(self):
         self._test_install(context.virtual_machine, origin_detection=True)
 
@@ -223,6 +227,10 @@ class TestInstallerAutoInjectManual(base.AutoInjectBaseTest):
 class TestSimpleInstallerAutoInjectManual(base.AutoInjectBaseTest):
     @irrelevant(context.library >= "python@4.0.0.dev" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library < "python@4.0.0.dev" and context.installed_language_runtime < "3.8.0")
+    @bug(
+        context.vm_name in ["CentOS_7_amd64", "RedHat_7_9_amd64"] and context.weblog_variant == "test-app-java-alpine",
+        reason="APMSP-3489",
+    )
     def test_install(self):
         virtual_machine = context.virtual_machine
         logger.info(
@@ -251,6 +259,10 @@ class TestSimpleInstallerAutoInjectManualOriginDetection(base.AutoInjectBaseTest
     )
     @irrelevant(context.library >= "python@4.0.0.dev" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library < "python@4.0.0.dev" and context.installed_language_runtime < "3.8.0")
+    @bug(
+        context.vm_name in ["CentOS_7_amd64", "RedHat_7_9_amd64"] and context.weblog_variant == "test-app-java-alpine",
+        reason="APMSP-3489",
+    )
     def test_origin_detection(self):
         virtual_machine = context.virtual_machine
         logger.info(


### PR DESCRIPTION
… 7.9 (APMSP-3489)

## Motivation

<!-- What inspired you to submit this pull request? -->
## What

Marks two Java SSI tests as `@bug` for `test-app-java-alpine` on `CentOS_7_amd64` and
`RedHat_7_9_amd64`:

- `TestInstallerAutoInjectManual::test_install_uninstall` (INSTALLER_AUTO_INJECTION)
- `TestSimpleInstallerAutoInjectManualAppsec::test_appsec` (SIMPLE_AUTO_INJECTION_APPSEC)

## Why

On these old VMs the Java tracer can't load its jffi native stub (`/tmp` noexec in
`alpine:latest`), so no traces reach the backend and both tests fail. Full analysis,
impact and scenario breakdown in **APMSP-3489**.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
