### PR TITLE
Add Ruby EVP fork isolation system test

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1898,7 +1898,18 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         rails72: v2.23.0-dev
-  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py:
+    - weblog_declaration:
+        "*": irrelevant
+        rails72: v2.36.0-dev
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation:
+    - weblog_declaration:
+        "*": irrelevant
+        rails72: missing_feature (Ruby writer can flush/reset before the shared 10k degradation threshold is reached)
+  tests/ffe/test_flag_eval_evp_ruby.py:
+    - weblog_declaration:
+        "*": irrelevant
+        rails72: v2.36.0-dev
   tests/ffe/test_flag_eval_metrics.py:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1898,18 +1898,11 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         rails72: v2.23.0-dev
-  tests/ffe/test_flag_eval_evp.py:
-    - weblog_declaration:
-        "*": irrelevant
-        rails72: v2.36.0-dev
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation:
-    - weblog_declaration:
-        "*": irrelevant
-        rails72: missing_feature (Ruby writer can flush/reset before the shared 10k degradation threshold is reached)
+  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_evp_ruby.py:
     - weblog_declaration:
         "*": irrelevant
-        rails72: v2.36.0-dev
+        rails72: missing_feature (FFL-2446 pending dd-trace-rb#5896)
   tests/ffe/test_flag_eval_metrics.py:
     - weblog_declaration:
         "*": irrelevant

--- a/tests/ffe/test_flag_eval_evp_ruby.py
+++ b/tests/ffe/test_flag_eval_evp_ruby.py
@@ -1,0 +1,138 @@
+"""Ruby-specific server-side EVP flagevaluation system tests."""
+
+import json
+from typing import TYPE_CHECKING
+from typing import cast
+
+import pytest
+
+from tests.ffe.test_flag_eval_evp import (
+    RC_PATH,
+    assert_batch_context,
+    assert_event_contract,
+    evp_flagevaluation_events_from_data,
+    find_evp_flagevaluation_events,
+    make_multi_flag_fixture,
+)
+from utils import HttpResponse
+from utils import context
+from utils import features
+from utils import interfaces
+from utils import irrelevant
+from utils import remote_config as rc
+from utils import scenarios
+from utils import weblog
+
+
+if TYPE_CHECKING:
+    from tests.ffe.utils.fixtures import JSON
+
+
+EVP_PREFORK_WAIT_TIMEOUT_SECONDS = 10
+
+
+def evaluate_flags_across_fork(
+    parent_flag_key: str,
+    child_flag_key: str,
+    *,
+    parent_targeting_key: str,
+    child_targeting_key: str,
+) -> HttpResponse:
+    return weblog.post(
+        "/ffe/fork-isolation",
+        json={
+            "parentFlag": parent_flag_key,
+            "childFlag": child_flag_key,
+            "variationType": "STRING",
+            "defaultValue": "default",
+            "parentTargetingKey": parent_targeting_key,
+            "childTargetingKey": child_targeting_key,
+            "attributes": {},
+        },
+    )
+
+
+def wait_for_prefork_child_event(flag_key: str) -> None:
+    assert interfaces.agent.wait_for(
+        lambda data: bool(evp_flagevaluation_events_from_data(cast("JSON", data), flag_key)),
+        timeout=EVP_PREFORK_WAIT_TIMEOUT_SECONDS,
+    ), f"Timed out waiting for forked Ruby EVP flagevaluation event for flag {flag_key}"
+
+
+def flag_keys_from_flagevaluation_batch(batch: object) -> set[str]:
+    if not isinstance(batch, dict):
+        return set()
+
+    events = batch.get("flagEvaluations")
+    if not isinstance(events, list):
+        return set()
+
+    flag_keys = set()
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+
+        flag = event.get("flag")
+        if not isinstance(flag, dict):
+            continue
+
+        key = flag.get("key")
+        if isinstance(key, str):
+            flag_keys.add(key)
+
+    return flag_keys
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_evp_flagevaluation
+@irrelevant(
+    context.library != "ruby" or context.weblog_variant != "rails72",
+    reason="Ruby Rails 7.2 fork isolation endpoint only",
+)
+@pytest.mark.skip_if_xfail
+class Test_FFE_EVP_Flagevaluation_Ruby_Fork_Isolation:
+    """Test that Ruby child processes do not flush parent EVP evaluation state."""
+
+    def setup_ffe_evp_flagevaluation_ruby_fork_isolation(self) -> None:
+        config_id = "ffe-evp-ruby-fork-isolation"
+        self.parent_flag_key = "evp-ruby-fork-parent-flag"
+        self.child_flag_key = "evp-ruby-fork-child-flag"
+        self.parent_targeting_key = "evp-ruby-prefork-parent"
+        self.child_targeting_key = "evp-ruby-prefork-child"
+        rc.tracer_rc_state.reset().set_config(
+            f"{RC_PATH}/{config_id}/config",
+            make_multi_flag_fixture([self.parent_flag_key, self.child_flag_key]),
+        ).apply()
+
+        self.r = evaluate_flags_across_fork(
+            self.parent_flag_key,
+            self.child_flag_key,
+            parent_targeting_key=self.parent_targeting_key,
+            child_targeting_key=self.child_targeting_key,
+        )
+
+    def test_ffe_evp_flagevaluation_ruby_fork_isolation(self) -> None:
+        assert self.r.status_code == 200, f"Fork isolation request failed: {self.r.text}"
+
+        response = json.loads(self.r.text)
+        assert response["parent"]["reason"] == "DEFAULT", f"Parent evaluation failed: {response}"
+        assert response["child"]["reason"] == "DEFAULT", f"Child evaluation failed: {response}"
+        assert response["diagnostics"]["evp_writer"], f"Parent process EVP writer is unavailable: {response}"
+        assert response["child"]["diagnostics_before_flush"]["evp_writer"], (
+            f"Child process EVP writer is unavailable: {response}"
+        )
+
+        wait_for_prefork_child_event(self.child_flag_key)
+        child_events = find_evp_flagevaluation_events(self.child_flag_key)
+
+        assert child_events, f"Expected child EVP flagevaluation event for flag {self.child_flag_key}"
+        for batch, event in child_events:
+            assert_batch_context(batch)
+            assert_event_contract(event, self.child_flag_key)
+
+        leaked_batches = [
+            batch for batch, _ in child_events if self.parent_flag_key in flag_keys_from_flagevaluation_batch(batch)
+        ]
+        assert not leaked_batches, (
+            f"Parent-process EVP flagevaluation state leaked into a forked child flush batch: {leaked_batches}"
+        )

--- a/utils/build/docker/ruby/rails72/Gemfile
+++ b/utils/build/docker/ruby/rails72/Gemfile
@@ -18,7 +18,7 @@ gem 'devise', '~> 4.9'
 gem 'faraday', '~> 2.13.0'
 gem 'faraday-follow_redirects', '~> 0.3'
 # FFE related dependencies
-gem 'openfeature-sdk', '~> 0.5'  # v0.5.1+ required for provider hooks support
+gem 'openfeature-sdk', '~> 0.5', '>= 0.5.1'  # v0.5.1+ required for provider hooks support
 
 group :development do
   gem 'pry-byebug'

--- a/utils/build/docker/ruby/rails72/Gemfile.lock
+++ b/utils/build/docker/ruby/rails72/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.9-aarch64-linux-gnu)
       racc (~> 1.4)
