### PR TITLE
test(parametric): decouple nodejs stable-config assertions from renamable tracer internals

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2022,7 +2022,6 @@ manifest:
     - declaration: missing_feature (Implemented in 5.38.0)
       component_version: <5.38.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: *ref_5_29_0
-  tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)
   tests/parametric/test_config_consistency.py::Test_Config_RateLimit: *ref_5_25_0
   tests/parametric/test_config_consistency.py::Test_Config_Tags: *ref_5_41_0
   tests/parametric/test_config_consistency.py::Test_Config_TraceAgentURL: *ref_5_25_0

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -131,3 +131,35 @@ class StableConfigWriter:
             cmd = "sudo " + cmd
         success, message = test_library.container_exec_run(cmd)
         assert success, message
+
+
+def nodejs_telemetry_value(test_agent: TestAgentAPI, dd_key: str) -> str | int | float | bool | None:
+    """Return the effective nodejs telemetry value for a dd_* config key.
+
+    dd-trace-js builds /trace/config from internal property paths that a series of config
+    PRs is renaming to canonical names; the telemetry keeps reporting the stable canonical
+    names (the dd_* key upper-cased), so asserting there stays decoupled from those
+    refactors. The effective value is the highest-seq_id entry (already sorted first).
+    """
+    configuration_by_name = test_agent.wait_for_telemetry_configurations()
+    entries = configuration_by_name.get(dd_key.upper())
+    assert entries, f"No telemetry configuration '{dd_key.upper()}'"
+    return entries[0].get("value")
+
+
+def assert_nodejs_telemetry_config(test_agent: TestAgentAPI, expected: dict) -> None:
+    """Assert expected dd_* config values against the nodejs telemetry configuration."""
+    configuration_by_name = test_agent.wait_for_telemetry_configurations()
+    for dd_key, expected_value in expected.items():
+        entries = configuration_by_name.get(dd_key.upper())
+        assert entries, f"No telemetry configuration '{dd_key.upper()}'"
+        actual = entries[0].get("value")
+        if dd_key == "dd_tags":
+            actual_tags = "" if actual is None else str(actual)
+            expected_tags = expected_value if isinstance(expected_value, list) else str(expected_value).split(",")
+            for tag in expected_tags:
+                assert tag in actual_tags, f"Expected tag '{tag}' not found in telemetry tags: {actual_tags}"
+        else:
+            assert str(actual).lower() == str(expected_value).lower(), (
+                f"Expected {dd_key.upper()}={expected_value}, got {actual}"
+            )

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -1,5 +1,6 @@
 import base64
 from collections.abc import Generator
+import json
 from pathlib import Path
 import shutil
 import subprocess
@@ -133,17 +134,27 @@ class StableConfigWriter:
         assert success, message
 
 
+# dd_* keys whose canonical telemetry name is not simply the upper-cased key. The tracer
+# reports the canonical name (e.g. DD_TRACE_LOG_LEVEL); DD_LOG_LEVEL is only an alias.
+_TELEMETRY_NAME_OVERRIDES = {"dd_log_level": "DD_TRACE_LOG_LEVEL"}
+
+
+def _telemetry_name(dd_key: str) -> str:
+    return _TELEMETRY_NAME_OVERRIDES.get(dd_key, dd_key.upper())
+
+
 def nodejs_telemetry_value(test_agent: TestAgentAPI, dd_key: str) -> str | int | float | bool | None:
     """Return the effective nodejs telemetry value for a dd_* config key.
 
     dd-trace-js builds /trace/config from internal property paths that a series of config
     PRs is renaming to canonical names; the telemetry keeps reporting the stable canonical
-    names (the dd_* key upper-cased), so asserting there stays decoupled from those
-    refactors. The effective value is the highest-seq_id entry (already sorted first).
+    names, so asserting there stays decoupled from those refactors. The effective value is
+    the highest-seq_id entry (already sorted first).
     """
+    name = _telemetry_name(dd_key)
     configuration_by_name = test_agent.wait_for_telemetry_configurations()
-    entries = configuration_by_name.get(dd_key.upper())
-    assert entries, f"No telemetry configuration '{dd_key.upper()}'"
+    entries = configuration_by_name.get(name)
+    assert entries, f"No telemetry configuration '{name}'"
     return entries[0].get("value")
 
 
@@ -151,8 +162,9 @@ def assert_nodejs_telemetry_config(test_agent: TestAgentAPI, expected: dict) -> 
     """Assert expected dd_* config values against the nodejs telemetry configuration."""
     configuration_by_name = test_agent.wait_for_telemetry_configurations()
     for dd_key, expected_value in expected.items():
-        entries = configuration_by_name.get(dd_key.upper())
-        assert entries, f"No telemetry configuration '{dd_key.upper()}'"
+        name = _telemetry_name(dd_key)
+        entries = configuration_by_name.get(name)
+        assert entries, f"No telemetry configuration '{name}'"
         actual = entries[0].get("value")
         if dd_key == "dd_tags":
             actual_tags = "" if actual is None else str(actual)
@@ -160,6 +172,20 @@ def assert_nodejs_telemetry_config(test_agent: TestAgentAPI, expected: dict) -> 
             for tag in expected_tags:
                 assert tag in actual_tags, f"Expected tag '{tag}' not found in telemetry tags: {actual_tags}"
         else:
-            assert str(actual).lower() == str(expected_value).lower(), (
-                f"Expected {dd_key.upper()}={expected_value}, got {actual}"
-            )
+            assert str(actual).lower() == str(expected_value).lower(), f"Expected {name}={expected_value}, got {actual}"
+
+
+def nodejs_startup_config(test_library: APMLibrary) -> dict:
+    """Parse the tracer's published `DATADOG TRACER CONFIGURATION - {json}` startup line.
+
+    Some facts have no telemetry signal: an unreachable agent never delivers telemetry (so the
+    resolved agent URL is unobservable that way), and OTEL_LOG_LEVEL=debug toggles debug logging
+    without a DD_TRACE_DEBUG telemetry entry. The startup diagnostic is a published, user-facing
+    log line that carries them, so it is the non-internal source for those cases.
+    """
+    marker = "DATADOG TRACER CONFIGURATION - "
+    for line in test_library.get_logs().splitlines():
+        index = line.find(marker)
+        if index != -1:
+            return json.loads(line[index + len(marker) :])
+    raise AssertionError("No 'DATADOG TRACER CONFIGURATION' line found in container logs")

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -142,11 +142,11 @@ class Test_Config_TraceAgentURL:
             }
         ],
     )
