### PR TITLE
Fix EVP flagevaluation contract and enable Go system tests

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -886,7 +886,7 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Unavailable: v2.4.0
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Unknown_Operator_Tolerance::test_unknown_operator_errors: bug (FFL-2182)
   tests/ffe/test_exposures.py: v2.6.0-dev  # Easy win for chi, echo, gin, net-http, net-http-orchestrion, uds-echo and version 2.5.0
-  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py: v2.10.0-dev
   tests/ffe/test_flag_eval_metrics.py: v2.8.0
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Metric_Parse_Error_Invalid_Regex: irrelevant (Go validates regex at config load time)
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Nested_Attributes_Ignored: irrelevant (FFL-1980)

--- a/tests/ffe/test_flag_eval_evp.py
+++ b/tests/ffe/test_flag_eval_evp.py
@@ -17,7 +17,7 @@ from utils import weblog
 
 RC_PRODUCT = "FFE_FLAGS"
 RC_PATH = f"datadog/2/{RC_PRODUCT}"
-EVP_FLAGEVALUATION_PATH = "/api/v2/flagevaluation"
+EVP_FLAGEVALUATIONS_PATH = "/api/v2/flagevaluation"
 EVP_WAIT_TIMEOUT_SECONDS = 30
 EVP_LOAD_WAIT_TIMEOUT_SECONDS = 60
 EVP_FULL_TIER_PER_FLAG_CAP = 10_000
@@ -54,7 +54,7 @@ def evaluate_flag(
 
 
 def evp_flagevaluation_events_from_data(data: JSON, flag_key: str) -> list[tuple[JSON, JSON]]:
-    if data.get("path") != EVP_FLAGEVALUATION_PATH:
+    if data.get("path") != EVP_FLAGEVALUATIONS_PATH:
         return []
 
     request = data.get("request")
@@ -91,7 +91,7 @@ def wait_for_evp_flagevaluation_event(flag_key: str) -> None:
 def find_evp_flagevaluation_events(flag_key: str) -> list[tuple[JSON, JSON]]:
     results: list[tuple[JSON, JSON]] = []
 
-    for data in interfaces.agent.get_data(path_filters=EVP_FLAGEVALUATION_PATH):
+    for data in interfaces.agent.get_data(path_filters=EVP_FLAGEVALUATIONS_PATH):
         results.extend(evp_flagevaluation_events_from_data(cast("JSON", data), flag_key))
 
     return results

--- a/tests/ffe/test_flag_eval_evp.py
+++ b/tests/ffe/test_flag_eval_evp.py
@@ -17,11 +17,11 @@ from utils import weblog
 
 RC_PRODUCT = "FFE_FLAGS"
 RC_PATH = f"datadog/2/{RC_PRODUCT}"
-EVP_FLAGEVALUATIONS_PATH = "/api/v2/flagevaluations"
+EVP_FLAGEVALUATION_PATH = "/api/v2/flagevaluation"
 EVP_WAIT_TIMEOUT_SECONDS = 30
 EVP_LOAD_WAIT_TIMEOUT_SECONDS = 60
 EVP_FULL_TIER_PER_FLAG_CAP = 10_000
-EVP_DEGRADATION_OVERFLOW_EVALS = 50
+EVP_DEGRADATION_OVERFLOW_EVALS = 2_000
 
 
 def make_multi_flag_fixture(flag_keys: list[str]) -> JSON:
@@ -54,7 +54,7 @@ def evaluate_flag(
 
 
 def evp_flagevaluation_events_from_data(data: JSON, flag_key: str) -> list[tuple[JSON, JSON]]:
-    if data.get("path") != EVP_FLAGEVALUATIONS_PATH:
+    if data.get("path") != EVP_FLAGEVALUATION_PATH:
         return []
 
     request = data.get("request")
@@ -91,7 +91,7 @@ def wait_for_evp_flagevaluation_event(flag_key: str) -> None:
 def find_evp_flagevaluation_events(flag_key: str) -> list[tuple[JSON, JSON]]:
     results: list[tuple[JSON, JSON]] = []
 
-    for data in interfaces.agent.get_data(path_filters=EVP_FLAGEVALUATIONS_PATH):
+    for data in interfaces.agent.get_data(path_filters=EVP_FLAGEVALUATION_PATH):
         results.extend(evp_flagevaluation_events_from_data(cast("JSON", data), flag_key))
 
     return results


### PR DESCRIPTION
## Motivation

Server-side EVP flagevaluation system tests need to match the live flageval-worker contract before SDK fanout can land with APM approval. Combining the shared contract fix with the already-validated Go manifest enablement gives reviewers one PR that proves the singular EVP intake path and turns on the first SDK against that corrected contract.

## Changes

- Updates the EVP intake assertion path value from `/api/v2/flagevaluations` to `/api/v2/flagevaluation` while keeping the existing `EVP_FLAGEVALUATIONS_PATH` constant name.
- Raises degradation overflow coverage from 50 extra evaluations to 2,000 extra evaluations beyond the 10,000 full-fidelity cap.
- Keeps the degradation test as a natural overflow scenario with one request containing all targeting keys for the evaluated flag.
- Enables `tests/ffe/test_flag_eval_evp.py` for Go in `manifests/golang.yml` at `v2.10.0-dev`.

## Decisions

- Combined the contract-fix PR and Go enablement PR because the Go manifest change is a one-line enablement that depends directly on this corrected system-test contract.
- Kept the path constant name plural to avoid unnecessary review churn while still matching the live singular worker endpoint.
- Left the Go enablement scoped to `golang` / `net-http`, matching the validated path.

## Validation Evidence

Local Go validation on June 20, 2026:

- SDK commit: `3fb4e80e6b16cd46b8b123f748e4a1ab35a0a770`
- system-tests commit from the original Go enablement validation: `95edcc8de242e0c70ddce87b6fab8a76e585f1e3`
- Weblog: `golang` / `net-http`
- Runtime context: Agent `7.80.1`; library `golang@2.10.0-dev`; Linux `aarch64`

Commands:

```bash
CI=true SYSTEM_TEST_BUILD_TIMEOUT=1200 ./build.sh golang -w net-http
TEST_LIBRARY=golang WEBLOG_VARIANT=net-http ./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION -k "test_flag_eval_evp"
```

Result: `8 passed, 2627 deselected in 68.51s`.

Static checks after combining:

- `git diff --check` - PASS.
- `python3 -m compileall -q tests/ffe/test_flag_eval_evp.py` - PASS.