-    openfeature-sdk (0.4.0)
+    openfeature-sdk (0.5.1)
     opentelemetry-api (1.5.0)
     opentelemetry-common (0.22.0)
       opentelemetry-api (~> 1.0)
@@ -263,7 +263,7 @@ DEPENDENCIES
   devise (~> 4.9)
   dogstatsd-ruby
   faraday (~> 2.13.0)
-  openfeature-sdk (~> 0.4)
+  openfeature-sdk (~> 0.5, >= 0.5.1)
   opentelemetry-api (~> 1.5.0)
   opentelemetry-sdk (~> 1.8.0)
   pry-byebug

--- a/utils/build/docker/ruby/rails72/app/controllers/internal_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/internal_controller.rb
@@ -37,6 +37,9 @@ class InternalController < ApplicationController
     if open_feature = Datadog.send(:components)&.open_feature
       worker = open_feature.instance_variable_get(:@worker)
       worker.send(:send_events, *worker.dequeue)
+
+      writer = open_feature.instance_variable_get(:@flag_eval_evp_writer)
+      writer&.send(:drain_and_flush)
     end
 
     # Flush OTel metrics

--- a/utils/build/docker/ruby/rails72/app/controllers/open_feature_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/open_feature_controller.rb
@@ -16,9 +16,33 @@ class OpenFeatureController < ApplicationController
   end
 
   def evaluate
