### PR TITLE
[golang] Activate CSS Test_Client_Stats::test_top_level_service

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1514,7 +1514,7 @@ manifest:
   tests/stats/test_stats.py: v1.54.0
   tests/stats/test_stats.py::Test_Client_Drop_P0s::test_client_drop_p0s_false: v2.6.0
   tests/stats/test_stats.py::Test_Client_Stats::test_grpc_status_code: irrelevant (variant has no gRPC endpoint)
-  tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service: missing_feature (Go does not set top-level Service field in stats payload)
+  tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service: v2.11.0-dev
   tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature


### PR DESCRIPTION
## Motivation

APMSP-3667 / APMSP-3042. dd-trace-go now populates the payload-level `Service` field in the client-side stats payload on `main` (2.11.0-dev), so `Test_Client_Stats::test_top_level_service` passes there. The latest release (v2.9.1) does not set it yet (CI showed `assert '' == 'weblog'` on the `prod` jobs), so the test must stay `missing_feature` for released versions.

## Changes

Version-gate `tests/stats/test_stats.py::Test_Client_Stats::test_top_level_service` at `v2.11.0-dev` in `manifests/golang.yml` (was an unconditional `missing_feature`). Expected-pass on the dev build, skipped on the released version until 2.11.0 ships.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
