### PR TITLE
Enable Ruby FFE APM span-enrichment parametric tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2129,7 +2129,7 @@ manifest:
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV2::test_capability_tracing_custom_tags: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV2::test_tracing_client_tracing_tags: missing_feature  # Created by easy win activation script
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation: v2.23.0
-  tests/parametric/test_ffe/test_span_enrichment.py: missing_feature
+  tests/parametric/test_ffe/test_span_enrichment.py: v2.36.0-dev
   tests/parametric/test_headers_b3.py::Test_Headers_B3::test_headers_b3_extract_invalid:  # Easy win for all weblogs and version 2.27.0
     - declaration: missing_feature (Missing for 2.x)
       component_version: '>1.99.0'

--- a/utils/build/docker/ruby/parametric/server.rb
+++ b/utils/build/docker/ruby/parametric/server.rb
@@ -816,7 +816,7 @@ class LogFlushReturn
 end
 
 class OpenFeatureArgs
-  attr_reader :flag, :variation_type, :default_value, :targeting_key, :attributes
+  attr_reader :flag, :variation_type, :default_value, :targeting_key, :attributes, :span_id
 
   def initialize(params)
     @flag = params['flag']
@@ -824,6 +824,9 @@ class OpenFeatureArgs
     @default_value = params['defaultValue']
     @targeting_key = params['targetingKey']
     @attributes = params['attributes']
+    # The test client sends span_id as a STRING (see _test_client_parametric.py:814-815). DD_SPANS is
+    # keyed by the integer span id (handle_trace_span_start: DD_SPANS[span.id]); cast for the lookup.
+    @span_id = params['span_id'].nil? ? nil : Integer(params['span_id'], exception: false)
   end
 end
 
@@ -872,7 +875,7 @@ def handle_ffe_evaluation(req, res)
       flag_key: args.flag, default_value: args.default_value, evaluation_context: context
     }
 
-    value =
+    evaluate = lambda do
       case args.variation_type
       when 'BOOLEAN'then client.fetch_boolean_value(**options)
       when 'STRING' then client.fetch_string_value(**options)
@@ -880,6 +883,27 @@ def handle_ffe_evaluation(req, res)
       when 'NUMERIC' then client.fetch_float_value(**options)
       when 'JSON' then client.fetch_object_value(**options)
       else 'FATAL_UNEXPECTED_VARIATION_TYPE'
+      end
+    end
+
+    # Re-activate the caller-supplied span's LIVE trace around the eval so the span-enrichment
+    # hook (Phase 2) accumulates onto the test's real root span. This is the in-process
+    # equivalent of the Node reference's `tracer.scope().activate(span, fn)`
+    # (utils/build/docker/nodejs/parametric/server.js): the hook keys its accumulator and its
+    # `span_before_finish` subscription by the ACTIVE TraceOperation, so every /ffe/evaluate call
+    # must run on the SAME live trace as the root span. Using `continue_from:` instead would fork a
+    # fresh TraceOperation per call -- each eval would land on a throwaway root and the test's root
+    # span would aggregate nothing. An unknown/missing span_id falls through to a plain eval --
+    # never throw (T-01-DOS).
+    trace_op =
+      if !args.span_id.nil? && (span = DD_SPANS[args.span_id])
+        DD_TRACES[span.trace_id]
+      end
+    value =
+      if trace_op
+        Datadog::Tracing.send(:tracer).send(:call_context).activate!(trace_op) { evaluate.call }
+      else
+        evaluate.call
       end
 
     res.write({value: value, reason: 'DEFAULT'}.to_json)


### PR DESCRIPTION
## Motivation

The FFE APM feature-flag span-enrichment contract (frozen against `dd-trace-js#8343`)
is now implemented in the Ruby tracer (`DataDog/dd-trace-rb#5910`). This PR enables the
existing frozen parametric suite `tests/parametric/test_ffe/test_span_enrichment.py`
for Ruby so the harness asserts Ruby's `ffe_*` tags (`ffe_flags_enc`,
`ffe_subjects_enc`, `ffe_runtime_defaults`) stay in parity with the backend/Trino
decode and the Node.js reference.

## Changes

Two language-scoped changes, no cross-language drift:

1. **`utils/build/docker/ruby/parametric/server.rb`** — the `/ffe/evaluate` handler now
   re-activates the caller-supplied span's **live `TraceOperation`** around the
   evaluation (the in-process equivalent of the Node reference's
   `tracer.scope().activate(span, fn)` in `utils/build/docker/nodejs/parametric/server.js`).
   - `OpenFeatureArgs` now reads `span_id` (cast to Integer — the test client sends it as
     a string, `DD_SPANS` is keyed by integer span id).
   - The eval runs via `call_context.activate!(trace_op) { ... }` so the SDK's
     `SpanEnrichmentHook` — which keys its accumulator and its `span_before_finish`
     subscription by the **active** `TraceOperation` — aggregates every flag onto the
     test's real root span.
   - Missing/unknown `span_id` falls through to a plain eval; never raises.

2. **`manifests/ruby.yml`** — flip `tests/parametric/test_ffe/test_span_enrichment.py`
   from `missing_feature` to `v2.36.0-dev`.

## Decisions

- **Why `call_context.activate!` and not `continue_from:`** — a `continue_from:` digest
  starts a *new* `TraceOperation` per call (`Tracer#continue_trace!` →
  `start_trace(continue_from:)`). Each `/ffe/evaluate` would then land on a throwaway
  forked root span, so multi-flag / multi-subject / child-span tests would aggregate
  nothing onto the test's actual root. Activating the stored live trace keeps all evals
  on the one trace the test created — matching the Node reference behavior exactly. This
  was a parametric-app harness fix; **no `dd-trace-rb` source change was needed.**

- **Limit-test parity** — serial IDs (200), subjects (10), experiments/subject (20),
  runtime defaults (5), 64-char value truncation all pass against the frozen assertions.

## Validation results

Run locally against the `dd-trace-rb#5910` gem (`datadog-2.36.0.dev`,
`libdatadog-33.0.0.1.0`):

```
TEST_LIBRARY=ruby ./run.sh PARAMETRIC -k span_enrichment
...
============================= 18 passed in 30.48s ==============================
```

All 18 cases green: delta-varint codec (5), serial-ID/subject aggregation, multiple
subjects tracked separately, child-span→root propagation, SHA256 subject hashing,
`__dd_do_log` gating, runtime-default detection + 64-char truncation, and all frozen
limits.

> **Host-arch note (not a code issue):** `utils/build/docker/ruby/parametric/Dockerfile`
> pins `FROM --platform=linux/amd64`. On an arm64 host the in-container native-ext build
> of `ext/libdatadog_api/di.c` segfaults under QEMU x86_64 emulation
> (`make: *** [di.o] Segmentation fault`). The 18-passing run above was produced on arm64
> using a **local-only** workaround (dropping the `--platform` pin so the ext compiles
> natively); that workaround is intentionally **not** part of this PR. The `server.rb`
> delta validated is byte-identical to the one in this PR, and the gem/enrichment behavior
> is platform-independent — so CI (amd64) exercises the same code path. Flagging the host
> QEMU bug explicitly so the PR is not blocked on it.
