### PR TITLE
[golang] Activate CSS Test_Client_Stats_With_Client_Obfuscation

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1551,7 +1551,7 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_Future_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
+  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: v2.9.1
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_baggage.py::Test_Baggage_Headers_Api_Datadog: incomplete_test_app (/otel_drop_in_baggage_api_datadog endpoint is not implemented)


### PR DESCRIPTION
## Motivation

APMSP-3668. dd-trace-go performs end-to-end client-side stats obfuscation negotiation (version-negotiated, no dedicated flag). `Test_Client_Stats_With_Client_Obfuscation` runs under the base `TRACE_STATS_COMPUTATION` scenario and already xpasses on the released tracer (observed on v2.9.1 in CI) while marked `missing_feature`.

## Changes

Version-gate `tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation` at `v2.9.1` in `manifests/golang.yml` (was an unconditional `missing_feature`). The `_With_Client_Obfuscation_Disabled` variant stays `missing_feature` (APMSP-3672) — Go, like dotnet, exposes no runtime switch to disable client obfuscation, so that scenario is not applicable.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
