### PR TITLE
Fix schema validation failure in new CSS obfuscation scenarios

### DIFF
--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -101,6 +101,10 @@ class Test_DdtraceSchemas:
                 in (
                     scenarios.appsec_blocking,
                     scenarios.trace_stats_computation,
+                    scenarios.trace_stats_computation_obfuscation_disabled,
+                    scenarios.trace_stats_computation_future_obfuscation_version,
+                    scenarios.trace_stats_computation_missing_obfuscation_version,
+                    scenarios.trace_stats_computation_obfuscation_version_zero,
                     scenarios.tracing_config_nondefault_3,
                 ),
                 ticket="APMSP-2158",


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The dd-trace-js (and python, ruby, etc.) scheduled System Tests started failing on 2026-06-13 with Test_DdtraceSchemas::test_library schema errors on /v0.6/stats payloads:


* .../v0.6_stats.json: 'Service' is a required property on instance $
* .../v0.6_stats.json: 'IsTraceRoot' is a required property on instance $.Stats[0].Stats[0]
This is the already-known, accepted gap APMSP-2158: several tracers don't emit the top-level Service field nor the per-stat IsTraceRoot field in their /v0.6/stats payloads. That gap is whitelisted in tests/schemas/test_schemas.py via a SchemaBug exclusion — but only for the appsec_blocking, trace_stats_computation, and tracing_config_nondefault_3 scenarios.

PR #6648 ("Add css obfuscation test [APMSP-2764]") introduced four new end-to-end scenarios that also generate /v0.6/stats payloads but were not added to the APMSP-2158 whitelist, so the previously-suppressed schema errors now fail across all affected tracers and weblogs.
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMSP-2764]: https://datadoghq.atlassian.net/browse/APMSP-2764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