### PR TITLE
Enable dbm dynamic service tests for golang

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -974,7 +974,13 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Psycopg: irrelevant (These are python only tests.)
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql: irrelevant (These are python only tests.)
-  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres: irrelevant
+  tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres:
+    - weblog_declaration:
+        "*": irrelevant
+        chi: v2.10.0
+        echo: v2.10.0
+        gin: v2.10.0
+        net-http: v2.10.0
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -977,10 +977,10 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_DynamicService_Postgres:
     - weblog_declaration:
         "*": irrelevant
-        chi: v2.10.0
-        echo: v2.10.0
-        gin: v2.10.0
-        net-http: v2.10.0
+        chi: v2.10.0-dev
+        echo: v2.10.0-dev
+        gin: v2.10.0-dev
+        net-http: v2.10.0-dev
   tests/integrations/test_dsm.py::Test_DsmContext_Extraction_Base64:
     - weblog_declaration:
         "*": irrelevant

--- a/tests/integrations/test_dbm.py
+++ b/tests/integrations/test_dbm.py
@@ -466,6 +466,7 @@ class Test_Dbm_DynamicService_Postgres(_BaseDbmDynamicService):
         "ruby": "pg",
         "php": "pdo-pgsql",
         "dotnet": "npgsql",
+        "golang": "pg",
     }
 
     @property


### PR DESCRIPTION
## Motivation

Enables dbm dynamic service tests for golang (implemented in https://github.com/DataDog/dd-trace-go/pull/4907)
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
