### PR TITLE
ruby:  omit LiveDebugging RC test on rails42 (Ruby 2.5)

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2420,7 +2420,10 @@ manifest:
   tests/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceASMDDNoCache: missing_feature
   tests/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceFeatures: missing_feature
   tests/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceFeaturesNoCache: missing_feature
-  tests/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceLiveDebugging: v1.13.0
+  tests/remote_config/test_remote_configuration.py::Test_RemoteConfigurationUpdateSequenceLiveDebugging:
+    - weblog_declaration:
+        "*": v1.13.0
+        rails42: irrelevant (DI requires MRI Ruby 2.6+; rails42 runs on Ruby 2.5)
   tests/serverless/span_pointers/aws/test_s3_span_pointers.py::Test_CopyObject: missing_feature
   tests/serverless/span_pointers/aws/test_s3_span_pointers.py::Test_MultipartUpload: missing_feature
   tests/serverless/span_pointers/aws/test_s3_span_pointers.py::Test_PutObject: missing_feature


### PR DESCRIPTION
## Motivation

[dd-trace-rb#5956](https://github.com/DataDog/dd-trace-rb/pull/5956) stops advertising the `LIVE_DEBUGGING` remote-config product (and the implicit-enablement capability bit 38) on runtimes that cannot run Dynamic Instrumentation: MRI < 2.6 and JRuby.

`Test_RemoteConfigurationUpdateSequenceLiveDebugging::test_tracer_update_sequence` asserts that the tracer stores and reports a `LIVE_DEBUGGING` config_state. The `rails42` weblog runs on **Ruby 2.5** (`utils/build/docker/ruby/rails42.Dockerfile`: `FROM ghcr.io/datadog/images-rb/engines/ruby:2.5`), below the DI minimum of MRI 2.6. With that PR the tracer correctly never subscribes to `LIVE_DEBUGGING` RC, so it reports zero config_states and the test fails:

```
AssertionError: client reporting more or less configs than expected
assert 0 == 1
  0 = len([])
  1 = len([{'product': 'LIVE_DEBUGGING', 'version': 1}])
```

All other Ruby weblogs run on Ruby >= 2.6 and continue to pass.

## Changes

Mark `Test_RemoteConfigurationUpdateSequenceLiveDebugging` as `irrelevant` for the `rails42` weblog only, preserving `v1.13.0` for every other weblog. This matches the existing convention in `manifests/ruby.yml` where DI/debugger tests are `irrelevant` on non-DI-capable weblogs.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)