### PR TITLE
Enable EVP flagevaluation system tests for Go

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -886,7 +886,7 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Unavailable: v2.4.0
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Unknown_Operator_Tolerance::test_unknown_operator_errors: bug (FFL-2182)
   tests/ffe/test_exposures.py: v2.6.0-dev  # Easy win for chi, echo, gin, net-http, net-http-orchestrion, uds-echo and version 2.5.0
-  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py: v2.10.0-dev
   tests/ffe/test_flag_eval_metrics.py: v2.8.0
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Metric_Parse_Error_Invalid_Regex: irrelevant (Go validates regex at config load time)
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Nested_Attributes_Ignored: irrelevant (FFL-1980)


### PR DESCRIPTION
## Motivation

Enable the merged server-side EVP flagevaluation system tests for Go after the Go SDK implementation validated the shared contract locally.

## Changes

- Changes `tests/ffe/test_flag_eval_evp.py` in `manifests/golang.yml` from `missing_feature (FFL-2446)` to `v2.10.0-dev`.

## Decisions

- This is a language-specific manifest enablement PR for Go.
- The PR remains draft until SDK fanout review is complete.
- The test is enabled against `golang` / `net-http`, matching the local validation path.

## Validation Evidence

Local validation on June 20, 2026:

- SDK commit: `3fb4e80e6b16cd46b8b123f748e4a1ab35a0a770`
- system-tests commit: `95edcc8de242e0c70ddce87b6fab8a76e585f1e3`
- Weblog: `golang` / `net-http`
- Runtime context: Agent `7.80.1`; library `golang@2.10.0-dev`; Linux `aarch64`

Commands:

```bash
CI=true SYSTEM_TEST_BUILD_TIMEOUT=1200 ./build.sh golang -w net-http
TEST_LIBRARY=golang WEBLOG_VARIANT=net-http ./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION -k "test_flag_eval_evp"
```

Result: `8 passed, 2627 deselected in 68.51s`.

Static check:

- `git diff --check` - pass
