### PR TITLE
fix(rust/parametric): report effective propagation style in /trace/config

### DIFF
--- a/utils/build/docker/rust/parametric/src/datadog/dto.rs
+++ b/utils/build/docker/rust/parametric/src/datadog/dto.rs
@@ -204,8 +204,12 @@ fn format_global_tags(config: &Config) -> String {
 }
 
 fn format_trace_propagation_extract(config: &Config) -> String {
+    // Mirror the library's effective-extractor resolution: use the extract-specific styles when
+    // set, otherwise fall back to the global propagation style (which is what OTEL_PROPAGATORS and
+    // a bare DD_TRACE_PROPAGATION_STYLE feed). See dd-trace-rs propagation/config.rs::get_extractors.
     config
         .trace_propagation_style_extract()
+        .or_else(|| config.trace_propagation_style())
         .map(|styles| {
             styles
                 .iter()


### PR DESCRIPTION
## Motivation

The Rust parametric app's `GET /trace/config` reported the propagation style from the extract-specific config only, so a global-only style — including one fed by `OTEL_PROPAGATORS` or a bare `DD_TRACE_PROPAGATION_STYLE` — was reported as empty. This is the companion to DataDog/dd-trace-rs#271, which adds `OTEL_PROPAGATORS` support to dd-trace-rs.

## Changes

`format_trace_propagation_extract` in the Rust parametric app now falls back to the global propagation style when the extract-specific style is unset, mirroring the library's effective-extractor resolution (`propagation/config.rs::get_extractors`): extract-specific styles if set, otherwise the global style. One function, four added lines.

Verified locally with `cargo check` against a linked dd-trace-rs source (the type signatures compose: both getters return `Option<&[TracePropagationStyle]>`).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
