### PR TITLE
feat(golang): implement /otel_drop_in_extract_and_make_distant_call endpoint

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1441,7 +1441,7 @@ manifest:
   tests/test_library_conf.py::Test_ExtractBehavior_Default: v2.10.0-dev
   tests/test_library_conf.py::Test_ExtractBehavior_Ignore: v2.10.0-dev
   tests/test_library_conf.py::Test_ExtractBehavior_Restart: v2.10.0-dev
-  tests/test_library_conf.py::Test_ExtractBehavior_Restart_Otel: missing_feature (OTel extraction endpoint not implemented)
+  tests/test_library_conf.py::Test_ExtractBehavior_Restart_Otel: v2.10.0-dev
   tests/test_library_conf.py::Test_ExtractBehavior_Restart_With_Extract_First: v2.10.0-dev
   tests/test_library_conf.py::Test_HeaderTags: v1.53.0
   tests/test_library_conf.py::Test_HeaderTags_Colon_Leading: v1.53.0

--- a/utils/build/docker/golang/app/chi/main.go
+++ b/utils/build/docker/golang/app/chi/main.go
@@ -205,9 +205,14 @@ func main() {
 			return
 		}
 
+		// Extract the incoming trace context via the OTel propagation API and start a new span.
+		// We intentionally use context.Background() instead of r.Context(): r.Context() already
+		// carries the server span created by the HTTP middleware, which would cause the dd-trace-go
+		// OTel bridge to parent otel_extract_distant_call to that span rather than creating a
+		// fresh root with a span link (the expected restart behavior).
 		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 		propagator := otel.GetTextMapPropagator()
-		ctx := propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+		ctx := propagator.Extract(context.Background(), propagation.HeaderCarrier(r.Header))
 
 		p := ddotel.NewTracerProvider()
 		otel.SetTracerProvider(p)

