### PR TITLE
Enable Ruby OpenFeature evaluation on older weblogs

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1882,7 +1882,9 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py:
     - weblog_declaration:
         "*": irrelevant
+        uds-sinatra: v2.24.0
         rails72: v2.23.0-dev
+        sinatra41: v2.24.0
   tests/ffe/test_exposures.py:
     - weblog_declaration:
         "*": irrelevant

--- a/utils/build/docker/ruby/sinatra41/Gemfile
+++ b/utils/build/docker/ruby/sinatra41/Gemfile
@@ -13,4 +13,5 @@ end
 
 gem 'dogstatsd-ruby'
 gem 'pg'
+gem 'openfeature-sdk', '~> 0.5.1'
 gem 'datadog', '~> 2.0', require: 'datadog/auto_instrument'

--- a/utils/build/docker/ruby/sinatra41/Gemfile.lock
+++ b/utils/build/docker/ruby/sinatra41/Gemfile.lock
@@ -16,6 +16,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
     ffi (1.17.2)
@@ -58,6 +60,14 @@ GEM
     net-http (0.6.0)
       uri
     nio4r (2.7.4)
+    openfeature-sdk (0.5.1)
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -111,6 +121,9 @@ DEPENDENCIES
   datadog (~> 2.0)
   dogstatsd-ruby
   faraday
+  faraday-follow_redirects (~> 0.3)
+  openfeature-sdk (~> 0.5.1)
+  pg
   pry-byebug
   puma (~> 6.0)
   rack-contrib

--- a/utils/build/docker/ruby/sinatra41/app.rb
+++ b/utils/build/docker/ruby/sinatra41/app.rb
@@ -6,6 +6,8 @@ require 'faraday'
 require 'faraday/follow_redirects'
 require 'sinatra/json'
 require 'pg'
+require 'open_feature/sdk'
+require 'datadog/open_feature/provider'
 
 begin
   require 'datadog/auto_instrument'
@@ -18,6 +20,10 @@ Datadog.configure do |c|
   c.tracing.log_injection = true if ENV['CONFIG_CHAINING_TEST'] == 'true'
 
   c.use :sinatra, service_name: ENV.fetch('DD_SERVICE', 'sinatra') unless c.respond_to?(:tracing)
+end
+
+OpenFeature::SDK.configure do |config|
+  config.set_provider(Datadog::OpenFeature::Provider.new)
 end
 
 require 'rack/contrib/json_body_parser'
@@ -56,6 +62,63 @@ end
 
 post '/' do
   'Hello, world!'
+end
+
+post '/ffe/start' do
+  OpenFeature::SDK.set_provider(Datadog::OpenFeature::Provider.new)
+
+  loop do
+    break unless Datadog::OpenFeature.evaluator.ufc_json.nil?
+    sleep 0.1
+  end
+
+  content_type :json
+  {}.to_json
+end
+
+post '/ffe' do
+  client = OpenFeature::SDK.build_client
+  payload = JSON.parse(request.body.read)
+
+  targeting_keys =
+    if payload['targetingKeys'].is_a?(Array) && !payload['targetingKeys'].empty?
+      payload['targetingKeys']
+    else
+      [payload['targetingKey']]
+    end
+
+  value = nil
+  targeting_keys.each do |targeting_key|
+    context = OpenFeature::SDK::EvaluationContext.new(
+      targeting_key: targeting_key,
+      **(payload['attributes'] || {})
+    )
+    options = {
+      flag_key: payload['flag'],
+      default_value: payload['defaultValue'],
+      evaluation_context: context
+    }
+
+    value =
+      case payload['variationType']
+      when 'BOOLEAN' then client.fetch_boolean_value(**options)
+      when 'STRING' then client.fetch_string_value(**options)
+      when 'INTEGER' then client.fetch_integer_value(**options)
+      when 'NUMERIC' then client.fetch_float_value(**options)
+      when 'JSON' then client.fetch_object_value(**options)
+      else 'FATAL_UNEXPECTED_VARIATION_TYPE'
+      end
+  end
+
+  content_type :json
+  {value: value, reason: 'DEFAULT', count: targeting_keys.length}.to_json
+rescue
+  content_type :json
+  {value: payload && payload['defaultValue'], reason: 'ERROR'}.to_json
+end
+
+post '/ffe/evaluate' do
+  call env.merge('PATH_INFO' => '/ffe')
 end
 
 get '/waf' do


### PR DESCRIPTION
## Motivation

APM needs Ruby Feature Flags validation beyond the newest Rails weblog. The oldest Ruby system-tests image that can use the current useful OpenFeature SDK line is Ruby 3.1, so this broadens non-metric flag evaluation coverage to that floor and documents the practical support boundary for customers using OpenFeature hooks.

## Changes

- Adds OpenFeature SDK support and `/ffe` evaluation endpoints to the `sinatra41` weblog.
- Enables `tests/ffe/test_dynamic_evaluation.py` for `uds-sinatra` and direct `sinatra41` on Ruby 3.1 while keeping `rails72` coverage.
- Leaves exposure, EVP, and OTel metric test declarations unchanged.

## Decisions

- Use `openfeature-sdk ~> 0.5.1` instead of a broader `~> 0.5` range so Ruby 3.1 does not resolve the Ruby 3.4-only 0.6.x line.
- Treat Ruby 3.1 as the oldest practical OpenFeature system-test target because the current useful OpenFeature Ruby SDK line requires Ruby >= 3.1.
- Keep OTel metrics scoped to `rails72`; this PR proves core flag evaluation behavior on older Ruby, not hook-heavy metrics validation.

## Validation Evidence

### System Tests

- Ruby implementation PR: https://github.com/DataDog/dd-trace-rb/pull/5896
- Ruby EVP `flagevaluation` system-tests PR: https://github.com/DataDog/system-tests/pull/7184
- Ruby OpenFeature runtime documentation PR: https://github.com/DataDog/documentation/pull/37674
- This PR enables the Ruby 3.1 system-test surface for non-metric OpenFeature evaluation coverage.
