### PR TITLE
[Java] Enable filenames tests for vertx3, vertx4 and spring-boot-jetty

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1926,10 +1926,10 @@ manifest:
         "*": v1.62.0-SNAPSHOT
         spring-boot: v1.61.0-SNAPSHOT
         uds-spring-boot: v1.61.0-SNAPSHOT
-        spring-boot-jetty: missing_feature (no instrumentation for Jetty)
+        spring-boot-jetty: v1.64.0-SNAPSHOT
         spring-boot-payara: v1.63.0-SNAPSHOT
-        vertx3: missing_feature (no instrumentation for Vert.x async multipart)
-        vertx4: missing_feature (no instrumentation for Vert.x async multipart)
+        vertx3: v1.64.0-SNAPSHOT
+        vertx4: v1.64.0-SNAPSHOT
         spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
   tests/appsec/test_blocking_addresses.py::Test_Blocking_request_body_files_content:
     - weblog_declaration:

--- a/tests/test_library_logs.py
+++ b/tests/test_library_logs.py
@@ -91,6 +91,13 @@ class Test_NoExceptions:
         if context.weblog_variant == "spring-boot-wildfly":
             # APPSEC-56111:
             allowed_patterns.append(re.escape("Failed to determine dependency for uri {}"))
+        if context.weblog_variant in ("vertx3", "vertx4"):
+            # AIDM-583: fixed in dd-trace-java#11268, remove this once that fix is in a released version
+            allowed_patterns.append(
+                re.escape(
+                    "Failed to handle exception in instrumentation for io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder"
+                )
+            )
         compiled_paterns = [re.compile(p, re.MULTILINE | re.DOTALL) for p in allowed_patterns]
         data = interfaces.library.get_telemetry_data()
         data = [d["request"]["content"] for d in data]

--- a/tests/test_library_logs.py
+++ b/tests/test_library_logs.py
@@ -91,13 +91,6 @@ class Test_NoExceptions:
         if context.weblog_variant == "spring-boot-wildfly":
             # APPSEC-56111:
             allowed_patterns.append(re.escape("Failed to determine dependency for uri {}"))
-        if context.weblog_variant in ("vertx3", "vertx4"):
-            # AIDM-583: fixed in dd-trace-java#11268, remove this once that PR is merged
-            allowed_patterns.append(
-                re.escape(
-                    "Failed to handle exception in instrumentation for io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder"
-                )
-            )
         compiled_paterns = [re.compile(p, re.MULTILINE | re.DOTALL) for p in allowed_patterns]
         data = interfaces.library.get_telemetry_data()
         data = [d["request"]["content"] for d in data]


### PR DESCRIPTION
# What Does This Do

- Enables `Test_Blocking_request_body_filenames` for `vertx3`, `vertx4` and `spring-boot-jetty` weblogs in `manifests/java.yml` (version `v1.64.0-SNAPSHOT`)
- Keeps the AIDM-583 workaround in `tests/test_library_logs.py` with an updated comment clarifying it must be removed once the fix ships in a released tracer version (not just merged to main)

# Motivation

Follow-up to:
- [dd-trace-java#11268](https://github.com/DataDog/dd-trace-java/pull/11268) — `server.request.body.filenames` for Vert.x 3.4/4.0/5.0 (merged to main)
- [dd-trace-java#10988](https://github.com/DataDog/dd-trace-java/pull/10988) — `server.request.body.filenames` for Jetty 8-11 (merged to main)

Both tracer PRs are merged, unblocking these weblogs. The manifest entries use `v1.64.0-SNAPSHOT` so CI only runs the tests once that version is the active release.

# Additional Notes

The AIDM-583 workaround (allowing the error log `Failed to handle exception in instrumentation for io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder` for vertx3/vertx4) must stay until the dd-trace-java#11268 fix is in a released tracer version. CI runs against the released artifact, not SNAPSHOT builds, so removing the workaround now would break `test_java_telemetry_logs` for vertx3/vertx4.

Jira ticket: [APPSEC-61873](https://datadoghq.atlassian.net/browse/APPSEC-61873)

***Note:*** **Once your PR is ready to merge, add it to the merge queue by commenting `/merge`.** `/merge -c` cancels the queue request. `/merge -f --reason "reason"` skips all merge queue checks; please use this judiciously, as some checks do not run at the PR-level. For more information, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue).

[APPSEC-61873]: https://datadoghq.atlassian.net/browse/APPSEC-61873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