### PR TITLE
ci: add upload/download artifact actions with retry

### DIFF
--- a/.github/actions/download_artifact/action.yml
+++ b/.github/actions/download_artifact/action.yml
@@ -1,0 +1,58 @@
+name: "Download artifact (with retry)"
+description: "Download artifact with automatic retry on failure"
+inputs:
+  name:
+    description: "Artifact name to download (empty = all artifacts)"
+    required: false
+    default: ''
+  path:
+    description: "Destination path"
+    required: false
+    default: ''
+  pattern:
+    description: "Glob pattern to match artifact names"
+    required: false
+    default: ''
+  merge-multiple:
+    description: "Merge multiple artifacts into a single directory"
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Download artifact (attempt 1)
+      id: download1
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        pattern: ${{ inputs.pattern }}
+        merge-multiple: ${{ inputs.merge-multiple }}
+    - name: Wait before retry (attempt 2)
+      if: steps.download1.outcome == 'failure'
+      shell: bash
+      run: sleep 5
+    - name: Download artifact (attempt 2)
+      id: download2
+      if: steps.download1.outcome == 'failure'
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        pattern: ${{ inputs.pattern }}
+        merge-multiple: ${{ inputs.merge-multiple }}
+    - name: Wait before retry (attempt 3)
+      if: steps.download2.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+    - name: Download artifact (attempt 3)
+      if: steps.download2.outcome == 'failure'
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        pattern: ${{ inputs.pattern }}
+        merge-multiple: ${{ inputs.merge-multiple }}

