### PR TITLE
[java] Enable Test_FFE_Eval_Metric_Count::test_ffe_eval_metric_count for v1.63.0

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3245,7 +3245,10 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         spring-boot: v1.62.0
-  tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Metric_Count::test_ffe_eval_metric_count: bug (FFL-1972)
+  tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Metric_Count::test_ffe_eval_metric_count:
+    - weblog_declaration:
+        "*": irrelevant
+        spring-boot: v1.63.0
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integration_frameworks/llm/openai/test_openai_apm.py: v1.61.0
   tests/integration_frameworks/llm/openai/test_openai_llmobs.py: v1.61.0


### PR DESCRIPTION
## Motivation

`tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Metric_Count::test_ffe_eval_metric_count` was marked as a known bug (`FFL-1972`) in the Java manifest. The fix shipped in **dd-trace-java v1.63.0** via DataDog/dd-trace-java#11426 ("fix(openfeature): use delta temporality for OTLP metrics export", merged 2026-05-22).

## Change

Replace the `bug (FFL-1972)` marker with a version gate at the release that contains the fix:

```yaml
  tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Metric_Count::test_ffe_eval_metric_count:
    - weblog_declaration:
        "*": irrelevant
        spring-boot: v1.63.0
```

The fix is present in `v1.63.0` and absent from `v1.62.0` (verified: the #11426 merge commit is an ancestor of the `v1.63.0` tag but not `v1.62.0`). Gating to `v1.63.0` — rather than letting the test inherit the file-level `spring-boot: v1.62.0` declaration — avoids asserting the test passes on `v1.62.0`, where the bug is still present.

This addresses the automated review note about gating activation to the fixed version.
