### PR TITLE
fix(weblog,parametric): make Node.js OTel apps work with dd-trace v6's optional @opentelemetry/api peer

### DIFF
--- a/utils/build/docker/nodejs/express4-typescript/bun.lock
+++ b/utils/build/docker/nodejs/express4-typescript/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "express4-typescript",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "@types/express-session": "^1.18.1",
         "@types/ldapjs": "^3.0.6",
         "@types/passport": "^1.0.17",
@@ -89,6 +90,8 @@
     "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.3", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg=="],
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.1.4", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 

--- a/utils/build/docker/nodejs/express4-typescript/package-lock.json
+++ b/utils/build/docker/nodejs/express4-typescript/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "@types/express-session": "^1.18.1",
         "@types/ldapjs": "^3.0.6",
         "@types/passport": "^1.0.17",
@@ -319,6 +320,15 @@
       "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {

--- a/utils/build/docker/nodejs/express4-typescript/package.json
+++ b/utils/build/docker/nodejs/express4-typescript/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@types/express-session": "^1.18.1",
     "@types/ldapjs": "^3.0.6",
     "@types/passport": "^1.0.17",

--- a/utils/build/docker/nodejs/nextjs/bun.lock
+++ b/utils/build/docker/nodejs/nextjs/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "nextjs",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "axios": "^1.5.1",
         "next": "^14.0.4",
         "pg": "^8.12.0",
@@ -70,6 +71,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, ""],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, ""],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
 

--- a/utils/build/docker/nodejs/nextjs/package-lock.json
+++ b/utils/build/docker/nodejs/nextjs/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs",
       "version": "0.1.0",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "axios": "^1.5.1",
         "next": "^14.0.4",
         "pg": "^8.12.0",
@@ -152,6 +153,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -3809,6 +3819,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
     },
     "@rushstack/eslint-patch": {
       "version": "1.5.1",

--- a/utils/build/docker/nodejs/nextjs/package.json
+++ b/utils/build/docker/nodejs/nextjs/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "axios": "^1.5.1",
     "next": "^14.0.4",
     "pg": "^8.12.0",


### PR DESCRIPTION
## Summary

[dd-trace-js#9077](https://github.com/DataDog/dd-trace-js/pull/9077) makes `@opentelemetry/api` an optional peer dependency in v6: dd-trace no longer bundles its own copy and instead shares the single copy the application installs. `express4-typescript` and `nextjs` never declared it.

The `OTLP_RUNTIME_METRICS` scenario runs these weblogs with `DD_METRICS_OTEL_ENABLED=true` and asserts dd-trace emits OTel-native runtime metric names (`nodejs.eventloop.delay.max`, ...) and none of the DD-proprietary ones (`runtime.node.event_loop.delay.max`, ...). On v6 the API can no longer be resolved, so dd-trace disables OTel metrics and falls back to the DD-proprietary names, failing both assertions. Adding the dependency restores the OTel metrics pipeline.

## Why

`^1.9.0`, matching the other Node.js weblogs. The open range is deliberate: it lets these jobs surface a future `@opentelemetry/api` release that drifts outside the range a dd-trace major supports, rather than masking that behind a pin.

## Test plan

- [ ] `OTLP_RUNTIME_METRICS` End-to-end jobs for `express4-typescript` and `nextjs` go green against dd-trace-js#9077 (both currently fail on `test_otel_metrics_are_present_and_attributed` and `test_dd_metrics_are_absent`).