### PR TITLE
Fix base image push job docker hub auth

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -239,8 +239,9 @@ count_amis:
 check_merge_labels:
   #Build docker images if it's needed. Check if the PR has the labels associated with the image build.
   image: registry.ddbuild.io/system-tests/base-image-builder
-  tags:
-    - arch:amd64
+  tags: ["docker-in-docker:amd64"]
+  # tags:
+  #   - arch:amd64
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
@@ -257,12 +258,10 @@ check_merge_labels:
     - docker buildx version
     - export GITHUB_TOKEN=$(cat token.txt)
     - |
-      export REPO="datadog/system-tests"
-      docker login -u "$DOCKER_LOGIN" --password-stdin <<< "$DOCKER_LOGIN_PASS"
-      curl -fsS -u "$DOCKER_LOGIN:$DOCKER_LOGIN_PASS" \
-        "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${REPO}:pull,push" \
-        >/dev/null
-    - echo $?
+      # Pull a tiny image and try to push it with a test tag
+      docker pull hello-world
+      docker tag hello-world datadog/system-tests:auth-test-DELETE-ME
+      docker push datadog/system-tests:auth-test-DELETE-ME
 
     # - ./utils/scripts/get_pr_merged_labels.sh
   # after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,6 +256,7 @@ check_merge_labels:
     - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text)
   script:
     - docker buildx version
+    - echo $DOCKER_LOGIN
     - export GITHUB_TOKEN=$(cat token.txt)
     - |
       # Pull a tiny image and try to push it with a test tag

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,20 +248,28 @@ check_merge_labels:
   stage: system-tests-utils
   before_script:
     # Get a token
-    - dd-octo-sts version
-    - dd-octo-sts debug --scope DataDog/system-tests --policy self.gitlab-read
-    - dd-octo-sts token --scope DataDog/system-tests --policy self.gitlab-read > token.txt
+    # - dd-octo-sts version
+    # - dd-octo-sts debug --scope DataDog/system-tests --policy self.gitlab-read
+    # - dd-octo-sts token --scope DataDog/system-tests --policy self.gitlab-read > token.txt
     - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-write --with-decryption --query "Parameter.Value" --out text)
     - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.system-tests.docker-login-pass-write --with-decryption --query "Parameter.Value" --out text)
   script:
     - docker buildx version
     - export GITHUB_TOKEN=$(cat token.txt)
-    - ./utils/scripts/get_pr_merged_labels.sh
-  after_script:
+    - |
+      export REPO="datadog/system-tests"
+      docker login -u "$DOCKER_LOGIN" --password-stdin <<< "$DOCKER_LOGIN_PASS"
+      curl -fsS -u "$DOCKER_LOGIN:$DOCKER_LOGIN_PASS" \
+        "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${REPO}:pull,push" \
+        >/dev/null
+    - echo $?
+
+    # - ./utils/scripts/get_pr_merged_labels.sh
+  # after_script:
     # Revoke the token after usage
-    - dd-octo-sts revoke -t $(cat token.txt)
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"
+    # - dd-octo-sts revoke -t $(cat token.txt)
+  # rules:
+  #   - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"
 
 generate_system_tests_lambda_proxy_image:
   image: registry.ddbuild.io/ci/libdatadog-build/ci_docker_base:100425777


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
