### PR TITLE
Add FFE flagevaluation EVP system tests

### DIFF
--- a/manifests/agent.yml
+++ b/manifests/agent.yml
@@ -70,6 +70,7 @@ manifest:
         net-http: bug (DEBUG-5421)
         net-http-orchestrion: bug (DEBUG-5421)
         uds-echo: bug (DEBUG-5421)
+  tests/ffe/test_flagevaluation_events.py: irrelevant (FFE EVP events are SDK behavior)
   tests/integrations/test_open_telemetry.py::Test_MsSql::test_error_exception_event:
     - component_version: "<7.75.0-0"
       declaration: irrelevant (new behavior implement in 7.75.0)

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -20,6 +20,7 @@ manifest:
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_stackoverflow: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot_svc: missing_feature (Not yet implemented)
+  tests/ffe/test_flagevaluation_events.py: missing_feature (FFL-2446)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_sqs.py::Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS: irrelevant (Localstack SQS does not support AWS Xray Header parsing)
   tests/integrations/test_base_service.py::Test_BaseService_SqlSpan: irrelevant (/rasp/sqli endpoint is not available)

--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -41,6 +41,7 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py: missing_feature
   tests/ffe/test_exposures.py: missing_feature
   tests/ffe/test_flag_eval_metrics.py: missing_feature
+  tests/ffe/test_flagevaluation_events.py: irrelevant (FFE EVP events require SDK OpenFeature support)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/: missing_feature (Endpoint not implemented)
   tests/integrations/crossed_integrations/test_sqs.py::Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS: irrelevant (Localstack SQS does not support AWS Xray Header parsing)

--- a/manifests/cpp_kong.yml
+++ b/manifests/cpp_kong.yml
@@ -9,6 +9,7 @@ manifest:
   tests/debugger/: irrelevant
   tests/ffe/: missing_feature
   tests/ffe/test_flag_eval_metrics.py: missing_feature
+  tests/ffe/test_flagevaluation_events.py: irrelevant (FFE EVP events require SDK OpenFeature support)
   tests/integrations/: missing_feature (Endpoints not implemented)
   tests/otel/: irrelevant (library does not implement OpenTelemetry)
   tests/parametric/: irrelevant (Parametric scenario is not applied on Kong)

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -268,6 +268,7 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py: missing_feature
   tests/ffe/test_exposures.py: missing_feature
   tests/ffe/test_flag_eval_metrics.py: missing_feature
+  tests/ffe/test_flagevaluation_events.py: irrelevant (FFE EVP events require SDK OpenFeature support)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_kafka.py::Test_Kafka: missing_feature
   tests/integrations/crossed_integrations/test_kinesis.py::Test_Kinesis_PROPAGATION_VIA_MESSAGE_ATTRIBUTES: missing_feature

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -711,6 +711,7 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Unknown_Operator_Tolerance: bug (FFL-2184)
   tests/ffe/test_exposures.py: v3.36.0
   tests/ffe/test_flag_eval_metrics.py: v3.44.0
+  tests/ffe/test_flagevaluation_events.py: missing_feature (FFL-2446)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_kafka.py::Test_Kafka: v2.0.0-prerelease
   tests/integrations/crossed_integrations/test_kinesis.py::Test_Kinesis_PROPAGATION_VIA_MESSAGE_ATTRIBUTES: missing_feature

--- a/manifests/envoy.yml
+++ b/manifests/envoy.yml
@@ -35,6 +35,7 @@ manifest:
   tests/appsec/test_traces.py::Test_AppSecEventSpanTags::test_header_collection: irrelevant (test)
   tests/appsec/test_traces.py::Test_CollectRespondHeaders::test_header_collection: missing_feature (The endpoint /headers is not implemented in the weblog)
   tests/appsec/test_versions.py::Test_Events: v1.72.0
