### PR TITLE
feat(parametric/java): activate FFE span-enrichment tests [java@typo/FFL-2224/ffe-span-enrichment]

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3708,7 +3708,7 @@ manifest:
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1_ServiceTargets::test_not_match_service_target: irrelevant (APMAPI-1003)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV2: v1.31.0
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation: v1.56.0
-  tests/parametric/test_ffe/test_span_enrichment.py: v1.64.0
+  tests/parametric/test_ffe/test_span_enrichment.py: v1.63.0-SNAPSHOT
   tests/parametric/test_headers_b3.py::Test_Headers_B3::test_headers_b3_migrated_extract_invalid:  # Modified by easy win activation script
     - declaration: missing_feature (Need to remove b3=b3multi alias)
       component_version: <1.58.2+06122213c8

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3708,7 +3708,7 @@ manifest:
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1_ServiceTargets::test_not_match_service_target: irrelevant (APMAPI-1003)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV2: v1.31.0
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation: v1.56.0
-  tests/parametric/test_ffe/test_span_enrichment.py: missing_feature
+  tests/parametric/test_ffe/test_span_enrichment.py: v1.64.0
   tests/parametric/test_headers_b3.py::Test_Headers_B3::test_headers_b3_migrated_extract_invalid:  # Modified by easy win activation script
     - declaration: missing_feature (Need to remove b3=b3multi alias)
       component_version: <1.58.2+06122213c8

--- a/utils/_context/_scenarios/_docker_fixtures.py
+++ b/utils/_context/_scenarios/_docker_fixtures.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from utils.docker_fixtures._test_agent import TestAgentFactory, TestAgentAPI
-from docker.errors import DockerException
+from docker.errors import DockerException, NotFound
 from utils._context.docker import get_docker_client
 from utils._logger import logger
 from .core import Scenario, ScenarioGroup, scenario_groups as groups
@@ -41,7 +41,20 @@ class DockerFixturesScenario(Scenario):
     def _clean_containers(self):
         """Some containers may still exists from previous unfinished sessions"""
 
-        for container in get_docker_client().containers.list(all=True):
+        try:
+            containers = get_docker_client().containers.list(all=True)
+        except NotFound:
+            # Docker SDK raises NotFound when a container disappears between list() and inspect().
+            # Fall back to the raw API which returns only IDs and names without a second inspect call.
+            raw = get_docker_client().api.containers(all=True)
+            containers = []
+            for r in raw:
+                try:
+                    containers.append(get_docker_client().containers.get(r["Id"]))
+                except NotFound:
+                    pass
+
+        for container in containers:
             if "test-client" in container.name or "test-agent" in container.name or "test-library" in container.name:
                 logger.info(f"Removing {container}")
 

--- a/utils/build/docker/java/parametric/run.sh
+++ b/utils/build/docker/java/parametric/run.sh
@@ -34,7 +34,7 @@ OPTIMIZATION_OPTIONS=(-XX:TieredStopAtLevel=1)
 
 # Start client application
 # shellcheck disable=SC2086
-java -Xmx128M -javaagent:"${DD_JAVA_AGENT}" \
+java -Xmx256M -javaagent:"${DD_JAVA_AGENT}" \
   $ENABLE_OTEL_TRACING_API \
   "${ENABLE_CRASH_TRACKING[@]}" \
   "${DISABLED_FEATURES[@]}" \

--- a/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/FeatureFlagEvaluatorController.java
+++ b/utils/build/docker/java/parametric/src/main/java/com/datadoghq/trace/controller/FeatureFlagEvaluatorController.java
@@ -2,7 +2,9 @@ package com.datadoghq.trace.controller;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import com.datadoghq.trace.opentracing.controller.OpenTracingController;
 import com.fasterxml.jackson.annotation.JsonAlias;
+import datadog.trace.api.DDSpanId;
 import datadog.trace.api.openfeature.Provider;
 import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.EvaluationContext;
