### PR TITLE
fix(ci): use absolute /system-tests path for gitlab_print_logs.sh in …

### DIFF
--- a/.gitlab/ssi_gitlab-ci.yml
+++ b/.gitlab/ssi_gitlab-ci.yml
@@ -67,7 +67,7 @@ ssi_tests:
         if [ "$CI_PROJECT_NAME" = "system-tests" ]; then
             SCRIPTS_DIR="./utils/scripts"
         else
-            SCRIPTS_DIR="./system-tests/utils/scripts"
+            SCRIPTS_DIR="/system-tests/utils/scripts"
         fi
         export SCENARIO_SUFIX
         export DEBUG_LOGS_DOC_URL="https://github.com/DataDog/system-tests/blob/main/docs/understand/scenarios/docker_ssi.md"
@@ -261,7 +261,7 @@ ssi_tests:
     if [ "$CI_PROJECT_NAME" = "system-tests" ]; then
         SCRIPTS_DIR="./utils/scripts"
     else
-        SCRIPTS_DIR="./system-tests/utils/scripts"
+        SCRIPTS_DIR="/system-tests/utils/scripts"
     fi
     export SCENARIO_SUFIX=$(echo "${K8S_SCENARIO:-logs}" | tr "[:upper:]" "[:lower:]")
     export DEBUG_LOGS_DOC_URL="https://github.com/DataDog/system-tests/blob/main/docs/understand/scenarios/k8s_lib_injection.md#how-to-debug-your-kubernetes-environment-and-tests-results"


### PR DESCRIPTION
…docker SSI and k8s jobs

## Motivation

<!-- What inspired you to submit this pull request? -->
When running the Docker SSI and K8s lib injection scenarios from a downstream
repository (e.g. the auto-inject repo, where `CI_PROJECT_NAME != "system-tests"`),
the `after_script` failed with:
`bash: ./system-tests/utils/scripts/gitlab_print_logs.sh: No such file or directory`

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
