### PR TITLE
APPSEC-65476: enable normalized route tests for django weblogs

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -155,14 +155,14 @@ manifest:
   tests/appsec/api_security_testing/test_normalized_route.py::Test_NormalizedRouteMultiParamsInSegment:
     - weblog_declaration:
         "*": missing_feature
-        *django: missing_feature
+        *django: v4.12.0-rc1
         fastapi: v4.11.0-rc1
         *flask: v4.11.0-rc1
         tornado: v4.12.0-rc1
   tests/appsec/api_security_testing/test_normalized_route.py::Test_NormalizedRouteOptionalParams:
     - weblog_declaration:
         "*": missing_feature
-        *django: missing_feature
+        *django: v4.12.0-rc1
         fastapi: v4.11.0-rc1
         *flask: v4.11.0-rc1
         tornado: v4.12.0-rc1


### PR DESCRIPTION
APPSEC-65476

Enable `Test_NormalizedRouteMultiParamsInSegment` and `Test_NormalizedRouteOptionalParams` for all Django weblogs at `v4.12.0-rc1`, following the fix in DataDog/dd-trace-py#18546.