### PR TITLE
adaptive sampling manifest cleanup: cpp bug entries + rust missing_feature unflagging

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -75,23 +75,8 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Default::test_extended_configs: missing_feature (extended configs are not supported)
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature
   tests/parametric/test_crashtracking.py: missing_feature
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_remote_sampling_rules_retention:
-    - declaration: bug (APMAPI-863)
-      component_version: <=1.0.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate:
-    - declaration: bug (APMAPI-1595)
-      component_version: <=1.0.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags:
-    - declaration: bug (APMAPI-866)
-      component_version: <=1.0.0
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_tracing_client_tracing_disable_one_way: irrelevant (APMAPI-1592)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_log_injection_enabled: missing_feature (Tracer doesn't support automatic logs injection)
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_trace_sampling_rate_override_env:
-    - declaration: bug (APMAPI-863)
-      component_version: <=1.0.0
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_trace_sampling_rate_with_sampling_rules:
-    - declaration: bug (APMAPI-864)
-      component_version: <=1.0.0
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1_EmptyServiceTargets: ">1.0.0"
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1_ServiceTargets::test_match_service_target_case_insensitively:
     - declaration: missing_feature (Tracer does case-sensitive checks for service and env)

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -75,8 +75,13 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Default::test_extended_configs: missing_feature (extended configs are not supported)
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature
   tests/parametric/test_crashtracking.py: missing_feature
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_remote_sampling_rules_retention: ">1.0.0"
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: ">1.0.0"
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: ">1.0.0"
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_tracing_client_tracing_disable_one_way: irrelevant (APMAPI-1592)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_log_injection_enabled: missing_feature (Tracer doesn't support automatic logs injection)
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_trace_sampling_rate_override_env: ">1.0.0"
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_trace_sampling_rate_with_sampling_rules: ">1.0.0"
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1_EmptyServiceTargets: ">1.0.0"
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1_ServiceTargets::test_match_service_target_case_insensitively:
     - declaration: missing_feature (Tracer does case-sensitive checks for service and env)

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -90,6 +90,7 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature  # Created by easy win activation script
   tests/parametric/test_crashtracking.py: missing_feature
   tests/parametric/test_dynamic_configuration.py: '>=0.2.1'  # Modified by easy win activation script
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env: '>=0.3.3'
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_capability_tracing_enabled: missing_feature  # Created by easy win activation script

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -90,7 +90,6 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Stable_Config_Rules: missing_feature  # Created by easy win activation script
   tests/parametric/test_crashtracking.py: missing_feature
   tests/parametric/test_dynamic_configuration.py: '>=0.2.1'  # Modified by easy win activation script
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_capability_tracing_enabled: missing_feature  # Created by easy win activation script

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -91,8 +91,6 @@ manifest:
   tests/parametric/test_crashtracking.py: missing_feature
   tests/parametric/test_dynamic_configuration.py: '>=0.2.1'  # Modified by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env: '>=0.3.3'
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate: missing_feature  # Created by easy win activation script
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_capability_tracing_enabled: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_default_capability_completeness: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_tracing_client_tracing_disable_one_way: missing_feature  # Created by easy win activation script
@@ -100,8 +98,6 @@ manifest:
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_apply_state: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_log_injection_enabled: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_trace_sampling_rate_override_default: missing_feature  # Created by easy win activation script
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_trace_sampling_rate_override_env: missing_feature  # Created by easy win activation script
-  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_trace_sampling_rate_with_sampling_rules: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1_ServiceTargets::test_not_match_service_target: missing_feature  # Created by easy win activation script
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV2: missing_feature  # Created by easy win activation script
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation: missing_feature


### PR DESCRIPTION
## Motivation

Consolidates three adaptive-sampling manifest PRs (#6948, #6949, #7007) into one cleanup. All changes are manifest-only — no test logic or framework code touched.

## Changes

**`manifests/cpp.yml`** (from #6949 + follow-up fix):
- Removes five stale `bug` declarations gated on `component_version: <=1.0.0` for adaptive-sampling parametric tests. The C++ tracer is on v2.1.1; those gates never apply. The entries were replaced with explicit `>1.0.0` version gates to make the floor unambiguous.
- Tests covered: `test_remote_sampling_rules_retention`, `test_trace_sampling_rules_override_rate`, `test_trace_sampling_rules_with_tags`, `test_trace_sampling_rate_override_env`, `test_trace_sampling_rate_with_sampling_rules`

**`manifests/rust.yml`** (from #6948 + #7007):
- Unflag `TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_env` — now passes on dd-trace-rs >= 0.3.3; gated to `>=0.3.3`.
- Remove four `missing_feature` entries now that dd-trace-rs#227 landed:
  - `TestDynamicConfigSamplingRules::test_trace_sampling_rules_override_rate`
  - `TestDynamicConfigSamplingRules::test_trace_sampling_rules_with_tags`
  - `TestDynamicConfigV1::test_trace_sampling_rate_override_env`
  - `TestDynamicConfigV1::test_trace_sampling_rate_with_sampling_rules`

## Workflow

1. Created as draft.
2. Manifest-only change — no R&P review needed.

Closes #6948, #6949. Supersedes #7007 (the rust unblock, which was draft-blocked on dd-trace-rs#227 and is now merged).

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified? No — only `manifests/cpp.yml` and `manifests/rust.yml` touched.
* [x] A docker base image is modified? No.
* [x] A scenario is added, removed or renamed? No.