@@ -13,6 +15,9 @@ import dev.openfeature.sdk.OpenFeatureAPI;
 import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Structure;
 import dev.openfeature.sdk.Value;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.util.GlobalTracer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,26 +83,19 @@ public class FeatureFlagEvaluatorController {
         Object value;
         String reason;
         final EvaluationContext context = context(request);
+        // Re-activate the caller-supplied root span around the eval so the ffe_* tags (Phase 2) land
+        // on the test's span. The client sends span_id as a decimal STRING (see
+        // _test_client_parametric.py:814-815); the OT registry is keyed by DDSpanId.from(...).
+        // An unknown/missing/unparsable span_id leaves target null -> skip activation, never throw (T-01-DOS).
+        final Span target = resolveSpan(request.getSpanId());
         try {
-            value = switch (request.getVariationType()) {
-                case "BOOLEAN" ->
-                        client.getBooleanValue(request.getFlag(), (Boolean) request.getDefaultValue(), context);
-                case "STRING" -> client.getStringValue(request.getFlag(), (String) request.getDefaultValue(), context);
-                case "INTEGER" -> {
-                    final Number integerEval = (Number) request.getDefaultValue();
-                    yield client.getIntegerValue(request.getFlag(), integerEval.intValue(), context);
+            if (target != null) {
+                try (Scope scope = GlobalTracer.get().scopeManager().activate(target)) {
+                    value = evaluate(request, context);
                 }
-                case "NUMERIC" -> {
-                    final Number doubleEval = (Number) request.getDefaultValue();
-                    yield client.getDoubleValue(request.getFlag(), doubleEval.doubleValue(), context);
-                }
-                case "JSON" -> {
-                    final Value objectValue = client.getObjectValue(request.getFlag(), Value.objectToValue(request.getDefaultValue()), context);
-                    yield context.convertValue(objectValue);
-                }
-                default -> request.getDefaultValue();
-            };
-
+            } else {
+                value = evaluate(request, context);
+            }
             reason = "DEFAULT";
         } catch (Throwable e) {
             LOGGER.error("Error on resolution", e);
@@ -108,6 +106,40 @@ public class FeatureFlagEvaluatorController {
         result.put("reason", reason);
         result.put("value", value);
         return ResponseEntity.ok(result);
+    }
+
+    /** Look up a span by the (string) span_id the test client sends; null when missing/unparsable. */
+    private static Span resolveSpan(final String spanId) {
+        if (spanId == null || spanId.isEmpty()) {
+            return null;
+        }
+        try {
+            return OpenTracingController.getSpan(DDSpanId.from(spanId));
+        } catch (Throwable e) {
+            LOGGER.warn("Could not resolve span for span_id {}", spanId, e);
+            return null;
+        }
+    }
+
+    private Object evaluate(final EvaluateRequest request, final EvaluationContext context) {
+        return switch (request.getVariationType()) {
+            case "BOOLEAN" ->
+                    client.getBooleanValue(request.getFlag(), (Boolean) request.getDefaultValue(), context);
+            case "STRING" -> client.getStringValue(request.getFlag(), (String) request.getDefaultValue(), context);
+            case "INTEGER" -> {
+                final Number integerEval = (Number) request.getDefaultValue();
+                yield client.getIntegerValue(request.getFlag(), integerEval.intValue(), context);
+            }
+            case "NUMERIC" -> {
+                final Number doubleEval = (Number) request.getDefaultValue();
+                yield client.getDoubleValue(request.getFlag(), doubleEval.doubleValue(), context);
+            }
+            case "JSON" -> {
+                final Value objectValue = client.getObjectValue(request.getFlag(), Value.objectToValue(request.getDefaultValue()), context);
+                yield context.convertValue(objectValue);
+            }
+            default -> request.getDefaultValue();
+        };
     }
 
     private static EvaluationContext context(final EvaluateRequest request) {
@@ -141,10 +173,21 @@ public class FeatureFlagEvaluatorController {
         private Object defaultValue;
         @JsonAlias("targeting_key")
         private String targetingKey;
+        // The test client sends span_id as a STRING (see _test_client_parametric.py:814-815).
+        @JsonAlias("span_id")
+        private String spanId;
         private Map<String, Object> attributes;
 
         public Map<String, Object> getAttributes() {
             return attributes;
+        }
+
+        public String getSpanId() {
+            return spanId;
+        }
+
+        public void setSpanId(String spanId) {
+            this.spanId = spanId;
         }
 
         public void setAttributes(Map<String, Object> attributes) {


### PR DESCRIPTION
## Motivation

Activates the frozen `tests/parametric/test_ffe/test_span_enrichment.py` suite for Java against
dd-trace-java#11658 (FFE APM span enrichment, gated behind
`DD_EXPERIMENTAL_FLAGGING_PROVIDER_SPAN_ENRICHMENT_ENABLED`).

Supersedes #7150 (Leo's draft) — same approach, rebased on current main with infrastructure
fixes needed to get the full 18-test suite passing locally.

## Changes

- **`manifests/java.yml`** — declare `tests/parametric/test_ffe/test_span_enrichment.py`
  at `v1.63.0-SNAPSHOT` (SNAPSHOT so CI runs against `java@typo/FFL-2224/ffe-span-enrichment`
  rather than xfailing; will be updated to the release version before merge).
- **`utils/build/docker/java/parametric/run.sh`** — bump JVM heap from 128M to 256M to
  prevent OOM kills when 16 parametric workers run concurrently with span enrichment enabled.
- **`utils/_context/_scenarios/_docker_fixtures.py`** — handle `docker.errors.NotFound` in
  `_clean_containers`: Docker SDK's `containers.list(all=True)` can return container IDs that
  no longer exist by the time `inspect_container` is called; fall back to raw API to avoid
  a crash that prevented test cleanup between runs.

## Validation

All 18 cases pass against `dd-java-agent 1.63.0-SNAPSHOT` (dd-trace-java#11658,
HEAD `109eab80bc`). The 16-parallel-worker run surfaces a startup timeout under CPU
contention — confirmed all tests pass when run with `--dist no`.