### PR TITLE
Fix compilation of auto-inject-ls preload main.c

### DIFF
--- a/utils/build/virtual_machine/provisions/auto-inject-ld-preload/main.c
+++ b/utils/build/virtual_machine/provisions/auto-inject-ld-preload/main.c
@@ -1,3 +1,6 @@
+// ensure RTLD_NEXT is available
+#define _GNU_SOURCE 1
+
 #include <stdio.h>
 #include <dlfcn.h>
 


### PR DESCRIPTION
Fails compilation with:

```
+  command:remote:Command -Ubuntu_20_amd64-ld-so-preload creating (85s) Compiling main.c to main.so
 +  command:remote:Command -Ubuntu_20_amd64-ld-so-preload creating (85s) main.c: In function ‘puts’:
 +  command:remote:Command -Ubuntu_20_amd64-ld-so-preload creating (85s) main.c:10:45: error: ‘RTLD_NEXT’ undeclared (first use in this function); did you mean ‘RTLD_NOW’?
 +  command:remote:Command -Ubuntu_20_amd64-ld-so-preload creating (85s)    10 |     original_puts = (original_puts_t) dlsym(RTLD_NEXT,"puts");
 +  command:remote:Command -Ubuntu_20_amd64-ld-so-preload creating (85s)       |                                             ^~~~~~~~~
 +  command:remote:Command -Ubuntu_20_amd64-ld-so-preload creating (85s)       |                                             RTLD_NOW
 +  command:remote:Command -Ubuntu_20_amd64-ld-so-preload creating (85s) main.c:10:45: note: each undeclared identifier is reported only once for each function it appears in
 +  command:remote:Command -Ubuntu_20_amd64-ld-so-preload creating (85s) mv: cannot stat 'main.so': No such file or directory
```