### PR TITLE
[nodejs] set DD_INJECT_FORCE=true in nextjs weblog

### DIFF
--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -13,4 +13,5 @@ ENV HOSTNAME=0.0.0.0
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN printf './node_modules/.bin/next start' >> app.sh
 ENV NODE_OPTIONS="--import dd-trace/initialize.mjs"
+ENV DD_INJECT_FORCE=true
 CMD ./app.sh


### PR DESCRIPTION
## Summary
- Adds `ENV DD_INJECT_FORCE=true` to `utils/build/docker/nodejs/nextjs.Dockerfile` so the dd-trace SSI guardrail does not abort tracer initialization when dd-trace-js's `engines.node` floor is bumped above the Node version shipped in `nextjs.base` (currently `node:20-alpine`).
- Only the nextjs weblog is affected because it loads dd-trace via `NODE_OPTIONS="--import dd-trace/initialize.mjs"`, which runs through the guardrail in `packages/dd-trace/src/guardrails/index.js`. The other Node weblogs call `require('dd-trace').init()` directly and skip the guardrail entirely.

## Context
Motivated by [dd-trace-js#9108](https://github.com/DataDog/dd-trace-js/pull/9108), which bumps the v6 engines floor to Node 22. With that bump, the system-tests nextjs end-to-end jobs in that PR all failed because the dd-trace guardrail bailed out with `Aborting application instrumentation due to incompatible_runtime`. The weblog container itself stayed up and responded to `/healthcheck`, but no telemetry was ever sent through the library proxy, so `_wait_for_app_readiness` raised `Library not ready`.

`DD_INJECT_FORCE=true` makes the guardrail log the mismatch but continue bootstrapping the tracer (see `packages/dd-trace/src/guardrails/index.js` in dd-trace-js).

## Test plan
- [ ] Rerun the nextjs end-to-end jobs from dd-trace-js#9108 against this branch and confirm they pass.
- [ ] Verify the express/express4/express5/fastify/parametric weblogs are unaffected (they don't go through `initialize.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)