### PR TITLE
python: mark iast unvalidated header and redirect tests as flaky

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -430,53 +430,22 @@ manifest:
         "*": v4.7.0-rc1 (implemented in v3.9.0.dev, but there was the APPSEC-57817 and APPSEC-61861 bugs)
   tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedHeader::test_secure:
     - weblog_declaration:
-        "*": bug (APPSEC-62470)
-        flask-poc: v4.9.0  # TODO: a lower version might be supported
-        python3.12: v4.9.0  # TODO: a lower version might be supported
-        django-py3.13: v4.9.0  # TODO: a lower version might be supported
-        fastapi: v4.9.0  # TODO: a lower version might be supported
-        uds-flask: v4.9.0  # TODO: a lower version might be supported
-        django-poc: v4.9.0  # TODO: a lower version might be supported
-        uwsgi-poc: v4.9.0  # TODO: a lower version might be supported
-  tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedHeader_ExtendedLocation:  # Easy win for django-poc, django-py3.13, fastapi, flask-poc, python3.12, uds-flask, uwsgi-poc and version 4.6.4
+        "*": flaky (APPSEC-62470)
+  tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedHeader_ExtendedLocation:
     - weblog_declaration:
-        "*": bug (APPSEC-62470)
-        # "*": v4.7.0-rc1 (implemented in v3.9.0.dev, but there was the APPSEC-57817 and APPSEC-61861 bugs)
-        flask-poc: v4.9.0  # TODO: a lower version might be supported
-        python3.12: v4.9.0  # TODO: a lower version might be supported
-        django-py3.13: v4.9.0  # TODO: a lower version might be supported
-        fastapi: v4.9.0  # TODO: a lower version might be supported
-        uds-flask: v4.9.0  # TODO: a lower version might be supported
-        django-poc: v4.9.0  # TODO: a lower version might be supported
-        uwsgi-poc: v4.9.0  # TODO: a lower version might be supported
+        "*": flaky (APPSEC-62470)
   tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedHeader_StackTrace:  # Easy win for django-poc, django-py3.13, fastapi, flask-poc, python3.12, uds-flask, uwsgi-poc and version 4.6.4
     - weblog_declaration:
         "*": v4.7.0-rc1 (implemented in v3.9.0.dev, but there was the APPSEC-57817 and APPSEC-61861 bugs)
   tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedRedirect:  # Easy win for django-poc, django-py3.13, fastapi, flask-poc, python3.12, uds-flask, uwsgi-poc and version 4.6.4
     - weblog_declaration:
         "*": v4.7.0-rc1 (implemented in v3.9.0.dev, but there was the APPSEC-57817 and APPSEC-61861 bugs)
-  tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedRedirect::test_secure:  # Easy win for django-poc, django-py3.13, fastapi, flask-poc, python3.12, uds-flask, uwsgi-poc and version 4.6.4
+  tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedRedirect::test_secure:
     - weblog_declaration:
-        "*": bug (APPSEC-62470)
-        # "*": v4.7.0-rc1 (implemented in v3.9.0.dev, but there was the APPSEC-57817 and APPSEC-61861 bugs)
-        flask-poc: v4.9.0  # TODO: a lower version might be supported
-        python3.12: v4.9.0  # TODO: a lower version might be supported
-        django-py3.13: v4.9.0  # TODO: a lower version might be supported
-        fastapi: v4.9.0  # TODO: a lower version might be supported
-        uds-flask: v4.9.0  # TODO: a lower version might be supported
-        django-poc: v4.9.0  # TODO: a lower version might be supported
-        uwsgi-poc: v4.9.0  # TODO: a lower version might be supported
-  tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedRedirect_ExtendedLocation:  # Easy win for django-poc, django-py3.13, fastapi, flask-poc, python3.12, uds-flask, uwsgi-poc and version 4.6.4
+        "*": flaky (APPSEC-62470)
+  tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedRedirect_ExtendedLocation:
     - weblog_declaration:
-        "*": bug (APPSEC-62470)
-        # "*": v4.7.0-rc1 (implemented in v3.9.0.dev, but there was the APPSEC-57817 and APPSEC-61861 bugs)
-        flask-poc: v4.9.0  # TODO: a lower version might be supported
-        python3.12: v4.9.0  # TODO: a lower version might be supported
-        django-py3.13: v4.9.0  # TODO: a lower version might be supported
-        fastapi: v4.9.0  # TODO: a lower version might be supported
-        uds-flask: v4.9.0  # TODO: a lower version might be supported
-        django-poc: v4.9.0  # TODO: a lower version might be supported
-        uwsgi-poc: v4.9.0  # TODO: a lower version might be supported
+        "*": flaky (APPSEC-62470)
   tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedRedirect_StackTrace:  # Easy win for django-poc, django-py3.13, fastapi, flask-poc, python3.12, uds-flask, uwsgi-poc and version 4.6.4
     - weblog_declaration:
         "*": v4.7.0-rc1 (implemented in v3.9.0.dev, but there was the APPSEC-57817 and APPSEC-61861 bugs)


### PR DESCRIPTION
## Motivation

Tests were marked bug instead of flaky and got wrongly re-enabled by the easywins automation. This fixes it. 
(The list of flaky tests is extracted from the [Test failures on default branch Dashboard](https://app.datadoghq.com/dashboard/eit-h7i-h4q?fromUser=false&refresh_mode=sliding&tile_focus=6648549132855474&tpl_var_codeowner%5B0%5D=%40DataDog%2Fasm-python&tpl_var_repo=%2A%2Fdd-trace-py&from_ts=1781165576835&to_ts=1781770376835&live=true) 


## Changes

Mark the four failing tests as flaky.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
