### PR TITLE
Update ddapm-test-agent docker image to v1.63.0

### DIFF
--- a/utils/_context/_scenarios/integration_frameworks.py
+++ b/utils/_context/_scenarios/integration_frameworks.py
@@ -30,7 +30,7 @@ class IntegrationFrameworksScenario(DockerFixturesScenario):
             name,
             doc=doc,
             github_workflow="endtoend",
-            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.62.0",
+            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.63.0",
             scenario_groups=(groups.integration_frameworks,),
         )
 

--- a/utils/_context/_scenarios/parametric.py
+++ b/utils/_context/_scenarios/parametric.py
@@ -63,7 +63,7 @@ class ParametricScenario(DockerFixturesScenario):
             name,
             doc=doc,
             github_workflow="parametric",
-            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.62.0",
+            agent_image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.63.0",
         )
         self._parametric_tests_confs = ParametricScenario.PersistentParametricTestConf(self)
 

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1462,7 +1462,7 @@ class OpenTelemetryCollectorContainer(TestedContainer):
 class APMTestAgentContainer(TestedContainer):
     def __init__(self, agent_port: int = 8126) -> None:
         super().__init__(
-            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.31.1",
+            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.63.0",
             name="ddapm-test-agent",
             environment={
                 "SNAPSHOT_CI": "0",
@@ -1495,7 +1495,7 @@ class VCRCassettesContainer(TestedContainer):
 
     def __init__(self, vcr_port: int = ContainerPorts.vcr_cassettes) -> None:
         super().__init__(
-            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.62.0",
+            image_name="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.63.0",
             name="vcr_cassettes",
             environment={
                 "PORT": str(vcr_port),

--- a/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
+++ b/utils/k8s_lib_injection/k8s_datadog_kubernetes.py
@@ -104,7 +104,7 @@ class K8sDatadog:
 
         container = client.V1Container(
             name="trace-agent",
-            image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.31.1",
+            image="ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.63.0",
             image_pull_policy="Always",
             ports=[client.V1ContainerPort(container_port=8126, host_port=8126, name="traceport", protocol="TCP")],
             command=["ddapm-test-agent"],


### PR DESCRIPTION
# What Does This Do

Bumps the `ddapm-test-agent` docker image to `v1.63.0` in all places where it is declared:
- `utils/_context/containers.py` — `APMTestAgentContainer` (was `v1.31.1`) and `VCRCassettesContainer` (was `v1.62.0`)
- `utils/_context/_scenarios/parametric.py` (was `v1.62.0`)
- `utils/_context/_scenarios/integration_frameworks.py` (was `v1.62.0`)
- `utils/k8s_lib_injection/k8s_datadog_kubernetes.py` (was `v1.31.1`)

# Motivation

Keep the test-agent container up to date so scenarios run against the latest agent behavior and validation logic.

# Additional Notes

- The `ddapm-test-agent==1.18.0` pip pin in `requirements.txt` is intentionally left untouched — it only provides the `Span`/`Trace` type imports for the harness and is versioned/updated independently of the container image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)