### PR TITLE
Puts the id array as a string so all the features are preserved when there is more than one

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -293,7 +293,7 @@ def _collect_item_metadata(item: pytest.Item):
         item.user_properties.append(
             (
                 "dd_tags[systest.case.feature_ids]",
-                str(filter(lambda x: x != NOT_REPORTED_FEATURE_ID, metadata["features"])),
+                str(list(filter(lambda x: x != NOT_REPORTED_FEATURE_ID, metadata["features"]))),
             )
         )
 

--- a/conftest.py
+++ b/conftest.py
@@ -289,9 +289,8 @@ def _collect_item_metadata(item: pytest.Item):
     # decorate test for junit
     item.user_properties.append(("test.codeowners", json.dumps(metadata["owners"])))
 
-    for feature_id in metadata["features"]:
-        if feature_id != NOT_REPORTED_FEATURE_ID:
-            item.user_properties.append(("dd_tags[systest.case.feature_id]", str(feature_id)))
+    if metadata["features"] != [NOT_REPORTED_FEATURE_ID]:
+        item.user_properties.append(("dd_tags[systest.case.feature_id]", str(metadata["features"])))
 
     if declaration:
         item.user_properties.append(("dd_tags[systest.case.declaration]", declaration))

--- a/conftest.py
+++ b/conftest.py
@@ -290,7 +290,12 @@ def _collect_item_metadata(item: pytest.Item):
     item.user_properties.append(("test.codeowners", json.dumps(metadata["owners"])))
 
     if metadata["features"] != [NOT_REPORTED_FEATURE_ID]:
-        item.user_properties.append(("dd_tags[systest.case.feature_ids]", str(metadata["features"])))
+        item.user_properties.append(
+            (
+                "dd_tags[systest.case.feature_ids]",
+                str(filter(lambda x: x != NOT_REPORTED_FEATURE_ID, metadata["features"])),
+            )
+        )
 
     if declaration:
         item.user_properties.append(("dd_tags[systest.case.declaration]", declaration))

--- a/conftest.py
+++ b/conftest.py
@@ -290,7 +290,7 @@ def _collect_item_metadata(item: pytest.Item):
     item.user_properties.append(("test.codeowners", json.dumps(metadata["owners"])))
 
     if metadata["features"] != [NOT_REPORTED_FEATURE_ID]:
-        item.user_properties.append(("dd_tags[systest.case.feature_id]", str(metadata["features"])))
+        item.user_properties.append(("dd_tags[systest.case.feature_ids]", str(metadata["features"])))
 
     if declaration:
         item.user_properties.append(("dd_tags[systest.case.declaration]", declaration))

--- a/tests/test_the_test/reportJunit_expected.xml
+++ b/tests/test_the_test/reportJunit_expected.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <testsuites>
-  <testsuite name="system_tests_suite" errors="1" failures="1" skipped="6" tests="10" time="0.804" timestamp="2026-06-23T16:51:44.127970" hostname="COMP-MKHXWVJ25H">
+  <testsuite name="system_tests_suite" errors="1" failures="1" skipped="6" tests="10" time="0.823" timestamp="2026-06-29T14:39:48.463003" hostname="COMP-MKHXWVJ25H">
     <properties>
       <property name="dd_tags[systest.suite.context.scenario]" value="MOCK_THE_TEST"/>
     </properties>
     <testcase name="tests.test_the_test.test_junit.Test_Cases.test_pass[spring]" time="0.000">
       <properties>
         <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
-        <property name="dd_tags[systest.case.feature_id]" value="346"/>
+        <property name="dd_tags[systest.case.feature_ids]" value="[346]"/>
         <property name="dd_tags[systest.case.outcome]" value="passed"/>
         <property name="dd_tags[test.final_status]" value="pass"/>
       </properties>
@@ -15,11 +15,11 @@
     <testcase name="tests.test_the_test.test_junit.Test_Cases.test_fail[spring]" time="0.000">
       <properties>
         <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
-        <property name="dd_tags[systest.case.feature_id]" value="346"/>
+        <property name="dd_tags[systest.case.feature_ids]" value="[346]"/>
         <property name="dd_tags[systest.case.outcome]" value="failed"/>
         <property name="dd_tags[test.final_status]" value="fail"/>
       </properties>
-      <failure message="Failed: dummy">self = &lt;tests.test_the_test.test_junit.Test_Cases object at 0x10cddf6b0&gt;
+      <failure message="Failed: dummy">self = &lt;tests.test_the_test.test_junit.Test_Cases object at 0x10ebe3fe0&gt;
 
     def test_fail(self):
 &gt;       pytest.fail("dummy")
@@ -32,7 +32,7 @@ tests/test_the_test/test_junit.py:25: Failed</failure>
         <property name="dd_tags[systest.case.outcome]" value="skipped"/>
         <property name="dd_tags[test.final_status]" value="skip"/>
         <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