-    def test_dd_trace_agent_unix_url_nonexistent(self, test_library: APMLibrary):
+    def test_dd_trace_agent_unix_url_nonexistent(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
-            resp = t.config()
+            agent_url = _trace_agent_url(test_agent, t)
 
-        url = urlparse(resp["dd_trace_agent_url"])
+        url = urlparse(agent_url)
         assert "unix" in url.scheme
         assert url.path == "/var/run/datadog/apm.socket"
 
@@ -161,11 +161,11 @@ class Test_Config_TraceAgentURL:
             }
         ],
     )
-    def test_dd_trace_agent_http_url_nonexistent(self, test_library: APMLibrary):
+    def test_dd_trace_agent_http_url_nonexistent(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
-            resp = t.config()
+            agent_url = _trace_agent_url(test_agent, t)
 
-        url = urlparse(resp["dd_trace_agent_url"])
+        url = urlparse(agent_url)
         assert url.scheme == "http"
         assert url.hostname == "random-host"
         assert url.port == 9999
@@ -180,11 +180,11 @@ class Test_Config_TraceAgentURL:
             }
         ],
     )
-    def test_dd_trace_agent_http_url_ipv6(self, test_library: APMLibrary):
+    def test_dd_trace_agent_http_url_ipv6(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
-            resp = t.config()
+            agent_url = _trace_agent_url(test_agent, t)
 
-        url = urlparse(resp["dd_trace_agent_url"])
+        url = urlparse(agent_url)
         assert url.scheme == "http"
         assert url.hostname == "::1"
         assert url.port == 5000
@@ -199,11 +199,11 @@ class Test_Config_TraceAgentURL:
             }
         ],
     )
