### PR TITLE
test(ffe): pin end-to-end scenario to remote config

### DIFF
--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -704,6 +704,7 @@ class _Scenarios:
         rc_api_enabled=True,
         weblog_env={
             "DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED": "true",
+            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE": "remote_config",
             # set_provider() in Python blocks until we receive RC
             # configuration for feature flags. But it is only sent
             # after weblog sucessfully boots and tests start


### PR DESCRIPTION
## Motivation

The `FEATURE_FLAGGING_AND_EXPERIMENTATION` end-to-end scenario delivers feature flag configuration through Remote Configuration. Java now defaults the Feature Flags configuration source to `agentless`, so leaving the source implicit prevents Java from subscribing to `FFE_FLAGS` and causes `/ffe` evaluations to time out while waiting for initial configuration.

Working on in-development: https://github.com/DataDog/dd-trace-java/pull/11892

## Changes

- Set `DD_FEATURE_FLAGS_CONFIGURATION_SOURCE=remote_config` in the legacy FFE end-to-end scenario.
- Keep the dedicated agentless configuration-source tests on their mocked agentless backend.

## Decisions

- Pin the delivery mode at the scenario boundary because these tests explicitly exercise Remote Configuration behavior.
- Preserve `agentless` as the SDK default; no Java behavior changes are needed for this failure.

## Validation

- `git diff --check`
- `ruff format --check utils/_context/_scenarios/__init__.py`
- `ruff check utils/_context/_scenarios/__init__.py`
- `python3 -m py_compile utils/_context/_scenarios/__init__.py`
