### PR TITLE
Filter job for auto_inject repo so system-tests specific jobs are excluded

### DIFF
--- a/utils/scripts/ci_orchestrators/external_gitlab_pipeline.py
+++ b/utils/scripts/ci_orchestrators/external_gitlab_pipeline.py
@@ -80,7 +80,7 @@ def main(language: str | None = None) -> None:
 
 def is_allowed_stage(stage: str | None, language: str | None) -> bool:
     """Check if a stage is allowed based on the language."""
-    if not language or language == "auto_inject":
+    if not language or language not in LANG_STAGES:
         return stage in LANG_STAGES or stage in {"configure", "pipeline-status"}
     return stage in {language, "configure", "pipeline-status"}
 

--- a/utils/scripts/ci_orchestrators/external_gitlab_pipeline.py
+++ b/utils/scripts/ci_orchestrators/external_gitlab_pipeline.py
@@ -78,7 +78,7 @@ def main(language: str | None = None) -> None:
     print(yaml.dump(data, default_flow_style=False, sort_keys=False))
 
 
-def is_allowed_stage(stage: str | None, language: str) -> bool:
+def is_allowed_stage(stage: str | None, language: str | None) -> bool:
     """Check if a stage is allowed based on the language."""
     if not language or language == "auto_inject":
         return stage in LANG_STAGES or stage in {"configure", "pipeline-status"}

--- a/utils/scripts/ci_orchestrators/external_gitlab_pipeline.py
+++ b/utils/scripts/ci_orchestrators/external_gitlab_pipeline.py
@@ -70,8 +70,7 @@ def main(language: str | None = None) -> None:
     # Ensure 'variables' section exists and update with new values
     data.setdefault("variables", {}).update(new_variables)
 
-    if language and language in LANG_STAGES:
-        data = filter_yaml(data, language)
+    data = filter_yaml(data, language)
 
     handle_parallelism(data)
 
@@ -81,10 +80,12 @@ def main(language: str | None = None) -> None:
 
 def is_allowed_stage(stage: str | None, language: str) -> bool:
     """Check if a stage is allowed based on the language."""
+    if not language or language == "auto_inject":
+        return stage in LANG_STAGES or stage in {"configure", "pipeline-status"}
     return stage in {language, "configure", "pipeline-status"}
 
 
-def filter_yaml(yaml_data: dict, language: str) -> dict:
+def filter_yaml(yaml_data: dict, language: str | None) -> dict:
     """Filter the pipeline to run only the jobs for the specified language"""
 
     # Find all jobs where stage == language


### PR DESCRIPTION
[Test PR in auto_inject](https://github.com/DataDog/auto_inject/pull/1144)
[Corresponding gitlab pipeline](https://gitlab.ddbuild.io/DataDog/auto_inject/-/pipelines/123593583)
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
