### PR TITLE
[dotnet] scrub empty static field

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -619,6 +619,7 @@ manifest:
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_multiframe:
     - declaration: bug (DEBUG-2799)
       component_version: <3.10.0
+    - declaration: missing_feature (Static field guard is not released yet)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_recursion_20:
     - declaration: bug (DEBUG-2799)
       component_version: <3.10.0

--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -237,7 +237,8 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                         field_name == "Empty"
                         and isinstance(field_value, dict)
                         and field_value.get("type") == "EmptyResult"
-                        and set(field_value) == {"type"}
+                        and set(field_value).issubset({"type", "notCapturedReason"})
+                        and field_value.get("notCapturedReason") in (None, "typeInitializer")
                     )
 
                 scrubbed_static_fields = {

--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -250,7 +250,7 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                 assert isinstance(value, str)
                 if "lambda_" in value:
                     value = re.sub(r"(lambda_method)\d+", r"\1<scrubbed>", value)
-                if re.search(r"<[^>]+>", value):
+                if re.search(r"<[^>]+>", value) and not value.endswith("<scrubbed>"):
                     value = re.sub(r"(.*>)(.*)", r"\1<scrubbed>", value)
                 return value
             elif key in ["stacktrace", "stack"]:

--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -231,10 +231,18 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                 value["value"] = "<scrubbed>"
                 return value
             elif key == "staticFields" and isinstance(value, dict):
+                def is_empty_result_static_field(field_name: str, field_value: object) -> bool:
+                    return (
+                        field_name == "Empty"
+                        and isinstance(field_value, dict)
+                        and field_value.get("type") == "EmptyResult"
+                        and set(field_value) == {"type"}
+                    )
+
                 scrubbed_static_fields = {
                     field_name: __scrub(field_value)
                     for field_name, field_value in value.items()
-                    if field_name != "Empty"
+                    if not is_empty_result_static_field(field_name, field_value)
                 }
                 return scrubbed_static_fields or None
             elif key == "function":
@@ -248,8 +256,12 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                 scrubbed = []
                 assert isinstance(value, list)
                 for entry in value:
+                    function = entry.get("function")
+                    if function is None:
+                        continue
+
                     # skip inner runtime methods from stack traces since they are not relevant to debugger
-                    if entry["function"].startswith(("Microsoft", "System", "Unknown")):
+                    if function.startswith(("Microsoft", "System", "Unknown")):
                         continue
 
                     scrubbed.append(__scrub(entry))

--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -231,6 +231,7 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                 value["value"] = "<scrubbed>"
                 return value
             elif key == "staticFields" and isinstance(value, dict):
+
                 def is_empty_result_static_field(field_name: str, field_value: object) -> bool:
                     return (
                         field_name == "Empty"

--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -63,7 +63,7 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
 
     ############ setup ############
     def _setup(self, request_path: str, exception_message: str):
-        self.weblog_responses = []
+        self.weblog_responses: list[object] = []
 
         retries = 0
         timeout = _timeout_first
@@ -230,6 +230,13 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
             elif key == "StackTrace" and isinstance(value, dict):
                 value["value"] = "<scrubbed>"
                 return value
+            elif key == "staticFields" and isinstance(value, dict):
+                scrubbed_static_fields = {
+                    field_name: __scrub(field_value)
+                    for field_name, field_value in value.items()
+                    if field_name != "Empty"
+                }
+                return scrubbed_static_fields or None
             elif key == "function":
                 assert isinstance(value, str)
                 if "lambda_" in value:
@@ -318,6 +325,8 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                 self._write_approval(snapshots, test_name, "snapshots_expected")
 
             expected_snapshots = self._read_approval(test_name, "snapshots_expected")
+            if self.get_tracer()["language"] == "dotnet" and not _SKIP_SCRUB:
+                expected_snapshots = [__scrub_dict(snapshot) for snapshot in expected_snapshots]  # type: ignore[assignment]
             if self.get_tracer()["language"] == "php":
                 expected_snapshots = __normalize_php_fields(expected_snapshots)  # type: ignore[assignment]
             assert expected_snapshots == snapshots
@@ -604,7 +613,7 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
 
     ############ Rock Paper Scissors ############
     def setup_exception_replay_rockpaperscissors(self):
-        self.weblog_responses = []
+        self.weblog_responses: list[object] = []
 
         retries = 0
         timeout = _timeout_first

--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -259,6 +259,8 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                 for entry in value:
                     function = entry.get("function")
                     if function is None:
+                        if entry != {"<runtime>": "<scrubbed>"}:
+                            scrubbed.append(__scrub(entry))
                         continue
 
                     # skip inner runtime methods from stack traces since they are not relevant to debugger


### PR DESCRIPTION
## Motivation

The .NET tracer is changing exception replay snapshot capture so static fields that may trigger type initializers are no longer captured. Current dotnet master still emits incidental framework static fields, such as `EmptyResult.Empty`, which makes the `exception_replay_multiframe` approval unstable while the tracer-side static field guard is not yet on master.

## Changes

Normalize .NET exception replay snapshot approvals by scrubbing incidental `staticFields.Empty` from received and expected snapshot data before comparison.

Temporarily marks the .NET `test_exception_replay_multiframe` system test as `missing_feature` in `manifests/dotnet.yml` until dotnet tracer master includes the static field guard. Once that tracer change lands on master, this manifest entry should be removed to re-enable the test.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
