### PR TITLE
[nodejs] Fix SSI tests after new major release

### DIFF
--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -43,6 +43,7 @@ class TestDockerSSIFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.0")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
+    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
     @irrelevant(context.library >= "python@4.0.0rc1" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime < "2.6.0")
     def test_install_supported_runtime(self):
@@ -78,6 +79,7 @@ class TestDockerSSIFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.0")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
+    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
     @irrelevant(context.library >= "python@4.0.0rc1" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime < "2.6.0")
     def test_telemetry(self):
@@ -107,6 +109,7 @@ class TestDockerSSIFeatures:
     @bug(context.library == "nodejs" and context.installed_language_runtime < "12.17.0", reason="INPLAT-252")
     @bug(context.library == "java" and context.installed_language_runtime == "1.7.0-201", reason="INPLAT-427")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime >= "17.0")
+    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
     @irrelevant(context.library == "dotnet" and context.installed_language_runtime >= "6.0.0")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime >= "2.6.0")
     def test_telemetry_abort(self):
@@ -146,6 +149,7 @@ class TestDockerSSIFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.1")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
+    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
     @irrelevant(context.library >= "python@4.0.0.dev" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library < "python@4.0.0.dev" and context.installed_language_runtime < "3.8.0")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime < "2.6.0")
@@ -169,6 +173,7 @@ class TestDockerSSIFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.1")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
+    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
     @irrelevant(context.library >= "python@4.0.0rc1" and context.installed_language_runtime < "3.9.0")
     def test_injection_metadata(self):
         logger.info("Testing injection result variables")

--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -43,7 +43,10 @@ class TestDockerSSIFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.0")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
-    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
+    @irrelevant(
+        context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0",
+        reason="dd-trace-js v6 supports Node.js v22+",
+    )
     @irrelevant(context.library >= "python@4.0.0rc1" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime < "2.6.0")
     def test_install_supported_runtime(self):
@@ -79,7 +82,10 @@ class TestDockerSSIFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.0")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
-    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
+    @irrelevant(
+        context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0",
+        reason="dd-trace-js v6 supports Node.js v22+",
+    )
     @irrelevant(context.library >= "python@4.0.0rc1" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime < "2.6.0")
     def test_telemetry(self):
@@ -109,7 +115,10 @@ class TestDockerSSIFeatures:
     @bug(context.library == "nodejs" and context.installed_language_runtime < "12.17.0", reason="INPLAT-252")
     @bug(context.library == "java" and context.installed_language_runtime == "1.7.0-201", reason="INPLAT-427")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime >= "17.0")
-    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
+    @irrelevant(
+        context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0",
+        reason="dd-trace-js v6 supports Node.js v22+",
+    )
     @irrelevant(context.library == "dotnet" and context.installed_language_runtime >= "6.0.0")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime >= "2.6.0")
     def test_telemetry_abort(self):
@@ -149,7 +158,10 @@ class TestDockerSSIFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.1")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
-    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
+    @irrelevant(
+        context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0",
+        reason="dd-trace-js v6 supports Node.js v22+",
+    )
     @irrelevant(context.library >= "python@4.0.0.dev" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library < "python@4.0.0.dev" and context.installed_language_runtime < "3.8.0")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime < "2.6.0")
@@ -173,7 +185,10 @@ class TestDockerSSIFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.1")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
-    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
+    @irrelevant(
+        context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0",
+        reason="dd-trace-js v6 supports Node.js v22+",
+    )
     @irrelevant(context.library >= "python@4.0.0rc1" and context.installed_language_runtime < "3.9.0")
     def test_injection_metadata(self):
         logger.info("Testing injection result variables")

--- a/tests/docker_ssi/test_docker_ssi.py
+++ b/tests/docker_ssi/test_docker_ssi.py
@@ -115,10 +115,6 @@ class TestDockerSSIFeatures:
     @bug(context.library == "nodejs" and context.installed_language_runtime < "12.17.0", reason="INPLAT-252")
     @bug(context.library == "java" and context.installed_language_runtime == "1.7.0-201", reason="INPLAT-427")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime >= "17.0")
