### PR TITLE
Harden pull image action against GHA connectivity instability

### DIFF
--- a/.github/actions/pull_images/action.yml
+++ b/.github/actions/pull_images/action.yml
@@ -66,34 +66,9 @@ runs:
       env:
         PYTHONPATH: "."
 
-    - name: Login to Docker Hub
-      if: inputs.dockerhub_username != '' && inputs.dockerhub_token != ''
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-      with:
-        username: ${{ inputs.dockerhub_username }}
-        password: ${{ inputs.dockerhub_token }}
-
-    - name: Pull
+    - name: Login to Docker Hub and pull images
       shell: bash
-      run: |
-        max_attempts=5
-        timeout_seconds=900
-        attempt=1
-        while true; do
-          echo "Running docker compose pull (attempt ${attempt}/${max_attempts}, timeout ${timeout_seconds}s)..."
-
-          if timeout "${timeout_seconds}" docker compose pull; then
-            break
-          fi
-
-          if [ "${attempt}" -ge "${max_attempts}" ]; then
-            echo "docker compose pull failed after ${attempt} attempts"
-            exit 1
-          fi
-
-          # Exponential backoff: 30s, 60s, 120s, 240s
-          retry_wait_seconds=$(( 30 * (1 << (attempt - 1)) ))
-          echo "docker compose pull failed (attempt ${attempt}/${max_attempts}), retrying in ${retry_wait_seconds}s..."
-          sleep "${retry_wait_seconds}"
-          attempt=$((attempt + 1))
-        done
+      run: .github/actions/pull_images/main.sh
+      env:
+        DOCKERHUB_USERNAME: ${{ inputs.dockerhub_username }}
+        DOCKERHUB_TOKEN: ${{ inputs.dockerhub_token }}

--- a/.github/actions/pull_images/main.sh
+++ b/.github/actions/pull_images/main.sh
@@ -22,7 +22,6 @@ NON_RETRYABLE_PATTERNS=(
   "no configuration file provided: not found"
   "empty compose file"
   "yaml: construct errors"
-  "failed to resolve reference"
 )
 
 retry_with_timeout() {

--- a/.github/actions/pull_images/main.sh
+++ b/.github/actions/pull_images/main.sh
@@ -71,7 +71,7 @@ docker_login() {
 }
 
 if [ -n "${DOCKERHUB_USERNAME:-}" ] && [ -n "${DOCKERHUB_TOKEN:-}" ]; then
-  export -f docker_login  # makes the function docker_login available in any child process spawned from it 
+  export -f docker_login  # makes the function docker_login available in any child process spawned from it
   retry_with_timeout "Logging in to Docker Hub" 60 bash -c docker_login
 fi
 

--- a/.github/actions/pull_images/main.sh
+++ b/.github/actions/pull_images/main.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Logs in to Docker Hub (if credentials are provided) and pulls the images
+# listed in compose.yaml, retrying on failure.
+#
+# When a command fails, unless the error is known to not be retryable, the command will be retried
+#
+# Expects DOCKERHUB_USERNAME / DOCKERHUB_TOKEN in the environment (may be empty).
+
+set -euo pipefail
+
+# Backoff delay (seconds) indexed by attempt number (1-based)
+# since github action
+BACKOFF_SECONDS=(10 20 40 80 160 320 320 320 320 320 320 320 320 320 320 320)
+MAX_ATTEMPTS="${#BACKOFF_SECONDS[@]}"
+
+# Error patterns that should never be retried (auth/permission/not-found errors
+# won't fix themselves on a retry).
+NON_RETRYABLE_PATTERNS=(
+  "incorrect username or password"
+  "unauthorized"
+  "unknown command: docker compose"
+  "no configuration file provided: not found"
+  "empty compose file"
+  "yaml: construct errors"
+  "failed to resolve reference"
+)
+
+retry_with_timeout() {
+  local description="$1"
+  local timeout_seconds="$2"
+  shift 2
+
+  local attempt=1
+  local retry_wait_seconds
+  local output_file
+  output_file="$(mktemp)"
+  trap 'rm -f "${output_file}"' RETURN
+
+  while true; do
+    echo "${description} (attempt ${attempt}/${MAX_ATTEMPTS}, timeout ${timeout_seconds}s)..."
+
+    # Both save the output in output_file and print it to stdout.
+    # exit function if the command succeed
+    if timeout "${timeout_seconds}" "$@" 2>&1 | tee "${output_file}"; then
+      return 0
+    fi
+
+    for pattern in "${NON_RETRYABLE_PATTERNS[@]}"; do
+      if grep -q "${pattern}" "${output_file}"; then
+        echo "${description} failed with a non-retryable error: ${pattern}"
+        return 1
+      fi
+    done
+
+    echo "${description} failed (attempt ${attempt}/${MAX_ATTEMPTS})"
+    if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
+      echo "${description} failed after ${attempt} attempts"
+      return 1
+    fi
+
+    retry_wait_seconds="${BACKOFF_SECONDS[attempt - 1]}"
+    attempt=$((attempt + 1))
+
+    echo "retrying in ${retry_wait_seconds}s..."
+    sleep "${retry_wait_seconds}"
+  done
+}
+
+docker_login() {
+  echo "${DOCKERHUB_TOKEN}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
+}
+
+if [ -n "${DOCKERHUB_USERNAME:-}" ] && [ -n "${DOCKERHUB_TOKEN:-}" ]; then
+  export -f docker_login  # makes the function docker_login available in any child process spawned from it 
+  retry_with_timeout "Logging in to Docker Hub" 60 bash -c docker_login
+fi
+
+retry_with_timeout "Running docker compose pull" 900 docker compose pull

--- a/.github/actions/pull_images/main.sh
+++ b/.github/actions/pull_images/main.sh
@@ -75,4 +75,4 @@ if [ -n "${DOCKERHUB_USERNAME:-}" ] && [ -n "${DOCKERHUB_TOKEN:-}" ]; then
   retry_with_timeout "Logging in to Docker Hub" 60 bash -c docker_login
 fi
 
-retry_with_timeout "Running docker compose pull" 900 docker compose pull
+retry_with_timeout "Running docker compose pull" 900 docker compose --progress plain pull

--- a/utils/scripts/libraries_and_scenarios_rules.yml
+++ b/utils/scripts/libraries_and_scenarios_rules.yml
@@ -157,7 +157,7 @@ patterns:
 # This section contains rules to apply to files related to GitHub Actions.
 ################################################################################
 
-    .github/actions/pull_images/action.yml:
+    .github/actions/pull_images/*:
         scenario_groups: end_to_end
     .github/chainguard/*:
         scenario_groups: null


### PR DESCRIPTION
## Motivation

Per title

## Changes

- Replace docker/login-action with a plain docker login --password-stdin call, passing credentials via env, as this action does not offer any retry logic
- Add retry logic around both the Docker Hub login and docker compose pull, with exponential backoff (10s → 320s, capped, up to 16 attempts) to ride out transient GitHub Actions runner connectivity issues.
- Skip retrying immediately on known non-retryable failures (bad credentials, unauthorized, missing/malformed compose file, unresolvable image reference, etc.) instead of burning through all retry attempts on errors that will never succeed.
- Extract the login/pull/retry logic out of inline YAML run: blocks into .github/actions/pull_images/main.sh for readability and testability.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
