### PR TITLE
Enable EVP flagevaluation system tests for PHP

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -622,7 +622,7 @@ manifest:
   tests/docker_ssi/test_docker_ssi_crash.py::TestDockerSSICrash::test_crash: missing_feature (No implemented the endpoint /crashme)
   tests/ffe/test_dynamic_evaluation.py: v1.21.0-dev
   tests/ffe/test_exposures.py: v1.21.0-dev
-  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py: v1.21.0-dev
   tests/ffe/test_flag_eval_metrics.py: v1.21.0-dev
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_kafka.py::Test_Kafka: missing_feature

--- a/tests/ffe/test_flag_eval_evp.py
+++ b/tests/ffe/test_flag_eval_evp.py
@@ -17,11 +17,11 @@ from utils import weblog
 
 RC_PRODUCT = "FFE_FLAGS"
 RC_PATH = f"datadog/2/{RC_PRODUCT}"
-EVP_FLAGEVALUATIONS_PATH = "/api/v2/flagevaluations"
+EVP_FLAGEVALUATION_PATH = "/api/v2/flagevaluation"
 EVP_WAIT_TIMEOUT_SECONDS = 30
 EVP_LOAD_WAIT_TIMEOUT_SECONDS = 60
 EVP_FULL_TIER_PER_FLAG_CAP = 10_000
-EVP_DEGRADATION_OVERFLOW_EVALS = 50
+EVP_DEGRADATION_OVERFLOW_EVALS = 2_000
 
 
 def make_multi_flag_fixture(flag_keys: list[str]) -> JSON:
@@ -54,7 +54,7 @@ def evaluate_flag(
 
 
 def evp_flagevaluation_events_from_data(data: JSON, flag_key: str) -> list[tuple[JSON, JSON]]:
-    if data.get("path") != EVP_FLAGEVALUATIONS_PATH:
+    if data.get("path") != EVP_FLAGEVALUATION_PATH:
         return []
 
     request = data.get("request")
@@ -91,7 +91,7 @@ def wait_for_evp_flagevaluation_event(flag_key: str) -> None:
 def find_evp_flagevaluation_events(flag_key: str) -> list[tuple[JSON, JSON]]:
     results: list[tuple[JSON, JSON]] = []
 
-    for data in interfaces.agent.get_data(path_filters=EVP_FLAGEVALUATIONS_PATH):
+    for data in interfaces.agent.get_data(path_filters=EVP_FLAGEVALUATION_PATH):
         results.extend(evp_flagevaluation_events_from_data(cast("JSON", data), flag_key))
 
     return results


### PR DESCRIPTION
## Motivation

Enable the server-side EVP `flagevaluation` system tests for PHP after the PHP SDK PR validated the shared contract, sidecar path, and local system-test path.

## Changes

Final diff against `main`:

- Carries the stacked shared flagevaluation contract update in `tests/ffe/test_flag_eval_evp.py`, including the singular `/api/v2/flagevaluation` path, no OpenFeature `reason`, omitted `targeting_rule` when no real rule metadata exists, evaluation-time first/last/count assertions, and degraded-bucket overflow coverage.
- Changes `tests/ffe/test_flag_eval_evp.py` in `manifests/php.yml` from `missing_feature (FFL-2446)` to `v1.21.0-dev`.

## Decisions

- This PR is stacked on the shared flagevaluation contract-fix PR so the language-specific commit remains a single PHP manifest entry.
- The matching SDK implementation is DataDog/dd-trace-php#3984, backed by DataDog/libdatadog#2117 for the sidecar path.
- The reviewer-facing diff is described against `main`, because the stack base only hides the shared contract file from GitHub's PR file list.
- This PR remains draft until the SDK fanout review is complete.

## Validation Evidence

- `git diff --check` - PASS.
- `./tooling/bin/build-debug-artifact gnu-aarch64-8.0-nts /Users/leo.romanovsky/gsd-workspaces/flag-evaluations-cross-sdk/system-tests-clean-php/binaries` from `dd-trace-php` - PASS; produced `dd-library-php-1.21.0-aarch64-linux-gnu.tar.gz`.
- `SYSTEM_TEST_BUILD_TIMEOUT=1800 ./build.sh --library php --weblog-variant apache-mod-8.0` from `system-tests-clean-php` - PASS on 2026-06-20.
- `TEST_LIBRARY=php WEBLOG_VARIANT=apache-mod-8.0 ./run.sh +l php FEATURE_FLAGGING_AND_EXPERIMENTATION -k "test_flag_eval_evp"` - PASS on 2026-06-20, `8 passed, 2627 deselected in 60.08s` with `Library: php@1.21.0`.
- Degradation payload evidence from the passing system-test run: `payloads=30`, `events=10195`, total `evaluation_count=12708`; `evp-degradation-flag` emitted `10001` rows with total `evaluation_count=12000`, including one degraded row with `evaluation_count=2000` and omitted `targeting_key`/`context`.
- Real-backend dogfooding prefixes recorded in the PHP SDK PR:
  - `server-evp-e2e-php7-1781931066-user-`
  - `server-evp-e2e-php8-openfeature-1781931066-user-`

