### PR TITLE
test(appsec): read lambda inferred-span AppSec data from the service-entry span

### DIFF
--- a/tests/appsec/test_inferred_spans.py
+++ b/tests/appsec/test_inferred_spans.py
@@ -16,11 +16,18 @@ class Test_Lambda_Inferred_Span_Tags:
         self.r = weblog.get("/waf/?message=<script>alert()</script>")
 
     def test_lambda_inferred_span(self) -> None:
+        # The AppSec report is carried by the service-entry span. Depending on
+        # the tracer / lambda layer version this is either the downstream
+        # aws.lambda span, or the inferred API Gateway span when it shares the
+        # function's service (serverless service representation) and therefore
+        # becomes the top-level service-entry span. Capture the AppSec data from
+        # whichever span reports it.
+        service_entry_appsec_data = None
         for _, _, span, appsec_data in interfaces.library.get_appsec_events(self.r):
-            if span.get("name") == "aws.lambda":
-                lambda_span_appsec_data = appsec_data
+            if span.get("name") == "aws.lambda" or span.get("name") in INFERRED_SPAN_NAMES:
+                service_entry_appsec_data = appsec_data
 
-        assert lambda_span_appsec_data, "Expected non empty appsec data on aws.lambda span"
+        assert service_entry_appsec_data, "Expected non empty appsec data on the service-entry span"
 
         def validate_inferred_span(span: DataDogLibrarySpan) -> bool:
             if span.get("name") not in INFERRED_SPAN_NAMES:
@@ -41,7 +48,7 @@ class Test_Lambda_Inferred_Span_Tags:
             inferred_payload = (
                 json.loads(inferred_span_payload) if isinstance(inferred_span_payload, str) else inferred_span_payload
             )
-            assert inferred_payload == lambda_span_appsec_data, "AppSec Data must match the service-entry span"
+            assert inferred_payload == service_entry_appsec_data, "AppSec Data must match the service-entry span"
 
             return True
 


### PR DESCRIPTION
## Motivation

`Test_Lambda_Inferred_Span_Tags::test_lambda_inferred_span` asserts the AppSec report is on the `aws.lambda` span. With the Serverless Service Representation (SSR) work, the inferred API Gateway span now uses `DD_SERVICE` (the same service as the function span). Because `_dd.top_level` / service-entry is computed by comparing a span's service to its parent's, the inferred span becomes the service-entry span and AppSec attaches its report there instead of on the downstream `aws.lambda` span.

This makes the test fail (`UnboundLocalError` — no AppSec data found on the `aws.lambda` span) for the Python lambda layer once the inferred-span service change ships (see DataDog/datadog-lambda-python#834).

## Change

Capture the reference AppSec payload from whichever span is the service-entry span: the `aws.lambda` span (older behavior / other tracers) or the inferred span (new SSR behavior). The inferred-span validation is unchanged.

This keeps the test green for:
- Older Python layer versions (AppSec on `aws.lambda`, mirrored to the inferred span)
- New Python layer versions (AppSec on the inferred service-entry span)

Note: this test is `missing_feature` for nodejs/java lambda, so only Python is affected.

## Test plan

- [ ] APPSEC_LAMBDA_INFERRED_SPANS scenario passes for python_lambda apigw-rest and apigw-http with the SSR inferred-span service change