### PR TITLE
Gitignore git worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ go.work*
 
 # Hypothesis Python package
 .hypothesis/
+
+# Git worktrees
+.claude/worktrees/
+.worktrees/


### PR DESCRIPTION
Adds `.claude/worktrees/` and `.worktrees/` to `.gitignore` so locally-created git worktrees don't appear as untracked files in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)