### PR TITLE
feat(parametric/java): enable FFE span-enrichment scenario for Java

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3703,7 +3703,7 @@ manifest:
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1_ServiceTargets::test_not_match_service_target: irrelevant (APMAPI-1003)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV2: v1.31.0
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation: v1.56.0
-  tests/parametric/test_ffe/test_span_enrichment.py: missing_feature
+  tests/parametric/test_ffe/test_span_enrichment.py: v1.64.0
   tests/parametric/test_headers_b3.py::Test_Headers_B3::test_headers_b3_migrated_extract_invalid:  # Modified by easy win activation script
     - declaration: missing_feature (Need to remove b3=b3multi alias)
       component_version: <1.58.2+06122213c8

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/FeatureFlagEvaluatorController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/FeatureFlagEvaluatorController.java
@@ -2,7 +2,9 @@ package com.datadoghq.trace.controller;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import com.datadoghq.trace.opentracing.controller.OpenTracingController;
 import com.fasterxml.jackson.annotation.JsonAlias;
+import datadog.trace.api.DDSpanId;
 import datadog.trace.api.openfeature.Provider;
 import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.EvaluationContext;
@@ -13,6 +15,9 @@ import dev.openfeature.sdk.OpenFeatureAPI;
 import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Structure;
 import dev.openfeature.sdk.Value;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.util.GlobalTracer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,26 +83,19 @@ public class FeatureFlagEvaluatorController {
         Object value;
         String reason;
         final EvaluationContext context = context(request);
+        // Re-activate the caller-supplied root span around the eval so the ffe_* tags (Phase 2) land
+        // on the test's span. The client sends span_id as a decimal STRING (see
+        // _test_client_parametric.py:814-815); the OT registry is keyed by DDSpanId.from(...).
+        // An unknown/missing/unparsable span_id leaves target null -> skip activation, never throw (T-01-DOS).
+        final Span target = resolveSpan(request.getSpanId());
         try {
-            value = switch (request.getVariationType()) {
-                case "BOOLEAN" ->
-                        client.getBooleanValue(request.getFlag(), (Boolean) request.getDefaultValue(), context);
-                case "STRING" -> client.getStringValue(request.getFlag(), (String) request.getDefaultValue(), context);
-                case "INTEGER" -> {
-                    final Number integerEval = (Number) request.getDefaultValue();
-                    yield client.getIntegerValue(request.getFlag(), integerEval.intValue(), context);
+            if (target != null) {
+                try (Scope scope = GlobalTracer.get().scopeManager().activate(target)) {
+                    value = evaluate(request, context);
                 }
-                case "NUMERIC" -> {
-                    final Number doubleEval = (Number) request.getDefaultValue();
-                    yield client.getDoubleValue(request.getFlag(), doubleEval.doubleValue(), context);
-                }
-                case "JSON" -> {
-                    final Value objectValue = client.getObjectValue(request.getFlag(), Value.objectToValue(request.getDefaultValue()), context);
-                    yield context.convertValue(objectValue);
-                }
-                default -> request.getDefaultValue();
-            };
-
+            } else {
+                value = evaluate(request, context);
+            }
             reason = "DEFAULT";
         } catch (Throwable e) {
             LOGGER.error("Error on resolution", e);
@@ -108,6 +106,40 @@ public class FeatureFlagEvaluatorController {
         result.put("reason", reason);
         result.put("value", value);
         return ResponseEntity.ok(result);
+    }
+
+    /** Look up a span by the (string) span_id the test client sends; null when missing/unparsable. */
+    private static Span resolveSpan(final String spanId) {
+        if (spanId == null || spanId.isEmpty()) {
+            return null;
+        }
+        try {
+            return OpenTracingController.getSpan(DDSpanId.from(spanId));
+        } catch (Throwable e) {
+            LOGGER.warn("Could not resolve span for span_id {}", spanId, e);
+            return null;
+        }
+    }
+
+    private Object evaluate(final EvaluateRequest request, final EvaluationContext context) {
+        return switch (request.getVariationType()) {
+            case "BOOLEAN" ->
+                    client.getBooleanValue(request.getFlag(), (Boolean) request.getDefaultValue(), context);
+            case "STRING" -> client.getStringValue(request.getFlag(), (String) request.getDefaultValue(), context);
+            case "INTEGER" -> {
+                final Number integerEval = (Number) request.getDefaultValue();
+                yield client.getIntegerValue(request.getFlag(), integerEval.intValue(), context);
+            }
+            case "NUMERIC" -> {
+                final Number doubleEval = (Number) request.getDefaultValue();
+                yield client.getDoubleValue(request.getFlag(), doubleEval.doubleValue(), context);
+            }
+            case "JSON" -> {
+                final Value objectValue = client.getObjectValue(request.getFlag(), Value.objectToValue(request.getDefaultValue()), context);
+                yield context.convertValue(objectValue);
+            }
+            default -> request.getDefaultValue();
+        };
     }
 
     private static EvaluationContext context(final EvaluateRequest request) {
@@ -141,10 +173,21 @@ public class FeatureFlagEvaluatorController {
         private Object defaultValue;
         @JsonAlias("targeting_key")
         private String targetingKey;
+        // The test client sends span_id as a STRING (see _test_client_parametric.py:814-815).
+        @JsonAlias("span_id")
+        private String spanId;
         private Map<String, Object> attributes;
 
         public Map<String, Object> getAttributes() {
             return attributes;
+        }
+
+        public String getSpanId() {
+            return spanId;
+        }
+
+        public void setSpanId(String spanId) {
+            this.spanId = spanId;
         }
 
         public void setAttributes(Map<String, Object> attributes) {


### PR DESCRIPTION
## Motivation

[DataDog/dd-trace-java#11658](https://github.com/DataDog/dd-trace-java/pull/11658) adds
FFE APM feature-flag **span enrichment** to the Java tracer (experimental, gated behind
`DD_EXPERIMENTAL_FLAGGING_PROVIDER_SPAN_ENRICHMENT_ENABLED`): the root APM span carries
`ffe_flags_enc` / `ffe_subjects_enc` / `ffe_runtime_defaults` tags, encoded against the
FROZEN contract (`dd-trace-js#8343`). The parametric suite
`tests/parametric/test_ffe/test_span_enrichment.py` already exists and is frozen; Java is
currently marked `missing_feature`. This PR enables it for Java.

## Changes

- **`manifests/java.yml`** — declare `tests/parametric/test_ffe/test_span_enrichment.py`
  at `v1.64.0` (the release that ships the feature), replacing `missing_feature`.
- **`FeatureFlagEvaluatorController.java`** (parametric test client) — re-activate the
  caller-supplied root span around the OpenFeature evaluation so the `ffe_*` tags land on
  the test's root span. The client sends `span_id` as a decimal string; it is resolved via
  the OpenTracing registry (`OpenTracingController.getSpan(DDSpanId.from(...))`). An
  unknown / missing / unparsable `span_id` leaves the target null → activation is skipped
  and never throws. The eval switch is extracted into an `evaluate(...)` helper so it can
  run inside or outside the re-activated scope.

The frozen test, fixture (`span-enrichment-flags.json`), and the Python client-side
`ffe_evaluate(..., span_id=...)` plumbing already exist on `main`, so the diff is limited
to the manifest line and the Java parametric controller.

## Decisions

- **`v1.64.0` (release) vs. a SNAPSHOT declaration** — the manifest declares the release
  version the feature ships in, matching the existing FFE convention
  (`test_dynamic_evaluation.py: v1.56.0`). Validated locally against a
  `1.64.0-SNAPSHOT` build of the SDK branch.
- **Why re-activate the span in the controller** — `ffe_*` tags are attached to the *root*
  span of the active trace at flag-evaluation time. The parametric test starts a span and
  passes its `span_id` to `/ffe/evaluate`; without re-activating that span around the eval,
  the evaluation runs outside the test's trace and the tags have no root span to attach to.

## Validation

The frozen suite (18 cases) was run locally against a `dd-java-agent 1.64.0-SNAPSHOT`
(+ custom `dd-trace-api` / `dd-openfeature`) built from dd-trace-java#11658
(HEAD `8491123c5d`):

```
TEST_LIBRARY=java ./run.sh PARAMETRIC -k span_enrichment
```

All 18 cases execute and pass — delta-varint codec, `ffe_flags_enc` serial-ID combination
+ child-span→root propagation + 200-ID cap, `ffe_subjects_enc` SHA256-hashed targeting keys
with doLog gating + 10-subject / 20-experiments-per-subject caps, and `ffe_runtime_defaults`
fallback + 64-char truncation + 5-key cap.