--- a/utils/build/docker/golang/app/chi/main.go
+++ b/utils/build/docker/golang/app/chi/main.go
@@ -27,9 +27,12 @@ import (
 	httptrace "github.com/DataDog/dd-trace-go/contrib/net/http/v2"
 	dd_logrus "github.com/DataDog/dd-trace-go/contrib/sirupsen/logrus/v2"
 	"github.com/DataDog/dd-trace-go/v2/appsec"
+	ddotel "github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry"
 	_ "github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry/metric"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/profiler"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 func main() {
@@ -170,6 +173,58 @@ func main() {
 			logrus.Fatalln("client.Do", err)
 		}
 
+		defer res.Body.Close()
+
+		requestHeaders := make(map[string]string, len(req.Header))
+		for key, values := range req.Header {
+			requestHeaders[strings.ToLower(key)] = strings.Join(values, ",")
+		}
+
+		responseHeaders := make(map[string]string, len(res.Header))
+		for key, values := range res.Header {
+			responseHeaders[key] = strings.Join(values, ",")
+		}
+
+		jsonResponse, err := json.Marshal(struct {
+			URL             string            `json:"url"`
+			StatusCode      int               `json:"status_code"`
+			RequestHeaders  map[string]string `json:"request_headers"`
+			ResponseHeaders map[string]string `json:"response_headers"`
+		}{URL: url, StatusCode: res.StatusCode, RequestHeaders: requestHeaders, ResponseHeaders: responseHeaders})
+		if err != nil {
+			logrus.Fatalln(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jsonResponse)
+	})
+
+	mux.HandleFunc("/otel_drop_in_extract_and_make_distant_call", func(w http.ResponseWriter, r *http.Request) {
+		url := r.URL.Query().Get("url")
+		if url == "" {
+			w.Write([]byte("OK"))
+			return
+		}
+
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+		propagator := otel.GetTextMapPropagator()
+		ctx := propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+
+		p := ddotel.NewTracerProvider()
+		otel.SetTracerProvider(p)
+		otelTracer := p.Tracer("")
+		ctx, span := otelTracer.Start(ctx, "otel_extract_distant_call")
+		defer span.End()
+
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if ddSpan, ok := tracer.SpanFromContext(ctx); ok {
+			tracer.Inject(ddSpan.Context(), tracer.HTTPHeadersCarrier(req.Header))
+		}
+		propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			logrus.Fatalln("client.Do", err)
+		}
 		defer res.Body.Close()
 
 		requestHeaders := make(map[string]string, len(req.Header))

--- a/utils/build/docker/golang/app/echo/main.go
+++ b/utils/build/docker/golang/app/echo/main.go
@@ -26,9 +26,12 @@ import (
 	httptrace "github.com/DataDog/dd-trace-go/contrib/net/http/v2"
 	dd_logrus "github.com/DataDog/dd-trace-go/contrib/sirupsen/logrus/v2"
 	"github.com/DataDog/dd-trace-go/v2/appsec"
+	ddotel "github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry"
 	_ "github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry/metric"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/profiler"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 func main() {
@@ -185,6 +188,52 @@ func main() {
 			logrus.Fatalln(err)
 		}
 
+		defer res.Body.Close()
+
+		requestHeaders := make(map[string]string, len(req.Header))
+		for key, values := range req.Header {
+			requestHeaders[strings.ToLower(key)] = strings.Join(values, ",")
+		}
+
+		responseHeaders := make(map[string]string, len(res.Header))
+		for key, values := range res.Header {
+			responseHeaders[key] = strings.Join(values, ",")
+		}
+
+		return c.JSON(200, struct {
+			URL             string            `json:"url"`
+			StatusCode      int               `json:"status_code"`
+			RequestHeaders  map[string]string `json:"request_headers"`
+			ResponseHeaders map[string]string `json:"response_headers"`
+		}{URL: url, StatusCode: res.StatusCode, RequestHeaders: requestHeaders, ResponseHeaders: responseHeaders})
+	})
+
+	r.Any("/otel_drop_in_extract_and_make_distant_call", func(c echo.Context) error {
+		url := c.Request().URL.Query().Get("url")
+		if url == "" {
+			return c.String(200, "OK")
+		}
+
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+		propagator := otel.GetTextMapPropagator()
+		ctx := propagator.Extract(c.Request().Context(), propagation.HeaderCarrier(c.Request().Header))
+
+		p := ddotel.NewTracerProvider()
+		otel.SetTracerProvider(p)
+		otelTracer := p.Tracer("")
+		ctx, span := otelTracer.Start(ctx, "otel_extract_distant_call")
+		defer span.End()
+
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if ddSpan, ok := tracer.SpanFromContext(ctx); ok {
+			tracer.Inject(ddSpan.Context(), tracer.HTTPHeadersCarrier(req.Header))
+		}
+		propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			logrus.Fatalln("client.Do", err)
+		}
 		defer res.Body.Close()
 
 		requestHeaders := make(map[string]string, len(req.Header))

--- a/utils/build/docker/golang/app/echo/main.go
+++ b/utils/build/docker/golang/app/echo/main.go
@@ -214,9 +214,14 @@ func main() {
 			return c.String(200, "OK")
 		}
 
+		// Extract the incoming trace context via the OTel propagation API and start a new span.
+		// We intentionally use context.Background() instead of c.Request().Context(): that context
+		// already carries the server span created by the HTTP middleware, which would cause the
+		// dd-trace-go OTel bridge to parent otel_extract_distant_call to that span rather than
+		// creating a fresh root with a span link (the expected restart behavior).
 		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 		propagator := otel.GetTextMapPropagator()
-		ctx := propagator.Extract(c.Request().Context(), propagation.HeaderCarrier(c.Request().Header))
+		ctx := propagator.Extract(context.Background(), propagation.HeaderCarrier(c.Request().Header))
 
 		p := ddotel.NewTracerProvider()
 		otel.SetTracerProvider(p)

--- a/utils/build/docker/golang/app/gin/main.go
+++ b/utils/build/docker/golang/app/gin/main.go
@@ -26,9 +26,12 @@ import (
 	httptrace "github.com/DataDog/dd-trace-go/contrib/net/http/v2"
 	dd_logrus "github.com/DataDog/dd-trace-go/contrib/sirupsen/logrus/v2"
 	"github.com/DataDog/dd-trace-go/v2/appsec"
+	ddotel "github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry"
 	_ "github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry/metric"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/profiler"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 func main() {
@@ -176,6 +179,53 @@ func main() {
 			logrus.Fatalln(err)
 		}
 
+		defer res.Body.Close()
+
+		requestHeaders := make(map[string]string, len(req.Header))
+		for key, values := range req.Header {
+			requestHeaders[strings.ToLower(key)] = strings.Join(values, ",")
+		}
+
+		responseHeaders := make(map[string]string, len(res.Header))
+		for key, values := range res.Header {
+			responseHeaders[key] = strings.Join(values, ",")
+		}
+
+		ctx.JSON(200, struct {
+			URL             string            `json:"url"`
+			StatusCode      int               `json:"status_code"`
+			RequestHeaders  map[string]string `json:"request_headers"`
+			ResponseHeaders map[string]string `json:"response_headers"`
+		}{URL: url, StatusCode: res.StatusCode, RequestHeaders: requestHeaders, ResponseHeaders: responseHeaders})
+	})
+
+	r.Any("/otel_drop_in_extract_and_make_distant_call", func(ctx *gin.Context) {
+		url := ctx.Request.URL.Query().Get("url")
+		if url == "" {
+			ctx.Writer.Write([]byte("OK"))
+			return
+		}
+
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+		propagator := otel.GetTextMapPropagator()
+		gctx := propagator.Extract(ctx.Request.Context(), propagation.HeaderCarrier(ctx.Request.Header))
+
+		p := ddotel.NewTracerProvider()
+		otel.SetTracerProvider(p)
+		otelTracer := p.Tracer("")
+		gctx, span := otelTracer.Start(gctx, "otel_extract_distant_call")
+		defer span.End()
+
+		req, _ := http.NewRequestWithContext(gctx, http.MethodGet, url, nil)
+		if ddSpan, ok := tracer.SpanFromContext(gctx); ok {
+			tracer.Inject(ddSpan.Context(), tracer.HTTPHeadersCarrier(req.Header))
+		}
+		propagator.Inject(gctx, propagation.HeaderCarrier(req.Header))
+
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			logrus.Fatalln("client.Do", err)
+		}
 		defer res.Body.Close()
 
 		requestHeaders := make(map[string]string, len(req.Header))

--- a/utils/build/docker/golang/app/gin/main.go
+++ b/utils/build/docker/golang/app/gin/main.go
@@ -206,9 +206,14 @@ func main() {
 			return
 		}
 
+		// Extract the incoming trace context via the OTel propagation API and start a new span.
+		// We intentionally use context.Background() instead of ctx.Request.Context(): that context
+		// already carries the server span created by the HTTP middleware, which would cause the
+		// dd-trace-go OTel bridge to parent otel_extract_distant_call to that span rather than
+		// creating a fresh root with a span link (the expected restart behavior).
 		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 		propagator := otel.GetTextMapPropagator()
-		gctx := propagator.Extract(ctx.Request.Context(), propagation.HeaderCarrier(ctx.Request.Header))
+		gctx := propagator.Extract(context.Background(), propagation.HeaderCarrier(ctx.Request.Header))
 
 		p := ddotel.NewTracerProvider()
 		otel.SetTracerProvider(p)

--- a/utils/build/docker/golang/app/net-http-orchestrion/main.go
+++ b/utils/build/docker/golang/app/net-http-orchestrion/main.go
@@ -195,9 +195,14 @@ func main() {
 			return
 		}
 
+		// Extract the incoming trace context via the OTel propagation API and start a new span.
+		// We intentionally use context.Background() instead of r.Context(): r.Context() already
+		// carries the server span created by the HTTP middleware, which would cause the dd-trace-go
+		// OTel bridge to parent otel_extract_distant_call to that span rather than creating a
+		// fresh root with a span link (the expected restart behavior).
 		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 		propagator := otel.GetTextMapPropagator()
-		ctx := propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+		ctx := propagator.Extract(context.Background(), propagation.HeaderCarrier(r.Header))
 
 		p := opentelemetry.NewTracerProvider()
 		otel.SetTracerProvider(p)

--- a/utils/build/docker/golang/app/net-http-orchestrion/main.go
+++ b/utils/build/docker/golang/app/net-http-orchestrion/main.go
@@ -188,6 +188,58 @@ func main() {
 		w.Write(jsonResponse)
 	})
 
