### PR TITLE
Fix system-tests parametric server for python RC changes

### DIFF
--- a/utils/build/docker/python/parametric/apm_test_client/server.py
+++ b/utils/build/docker/python/parametric/apm_test_client/server.py
@@ -472,6 +472,9 @@ class TraceRemoteConfigApplyReturn(BaseModel):
 # threadpool). A timed-out drain keeps the lock until its worker thread exits.
 _rc_apply_lock = threading.Lock()
 
+# Currently-applied Remote Config set, keyed by config path.
+_applied_configs: Dict[str, "AppliedConfigEntry"] = {}
+
 
 @app.post("/trace/remote-config/apply")
 def trace_remote_config_apply(
@@ -498,14 +501,37 @@ def trace_remote_config_apply(
             },
         )
 
+    # Detect which Remote Config client API is in use. The libdatadog rewrite
+    # replaced the pure-Python fetch/apply path (client.request() plus a
+    # Python-side client._applied_configs cache) with a native client
+    # (client._ensure_native().poll()) that owns the file set, so on the new
+    # API we reconstruct the applied set ourselves. Support both so this server
+    # works against tracer versions from before and after the rewrite.
+    uses_native_rc = hasattr(client, "_ensure_native")
+
     lock_ownership_transferred = False
     try:
         drain_error: List[BaseException] = []
 
         def _drain() -> None:
             try:
-                client.request()
-                client._global_subscriber.periodic()
+                if uses_native_rc:
+                    native = client._ensure_native()
+                    changes = native.poll(
+                        list(client._enabled_products),
+                        list(ddtrace.config._get_extra_services()),
+                    )
+                    client._dispatch_to_products(client._build_payloads(changes))
+                    for change in changes:
+                        if change.content is None:
+                            _applied_configs.pop(change.path, None)
+                        else:
+                            _applied_configs[change.path] = AppliedConfigEntry(
+                                config_id=change.config_id, product=str(change.product)
+                            )
+                else:
+                    client.request()
+                    client._global_subscriber.periodic()
             except BaseException as exc:  # noqa: BLE001
                 drain_error.append(exc)
 
@@ -543,12 +569,15 @@ def trace_remote_config_apply(
                 content={"error": f"remote config apply failed: {drain_error[0]!r}"},
             )
 
-        success = TraceRemoteConfigApplyReturn(
-            applied_configs=[
+        if uses_native_rc:
+            applied_configs = list(_applied_configs.values())
+        else:
+            # Old client: read the Python-side applied-config cache directly.
+            applied_configs = [
                 AppliedConfigEntry(config_id=metadata.id, product=metadata.product_name)
                 for metadata in client._applied_configs.values()
             ]
-        )
+        success = TraceRemoteConfigApplyReturn(applied_configs=applied_configs)
         # Pydantic v1 (fastapi==0.89.1): .dict(), not v2's .model_dump().
         return JSONResponse(status_code=200, content=success.dict())
     finally:


### PR DESCRIPTION
The RC client was rewritten on top of libdatadog: the native client owns the current file set and no longer keeps a Python-side applied-config cache, hence we reconstruct that manually here.

Detect which client API is in use at runtime (native client exposes _ensure_native) and keep the old client.request()/_applied_configs path as a fallback, so the parametric server works against tracer versions from both before and after the rewrite.