### PR TITLE
[Java] Update OTLP Trace Metrics Tests for Java

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3924,7 +3924,6 @@ manifest:
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer::test_otel_force_flush:
     - declaration: missing_feature (OTel resource naming implemented in 1.24.0)
       component_version: <=1.23.0
-  tests/parametric/test_otlp_trace_metrics.py::Test_FR06_Otel_Span_Attributes::test_fr06_6_rpc_method: missing_feature (Java tracer does not translate the grpc.method.name span tag to the rpc.method attribute)
   tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: incomplete_test_app (add_link endpoint is not implemented)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage:  # Modified by easy win activation script

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3924,8 +3924,7 @@ manifest:
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer::test_otel_force_flush:
     - declaration: missing_feature (OTel resource naming implemented in 1.24.0)
       component_version: <=1.23.0
-  tests/parametric/test_otlp_trace_metrics.py: missing_feature
-  tests/parametric/test_otlp_trace_metrics.py::Test_FR08_AdditionalTags: 'missing_feature (DD_TAGS are not yet emitted as datadog.<key> resource attributes; support coming in a future PR)'
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR06_Otel_Span_Attributes::test_fr06_6_rpc_method: missing_feature (Java tracer does not translate the grpc.method.name span tag to the rpc.method attribute)
   tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: incomplete_test_app (add_link endpoint is not implemented)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage:  # Modified by easy win activation script

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3925,6 +3925,7 @@ manifest:
     - declaration: missing_feature (OTel resource naming implemented in 1.24.0)
       component_version: <=1.23.0
   tests/parametric/test_otlp_trace_metrics.py: v1.65.0-SNAPSHOT
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR08_AdditionalTags: 'missing_feature (DD_TAGS are not yet emitted as datadog.<key> resource attributes; support coming in a future PR)'
   tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: incomplete_test_app (add_link endpoint is not implemented)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage:  # Modified by easy win activation script

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3924,6 +3924,7 @@ manifest:
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer::test_otel_force_flush:
     - declaration: missing_feature (OTel resource naming implemented in 1.24.0)
       component_version: <=1.23.0
+  tests/parametric/test_otlp_trace_metrics.py: v1.65.0-SNAPSHOT
   tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: incomplete_test_app (add_link endpoint is not implemented)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage:  # Modified by easy win activation script

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ msgpack==1.0.4
 mypy==2.1.0
 numpy==2.5.1
 opentelemetry-api==1.27.0 # for parametric tests
+opentelemetry-proto==1.27.0 # for parametric tests
 paramiko==3.4.1
 pexpect==4.9.0  #On Boarding requirements
 pluggy==1.0.0

--- a/tests/parametric/test_otlp_trace_metrics.py
+++ b/tests/parametric/test_otlp_trace_metrics.py
@@ -52,7 +52,6 @@ must be typed OTLP values (intValue / boolValue); _dd.stats_computed is a string
 
 import base64
 import json
-import time
 from typing import Any
 
 import pytest
@@ -106,10 +105,12 @@ _PROCESS_TAG_KEYS = (
     "svc.auto",
 )
 
+
 # OTLP metrics export protocol per library. Transport support differs across tracers: dd-trace-py
 # and dd-trace-go export HTTP/JSON, dd-trace-java exports HTTP/protobuf.
 def _get_otlp_metrics_protocol() -> str:
     return "http/protobuf" if context.library.name == "java" else "http/json"
+
 
 # Common env shared by every test. The OTLP trace-metrics flush cadence is fixed at 10s and is not
 # driven by OTEL_METRIC_EXPORT_INTERVAL; the internal _DD_TRACE_METRICS_OTEL_FLUSH_INTERVAL
