### PR TITLE
[docker-ssi] Disable ruby-app-deployment-mode on Ruby 3.1 (RB31)

### DIFF
--- a/utils/scripts/ci_orchestrators/docker_ssi.json
+++ b/utils/scripts/ci_orchestrators/docker_ssi.json
@@ -251,7 +251,6 @@
                         "allowed_runtime_versions": [
                             "RB27",
                             "RB30",
-                            "RB31",
                             "RB32",
                             "RB33",
                             "RB34"
@@ -262,7 +261,6 @@
                         "allowed_runtime_versions": [
                             "RB27",
                             "RB30",
-                            "RB31",
                             "RB32",
                             "RB33",
                             "RB34"


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Removes the `RB31` (Ruby 3.1.7) runtime from the `ruby-app-deployment-mode`
weblog spec in the docker SSI matrix (`utils/scripts/ci_orchestrators/docker_ssi.json`),
for both `Ubuntu_22_arm64` and `Ubuntu_22_amd64`.

This weblog running un ruby 3.1 fails because the deployment-mode Dockerfile runs `bundle lock --update`, which
discards the pinned `Gemfile.lock` and resolves dependencies to the newest versions allowed by the `Gemfile`. Since `i18n` is an unpinned transitive dependency (`>= 1.6, < 2`), the build now pulls `i18n 1.15.0`, which uses the
`Fiber[]` API introduced in Ruby 3.2 and therefore crashes on Ruby 3.1.
This is why the test started failing without any source changes on our side: a newly published gem version became incompatible with the Ruby 3.1 runtime.
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