--- a/.github/actions/upload_artifact/action.yml
+++ b/.github/actions/upload_artifact/action.yml
@@ -1,0 +1,63 @@
+name: "Upload artifact (with retry)"
+description: "Upload artifact with automatic retry on failure"
+inputs:
+  name:
+    description: "Artifact name"
+    required: true
+  path:
+    description: "Path(s) to upload"
+    required: true
+  retention-days:
+    description: "Number of days to retain the artifact (empty = repo default)"
+    required: false
+    default: ''
+  if-no-files-found:
+    description: "Behavior when no files are found: warn, error, or ignore"
+    required: false
+    default: 'warn'
+  include-hidden-files:
+    description: "Whether to include hidden files in the artifact"
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Upload artifact (attempt 1)
+      id: upload1
+      continue-on-error: true
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        retention-days: ${{ inputs.retention-days }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        include-hidden-files: ${{ inputs.include-hidden-files }}
+    - name: Wait before retry (attempt 2)
+      if: steps.upload1.outcome == 'failure'
+      shell: bash
+      run: sleep 5
+    - name: Upload artifact (attempt 2)
+      id: upload2
+      if: steps.upload1.outcome == 'failure'
+      continue-on-error: true
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        retention-days: ${{ inputs.retention-days }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        include-hidden-files: ${{ inputs.include-hidden-files }}
+    - name: Wait before retry (attempt 3)
+      if: steps.upload2.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+    - name: Upload artifact (attempt 3)
+      if: steps.upload2.outcome == 'failure'
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        retention-days: ${{ inputs.retention-days }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        include-hidden-files: ${{ inputs.include-hidden-files }}

--- a/.github/workflows/compute-workflow-parameters.yml
+++ b/.github/workflows/compute-workflow-parameters.yml
@@ -190,7 +190,7 @@ jobs:
 
     - name: Upload artifact
       if: ${{ inputs._system_tests_dev_mode }}
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: ./.github/actions/upload_artifact
       with:
         name: binaries_dev_${{ inputs.library }}
         path: binaries/

--- a/.github/workflows/debug-harness.yml
+++ b/.github/workflows/debug-harness.yml
@@ -78,7 +78,7 @@ jobs:
             echo "Token file not found — nothing to clean up"
           fi
       - name: Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: ./.github/actions/upload_artifact
         with:
           name: weblog
           path: binaries/
@@ -98,7 +98,7 @@ jobs:
       uses: ./.github/actions/install_runner
 
     - name: Get binaries artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      uses: ./.github/actions/download_artifact
       with:
         name: weblog
         path: binaries/
@@ -116,7 +116,7 @@ jobs:
 
     - name: Upload artifact
       if: steps.build.outcome == 'success' && !cancelled()
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: ./.github/actions/upload_artifact
       with:
         name: logs_${{ matrix.n }}
         path: logs_*

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,8 +56,13 @@ jobs:
       - nightly
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
       - name: Download logs artifact
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        uses: ./.github/actions/download_artifact
         with:
           merge-multiple: false
           pattern: logs_*
@@ -69,7 +74,7 @@ jobs:
               fi
             done
       - name: Upload test report
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: ./.github/actions/upload_artifact
         with:
           name: test-report
           path: |
@@ -154,7 +159,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: ./.github/actions/download_artifact
         with:
           name: test-report
           path: data

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -132,7 +132,7 @@ jobs:
       uses: ./.github/actions/install_runner
     - name: Get binaries artifact
       if : ${{ inputs.binaries_artifact != '' }}
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      uses: ./.github/actions/download_artifact
       with:
         name: ${{ inputs.binaries_artifact }}
         path: binaries/
@@ -532,7 +532,7 @@ jobs:
         fi
     - name: Upload artifact
       if: steps.compress_logs.outcome == 'success' && !cancelled()
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: ./.github/actions/upload_artifact
       with:
         # log name convention to respect : logs_$SCENARIO-FAMILY_$LIBRARY_$WEBLOG_$CI-ENVIRONMENT
         name: ${{ inputs.logs_artifact_name }}

--- a/.github/workflows/run-parametric.yml
+++ b/.github/workflows/run-parametric.yml
@@ -111,7 +111,7 @@ jobs:
         uses: ./.github/actions/install_runner
       - name: Get binaries artifact
         if : ${{ inputs.binaries_artifact != '' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: ./.github/actions/download_artifact
         with:
           name: ${{ inputs.binaries_artifact }}
           path: binaries/
@@ -149,7 +149,7 @@ jobs:
           fi
       - name: Upload artifact
         if: steps.compress_logs.outcome == 'success' && !cancelled()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: ./.github/actions/upload_artifact
         with:
           name: logs_parametric_${{ inputs.library}}_parametric_${{ inputs.ci_environment }}_${{ matrix.job_instance }}_${{ inputs.unique_id }}
           path: artifact.tar.gz

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -220,7 +220,7 @@ jobs:
           ref: ${{ steps.compute_ref.outputs.ref }}
       - name: Get binaries artifact
         if : ${{ needs.compute_parameters.outputs.binaries_artifact != '' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: ./.github/actions/download_artifact
         with:
           name: ${{ needs.compute_parameters.outputs.binaries_artifact }}
           path: binaries/
@@ -255,7 +255,7 @@ jobs:
             echo "Token file not found — nothing to clean up"
           fi
       - name: Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: ./.github/actions/upload_artifact
         with:
           name: ${{ matrix.weblog.artifact_name }}
           path: binaries/


### PR DESCRIPTION
## Summary

- Add two composite actions (`upload_artifact`, `download_artifact`) that wrap `actions/upload-artifact@v7` and `actions/download-artifact@v8` with up to 3 attempts and short delays (5s, then 10s) to handle transient flakes
- Replace all direct usages of the official artifact actions across 6 workflow files with the new custom actions
- Add a sparse checkout of `.github/actions` to `nightly.yml`'s `create_test_report` job (which previously had no checkout) to enable referencing the local action

## Why

Artifact uploads and downloads occasionally fail transiently in GitHub Actions — the request simply errors out for no persistent reason. When this happens, the entire job fails and must be re-run manually, wasting time and CI resources. Since these failures are random rather than caused by a server-side issue, a fast retry (5s, then 10s) is enough to recover without adding meaningful overhead to the workflow.

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)