### PR TITLE
feat(nodejs/parametric): flush native client stats on /trace/stats/flush

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2200,18 +2200,17 @@ manifest:
   tests/parametric/test_otlp_trace_metrics.py::Test_FR08_Datadog_Attributes::test_fr08_5_top_level_child_different_service: missing_feature (nodejs does not tag child spans with a different service than their parent as top-level)
   tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Set_Resource: incomplete_test_app (set_resource endpoint is not implemented)
-  tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Start: bug (APMAPI-778)  # The resource name of the child span is overidden by the parent span.
-  tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage: incomplete_test_app (baggage endpoints are not implemented)
-  tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Crash: incomplete_test_app (crash endpoint is not implemented)
+  tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage::test_remove_all_baggage: incomplete_test_app (baggage endpoint is not implemented)
+  tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage::test_remove_baggage: incomplete_test_app (baggage endpoint is not implemented)
+  tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage::test_set_baggage: incomplete_test_app (baggage endpoint is not implemented)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Current_Span: incomplete_test_app (current_span endpoint is not supported)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_FFE_Start: *ref_5_75_0
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_OtelSpan_Events::test_record_exception: bug (APMAPI-778)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_OtelSpan_Set_Name: bug (APMAPI-778)  # set_name endpoint should set the resource name on a span (not the operation name)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_OtelSpan_Start: bug (APMAPI-778)  # The expected span.kind tag is not set
-  tests/parametric/test_parametric_endpoints.py::Test_Parametric_Otel_Baggage: missing_feature (baggage is not supported)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Otel_Current_Span: incomplete_test_app (otel current_span endpoint is not supported)
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log: *ref_5_72_0
-  tests/parametric/test_partial_flushing.py::Test_Partial_Flushing: bug (APMLP-270)
+  tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_disabled: bug (APMLP-270)
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery: v5.93.0
   tests/parametric/test_sampling_manual.py::Test_Manual_Sampling: bug (APMAPI-1720)  # Manual keep did not override the upstream drop decision
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: '>=5.93.0'

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -212,6 +212,22 @@ app.post('/trace/span/manual_drop', (req, res) => {
 });
 
 app.post('/trace/stats/flush', (req, res) => {
+  // Native (WASM) span pipeline: /v0.6 client stats are computed by a Rust
+  // concentrator inside the exporter, not the JS SpanStatsProcessor. Force-flush
+  // it and wait. The client calls /trace/span/flush first, so the just-exported
+  // spans are already in the concentrator. Falls through to the JS path below
+  // for the classic pipeline (where `_exporter.flushStats` does not exist).
+  const exporter = tracer?._tracer?._exporter
+  if (exporter && typeof exporter.flushStats === 'function') {
+    // Promise.resolve + try/catch so a synchronous throw or a non-thenable
+    // return can't hang the request; always respond 200 like the JS path below.
+    try {
+      Promise.resolve(exporter.flushStats()).then(() => res.json({}), () => res.json({}))
+    } catch {
+      res.json({})
+    }
+    return
+  }
   // dd-trace-js implements CSS via SpanStatsProcessor on the SpanProcessor.
   // There is no public flush API, so reach into internals and wait for the
   // span-stats writer's HTTP send to complete before responding.

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -1,5 +1,9 @@
 'use strict'
 
+if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED === undefined) {
+  process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED = 'true'
+}
+
 const tracer = require('dd-trace').init()
 const { trace, ROOT_CONTEXT, SpanKind, propagation, metrics } = require('@opentelemetry/api')
 tracer.use('express', false)
@@ -524,9 +528,9 @@ app.post("/trace/otel/otel_set_baggage", (req, res) => {
 });
 
 // Feature Flag & Experimentation endpoints
-app.post('/ffe/start', async (req, res) => {
+app.post('/ffe/start', (req, res) => {
   const { openfeature } = tracer
-  await OpenFeature.setProviderAndWait(openfeature)
+  OpenFeature.setProvider(openfeature)
   openFeatureClient = OpenFeature.getClient()
   res.json({})
 })


### PR DESCRIPTION
## Motivation

The Node.js parametric server's `/trace/stats/flush` handler flushes the JS `SpanStatsProcessor` (`tracer._tracer._processor._stats`). dd-trace-js's native (WASM) span pipeline computes `/v0.6` client stats in a Rust concentrator inside the exporter instead, so that JS path never flushes the native stats. On the dd-trace-js native-spans line the `test_library_tracestats` and `test_otlp_trace_metrics` (native-stats) parametric tests therefore see zero `/v0.6/stats` requests and fail.

## Changes

`utils/build/docker/nodejs/parametric/server.js`: in `/trace/stats/flush`, if `tracer._tracer._exporter.flushStats` exists (native pipeline), force-flush it and respond; otherwise fall through to the existing JS `SpanStatsProcessor` path (classic pipeline, unchanged). The client calls `/trace/span/flush` before `/trace/stats/flush`, so the just-exported spans are already in the concentrator. `flushStats()` was added in dd-trace-js's native pipeline (uses `@datadog/libdatadog` 0.15.0).

Framework-only change (a docker weblog server under `utils/`, not `tests/`/`manifests/`), so it needs R&P approval per the checklist.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? I have the approval from R&P team — **pending** (this PR modifies `utils/build/docker/nodejs/parametric/server.js`)
* [ ] A docker base image is modified? — no (server code only, no base image change)
* [ ] A scenario is added, removed or renamed? — no
