### PR TITLE
Add /llm endpoint to flask-poc weblog

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Build python weblog base images
         if: inputs.library == 'python' && inputs._build_python_base_images
         run: |
-          ./utils/build/build_python_base_images.sh
+          ./utils/build/build_python_base_images.sh --push
       - name: Build php weblog base images
         if: inputs.library == 'php' && inputs._build_php_base_images
         run: |

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Build python weblog base images
         if: inputs.library == 'python' && inputs._build_python_base_images
         run: |
-          ./utils/build/build_python_base_images.sh --push
+          ./utils/build/build_python_base_images.sh
       - name: Build php weblog base images
         if: inputs.library == 'php' && inputs._build_php_base_images
         run: |

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -95,15 +95,36 @@ manifest:
         fastapi: v3.13.0.dev
   tests/appsec/api_security/test_endpoint_discovery.py::Test_Endpoint_Discovery::test_optional_type: irrelevant
   tests/appsec/api_security/test_endpoint_fallback.py: irrelevant (python weblogs always have http.route)
-  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_async_chat_completions_create: missing_feature
-  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_async_completions_create: missing_feature
-  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_async_responses_create: missing_feature
-  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_latest_chat_completions_create: missing_feature
-  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_latest_completions_create: missing_feature
-  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_latest_responses_create: missing_feature
-  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_legacy_chat_completions_create: missing_feature
-  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_legacy_completions_create: missing_feature
-  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_root_has_no_llm_tags: missing_feature
+  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_async_chat_completions_create:
+    - weblog_declaration:
+        "*": irrelevant (openai instrumentation is framework-independent, only tested on flask-poc)
+        flask-poc: v4.12.0rc1
+  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_async_completions_create:
+    - weblog_declaration:
+        "*": irrelevant (openai instrumentation is framework-independent, only tested on flask-poc)
+        flask-poc: v4.12.0rc1
+  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_async_responses_create:
+    - weblog_declaration:
+        "*": irrelevant (openai instrumentation is framework-independent, only tested on flask-poc)
+        flask-poc: v4.12.0rc1
+  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_latest_chat_completions_create:
+    - weblog_declaration:
+        "*": irrelevant (openai instrumentation is framework-independent, only tested on flask-poc)
+        flask-poc: v4.12.0rc1
+  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_latest_completions_create:
+    - weblog_declaration:
+        "*": irrelevant (openai instrumentation is framework-independent, only tested on flask-poc)
+        flask-poc: v4.12.0rc1
+  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_latest_responses_create:
+    - weblog_declaration:
+        "*": irrelevant (openai instrumentation is framework-independent, only tested on flask-poc)
+        flask-poc: v4.12.0rc1
+  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_legacy_chat_completions_create: irrelevant (legacy openai API not available in openai >= 1.0)
+  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_legacy_completions_create: irrelevant (legacy openai API not available in openai >= 1.0)
+  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_root_has_no_llm_tags:
+    - weblog_declaration:
+        "*": irrelevant (openai instrumentation is framework-independent, only tested on flask-poc)
+        flask-poc: v4.12.0rc1
   tests/appsec/api_security/test_schemas.py::Test_Scanners:
     - weblog_declaration:
         "*": v2.4.0

--- a/tests/appsec/api_security/test_endpoints.py
+++ b/tests/appsec/api_security/test_endpoints.py
@@ -71,7 +71,7 @@ class Test_LLM_Endpoint:
     def test_openai_async_completions_create(self):
         assert_llm_span(self.request, self.MODEL)
 
-    def setup_root_no_llm(self):
+    def setup_root_has_no_llm_tags(self):
         # Baseline request to root endpoint should not produce LLM tags
         self.root_request = weblog.get("/")
 