-    def test_dd_agent_host_ipv6(self, test_library: APMLibrary):
+    def test_dd_agent_host_ipv6(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
-            resp = t.config()
+            agent_url = _trace_agent_url(test_agent, t)
 
-        url = urlparse(resp["dd_trace_agent_url"])
+        url = urlparse(agent_url)
         assert url.scheme == "http"
         assert url.hostname == "::1"
         assert url.port == 5000
@@ -217,8 +217,11 @@ class Test_Config_RateLimit:
     # which would be unreliable for testing and require significant effort for each tracer's weblog application.
     # The feature is mainly tested in the second test case, where the rate limit is set to 1 to ensure it works as expected.
     @parametrize("library_env", [{"DD_TRACE_SAMPLE_RATE": "1"}])
-    def test_default_trace_rate_limit(self, test_library: APMLibrary):
+    def test_default_trace_rate_limit(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert_nodejs_telemetry_config(test_agent, {"dd_trace_rate_limit": "100"})
+                return
             resp = t.config()
         assert resp["dd_trace_rate_limit"] == "100"
 
@@ -359,27 +362,41 @@ class Test_Config_Dogstatsd:
     @parametrize(
         "library_env", [{"DD_AGENT_HOST": "localhost"}]
     )  # Adding DD_AGENT_HOST because some SDKs use DD_AGENT_HOST to set the dogstatsd host if unspecified
-    def test_dogstatsd_default(self, test_library: APMLibrary):
+    def test_dogstatsd_default(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert_nodejs_telemetry_config(
+                    test_agent, {"dd_dogstatsd_host": "localhost", "dd_dogstatsd_port": "8125"}
+                )
+                return
             resp = t.config()
         assert resp["dd_dogstatsd_host"] == "localhost"
         assert resp["dd_dogstatsd_port"] == "8125"
 
     @parametrize("library_env", [{"DD_DOGSTATSD_HOST": "192.168.10.1"}])
-    def test_dogstatsd_custom_ip_address(self, test_library: APMLibrary):
+    def test_dogstatsd_custom_ip_address(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert_nodejs_telemetry_config(test_agent, {"dd_dogstatsd_host": "192.168.10.1"})
+                return
             resp = t.config()
         assert resp["dd_dogstatsd_host"] == "192.168.10.1"
 
     @parametrize("library_env", [{"DD_DOGSTATSD_HOST": "127.0.0.1"}])
-    def test_dogstatsd_custom_hostname(self, test_library: APMLibrary):
+    def test_dogstatsd_custom_hostname(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert_nodejs_telemetry_config(test_agent, {"dd_dogstatsd_host": "127.0.0.1"})
+                return
             resp = t.config()
         assert resp["dd_dogstatsd_host"] == "127.0.0.1"
 
     @parametrize("library_env", [{"DD_DOGSTATSD_PORT": "8150"}])
-    def test_dogstatsd_custom_port(self, test_library: APMLibrary):
+    def test_dogstatsd_custom_port(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert_nodejs_telemetry_config(test_agent, {"dd_dogstatsd_port": "8150"})
+                return
             resp = t.config()
         assert resp["dd_dogstatsd_port"] == "8150"
 
@@ -406,19 +423,33 @@ SDK_DEFAULT_STABLE_CONFIG = {
 }
 
 
-def assert_nodejs_telemetry_config(test_agent: TestAgentAPI, expected: dict) -> None:
-    """Assert expected dd_* config values against the nodejs telemetry configuration.
+def nodejs_telemetry_value(test_agent: TestAgentAPI, dd_key: str):
+    """Return the effective nodejs telemetry value for a dd_* config key.
 
     dd-trace-js builds /trace/config from internal property paths that a series of config
     PRs is renaming to canonical names; the telemetry keeps reporting the stable canonical
     names (the dd_* key upper-cased), so asserting there stays decoupled from those
-    refactors. The effective value per name is the highest-seq_id entry.
+    refactors. The effective value is the highest-seq_id entry (already sorted first).
     """
     configuration_by_name = test_agent.wait_for_telemetry_configurations()
+    entries = configuration_by_name.get(dd_key.upper())
+    assert entries, f"No telemetry configuration '{dd_key.upper()}'"
+    return entries[0].get("value")
+
+
+def _trace_agent_url(test_agent: TestAgentAPI, test_library: APMLibrary) -> str:
+    """Resolve dd_trace_agent_url from telemetry (nodejs) or /trace/config (other languages)."""
+    if test_library.lang == "nodejs":
+        return nodejs_telemetry_value(test_agent, "dd_trace_agent_url")
+    return test_library.config()["dd_trace_agent_url"]
+
+
+def assert_nodejs_telemetry_config(test_agent: TestAgentAPI, expected: dict) -> None:
+    """Assert expected dd_* config values against the nodejs telemetry configuration."""
+    configuration_by_name = test_agent.wait_for_telemetry_configurations()
     for dd_key, expected_value in expected.items():
-        telemetry_name = dd_key.upper()
-        entries = configuration_by_name.get(telemetry_name)
-        assert entries, f"No telemetry configuration '{telemetry_name}'"
+        entries = configuration_by_name.get(dd_key.upper())
+        assert entries, f"No telemetry configuration '{dd_key.upper()}'"
         actual = entries[0].get("value")
         if dd_key == "dd_tags":
             actual_tags = "" if actual is None else str(actual)
@@ -427,7 +458,7 @@ def assert_nodejs_telemetry_config(test_agent: TestAgentAPI, expected: dict) -> 
                 assert tag in actual_tags, f"Expected tag '{tag}' not found in telemetry tags: {actual_tags}"
         else:
             assert str(actual).lower() == str(expected_value).lower(), (
-                f"Expected {telemetry_name}={expected_value}, got {actual}"
+                f"Expected {dd_key.upper()}={expected_value}, got {actual}"
             )
 
 

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -13,7 +13,7 @@ from utils import (
 )
 from utils.docker_fixtures.spec.trace import find_span_in_traces, find_only_span
 from utils.docker_fixtures import TestAgentAPI
-from .conftest import APMLibrary, StableConfigWriter
+from .conftest import APMLibrary, StableConfigWriter, assert_nodejs_telemetry_config, nodejs_telemetry_value
 
 parametrize = pytest.mark.parametrize
 
@@ -423,43 +423,11 @@ SDK_DEFAULT_STABLE_CONFIG = {
 }
 
 
-def nodejs_telemetry_value(test_agent: TestAgentAPI, dd_key: str):
-    """Return the effective nodejs telemetry value for a dd_* config key.
-
-    dd-trace-js builds /trace/config from internal property paths that a series of config
-    PRs is renaming to canonical names; the telemetry keeps reporting the stable canonical
-    names (the dd_* key upper-cased), so asserting there stays decoupled from those
-    refactors. The effective value is the highest-seq_id entry (already sorted first).
-    """
-    configuration_by_name = test_agent.wait_for_telemetry_configurations()
-    entries = configuration_by_name.get(dd_key.upper())
-    assert entries, f"No telemetry configuration '{dd_key.upper()}'"
-    return entries[0].get("value")
-
-
 def _trace_agent_url(test_agent: TestAgentAPI, test_library: APMLibrary) -> str:
     """Resolve dd_trace_agent_url from telemetry (nodejs) or /trace/config (other languages)."""
     if test_library.lang == "nodejs":
-        return nodejs_telemetry_value(test_agent, "dd_trace_agent_url")
+        return str(nodejs_telemetry_value(test_agent, "dd_trace_agent_url"))
     return test_library.config()["dd_trace_agent_url"]
-
-
-def assert_nodejs_telemetry_config(test_agent: TestAgentAPI, expected: dict) -> None:
-    """Assert expected dd_* config values against the nodejs telemetry configuration."""
-    configuration_by_name = test_agent.wait_for_telemetry_configurations()
-    for dd_key, expected_value in expected.items():
-        entries = configuration_by_name.get(dd_key.upper())
-        assert entries, f"No telemetry configuration '{dd_key.upper()}'"
-        actual = entries[0].get("value")
-        if dd_key == "dd_tags":
-            actual_tags = "" if actual is None else str(actual)
-            expected_tags = expected_value if isinstance(expected_value, list) else str(expected_value).split(",")
-            for tag in expected_tags:
-                assert tag in actual_tags, f"Expected tag '{tag}' not found in telemetry tags: {actual_tags}"
-        else:
-            assert str(actual).lower() == str(expected_value).lower(), (
-                f"Expected {dd_key.upper()}={expected_value}, got {actual}"
-            )
 
 
 class QuotedStr(str):

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -13,7 +13,7 @@ from utils import (
 )
 from utils.docker_fixtures.spec.trace import find_span_in_traces, find_only_span
 from utils.docker_fixtures import TestAgentAPI
-from .conftest import APMLibrary, StableConfigWriter, assert_nodejs_telemetry_config, nodejs_telemetry_value
+from .conftest import APMLibrary, StableConfigWriter, assert_nodejs_telemetry_config, nodejs_startup_config
 
 parametrize = pytest.mark.parametrize
 
@@ -136,15 +136,16 @@ class Test_Config_TraceAgentURL:
         "library_env",
         [
             {
+                "DD_TRACE_STARTUP_LOGS": "true",
                 "DD_TRACE_AGENT_URL": "unix:///var/run/datadog/apm.socket",
                 "DD_AGENT_HOST": "localhost",
                 "DD_TRACE_AGENT_PORT": "8126",
             }
         ],
     )
-    def test_dd_trace_agent_unix_url_nonexistent(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+    def test_dd_trace_agent_unix_url_nonexistent(self, test_library: APMLibrary):
         with test_library as t:
-            agent_url = _trace_agent_url(test_agent, t)
+            agent_url = _trace_agent_url(t)
 
         url = urlparse(agent_url)
         assert "unix" in url.scheme
@@ -155,15 +156,16 @@ class Test_Config_TraceAgentURL:
         "library_env",
         [
             {
+                "DD_TRACE_STARTUP_LOGS": "true",
                 "DD_TRACE_AGENT_URL": "http://random-host:9999/",
                 "DD_AGENT_HOST": "localhost",
                 "DD_TRACE_AGENT_PORT": "8126",
             }
         ],
     )
-    def test_dd_trace_agent_http_url_nonexistent(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+    def test_dd_trace_agent_http_url_nonexistent(self, test_library: APMLibrary):
         with test_library as t:
-            agent_url = _trace_agent_url(test_agent, t)
+            agent_url = _trace_agent_url(t)
 
         url = urlparse(agent_url)
         assert url.scheme == "http"
@@ -174,15 +176,16 @@ class Test_Config_TraceAgentURL:
         "library_env",
         [
             {
+                "DD_TRACE_STARTUP_LOGS": "true",
                 "DD_TRACE_AGENT_URL": "http://[::1]:5000",
                 "DD_AGENT_HOST": "localhost",
                 "DD_TRACE_AGENT_PORT": "8126",
             }
         ],
     )
-    def test_dd_trace_agent_http_url_ipv6(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+    def test_dd_trace_agent_http_url_ipv6(self, test_library: APMLibrary):
         with test_library as t:
-            agent_url = _trace_agent_url(test_agent, t)
+            agent_url = _trace_agent_url(t)
 
         url = urlparse(agent_url)
         assert url.scheme == "http"
@@ -193,15 +196,16 @@ class Test_Config_TraceAgentURL:
         "library_env",
         [
             {
+                "DD_TRACE_STARTUP_LOGS": "true",
                 "DD_TRACE_AGENT_URL": "",  # Empty string passed to make sure conftest.py does not set trace agent url
                 "DD_AGENT_HOST": "[::1]",
                 "DD_TRACE_AGENT_PORT": "5000",
             }
         ],
     )
-    def test_dd_agent_host_ipv6(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+    def test_dd_agent_host_ipv6(self, test_library: APMLibrary):
         with test_library as t:
-            agent_url = _trace_agent_url(test_agent, t)
+            agent_url = _trace_agent_url(t)
 
         url = urlparse(agent_url)
         assert url.scheme == "http"
@@ -423,10 +427,14 @@ SDK_DEFAULT_STABLE_CONFIG = {
 }
 
 
-def _trace_agent_url(test_agent: TestAgentAPI, test_library: APMLibrary) -> str:
-    """Resolve dd_trace_agent_url from telemetry (nodejs) or /trace/config (other languages)."""
+def _trace_agent_url(test_library: APMLibrary) -> str:
+    """Resolve dd_trace_agent_url from the tracer's startup log (nodejs) or /trace/config (others).
+
+    These tests point the tracer at an unreachable agent, so telemetry never arrives; the
+    published startup-config line is the non-internal source for the resolved URL.
+    """
     if test_library.lang == "nodejs":
-        return str(nodejs_telemetry_value(test_agent, "dd_trace_agent_url"))
+        return str(nodejs_startup_config(test_library)["agent_url"])
     return test_library.config()["dd_trace_agent_url"] or ""
 
 

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -427,7 +427,7 @@ def _trace_agent_url(test_agent: TestAgentAPI, test_library: APMLibrary) -> str:
     """Resolve dd_trace_agent_url from telemetry (nodejs) or /trace/config (other languages)."""
     if test_library.lang == "nodejs":
         return str(nodejs_telemetry_value(test_agent, "dd_trace_agent_url"))
-    return test_library.config()["dd_trace_agent_url"]
+    return test_library.config()["dd_trace_agent_url"] or ""
 
 
 class QuotedStr(str):

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -489,6 +489,7 @@ class Test_Stable_Config_Default(StableConfigWriter):
     )
     def test_default_config(
         self,
+        test_agent: TestAgentAPI,
         test_library: APMLibrary,
         path: str,
         name: str,
@@ -505,8 +506,23 @@ class Test_Stable_Config_Default(StableConfigWriter):
                 test_library,
             )
             test_library.container_restart()
-            config = test_library.config()
-            assert expected.items() <= config.items()
+            if test_library.lang == "nodejs":
+                # dd-trace-js builds /trace/config from internal property paths that are
+                # being renamed to canonical names; its telemetry keeps reporting the stable
+                # canonical names, so assert there to stay decoupled from those refactors.
+                origin = "fleet_stable_config" if "managed" in path else "local_stable_config"
+                configuration_by_name = test_agent.wait_for_telemetry_configurations()
+                for env_name, set_value in apm_configuration_default.items():
+                    cfg_value = test_agent.get_telemetry_config_by_origin(
+                        configuration_by_name, env_name, origin, return_value_only=True
+                    )
+                    assert cfg_value is not None, f"No telemetry configuration '{env_name}' with origin '{origin}'"
+                    assert str(cfg_value).lower() == str(set_value).lower(), (
+                        f"Unexpected telemetry value for '{env_name}': {cfg_value!r}"
+                    )
+            else:
+                config = test_library.config()
+                assert expected.items() <= config.items()
 
     @pytest.mark.parametrize("library_env", [{}])
     @pytest.mark.parametrize(

--- a/tests/parametric/test_config_consistency.py
+++ b/tests/parametric/test_config_consistency.py
@@ -406,6 +406,31 @@ SDK_DEFAULT_STABLE_CONFIG = {
 }
 
 
+def assert_nodejs_telemetry_config(test_agent: TestAgentAPI, expected: dict) -> None:
+    """Assert expected dd_* config values against the nodejs telemetry configuration.
+
+    dd-trace-js builds /trace/config from internal property paths that a series of config
+    PRs is renaming to canonical names; the telemetry keeps reporting the stable canonical
+    names (the dd_* key upper-cased), so asserting there stays decoupled from those
+    refactors. The effective value per name is the highest-seq_id entry.
+    """
+    configuration_by_name = test_agent.wait_for_telemetry_configurations()
+    for dd_key, expected_value in expected.items():
+        telemetry_name = dd_key.upper()
+        entries = configuration_by_name.get(telemetry_name)
+        assert entries, f"No telemetry configuration '{telemetry_name}'"
+        actual = entries[0].get("value")
+        if dd_key == "dd_tags":
+            actual_tags = "" if actual is None else str(actual)
+            expected_tags = expected_value if isinstance(expected_value, list) else str(expected_value).split(",")
+            for tag in expected_tags:
+                assert tag in actual_tags, f"Expected tag '{tag}' not found in telemetry tags: {actual_tags}"
+        else:
+            assert str(actual).lower() == str(expected_value).lower(), (
+                f"Expected {telemetry_name}={expected_value}, got {actual}"
+            )
+
+
 class QuotedStr(str):
     __slots__ = ()
 
@@ -507,19 +532,7 @@ class Test_Stable_Config_Default(StableConfigWriter):
             )
             test_library.container_restart()
             if test_library.lang == "nodejs":
-                # dd-trace-js builds /trace/config from internal property paths that are
-                # being renamed to canonical names; its telemetry keeps reporting the stable
-                # canonical names, so assert there to stay decoupled from those refactors.
-                origin = "fleet_stable_config" if "managed" in path else "local_stable_config"
-                configuration_by_name = test_agent.wait_for_telemetry_configurations()
-                for env_name, set_value in apm_configuration_default.items():
-                    cfg_value = test_agent.get_telemetry_config_by_origin(
-                        configuration_by_name, env_name, origin, return_value_only=True
-                    )
-                    assert cfg_value is not None, f"No telemetry configuration '{env_name}' with origin '{origin}'"
-                    assert str(cfg_value).lower() == str(set_value).lower(), (
-                        f"Unexpected telemetry value for '{env_name}': {cfg_value!r}"
-                    )
+                assert_nodejs_telemetry_config(test_agent, expected)
             else:
                 config = test_library.config()
                 assert expected.items() <= config.items()
@@ -554,6 +567,7 @@ class Test_Stable_Config_Default(StableConfigWriter):
     )
     def test_extended_configs(
         self,
+        test_agent: TestAgentAPI,
         test_library: APMLibrary,
         path: str,
         name: str,
@@ -577,6 +591,10 @@ class Test_Stable_Config_Default(StableConfigWriter):
                 test_library,
             )
             test_library.container_restart()
+            if test_library.lang == "nodejs":
+                assert_nodejs_telemetry_config(test_agent, expected)
+                return
+
             config = test_library.config()
 
             # Special handling for dd_tags: check if expected tags are present in actual tags
@@ -621,7 +639,7 @@ class Test_Stable_Config_Default(StableConfigWriter):
             "/etc/datadog-agent/application_monitoring.yaml",
         ],
     )
-    def test_unknown_key_skipped(self, test_library: APMLibrary, path: str, test: dict):
+    def test_unknown_key_skipped(self, test_agent: TestAgentAPI, test_library: APMLibrary, path: str, test: dict):
         with test_library:
             self.write_stable_config(
                 {
@@ -632,8 +650,11 @@ class Test_Stable_Config_Default(StableConfigWriter):
                 test_library,
             )
             test_library.container_restart()
-            config = test_library.config()
-            assert test["expected"].items() <= config.items()
+            if test_library.lang == "nodejs":
+                assert_nodejs_telemetry_config(test_agent, test["expected"])
+            else:
+                config = test_library.config()
+                assert test["expected"].items() <= config.items()
 
     @pytest.mark.parametrize(
         "path",
@@ -642,7 +663,7 @@ class Test_Stable_Config_Default(StableConfigWriter):
             "/etc/datadog-agent/application_monitoring.yaml",
         ],
     )
-    def test_invalid_files(self, test_library: APMLibrary, path: str):
+    def test_invalid_files(self, test_agent: TestAgentAPI, test_library: APMLibrary, path: str):
         with test_library:
             self.write_stable_config_content(
                 "?? ??; ??\t\n\n --- `??",
@@ -650,8 +671,11 @@ class Test_Stable_Config_Default(StableConfigWriter):
                 test_library,
             )
             test_library.container_restart()
-            config = test_library.config()
-            assert SDK_DEFAULT_STABLE_CONFIG.items() <= config.items()
+            if test_library.lang == "nodejs":
+                assert_nodejs_telemetry_config(test_agent, SDK_DEFAULT_STABLE_CONFIG)
+            else:
+                config = test_library.config()
+                assert SDK_DEFAULT_STABLE_CONFIG.items() <= config.items()
 
     @pytest.mark.parametrize(
         ("name", "local_cfg", "library_env", "fleet_cfg", "expected"),
@@ -695,6 +719,7 @@ class Test_Stable_Config_Default(StableConfigWriter):
     )
     def test_config_precedence(
         self,
+        test_agent: TestAgentAPI,
         name: str,
         test_library: APMLibrary,
         local_cfg: dict,
@@ -719,6 +744,10 @@ class Test_Stable_Config_Default(StableConfigWriter):
             )
 
             test_library.container_restart()
+            if test_library.lang == "nodejs":
+                assert_nodejs_telemetry_config(test_agent, expected)
+                return
+
             config = test_library.config()
             assert expected.items() <= config.items(), format(
                 "unexpected values for the following configurations: {}"
@@ -732,7 +761,7 @@ class Test_Stable_Config_Rules(StableConfigWriter):
     """Verify that stable config targeting rules work as intended (apm_configuration_rules)"""
 
     @pytest.mark.parametrize("library_env", [{"STABLE_CONFIG_SELECTOR": "true", "DD_SERVICE": "not-my-service"}])
-    def test_targeting_rules(self, test_library: APMLibrary):
+    def test_targeting_rules(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         path = "/etc/datadog-agent/managed/datadog-agent/stable/application_monitoring.yaml"
         with test_library:
             self.write_stable_config(
@@ -755,10 +784,13 @@ class Test_Stable_Config_Rules(StableConfigWriter):
                 test_library,
             )
             test_library.container_restart()
-            config = test_library.config()
-            assert config["dd_service"] == "my-service", (
-                f"Service name is '{config['dd_service']}' instead of 'my-service'"
-            )
+            if test_library.lang == "nodejs":
+                assert_nodejs_telemetry_config(test_agent, {"dd_service": "my-service"})
+            else:
+                config = test_library.config()
+                assert config["dd_service"] == "my-service", (
+                    f"Service name is '{config['dd_service']}' instead of 'my-service'"
+                )
 
     @pytest.mark.parametrize(
         "library_extra_command_arguments",
@@ -766,7 +798,7 @@ class Test_Stable_Config_Rules(StableConfigWriter):
             ["-Darg1=value"]
         ],  # Note: This test was written for Java, so if this arg is not compatible for other libs, we may need to dynamically set library_extra_command_arguments based on context.library.name
     )
-    def test_process_arguments(self, test_library: APMLibrary):
+    def test_process_arguments(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         path = "/etc/datadog-agent/managed/datadog-agent/stable/application_monitoring.yaml"
         with test_library:
             config = {
@@ -788,7 +820,10 @@ class Test_Stable_Config_Rules(StableConfigWriter):
             stable_config_content = yaml.dump(config, Dumper=CustomDumper)
             self.write_stable_config_content(stable_config_content, path, test_library)
             test_library.container_restart()
-            lib_config = test_library.config()
-            assert lib_config["dd_service"] == "value", (
-                f"Service name is '{lib_config['dd_service']}' instead of 'value'"
-            )
+            if test_library.lang == "nodejs":
+                assert_nodejs_telemetry_config(test_agent, {"dd_service": "value"})
+            else:
+                lib_config = test_library.config()
+                assert lib_config["dd_service"] == "value", (
+                    f"Service name is '{lib_config['dd_service']}' instead of 'value'"
+                )

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -63,12 +63,12 @@ class Test_Otel_Env_Vars:
         assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
         assert float(resp["dd_trace_sample_rate"]) == 0.5
         assert resp["dd_trace_enabled"] == "true"
-        tags = resp["dd_tags"]
-        assert isinstance(tags, (str, list))
-        assert "foo:bar" in tags
-        assert "baz:qux" in tags
-        assert "foo:otel_bar" not in tags
-        assert "baz:otel_qux" not in tags
+        resp_tags: str | list | None = resp["dd_tags"]
+        assert isinstance(resp_tags, (str, list))
+        assert "foo:bar" in resp_tags
+        assert "baz:qux" in resp_tags
+        assert "foo:otel_bar" not in resp_tags
+        assert "baz:otel_qux" not in resp_tags
         assert resp["dd_trace_debug"] == "false"
 
         if context.library != "java":

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -2,7 +2,7 @@ import pytest
 from utils import context, scenarios, features
 from utils.docker_fixtures import TestAgentAPI
 from utils.docker_fixtures.spec.trace import find_only_span
-from .conftest import APMLibrary, assert_nodejs_telemetry_config, nodejs_telemetry_value
+from .conftest import APMLibrary, assert_nodejs_telemetry_config, nodejs_startup_config, nodejs_telemetry_value
 
 
 @scenarios.parametric
@@ -265,13 +265,16 @@ class Test_Otel_Env_Vars:
             resp = t.config()
         assert resp["dd_trace_enabled"] == "false"
 
-    @pytest.mark.parametrize("library_env", [{"OTEL_LOG_LEVEL": "debug", "DD_TRACE_OTEL_ENABLED": "true"}])
+    @pytest.mark.parametrize(
+        "library_env",
+        [{"OTEL_LOG_LEVEL": "debug", "DD_TRACE_OTEL_ENABLED": "true", "DD_TRACE_STARTUP_LOGS": "true"}],
+    )
     def test_otel_log_level_to_debug_mapping(self, test_library: APMLibrary):
         with test_library as t:
             if t.lang == "nodejs":
-                # OTEL_LOG_LEVEL=debug activates debug logging; the tracer's startup config
-                # line reports the resulting debug state in the container output.
-                assert '"debug":true' in t.get_logs()
+                # OTEL_LOG_LEVEL=debug activates debug logging without a DD_TRACE_DEBUG telemetry
+                # entry; the tracer's published startup-config line reports the resulting state.
+                assert nodejs_startup_config(t)["debug"] is True
                 return
             resp = t.config()
         assert resp["dd_trace_debug"] == "true"

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -1,6 +1,8 @@
 import pytest
 from utils import context, scenarios, features
-from .conftest import APMLibrary
+from utils.docker_fixtures import TestAgentAPI
+from utils.docker_fixtures.spec.trace import find_only_span
+from .conftest import APMLibrary, assert_nodejs_telemetry_config, nodejs_telemetry_value
 
 
 @scenarios.parametric
@@ -31,8 +33,27 @@ class Test_Otel_Env_Vars:
             }
         ],
     )
-    def test_dd_env_var_take_precedence(self, test_library: APMLibrary):
+    def test_dd_env_var_take_precedence(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert_nodejs_telemetry_config(
+                    test_agent,
+                    {
+                        "dd_service": "service",
+                        "dd_trace_sample_rate": "0.5",
+                        "dd_trace_enabled": "true",
+                        "dd_trace_debug": "false",
+                        "dd_runtime_metrics_enabled": "true",
+                        "dd_trace_propagation_style": "b3,tracecontext",
+                    },
+                )
+                tags = str(nodejs_telemetry_value(test_agent, "dd_tags"))
+                assert "foo:bar" in tags
+                assert "baz:qux" in tags
+                assert "foo:otel_bar" not in tags
+                assert "baz:otel_qux" not in tags
+                assert nodejs_telemetry_value(test_agent, "dd_log_level") != "debug"
+                return
             resp = t.config()
 
         assert resp["dd_service"] == "service"
@@ -72,8 +93,26 @@ class Test_Otel_Env_Vars:
             }
         ],
     )
-    def test_otel_env_vars_set(self, test_library: APMLibrary):
+    def test_otel_env_vars_set(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert_nodejs_telemetry_config(
+                    test_agent,
+                    {
+                        "dd_service": "otel_service",
+                        "dd_trace_sample_rate": "0.1",
+                        "dd_trace_enabled": "true",
+                        "dd_trace_propagation_style": "b3,tracecontext",
+                        "dd_runtime_metrics_enabled": "false",
+                    },
+                )
+                # OTEL_RESOURCE_ATTRIBUTES tags surface on spans, not in the DD_TAGS telemetry value
+                with t.dd_start_span(name="otel_tags"):
+                    pass
+                span = find_only_span(test_agent.wait_for_num_traces(1))
+                assert span["meta"]["foo"] == "bar1"
+                assert span["meta"]["baz"] == "qux1"
+                return
             resp = t.config()
 
         assert resp["dd_service"] == "otel_service"
@@ -96,8 +135,11 @@ class Test_Otel_Env_Vars:
             assert resp["dd_runtime_metrics_enabled"] == "false"
 
     @pytest.mark.parametrize("library_env", [{"OTEL_LOG_LEVEL": "error"}])
-    def test_otel_log_level_env(self, test_library: APMLibrary):
+    def test_otel_log_level_env(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert_nodejs_telemetry_config(test_agent, {"dd_log_level": "error"})
+                return
             resp = t.config()
 
         assert resp["dd_log_level"] == "error"
@@ -111,8 +153,19 @@ class Test_Otel_Env_Vars:
             }
         ],
     )
-    def test_otel_attribute_mapping(self, test_library: APMLibrary):
+    def test_otel_attribute_mapping(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert_nodejs_telemetry_config(
+                    test_agent, {"dd_service": "test2", "dd_env": "test1", "dd_version": "5"}
+                )
+                # OTEL_RESOURCE_ATTRIBUTES tags surface on spans, not in the DD_TAGS telemetry value
+                with t.dd_start_span(name="otel_attrs"):
+                    pass
+                span = find_only_span(test_agent.wait_for_num_traces(1))
+                assert span["meta"]["foo"] == "bar1"
+                assert span["meta"]["baz"] == "qux1"
+                return
             resp = t.config()
 
         assert resp["dd_service"] == "test2"
@@ -124,15 +177,21 @@ class Test_Otel_Env_Vars:
         assert "baz:qux1" in tags
 
     @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "always_on", "DD_TRACE_OTEL_ENABLED": "true"}])
-    def test_otel_traces_always_on(self, test_library: APMLibrary):
+    def test_otel_traces_always_on(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 1.0
+                return
             resp = t.config()
             assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
             assert float(resp["dd_trace_sample_rate"]) == 1.0
 
     @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "always_off", "DD_TRACE_OTEL_ENABLED": "true"}])
-    def test_otel_traces_always_off(self, test_library: APMLibrary):
+    def test_otel_traces_always_off(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 0.0
+                return
             resp = t.config()
         assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
         assert float(resp["dd_trace_sample_rate"]) == 0.0
@@ -141,8 +200,11 @@ class Test_Otel_Env_Vars:
         "library_env",
         [{"OTEL_TRACES_SAMPLER": "traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.1", "DD_TRACE_OTEL_ENABLED": "true"}],
     )
-    def test_otel_traces_traceidratio(self, test_library: APMLibrary):
+    def test_otel_traces_traceidratio(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 0.1
+                return
             resp = t.config()
         assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
         assert float(resp["dd_trace_sample_rate"]) == 0.1
@@ -150,8 +212,11 @@ class Test_Otel_Env_Vars:
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_on", "DD_TRACE_OTEL_ENABLED": "true"}]
     )
-    def test_otel_traces_parentbased_on(self, test_library: APMLibrary):
+    def test_otel_traces_parentbased_on(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 1.0
+                return
             resp = t.config()
         assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
         assert float(resp["dd_trace_sample_rate"]) == 1.0
@@ -159,8 +224,11 @@ class Test_Otel_Env_Vars:
     @pytest.mark.parametrize(
         "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off", "DD_TRACE_OTEL_ENABLED": "true"}]
     )
-    def test_otel_traces_parentbased_off(self, test_library: APMLibrary):
+    def test_otel_traces_parentbased_off(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 0.0
+                return
             resp = t.config()
         assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
         assert float(resp["dd_trace_sample_rate"]) == 0.0
@@ -175,21 +243,36 @@ class Test_Otel_Env_Vars:
             }
         ],
     )
-    def test_otel_traces_parentbased_ratio(self, test_library: APMLibrary):
+    def test_otel_traces_parentbased_ratio(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 0.1
+                return
             resp = t.config()
         assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
         assert float(resp["dd_trace_sample_rate"]) == 0.1
 
     @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_EXPORTER": "none", "DD_TRACE_OTEL_ENABLED": "true"}])
-    def test_otel_traces_exporter_none(self, test_library: APMLibrary):
+    def test_otel_traces_exporter_none(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                # OTEL_TRACES_EXPORTER=none disables tracing; assert no trace is produced
+                with t.dd_start_span(name="disabled"):
+                    pass
+                with pytest.raises(ValueError):
+                    test_agent.wait_for_num_traces(num=1)
+                return
             resp = t.config()
         assert resp["dd_trace_enabled"] == "false"
 
     @pytest.mark.parametrize("library_env", [{"OTEL_LOG_LEVEL": "debug", "DD_TRACE_OTEL_ENABLED": "true"}])
     def test_otel_log_level_to_debug_mapping(self, test_library: APMLibrary):
         with test_library as t:
+            if t.lang == "nodejs":
+                # OTEL_LOG_LEVEL=debug activates debug logging; the tracer's startup config
+                # line reports the resulting debug state in the container output.
+                assert '"debug":true' in t.get_logs()
+                return
             resp = t.config()
         assert resp["dd_trace_debug"] == "true"
         # If dd_log_level is set it must be consistent with dd_trace_debug

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -403,32 +403,11 @@ app.post('/trace/otel/set_attributes', (req, res) => {
 });
 
 app.get('/trace/config', (req, res) => {
-  const dummyTracer = require('dd-trace').init()
-  const config = dummyTracer._tracer._config
-  const agentUrl = dummyTracer._tracer?._url ||  config?.url
-  res.json( {
-    config: {
-      'dd_service': config?.service !== undefined ? `${config.service}`.toLowerCase() : 'null',
-      'dd_log_level': config?.logLevel !== undefined ? `${config.logLevel}`.toLowerCase() : 'null',
-      'dd_trace_debug': config?.debug !== undefined ? `${config.debug}`.toLowerCase() : 'null',
-      'dd_trace_sample_rate': config?.sampleRate !== undefined ? `${config.sampleRate}` : 'null',
-      'dd_trace_enabled': config ? 'true' : 'false', // in node if dd_trace_enabled is true the tracer won't have a config object
-      'dd_runtime_metrics_enabled': config?.runtimeMetrics !== undefined ? `${config.runtimeMetrics.enabled ?? config.runtimeMetrics}`.toLowerCase() : 'null',
-      'dd_tags': config?.tags !== undefined ? Object.entries(config.tags).map(([key, val]) => `${key}:${val}`).join(',') : 'null',
-      'dd_trace_propagation_style': config?.tracePropagationStyle?.inject.join(',') ?? 'null',
-      'dd_trace_sample_ignore_parent': 'null', // not implemented in node
-      'dd_trace_otel_enabled': 'null', // not exposed in config object in node
-      'dd_env': config?.tags?.env !== undefined ? `${config.tags.env}` : 'null',
-      'dd_version': config?.tags?.version !== undefined ? `${config.tags.version}` : 'null',
-      'dd_trace_agent_url': agentUrl !== undefined ? agentUrl.toString() : 'null',
-      'dd_trace_rate_limit': config?.sampler?.rateLimit !== undefined ? `${config?.sampler?.rateLimit}` : 'null',
-      'dd_dogstatsd_host': config?.dogstatsd?.hostname !== undefined ? `${config.dogstatsd.hostname}` : 'null',
-      'dd_dogstatsd_port': config?.dogstatsd?.port !== undefined ? `${config.dogstatsd.port}` : 'null',
-      'dd_profiling_enabled': config?.profiling?.enabled !== undefined ? `${config.profiling.enabled}` : 'false',
-      'dd_data_streams_enabled': config?.dsmEnabled !== undefined ? `${config.dsmEnabled}` : 'null',
-      'dd_logs_injection': config?.logInjection !== undefined ? `${config.logInjection}` : 'null',
-    }
-  });
+  // The tracer's resolved config is an internal shape whose property paths rename across
+  // refactors, so this endpoint reports nothing from it. Node config consistency is asserted
+  // via telemetry and observable behaviour in the parametric suite; the test client fills
+  // every documented key with null, so the cross-language parity contract still holds.
+  res.json({ config: {} })
 });
 
 app.post("/otel/logger/create", (req, res) => {

--- a/utils/docker_fixtures/_test_agent.py
+++ b/utils/docker_fixtures/_test_agent.py
@@ -625,7 +625,7 @@ class TestAgentAPI:
         raise AssertionError(f"Telemetry event {event_name} not found")
 
     def wait_for_telemetry_configurations(
-        self, *, service: str | None = None, clear: bool = False
+        self, *, service: str | None = None, clear: bool = False, wait_loops: int = 100
     ) -> dict[str, list[dict]]:
         """Waits for and returns configurations captured in telemetry events.
 
@@ -637,12 +637,16 @@ class TestAgentAPI:
         """
         events = []
         configurations: dict[str, list[dict]] = {}
-        # Allow time for telemetry events to be captured
-        time.sleep(1)
-        # Attempt to retrieve telemetry events, suppressing request-related exceptions
-        with contextlib.suppress(requests.exceptions.RequestException):
-            events = self.telemetry(clear=False)
-        if not events:
+        # Poll until telemetry is captured instead of sleeping a fixed delay: returns as soon as
+        # app-started arrives (usually within a heartbeat) and retries the empty-read window that
+        # a single fixed-delay read can land in.
+        for _ in range(wait_loops):
+            with contextlib.suppress(requests.exceptions.RequestException):
+                events = self.telemetry(clear=False)
+            if events:
+                break
+            time.sleep(0.05)
+        else:
             raise AssertionError("No telemetry events were found. Ensure the application is sending telemetry events.")
 
         # Sort events by tracer_time to ensure configurations are processed in order

--- a/utils/docker_fixtures/_test_clients/_test_client_parametric.py
+++ b/utils/docker_fixtures/_test_clients/_test_client_parametric.py
@@ -282,6 +282,9 @@ class ParametricTestClientApi(TestClientApi):
         except RequestException as e:
             logger.info(f"Expected exception when calling /trace/crash: {e}")
 
+    def get_logs(self) -> str:
+        return self.container.logs().decode("utf-8")
+
     def container_exec_run_raw(self, command: str) -> tuple[bool, str]:
         try:
             code, (stdout, _) = self.container.exec_run(command, demux=True)
@@ -1033,6 +1036,9 @@ class APMLibrary:
 
     def container_exec_run_raw(self, command: str) -> tuple[bool, str]:
         return self._client.container_exec_run_raw(command)
+
+    def get_logs(self) -> str:
+        return self._client.get_logs()
 
     @contextlib.contextmanager
     def dd_start_span(


### PR DESCRIPTION
## Summary
dd-trace-js [#8943](https://github.com/DataDog/dd-trace-js/pull/8943) (and a planned series of config PRs) renames internal config property paths to canonical names. The node parametric server's /trace/config endpoint read those paths directly, so each rename either broke an assertion or silently returned the wrong value.

The fix:

1. The /trace/config handler is stripped to { config: {} }. Its internal _config reads were fragile by construction; the test client defaults every documented key to null, so the cross-language parity shape contract (Test_Parametric_DDTrace_Config) holds unchanged.
2. All node stable-config assertions (Test_Stable_Config_Default, Test_Stable_Config_Rules) route through a shared telemetry helper in conftest.py that reads canonical names — the names the tracer guarantees stable across its internal renames.
3. The Test_Config_TraceAgentURL, Test_Config_RateLimit, Test_Config_Dogstatsd, and Test_Otel_Env_Vars node branches assert via telemetry, span meta, trace presence, and the tracer's startup-config log line — whichever tier can express the fact without touching internal shape. All values verified against the tracer before migrating.

## Why
Building /trace/config from the tracer's internal configWithOrigin map (the alternative) is more internal than _config, not less, and has no public API. Stripping the endpoint and asserting facts through their correct observable signals is the right architecture: behaviour doesn't rename.

Refs: https://github.com/DataDog/dd-trace-js/pull/8943