+  tests/ffe/test_flagevaluation_events.py: irrelevant (FFE EVP events require SDK OpenFeature support)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/test_config_consistency.py::Test_Config_UnifiedServiceTagging_CustomService: v1.72.0
   tests/test_scrubbing.py: v1.72.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -888,6 +888,7 @@ manifest:
   tests/ffe/test_flag_eval_metrics.py: v2.8.0
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Metric_Parse_Error_Invalid_Regex: irrelevant (Go validates regex at config load time)
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Nested_Attributes_Ignored: irrelevant (FFL-1980)
+  tests/ffe/test_flagevaluation_events.py: missing_feature (FFL-2446)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_kafka.py::Test_Kafka:
     - weblog_declaration:

--- a/manifests/haproxy.yml
+++ b/manifests/haproxy.yml
@@ -33,6 +33,7 @@ manifest:
   tests/appsec/test_traces.py::Test_AppSecEventSpanTags::test_header_collection: irrelevant (test)
   tests/appsec/test_traces.py::Test_CollectRespondHeaders::test_header_collection: missing_feature (The endpoint /headers is not implemented in the weblog)
   tests/appsec/test_versions.py::Test_Events: v2.4.0
+  tests/ffe/test_flagevaluation_events.py: irrelevant (FFE EVP events require SDK OpenFeature support)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/test_config_consistency.py::Test_Config_UnifiedServiceTagging_CustomService: v2.4.0
   tests/test_scrubbing.py: v2.4.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3240,6 +3240,7 @@ manifest:
         "*": irrelevant
         spring-boot: v1.62.0
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Metric_Count::test_ffe_eval_metric_count: bug (FFL-1972)
+  tests/ffe/test_flagevaluation_events.py: missing_feature (FFL-2446)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integration_frameworks/llm/openai/test_openai_apm.py: v1.61.0
   tests/integration_frameworks/llm/openai/test_openai_llmobs.py: v1.61.0

--- a/manifests/java_lambda.yml
+++ b/manifests/java_lambda.yml
@@ -61,6 +61,7 @@ manifest:
   tests/appsec/waf/test_blocking.py::Test_Blocking: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking_strip_response_headers: missing_feature
   tests/appsec/waf/test_blocking.py::Test_CustomBlockingResponse: missing_feature
+  tests/ffe/test_flagevaluation_events.py: irrelevant (FFE EVP events require long-running SDK OpenFeature support)
   tests/test_resource_renaming.py: missing_feature
   tests/test_rum_injection.py: irrelevant (RUM injection only supported for Java)
   tests/test_v1_payloads.py: missing_feature

--- a/manifests/java_otel.yml
+++ b/manifests/java_otel.yml
@@ -12,6 +12,7 @@ manifest:
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_stackoverflow: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot_svc: missing_feature (Not yet implemented)
+  tests/ffe/test_flagevaluation_events.py: irrelevant (OpenTelemetry wrapper is not the SDK FFE provider)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_sqs.py::Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS: irrelevant (Localstack SQS does not support AWS Xray Header parsing)
   tests/integrations/test_cassandra.py::Test_Cassandra: missing_feature (Endpoint is not implemented on weblog)

--- a/manifests/k8s_cluster_agent.yml
+++ b/manifests/k8s_cluster_agent.yml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/DataDog/system-tests/refs/heads/main/utils/manifest/schema.json
 ---
 manifest:
+  tests/ffe/test_flagevaluation_events.py: irrelevant (FFE EVP events are SDK behavior)
   tests/k8s_lib_injection/test_k8s_lib_injection_profiling.py::TestK8sLibInjectioProfilingClusterEnabled: v7.57.0
   tests/k8s_lib_injection/test_k8s_lib_injection_profiling.py::TestK8sLibInjectioProfilingClusterOverride: v7.57.0
   tests/k8s_lib_injection/test_k8s_lib_injection_profiling.py::TestK8sLibInjectioProfilingDisabledByDefault: v7.57.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1707,6 +1707,7 @@ manifest:
   : bug (FFL-2313)
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Reason_Split::test_ffe_eval_reason_split: bug (FFL-2313)
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Targeting_Key_Optional: bug (FFL-1730)
+  tests/ffe/test_flagevaluation_events.py: missing_feature (FFL-2446)
   tests/integration_frameworks/llm/anthropic/test_anthropic_apm.py::TestAnthropicApmMessages: *ref_5_71_0
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages: *ref_5_71_0
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create: missing_feature  # ephemeral cache TTL metrics not yet released