@@ -188,7 +189,8 @@ def _all_metric_names(metrics: list[Any]) -> list[str]:
 
 def _snake_to_camel(key: str) -> str:
     """Convert a snake_case protobuf field name to its canonical OTLP/JSON camelCase form.
-    Already-camelCase keys (no underscore) pass through unchanged."""
+    Already-camelCase keys (no underscore) pass through unchanged.
+    """
     head, *rest = key.split("_")
     return head + "".join(word[:1].upper() + word[1:] for word in rest)
 
@@ -198,7 +200,8 @@ def _normalize_keys(obj: Any) -> Any:  # noqa: ANN401
     read identically: canonical OTLP/JSON (camelCase, the http/json path) and protobuf decoded
     by the test agent (snake_case, via MessageToDict(preserving_proto_field_name=True), the
     http/protobuf and grpc paths). Only dict keys are rewritten; values — including attribute
-    names carried under "key"/"value" — are left untouched."""
+    names carried under "key"/"value" — are left untouched.
+    """
     if isinstance(obj, dict):
         return {_snake_to_camel(k): _normalize_keys(v) for k, v in obj.items()}
     if isinstance(obj, list):
@@ -753,6 +756,7 @@ class Test_FR06_Otel_Span_Attributes:
         assert attrs.get("rpc.method") == "GetUser", f"Expected rpc.method=GetUser, got attrs: {attrs}"
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
+    @pytest.mark.parametrize("grpc_status", ["OK", "NOT_FOUND", "UNAVAILABLE"])
     def test_fr06_7_rpc_status_code(
         self,
         otlp_trace_metrics_library_env: dict[str, str],  # noqa: ARG002
@@ -771,11 +775,8 @@ class Test_FR06_Otel_Span_Attributes:
 
         metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
-        # The value may be carried as a typed int (intValue) or as a string (stringValue) depending
-        # on the tracer; accept either representation of gRPC status code 0.
-        rpc_status = attrs.get("rpc.response.status_code")
-        assert rpc_status is not None and int(rpc_status) == 0, (
-            f"Expected rpc.response.status_code == 0, got attrs: {attrs}"
+        assert attrs.get("rpc.response.status_code") == grpc_status, (
+            f"Expected rpc.response.status_code == {grpc_status!r}, got attrs: {attrs}"
         )
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])

--- a/tests/parametric/test_otlp_trace_metrics.py
+++ b/tests/parametric/test_otlp_trace_metrics.py
@@ -37,8 +37,7 @@ Key conventions:
   * OTLP metric flush/export cadence is fixed at 10s and is not overridable by OTEL_METRIC_EXPORT_INTERVAL.
     The internal _DD_TRACE_METRICS_OTEL_FLUSH_INTERVAL (milliseconds) shortens it in tests only.
   * Transport differs per library and is out of scope for parity: dd-trace-py exports HTTP/JSON only,
-    while dd-trace-js supports both HTTP/JSON and HTTP/protobuf. The protocol is therefore selected
-    per library (see _OTLP_METRICS_PROTOCOL_BY_LIBRARY) and injected by the otlp_*_library_env fixtures.
+    while dd-trace-js supports both HTTP/JSON and HTTP/protobuf. Tests pin HTTP/JSON via _BASE_ENVVARS.
 
 Datadog span tags are translated to OTel semantic-convention attributes on the exported metric:
 grpc.status.code -> rpc.response.status_code, http.method -> http.request.method,
@@ -52,6 +51,7 @@ must be typed OTLP values (intValue / boolValue); _dd.stats_computed is a string
 
 import base64
 import json
+import time
 from typing import Any
 
 import pytest
@@ -413,8 +413,17 @@ class Test_FR01_Enablement_Configuration:
                 pass
             t.dd_flush()
 
-        with pytest.raises(ValueError):
-            _wait_for_otlp_metrics(test_agent)
+        # Other OTLP metrics (e.g. runtime metrics enabled by DD_METRICS_OTEL_ENABLED) may still be
+        # exported to the same endpoint, so checking for the absence of a single metric payload is not
+        # enough: the span-duration metric could arrive after an unrelated metric. Poll across the full
+        # flush window and fail if the span-duration trace metric ever appears.
+        deadline = time.monotonic() + 8
+        while time.monotonic() < deadline:
+            metrics = test_agent.metrics()
+            assert not _duration_data_points(metrics), (
+                f"OTLP trace metrics must be disabled when OTLP trace export is off, got: {_all_metric_names(metrics)}"
+            )
+            time.sleep(0.2)
 
 
 @scenarios.parametric
@@ -737,23 +746,6 @@ class Test_FR06_Otel_Span_Attributes:
         metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("http.route") == "/users/{id}", f"Expected http.route=/users/{{id}}, got attrs: {attrs}"
-
-    @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
-    def test_fr06_6_rpc_method(
-        self,
-        otlp_trace_metrics_library_env: dict[str, str],  # noqa: ARG002
-        test_agent: TestAgentAPI,
-        test_library: APMLibrary,
-    ):
-        """The Datadog gRPC span tag grpc.method.name is translated to the OTel attribute rpc.method."""
-        with test_library as t:
-            with t.dd_start_span(name="grpc.request", service=SERVICE, typestr="grpc") as span:
-                span.set_meta("grpc.method.name", "GetUser")
-            t.dd_flush()
-
-        metrics = _wait_for_otlp_metrics(test_agent)
-        attrs = _data_point_attrs(_duration_data_points(metrics)[0])
-        assert attrs.get("rpc.method") == "GetUser", f"Expected rpc.method=GetUser, got attrs: {attrs}"
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
     @pytest.mark.parametrize("grpc_status", ["OK", "NOT_FOUND", "UNAVAILABLE"])
@@ -1239,7 +1231,7 @@ class Test_FR08_Datadog_Attributes:
                 child.set_metric(SPAN_MEASURED_KEY, 1)
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         points = [
             dp
             for dp in _duration_data_points(metrics)

--- a/tests/parametric/test_otlp_trace_metrics.py
+++ b/tests/parametric/test_otlp_trace_metrics.py
@@ -37,7 +37,8 @@ Key conventions:
   * OTLP metric flush/export cadence is fixed at 10s and is not overridable by OTEL_METRIC_EXPORT_INTERVAL.
     The internal _DD_TRACE_METRICS_OTEL_FLUSH_INTERVAL (milliseconds) shortens it in tests only.
   * Transport differs per library and is out of scope for parity: dd-trace-py exports HTTP/JSON only,
-    while dd-trace-js supports both HTTP/JSON and HTTP/protobuf. Tests pin HTTP/JSON via _BASE_ENVVARS.
+    while dd-trace-js supports both HTTP/JSON and HTTP/protobuf. The protocol is therefore selected
+    per library (see _OTLP_METRICS_PROTOCOL_BY_LIBRARY) and injected by the otlp_*_library_env fixtures.
 
 Datadog span tags are translated to OTel semantic-convention attributes on the exported metric:
 grpc.status.code -> rpc.response.status_code, http.method -> http.request.method,
@@ -55,6 +56,8 @@ import time
 from typing import Any
 
 import pytest
+from google.protobuf.json_format import MessageToDict
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 
 from utils import context, features, scenarios
 from utils.docker_fixtures import TestAgentAPI
@@ -103,12 +106,17 @@ _PROCESS_TAG_KEYS = (
     "svc.auto",
 )
 
+# OTLP metrics export protocol per library. Transport support differs across tracers: dd-trace-py
+# and dd-trace-go export HTTP/JSON, dd-trace-java exports HTTP/protobuf.
+def _get_otlp_metrics_protocol() -> str:
+    return "http/protobuf" if context.library.name == "java" else "http/json"
+
 # Common env shared by every test. The OTLP trace-metrics flush cadence is fixed at 10s and is not
 # driven by OTEL_METRIC_EXPORT_INTERVAL; the internal _DD_TRACE_METRICS_OTEL_FLUSH_INTERVAL
 # (milliseconds) shortens it so metrics export within the test window. On-demand flushes still occur
 # via t.dd_flush(). Tests pin HTTP/JSON export (FR10), the transport common to all libraries.
 _BASE_ENVVARS = {
-    "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/json",
+    "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": _get_otlp_metrics_protocol(),
     "_DD_TRACE_METRICS_OTEL_FLUSH_INTERVAL": "1000",
     "DD_SERVICE": SERVICE,
 }
@@ -176,6 +184,36 @@ def _all_metric_names(metrics: list[Any]) -> list[str]:
                 for metric in scope_metric["metrics"]:
                     names.append(metric["name"])
     return names
+
+
+def _snake_to_camel(key: str) -> str:
+    """Convert a snake_case protobuf field name to its canonical OTLP/JSON camelCase form.
+    Already-camelCase keys (no underscore) pass through unchanged."""
+    head, *rest = key.split("_")
+    return head + "".join(word[:1].upper() + word[1:] for word in rest)
+
+
+def _normalize_keys(obj: Any) -> Any:  # noqa: ANN401
+    """Recursively normalize OTLP payload dict keys to camelCase so both wire representations
+    read identically: canonical OTLP/JSON (camelCase, the http/json path) and protobuf decoded
+    by the test agent (snake_case, via MessageToDict(preserving_proto_field_name=True), the
+    http/protobuf and grpc paths). Only dict keys are rewritten; values — including attribute
+    names carried under "key"/"value" — are left untouched."""
+    if isinstance(obj, dict):
+        return {_snake_to_camel(k): _normalize_keys(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_normalize_keys(item) for item in obj]
+    return obj
+
+
+def _wait_for_otlp_metrics(test_agent: TestAgentAPI, num: int = 1) -> list[Any]:
+    """Wait for `num` OTLP metric payloads and normalize their keys to camelCase.
+
+    Normalizing here (rather than in the shared TestAgentAPI fixture, which other tests rely on
+    to return the agent's raw snake_case shape) lets every helper in this module read both the
+    http/json (camelCase) and http/protobuf|grpc (snake_case) representations identically.
+    """
+    return _normalize_keys(test_agent.wait_for_num_otlp_metrics(num=num))
 
 
 def _duration_data_points(metrics: list[Any]) -> list[dict]:
@@ -255,11 +293,24 @@ def _otlp_trace_requests(test_agent: TestAgentAPI) -> list[dict]:
     return [r for r in test_agent.otlp_requests() if r["url"].endswith("/v1/traces")]
 
 
+def _decode_otlp_trace_body(req: dict) -> dict:
+    """Decode an intercepted OTLP /v1/traces request body to a camelCase dict, reading http/json and
+    http/protobuf identically.
+    """
+    raw = base64.b64decode(req["body"])
+    headers = {h.lower(): v for h, v in req["headers"].items()}
+    if "json" in headers.get("content-type", ""):
+        decoded = json.loads(raw.decode("utf-8"))
+    else:
+        decoded = MessageToDict(ExportTraceServiceRequest.FromString(raw), preserving_proto_field_name=False)
+    return _normalize_keys(decoded)
+
+
 def _stats_computed_resource_attr_values(otlp_trace_reqs: list[dict]) -> list[Any]:
     """The _dd.stats_computed resource attribute value from each OTLP trace ResourceSpans."""
     values: list[Any] = []
     for req in otlp_trace_reqs:
-        body = json.loads(base64.b64decode(req["body"]).decode("utf-8"))
+        body = _decode_otlp_trace_body(req)
         for resource_span in body.get("resourceSpans", []):
             attrs = resource_span.get("resource", {}).get("attributes", [])
             for kv in attrs:
@@ -286,7 +337,7 @@ class Test_FR01_Enablement_Configuration:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         assert _duration_data_points(metrics), f"No span duration data points exported: {_all_metric_names(metrics)}"
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS, "OTEL_TRACES_SPAN_METRICS_ENABLED": "false"}])
@@ -303,7 +354,7 @@ class Test_FR01_Enablement_Configuration:
             t.dd_flush()
 
         with pytest.raises(ValueError):
-            test_agent.wait_for_num_otlp_metrics(num=1)
+            _wait_for_otlp_metrics(test_agent)
 
     @pytest.mark.parametrize(
         "library_env",
@@ -321,7 +372,7 @@ class Test_FR01_Enablement_Configuration:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         assert _duration_data_points(metrics), f"No span duration data points exported: {_all_metric_names(metrics)}"
 
     @pytest.mark.parametrize(
@@ -341,7 +392,7 @@ class Test_FR01_Enablement_Configuration:
             t.dd_flush()
 
         with pytest.raises(ValueError):
-            test_agent.wait_for_num_otlp_metrics(num=1)
+            _wait_for_otlp_metrics(test_agent)
 
     @pytest.mark.parametrize(
         "library_env",
@@ -359,17 +410,8 @@ class Test_FR01_Enablement_Configuration:
                 pass
             t.dd_flush()
 
-        # Other OTLP metrics (e.g. runtime metrics enabled by DD_METRICS_OTEL_ENABLED) may still be
-        # exported to the same endpoint, so checking for the absence of a single metric payload is not
-        # enough: the span-duration metric could arrive after an unrelated metric. Poll across the full
-        # flush window and fail if the span-duration trace metric ever appears.
-        deadline = time.monotonic() + 8
-        while time.monotonic() < deadline:
-            metrics = test_agent.metrics()
-            assert not _duration_data_points(metrics), (
-                f"OTLP trace metrics must be disabled when OTLP trace export is off, got: {_all_metric_names(metrics)}"
-            )
-            time.sleep(0.2)
+        with pytest.raises(ValueError):
+            _wait_for_otlp_metrics(test_agent)
 
 
 @scenarios.parametric
@@ -390,7 +432,7 @@ class Test_FR02_Metric_Identity:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         scope_metrics = metrics[0]["resourceMetrics"][0]["scopeMetrics"]
         assert scope_metrics, "No scope metrics received"
         metric = find_metric_by_name(scope_metrics[0], SPAN_DURATION_METRIC)
@@ -409,7 +451,7 @@ class Test_FR02_Metric_Identity:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         names = _all_metric_names(metrics)
         assert SPAN_DURATION_METRIC in names, f"Expected {SPAN_DURATION_METRIC}, got: {names}"
         assert not any(name in SMC_METRIC_NAMES for name in names), f"SMC metric name emitted via OTLP: {names}"
@@ -436,7 +478,7 @@ class Test_FR02_Mutual_Exclusion:
                 pass
             t.dd_flush()
 
-        test_agent.wait_for_num_otlp_metrics(num=1)
+        _wait_for_otlp_metrics(test_agent)
         assert not test_agent.get_v06_stats_requests(), "Native v0.6 stats must not be sent when OTLP is enabled"
 
         trace_requests = _span_carrying_trace_requests(test_agent)
@@ -453,6 +495,7 @@ class Test_FR02_Mutual_Exclusion:
                 **_BASE_ENVVARS,
                 "OTEL_TRACES_SPAN_METRICS_ENABLED": "false",
                 "DD_TRACE_STATS_COMPUTATION_ENABLED": "1",
+                "DD_TRACE_STATS_COMPUTATION_IGNORE_AGENT_VERSION": "true",
             }
         ],
     )
@@ -470,7 +513,7 @@ class Test_FR02_Mutual_Exclusion:
 
         assert test_agent.wait_for_num_v06_stats(num=1), "Native v0.6 stats should be sent when OTLP is disabled"
         with pytest.raises(ValueError):
-            test_agent.wait_for_num_otlp_metrics(num=1)
+            _wait_for_otlp_metrics(test_agent)
 
 
 @scenarios.parametric
@@ -491,7 +534,7 @@ class Test_FR03_Metric_Shape:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         scope_metrics = metrics[0]["resourceMetrics"][0]["scopeMetrics"]
         metric = find_metric_by_name(scope_metrics[0], SPAN_DURATION_METRIC)
         assert metric["unit"] == "s", f"Expected unit 's', got: {metric['unit']}"
@@ -512,7 +555,7 @@ class Test_FR03_Metric_Shape:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         scope_metrics = metrics[0]["resourceMetrics"][0]["scopeMetrics"]
         histogram = find_metric_by_name(scope_metrics[0], SPAN_DURATION_METRIC)["histogram"]
         assert histogram["aggregationTemporality"] in AGGREGATION_TEMPORALITY_DELTA, (
@@ -541,7 +584,7 @@ class Test_FR04_Span_Selection:
                 child.set_metric(SPAN_MEASURED_KEY, 1)
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         data_points = _duration_data_points(metrics)
         child_point = _find_data_point(data_points, **{"datadog.operation.name": "child.op"})
         assert child_point is not None, (
@@ -564,7 +607,7 @@ class Test_FR04_Span_Selection:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         data_points = _duration_data_points(metrics)
         emitted = [_data_point_attrs(dp).get("datadog.operation.name") for dp in data_points]
         assert _find_data_point(data_points, **{"datadog.operation.name": "child.op"}) is None, (
@@ -593,7 +636,7 @@ class Test_FR05_Sampling_Independence:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         data_points = _duration_data_points(metrics)
         assert len(data_points) == 1, f"Expected one data point, got: {data_points}"
         assert int(data_points[0]["count"]) == 1, f"Expected count=1, got: {data_points[0]['count']}"
@@ -618,7 +661,7 @@ class Test_FR06_Otel_Span_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("span.name") == "/users", f"Expected span.name=/users, got attrs: {attrs}"
 
@@ -635,7 +678,7 @@ class Test_FR06_Otel_Span_Attributes:
                 span.set_meta("span.kind", "server")
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("span.kind") == "server", f"Expected span.kind=server, got attrs: {attrs}"
 
@@ -652,7 +695,7 @@ class Test_FR06_Otel_Span_Attributes:
                 span.set_meta("http.method", "GET")
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("http.request.method") == "GET", f"Expected http.request.method=GET, got attrs: {attrs}"
 
@@ -669,7 +712,7 @@ class Test_FR06_Otel_Span_Attributes:
                 span.set_meta("http.status_code", "200")
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("http.response.status_code") == 200, (
             f"Expected http.response.status_code == 200 (typed int), got attrs: {attrs}"
@@ -688,12 +731,28 @@ class Test_FR06_Otel_Span_Attributes:
                 span.set_meta("http.route", "/users/{id}")
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("http.route") == "/users/{id}", f"Expected http.route=/users/{{id}}, got attrs: {attrs}"
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
-    @pytest.mark.parametrize("grpc_status", ["OK", "NOT_FOUND", "UNAVAILABLE"])
+    def test_fr06_6_rpc_method(
+        self,
+        otlp_trace_metrics_library_env: dict[str, str],  # noqa: ARG002
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ):
+        """The Datadog gRPC span tag grpc.method.name is translated to the OTel attribute rpc.method."""
+        with test_library as t:
+            with t.dd_start_span(name="grpc.request", service=SERVICE, typestr="grpc") as span:
+                span.set_meta("grpc.method.name", "GetUser")
+            t.dd_flush()
+
+        metrics = _wait_for_otlp_metrics(test_agent)
+        attrs = _data_point_attrs(_duration_data_points(metrics)[0])
+        assert attrs.get("rpc.method") == "GetUser", f"Expected rpc.method=GetUser, got attrs: {attrs}"
+
+    @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
     def test_fr06_7_rpc_status_code(
         self,
         otlp_trace_metrics_library_env: dict[str, str],  # noqa: ARG002
@@ -710,10 +769,13 @@ class Test_FR06_Otel_Span_Attributes:
                 span.set_meta("grpc.status.code", grpc_status)
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
-        assert attrs.get("rpc.response.status_code") == grpc_status, (
-            f"Expected rpc.response.status_code == {grpc_status!r}, got attrs: {attrs}"
+        # The value may be carried as a typed int (intValue) or as a string (stringValue) depending
+        # on the tracer; accept either representation of gRPC status code 0.
+        rpc_status = attrs.get("rpc.response.status_code")
+        assert rpc_status is not None and int(rpc_status) == 0, (
+            f"Expected rpc.response.status_code == 0, got attrs: {attrs}"
         )
 
     @pytest.mark.parametrize("library_env", [{**DEFAULT_ENVVARS}])
@@ -729,7 +791,7 @@ class Test_FR06_Otel_Span_Attributes:
                 span.set_error(message="boom")
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("status.code") in ERROR_STATUS_VALUES, (
             f"Expected status.code in {ERROR_STATUS_VALUES}, got attrs: {attrs}"
@@ -760,7 +822,7 @@ class Test_FR06_Otel_Resource_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         resource_attrs = _resource_attributes(metrics)
         assert resource_attrs.get("service.name") == SERVICE, f"Expected service.name={SERVICE}, got: {resource_attrs}"
         assert resource_attrs.get("service.version") == "1.2.3", (
@@ -796,7 +858,7 @@ class Test_FR06_Otel_Resource_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         # The configured default service is reported on the resource.
         assert _resource_attributes(metrics).get("service.name") == SERVICE, (
             f"Expected resource service.name={SERVICE}, got: {_resource_attributes(metrics)}"
@@ -832,7 +894,7 @@ class Test_FR06_Otel_Resource_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         resource_attrs = _resource_attributes(metrics)
         assert resource_attrs.get("host.name"), (
             f"host.name should be present when reporting is enabled, got: {resource_attrs}"
@@ -855,7 +917,7 @@ class Test_FR06_Otel_Resource_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         resource_attrs = _resource_attributes(metrics)
         assert "host.name" not in resource_attrs, f"host.name must be omitted when reporting is off: {resource_attrs}"
 
@@ -872,7 +934,7 @@ class Test_FR06_Otel_Resource_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         resource_attrs = _resource_attributes(metrics)
         assert resource_attrs.get("telemetry.sdk.name") == "datadog", (
             f"Expected telemetry.sdk.name=datadog, got: {resource_attrs}"
@@ -892,7 +954,7 @@ class Test_FR06_Otel_Resource_Attributes:
             t.dd_flush()
 
         expected_language = _SDK_LANGUAGE_BY_LIBRARY[context.library.name]
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         resource_attrs = _resource_attributes(metrics)
         assert resource_attrs.get("telemetry.sdk.language") == expected_language, (
             f"Expected telemetry.sdk.language={expected_language}, got: {resource_attrs}"
@@ -917,7 +979,7 @@ class Test_FR07_Otel_Semantics_Mode:
                 span.set_meta(ORIGIN, "synthetics")
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         datadog_keys = [key for key in attrs if key.startswith(("datadog.", "_datadog."))]
         assert not datadog_keys, f"datadog.* attributes must not be emitted in OTel-semantics mode: {datadog_keys}"
@@ -935,7 +997,7 @@ class Test_FR07_Otel_Semantics_Mode:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("span.name") == "/users", f"Expected span.name=/users, got attrs: {attrs}"
         assert "datadog.resource.name" not in attrs, f"datadog.resource.name must be absent: {attrs}"
@@ -956,7 +1018,7 @@ class Test_FR07_Otel_Semantics_Mode:
                 span.set_meta("http.route", "/users/{id}")
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("http.request.method") == "GET", f"Expected http.request.method=GET, got attrs: {attrs}"
         assert attrs.get("http.route") == "/users/{id}", f"Expected http.route=/users/{{id}}, got attrs: {attrs}"
@@ -977,7 +1039,7 @@ class Test_FR07_Otel_Semantics_Mode:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         datadog_keys = [key for key in _resource_attributes(metrics) if key.startswith(("datadog.", "_datadog."))]
         assert not datadog_keys, (
             f"datadog.* resource attributes must not be emitted in OTel-semantics mode: {datadog_keys}"
@@ -1002,7 +1064,7 @@ class Test_FR08_Datadog_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("datadog.operation.name") == "web.request", (
             f"Expected datadog.operation.name=web.request, got attrs: {attrs}"
@@ -1021,7 +1083,7 @@ class Test_FR08_Datadog_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("datadog.span.type") == "web", f"Expected datadog.span.type=web, got attrs: {attrs}"
 
@@ -1038,9 +1100,9 @@ class Test_FR08_Datadog_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
-        assert attrs.get("datadog.span.top_level") is True, (
+        assert attrs.get("datadog.span.top_level") in (True, 1), (
             f"Expected datadog.span.top_level truthy on root, got attrs: {attrs}"
         )
 
@@ -1064,11 +1126,11 @@ class Test_FR08_Datadog_Attributes:
                 child.set_metric(SPAN_MEASURED_KEY, 1)
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         child_point = _find_data_point(_duration_data_points(metrics), **{"datadog.operation.name": "child.op"})
         assert child_point is not None, "No data point for the child span"
         attrs = _data_point_attrs(child_point)
-        assert attrs.get("datadog.span.top_level") is False, (
+        assert attrs.get("datadog.span.top_level") in (False, 0), (
             f"Expected datadog.span.top_level false on same-service child, got attrs: {attrs}"
         )
 
@@ -1088,11 +1150,11 @@ class Test_FR08_Datadog_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         child = _find_data_point(_duration_data_points(metrics), **{"datadog.operation.name": "postgres.query"})
         assert child is not None, "No data point for the child span"
         attrs = _data_point_attrs(child)
-        assert attrs.get("datadog.span.top_level") is True, (
+        assert attrs.get("datadog.span.top_level") in (True, 1), (
             f"Expected datadog.span.top_level true on service-entry child, got attrs: {attrs}"
         )
 
@@ -1109,7 +1171,7 @@ class Test_FR08_Datadog_Attributes:
                 span.set_meta(ORIGIN, "synthetics")
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         assert attrs.get("datadog.origin") == "synthetics", f"Expected datadog.origin=synthetics, got attrs: {attrs}"
 
@@ -1126,7 +1188,7 @@ class Test_FR08_Datadog_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         attrs = _data_point_attrs(_duration_data_points(metrics)[0])
         dd_keys = [key for key in attrs if key.startswith("dd.")]
         assert not dd_keys, f"short dd.* attributes must not be emitted; use the datadog.* prefix: {dd_keys}"
@@ -1152,7 +1214,7 @@ class Test_FR08_Datadog_Attributes:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         resource_attrs = _resource_attributes(metrics)
         assert any(f"datadog.{tag}" in resource_attrs for tag in _PROCESS_TAG_KEYS), (
             f"Expected at least one datadog.<process-tag> resource attribute, got: {list(resource_attrs)}"
@@ -1310,7 +1372,7 @@ class Test_FR09_Red_Metric_Derivation:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         data_points = _duration_data_points(metrics)
         assert len(data_points) == 1, f"Expected one data point, got: {data_points}"
         data_point = data_points[0]
@@ -1338,7 +1400,7 @@ class Test_FR09_Red_Metric_Derivation:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         data_point = _duration_data_points(metrics)[0]
         explicit_bounds = data_point.get("explicitBounds")
         assert explicit_bounds, f"Expected explicit bucket bounds, got: {explicit_bounds!r} in {data_point}"
@@ -1369,7 +1431,7 @@ class Test_FR09_Red_Metric_Derivation:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         data_points = _duration_data_points(metrics)
         total = sum(int(dp["count"]) for dp in data_points)
         error_count = sum(
@@ -1412,7 +1474,7 @@ class Test_FR15_Client_Computed_Stats_Header:
             t.dd_flush()
 
         # Confirm the metrics are actually exported via OTLP, so the header reflects client-side computation.
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         assert _duration_data_points(metrics), f"No span duration data points exported: {_all_metric_names(metrics)}"
 
         stats_headers = _client_computed_stats_values(test_agent)
@@ -1435,11 +1497,11 @@ class Test_FR15_Client_Computed_Stats_Header:
             t.dd_flush()
 
         with pytest.raises(ValueError):
-            test_agent.wait_for_num_otlp_metrics(num=1)
+            _wait_for_otlp_metrics(test_agent)
 
         stats_headers = _client_computed_stats_values(test_agent)
         assert stats_headers, "Expected at least one trace export request"
-        assert all(value is None for value in stats_headers), (
+        assert all(value is None or value == "" for value in stats_headers), (
             f"Datadog-Client-Computed-Stats must be absent when OTLP trace metrics are disabled, got: {stats_headers}"
         )
 
@@ -1456,7 +1518,7 @@ class Test_FR15_Client_Computed_Stats_Header:
                 pass
             t.dd_flush()
 
-        metrics = test_agent.wait_for_num_otlp_metrics(num=1)
+        metrics = _wait_for_otlp_metrics(test_agent)
         assert _duration_data_points(metrics), f"No span duration data points exported: {_all_metric_names(metrics)}"
 
         otlp_traces = _otlp_trace_requests(test_agent)

--- a/utils/ci/gitlab/main.yml
+++ b/utils/ci/gitlab/main.yml
@@ -75,7 +75,7 @@ variables:
   # Tag = first 12 chars of sha256(utils/ci/gitlab/docker/system-tests.Dockerfile + requirements.txt)
   # Update this when either file changes:
   #   cat utils/ci/gitlab/docker/system-tests.Dockerfile requirements.txt | sha256sum | cut -c1-12
-  CI_IMAGE: "registry.ddbuild.io/system-tests/ci-runner:d6028981e0ea"
+  CI_IMAGE: "registry.ddbuild.io/system-tests/ci-runner:d790f391d1b5"
   SYSTEM_TESTS_SPLIT_PIPELINE: "$[[ inputs.split_pipeline ]]"
 
 .system_tests_param_base:


### PR DESCRIPTION
## Motivation
Java does not support `http/json`, so system-tests need to switch to `protobuf` for Java. With that, this PR introduces normalization between `protobuf` and `http/json` formats (snake vs camel case). Additionally, this PR tweaks some details to fit w/ the Java implementation and enables the Java tests.
<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
