### PR TITLE
golang(debugger): add probe budget system tests for Go live debugger

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -844,8 +844,8 @@ manifest:
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Exception_Replay: missing_feature
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction: missing_feature (feature not implemented)
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers: missing_feature (feature not implemented)
-  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets: missing_feature (feature not implemented)
-  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_budgets: missing_feature (Not yet implemented)
+  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets: v2.2.3
+  tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_span_probe_expression_budgets: missing_feature (span decoration probes not yet implemented for Go)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots: v2.2.3
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_default_max_collection_size: missing_feature (no /debugger/snapshot/limits endpoint)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_default_max_field_count: missing_feature (no /debugger/snapshot/limits endpoint)

--- a/tests/debugger/test_debugger_probe_budgets.py
+++ b/tests/debugger/test_debugger_probe_budgets.py
@@ -31,7 +31,7 @@ class Test_Debugger_Probe_Budgets(debugger.BaseDebuggerTest):
         for probe in probes:
             if "methodName" in probe["where"]:
                 del probe["where"]["methodName"]
-            probe["where"]["lines"] = lines
+            probe["where"]["lines"] = [str(n) for n in lines] if lines is not None else lines
             probe["where"]["sourceFile"] = "ACTUAL_SOURCE_FILE"
             probe["where"]["typeName"] = None
 

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -158,7 +158,7 @@ class BaseDebuggerTest:
     def method_and_language_to_line_number(self, method: str, language: str) -> list:
         """method_and_language_to_line_number returns the respective line number given the method and language"""
         definitions: dict[str, dict[str, list[int]]] = {
-            "Budgets": {"java": [138], "dotnet": [136], "python": [142]},
+            "Budgets": {"java": [138], "dotnet": [136], "python": [142], "golang": [117]},
             "LogProbe": {"nodejs": [20]},
             "Expression": {"java": [71], "dotnet": [74], "python": [72], "ruby": [82], "nodejs": [82], "golang": [71]},
             # The `@exception` variable is not available in the context of line probes.
@@ -286,8 +286,9 @@ class BaseDebuggerTest:
                         golang_line_to_method = {
                             "20": "main.(*DebuggerController).logProbe",
                             "71": "main.(*DebuggerController).expression",
+                            "117": "main.(*DebuggerController).budgetStep",
                         }
-                        line = probe["where"]["lines"][0]
+                        line = str(probe["where"]["lines"][0])
                         if line in golang_line_to_method:
                             probe["where"]["methodName"] = golang_line_to_method[line]
 

--- a/utils/build/docker/golang/app/chi/debugger.go
+++ b/utils/build/docker/golang/app/chi/debugger.go
@@ -101,3 +101,18 @@ func intLen(s string) int {
 func expressionWrite(w http.ResponseWriter, localValue int, testStruct ExpressionTestStruct, inputValue string) {
 	w.Write([]byte(fmt.Sprintf("Great success number %d %s %s", localValue, testStruct.StringValue, inputValue)))
 }
+
+//go:noinline
+func (d *DebuggerController) budgets(w http.ResponseWriter, r *http.Request, loops int) {
+	total := 0
+	for i := 0; i < loops; i++ {
+		total += d.budgetStep(i, loops)
+	}
+	runtime.KeepAlive(total)
+	w.Write([]byte("Budgets"))
+}
+
+//go:noinline
+func (d *DebuggerController) budgetStep(i, loops int) int {
+	return i + loops // loops is referenced so the capture-expression probe can read it at this line.
+}

--- a/utils/build/docker/golang/app/chi/main.go
+++ b/utils/build/docker/golang/app/chi/main.go
@@ -415,6 +415,10 @@ func main() {
 	mux.HandleFunc("/debugger/log", d.logProbe)
 	mux.HandleFunc("/debugger/mix", d.mixProbe)
 	mux.HandleFunc("/debugger/expression", d.expression)
+	mux.HandleFunc("/debugger/budgets/{count}", func(w http.ResponseWriter, r *http.Request) {
+		loops, _ := strconv.Atoi(chi.RouteContext(r.Context()).URLParam("count"))
+		d.budgets(w, r, loops)
+	})
 
 	srv := &http.Server{
 		Addr:    ":7777",

--- a/utils/build/docker/golang/app/echo/debugger.go
+++ b/utils/build/docker/golang/app/echo/debugger.go
@@ -101,3 +101,18 @@ func intLen(s string) int {
 func expressionWrite(w http.ResponseWriter, localValue int, testStruct ExpressionTestStruct, inputValue string) {
 	w.Write([]byte(fmt.Sprintf("Great success number %d %s %s", localValue, testStruct.StringValue, inputValue)))
 }
+
+//go:noinline
+func (d *DebuggerController) budgets(w http.ResponseWriter, r *http.Request, loops int) {
+	total := 0
+	for i := 0; i < loops; i++ {
+		total += d.budgetStep(i, loops)
+	}
+	runtime.KeepAlive(total)
+	w.Write([]byte("Budgets"))
+}
+
+//go:noinline
+func (d *DebuggerController) budgetStep(i, loops int) int {
+	return i + loops // loops is referenced so the capture-expression probe can read it at this line.
+}

--- a/utils/build/docker/golang/app/echo/main.go
+++ b/utils/build/docker/golang/app/echo/main.go
@@ -389,6 +389,11 @@ func main() {
 	r.Any("/debugger/log", echoHandleFunc(d.logProbe))
 	r.Any("/debugger/mix", echoHandleFunc(d.mixProbe))
 	r.Any("/debugger/expression", echoHandleFunc(d.expression))
+	r.Any("/debugger/budgets/:count", func(c echo.Context) error {
+		loops, _ := strconv.Atoi(c.Param("count"))
+		d.budgets(c.Response().Writer, c.Request(), loops)
+		return nil
+	})
 
 	common.InitDatadog()
 	go grpc.ListenAndServe()

--- a/utils/build/docker/golang/app/gin/debugger.go
+++ b/utils/build/docker/golang/app/gin/debugger.go
@@ -101,3 +101,18 @@ func intLen(s string) int {
 func expressionWrite(w http.ResponseWriter, localValue int, testStruct ExpressionTestStruct, inputValue string) {
 	w.Write([]byte(fmt.Sprintf("Great success number %d %s %s", localValue, testStruct.StringValue, inputValue)))
 }
+
+//go:noinline
+func (d *DebuggerController) budgets(w http.ResponseWriter, r *http.Request, loops int) {
+	total := 0
+	for i := 0; i < loops; i++ {
+		total += d.budgetStep(i, loops)
+	}
+	runtime.KeepAlive(total)
+	w.Write([]byte("Budgets"))
+}
+
+//go:noinline
+func (d *DebuggerController) budgetStep(i, loops int) int {
+	return i + loops // loops is referenced so the capture-expression probe can read it at this line.
+}

--- a/utils/build/docker/golang/app/gin/main.go
+++ b/utils/build/docker/golang/app/gin/main.go
@@ -375,6 +375,10 @@ func main() {
 	r.Any("/debugger/log", ginHandleFunc(d.logProbe))
 	r.Any("/debugger/mix", ginHandleFunc(d.mixProbe))
 	r.Any("/debugger/expression", ginHandleFunc(d.expression))
+	r.Any("/debugger/budgets/:count", func(ctx *gin.Context) {
+		loops, _ := strconv.Atoi(ctx.Param("count"))
+		d.budgets(ctx.Writer, ctx.Request, loops)
+	})
 
 	srv := &http.Server{
 		Addr:    ":7777",

--- a/utils/build/docker/golang/app/net-http-orchestrion/debugger.go
+++ b/utils/build/docker/golang/app/net-http-orchestrion/debugger.go
@@ -101,3 +101,18 @@ func intLen(s string) int {
 func expressionWrite(w http.ResponseWriter, localValue int, testStruct ExpressionTestStruct, inputValue string) {
 	w.Write([]byte(fmt.Sprintf("Great success number %d %s %s", localValue, testStruct.StringValue, inputValue)))
 }
+
+//go:noinline
+func (d *DebuggerController) budgets(w http.ResponseWriter, r *http.Request, loops int) {
+	total := 0
+	for i := 0; i < loops; i++ {
+		total += d.budgetStep(i, loops)
+	}
+	runtime.KeepAlive(total)
+	w.Write([]byte("Budgets"))
+}
+
+//go:noinline
+func (d *DebuggerController) budgetStep(i, loops int) int {
+	return i + loops // loops is referenced so the capture-expression probe can read it at this line.
+}

--- a/utils/build/docker/golang/app/net-http-orchestrion/main.go
+++ b/utils/build/docker/golang/app/net-http-orchestrion/main.go
@@ -637,6 +637,10 @@ func main() {
 	mux.HandleFunc("/debugger/log", d.logProbe)
 	mux.HandleFunc("/debugger/mix", d.mixProbe)
 	mux.HandleFunc("/debugger/expression", d.expression)
+	mux.HandleFunc("/debugger/budgets/{count}", func(w http.ResponseWriter, r *http.Request) {
+		loops, _ := strconv.Atoi(r.PathValue("count"))
+		d.budgets(w, r, loops)
+	})
 
 	srv := &http.Server{
 		Addr:    ":7777",

--- a/utils/build/docker/golang/app/net-http/debugger.go
+++ b/utils/build/docker/golang/app/net-http/debugger.go
@@ -101,3 +101,18 @@ func intLen(s string) int {
 func expressionWrite(w http.ResponseWriter, localValue int, testStruct ExpressionTestStruct, inputValue string) {
 	w.Write([]byte(fmt.Sprintf("Great success number %d %s %s", localValue, testStruct.StringValue, inputValue)))
 }
+
+//go:noinline
+func (d *DebuggerController) budgets(w http.ResponseWriter, r *http.Request, loops int) {
+	total := 0
+	for i := 0; i < loops; i++ {
+		total += d.budgetStep(i, loops)
+	}
+	runtime.KeepAlive(total)
+	w.Write([]byte("Budgets"))
+}
+
+//go:noinline
+func (d *DebuggerController) budgetStep(i, loops int) int {
+	return i + loops // loops is referenced so the capture-expression probe can read it at this line.
+}

--- a/utils/build/docker/golang/app/net-http/main.go
+++ b/utils/build/docker/golang/app/net-http/main.go
@@ -774,6 +774,10 @@ func main() {
 	mux.HandleFunc("/debugger/log", d.logProbe)
 	mux.HandleFunc("/debugger/mix", d.mixProbe)
 	mux.HandleFunc("/debugger/expression", d.expression)
+	mux.HandleFunc("/debugger/budgets/{count}", func(w http.ResponseWriter, r *http.Request) {
+		loops, _ := strconv.Atoi(r.PathValue("count"))
+		d.budgets(w, r, loops)
+	})
 
 	srv := &http.Server{
 		Addr:    ":7777",


### PR DESCRIPTION
## Motivation

The Go live debugger (eBPF/system-probe based) now supports snapshot probes, and probe budget enforcement is a core correctness property: the eBPF throttler rate-limits snapshot captures to ~1 per second to prevent overwhelming the system. This PR adds system tests to verify that budget behavior for Go.

## Changes

Adds weblog endpoints and manifest entries to enable Test_Debugger_Probe_Budgets::test_log_line_budgets for Go.

  - All 5 Go weblog variants (net-http, gin, chi, echo, net-http-orchestrion): adds a /debugger/budgets/{count} endpoint that calls a probe-targeted method in a tight loop. The target method (budgets, line 108) is marked //go:noinline to ensure a reliable uprobe
  attachment point.
  - tests/debugger/utils.py: registers line 108 in the golang_line_to_method dispatch table (Go's eBPF system-probe requires an explicit fully-qualified method name for line probes), adds "golang": [108] to the Budgets line-number map, and fixes a latent type bug where
  integer line numbers were looked up against string dict keys.
  - manifests/golang.yml: enables Test_Debugger_Probe_Budgets at v2.2.3 and marks test_span_probe_expression_budgets as missing_feature (span decoration probes are not yet implemented for Go).

  test_log_line_budgets fires a snapshot probe 150 times in rapid succession and asserts that between 1 and 20 snapshots were captured. This passes because snapshotThrottleConfig in the system-probe limits captures to 1 per second at the eBPF level, so only ~1 snapshot is emitted for 150 rapid invocations.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
