### PR TITLE
Cherry-pick fixes for Java tracer release 1.63.1

### DIFF
--- a/tests/auto_inject/test_auto_inject_install.py
+++ b/tests/auto_inject/test_auto_inject_install.py
@@ -93,6 +93,10 @@ class TestContainerAutoInjectInstallScript(base.AutoInjectBaseTest):
         "Ubuntu_25_04_arm64",
     ]
 
+    @bug(
+        context.vm_name in ["CentOS_7_amd64", "RedHat_7_9_amd64"] and context.weblog_variant == "test-app-java-alpine",
+        reason="APMSP-3489",
+    )
     def test_install(self):
         self._test_install(context.virtual_machine, origin_detection=True)
 
@@ -189,6 +193,10 @@ class TestInstallerAutoInjectManual(base.AutoInjectBaseTest):
     # the uninstall test today
 
     @irrelevant(condition=context.weblog_variant == "test-app-dotnet-iis")
+    @bug(
+        context.vm_name in ["CentOS_7_amd64", "RedHat_7_9_amd64"] and context.weblog_variant == "test-app-java-alpine",
+        reason="APMSP-3489",
+    )
     def test_install_uninstall(self):
         virtual_machine = context.virtual_machine
         logger.info(f"Launching test_install_uninstall for : [{virtual_machine.name}]...")
@@ -219,6 +227,10 @@ class TestInstallerAutoInjectManual(base.AutoInjectBaseTest):
 class TestSimpleInstallerAutoInjectManual(base.AutoInjectBaseTest):
     @irrelevant(context.library >= "python@4.0.0.dev" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library < "python@4.0.0.dev" and context.installed_language_runtime < "3.8.0")
