### PR TITLE
Fix code origin setup race

### DIFF
--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -3,7 +3,7 @@
 # Copyright 2021 Datadog, Inc.
 
 import tests.debugger.utils as debugger
-from utils import context, features, logger, scenarios, slow
+from utils import context, features, interfaces, logger, scenarios, slow
 import json
 import time
 
@@ -220,8 +220,14 @@ class Test_Debugger_InProduct_Enablement_Code_Origin(debugger.BaseDebuggerTest):
 class Test_Debugger_InProduct_Enablement_Code_Origin_Default_On(debugger.BaseDebuggerTest):
     def setup_code_origin_enabled_by_default(self):
         self.initialize_weblog_remote_config()
+        threshold = self._get_max_trace_file_number()
+        self._span_found = False
         self.send_weblog_request("/")
-        self.code_origin_enabled_by_default = self.wait_for_code_origin_span(TIMEOUT)
+        interfaces.agent.wait_for(
+            lambda data: self._wait_for_code_origin_span(data, threshold=threshold),
+            timeout=TIMEOUT,
+        )
+        self.code_origin_enabled_by_default = self._span_found
 
     def test_code_origin_enabled_by_default(self):
         self.assert_setup_ok()


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f06d47f2-f38e-4d51-8235-a75b463d696f","source":"chat","resourceId":"c0ecd1d7-d53d-43fa-aa8b-fff603edb866","workflowId":"0783f515-646a-452e-bdac-9286cd244a00","codeChangeId":"0783f515-646a-452e-bdac-9286cd244a00","sourceType":"chat"} -->
## Motivation

`Test_Debugger_InProduct_Enablement_Code_Origin_Default_On.test_code_origin_enabled_by_default[flask-poc]` can miss the span generated by its setup request. The setup sent `/` before the code-origin wait helper captured the trace-file threshold, so a fast trace file could be excluded by the helper's `> threshold` check and fail with `Expected code origin enabled by default`.

## Changes

- Capture the current agent trace-file threshold before sending the setup request.
- Reuse the existing code-origin span predicate with that threshold via `interfaces.agent.wait_for`.
- Store the resulting `_span_found` state as `code_origin_enabled_by_default` without changing production code.

## Testing/Validation

- `python -m py_compile tests/debugger/test_debugger_inproduct_enablement.py`
- `./format.sh --check` reached mypy, ruff format, ruff check, and trailing whitespace checks successfully, then stopped while installing `yamlfmt` because the network proxy returned `CONNECT tunnel failed, response 502`.
- `SYSTEM_TEST_BUILD_TIMEOUT=900 ./build.sh python -i runner,weblog -w flask-poc` reached the weblog build, then stopped because Docker could not pull `datadog/system-tests:flask-poc.base-v14` from Docker Hub due `Bad Gateway`.
- The requested four local runs of the target E2E test could not be completed because the `flask-poc` weblog image could not be built in this environment.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/c0ecd1d7-d53d-43fa-aa8b-fff603edb866)

Comment @datadog to request changes