### PR TITLE
test(otel): exercise http/protobuf in APM_TRACING_OTLP scenario

### DIFF
--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -744,6 +744,7 @@ class _Scenarios:
             "OTEL_TRACES_EXPORTER": "otlp",
             "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": f"http://proxy:{ProxyPorts.open_telemetry_weblog}/v1/traces",
             "OTEL_EXPORTER_OTLP_TRACES_HEADERS": "dd-protocol=otlp,dd-otlp-path=agent",
+            "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf",
             "DD_TRACE_OTEL_ENABLED": "true",
         },
         backend_interface_timeout=5,


### PR DESCRIPTION
## Motivation

`APM_TRACING_OTLP` exercises the OTLP trace-export path but does not pin a protocol, so the new `http/protobuf` OTLP encoding in dd-trace-py is not covered. This adds protobuf coverage to `Test_Otel_Tracing_OTLP`.

## Changes

Sets `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf` on the `APM_TRACING_OTLP` scenario weblog env. `Test_Otel_Tracing_OTLP` already normalizes both JSON and protobuf payloads (the `is_json` content-type branch + the `_trace_id_to_hex` helper), so no test-logic change is needed.

**Depends on the dd-trace-py OTLP http/protobuf feature** (DataDog/dd-trace-py#18609) being present in the tested tracer build.

## Workflow

1. ⚠️ Created as draft ⚠️
2. Blocked on the dd-trace-py feature landing/releasing before CI can pass.

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? Yes — `utils/_context/_scenarios/__init__.py` (scenario env). Will get R&P approval before marking ready.
* [ ] A docker base image is modified? No.
* [ ] A scenario is added, removed or renamed? No — an existing scenario's env is extended.