--- a/manifests/nodejs_lambda.yml
+++ b/manifests/nodejs_lambda.yml
@@ -63,6 +63,7 @@ manifest:
   tests/appsec/waf/test_blocking.py::Test_Blocking: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking_strip_response_headers: missing_feature
   tests/appsec/waf/test_blocking.py::Test_CustomBlockingResponse: missing_feature
+  tests/ffe/test_flagevaluation_events.py: irrelevant (FFE EVP events require long-running SDK OpenFeature support)
   tests/test_resource_renaming.py: missing_feature
   tests/test_rum_injection.py: irrelevant
   tests/test_v1_payloads.py: missing_feature

--- a/manifests/nodejs_otel.yml
+++ b/manifests/nodejs_otel.yml
@@ -11,6 +11,7 @@ manifest:
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_stackoverflow: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot_svc: missing_feature (Not yet implemented)
+  tests/ffe/test_flagevaluation_events.py: irrelevant (OpenTelemetry wrapper is not the SDK FFE provider)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_sqs.py::Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS: irrelevant (Localstack SQS does not support AWS Xray Header parsing)
   tests/integrations/test_cassandra.py::Test_Cassandra: missing_feature (Endpoint is not implemented on weblog)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -622,6 +622,7 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py: v1.21.0-dev
   tests/ffe/test_exposures.py: v1.21.0-dev
   tests/ffe/test_flag_eval_metrics.py: v1.21.0-dev
+  tests/ffe/test_flagevaluation_events.py: missing_feature (FFL-2446)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_kafka.py::Test_Kafka: missing_feature
   tests/integrations/crossed_integrations/test_kinesis.py::Test_Kinesis_PROPAGATION_VIA_MESSAGE_ATTRIBUTES: missing_feature

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1370,6 +1370,7 @@ manifest:
   tests/ffe/test_exposures.py: v4.2.0-dev
   tests/ffe/test_flag_eval_metrics.py: v4.7.0
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Nested_Attributes_Ignored: irrelevant (FFL-1980)
+  tests/ffe/test_flagevaluation_events.py: missing_feature (FFL-2446)
   tests/integration_frameworks/llm/anthropic/test_anthropic_apm.py::TestAnthropicApmMessages: v3.16.0
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages: v3.16.0
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)

--- a/manifests/python_lambda.yml
+++ b/manifests/python_lambda.yml
@@ -281,6 +281,7 @@ manifest:
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_stackoverflow: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot_svc: missing_feature (Not yet implemented)
+  tests/ffe/test_flagevaluation_events.py: irrelevant (FFE EVP events require long-running SDK OpenFeature support)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_sqs.py::Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS: irrelevant (Localstack SQS does not support AWS Xray Header parsing)
   tests/integrations/test_cassandra.py::Test_Cassandra: missing_feature (Endpoint is not implemented on weblog)

--- a/manifests/python_otel.yml
+++ b/manifests/python_otel.yml
@@ -11,6 +11,7 @@ manifest:
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_stackoverflow: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_process_tags_snapshot_svc: missing_feature (Not yet implemented)
+  tests/ffe/test_flagevaluation_events.py: irrelevant (OpenTelemetry wrapper is not the SDK FFE provider)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_sqs.py::Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS: irrelevant (Localstack SQS does not support AWS Xray Header parsing)
   tests/integrations/test_cassandra.py::Test_Cassandra: missing_feature (Endpoint is not implemented on weblog)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1890,6 +1890,7 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         rails72: v2.32.0
+  tests/ffe/test_flagevaluation_events.py: missing_feature (FFL-2446)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_kafka.py::Test_Kafka:
     - weblog_declaration:

--- a/manifests/ruby_lambda.yml
+++ b/manifests/ruby_lambda.yml
@@ -77,3 +77,4 @@ manifest:
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_html_template_v2: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking_strip_response_headers: missing_feature
   tests/appsec/waf/test_blocking.py::Test_CustomBlockingResponse: v3.29.0
