### PR TITLE
fix(v1): surface promoted span fields through meta compatibility layer

### DIFF
--- a/utils/dd_types/_datadog_library_trace.py
+++ b/utils/dd_types/_datadog_library_trace.py
@@ -184,6 +184,20 @@ class DataDogLibrarySpanLegacy(DataDogLibrarySpan):
 class DataDogLibrarySpanV1(DataDogLibrarySpan):
     trace: DataDogLibraryTracev1
 
+    # v1 promotes these fields out of attributes into top-level span fields.
+    # Map them back into meta so existing assertions using span["meta"]["x"] still work.
+    _V1_TOP_LEVEL_TO_META: dict[str, str] = {
+        "component": "component",
+        "span_kind": "span.kind",
+    }
+
+    def _meta_dict(self) -> dict[str, Any]:
+        result = dict(self.raw_span.get("attributes", {}))
+        for v1_key, meta_key in self._V1_TOP_LEVEL_TO_META.items():
+            if v1_key in self.raw_span:
+                result[meta_key] = self.raw_span[v1_key]
+        return result
+
     def __contains__(self, key: str) -> bool:
         if key in ("meta", "meta_struct", "metrics"):
             return "attributes" in self.raw_span
@@ -197,8 +211,11 @@ class DataDogLibrarySpanV1(DataDogLibrarySpan):
         if key == "trace_id":
             return self.trace.trace_id
 
-        if key in ("meta", "meta_struct", "metrics"):
-            return self.raw_span["attributes"]
+        if key in ("meta", "meta_struct"):
+            return self._meta_dict()
+
+        if key == "metrics":
+            return self.raw_span.get("attributes", {})
 
         return self.raw_span.get(key, default)
 
@@ -206,7 +223,10 @@ class DataDogLibrarySpanV1(DataDogLibrarySpan):
         if key == "trace_id":
             return self.trace.trace_id
 
-        if key in ("meta", "meta_struct", "metrics"):
+        if key in ("meta", "meta_struct"):
+            return self._meta_dict()
+
+        if key == "metrics":
             return self.raw_span["attributes"]
 
         return self.raw_span[key]
@@ -214,7 +234,7 @@ class DataDogLibrarySpanV1(DataDogLibrarySpan):
     @property
     def meta(self) -> dict[str, Any]:
         assert "attributes" in self.raw_span
-        return self.raw_span["attributes"]
+        return self._meta_dict()
 
     @property
     def metrics(self) -> dict[str, Any]:

--- a/utils/dd_types/_datadog_library_trace.py
+++ b/utils/dd_types/_datadog_library_trace.py
@@ -188,7 +188,9 @@ class DataDogLibrarySpanV1(DataDogLibrarySpan):
     # Map them back into meta so existing assertions using span["meta"]["x"] still work.
     _V1_TOP_LEVEL_TO_META: dict[str, str] = {
         "component": "component",
+        "env": "env",
         "span_kind": "span.kind",
+        "version": "version",
     }
 
     def _meta_dict(self) -> dict[str, Any]:

--- a/utils/dd_types/_datadog_library_trace.py
+++ b/utils/dd_types/_datadog_library_trace.py
@@ -193,11 +193,24 @@ class DataDogLibrarySpanV1(DataDogLibrarySpan):
         "version": "version",
     }
 
+    # span_kind is stored as an integer in v1; map it to the lowercase string expected by tests.
+    _SPAN_KIND_INT_TO_STR: dict[int, str] = {
+        0: "unspecified",
+        1: "internal",
+        2: "server",
+        3: "client",
+        4: "producer",
+        5: "consumer",
+    }
+
     def _meta_dict(self) -> dict[str, Any]:
         result = dict(self.raw_span.get("attributes", {}))
         for v1_key, meta_key in self._V1_TOP_LEVEL_TO_META.items():
             if v1_key in self.raw_span:
-                result[meta_key] = self.raw_span[v1_key]
+                value = self.raw_span[v1_key]
+                if v1_key == "span_kind" and isinstance(value, int):
+                    value = self._SPAN_KIND_INT_TO_STR.get(value, str(value))
+                result[meta_key] = value
         return result
 
     def __contains__(self, key: str) -> bool:


### PR DESCRIPTION
## Summary

In v1 trace format, several fields are promoted to top-level span fields rather than living inside \`attributes\`. The existing \`DataDogLibrarySpanV1\` compatibility layer mapped \`span["meta"]\` directly to \`raw_span["attributes"]\`, so assertions like \`span["meta"]["component"]\` silently missed them.

Added \`_meta_dict()\` to \`DataDogLibrarySpanV1\` that merges top-level promoted fields back into the returned dict:

| v1 top-level field | meta key |
|---|---|
| \`component\` | \`component\` |
| \`env\` | \`env\` |
| \`span_kind\` | \`span.kind\` |
| \`version\` | \`version\` |

All existing test assertions using \`span["meta"]["component"]\`, \`span.get("meta", {}).get("env")\`, etc. now work correctly for v1 spans without any test code changes.

## Motivation

Fixes test failures seen in dd-trace-go CI ([example run](https://github.com/DataDog/dd-trace-go/actions/runs/27960250134/job/82740461370)) where \`assert "component" in span["meta"]\` failed because \`component\` is a top-level v1 field, not in \`attributes\`. The same structural bug affects \`env\` (silently broken in \`test_reports.py::Test_Info::test_service\`) and \`version\`/\`span_kind\` wherever those are accessed via \`meta\`.

## Test plan

- [x] Ran \`TEST_LIBRARY=golang ./run.sh INTEGRATIONS -k test_inferred_proxy\` against \`dd-trace-go@hannahkm/enable-etp-210\` — previously 3 failures, now 3 passed
- [ ] Verify no regressions in other languages that use \`span["meta"]["component"]\` (e.g. \`test_semantic_conventions.py\`, \`test_graphql.py\`, \`test_shell_execution.py\`)
- [ ] Verify \`test_reports.py::Test_Info::test_service\` passes for Go (env mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)