### PR TITLE
[INPLAT-1274] Preserve hidden job templates in the system-tests pipeline generator

### DIFF
--- a/utils/scripts/ci_orchestrators/external_gitlab_pipeline.py
+++ b/utils/scripts/ci_orchestrators/external_gitlab_pipeline.py
@@ -88,11 +88,17 @@ def is_allowed_stage(stage: str | None, language: str | None) -> bool:
 def filter_yaml(yaml_data: dict, language: str | None) -> dict:
     """Filter the pipeline to run only the jobs for the specified language"""
 
-    # Find all jobs where stage == language
+    # Find all jobs where stage == language.
+    # Hidden jobs (`.`-prefixed templates, e.g. `.delayed_base_job`) have no
+    # stage and are never run on their own — they only exist to be pulled in via
+    # `extends`. Keep them regardless of stage; dropping them leaves any job that
+    # extends them dangling (`unknown keys in extends`), which fails compilation
+    # of the generated child pipeline.
     allowed_jobs = {
         job_name: job_data
         for job_name, job_data in yaml_data.items()
-        if isinstance(job_data, dict) and is_allowed_stage(job_data.get("stage"), language)
+        if isinstance(job_data, dict)
+        and (job_name.startswith(".") or is_allowed_stage(job_data.get("stage"), language))
     }
 
     # Keep only relevant sections


### PR DESCRIPTION
## What this fixes

`filter_yaml` in `utils/scripts/ci_orchestrators/external_gitlab_pipeline.py` filters jobs by stage when generating a consumer's system-tests pipeline. Hidden (`.`-prefixed) job templates have no stage, so they get dropped — even when other jobs `extends` them.

When the generated pipeline then contains a job that extends a dropped template (e.g. `.delayed_base_job`), GitLab rejects the child pipeline with `unknown keys in extends`, producing an empty pipeline and failing the parent job.

This keeps `.`-prefixed template jobs regardless of stage. No behavior change otherwise; single-language consumers are still filtered to their language, and non-template internal jobs are still dropped.

## How this was tested

- Unit-checked `filter_yaml`: hidden templates are preserved, non-matching real jobs are still dropped, single-language consumers still filter to one language.
- Reconstructed a previously-failing generated release pipeline with the fix applied and confirmed it passes the GitLab CI Lint API (`valid: true`).

INPLAT-1274
