### PR TITLE
New e2e jobs were included in one pipeline which shouldn't have happened

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/one-pipeline/ca/0b4d88122bb64a87131eeb9446a3671598790917ec30fc31851ccb6ee8375b8a/single-step-instrumentation-tests.yml
   - local: /utils/ci/gitlab/main.yml
     inputs:
-      stage: "configure"
+      stage: "e2e"
       ref: "$CI_COMMIT_SHA"
       push_to_test_optimization: true
       split_pipeline: true
@@ -15,6 +15,7 @@ stages:
   - php
   - ruby
   - pipeline-status
+  - e2e
   - system-tests-utils
 
 variables:
@@ -323,7 +324,7 @@ generate_system_tests_lib_injection_images:
 
 system_tests_param:
   extends: .system_tests_param_base
-  stage: configure
+  stage: e2e
   needs:
     - job: build_ci_image
       artifacts: false
@@ -379,7 +380,7 @@ build_ci_image:
   interruptible: false
   tags:
     - docker-in-docker:amd64
-  stage: configure
+  stage: e2e
   script:
     - IMAGE_TAG=$(cat utils/ci/gitlab/docker/system-tests.Dockerfile requirements.txt | sha256sum | cut -c1-12)
     - EXPECTED_IMAGE="registry.ddbuild.io/system-tests/ci-runner:$IMAGE_TAG"
@@ -426,7 +427,7 @@ mirror_images:
   image: $CI_IMAGE
   # Runs in e2e (not the last stage) so the build/run jobs can depend on it and
   # only start once the mirror is populated.
-  stage: configure
+  stage: e2e
   tags:
     - arch:amd64
   needs:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