+	mux.HandleFunc("/otel_drop_in_extract_and_make_distant_call", func(w http.ResponseWriter, r *http.Request) {
+		url := r.URL.Query().Get("url")
+		if url == "" {
+			w.Write([]byte("OK"))
+			return
+		}
+
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+		propagator := otel.GetTextMapPropagator()
+		ctx := propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+
+		p := opentelemetry.NewTracerProvider()
+		otel.SetTracerProvider(p)
+		otelTracer := p.Tracer("")
+		ctx, span := otelTracer.Start(ctx, "otel_extract_distant_call")
+		defer span.End()
+
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if ddSpan, ok := tracer.SpanFromContext(ctx); ok {
+			tracer.Inject(ddSpan.Context(), tracer.HTTPHeadersCarrier(req.Header))
+		}
+		propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.Fatalln("client.Do", err)
+		}
+		defer res.Body.Close()
+
+		requestHeaders := make(map[string]string, len(req.Header))
+		for key, values := range req.Header {
+			requestHeaders[strings.ToLower(key)] = strings.Join(values, ",")
+		}
+
+		responseHeaders := make(map[string]string, len(res.Header))
+		for key, values := range res.Header {
+			responseHeaders[key] = strings.Join(values, ",")
+		}
+
+		jsonResponse, err := json.Marshal(struct {
+			URL             string            `json:"url"`
+			StatusCode      int               `json:"status_code"`
+			RequestHeaders  map[string]string `json:"request_headers"`
+			ResponseHeaders map[string]string `json:"response_headers"`
+		}{URL: url, StatusCode: res.StatusCode, RequestHeaders: requestHeaders, ResponseHeaders: responseHeaders})
+		if err != nil {
+			log.Fatalln(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jsonResponse)
+	})
+
 	mux.HandleFunc("/headers", headers)
 	mux.HandleFunc("/headers/", headers)
 