-        <property name="dd_tags[systest.case.feature_id]" value="346"/>
+        <property name="dd_tags[systest.case.feature_ids]" value="[346]"/>
         <property name="dd_tags[systest.case.declaration]" value="irrelevant"/>
       </properties>
       <skipped type="pytest.skip" message="irrelevant">/Users/nicolas.catoni/repos/system-tests/tests/test_the_test/test_junit.py:27: irrelevant</skipped>
@@ -40,7 +40,7 @@ tests/test_the_test/test_junit.py:25: Failed</failure>
     <testcase name="tests.test_the_test.test_junit.Test_Cases.test_xfail[spring]" time="0.000">
       <properties>
         <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
-        <property name="dd_tags[systest.case.feature_id]" value="346"/>
+        <property name="dd_tags[systest.case.feature_ids]" value="[346]"/>
         <property name="dd_tags[systest.case.declaration]" value="bug"/>
         <property name="dd_tags[systest.case.declarationDetails]" value="APMRP-360"/>
         <property name="dd_tags[systest.case.outcome]" value="xfailed"/>
@@ -51,7 +51,7 @@ tests/test_the_test/test_junit.py:25: Failed</failure>
     <testcase name="tests.test_the_test.test_junit.Test_Cases.test_xpass[spring]" time="0.000">
       <properties>
         <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
-        <property name="dd_tags[systest.case.feature_id]" value="346"/>
+        <property name="dd_tags[systest.case.feature_ids]" value="[346]"/>
         <property name="dd_tags[systest.case.declaration]" value="bug"/>
         <property name="dd_tags[systest.case.declarationDetails]" value="APMRP-360"/>
         <property name="dd_tags[systest.case.outcome]" value="xpassed"/>
@@ -63,7 +63,7 @@ tests/test_the_test/test_junit.py:25: Failed</failure>
         <property name="dd_tags[systest.case.outcome]" value="skipped"/>
         <property name="dd_tags[test.final_status]" value="skip"/>
         <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
-        <property name="dd_tags[systest.case.feature_id]" value="346"/>
+        <property name="dd_tags[systest.case.feature_ids]" value="[346]"/>
         <property name="dd_tags[systest.case.declaration]" value="flaky"/>
         <property name="dd_tags[systest.case.declarationDetails]" value="APMRP-360"/>
       </properties>
@@ -74,7 +74,7 @@ tests/test_the_test/test_junit.py:25: Failed</failure>
         <property name="dd_tags[systest.case.outcome]" value="xfailed"/>
         <property name="dd_tags[test.final_status]" value="skip"/>
         <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
-        <property name="dd_tags[systest.case.feature_id]" value="346"/>
+        <property name="dd_tags[systest.case.feature_ids]" value="[346]"/>
         <property name="dd_tags[systest.case.declaration]" value="bug"/>
         <property name="dd_tags[systest.case.declarationDetails]" value="APMRP-360"/>
       </properties>
@@ -85,7 +85,7 @@ tests/test_the_test/test_junit.py:25: Failed</failure>
         <property name="dd_tags[systest.case.outcome]" value="xfailed"/>
         <property name="dd_tags[test.final_status]" value="skip"/>
         <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
-        <property name="dd_tags[systest.case.feature_id]" value="346"/>
+        <property name="dd_tags[systest.case.feature_ids]" value="[346]"/>
         <property name="dd_tags[systest.case.declaration]" value="missing_feature"/>
         <property name="dd_tags[systest.case.declarationDetails]" value="APMRP-360"/>
       </properties>
@@ -96,7 +96,7 @@ tests/test_the_test/test_junit.py:25: Failed</failure>
         <property name="dd_tags[systest.case.outcome]" value="error"/>
         <property name="dd_tags[test.final_status]" value="fail"/>
         <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
-        <property name="dd_tags[systest.case.feature_id]" value="346"/>
+        <property name="dd_tags[systest.case.feature_ids]" value="[346]"/>
       </properties>
       <error message="failed on setup with &quot;TypeError: nope!&quot;">@pytest.fixture
     def error_fixture():
@@ -110,7 +110,7 @@ tests/test_the_test/test_junit.py:15: TypeError</error>
         <property name="dd_tags[systest.case.outcome]" value="skipped"/>
         <property name="dd_tags[test.final_status]" value="skip"/>
         <property name="test.codeowners" value="[&quot;@DataDog/apm-sdk-capabilities&quot;]"/>
-        <property name="dd_tags[systest.case.feature_id]" value="346"/>
+        <property name="dd_tags[systest.case.feature_ids]" value="[346]"/>
         <property name="dd_tags[systest.case.declaration]" value="bug"/>
         <property name="dd_tags[systest.case.declarationDetails]" value="APMRP-360"/>
       </properties>


### PR DESCRIPTION
## Motivation

Test optimization doesn't support arrays

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
