### PR TITLE
test(otel): gate python 128-bit OTLP trace ID test on v4.12.0rc1

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1770,7 +1770,7 @@ manifest:
         uds-flask: v4.3.1  # Modified by easy win activation script
         uwsgi-poc: v4.3.1  # Modified by easy win activation script
   tests/otel/test_tracing_otlp.py::Test_Otel_Tracing_OTLP: v4.8.0
-  tests/otel/test_tracing_otlp.py::Test_Otel_Tracing_OTLP::test_128bit_trace_id_consistent_across_spans: v4.11.0
+  tests/otel/test_tracing_otlp.py::Test_Otel_Tracing_OTLP::test_128bit_trace_id_consistent_across_spans: v4.12.0rc1
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant


### PR DESCRIPTION
## Motivation

The system-tests manifest declared `test_128bit_trace_id_consistent_across_spans` as expected-to-pass on dd-trace-py `v4.11.0`. That gate is wrong.

The test checks that OTLP-exported spans keep the full 128-bit trace ID: `_dd.p.tid` (the high 64 bits, set only on the chunk root per RFC #85) must be applied to every span in the chunk during OTLP serialization. That serialization happens in libdatadog, and the fix (libdatadog #2014) shipped in libdatadog **v35.0.0**.

dd-trace-py v4.11.0 ships libdatadog **v34.0.0**, which lacks the fix. The libdatadog v35 upgrade (dd-trace-py #18414) landed on `main` after the 4.11 release branch was cut, so it was never in 4.11. When v4.11.0 released, the `APM_TRACING_OTLP` scenario began failing across every Python weblog variant, because the manifest expected a version without the fix to pass. Child spans export with the upper 64 bits zeroed, so a single trace fragments into two trace IDs.

The first dd-trace-py release containing the fix is **v4.12.0rc1**.

## Changes

Bump the manifest gate for this test from `v4.11.0` to `v4.12.0rc1`, so it is only expected to pass on versions that actually contain the fix. v4.11.x is correctly treated as not-yet-fixed; v4.12.0rc1, v4.12.0, and later are expected to pass (verified against the manifest's version comparison for 4.11.0, 4.11.0rc7, 4.12.0rc1, 4.12.0rc2, 4.13.0rc1, and 4.12.0).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)