### PR TITLE
test(parametric): enable Python FFE span-enrichment suite

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1831,12 +1831,6 @@ manifest:
       component_version: '>3.7.0'
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation: v4.0.0
   tests/parametric/test_ffe/test_span_enrichment.py: '>=4.9.0'  # TODO: a lower version might be supported
-  tests/parametric/test_ffe/test_span_enrichment.py::Test_Span_Enrichment_Child_Span_Propagation: missing_feature
-  tests/parametric/test_ffe/test_span_enrichment.py::Test_Span_Enrichment_Default_Fallback: missing_feature
-  tests/parametric/test_ffe/test_span_enrichment.py::Test_Span_Enrichment_Max_Experiments_Per_Subject: missing_feature
-  tests/parametric/test_ffe/test_span_enrichment.py::Test_Span_Enrichment_Max_Serial_IDs: missing_feature
-  tests/parametric/test_ffe/test_span_enrichment.py::Test_Span_Enrichment_Serial_IDs: missing_feature
-  tests/parametric/test_ffe/test_span_enrichment.py::Test_Span_Enrichment_Subjects: missing_feature
   tests/parametric/test_headers_b3.py::Test_Headers_B3: v2.8.0
   tests/parametric/test_headers_b3.py::Test_Headers_B3::test_headers_b3_extract_invalid:
     - declaration: irrelevant (Deprecated in 3.x)

--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -1431,8 +1431,23 @@ async def ffe_evaluate(request: Request) -> JSONResponse:
         default_value = body.get("defaultValue")
         targeting_key = body.get("targetingKey")
         attributes = body.get("attributes", {})
+        # span_id is sent by the test client as a STRING (see _test_client_parametric.py:814-815);
+        # re-activate the caller-supplied root span around the eval so the ffe_* tags (Phase 2) land
+        # on the test's span. Unknown/missing/unparsable id -> skip activation, never throw (T-01-DOS).
+        span_id = body.get("span_id")
         # Build context
         context = EvaluationContext(targeting_key=targeting_key, attributes=attributes)
+
+        # Look up the registered span and re-activate it for the duration of the eval, reusing the
+        # same context-activation primitive that /trace/span/start's start_span(activate=True) relies on.
+        target_span = None
+        if span_id is not None:
+            try:
+                target_span = spans.get(int(span_id))
+            except (TypeError, ValueError):
+                target_span = None
+        if target_span is not None:
+            ddtrace.tracer.context_provider.activate(target_span)
 
         # Evaluate based on variation type
         value = default_value


### PR DESCRIPTION
## Motivation

The FFE APM feature-flag span-enrichment feature (frozen against `dd-trace-js#8343`)
is being fanned out to the remaining Datadog server SDKs. The Python tracer
(`dd-trace-py`) now implements it (gated behind
`DD_EXPERIMENTAL_FLAGGING_PROVIDER_SPAN_ENRICHMENT_ENABLED`), attaching
`ffe_flags_enc`, `ffe_subjects_enc`, and `ffe_runtime_defaults` to the root APM span.

This PR enables the existing, frozen parametric enrichment suite
(`tests/parametric/test_ffe/test_span_enrichment.py`) to actually run and assert for
Python, so the contract is enforced in CI rather than skipped via `missing_feature`.

## Changes

- **`utils/build/docker/python/parametric/apm_test_client/server.py`** -- the
  `/ffe/evaluate` handler now honors the optional `span_id` field sent by the test
  client (`_test_client_parametric.py`). It looks up the caller-supplied root span in
  the existing `spans` registry and re-activates it via
  `ddtrace.tracer.context_provider.activate(...)` around the OpenFeature evaluation,
  so the `ffe_*` tags land on the test's intended root span. An unknown / missing /
  unparsable id simply skips activation and never throws. This reuses the same
  context-activation primitive that `/trace/span/start`'s `start_span(activate=True)`
  relies on; the base `/ffe/start` + `/ffe/evaluate` handlers already exist on `main`.

- **`manifests/python.yml`** -- removed the six class-level `missing_feature` entries for
  `test_span_enrichment.py` so those classes inherit the file-level `>=4.9.0` gate and
  must pass. The validated artifact reports version `4.12.0rc1`, which satisfies the gate.
  No change to the frozen test file, encoding, or limits.

## Decisions

- **Scope kept minimal and language-scoped.** Only the Python parametric server handler
  and the Python manifest are touched. The shared HTTP test-client (`ffe_start` /
  `ffe_evaluate` with `span_id`) already exists on `main` and needed no change. No
  `_test_agent.py` change is required -- the enrichment tests only use
  `set_remote_config` / `wait_for_rc_apply_state` / `wait_for_num_traces`.
- **Gate via inheritance, not a pinned version.** Removing the per-class
  `missing_feature` lets the classes inherit the existing `>=4.9.0` file gate rather than
  introducing a new hard-coded version, keeping the manifest forward-compatible.
- **Frozen contract untouched.** `tests/parametric/test_ffe/test_span_enrichment.py` and
  the codec/limits are unchanged; product behavior lives in `dd-trace-py`
  (`DataDog/dd-trace-py#18640`).

## Local validation

Built a `cp311` wheel from `dd-trace-py` branch `leo.romanovsky/ffe-apm-span-enrichment`
(`ddtrace-4.12.0rc1-cp311-cp311-linux_aarch64.whl`), placed it in `binaries/`, and ran
the suite on this PR branch:

```
TEST_LIBRARY=python ./run.sh PARAMETRIC -k span_enrichment
```

Result -- all 8 enrichment classes, 18/18 tests passed, 0 skipped:

```
Scenario: PARAMETRIC
Library: python@4.12.0-rc1
============================= test session starts ==============================
....................                                                     [100%]
============================= 18 passed in 58.68s ==============================
```

Classes exercised (all passing): `Test_Span_Enrichment_Serial_IDs`,
`Test_Span_Enrichment_Child_Span_Propagation`, `Test_Span_Enrichment_Max_Serial_IDs`,
`Test_Span_Enrichment_Default_Fallback`, `Test_Span_Enrichment_Max_Subjects`,
`Test_Span_Enrichment_Max_Experiments_Per_Subject`, `Test_Span_Enrichment_Subjects`,
`Test_Span_Enrichment_Delta_Varint`.