+    @bug(
+        context.vm_name in ["CentOS_7_amd64", "RedHat_7_9_amd64"] and context.weblog_variant == "test-app-java-alpine",
+        reason="APMSP-3489",
+    )
     def test_install(self):
         virtual_machine = context.virtual_machine
         logger.info(
@@ -247,6 +259,10 @@ class TestSimpleInstallerAutoInjectManualOriginDetection(base.AutoInjectBaseTest
     )
     @irrelevant(context.library >= "python@4.0.0.dev" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library < "python@4.0.0.dev" and context.installed_language_runtime < "3.8.0")
+    @bug(
+        context.vm_name in ["CentOS_7_amd64", "RedHat_7_9_amd64"] and context.weblog_variant == "test-app-java-alpine",
+        reason="APMSP-3489",
+    )
     def test_origin_detection(self):
         virtual_machine = context.virtual_machine
         logger.info(
@@ -261,6 +277,10 @@ class TestSimpleInstallerAutoInjectManualOriginDetection(base.AutoInjectBaseTest
 @features.auto_instrumentation_appsec
 @scenarios.simple_auto_injection_appsec
 class TestSimpleInstallerAutoInjectManualAppsec(base.AutoInjectBaseTest):
+    @bug(
+        context.vm_name in ["CentOS_7_amd64", "RedHat_7_9_amd64"] and context.weblog_variant == "test-app-java-alpine",
+        reason="APMSP-3489",
+    )
     def test_appsec(self):
         logger.info(f"Launching test_appsec for : [{context.vm_name}]...")
         self._test_install(context.virtual_machine, appsec=True)

--- a/utils/build/ssi/java/resources/websphere-app/renew_cert.sh
+++ b/utils/build/ssi/java/resources/websphere-app/renew_cert.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Re-issue the WebSphere SOAP/SSL personal certificate during the image build.
+#
+# The base image ships a self-signed "default" certificate with a 1-year
+# validity. Once it expires, the wsadmin SOAP-over-SSL handshake fails with
+# "PKIX path building failed: unable to find valid certification path to
+# requested target" and the application deployment cannot run. We re-issue the
+# certificate signed by the existing (long-lived, ~2040) root CA so the client
+# truststore keeps trusting it without any further changes.
+set -euo pipefail
+
+WAS=/opt/IBM/WebSphere/AppServer
+KT="${WAS}/java/8.0/bin/keytool"
+CFG="${WAS}/profiles/AppSrv01/config/cells/DefaultCell01/nodes/DefaultNode01"
+PW=WebAS
+# keytool requires new key passwords to be at least 6 chars, but the WebSphere
+# keystore password is 5 chars, so we mint the key in a temp store first.
+TMP=changeit
+DN="CN=localhost,OU=DefaultCell01,OU=DefaultNode01,O=IBM,C=US"
+NEW=/tmp/new_default.p12
+
+"${KT}" -genkeypair -alias default -dname "${DN}" -keyalg RSA -keysize 2048 \
+  -sigalg SHA256withRSA -validity 7300 -keystore "${NEW}" -storepass "${TMP}" \
+  -keypass "${TMP}" -storetype PKCS12
+"${KT}" -certreq -alias default -keystore "${NEW}" -storepass "${TMP}" \
+  -file /tmp/default.csr
+"${KT}" -gencert -alias root -keystore "${CFG}/root-key.p12" -storepass "${PW}" \
+  -storetype PKCS12 -infile /tmp/default.csr -outfile /tmp/default.cer \
+  -validity 7300 -sigalg SHA256withRSA -rfc
+"${KT}" -exportcert -alias root -keystore "${CFG}/root-key.p12" -storepass "${PW}" \
+  -storetype PKCS12 -rfc -file /tmp/root.cer
+"${KT}" -importcert -noprompt -alias root -file /tmp/root.cer -keystore "${NEW}" \
+  -storepass "${TMP}" -storetype PKCS12
+"${KT}" -importcert -noprompt -alias default -file /tmp/default.cer -keystore "${NEW}" \
+  -storepass "${TMP}" -storetype PKCS12
+"${KT}" -delete -alias default -keystore "${CFG}/key.p12" -storepass "${PW}" \
+  -storetype PKCS12 || true
+"${KT}" -importkeystore -noprompt -srckeystore "${NEW}" -srcstorepass "${TMP}" \
+  -srcstoretype PKCS12 -srcalias default -destkeystore "${CFG}/key.p12" \
+  -deststorepass "${PW}" -destkeypass "${PW}" -deststoretype PKCS12 -destalias default
+
+echo "WebSphere SOAP/SSL certificate re-issued (signed by existing root CA)."

--- a/utils/build/ssi/java/websphere-app.Dockerfile
+++ b/utils/build/ssi/java/websphere-app.Dockerfile
@@ -11,7 +11,9 @@ RUN ln -s /opt/IBM/WebSphere/AppServer/java/8.0/bin/java /usr/bin/java
 COPY --from=build app/ee-app-ear/target/ee-app.ear /tmp/
 COPY utils/build/ssi/java/resources/common/netstat.sh /tmp/
 COPY utils/build/ssi/java/resources/websphere-app/ws_deploy.jacl /tmp/
-RUN /bin/bash -c '/work/start_server.sh &' && \
+COPY utils/build/ssi/java/resources/websphere-app/renew_cert.sh /tmp/
+RUN /bin/bash /tmp/renew_cert.sh && \
+/bin/bash -c '/work/start_server.sh &' && \
 /bin/bash -c 'while ! /tmp/netstat.sh | grep ":9043"; do sleep 1; done' && \
 /bin/bash -c 'yes | /opt/IBM/WebSphere/AppServer/bin/wsadmin.sh -f /tmp/ws_deploy.jacl -user wsadmin -password $(cat /tmp/PASSWORD) -lang jacl' && \
 /bin/bash -c '/opt/IBM/WebSphere/AppServer/bin/stopServer.sh server1 -user wsadmin -password $(cat /tmp/PASSWORD)'


### PR DESCRIPTION
## Motivation

Fix `dd-trace-java` release `1.63.2`.

`dd-trace-java` pins `system-tests` on release branches so that subsequent patch releases are made off of the same `system-tests` SHA that the corresponding minor was made off of. For the `1.63.0` minor release, we pinned the `system-tests` SHA to `520d79a6eb2522aa90f62d1bae705337f3967d90` in https://github.com/DataDog/dd-trace-java/pull/11519.

However, between release `1.63.0` and `1.63.1`, failures were introduced and their fixes were made after the pinned SHA. This PR cherry-picks the fixes to the previously pinned SHA so that we can make the `1.63.2` release.

## Changes

Cherry-pick fixes made in https://github.com/DataDog/system-tests/pull/7218 and https://github.com/DataDog/system-tests/pull/7122 onto SHA `520d79a6eb2522aa90f62d1bae705337f3967d90`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