--- a/utils/build/docker/golang/app/net-http/main.go
+++ b/utils/build/docker/golang/app/net-http/main.go
@@ -687,6 +687,58 @@ func main() {
 		w.Write(jsonData)
 	})
 
+	mux.HandleFunc("/otel_drop_in_extract_and_make_distant_call", func(w http.ResponseWriter, r *http.Request) {
+		url := r.URL.Query().Get("url")
+		if url == "" {
+			w.Write([]byte("OK"))
+			return
+		}
+
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+		propagator := otel.GetTextMapPropagator()
+		ctx := propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+
+		p := ddotel.NewTracerProvider()
+		otel.SetTracerProvider(p)
+		otelTracer := p.Tracer("")
+		ctx, span := otelTracer.Start(ctx, "otel_extract_distant_call")
+		defer span.End()
+
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if ddSpan, ok := tracer.SpanFromContext(ctx); ok {
+			tracer.Inject(ddSpan.Context(), tracer.HTTPHeadersCarrier(req.Header))
+		}
+		propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			logrus.Fatalln("client.Do", err)
+		}
+		defer res.Body.Close()
+
+		requestHeaders := make(map[string]string, len(req.Header))
+		for key, values := range req.Header {
+			requestHeaders[strings.ToLower(key)] = strings.Join(values, ",")
+		}
+
+		responseHeaders := make(map[string]string, len(res.Header))
+		for key, values := range res.Header {
+			responseHeaders[key] = strings.Join(values, ",")
+		}
+
+		jsonResponse, err := json.Marshal(struct {
+			URL             string            `json:"url"`
+			StatusCode      int               `json:"status_code"`
+			RequestHeaders  map[string]string `json:"request_headers"`
+			ResponseHeaders map[string]string `json:"response_headers"`
+		}{URL: url, StatusCode: res.StatusCode, RequestHeaders: requestHeaders, ResponseHeaders: responseHeaders})
+		if err != nil {
+			logrus.Fatalln(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jsonResponse)
+	})
+
 	mux.HandleFunc("/session/new", func(w http.ResponseWriter, r *http.Request) {
 		sessionID := strconv.Itoa(rand.Int())
 		w.Header().Add("Set-Cookie", "session="+sessionID+"; Path=/; Max-Age=3600; Secure; HttpOnly")

--- a/utils/build/docker/golang/app/net-http/main.go
+++ b/utils/build/docker/golang/app/net-http/main.go
@@ -694,9 +694,14 @@ func main() {
 			return
 		}
 
+		// Extract the incoming trace context via the OTel propagation API and start a new span.
+		// We intentionally use context.Background() instead of r.Context(): r.Context() already
+		// carries the server span created by the HTTP middleware, which would cause the dd-trace-go
+		// OTel bridge to parent otel_extract_distant_call to that span rather than creating a
+		// fresh root with a span link (the expected restart behavior).
 		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 		propagator := otel.GetTextMapPropagator()
-		ctx := propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+		ctx := propagator.Extract(context.Background(), propagation.HeaderCarrier(r.Header))
 
 		p := ddotel.NewTracerProvider()
 		otel.SetTracerProvider(p)


### PR DESCRIPTION
## Motivation

Enable `Test_ExtractBehavior_Restart_Otel` for Go weblogs. This test covers the case where a trace is initiated via the OTel propagation API rather than the auto-instrumented HTTP path, and verifies that span links are correctly created when `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT=restart`.

The endpoint was already implemented for Java, .NET, and Ruby but was missing for Go. Tracked as `missing_feature (OTel extraction endpoint not implemented)` in `manifests/golang.yml`.

## Changes

- Add `/otel_drop_in_extract_and_make_distant_call` endpoint to all 5 Go weblogs (`net-http`, `chi`, `echo`, `gin`, `net-http-orchestrion`)
  - Extracts incoming trace context via OTel propagation API
  - Starts an OTel span named `otel_extract_distant_call` using the dd-trace-go OTel bridge
  - Injects both DD headers and OTel baggage into the outgoing request
  - Returns JSON with `url`, `status_code`, `request_headers`, `response_headers`
- Add OTel imports (`ddotel`, `go.opentelemetry.io/otel`, `go.opentelemetry.io/otel/propagation`) to `chi`, `echo`, and `gin` which previously had none
- Update `manifests/golang.yml`: `Test_ExtractBehavior_Restart_Otel: missing_feature` → `v2.10.0-dev`

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)