-    @irrelevant(
-        context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0",
-        reason="dd-trace-js v6 supports Node.js v22+",
-    )
     @irrelevant(context.library == "dotnet" and context.installed_language_runtime >= "6.0.0")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime >= "2.6.0")
     def test_telemetry_abort(self):

--- a/tests/docker_ssi/test_docker_ssi_appsec.py
+++ b/tests/docker_ssi/test_docker_ssi_appsec.py
@@ -18,6 +18,7 @@ class TestDockerSSIAppsecFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.1")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
+    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
     @irrelevant(context.library >= "python@4.0.0.dev" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library < "python@4.0.0.dev" and context.installed_language_runtime < "3.8.0")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime < "2.6.0", reason="Ruby 2.6+ required")

--- a/tests/docker_ssi/test_docker_ssi_appsec.py
+++ b/tests/docker_ssi/test_docker_ssi_appsec.py
@@ -18,7 +18,10 @@ class TestDockerSSIAppsecFeatures:
     @irrelevant(context.library == "java" and context.installed_language_runtime < "1.8.0_0")
     @irrelevant(context.library == "php" and context.installed_language_runtime < "7.1")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
-    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
+    @irrelevant(
+        context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0",
+        reason="dd-trace-js v6 supports Node.js v22+",
+    )
     @irrelevant(context.library >= "python@4.0.0.dev" and context.installed_language_runtime < "3.9.0")
     @irrelevant(context.library < "python@4.0.0.dev" and context.installed_language_runtime < "3.8.0")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime < "2.6.0", reason="Ruby 2.6+ required")

--- a/tests/docker_ssi/test_docker_ssi_crash.py
+++ b/tests/docker_ssi/test_docker_ssi_crash.py
@@ -37,6 +37,7 @@ class TestDockerSSICrash:
     @features.ssi_crashtracking
     @irrelevant(context.library == "python" and context.installed_language_runtime < "3.7.0")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
+    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
     @irrelevant(context.library == "ruby" and context.installed_language_runtime < "2.6.0")
     def test_crash(self):
         """Validate that a crash report is generated when the application crashes"""

--- a/tests/docker_ssi/test_docker_ssi_crash.py
+++ b/tests/docker_ssi/test_docker_ssi_crash.py
@@ -37,7 +37,10 @@ class TestDockerSSICrash:
     @features.ssi_crashtracking
     @irrelevant(context.library == "python" and context.installed_language_runtime < "3.7.0")
     @irrelevant(context.library == "nodejs" and context.installed_language_runtime < "17.0")
-    @irrelevant(context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0", reason="dd-trace-js v6 supports Node.js v22+")
+    @irrelevant(
+        context.library >= "nodejs@6.0.0" and context.installed_language_runtime < "22.0",
+        reason="dd-trace-js v6 supports Node.js v22+",
+    )
     @irrelevant(context.library == "ruby" and context.installed_language_runtime < "2.6.0")
     def test_crash(self):
         """Validate that a crash report is generated when the application crashes"""

--- a/utils/build/ssi/base/install_script_ssi.sh
+++ b/utils/build/ssi/base/install_script_ssi.sh
@@ -30,8 +30,8 @@ if [ -n "${DD_INSTALLER_LIBRARY_VERSION}" ]; then
 fi
 
 if [ "${DD_LANG}" == "js" ] && [ "${SSI_ENV}" == "dev" ] && [ -z "${DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_LIBRARY_JS}" ]; then
-    # Special case for Node.js, the staging major version is 1 above the prod major (6 here)
-    export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_LIBRARY_JS="6"
+    # Special case for Node.js, the staging major version is 1 above the prod major (7 here)
+    export DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_LIBRARY_JS="7"
 fi
 
 #We want specfic injector version (to run on auto_inject pipelines)


### PR DESCRIPTION
## Motivation

Update SSI test after dd-trace v6 release

## Changes

Bump CI dev/staging test version of dd-trace.
Cap SSI tests with the correct runtime / dd-trace version

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
