### PR TITLE
Temporarily disable Java FFE evaluation tests

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3264,10 +3264,7 @@ manifest:
         spring-boot: v1.56.0
   tests/ffe/test_exposures.py::Test_FFE_EXP_5_Missing_Targeting_Key: bug (FFL-1729)
   tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
-  tests/ffe/test_flag_eval_metrics.py:
-    - weblog_declaration:
-        "*": irrelevant
-        spring-boot: v1.62.0
+  tests/ffe/test_flag_eval_metrics.py: bug (FFL-2339)
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Metric_Count::test_ffe_eval_metric_count:
     - weblog_declaration:
         "*": irrelevant


### PR DESCRIPTION
## Motivation
Java FFE evaluation metrics system tests exercise flag allocations that include ISO8601 `startAt`/`endAt` window dates. The current Java tracer mainline still has a date-model/parsing mismatch for those allocation windows: system-tests provides ISO8601 strings, while Java needs the `Instant` allocation-window parsing/model change in DataDog/dd-trace-java#11535. Until that Java tracer PR lands, these evaluation metrics tests fail for a known tracer-side `Instant` mismatch rather than a system-tests regression.

This PR temporarily disables the Java evaluation metrics manifest entry so system-tests does not gate on that pending Java tracer fix. We will re-enable the entry once DataDog/dd-trace-java#11535 lands on main.

## Changes and Decisions
This PR changes the Java manifest entry for `tests/ffe/test_flag_eval_metrics.py` from the spring-boot version gate to `bug (FFL-2339)`. The file-level manifest rule matches all tests in `test_flag_eval_metrics.py`, including the metric-count child test, so this keeps the disablement scoped to Java FFE evaluation metrics and leaves the EVP manifest entry unchanged.

## Validation
- `./format.sh` progressed through mypy, ruff, whitespace, yamlfmt, yamllint, manifest parser, and shellcheck checks; local Docker failed at the later Node lint stage with a containerd input/output error.
- `./venv/bin/yamlfmt -lint manifests/`
- `./venv/bin/yamllint -s manifests/`
- `./venv/bin/python utils/manifest/validate.py`
- `git diff --check`
- Manifest behavior check confirmed Java spring-boot eval-metrics nodeids resolve to `bug (FFL-2339)`.