+    payload = JSON.parse(request.body.string)
+
+    render json: evaluate_payload(payload)
+  end
+
+  def fork_isolation
+    payload = JSON.parse(request.body.string)
+    parent_payload = payload.merge(
+      'flag' => payload['parentFlag'],
+      'targetingKey' => payload['parentTargetingKey'] || 'evp-prefork-parent'
+    )
+    child_payload = payload.merge(
+      'flag' => payload['childFlag'],
+      'targetingKey' => payload['childTargetingKey'] || 'evp-prefork-child'
+    )
+
+    parent_result = evaluate_payload(parent_payload)
+    child_result = evaluate_in_fork(child_payload)
+
+    render json: {parent: parent_result, child: child_result, diagnostics: open_feature_diagnostics}
+  end
+
+  private
+
+  def evaluate_payload(payload)
     client = OpenFeature::SDK.build_client
 
-    payload = JSON.parse(request.body.string)
     args = {
       flag: payload['flag'],
       variation_type: payload['variationType'],
@@ -47,7 +71,7 @@ class OpenFeatureController < ApplicationController
 
         value =
           case args[:variation_type]
-          when 'BOOLEAN'then client.fetch_boolean_value(**options)
+          when 'BOOLEAN' then client.fetch_boolean_value(**options)
           when 'STRING' then client.fetch_string_value(**options)
           when 'INTEGER' then client.fetch_integer_value(**options)
           when 'NUMERIC' then client.fetch_float_value(**options)
@@ -56,9 +80,66 @@ class OpenFeatureController < ApplicationController
           end
       end
 
-      render json: {value: value, reason: 'DEFAULT', count: targeting_keys.length}
+      {value: value, reason: 'DEFAULT', count: targeting_keys.length}
     rescue
-      render json: {value: args[:default_value], reason: 'ERROR'}
+      {value: args[:default_value], reason: 'ERROR'}
     end
+  end
+
+  def evaluate_in_fork(payload)
+    return {value: payload['defaultValue'], reason: 'ERROR', error: 'fork unavailable'} unless Process.respond_to?(:fork)
+
+    reader, writer = IO.pipe
+    pid = Process.fork do
+      reader.close
+      result = evaluate_payload(payload)
+      result[:diagnostics_before_flush] = open_feature_diagnostics
+      flush_open_feature
+      result[:diagnostics_after_flush] = open_feature_diagnostics
+      writer.write(JSON.generate(result))
+      writer.close
+      exit! 0
+    rescue StandardError => e
+      writer.write(JSON.generate(value: payload['defaultValue'], reason: 'ERROR', error: "#{e.class}: #{e.message}"))
+      exit! 1
+    end
+
+    writer.close
+    body = reader.read
+    _, status = Process.wait2(pid)
+    result = body.empty? ? {} : JSON.parse(body)
+    result['forkStatus'] = status.exitstatus unless status.success?
+    result
+  ensure
+    reader&.close unless reader&.closed?
+    writer&.close unless writer&.closed?
+  end
+
+  def flush_open_feature
+    open_feature = Datadog.send(:components)&.open_feature
+    worker = open_feature&.instance_variable_get(:@worker)
+    worker&.send(:send_events, *worker.dequeue)
+
+    writer = open_feature&.instance_variable_get(:@flag_eval_evp_writer)
+    writer&.send(:drain_and_flush)
+  end
+
+  def open_feature_diagnostics
+    open_feature = Datadog.send(:components)&.open_feature
+    evp_writer = open_feature&.instance_variable_get(:@flag_eval_evp_writer)
+    evp_hook =
+      if open_feature&.respond_to?(:flag_eval_evp_hook)
+        !open_feature.flag_eval_evp_hook.nil?
+      else
+        false
+      end
+
+    {
+      open_feature: !open_feature.nil?,
+      evp_hook: evp_hook,
+      evp_writer: !evp_writer.nil?,
+      evp_writer_class: evp_writer&.class&.name,
+      openfeature_hook_api: !!defined?(::OpenFeature::SDK::Hooks::Hook)
+    }
   end
 end

--- a/utils/build/docker/ruby/rails72/config/routes.rb
+++ b/utils/build/docker/ruby/rails72/config/routes.rb
@@ -94,6 +94,7 @@ Rails.application.routes.draw do
   post '/ffe' => 'open_feature#evaluate'
   post '/ffe/start' => 'open_feature#start'
   post '/ffe/evaluate' => 'open_feature#evaluate'
+  post '/ffe/fork-isolation' => 'open_feature#fork_isolation'
 
   post '/ai_guard/evaluate' => 'ai_guard#evaluate'
 


### PR DESCRIPTION
## Motivation

Ruby EVP flagevaluation has fork/prefork behavior that is hard to prove from unit tests alone: the child process must not flush parent-process queued EVP evaluation state. This PR pre-wires Rails72 system-test coverage for that runtime path without activating it yet.

## Changes

- Add a Rails72 `/ffe/fork-isolation` endpoint that evaluates one flag in the parent process, evaluates another in a forked child, and flushes OpenFeature exposure and EVP flagevaluation writers deterministically.
- Add a Ruby-specific EVP flagevaluation system test asserting the child-emitted batch does not contain the parent flag.
- Keep the shared Ruby EVP flagevaluation manifest disabled as `missing_feature (FFL-2446)`.
- Keep the new Ruby fork-isolation test disabled for Rails72 until `DataDog/dd-trace-rb#5896` lands.
- Pin Rails72 `openfeature-sdk` to `>= 0.5.1` so provider hooks are available when Ruby EVP coverage is activated.

## Decisions

- Do not activate Ruby EVP system-tests in this PR. The Ruby tracer implementation is still in `DataDog/dd-trace-rb#5896`, so merging activation into `system-tests` first would advertise coverage before the default Ruby tracer can satisfy it.
- Keep the fork/prefork regression proof in system-tests because it validates real Rails + OpenFeature + tracer + Agent EVP dataflow across process boundaries. Ruby repo unit tests still cover the writer-level fork reset behavior, but they do not prove the full weblog/Agent payload path.
- Avoid asserting that the parent never emits its own event; the harness legitimately flushes the parent process later. The test only rejects parent state appearing in the child flush batch.

## Validation

Validation was run locally against `DataDog/dd-trace-rb#5896` by building Rails72 with that local Ruby tracer source:

- `./build.sh --library ruby --weblog-variant rails72 --images weblog --binary-path /tmp/system-tests-ruby-binary`
- Verified image installed `datadog 2.37.0.dev`, `openfeature-sdk 0.5.1`, `libdatadog 36.0.0.1.0`.
- `TEST_LIBRARY=ruby ./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION tests/ffe/test_flag_eval_evp_ruby.py::Test_FFE_EVP_Flagevaluation_Ruby_Fork_Isolation --library ruby` -> `1 passed in 24.65s`
**- `TEST_LIBRARY=ruby ./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION tests/ffe/test_flag_eval_evp.py tests/ffe/test_flag_eval_evp_ruby.py --library ruby` -> `8 passed, 1 skipped in 46.39s`**
- Ruby syntax checks for Rails72 controllers/routes.
- `python3 -m compileall -q tests/ffe/test_flag_eval_evp_ruby.py`
- `venv/bin/ruff check tests/ffe/test_flag_eval_evp_ruby.py`
- targeted `mypy` for `tests/ffe/test_flag_eval_evp_ruby.py` and `tests/ffe/test_flag_eval_evp.py`
- `venv/bin/python utils/manifest/validate.py`
- `venv/bin/yamllint -s manifests/ruby.yml`
- `git diff --check`
