### PR TITLE
Enable service override tests for php

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -706,7 +706,7 @@ manifest:
     - declaration: missing_feature (OTel SDK requires PHP >= 8.1)
       excluded_weblog: [apache-mod-8.1, apache-mod-8.1-zts, apache-mod-8.2, apache-mod-8.2-zts, php-fpm-8.1, php-fpm-8.2, php-fpm-8.5]
   tests/integrations/test_otel_drop_in.py::Test_Otel_Drop_In::test_otel_drop_in_span_metrics: missing_feature
-  tests/integrations/test_service_overrides.py::Test_SqlServiceNameSource: irrelevant (Only implemented for Java)
+  tests/integrations/test_service_overrides.py::Test_SqlServiceNameSource: v1.22.0
   tests/integrations/test_sql.py::Test_Sql: v1.17.0
   tests/k8s_lib_injection/test_k8s_lib_injection_appsec.py::TestK8sLibInjectionAppsecClusterEnabled: v1.16.0
   tests/k8s_lib_injection/test_k8s_lib_injection_appsec.py::TestK8sLibInjectionAppsecDisabledByDefault: v1.16.0
@@ -956,7 +956,7 @@ manifest:
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_With_W3C: missing_feature
   tests/parametric/test_tracer.py::Test_ProcessTags_ServiceName: missing_feature
   tests/parametric/test_tracer.py::Test_TracerSCITagging: v1.2.0
-  tests/parametric/test_tracer.py::Test_TracerServiceNameSource: irrelevant
+  tests/parametric/test_tracer.py::Test_TracerServiceNameSource: v1.22.0
   tests/parametric/test_tracer.py::Test_TracerUniversalServiceTagging::test_tracer_service_name_environment_variable: "missing_feature (FIXME: library test client sets empty string as the service name)"
   tests/parametric/test_tracer_flare.py::TestTracerFlareV1: missing_feature
   tests/parametric/test_tracer_flare.py::TestTracerFlareV1::test_flare_log_level_order: '>=1.16.0'

--- a/utils/build/docker/php/common/rasp/sqli.php
+++ b/utils/build/docker/php/common/rasp/sqli.php
@@ -1,1 +1,28 @@
-<?php echo "Hello, SQLi!";
+<?php
+
+$user_id = null;
+$contentType = $_SERVER['CONTENT_TYPE'] ?? "";
+switch ($contentType) {
+	case 'application/json':
+		$body = file_get_contents("php://input");
+		$decoded = json_decode($body, 1);
+		$user_id = $decoded["user_id"];
+		break;
+	case 'application/xml':
+		$body = file_get_contents("php://input");
+		$decoded = simplexml_load_string(stripslashes($body));
+		$user_id = (string)$decoded[0];
+		break;
+	default:
+		$user_id = $_REQUEST["user_id"] ?? null;
+		break;
+}
+
+try {
+	$pdo = new PDO("mysql:dbname=mysql_dbname;host=mysqldb", "mysqldb", "mysqldb");
+	$pdo->query("SELECT * FROM users WHERE id='" . $user_id . "'");
+} catch (\Exception $e) {
+	// Ignore connection/query errors (e.g. RASP block)
+}
+
+echo "Hello, SQLi!";


### PR DESCRIPTION
## Motivation

Enables service override tests for PHP and implement the sqli endpoint that was only stubbed and required for this test (to generate sql spans)


## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
