### PR TITLE
chore: upgrade dd-apm-test-agent to v1.62.0

### DIFF
--- a/utils/_context/_scenarios/integration_frameworks.py
+++ b/utils/_context/_scenarios/integration_frameworks.py
@@ -30,7 +30,7 @@ class IntegrationFrameworksScenario(DockerFixturesScenario):
             name,
             doc=doc,
             github_workflow="endtoend",
-            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.61.1",
+            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.62.0",
             scenario_groups=(groups.integration_frameworks,),
         )
 

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -63,7 +63,7 @@ class ParametricScenario(DockerFixturesScenario):
             name,
             doc=doc,
             github_workflow="parametric",
-            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.61.1",
+            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.62.0",
         )
         self._parametric_tests_confs = ParametricScenario.PersistentParametricTestConf(self)
 

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1462,7 +1462,7 @@ class OpenTelemetryCollectorContainer(TestedContainer):
 class APMTestAgentContainer(TestedContainer):
     def __init__(self, agent_port: int = 8126) -> None:
         super().__init__(
-            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.20.0",
+            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.62.0",
             name="ddapm-test-agent",
             environment={
                 "SNAPSHOT_CI": "0",
@@ -1495,7 +1495,7 @@ class VCRCassettesContainer(TestedContainer):
 
     def __init__(self, vcr_port: int = ContainerPorts.vcr_cassettes) -> None:
         super().__init__(
-            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.61.1",
+            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.62.0",
             name="vcr_cassettes",
             environment={
                 "PORT": str(vcr_port),

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1462,7 +1462,7 @@ class OpenTelemetryCollectorContainer(TestedContainer):
 class APMTestAgentContainer(TestedContainer):
     def __init__(self, agent_port: int = 8126) -> None:
         super().__init__(
-            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.62.0",
+            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.20.0",
             name="ddapm-test-agent",
             environment={
                 "SNAPSHOT_CI": "0",

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1462,7 +1462,7 @@ class OpenTelemetryCollectorContainer(TestedContainer):
 class APMTestAgentContainer(TestedContainer):
     def __init__(self, agent_port: int = 8126) -> None:
         super().__init__(
-            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.20.0",
+            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.31.1",
             name="ddapm-test-agent",
             environment={
                 "SNAPSHOT_CI": "0",

--- a/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
+++ b/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
@@ -104,7 +104,7 @@ class K8sDatadog:
 
         container = client.V1Container(
             name="trace-agent",
-            image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.31.1",
+            image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.62.0",
             image_pull_policy="Always",
             ports=[client.V1ContainerPort(container_port=8126, host_port=8126, name="traceport", protocol="TCP")],
             command=["ddapm-test-agent"],

--- a/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
+++ b/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
@@ -104,7 +104,7 @@ class K8sDatadog:
 
         container = client.V1Container(
             name="trace-agent",
-            image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.62.0",
+            image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.31.1",
             image_pull_policy="Always",
             ports=[client.V1ContainerPort(container_port=8126, host_port=8126, name="traceport", protocol="TCP")],
             command=["ddapm-test-agent"],


### PR DESCRIPTION
## Motivation

Bump `dd-apm-test-agent` to the latest version to use it in system-tests.

## Changes

Updated 3 places with agent version. And found 2 outdated places that should be fixed in separate PR.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