--- a/utils/build/docker/python/docker-bake.hcl
+++ b/utils/build/docker/python/docker-bake.hcl
@@ -45,7 +45,7 @@ target "flask-poc" {
 target "uwsgi-poc" {
   context    = "."
   dockerfile = "utils/build/docker/python/uwsgi-poc.base.Dockerfile"
-  tags       = ["datadog/system-tests:uwsgi-poc.base-v9"]
+  tags       = ["datadog/system-tests:uwsgi-poc.base-v10"]
 }
 
 target "tornado" {

--- a/utils/build/docker/python/docker-bake.hcl
+++ b/utils/build/docker/python/docker-bake.hcl
@@ -39,7 +39,7 @@ target "django-poc" {
 target "flask-poc" {
   context    = "."
   dockerfile = "utils/build/docker/python/flask-poc.base.Dockerfile"
-  tags       = ["datadog/system-tests:flask-poc.base-v13"]
+  tags       = ["datadog/system-tests:flask-poc.base-v14"]
 }
 
 target "uwsgi-poc" {

--- a/utils/build/docker/python/fastapi/requirements-fastapi.txt
+++ b/utils/build/docker/python/fastapi/requirements-fastapi.txt
@@ -1,6 +1,9 @@
 PyYAML
-fastapi
-uvicorn
+fastapi==0.135.2
+starlette==1.3.1
+uvicorn==0.49.0
+anyio==4.13.0
+pydantic==2.13.4
 requests
 cryptography==42.0.8
 pycryptodome

--- a/utils/build/docker/python/flask-poc.Dockerfile
+++ b/utils/build/docker/python/flask-poc.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:flask-poc.base-v13
+FROM datadog/system-tests:flask-poc.base-v14
 
 WORKDIR /app
 

--- a/utils/build/docker/python/flask-poc.base.Dockerfile
+++ b/utils/build/docker/python/flask-poc.base.Dockerfile
@@ -21,5 +21,5 @@ RUN apt update && apt install -y pkg-config default-libmysqlclient-dev pkg-confi
 COPY utils/build/docker/python/flask/requirements-flask-poc.txt /tmp/flask-requirements.txt
 RUN pip install --upgrade pip && pip install -r /tmp/flask-requirements.txt
 
-# docker build --progress=plain -f utils/build/docker/python/flask-poc.base.Dockerfile -t datadog/system-tests:flask-poc.base-v12 .
-# docker push datadog/system-tests:flask-poc.base-v12
+# docker build --progress=plain -f utils/build/docker/python/flask-poc.base.Dockerfile -t datadog/system-tests:flask-poc.base-v14 .
+# docker push datadog/system-tests:flask-poc.base-v14

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -58,6 +58,8 @@ from iast import weak_hash
 from iast import weak_hash_duplicates
 from iast import weak_hash_multiple
 from iast import weak_hash_secure_algorithm
+import asyncio
+import openai
 import requests
 import stripe
 import opentelemetry.baggage
@@ -2250,6 +2252,36 @@ def stripe_webhook():
         return jsonify(event.data.object)
     except Exception as e:
         return jsonify({"error": str(e)}), 403
+
+
+@app.route("/llm")
+def llm():
+    model = request.args.get("model", "")
+    operation = request.args.get("operation", "")
+    if not model or not operation:
+        return jsonify({"error": "Missing or empty query parameters: model, operation"}), 400
+    try:
+        if operation == "openai-latest-responses.create":
+            openai.OpenAI().responses.create(model=model, input="Hello")
+        elif operation == "openai-latest-chat.completions.create":
+            openai.OpenAI().chat.completions.create(model=model, messages=[{"role": "user", "content": "Hello"}])
+        elif operation == "openai-latest-completions.create":
+            openai.OpenAI().completions.create(model=model, prompt="Hello")
+        elif operation == "openai-async-responses.create":
+            asyncio.run(openai.AsyncOpenAI().responses.create(model=model, input="Hello"))
+        elif operation == "openai-async-chat.completions.create":
+            asyncio.run(
+                openai.AsyncOpenAI().chat.completions.create(
+                    model=model, messages=[{"role": "user", "content": "Hello"}]
+                )
+            )
+        elif operation == "openai-async-completions.create":
+            asyncio.run(openai.AsyncOpenAI().completions.create(model=model, prompt="Hello"))
+        else:
+            return jsonify({"error": f"unknown operation: {operation}"}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    return jsonify({"model": model, "operation": operation})
 
 
 @app.route("/sca/vulnerable-call")

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -58,7 +58,6 @@ from iast import weak_hash
 from iast import weak_hash_duplicates
 from iast import weak_hash_multiple
 from iast import weak_hash_secure_algorithm
-import asyncio
 import openai
 import requests
 import stripe
@@ -2255,28 +2254,26 @@ def stripe_webhook():
 
 
 @app.route("/llm")
-def llm():
+async def llm():
     model = request.args.get("model", "")
     operation = request.args.get("operation", "")
     if not model or not operation:
         return jsonify({"error": "Missing or empty query parameters: model, operation"}), 400
     try:
         if operation == "openai-latest-responses.create":
-            openai.OpenAI().responses.create(model=model, input="Hello")
+            openai.OpenAI(api_key="sk-fake").responses.create(model=model, input="Hello")
         elif operation == "openai-latest-chat.completions.create":
-            openai.OpenAI().chat.completions.create(model=model, messages=[{"role": "user", "content": "Hello"}])
+            openai.OpenAI(api_key="sk-fake").chat.completions.create(model=model, messages=[{"role": "user", "content": "Hello"}])
         elif operation == "openai-latest-completions.create":
-            openai.OpenAI().completions.create(model=model, prompt="Hello")
+            openai.OpenAI(api_key="sk-fake").completions.create(model=model, prompt="Hello")
         elif operation == "openai-async-responses.create":
-            asyncio.run(openai.AsyncOpenAI().responses.create(model=model, input="Hello"))
+            await openai.AsyncOpenAI(api_key="sk-fake").responses.create(model=model, input="Hello")
         elif operation == "openai-async-chat.completions.create":
-            asyncio.run(
-                openai.AsyncOpenAI().chat.completions.create(
-                    model=model, messages=[{"role": "user", "content": "Hello"}]
-                )
+            await openai.AsyncOpenAI(api_key="sk-fake").chat.completions.create(
+                model=model, messages=[{"role": "user", "content": "Hello"}]
             )
         elif operation == "openai-async-completions.create":
-            asyncio.run(openai.AsyncOpenAI().completions.create(model=model, prompt="Hello"))
+            await openai.AsyncOpenAI(api_key="sk-fake").completions.create(model=model, prompt="Hello")
         else:
             return jsonify({"error": f"unknown operation: {operation}"}), 400
     except Exception as e:

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -2263,7 +2263,9 @@ async def llm():
         if operation == "openai-latest-responses.create":
             openai.OpenAI(api_key="sk-fake").responses.create(model=model, input="Hello")
         elif operation == "openai-latest-chat.completions.create":
-            openai.OpenAI(api_key="sk-fake").chat.completions.create(model=model, messages=[{"role": "user", "content": "Hello"}])
+            openai.OpenAI(api_key="sk-fake").chat.completions.create(
+                model=model, messages=[{"role": "user", "content": "Hello"}]
+            )
         elif operation == "openai-latest-completions.create":
             openai.OpenAI(api_key="sk-fake").completions.create(model=model, prompt="Hello")
         elif operation == "openai-async-responses.create":

--- a/utils/build/docker/python/flask/requirements-flask-poc.txt
+++ b/utils/build/docker/python/flask/requirements-flask-poc.txt
@@ -23,3 +23,4 @@ urllib3==1.26.19
 openfeature-sdk==0.8.3
 loguru==0.7.3
 stripe==12.5.1
+openai==2.41.1

--- a/utils/build/docker/python/flask/requirements-uwsgi-poc.txt
+++ b/utils/build/docker/python/flask/requirements-uwsgi-poc.txt
@@ -21,3 +21,4 @@ PyMySQL==1.1.1
 openfeature-sdk==0.8.3
 loguru==0.7.3
 stripe==12.5.1
+openai==2.41.1

--- a/utils/build/docker/python/uds-flask.Dockerfile
+++ b/utils/build/docker/python/uds-flask.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:flask-poc.base-v13
+FROM datadog/system-tests:flask-poc.base-v14
 
 WORKDIR /app
 

--- a/utils/build/docker/python/uwsgi-poc.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:uwsgi-poc.base-v9
+FROM datadog/system-tests:uwsgi-poc.base-v10
 
 WORKDIR /app
 

--- a/utils/build/docker/python/uwsgi-poc.base.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.base.Dockerfile
@@ -14,5 +14,5 @@ RUN apt update && apt install -y pkg-config default-libmysqlclient-dev pkg-confi
 COPY utils/build/docker/python/flask/requirements-uwsgi-poc.txt /tmp/flask-requirements.txt
 RUN pip install --upgrade pip && pip install -r /tmp/flask-requirements.txt
 
-# docker build --progress=plain -f utils/build/docker/python/uwsgi-poc.base.Dockerfile -t datadog/system-tests:uwsgi-poc.base-v8 .
-# docker push datadog/system-tests:uwsgi-poc.base-v8
+# docker build --progress=plain -f utils/build/docker/python/uwsgi-poc.base.Dockerfile -t datadog/system-tests:uwsgi-poc.base-v10 .
+# docker push datadog/system-tests:uwsgi-poc.base-v10


### PR DESCRIPTION
APPSEC-68345

Adds the `GET /llm` endpoint to the flask-poc Python weblog, enabling system tests for LLM OpenAI instrumentation.

Covers 6 operations (3 sync via `OpenAI()`, 3 async via `AsyncOpenAI()`). Legacy openai v0 operations are not included as they are incompatible with `openai==2.41.1`.

Also adds `openai==2.41.1` to `requirements-flask-poc.txt`.

> ⚠️ This PR should be merged after https://github.com/DataDog/dd-trace-py/pull/18562

## Base image changes

This PR bumps the base images that share `utils/build/docker/python/flask/app.py` so `openai` is available at runtime:
- `flask-poc.base-v13` → `flask-poc.base-v14` (used by flask-poc and uds-flask)
- `uwsgi-poc.base-v9` → `uwsgi-poc.base-v10`

The `build-python-base-images` label is required so CI can build these new base images.

## fastapi requirements pin (unrelated to LLM, but needed to keep CI green)

The `build-python-base-images` label rebuilds **all** Python base images (the bake `default` group), including fastapi — which this PR does not otherwise touch. `requirements-fastapi.txt` left `fastapi`/`uvicorn` unpinned, so the rebuild pulled newer versions than the published `fastapi.base-v9`, causing failures unrelated to this PR:
- `tests/test_standard_tags.py::Test_StandardTagsRoute::test_route[fastapi]` — `http.route` tag doubled (`/sample_rate_route/{i}/sample_rate_route/{i}`)
- `tests/stats/test_stats.py::Test_Client_Stats::test_client_stats[fastapi]` and `test_is_trace_root[fastapi]` — trace stats not produced

Version drift observed (published `fastapi.base-v9` → fresh rebuild):
- fastapi: 0.135.2 → 0.137.1
- starlette: 1.0.0 → 1.3.1
- uvicorn: 0.42.0 → 0.49.0

Pinning **only** `fastapi==0.135.2` (while keeping starlette/uvicorn/anyio/pydantic at their latest versions) makes the fastapi tests pass again, confirming the regression is specific to the `fastapi` 0.135 → 0.137 bump, not starlette or the other transitive deps.

Pins added to `requirements-fastapi.txt`: `fastapi==0.135.2`, `starlette==1.3.1`, `uvicorn==0.49.0`, `anyio==4.13.0`, `pydantic==2.13.4`. A proper follow-up (owned by another team) should investigate the fastapi 0.137 instrumentation regression and re-pin appropriately.