+  tests/ffe/test_flagevaluation_events.py: irrelevant (FFE EVP events require long-running SDK OpenFeature support)

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -26,6 +26,7 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py: missing_feature
   tests/ffe/test_exposures.py: missing_feature
   tests/ffe/test_flag_eval_metrics.py: missing_feature
+  tests/ffe/test_flagevaluation_events.py: missing_feature (FFL-2446)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_sqs.py::Test_SQS_PROPAGATION_VIA_AWS_XRAY_HEADERS: irrelevant (Localstack SQS does not support AWS Xray Header parsing)
   tests/integrations/test_cassandra.py::Test_Cassandra: missing_feature (Endpoint is not implemented on weblog)

--- a/tests/ffe/README.md
+++ b/tests/ffe/README.md
@@ -8,6 +8,7 @@ This directory contains system tests for the Feature Flags & Experimentation (FF
 |------|-------------|
 | `test_dynamic_evaluation.py` | Dynamic flag evaluation via Remote Config |
 | `test_exposures.py` | Flag exposure tracking and reporting |
+| `test_flagevaluation_events.py` | Server-side EVP flagevaluation event aggregation |
 | `test_flag_eval_metrics.py` | Evaluation metrics (OTel counter) |
 
 ## Running FFE Tests
@@ -120,6 +121,16 @@ The system tests cover:
 - `Test_FFE_Eval_Targeting_Key_Optional` — Targeting key is optional
 - `Test_FFE_Eval_Nested_Attributes_Ignored` — Nested attributes silently ignored (OF.3)
 - `Test_FFE_Eval_Lowercase_Consistency` — All tag values are lowercase
+
+### EVP Flagevaluation Events
+- `Test_FFE_FlagEvaluation_Visible_Schema` — Required fields and no-rule optional field shape
+- `Test_FFE_FlagEvaluation_Aggregation_Count` — Aggregated `evaluation_count` preserves repeated evaluations
+- `Test_FFE_FlagEvaluation_Bounded_Context` — Emitted context is omitted or bounded before buffering
+- `Test_FFE_FlagEvaluation_Runtime_Default` — Runtime defaults are marked with `runtime_default_used`
+- `Test_FFE_FlagEvaluation_Concurrent_Identical_Evaluations` — Concurrent identical evaluations preserve counts
+- `Test_FFE_FlagEvaluation_High_Cardinality` — High-cardinality subjects preserve aggregate counts
+- `Test_FFE_FlagEvaluation_Targeting_Rule_Metadata` — `targeting_rule` is asserted only when rule metadata exists
+- `Test_FFE_FlagEvaluation_Degraded_Shape` — Documents why degradation cannot be forced externally
 
 ---
 

--- a/tests/ffe/test_flagevaluation_events.py
+++ b/tests/ffe/test_flagevaluation_events.py
@@ -1,0 +1,392 @@
+"""Test server-side FFE EVP flagevaluation events."""
+
+from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from utils import (
+    weblog,
+    interfaces,
+    scenarios,
+    features,
+    remote_config as rc,
+)
+
+
+RC_PRODUCT = "FFE_FLAGS"
+RC_PATH = f"datadog/2/{RC_PRODUCT}"
+FLAGEVALUATIONS_PATH = "/api/v2/flagevaluations"
+SCHEMA_MIN_TIMESTAMP_MS = 1759276800000
+MAX_CONTEXT_FIELDS = 256
+MAX_CONTEXT_STRING_LENGTH = 256
+
+
+def make_ufc_fixture(flag_key: str, variant_key: str = "on", *, enabled: bool = True):
+    return {
+        "createdAt": "2024-04-17T19:40:53.716Z",
+        "format": "SERVER",
+        "environment": {"name": "Test"},
+        "flags": {
+            flag_key: {
+                "key": flag_key,
+                "enabled": enabled,
+                "variationType": "STRING",
+                "variations": {
+                    "on": {"key": "on", "value": "on-value"},
+                    "off": {"key": "off", "value": "off-value"},
+                },
+                "allocations": [
+                    {
+                        "key": "default-allocation",
+                        "rules": [],
+                        "splits": [{"variationKey": variant_key, "shards": []}],
+                        "doLog": True,
+                    }
+                ],
+            }
+        },
+    }
+
+
+def make_targeting_fixture(flag_key: str):
+    return {
+        "createdAt": "2024-04-17T19:40:53.716Z",
+        "format": "SERVER",
+        "environment": {"name": "Test"},
+        "flags": {
+            flag_key: {
+                "key": flag_key,
+                "enabled": True,
+                "variationType": "STRING",
+                "variations": {
+                    "on": {"key": "on", "value": "on-value"},
+                    "off": {"key": "off", "value": "off-value"},
+                },
+                "allocations": [
+                    {
+                        "key": "targeted-allocation",
+                        "rules": [
+                            {
+                                "key": "tier-premium-rule",
+                                "conditions": [
+                                    {
+                                        "operator": "ONE_OF",
+                                        "attribute": "tier",
+                                        "value": ["premium"],
+                                    }
+                                ],
+                            }
+                        ],
+                        "splits": [{"variationKey": "on", "shards": []}],
+                        "doLog": True,
+                    }
+                ],
+            }
+        },
+    }
+
+
+def evaluate_flag(flag_key: str, targeting_key: str, attributes: dict | None = None, default_value: str = "default"):
+    return weblog.post(
+        "/ffe",
+        json={
+            "flag": flag_key,
+            "variationType": "STRING",
+            "defaultValue": default_value,
+            "targetingKey": targeting_key,
+            "attributes": attributes or {},
+        },
+    )
+
+
+def _payload_flag_evaluations(data: dict) -> list[dict]:
+    if data.get("path") != FLAGEVALUATIONS_PATH:
+        return []
+
+    content = data.get("request", {}).get("content")
+    assert isinstance(content, dict), f"Expected object payload for {FLAGEVALUATIONS_PATH}, got {content!r}"
+
+    evaluations = content.get("flagEvaluations")
+    assert isinstance(evaluations, list), f"Expected flagEvaluations list in payload, got {content!r}"
+    return evaluations
+
+
+def find_flag_evaluations(flag_key: str) -> list[dict]:
+    evaluations = []
+    for data in interfaces.agent.get_data(path_filters=FLAGEVALUATIONS_PATH):
+        for event in _payload_flag_evaluations(data):
+            if event.get("flag", {}).get("key") == flag_key:
+                evaluations.append(event)
+    return evaluations
+
+
+def _total_count(events: Iterable[dict]) -> int:
+    return sum(event.get("evaluation_count", 0) for event in events)
+
+
+def wait_for_flag_evaluations(flag_key: str, min_count: int = 1, timeout: int = 20) -> list[dict]:
+    def observed(data: dict) -> bool:
+        _payload_flag_evaluations(data)
+        return _total_count(find_flag_evaluations(flag_key)) >= min_count
+
+    assert interfaces.agent.wait_for(observed, timeout=timeout), (
+        f"Timed out waiting for at least {min_count} flagevaluation event(s) for flag {flag_key!r}; "
+        f"observed {find_flag_evaluations(flag_key)!r}"
+    )
+
+    events = find_flag_evaluations(flag_key)
+    assert _total_count(events) >= min_count, (
+        f"Expected at least {min_count} evaluation(s) for {flag_key!r}, got {events!r}"
+    )
+    return events
+
+
+def assert_no_key_recursive(value: object, key_name: str):
+    if isinstance(value, dict):
+        assert key_name not in value, f"Unexpected {key_name!r} field in {value!r}"
+        for child in value.values():
+            assert_no_key_recursive(child, key_name)
+    elif isinstance(value, list):
+        for child in value:
+            assert_no_key_recursive(child, key_name)
+
+
+def assert_common_event_shape(event: dict, flag_key: str):
+    allowed_fields = {
+        "timestamp",
+        "flag",
+        "first_evaluation",
+        "last_evaluation",
+        "evaluation_count",
+        "runtime_default_used",
+        "targeting_key",
+        "context",
+        "variant",
+        "allocation",
+        "targeting_rule",
+        "error",
+    }
+    assert set(event).issubset(allowed_fields), f"Unexpected flagevaluation fields: {event!r}"
+    assert_no_key_recursive(event, "reason")
+
+    assert event["flag"]["key"] == flag_key
+    assert isinstance(event["timestamp"], int)
+    assert isinstance(event["first_evaluation"], int)
+    assert isinstance(event["last_evaluation"], int)
+    assert event["timestamp"] >= SCHEMA_MIN_TIMESTAMP_MS
+    assert event["first_evaluation"] >= SCHEMA_MIN_TIMESTAMP_MS
+    assert event["last_evaluation"] >= event["first_evaluation"]
+    assert event["evaluation_count"] >= 1
+
+    if "variant" in event:
+        assert isinstance(event["variant"].get("key"), str)
+    if "allocation" in event:
+        assert isinstance(event["allocation"].get("key"), str)
+    if "targeting_rule" in event:
+        assert isinstance(event["targeting_rule"].get("key"), str)
+    if "runtime_default_used" in event:
+        assert isinstance(event["runtime_default_used"], bool)
+
+
+def assert_context_is_bounded(event: dict):
+    context = event.get("context")
+    if not context:
+        return
+
+    evaluation_context = context.get("evaluation")
+    if not evaluation_context:
+        return
+
+    assert len(evaluation_context) <= MAX_CONTEXT_FIELDS, (
+        f"Expected at most {MAX_CONTEXT_FIELDS} context fields, got {len(evaluation_context)}"
+    )
+
+    oversized_values = {
+        key: value for key, value in evaluation_context.items() if isinstance(value, str) and len(value) > 256
+    }
+    assert not oversized_values, f"Expected oversized context strings to be pruned, got {oversized_values!r}"
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_eval_metrics
+class Test_FFE_FlagEvaluation_Visible_Schema:
+    def setup_ffe_flagevaluation_visible_schema(self):
+        self.flag_key = "evp-visible-schema-flag"
+        rc.tracer_rc_state.reset().set_config(
+            f"{RC_PATH}/evp-visible-schema/config", make_ufc_fixture(self.flag_key)
+        ).apply()
+
+        self.r = evaluate_flag(self.flag_key, "user-visible-schema", {"tier": "free"})
+
+    def test_ffe_flagevaluation_visible_schema(self):
+        assert self.r.status_code == 200, f"Flag evaluation failed: {self.r.text}"
+
+        events = wait_for_flag_evaluations(self.flag_key)
+        for event in events:
+            assert_common_event_shape(event, self.flag_key)
+
+        matching_event = events[0]
+        assert matching_event.get("variant", {}).get("key") == "on"
+        assert matching_event.get("allocation", {}).get("key") == "default-allocation"
+        assert "targeting_rule" not in matching_event, (
+            f"No-rule fixture must omit targeting_rule, got {matching_event!r}"
+        )
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_eval_metrics
+class Test_FFE_FlagEvaluation_Aggregation_Count:
+    def setup_ffe_flagevaluation_aggregation_count(self):
+        self.flag_key = "evp-aggregation-count-flag"
+        self.eval_count = 5
+        rc.tracer_rc_state.reset().set_config(
+            f"{RC_PATH}/evp-aggregation-count/config", make_ufc_fixture(self.flag_key)
+        ).apply()
+
+        self.responses = [evaluate_flag(self.flag_key, "user-count", {"plan": "pro"}) for _ in range(self.eval_count)]
+
+    def test_ffe_flagevaluation_aggregation_count(self):
+        for i, response in enumerate(self.responses):
+            assert response.status_code == 200, f"Request {i + 1} failed: {response.text}"
+
+        events = wait_for_flag_evaluations(self.flag_key, min_count=self.eval_count)
+        assert _total_count(events) >= self.eval_count, f"Expected count >= {self.eval_count}, got {events!r}"
+        for event in events:
+            assert_common_event_shape(event, self.flag_key)
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_eval_metrics
+class Test_FFE_FlagEvaluation_Bounded_Context:
+    def setup_ffe_flagevaluation_bounded_context(self):
+        self.flag_key = "evp-bounded-context-flag"
+        rc.tracer_rc_state.reset().set_config(
+            f"{RC_PATH}/evp-bounded-context/config", make_ufc_fixture(self.flag_key)
+        ).apply()
+
+        attributes = {f"field_{i:03}": f"value-{i}" for i in range(MAX_CONTEXT_FIELDS + 50)}
+        attributes["oversized"] = "x" * (MAX_CONTEXT_STRING_LENGTH + 1)
+        self.r = evaluate_flag(self.flag_key, "user-bounded-context", attributes)
+
+    def test_ffe_flagevaluation_bounded_context(self):
+        assert self.r.status_code == 200, f"Flag evaluation failed: {self.r.text}"
+
+        events = wait_for_flag_evaluations(self.flag_key)
+        for event in events:
+            assert_common_event_shape(event, self.flag_key)
+            assert_context_is_bounded(event)
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_eval_metrics
+class Test_FFE_FlagEvaluation_Runtime_Default:
+    def setup_ffe_flagevaluation_runtime_default(self):
+        self.config_flag_key = "evp-runtime-default-existing-flag"
+        self.missing_flag_key = "evp-runtime-default-missing-flag"
+        self.default_value = "runtime-default"
+        rc.tracer_rc_state.reset().set_config(
+            f"{RC_PATH}/evp-runtime-default/config", make_ufc_fixture(self.config_flag_key)
+        ).apply()
+
+        self.r = evaluate_flag(self.missing_flag_key, "user-runtime-default", default_value=self.default_value)
+
+    def test_ffe_flagevaluation_runtime_default(self):
+        assert self.r.status_code == 200, f"Flag evaluation request failed: {self.r.text}"
+        assert self.r.json().get("value") == self.default_value
+
+        events = wait_for_flag_evaluations(self.missing_flag_key)
+        default_events = [event for event in events if event.get("runtime_default_used") is True]
+        assert default_events, f"Expected runtime_default_used=true for {self.missing_flag_key!r}, got {events!r}"
+        for event in default_events:
+            assert_common_event_shape(event, self.missing_flag_key)
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_eval_metrics
+class Test_FFE_FlagEvaluation_Concurrent_Identical_Evaluations:
+    def setup_ffe_flagevaluation_concurrent_identical_evaluations(self):
+        self.flag_key = "evp-concurrent-identical-flag"
+        self.eval_count = 20
+        rc.tracer_rc_state.reset().set_config(
+            f"{RC_PATH}/evp-concurrent-identical/config", make_ufc_fixture(self.flag_key)
+        ).apply()
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            self.responses = list(
+                executor.map(
+                    lambda _: evaluate_flag(self.flag_key, "user-concurrent", {"cohort": "same"}),
+                    range(self.eval_count),
+                )
+            )
+
+    def test_ffe_flagevaluation_concurrent_identical_evaluations(self):
+        for i, response in enumerate(self.responses):
+            assert response.status_code == 200, f"Concurrent request {i + 1} failed: {response.text}"
+
+        events = wait_for_flag_evaluations(self.flag_key, min_count=self.eval_count)
+        assert _total_count(events) >= self.eval_count, f"Expected count >= {self.eval_count}, got {events!r}"
+        for event in events:
+            assert_common_event_shape(event, self.flag_key)
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_eval_metrics
+class Test_FFE_FlagEvaluation_High_Cardinality:
+    def setup_ffe_flagevaluation_high_cardinality(self):
+        self.flag_key = "evp-high-cardinality-flag"
+        self.eval_count = 24
+        rc.tracer_rc_state.reset().set_config(
+            f"{RC_PATH}/evp-high-cardinality/config", make_ufc_fixture(self.flag_key)
+        ).apply()
+
+        self.responses = [
+            evaluate_flag(self.flag_key, f"user-cardinality-{i}", {"account": f"account-{i}"})
+            for i in range(self.eval_count)
+        ]
+
+    def test_ffe_flagevaluation_high_cardinality(self):
+        for i, response in enumerate(self.responses):
+            assert response.status_code == 200, f"High-cardinality request {i + 1} failed: {response.text}"
+
+        events = wait_for_flag_evaluations(self.flag_key, min_count=self.eval_count)
+        assert _total_count(events) >= self.eval_count, f"Expected count >= {self.eval_count}, got {events!r}"
+        for event in events:
+            assert_common_event_shape(event, self.flag_key)
+            assert_context_is_bounded(event)
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_eval_metrics
+class Test_FFE_FlagEvaluation_Targeting_Rule_Metadata:
+    def setup_ffe_flagevaluation_targeting_rule_metadata(self):
+        self.flag_key = "evp-targeting-rule-flag"
+        rc.tracer_rc_state.reset().set_config(
+            f"{RC_PATH}/evp-targeting-rule/config", make_targeting_fixture(self.flag_key)
+        ).apply()
+
+        self.r = evaluate_flag(self.flag_key, "user-targeting-rule", {"tier": "premium"})
+
+    def test_ffe_flagevaluation_targeting_rule_metadata(self):
+        assert self.r.status_code == 200, f"Flag evaluation failed: {self.r.text}"
+
+        events = wait_for_flag_evaluations(self.flag_key)
+        targeted_events = [event for event in events if event.get("allocation", {}).get("key") == "targeted-allocation"]
+        assert targeted_events, f"Expected targeted allocation event, got {events!r}"
+
+        for event in targeted_events:
+            assert_common_event_shape(event, self.flag_key)
+            assert event.get("targeting_rule", {}).get("key") == "tier-premium-rule", (
+                f"Expected targeting_rule.key from real rule metadata, got {event!r}"
+            )
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_eval_metrics
+class Test_FFE_FlagEvaluation_Degraded_Shape:
+    def test_ffe_flagevaluation_degraded_shape(self):
+        pytest.skip(
+            "System tests cannot force tracer aggregation caps or async queue overflow through the public /ffe "
+            "weblog endpoint without SDK-specific test-only controls. FFL-2446 reviewers should validate degraded "
+            "shape in SDK unit tests and treat this system test as the external-path coverage."
+        )

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -700,6 +700,7 @@ class _Scenarios:
             # fast, weblog boots, and provider recovers when we set RC
             # configuration later.
             "DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS": "100",
+            "DD_FLAGGING_EVALUATION_COUNTS_ENABLED": "true",
             "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.2",
             "DD_METRICS_OTEL_ENABLED": "true",
             "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf",


### PR DESCRIPTION
## Motivation

Server-side FFE EVP emission needs a system-test contract for Agent `/api/v2/flagevaluations` payloads. These tests validate the observable batch/event shape without vendoring dd-source JSON schema validation.

## Changes

- Add `tests/ffe/test_flagevaluation_events.py` covering visible fields, count preservation, bounded context behavior, runtime defaults, concurrent identical evaluations, high-cardinality aggregation, targeting rule metadata, and the externally-unforceable degradation path.
- Enable the FFE scenario env for `DD_FLAGGING_EVALUATION_COUNTS_ENABLED=true`.
- Add FFE README coverage notes.
- Add explicit manifest entries for the new test across all components. SDK language manifests are `missing_feature (FFL-2446)` for first review; proxy, Lambda, OTel, Agent, and Cluster Agent manifests are marked `irrelevant`.

## Decisions

- Validate only observable payload fields from `/api/v2/flagevaluations`; do not add a `jsonschema` dependency or vendor dd-source schemas.
- Do not accept or expect OpenFeature `reason` in the payload. The tests assert that `reason` is absent recursively from emitted events.
- Expect `targeting_rule` only when the fixture includes real rule metadata. The no-rule fixture asserts omission.
- Degradation shape cannot be forced from system-tests through the public `/ffe` weblog endpoint without SDK-specific test controls, so the degradation test is an explicit skip documenting that boundary.
- All manifests stay disabled for first review.

Validation:

- `PATH="$PWD/venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" ./format.sh` passed.
- `./venv/bin/python -m py_compile tests/ffe/test_flagevaluation_events.py` passed.
- `./venv/bin/ruff check tests/ffe/test_flagevaluation_events.py utils/_context/_scenarios/__init__.py` passed.
- `./venv/bin/python utils/manifest/validate.py` passed.
- `PATH="$PWD/venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" yamlfmt -lint manifests/` passed.
- `./venv/bin/yamllint -s manifests/` passed.
- `git diff --check` passed.
