### PR TITLE
Add k8s test: init container can reach HTTPS endpoints (CA trust store)

### DIFF
--- a/tests/k8s_lib_injection/test_k8s_lib_injection.py
+++ b/tests/k8s_lib_injection/test_k8s_lib_injection.py
@@ -1,5 +1,10 @@
 from utils import scenarios, features, context, bug, logger
-from tests.k8s_lib_injection.utils import get_dev_agent_traces, get_cluster_info, run_https_probe_pod
+from tests.k8s_lib_injection.utils import (
+    get_dev_agent_traces,
+    get_cluster_info,
+    get_library_init_image,
+    run_https_probe_pod,
+)
 from utils.onboarding.weblog_interface import make_get_request, warmup_weblog
 from utils.onboarding.backend_interface import wait_backend_trace_id
 from utils.onboarding.wait_for_tcp_port import wait_for_port
@@ -27,7 +32,7 @@ class TestK8sLibInjection:
         pod from the init image doing `curl -fsS https://...` (verification on) and asserts it
         succeeds; a missing or broken cert store makes curl exit non-zero.
         """
-        image = context.scenario.test_weblog.library_init_image
+        image = get_library_init_image()
         phase, logs = run_https_probe_pod(get_cluster_info(), image, "https://app.datadoghq.com")
         if phase != "Succeeded":
             logger.error(f"[HTTPS probe] init image {image} failed HTTPS egress; pod logs:\n{logs}")

--- a/tests/k8s_lib_injection/test_k8s_lib_injection.py
+++ b/tests/k8s_lib_injection/test_k8s_lib_injection.py
@@ -1,5 +1,5 @@
 from utils import scenarios, features, context, bug, logger
-from tests.k8s_lib_injection.utils import get_dev_agent_traces, get_cluster_info
+from tests.k8s_lib_injection.utils import get_dev_agent_traces, get_cluster_info, run_https_probe_pod
 from utils.onboarding.weblog_interface import make_get_request, warmup_weblog
 from utils.onboarding.backend_interface import wait_backend_trace_id
 from utils.onboarding.wait_for_tcp_port import wait_for_port
@@ -18,6 +18,20 @@ class TestK8sLibInjection:
     def test_k8s_lib_injection(self):
         traces_json = get_dev_agent_traces(get_cluster_info())
         assert len(traces_json) > 0, "No traces found"
+
+    def test_k8s_init_container_https_egress(self):
+        """The init image must be able to complete a TLS-verified HTTPS request.
+
+        The init container ships a CA trust store so admission-controller wrappers that dial
+        HTTPS from inside it (e.g. bank-vaults' vault-env) keep working. This runs a throwaway
+        pod from the init image doing `curl -fsS https://...` (verification on) and asserts it
+        succeeds; a missing or broken cert store makes curl exit non-zero.
+        """
+        image = context.scenario.test_weblog.library_init_image
+        phase, logs = run_https_probe_pod(get_cluster_info(), image, "https://app.datadoghq.com")
+        if phase != "Succeeded":
+            logger.error(f"[HTTPS probe] init image {image} failed HTTPS egress; pod logs:\n{logs}")
+        assert phase == "Succeeded", f"init image could not complete a verified HTTPS request (pod phase: {phase})"
 
 
 @features.k8s_admission_controller

--- a/tests/k8s_lib_injection/utils.py
+++ b/tests/k8s_lib_injection/utils.py
@@ -5,7 +5,7 @@ from kubernetes import client
 
 from utils import logger, context
 from utils.k8s_lib_injection.k8s_cluster_provider import K8sClusterInfo
-from utils._context._scenarios.k8s_lib_injection import K8sScenarioWithClusterProvider
+from utils._context._scenarios.k8s_lib_injection import K8sScenario, K8sScenarioWithClusterProvider
 
 
 def get_dev_agent_traces(k8s_cluster_info: K8sClusterInfo, retry: int = 10) -> list:
@@ -26,6 +26,13 @@ def get_cluster_info() -> K8sClusterInfo:
     assert isinstance(context.scenario, K8sScenarioWithClusterProvider)
 
     return context.scenario.k8s_cluster_provider.get_cluster_info()
+
+
+def get_library_init_image() -> str:
+    """Return the init image under test (the image the scenario deploys as the init container)."""
+    assert isinstance(context.scenario, K8sScenario)
+
+    return context.scenario.test_weblog.library_init_image
 
 
 def run_https_probe_pod(

--- a/tests/k8s_lib_injection/utils.py
+++ b/tests/k8s_lib_injection/utils.py
@@ -1,6 +1,8 @@
 import time
 
 import requests
+from kubernetes import client
+
 from utils import logger, context
 from utils.k8s_lib_injection.k8s_cluster_provider import K8sClusterInfo
 from utils._context._scenarios.k8s_lib_injection import K8sScenarioWithClusterProvider
@@ -24,3 +26,51 @@ def get_cluster_info() -> K8sClusterInfo:
     assert isinstance(context.scenario, K8sScenarioWithClusterProvider)
 
     return context.scenario.k8s_cluster_provider.get_cluster_info()
+
+
+def run_https_probe_pod(
+    k8s_cluster_info: K8sClusterInfo, image: str, url: str, *, namespace: str = "default", timeout: int = 120
+) -> tuple[str | None, str]:
+    """Run a one-shot pod from `image` performing a TLS-verified HTTPS GET to `url`.
+
+    Uses the image's curl with verification on (no -k), so a missing or invalid CA trust
+    store makes curl exit non-zero. Returns (pod_phase, logs); phase "Succeeded" means the
+    image completed a verified HTTPS request. The probe pod is always cleaned up.
+    """
+    api = k8s_cluster_info.core_v1_api()
+    name = "init-https-probe"
+    pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(name=name),
+        spec=client.V1PodSpec(
+            restart_policy="Never",
+            containers=[
+                client.V1Container(
+                    name="probe",
+                    image=image,
+                    image_pull_policy="Always",
+                    command=["/usr/bin/curl", "-fsS", "-o", "/dev/null", "--max-time", "15", url],
+                )
+            ],
+        ),
+    )
+    logger.info(f"[HTTPS probe] running {image} -> curl {url}")
+    api.create_namespaced_pod(namespace=namespace, body=pod)
+    try:
+        phase: str | None = None
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            phase = api.read_namespaced_pod_status(name=name, namespace=namespace).status.phase
+            if phase in ("Succeeded", "Failed"):
+                break
+            time.sleep(2)
+        logs = ""
+        try:
+            logs = api.read_namespaced_pod_log(name=name, namespace=namespace)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[HTTPS probe] could not read probe pod logs: {e}")
+        return phase, logs
+    finally:
+        try:
+            api.delete_namespaced_pod(name=name, namespace=namespace)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[HTTPS probe] could not delete probe pod: {e}")

--- a/tests/k8s_lib_injection/utils.py
+++ b/tests/k8s_lib_injection/utils.py
@@ -73,11 +73,11 @@ def run_https_probe_pod(
         logs = ""
         try:
             logs = api.read_namespaced_pod_log(name=name, namespace=namespace)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(f"[HTTPS probe] could not read probe pod logs: {e}")
         return phase, logs
     finally:
         try:
             api.delete_namespaced_pod(name=name, namespace=namespace)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(f"[HTTPS probe] could not delete probe pod: {e}")


### PR DESCRIPTION
## Motivation

Adds a `k8s_lib_injection` test asserting the **init container can complete a TLS-verified HTTPS request** — i.e. the image ships a working CA trust store. Init images carry CA certs so admission-controller wrappers that dial HTTPS from inside the init container (e.g. bank-vaults' `vault-env`) keep working.

There was no coverage for this. It becomes important now because **DataDog/libdatadog-build#235** moves the `dd-lib-*-init` images off busybox to a `FROM scratch` + statically-linked dash/toybox/curl base — the kind of base change where a cert store can silently regress. This test guards against that.

## What it does

- New helper `run_https_probe_pod()` (`tests/k8s_lib_injection/utils.py`): runs a one-shot pod from the init image doing `curl -fsS https://app.datadoghq.com` (verification **on**, no `-k`), waits for the pod phase, and always cleans the pod up.
- New test `TestK8sLibInjection::test_k8s_init_container_https_egress`: asserts the probe pod reaches `Succeeded`. A missing/invalid CA store makes curl exit non-zero → pod `Failed` → test fails.

The test is fully isolated (its own throwaway pod, separate `test_*` method) so a cert regression fails only this test, not the injection/traces assertions. It reuses the existing scenarios + `@features.k8s_admission_controller`; no manifest changes.

## How this was tested

- Verified the same probe manually against the toybox+dash init image built by libdatadog-build#235's CI (`registry.ddbuild.io/ssi/dd-lib-js-init:<sha>`): `curl https://… → HTTP 200, ssl_verify_result=0`, CAfile `/etc/ssl/certs/ca-certificates.crt`.
- Both edited files parse; hand-formatted to the repo ruff style (could not run `./format.sh` in this environment — CI `--check` will confirm).
