### PR TITLE
Fix flaky runtime-metrics tests with condition-based collection wait

### DIFF
--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -662,6 +662,7 @@ class Test_Config_RuntimeMetrics_Enabled:
 
     def setup_main(self):
         self.req = weblog.get("/")
+        wait_for_runtime_metrics()
 
     def test_main(self):
         assert self.req.status_code == 200
@@ -696,6 +697,7 @@ class Test_Config_RuntimeMetrics_Enabled_WithRuntimeId:
 
     def setup_main(self):
         self.req = weblog.get("/")
+        wait_for_runtime_metrics()
 
     def test_main(self):
         assert self.req.status_code == 200
@@ -744,6 +746,18 @@ def get_runtime_metrics():
     ]
 
     return runtime_metrics_gauges, runtime_metrics_sketches
+
+
+RUNTIME_METRICS_WAIT_TIMEOUT = 60
+
+
+def wait_for_runtime_metrics() -> None:
+    # Runtime metrics are emitted on an interval, so wait (while the weblog is still up) until at least one
+    # reaches the agent instead of relying on the fixed collection window, which is racy.
+    interfaces.agent.wait_for(
+        lambda _: any(len(metrics) > 0 for metrics in get_runtime_metrics()),
+        timeout=RUNTIME_METRICS_WAIT_TIMEOUT,
+    )
 
 
 def parse_log_injection_message(log_message: str) -> dict:

--- a/tests/test_otlp_runtime_metrics.py
+++ b/tests/test_otlp_runtime_metrics.py
@@ -251,6 +251,22 @@ def get_runtime_metrics_by_name() -> dict[str, list[dict[str, str]]]:
     return result
 
 
+RUNTIME_METRICS_WAIT_TIMEOUT = 60
+
+
+def wait_for_runtime_metrics(library: str) -> None:
+    # OTLP metrics are exported on an interval, so wait (while the weblog is still up) until every expected
+    # metric for this library reaches the agent instead of relying on the fixed collection window.
+    expected = EXPECTED_METRICS.get(library)
+    if not expected:
+        return
+
+    interfaces.agent.wait_for(
+        lambda _: expected.keys() <= get_runtime_metrics_by_name().keys(),
+        timeout=RUNTIME_METRICS_WAIT_TIMEOUT,
+    )
+
+
 @scenarios.otlp_runtime_metrics
 @features.runtime_metrics
 class Test_OtlpRuntimeMetrics:
@@ -258,6 +274,7 @@ class Test_OtlpRuntimeMetrics:
 
     def setup_otel_metrics_are_present_and_attributed(self) -> None:
         self.req = weblog.get("/")
+        wait_for_runtime_metrics(context.library.name)
 
     def test_otel_metrics_are_present_and_attributed(self) -> None:
         assert self.req.status_code == 200


### PR DESCRIPTION
## Motivation

`Test_Config_RuntimeMetrics_Enabled[*]` and `Test_OtlpRuntimeMetrics.test_otel_metrics_are_present_and_attributed[*]` are flaky: they pass overall but get flagged on retry in the Flaky Test Registry (owned by `@DataDog/apm-sdk-capabilities`).

The cause is timing. These tests assert that runtime metrics are present, but metrics are emitted on an interval and the `RUNTIME_METRICS_ENABLED` / `OTLP_RUNTIME_METRICS` scenarios collect them in a fixed window. When the window closes before a metric arrives, the assertion fails, then passes on the next run.

## Changes

Wait for the runtime metrics to reach the agent before the scenario tears down, instead of relying on the fixed window. The wait lives in each test's `setup_` method (a small `wait_for_runtime_metrics` helper), so it runs while the weblog is still up and returns as soon as the metrics arrive:

- `Test_Config_RuntimeMetrics_Enabled[*]` waits until a `runtime.*` / `jvm.*` metric is collected.
- `Test_OtlpRuntimeMetrics` waits until every expected metric for the library is collected.

Only `tests/` changes; no scenario or framework changes.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
