### PR TITLE
test(parametric): validate Go offline LLM Obs export

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1405,6 +1405,10 @@ manifest:
       component_version: '<=2.10.0-dev'
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_relative_error_TS008: missing_feature (relative error test is broken)
   tests/parametric/test_llm_observability/: v2.11.0-dev
+  tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: missing_feature (prompt annotation needs llmobs.WithAnnotatedPrompt, not in a released dd-trace-go yet)
+  tests/parametric/test_llm_observability/test_llm_observability.py::Test_CostTags: missing_feature (cost tags need llmobs.WithAnnotatedCostTagKeys, not in a released dd-trace-go yet)
+  tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement::test_ml_app: missing_feature (Go llmobs does not default ml_app to the service name when unset)
+  tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset::test_dataset_create_delete: missing_feature (no public delete-dataset-by-id API in dd-trace-go; delete is stubbed)
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.66.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_otel_enabled_takes_precedence: irrelevant (does not support enabling opentelemetry via DD_TRACE_OTEL_ENABLED)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1404,11 +1404,8 @@ manifest:
     - declaration: missing_feature (CSS v1.2.0 - dd-trace-go does not set payload-level RuntimeID; stats.go PayloadAggregationKey omits it)
       component_version: '<=2.10.0-dev'
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_relative_error_TS008: missing_feature (relative error test is broken)
-  tests/parametric/test_llm_observability/: v2.11.0-dev
-  tests/parametric/test_llm_observability/test_llm_observability.py::Test_CostTags: missing_feature (cost tags need llmobs.WithAnnotatedCostTagKeys, not in a released dd-trace-go yet)
-  tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement::test_ml_app: missing_feature (only the unset/default params fail; Go llmobs emits no span when ml_app is unset, vs dd-trace-py defaulting to the service; per-param gating is unsupported and the configured-ml_app path is covered elsewhere)
-  tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: missing_feature (prompt annotation needs llmobs.WithAnnotatedPrompt, not in a released dd-trace-go yet)
-  tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset::test_dataset_create_delete: missing_feature (no public delete-dataset-by-id API in dd-trace-go; delete is stubbed)
+  tests/parametric/test_llm_observability/: incomplete_test_app
+  tests/parametric/test_llm_observability/test_llm_observability_gen_ai_otlp.py: v2.11.0-dev
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.66.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_otel_enabled_takes_precedence: irrelevant (does not support enabling opentelemetry via DD_TRACE_OTEL_ENABLED)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1404,7 +1404,7 @@ manifest:
     - declaration: missing_feature (CSS v1.2.0 - dd-trace-go does not set payload-level RuntimeID; stats.go PayloadAggregationKey omits it)
       component_version: '<=2.10.0-dev'
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_relative_error_TS008: missing_feature (relative error test is broken)
-  tests/parametric/test_llm_observability/: incomplete_test_app
+  tests/parametric/test_llm_observability/: v2.11.0-dev
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.66.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_otel_enabled_takes_precedence: irrelevant (does not support enabling opentelemetry via DD_TRACE_OTEL_ENABLED)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1405,9 +1405,9 @@ manifest:
       component_version: '<=2.10.0-dev'
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_relative_error_TS008: missing_feature (relative error test is broken)
   tests/parametric/test_llm_observability/: v2.11.0-dev
-  tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: missing_feature (prompt annotation needs llmobs.WithAnnotatedPrompt, not in a released dd-trace-go yet)
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_CostTags: missing_feature (cost tags need llmobs.WithAnnotatedCostTagKeys, not in a released dd-trace-go yet)
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement::test_ml_app: missing_feature (Go llmobs does not default ml_app to the service name when unset)
+  tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: missing_feature (prompt annotation needs llmobs.WithAnnotatedPrompt, not in a released dd-trace-go yet)
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset::test_dataset_create_delete: missing_feature (no public delete-dataset-by-id API in dd-trace-go; delete is stubbed)
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.66.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1406,7 +1406,7 @@ manifest:
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_relative_error_TS008: missing_feature (relative error test is broken)
   tests/parametric/test_llm_observability/: v2.11.0-dev
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_CostTags: missing_feature (cost tags need llmobs.WithAnnotatedCostTagKeys, not in a released dd-trace-go yet)
-  tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement::test_ml_app: missing_feature (Go llmobs does not default ml_app to the service name when unset)
+  tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement::test_ml_app: missing_feature (only the unset/default params fail; Go llmobs emits no span when ml_app is unset, vs dd-trace-py defaulting to the service; per-param gating is unsupported and the configured-ml_app path is covered elsewhere)
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: missing_feature (prompt annotation needs llmobs.WithAnnotatedPrompt, not in a released dd-trace-go yet)
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset::test_dataset_create_delete: missing_feature (no public delete-dataset-by-id API in dd-trace-go; delete is stubbed)
   tests/parametric/test_otel_api_interoperability.py: missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1491,7 +1491,7 @@ manifest:
       component_version: '<=2.10.0-dev'
   tests/parametric/test_llm_observability/test_llm_observability.py: incomplete_test_app
   tests/parametric/test_llm_observability/test_llm_observability_dne.py: incomplete_test_app
-  tests/parametric/test_llm_observability/test_llm_observability_export.py: v2.11.0-dev.1
+  tests/parametric/test_llm_observability/test_llm_observability_export.py: '>=2.11.0-dev.1'
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.66.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_otel_enabled_takes_precedence: irrelevant (does not support enabling opentelemetry via DD_TRACE_OTEL_ENABLED)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1489,7 +1489,8 @@ manifest:
   tests/parametric/test_library_tracestats.py::Test_Library_Tracestats::test_payload_metadata_TS012:
     - declaration: missing_feature (CSS v1.2.0 - dd-trace-go does not set payload-level RuntimeID; stats.go PayloadAggregationKey omits it)
       component_version: '<=2.10.0-dev'
-  tests/parametric/test_llm_observability/: incomplete_test_app
+  tests/parametric/test_llm_observability/test_llm_observability.py: incomplete_test_app
+  tests/parametric/test_llm_observability/test_llm_observability_dne.py: incomplete_test_app
   tests/parametric/test_llm_observability/test_llm_observability_export.py: v2.11.0-dev.1
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.66.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1490,6 +1490,7 @@ manifest:
     - declaration: missing_feature (CSS v1.2.0 - dd-trace-go does not set payload-level RuntimeID; stats.go PayloadAggregationKey omits it)
       component_version: '<=2.10.0-dev'
   tests/parametric/test_llm_observability/: incomplete_test_app
+  tests/parametric/test_llm_observability/test_llm_observability_export.py: v2.11.0-dev.1
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.66.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_otel_enabled_takes_precedence: irrelevant (does not support enabling opentelemetry via DD_TRACE_OTEL_ENABLED)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3826,6 +3826,7 @@ manifest:
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts::test_prompt_annotation_updates_existing_prompt: missing_feature (prompt annotation not supported in Java LLMObs SDK)
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts::test_prompt_annotation_with_string_template: missing_feature (prompt annotation not supported in Java LLMObs SDK)
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset::test_dataset_create_delete: incomplete_test_app (Java parametric app does not implement /llm_observability/dataset endpoints)
+  tests/parametric/test_llm_observability/test_llm_observability_gen_ai_otlp.py: incomplete_test_app (parametric app emits native llmobs, not gen_ai OTLP; gen_ai OTLP emitter is golang-only for now)
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.35.2
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3947,6 +3947,7 @@ manifest:
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts::test_prompt_annotation_updates_existing_prompt: missing_feature (prompt annotation not supported in Java LLMObs SDK)
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts::test_prompt_annotation_with_string_template: missing_feature (prompt annotation not supported in Java LLMObs SDK)
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset::test_dataset_create_delete: incomplete_test_app (Java parametric app does not implement /llm_observability/dataset endpoints)
+  tests/parametric/test_llm_observability/test_llm_observability_export.py: incomplete_test_app (offline LLM Obs export endpoint is implemented only by the Go parametric app)
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.35.2
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2118,6 +2118,7 @@ manifest:
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement: *ref_5_66_0
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: *ref_5_83_0
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset: missing_feature
+  tests/parametric/test_llm_observability/test_llm_observability_gen_ai_otlp.py: incomplete_test_app (parametric app emits native llmobs, not gen_ai OTLP; gen_ai OTLP emitter is golang-only for now)
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v5.11.0  #implemented in v5.11.0, v4.35.0, &v3.56.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_otel_enabled_takes_precedence: missing_feature (this setting is not exposed in the Node.js config object)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2345,6 +2345,7 @@ manifest:
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement: *ref_5_66_0
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: *ref_5_83_0
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset: missing_feature
+  tests/parametric/test_llm_observability/test_llm_observability_export.py: incomplete_test_app (offline LLM Obs export endpoint is implemented only by the Go parametric app)
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v5.11.0  #implemented in v5.11.0, v4.35.0, &v3.56.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_otel_enabled_takes_precedence: missing_feature (this setting is not exposed in the Node.js config object)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1907,6 +1907,7 @@ manifest:
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement: v3.14.0
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: v3.15.0
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset: v4.2.0
+  tests/parametric/test_llm_observability/test_llm_observability_gen_ai_otlp.py: incomplete_test_app (parametric app emits native llmobs, not gen_ai OTLP; gen_ai OTLP emitter is golang-only for now)
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability: '>=4.3.1'  # Modified by easy win activation script
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability::test_concurrent_traces_in_order: missing_feature  # Created by easy win activation script
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability::test_concurrent_traces_nested_dd_root: missing_feature  # Created by easy win activation script

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2025,6 +2025,7 @@ manifest:
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement: v3.14.0
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: v3.15.0
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset: v4.2.0
+  tests/parametric/test_llm_observability/test_llm_observability_export.py: incomplete_test_app (offline LLM Obs export endpoint is implemented only by the Go parametric app)
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability: '>=4.3.1'  # Modified by easy win activation script
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability::test_concurrent_traces_in_order: missing_feature  # Created by easy win activation script
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability::test_concurrent_traces_nested_dd_root: missing_feature  # Created by easy win activation script

--- a/tests/parametric/test_llm_observability/test_llm_observability_export.py
+++ b/tests/parametric/test_llm_observability/test_llm_observability_export.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any, cast
 
 from utils import features, scenarios
@@ -162,6 +163,7 @@ class Test_Offline_Export:
         assert step_span["status"] == "ok"
 
     def test_evaluation_contract(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        timestamp_ms = int(time.time() * 1000)
         response = test_library.llmobs_export(
             LlmObsExportRequest(
                 ml_app="client-app",
@@ -174,7 +176,7 @@ class Test_Offline_Export:
                         metric_type="score",
                         score_value=0.9,
                         tags=["judge:test"],
-                        timestamp_ms=1_700_000_000_123,
+                        timestamp_ms=timestamp_ms,
                         assessment="mostly correct",
                         reasoning="grounded in the supplied context",
                         metadata={"judge": "gpt-4o", "rubric_version": 3},
@@ -186,7 +188,7 @@ class Test_Offline_Export:
                         metric_type="json",
                         json_value={"score": 0.95, "reasons": ["grounded", "concise"]},
                         ml_app="row-app",
-                        timestamp_ms=1_700_000_000_124,
+                        timestamp_ms=timestamp_ms,
                     ),
                 ],
             )
@@ -208,7 +210,7 @@ class Test_Offline_Export:
         assert score_metric["metric_type"] == "score"
         assert score_metric["score_value"] == 0.9
         assert score_metric["ml_app"] == "call-app"
-        assert score_metric["timestamp_ms"] == 1_700_000_000_123
+        assert score_metric["timestamp_ms"] == timestamp_ms
         assert score_metric["assessment"] == "mostly correct"
         assert score_metric["reasoning"] == "grounded in the supplied context"
         assert score_metric["metadata"] == {"judge": "gpt-4o", "rubric_version": 3}

--- a/tests/parametric/test_llm_observability/test_llm_observability_export.py
+++ b/tests/parametric/test_llm_observability/test_llm_observability_export.py
@@ -1,0 +1,221 @@
+from typing import Any, cast
+
+from utils import features, scenarios
+from utils.docker_fixtures import TestAgentAPI
+from utils.docker_fixtures.spec.llm_observability import (
+    LlmObsExportErrorRequest,
+    LlmObsExportEvaluationRequest,
+    LlmObsExportKind,
+    LlmObsExportRequest,
+    LlmObsExportSpanLinkRequest,
+    LlmObsExportSpanRequest,
+)
+from ..conftest import APMLibrary  # noqa: TID252
+
+
+SPAN_KINDS: tuple[LlmObsExportKind, ...] = (
+    "llm",
+    "agent",
+    "workflow",
+    "task",
+    "step",
+    "tool",
+    "embedding",
+    "retrieval",
+)
+
+
+@features.llm_observability_sdk_enablement
+@scenarios.parametric
+class Test_Offline_Export:
+    def test_span_contract(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        spans = [
+            LlmObsExportSpanRequest(
+                trace_id="trace-offline-123",
+                span_id="span-offline-456",
+                parent_id="parent-offline-789",
+                session_id="session-offline-123",
+                name="offline-chat",
+                service="span-service",
+                kind="llm",
+                start_ns=1_700_000_000_123_456_789,
+                duration_ns=42_000_000,
+                model_name="gpt-4o",
+                model_provider="OpenAI",
+                input="hello",
+                output="hi there",
+                metadata={"temperature": 0.7, "nested": {"enabled": True}},
+                metrics={"input_tokens": 10, "output_tokens": 5},
+                tags=["custom:value"],
+                span_links=[
+                    LlmObsExportSpanLinkRequest(
+                        trace_id="18446744073709551615",
+                        trace_id_high=9_223_372_036_854_775_808,
+                        span_id="42",
+                        attributes={"reason": "offline-parent"},
+                        tracestate="dd=s:1",
+                        flags=1,
+                    )
+                ],
+                apm_trace_id="apm-trace-123",
+                error=LlmObsExportErrorRequest(
+                    type="provider_error",
+                    message="upstream refused",
+                    stack="stack trace",
+                ),
+            )
+        ]
+        spans.extend(
+            LlmObsExportSpanRequest(
+                trace_id=f"trace-{kind}",
+                span_id=f"span-{kind}",
+                kind=kind,
+                start_ns=1_700_000_000_123_456_789 + index,
+                duration_ns=1,
+            )
+            for index, kind in enumerate(SPAN_KINDS[1:], start=1)
+        )
+
+        response = test_library.llmobs_export(
+            LlmObsExportRequest(
+                ml_app="test-app",
+                service="client-service",
+                env="test-env",
+                version="test-version",
+                call_service="call-service",
+                spans=spans,
+            )
+        )
+
+        assert response["spans"] == {"sent": len(SPAN_KINDS), "dropped": 0, "failed": 0}
+        envelopes = cast(
+            "list[dict[str, Any]]",
+            test_agent.wait_for_llmobs_requests(num=1, sort_by_start=False),
+        )
+        assert len(envelopes) == len(SPAN_KINDS)
+        for envelope in envelopes:
+            assert set(envelope) == {"_dd.stage", "_dd.tracer_version", "event_type", "spans"}
+            assert envelope["_dd.stage"] == "raw"
+            assert envelope["event_type"] == "span"
+            assert envelope["_dd.tracer_version"]
+            assert len(envelope["spans"]) == 1
+
+        spans_by_kind = {envelope["spans"][0]["meta"]["span.kind"]: envelope["spans"][0] for envelope in envelopes}
+        assert set(spans_by_kind) == set(SPAN_KINDS)
+
+        llm_span = spans_by_kind["llm"]
+        assert llm_span["trace_id"] == "trace-offline-123"
+        assert llm_span["span_id"] == "span-offline-456"
+        assert llm_span["parent_id"] == "parent-offline-789"
+        assert llm_span["session_id"] == "session-offline-123"
+        assert llm_span["name"] == "offline-chat"
+        assert llm_span["service"] == "span-service"
+        assert llm_span["start_ns"] == 1_700_000_000_123_456_789
+        assert llm_span["duration"] == 42_000_000
+        assert llm_span["status"] == "error"
+        assert llm_span["metrics"] == {"input_tokens": 10, "output_tokens": 5}
+        assert llm_span["_dd"] == {
+            "span_id": "span-offline-456",
+            "trace_id": "trace-offline-123",
+            "apm_trace_id": "apm-trace-123",
+        }
+
+        meta = llm_span["meta"]
+        assert meta == {
+            "span.kind": "llm",
+            "model_name": "gpt-4o",
+            "model_provider": "openai",
+            "input": {"value": "hello"},
+            "output": {"value": "hi there"},
+            "metadata": {"temperature": 0.7, "nested": {"enabled": True}},
+            "error.type": "provider_error",
+            "error.message": "upstream refused",
+            "error.stack": "stack trace",
+        }
+        assert {
+            "custom:value",
+            "ml_app:test-app",
+            "env:test-env",
+            "version:test-version",
+            "service:span-service",
+            "source:integration",
+            "language:go",
+            "error:1",
+        }.issubset(set(llm_span["tags"]))
+        assert any(tag.startswith("ddtrace.version:") for tag in llm_span["tags"])
+        assert llm_span["span_links"] == [
+            {
+                "trace_id": "18446744073709551615",
+                "trace_id_high": 9_223_372_036_854_775_808,
+                "span_id": "42",
+                "attributes": {"reason": "offline-parent"},
+                "tracestate": "dd=s:1",
+                "flags": 1,
+            }
+        ]
+
+        step_span = spans_by_kind["step"]
+        assert step_span["name"] == "step"
+        assert step_span["parent_id"] == "undefined"
+        assert step_span["service"] == "call-service"
+        assert "service:call-service" in step_span["tags"]
+        assert step_span["status"] == "ok"
+
+    def test_evaluation_contract(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        response = test_library.llmobs_export(
+            LlmObsExportRequest(
+                ml_app="client-app",
+                call_ml_app="call-app",
+                evaluations=[
+                    LlmObsExportEvaluationRequest(
+                        span_id="span-offline-456",
+                        trace_id="trace-offline-123",
+                        label="quality",
+                        metric_type="score",
+                        score_value=0.9,
+                        tags=["judge:test"],
+                        timestamp_ms=1_700_000_000_123,
+                        assessment="mostly correct",
+                        reasoning="grounded in the supplied context",
+                        metadata={"judge": "gpt-4o", "rubric_version": 3},
+                    ),
+                    LlmObsExportEvaluationRequest(
+                        span_id="span-json",
+                        trace_id="trace-json",
+                        label="structured-quality",
+                        metric_type="json",
+                        json_value={"score": 0.95, "reasons": ["grounded", "concise"]},
+                        ml_app="row-app",
+                        timestamp_ms=1_700_000_000_124,
+                    ),
+                ],
+            )
+        )
+
+        assert response["evaluations"] == {"sent": 2, "dropped": 0, "failed": 0}
+        requests = cast(
+            "list[dict[str, Any]]",
+            test_agent.wait_for_llmobs_evaluations_requests(num=1),
+        )
+        assert len(requests) == 1
+        assert requests[0]["data"]["type"] == "evaluation_metric"
+        metrics = requests[0]["data"]["attributes"]["metrics"]
+        assert len(metrics) == 2
+
+        score_metric = metrics[0]
+        assert score_metric["join_on"] == {"span": {"span_id": "span-offline-456", "trace_id": "trace-offline-123"}}
+        assert score_metric["label"] == "quality"
+        assert score_metric["metric_type"] == "score"
+        assert score_metric["score_value"] == 0.9
+        assert score_metric["ml_app"] == "call-app"
+        assert score_metric["timestamp_ms"] == 1_700_000_000_123
+        assert score_metric["assessment"] == "mostly correct"
+        assert score_metric["reasoning"] == "grounded in the supplied context"
+        assert score_metric["eval_metric_metadata"] == {"judge": "gpt-4o", "rubric_version": 3}
+        assert "judge:test" in score_metric["tags"]
+        assert any(tag.startswith("ddtrace.version:") for tag in score_metric["tags"])
+
+        json_metric = metrics[1]
+        assert json_metric["metric_type"] == "json"
+        assert json_metric["json_value"] == {"score": 0.95, "reasons": ["grounded", "concise"]}
+        assert json_metric["ml_app"] == "row-app"

--- a/tests/parametric/test_llm_observability/test_llm_observability_export.py
+++ b/tests/parametric/test_llm_observability/test_llm_observability_export.py
@@ -211,7 +211,7 @@ class Test_Offline_Export:
         assert score_metric["timestamp_ms"] == 1_700_000_000_123
         assert score_metric["assessment"] == "mostly correct"
         assert score_metric["reasoning"] == "grounded in the supplied context"
-        assert score_metric["eval_metric_metadata"] == {"judge": "gpt-4o", "rubric_version": 3}
+        assert score_metric["metadata"] == {"judge": "gpt-4o", "rubric_version": 3}
         assert "judge:test" in score_metric["tags"]
         assert any(tag.startswith("ddtrace.version:") for tag in score_metric["tags"])
 

--- a/tests/parametric/test_llm_observability/test_llm_observability_gen_ai_otlp.py
+++ b/tests/parametric/test_llm_observability/test_llm_observability_gen_ai_otlp.py
@@ -1,0 +1,162 @@
+import base64
+import json
+import time
+
+import pytest
+
+from utils import scenarios, features
+from utils.docker_fixtures import TestAgentAPI
+from ..conftest import APMLibrary  # noqa: TID252
+from utils.docker_fixtures.spec.llm_observability import (
+    LlmObsSpanRequest,
+    LlmObsAnnotationRequest,
+)
+
+
+@pytest.fixture
+def llmobs_ml_app() -> str:
+    return "test-app"
+
+
+@pytest.fixture
+def llmobs_gen_ai_otlp_library_env(library_env: dict, test_agent: TestAgentAPI) -> dict:
+    """Route dd-trace-go's OTLP trace exporter at the test-agent OTLP receiver and
+    tag the export as llmobs intake, mirroring test_otlp_trace_metrics.py plumbing.
+
+    - http/json is required so the captured request body is JSON-decodable by the
+      assertions below (matches the metrics tests' protocol pin).
+    - The endpoint uses the in-Docker-network container name + container port 4318.
+    - dd-otlp-source=llmobs and dd-ml-app are set as OTLP export headers so they
+      appear on the captured /v1/traces request (asserted hermetically below).
+    """
+    library_env["OTEL_TRACES_EXPORTER"] = "otlp"
+    library_env["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/json"
+    library_env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = f"http://{test_agent.container_name}:4318/v1/traces"
+    library_env["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = "dd-otlp-source=llmobs,dd-ml-app=test-app"
+    # A (fake) api key so the intake-style header set is complete; never read back.
+    library_env["DD_API_KEY"] = "<not-a-real-key>"
+    return library_env
+
+
+def _attr_value(item: dict):
+    """Read an OTLP attribute value across the typed fields (OTLP/JSON camelCase)."""
+    value = item["value"]
+    if "stringValue" in value:
+        return value["stringValue"]
+    if "boolValue" in value:
+        return value["boolValue"]
+    if "intValue" in value:
+        return int(value["intValue"])
+    if "doubleValue" in value:
+        return value["doubleValue"]
+    return None
+
+
+def _otlp_trace_bodies(test_agent: TestAgentAPI) -> list[tuple[dict, dict]]:
+    """(lower-cased headers, decoded body) for each captured /v1/traces request."""
+    out: list[tuple[dict, dict]] = []
+    for r in test_agent.otlp_requests():
+        if not r["url"].endswith("/v1/traces"):
+            continue
+        headers = {h.lower(): v for h, v in r["headers"].items()}
+        body = json.loads(base64.b64decode(r["body"]).decode("utf-8"))
+        out.append((headers, body))
+    return out
+
+
+def _wait_for_otlp_trace_spans(test_agent: TestAgentAPI, *, deadline_s: float = 20.0) -> list[tuple[dict, dict]]:
+    """Poll the OTLP receiver until a /v1/traces request carrying spans is captured.
+
+    There is no wait_for_num_otlp_traces helper on TestAgentAPI, so poll
+    otlp_requests() with a deadline (option (b) from the OTLP capture research).
+    """
+    deadline = time.monotonic() + deadline_s
+    captured: list[tuple[dict, dict]] = []
+    while time.monotonic() < deadline:
+        captured = _otlp_trace_bodies(test_agent)
+        for _headers, body in captured:
+            for rs in body.get("resourceSpans", []):
+                for ss in rs.get("scopeSpans", []):
+                    if ss.get("spans"):
+                        return captured
+        time.sleep(0.2)
+    raise AssertionError("No OTLP /v1/traces spans captured before deadline")
+
+
+@features.llm_observability_sdk_enablement
+@scenarios.parametric
+class Test_GenAI_OTLP:
+    """Hermetic: drive the shared SpanRequest tree, assert the emitted OTLP payload
+    carries the correct gen_ai.* attributes + dd-otlp-source=llmobs. No backend
+    read-back, no claim about Datadog's internal gen_ai -> LLM Obs mapping.
+    """
+
+    def test_llm_span_gen_ai_attributes(
+        self,
+        llmobs_gen_ai_otlp_library_env: dict,  # noqa: ARG002  (mutates library_env before test_library builds)
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ):
+        req = LlmObsSpanRequest(
+            kind="llm",
+            name="chat",
+            model_name="gpt-4o",
+            model_provider="openai",
+            session_id="session-123",
+            export_span="explicit",
+            annotations=[
+                LlmObsAnnotationRequest(
+                    input_data=[{"role": "user", "content": "hello"}],
+                    output_data=[{"role": "assistant", "content": "hi there"}],
+                    metadata={"temperature": 0.7},
+                    metrics={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+            ],
+        )
+        with test_library as t:
+            t.llmobs_trace(req)
+
+        captured = _wait_for_otlp_trace_spans(test_agent)
+
+        gen_ai_span: dict | None = None
+        resource_attrs: dict = {}
+        headers_seen: dict = {}
+        for headers, body in captured:
+            headers_seen.update(headers)
+            for rs in body.get("resourceSpans", []):
+                for kv in rs.get("resource", {}).get("attributes", []):
+                    resource_attrs[kv["key"]] = _attr_value(kv)
+                for ss in rs.get("scopeSpans", []):
+                    for span in ss.get("spans", []):
+                        attrs = {kv["key"]: _attr_value(kv) for kv in span.get("attributes", [])}
+                        if attrs.get("gen_ai.operation.name") == "chat":
+                            gen_ai_span = attrs
+
+        assert gen_ai_span is not None, "No captured span with gen_ai.operation.name=chat"
+
+        # gen_ai schema assertions.
+        assert gen_ai_span["gen_ai.operation.name"] == "chat"
+        assert gen_ai_span["gen_ai.request.model"] == "gpt-4o"
+        assert gen_ai_span["gen_ai.provider.name"] == "openai"
+        assert gen_ai_span["gen_ai.conversation.id"] == "session-123"
+        assert gen_ai_span["gen_ai.usage.input_tokens"] == 10
+        assert gen_ai_span["gen_ai.usage.output_tokens"] == 5
+        assert gen_ai_span["gen_ai.usage.total_tokens"] == 15
+
+        input_messages = json.loads(gen_ai_span["gen_ai.input.messages"])
+        assert input_messages == [{"role": "user", "content": "hello"}]
+        output_messages = json.loads(gen_ai_span["gen_ai.output.messages"])
+        assert output_messages == [{"role": "assistant", "content": "hi there"}]
+
+        metadata = json.loads(gen_ai_span["_dd.ml_obs.metadata"])
+        assert metadata["temperature"] == 0.7
+
+        # llmobs OTLP intake header, asserted from the captured request headers.
+        assert headers_seen.get("dd-otlp-source") == "llmobs"
+        assert headers_seen.get("dd-ml-app") == "test-app"
+
+        # resource service.name -> ml_app / tags.service.
+        # TODO(draft): service.name resource-attr fidelity depends on how
+        # dd-trace-go populates the OTLP Resource; relax to "in resource_attrs"
+        # if the exact value differs.
+        assert resource_attrs.get("service.name") == "test-service"

--- a/tests/parametric/test_llm_observability/test_llm_observability_gen_ai_otlp.py
+++ b/tests/parametric/test_llm_observability/test_llm_observability_gen_ai_otlp.py
@@ -20,26 +20,16 @@ def llmobs_ml_app() -> str:
 
 @pytest.fixture
 def llmobs_gen_ai_otlp_library_env(library_env: dict, test_agent: TestAgentAPI) -> dict:
-    """Route dd-trace-go's OTLP trace exporter at the test-agent OTLP receiver and
-    tag the export as llmobs intake, mirroring test_otlp_trace_metrics.py plumbing.
-
-    - http/json is required so the captured request body is JSON-decodable by the
-      assertions below (matches the metrics tests' protocol pin).
-    - The endpoint uses the in-Docker-network container name + container port 4318.
-    - dd-otlp-source=llmobs and dd-ml-app are set as OTLP export headers so they
-      appear on the captured /v1/traces request (asserted hermetically below).
-    """
     library_env["OTEL_TRACES_EXPORTER"] = "otlp"
+    # The test agent must capture JSON-decodable OTLP payloads.
     library_env["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/json"
     library_env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = f"http://{test_agent.container_name}:4318/v1/traces"
     library_env["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = "dd-otlp-source=llmobs,dd-ml-app=test-app"
-    # A (fake) api key so the intake-style header set is complete; never read back.
     library_env["DD_API_KEY"] = "<not-a-real-key>"
     return library_env
 
 
 def _attr_value(item: dict):
-    """Read an OTLP attribute value across the typed fields (OTLP/JSON camelCase)."""
     value = item["value"]
     if "stringValue" in value:
         return value["stringValue"]
@@ -53,7 +43,6 @@ def _attr_value(item: dict):
 
 
 def _otlp_trace_bodies(test_agent: TestAgentAPI) -> list[tuple[dict, dict]]:
-    """(lower-cased headers, decoded body) for each captured /v1/traces request."""
     out: list[tuple[dict, dict]] = []
     for r in test_agent.otlp_requests():
         if not r["url"].endswith("/v1/traces"):
@@ -65,11 +54,6 @@ def _otlp_trace_bodies(test_agent: TestAgentAPI) -> list[tuple[dict, dict]]:
 
 
 def _wait_for_otlp_trace_spans(test_agent: TestAgentAPI, *, deadline_s: float = 20.0) -> list[tuple[dict, dict]]:
-    """Poll the OTLP receiver until a /v1/traces request carrying spans is captured.
-
-    There is no wait_for_num_otlp_traces helper on TestAgentAPI, so poll
-    otlp_requests() with a deadline (option (b) from the OTLP capture research).
-    """
     deadline = time.monotonic() + deadline_s
     captured: list[tuple[dict, dict]] = []
     while time.monotonic() < deadline:
@@ -86,10 +70,7 @@ def _wait_for_otlp_trace_spans(test_agent: TestAgentAPI, *, deadline_s: float = 
 @features.llm_observability_sdk_enablement
 @scenarios.parametric
 class Test_GenAI_OTLP:
-    """Hermetic: drive the shared SpanRequest tree, assert the emitted OTLP payload
-    carries the correct gen_ai.* attributes + dd-otlp-source=llmobs. No backend
-    read-back, no claim about Datadog's internal gen_ai -> LLM Obs mapping.
-    """
+    """Assert the emitted gen_ai OTLP schema without backend read-back."""
 
     def test_llm_span_gen_ai_attributes(
         self,
@@ -134,7 +115,6 @@ class Test_GenAI_OTLP:
 
         assert gen_ai_span is not None, "No captured span with gen_ai.operation.name=chat"
 
-        # gen_ai schema assertions.
         assert gen_ai_span["gen_ai.operation.name"] == "chat"
         assert gen_ai_span["gen_ai.request.model"] == "gpt-4o"
         assert gen_ai_span["gen_ai.provider.name"] == "openai"
@@ -151,12 +131,7 @@ class Test_GenAI_OTLP:
         metadata = json.loads(gen_ai_span["_dd.ml_obs.metadata"])
         assert metadata["temperature"] == 0.7
 
-        # llmobs OTLP intake header, asserted from the captured request headers.
         assert headers_seen.get("dd-otlp-source") == "llmobs"
         assert headers_seen.get("dd-ml-app") == "test-app"
 
-        # resource service.name -> ml_app / tags.service.
-        # TODO(draft): service.name resource-attr fidelity depends on how
-        # dd-trace-go populates the OTLP Resource; relax to "in resource_attrs"
-        # if the exact value differs.
         assert resource_attrs.get("service.name") == "test-service"

--- a/tests/parametric/test_llm_observability/test_llm_observability_gen_ai_otlp.py
+++ b/tests/parametric/test_llm_observability/test_llm_observability_gen_ai_otlp.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import time
+from typing import TypedDict, cast
 
 import pytest
 
@@ -13,13 +14,93 @@ from utils.docker_fixtures.spec.llm_observability import (
 )
 
 
+type Headers = dict[str, str]
+type LibraryEnvironment = dict[str, str | bool]
+type OtlpAttributeScalar = str | bool | int | float | None
+type OtlpAttributes = dict[str, OtlpAttributeScalar]
+
+
+class OtlpAttributeValue(TypedDict, total=False):
+    stringValue: str
+    boolValue: bool
+    intValue: str | int
+    doubleValue: float | str
+
+
+class OtlpAttribute(TypedDict):
+    key: str
+    value: OtlpAttributeValue
+
+
+class OtlpSpan(TypedDict, total=False):
+    attributes: list[OtlpAttribute]
+
+
+class OtlpScopeSpans(TypedDict, total=False):
+    spans: list[OtlpSpan]
+
+
+class OtlpResource(TypedDict, total=False):
+    attributes: list[OtlpAttribute]
+
+
+class OtlpResourceSpans(TypedDict, total=False):
+    resource: OtlpResource
+    scopeSpans: list[OtlpScopeSpans]
+
+
+class OtlpTraceBody(TypedDict, total=False):
+    resourceSpans: list[OtlpResourceSpans]
+
+
+class CapturedRawOtlpRequest(TypedDict):
+    url: str
+    headers: Headers
+    body: str
+
+
+class DecodedOtlpTraceRequest(TypedDict):
+    headers: Headers
+    body: OtlpTraceBody
+
+
+class GenAiChatCapture(TypedDict):
+    headers: Headers
+    resource_attributes: OtlpAttributes
+    span_attributes: OtlpAttributes
+
+
+class GenAiMessage(TypedDict):
+    role: str
+    content: str
+
+
+class GenAiMetadata(TypedDict):
+    temperature: float
+
+
+INVALID_TARGET_METADATA_CASES: tuple[tuple[Headers, str, str], ...] = (
+    ({"dd-ml-app": "test-app"}, "test-service", "dd-otlp-source=llmobs"),
+    (
+        {"dd-otlp-source": "llmobs", "dd-ml-app": "wrong-app"},
+        "test-service",
+        "dd-ml-app=test-app",
+    ),
+    (
+        {"dd-otlp-source": "llmobs", "dd-ml-app": "test-app"},
+        "wrong-service",
+        "service.name=test-service",
+    ),
+)
+
+
 @pytest.fixture
 def llmobs_ml_app() -> str:
     return "test-app"
 
 
 @pytest.fixture
-def llmobs_gen_ai_otlp_library_env(library_env: dict, test_agent: TestAgentAPI) -> dict:
+def llmobs_gen_ai_otlp_library_env(library_env: LibraryEnvironment, test_agent: TestAgentAPI) -> LibraryEnvironment:
     library_env["OTEL_TRACES_EXPORTER"] = "otlp"
     # The test agent must capture JSON-decodable OTLP payloads.
     library_env["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/json"
@@ -29,7 +110,7 @@ def llmobs_gen_ai_otlp_library_env(library_env: dict, test_agent: TestAgentAPI) 
     return library_env
 
 
-def _attr_value(item: dict):
+def _attr_value(item: OtlpAttribute) -> OtlpAttributeScalar:
     value = item["value"]
     if "stringValue" in value:
         return value["stringValue"]
@@ -42,29 +123,95 @@ def _attr_value(item: dict):
     return None
 
 
-def _otlp_trace_bodies(test_agent: TestAgentAPI) -> list[tuple[dict, dict]]:
-    out: list[tuple[dict, dict]] = []
-    for r in test_agent.otlp_requests():
-        if not r["url"].endswith("/v1/traces"):
+def _attribute_map(attributes: list[OtlpAttribute]) -> OtlpAttributes:
+    return {item["key"]: _attr_value(item) for item in attributes}
+
+
+def _otlp_trace_bodies(test_agent: TestAgentAPI) -> list[DecodedOtlpTraceRequest]:
+    out: list[DecodedOtlpTraceRequest] = []
+    raw_requests = cast("list[CapturedRawOtlpRequest]", test_agent.otlp_requests())
+    for request in raw_requests:
+        if not request["url"].endswith("/v1/traces"):
             continue
-        headers = {h.lower(): v for h, v in r["headers"].items()}
-        body = json.loads(base64.b64decode(r["body"]).decode("utf-8"))
-        out.append((headers, body))
+        headers: Headers = {name.lower(): value for name, value in request["headers"].items()}
+        body = cast("OtlpTraceBody", json.loads(base64.b64decode(request["body"]).decode("utf-8")))
+        out.append({"headers": headers, "body": body})
     return out
 
 
-def _wait_for_otlp_trace_spans(test_agent: TestAgentAPI, *, deadline_s: float = 20.0) -> list[tuple[dict, dict]]:
+def _wait_for_otlp_trace_spans(test_agent: TestAgentAPI, *, deadline_s: float = 20.0) -> list[DecodedOtlpTraceRequest]:
     deadline = time.monotonic() + deadline_s
-    captured: list[tuple[dict, dict]] = []
+    captured: list[DecodedOtlpTraceRequest] = []
     while time.monotonic() < deadline:
         captured = _otlp_trace_bodies(test_agent)
-        for _headers, body in captured:
+        for request in captured:
+            body = request["body"]
             for rs in body.get("resourceSpans", []):
                 for ss in rs.get("scopeSpans", []):
                     if ss.get("spans"):
                         return captured
         time.sleep(0.2)
     raise AssertionError("No OTLP /v1/traces spans captured before deadline")
+
+
+def _find_gen_ai_chat_capture(captured: list[DecodedOtlpTraceRequest]) -> GenAiChatCapture:
+    for request in captured:
+        for resource_spans in request["body"].get("resourceSpans", []):
+            resource_attributes = _attribute_map(resource_spans.get("resource", {}).get("attributes", []))
+            for scope_spans in resource_spans.get("scopeSpans", []):
+                for span in scope_spans.get("spans", []):
+                    span_attributes = _attribute_map(span.get("attributes", []))
+                    if span_attributes.get("gen_ai.operation.name") == "chat":
+                        return {
+                            "headers": request["headers"],
+                            "resource_attributes": resource_attributes,
+                            "span_attributes": span_attributes,
+                        }
+    raise AssertionError("No captured span with gen_ai.operation.name=chat")
+
+
+def _validated_gen_ai_chat_span(captured: list[DecodedOtlpTraceRequest]) -> OtlpAttributes:
+    match = _find_gen_ai_chat_capture(captured)
+    headers = match["headers"]
+    resource_attributes = match["resource_attributes"]
+
+    assert headers.get("dd-otlp-source") == "llmobs", "Expected matching OTLP request dd-otlp-source=llmobs"
+    assert headers.get("dd-ml-app") == "test-app", "Expected matching OTLP request dd-ml-app=test-app"
+    assert resource_attributes.get("service.name") == "test-service", (
+        "Expected matching OTLP resource service.name=test-service"
+    )
+    return match["span_attributes"]
+
+
+def _synthetic_trace_request(*, headers: Headers, service_name: str, operation_name: str) -> DecodedOtlpTraceRequest:
+    return {
+        "headers": headers,
+        "body": {
+            "resourceSpans": [
+                {
+                    "resource": {
+                        "attributes": [
+                            {"key": "service.name", "value": {"stringValue": service_name}},
+                        ]
+                    },
+                    "scopeSpans": [
+                        {
+                            "spans": [
+                                {
+                                    "attributes": [
+                                        {
+                                            "key": "gen_ai.operation.name",
+                                            "value": {"stringValue": operation_name},
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                }
+            ]
+        },
+    }
 
 
 @features.llm_observability_sdk_enablement
@@ -74,10 +221,10 @@ class Test_GenAI_OTLP:
 
     def test_llm_span_gen_ai_attributes(
         self,
-        llmobs_gen_ai_otlp_library_env: dict,  # noqa: ARG002  (mutates library_env before test_library builds)
+        llmobs_gen_ai_otlp_library_env: LibraryEnvironment,  # noqa: ARG002
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
-    ):
+    ) -> None:
         req = LlmObsSpanRequest(
             kind="llm",
             name="chat",
@@ -98,22 +245,7 @@ class Test_GenAI_OTLP:
             t.llmobs_trace(req)
 
         captured = _wait_for_otlp_trace_spans(test_agent)
-
-        gen_ai_span: dict | None = None
-        resource_attrs: dict = {}
-        headers_seen: dict = {}
-        for headers, body in captured:
-            headers_seen.update(headers)
-            for rs in body.get("resourceSpans", []):
-                for kv in rs.get("resource", {}).get("attributes", []):
-                    resource_attrs[kv["key"]] = _attr_value(kv)
-                for ss in rs.get("scopeSpans", []):
-                    for span in ss.get("spans", []):
-                        attrs = {kv["key"]: _attr_value(kv) for kv in span.get("attributes", [])}
-                        if attrs.get("gen_ai.operation.name") == "chat":
-                            gen_ai_span = attrs
-
-        assert gen_ai_span is not None, "No captured span with gen_ai.operation.name=chat"
+        gen_ai_span = _validated_gen_ai_chat_span(captured)
 
         assert gen_ai_span["gen_ai.operation.name"] == "chat"
         assert gen_ai_span["gen_ai.request.model"] == "gpt-4o"
@@ -123,15 +255,41 @@ class Test_GenAI_OTLP:
         assert gen_ai_span["gen_ai.usage.output_tokens"] == 5
         assert gen_ai_span["gen_ai.usage.total_tokens"] == 15
 
-        input_messages = json.loads(gen_ai_span["gen_ai.input.messages"])
+        input_messages_json = gen_ai_span["gen_ai.input.messages"]
+        assert isinstance(input_messages_json, str)
+        input_messages = cast("list[GenAiMessage]", json.loads(input_messages_json))
         assert input_messages == [{"role": "user", "content": "hello"}]
-        output_messages = json.loads(gen_ai_span["gen_ai.output.messages"])
+        output_messages_json = gen_ai_span["gen_ai.output.messages"]
+        assert isinstance(output_messages_json, str)
+        output_messages = cast("list[GenAiMessage]", json.loads(output_messages_json))
         assert output_messages == [{"role": "assistant", "content": "hi there"}]
 
-        metadata = json.loads(gen_ai_span["_dd.ml_obs.metadata"])
+        metadata_json = gen_ai_span["_dd.ml_obs.metadata"]
+        assert isinstance(metadata_json, str)
+        metadata = cast("GenAiMetadata", json.loads(metadata_json))
         assert metadata["temperature"] == 0.7
 
-        assert headers_seen.get("dd-otlp-source") == "llmobs"
-        assert headers_seen.get("dd-ml-app") == "test-app"
+    @pytest.mark.parametrize(
+        ("target_headers", "target_service_name", "expected_failure"), INVALID_TARGET_METADATA_CASES
+    )
+    def test_matching_request_metadata_is_not_merged(
+        self,
+        target_headers: Headers,
+        target_service_name: str,
+        expected_failure: str,
+    ) -> None:
+        captured = [
+            _synthetic_trace_request(
+                headers=target_headers,
+                service_name=target_service_name,
+                operation_name="chat",
+            ),
+            _synthetic_trace_request(
+                headers={"dd-otlp-source": "llmobs", "dd-ml-app": "test-app"},
+                service_name="test-service",
+                operation_name="unrelated",
+            ),
+        ]
 
-        assert resource_attrs.get("service.name") == "test-service"
+        with pytest.raises(AssertionError, match=expected_failure):
+            _validated_gen_ai_chat_span(captured)

--- a/utils/build/docker/golang/parametric/Dockerfile
+++ b/utils/build/docker/golang/parametric/Dockerfile
@@ -15,6 +15,11 @@ COPY utils/build/docker/golang/parametric/system_tests_library_version.sh system
 RUN /binaries/install_ddtrace.sh
 RUN mkdir /parametric-tracer-logs
 
-RUN go install
+# Go ignores underscore-prefixed files, keeping tracer versions without llmobs/export buildable.
+RUN if go list github.com/DataDog/dd-trace-go/v2/llmobs/export >/dev/null 2>&1; then \
+        cp _llmobs_export_supported.go llmobs_export_supported.go; \
+    fi \
+    && go mod tidy \
+    && go install
 
 CMD ["main"]

--- a/utils/build/docker/golang/parametric/_llmobs_export_supported.go
+++ b/utils/build/docker/golang/parametric/_llmobs_export_supported.go
@@ -10,28 +10,10 @@ import (
 	llmobsexport "github.com/DataDog/dd-trace-go/v2/llmobs/export"
 )
 
-// The endpoint DTOs below mirror the LlmObsExport* parametric protocol in
-// utils/docker_fixtures/spec/llm_observability.py. The dd-trace-go types are
-// producer-side inputs; the canonical intake consumer and contracts are pinned
-// here:
-// https://github.com/ddoghq/dd-go/tree/0293d577fbc211484fda1815eafbbbaa7a111f17
-// https://github.com/ddoghq/dd-source/tree/7b1e4d9f79cf6ef25fb288a691775d24be59c789
-//
-// Intake sources:
-//   - the intake processor decoding spans and evaluation metrics:
-//     https://github.com/ddoghq/dd-go/blob/0293d577fbc211484fda1815eafbbbaa7a111f17/domains/ml-observability/apps/llm-obs-events-processor/decoder/decoder.go
-//   - common event envelope and internal attributes:
-//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/shared/libs/llmobs-internal/types.go
-//   - span payload, SpanLink, and ErrorField definitions:
-//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/shared/libs/llmobs-internal/types_span.go
-//   - raw span metadata and error placement:
-//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/shared/libs/llmobs-internal/types_span_deprecated.go
-//   - v2 evaluation intake request and handler:
-//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/internal/adapters/handlersv1/http/eval_metric.go
-//   - v2 evaluation metric fields:
-//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/internal/core/domain/eval_metric.go
-//   - intake route registration:
-//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/bootstrap.go
+// The endpoint DTOs below mirror the cross-SDK LlmObsExport* parametric
+// protocol in utils/docker_fixtures/spec/llm_observability.py. They are
+// transport DTOs, not intake schemas. The shared spec pins the canonical
+// intake consumers used by the tests.
 type llmObsExportRequest struct {
 	MLApp       string                          `json:"ml_app"`
 	Service     string                          `json:"service"`

--- a/utils/build/docker/golang/parametric/_llmobs_export_supported.go
+++ b/utils/build/docker/golang/parametric/_llmobs_export_supported.go
@@ -11,26 +11,27 @@ import (
 )
 
 // The endpoint DTOs below mirror the LlmObsExport* parametric protocol in
-// utils/docker_fixtures/spec/llm_observability.py. They map into the public API
-// introduced by DataDog/dd-trace-go#4936 at these pinned sources:
-//   - client and submission options:
-//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/llmobs/export/client.go
-//   - SpanEvent, SpanLink, and ErrorMessage:
-//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/llmobs/export/span.go
-//   - EvaluationMetric:
-//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/llmobs/export/eval_metric.go
-//   - Result:
-//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/llmobs/export/result.go
+// utils/docker_fixtures/spec/llm_observability.py. The dd-trace-go types are
+// producer-side inputs; the canonical intake consumer and contracts are pinned
+// here:
+// https://github.com/ddoghq/dd-go/tree/0293d577fbc211484fda1815eafbbbaa7a111f17
+// https://github.com/ddoghq/dd-source/tree/7b1e4d9f79cf6ef25fb288a691775d24be59c789
 //
-// The intake wire sources are distinct from those public input types:
-//   - SpanEvent and SpanLink:
-//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/internal/llmobs/transport/span.go
-//   - ErrorMessage:
-//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/internal/llmobs/transport/transport.go
-//   - EvaluationMetric input and its lowering into the intake payload:
-//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/internal/llmobs/evaluation.go
-//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/internal/llmobs/export.go
-//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/internal/llmobs/transport/eval_metric.go
+// Intake sources:
+//   - the intake processor decoding spans and evaluation metrics:
+//     https://github.com/ddoghq/dd-go/blob/0293d577fbc211484fda1815eafbbbaa7a111f17/domains/ml-observability/apps/llm-obs-events-processor/decoder/decoder.go
+//   - common event envelope and internal attributes:
+//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/shared/libs/llmobs-internal/types.go
+//   - span payload, SpanLink, and ErrorField definitions:
+//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/shared/libs/llmobs-internal/types_span.go
+//   - raw span metadata and error placement:
+//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/shared/libs/llmobs-internal/types_span_deprecated.go
+//   - v2 evaluation intake request and handler:
+//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/internal/adapters/handlersv1/http/eval_metric.go
+//   - v2 evaluation metric fields:
+//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/internal/core/domain/eval_metric.go
+//   - intake route registration:
+//     https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/bootstrap.go
 type llmObsExportRequest struct {
 	MLApp       string                          `json:"ml_app"`
 	Service     string                          `json:"service"`

--- a/utils/build/docker/golang/parametric/_llmobs_export_supported.go
+++ b/utils/build/docker/golang/parametric/_llmobs_export_supported.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	llmobsexport "github.com/DataDog/dd-trace-go/v2/llmobs/export"
+)
+
+// The endpoint DTOs below mirror the LlmObsExport* parametric protocol in
+// utils/docker_fixtures/spec/llm_observability.py. They map into these public
+// dd-trace-go types introduced by DataDog/dd-trace-go#4936:
+//   - client and submission options: llmobs/export/client.go
+//   - SpanEvent, SpanLink, and ErrorMessage: llmobs/export/span.go
+//   - EvaluationMetric: llmobs/export/eval_metric.go
+//   - Result: llmobs/export/result.go
+//
+// Pinned upstream source root:
+// https://github.com/DataDog/dd-trace-go/tree/81a6224f9794276d093e92c4e1f29af06ef4bff0
+// SpanEvent, SpanLink, and ErrorMessage alias the canonical wire types in
+// internal/llmobs/transport/span.go; EvaluationMetric aliases EvaluationConfig
+// from internal/llmobs/evaluation.go.
+type llmObsExportRequest struct {
+	MLApp       string                          `json:"ml_app"`
+	Service     string                          `json:"service"`
+	Env         string                          `json:"env"`
+	Version     string                          `json:"version"`
+	CallService string                          `json:"call_service"`
+	CallMLApp   string                          `json:"call_ml_app"`
+	Spans       []llmObsExportSpanRequest       `json:"spans"`
+	Evaluations []llmObsExportEvaluationRequest `json:"evaluations"`
+}
+
+type llmObsExportSpanRequest struct {
+	TraceID       string                        `json:"trace_id"`
+	SpanID        string                        `json:"span_id"`
+	ParentID      string                        `json:"parent_id"`
+	SessionID     string                        `json:"session_id"`
+	Name          string                        `json:"name"`
+	Service       string                        `json:"service"`
+	Kind          string                        `json:"kind"`
+	StartNS       int64                         `json:"start_ns"`
+	DurationNS    int64                         `json:"duration_ns"`
+	ModelName     string                        `json:"model_name"`
+	ModelProvider string                        `json:"model_provider"`
+	Input         string                        `json:"input"`
+	Output        string                        `json:"output"`
+	Metadata      map[string]any                `json:"metadata"`
+	Metrics       map[string]float64            `json:"metrics"`
+	Tags          []string                      `json:"tags"`
+	SpanLinks     []llmObsExportSpanLinkRequest `json:"span_links"`
+	APMTraceID    string                        `json:"apm_trace_id"`
+	Error         *llmObsExportErrorRequest     `json:"error"`
+}
+
+type llmObsExportSpanLinkRequest struct {
+	TraceID     string            `json:"trace_id"`
+	TraceIDHigh uint64            `json:"trace_id_high"`
+	SpanID      string            `json:"span_id"`
+	Attributes  map[string]string `json:"attributes"`
+	Tracestate  string            `json:"tracestate"`
+	Flags       uint32            `json:"flags"`
+}
+
+type llmObsExportErrorRequest struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	Stack   string `json:"stack"`
+}
+
+type llmObsExportEvaluationRequest struct {
+	SpanID           string         `json:"span_id"`
+	TraceID          string         `json:"trace_id"`
+	TagKey           string         `json:"tag_key"`
+	TagValue         string         `json:"tag_value"`
+	Label            string         `json:"label"`
+	MetricType       string         `json:"metric_type"`
+	CategoricalValue *string        `json:"categorical_value"`
+	ScoreValue       *float64       `json:"score_value"`
+	BooleanValue     *bool          `json:"boolean_value"`
+	JSONValue        map[string]any `json:"json_value"`
+	Tags             []string       `json:"tags"`
+	MLApp            string         `json:"ml_app"`
+	TimestampMS      int64          `json:"timestamp_ms"`
+	Assessment       string         `json:"assessment"`
+	Reasoning        string         `json:"reasoning"`
+	Metadata         map[string]any `json:"metadata"`
+}
+
+type llmObsExportResponse struct {
+	Spans       llmObsExportResult `json:"spans"`
+	Evaluations llmObsExportResult `json:"evaluations"`
+}
+
+type llmObsExportResult struct {
+	Sent    int `json:"sent"`
+	Dropped int `json:"dropped"`
+	Failed  int `json:"failed"`
+}
+
+func init() {
+	llmObsExportHandlerImpl = submitLlmObsExport
+}
+
+func submitLlmObsExport(s *apmClientServer, w http.ResponseWriter, r *http.Request) {
+	var req llmObsExportRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("Error decoding JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	client, err := llmobsexport.NewClient(
+		req.MLApp,
+		llmobsexport.WithAgentURL(os.Getenv("DD_TRACE_AGENT_URL")),
+		llmobsexport.WithService(req.Service),
+		llmobsexport.WithEnv(req.Env),
+		llmobsexport.WithVersion(req.Version),
+	)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	response := llmObsExportResponse{}
+	if len(req.Spans) > 0 {
+		result, submitErr := client.SubmitSpans(r.Context(), exportSpans(req.Spans), spanSubmitOptions(req)...)
+		if submitErr != nil {
+			http.Error(w, submitErr.Error(), http.StatusBadGateway)
+			return
+		}
+		response.Spans = exportResult(result)
+	}
+	if len(req.Evaluations) > 0 {
+		result, submitErr := client.SubmitEvaluations(
+			r.Context(),
+			exportEvaluations(req.Evaluations),
+			evaluationSubmitOptions(req)...,
+		)
+		if submitErr != nil {
+			http.Error(w, submitErr.Error(), http.StatusBadGateway)
+			return
+		}
+		response.Evaluations = exportResult(result)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func exportSpans(requests []llmObsExportSpanRequest) []llmobsexport.SpanEvent {
+	events := make([]llmobsexport.SpanEvent, 0, len(requests))
+	for _, req := range requests {
+		options := []llmobsexport.SpanEventOption{
+			llmobsexport.WithTiming(time.Unix(0, req.StartNS), time.Duration(req.DurationNS)),
+			llmobsexport.WithModel(req.ModelName, req.ModelProvider),
+			llmobsexport.WithTextIO(req.Input, req.Output),
+			llmobsexport.WithMetadata(req.Metadata),
+		}
+		if req.Error != nil {
+			options = append(options, llmobsexport.WithSpanError(llmobsexport.ErrorMessage{
+				Type: req.Error.Type, Message: req.Error.Message, Stack: req.Error.Stack,
+			}))
+		}
+		event := llmobsexport.NewSpanEvent(req.TraceID, req.SpanID, llmobsexport.Kind(req.Kind), options...)
+		event.ParentID = req.ParentID
+		event.SessionID = req.SessionID
+		event.Name = req.Name
+		event.Service = req.Service
+		event.Tags = req.Tags
+		event.Metrics = req.Metrics
+		event.SpanLinks = exportSpanLinks(req.SpanLinks)
+		event.DDAttributes.APMTraceID = req.APMTraceID
+		events = append(events, event)
+	}
+	return events
+}
+
+func exportSpanLinks(requests []llmObsExportSpanLinkRequest) []llmobsexport.SpanLink {
+	links := make([]llmobsexport.SpanLink, 0, len(requests))
+	for _, req := range requests {
+		links = append(links, llmobsexport.SpanLink{
+			TraceID:     req.TraceID,
+			TraceIDHigh: req.TraceIDHigh,
+			SpanID:      req.SpanID,
+			Attributes:  req.Attributes,
+			Tracestate:  req.Tracestate,
+			Flags:       req.Flags,
+		})
+	}
+	return links
+}
+
+func exportEvaluations(requests []llmObsExportEvaluationRequest) []llmobsexport.EvaluationMetric {
+	evaluations := make([]llmobsexport.EvaluationMetric, 0, len(requests))
+	for _, req := range requests {
+		evaluations = append(evaluations, llmobsexport.EvaluationMetric{
+			SpanID:           req.SpanID,
+			TraceID:          req.TraceID,
+			TagKey:           req.TagKey,
+			TagValue:         req.TagValue,
+			Label:            req.Label,
+			MetricType:       llmobsexport.MetricType(req.MetricType),
+			CategoricalValue: req.CategoricalValue,
+			ScoreValue:       req.ScoreValue,
+			BooleanValue:     req.BooleanValue,
+			JSONValue:        req.JSONValue,
+			Tags:             req.Tags,
+			MLApp:            req.MLApp,
+			TimestampMS:      req.TimestampMS,
+			Assessment:       req.Assessment,
+			Reasoning:        req.Reasoning,
+			Metadata:         req.Metadata,
+		})
+	}
+	return evaluations
+}
+
+func spanSubmitOptions(req llmObsExportRequest) []llmobsexport.SubmitSpansOption {
+	if req.CallService == "" {
+		return nil
+	}
+	return []llmobsexport.SubmitSpansOption{llmobsexport.WithCallService(req.CallService)}
+}
+
+func evaluationSubmitOptions(req llmObsExportRequest) []llmobsexport.SubmitEvaluationsOption {
+	if req.CallMLApp == "" {
+		return nil
+	}
+	return []llmobsexport.SubmitEvaluationsOption{llmobsexport.WithCallMLApp(req.CallMLApp)}
+}
+
+func exportResult(result *llmobsexport.Result) llmObsExportResult {
+	return llmObsExportResult{Sent: result.Sent, Dropped: result.Dropped, Failed: result.Failed}
+}

--- a/utils/build/docker/golang/parametric/_llmobs_export_supported.go
+++ b/utils/build/docker/golang/parametric/_llmobs_export_supported.go
@@ -11,18 +11,26 @@ import (
 )
 
 // The endpoint DTOs below mirror the LlmObsExport* parametric protocol in
-// utils/docker_fixtures/spec/llm_observability.py. They map into these public
-// dd-trace-go types introduced by DataDog/dd-trace-go#4936:
-//   - client and submission options: llmobs/export/client.go
-//   - SpanEvent, SpanLink, and ErrorMessage: llmobs/export/span.go
-//   - EvaluationMetric: llmobs/export/eval_metric.go
-//   - Result: llmobs/export/result.go
+// utils/docker_fixtures/spec/llm_observability.py. They map into the public API
+// introduced by DataDog/dd-trace-go#4936 at these pinned sources:
+//   - client and submission options:
+//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/llmobs/export/client.go
+//   - SpanEvent, SpanLink, and ErrorMessage:
+//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/llmobs/export/span.go
+//   - EvaluationMetric:
+//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/llmobs/export/eval_metric.go
+//   - Result:
+//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/llmobs/export/result.go
 //
-// Pinned upstream source root:
-// https://github.com/DataDog/dd-trace-go/tree/81a6224f9794276d093e92c4e1f29af06ef4bff0
-// SpanEvent, SpanLink, and ErrorMessage alias the canonical wire types in
-// internal/llmobs/transport/span.go; EvaluationMetric aliases EvaluationConfig
-// from internal/llmobs/evaluation.go.
+// The intake wire sources are distinct from those public input types:
+//   - SpanEvent and SpanLink:
+//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/internal/llmobs/transport/span.go
+//   - ErrorMessage:
+//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/internal/llmobs/transport/transport.go
+//   - EvaluationMetric input and its lowering into the intake payload:
+//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/internal/llmobs/evaluation.go
+//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/internal/llmobs/export.go
+//     https://github.com/DataDog/dd-trace-go/blob/b8d0489ecfe4664faae4adcbf2480962ddd8eb4c/internal/llmobs/transport/eval_metric.go
 type llmObsExportRequest struct {
 	MLApp       string                          `json:"ml_app"`
 	Service     string                          `json:"service"`

--- a/utils/build/docker/golang/parametric/llmobs.go
+++ b/utils/build/docker/golang/parametric/llmobs.go
@@ -1,47 +1,50 @@
 package main
 
+// This file reorients the /llm_observability/trace endpoint from the native
+// dd-trace-go llmobs SDK path to an OTel gen_ai OTLP path.
+//
+// Design (verified against the parametric app + OTLP capture research):
+//   - We DO NOT add any new module. Spans are created through the app's EXISTING
+//     ddotel bridge provider (s.tp, a *ddotel.TracerProvider created in
+//     newServer()). dd-trace-go's own OTLP trace exporter — enabled by the
+//     scenario via OTEL_TRACES_EXPORTER=otlp + OTEL_EXPORTER_OTLP_TRACES_* — ships
+//     these spans as OTLP/JSON to the ddapm-test-agent OTLP receiver, exactly the
+//     transport the hermetic test_otlp_trace_metrics.py tests already rely on
+//     (see test_fr15_3, which reads /v1/traces off the OTLP receiver for spans
+//     produced by dd-trace-go's OTLP export). No upstream otlptrace exporter and
+//     no sdktrace provider is introduced, so this compiles against the deps
+//     already in parametric/go.mod.
+//   - The intake headers (dd-otlp-source=llmobs, dd-ml-app, dd-api-key) are set on
+//     the exporter via OTEL_EXPORTER_OTLP_TRACES_HEADERS (scenario env), not in
+//     code, because dd-trace-go's OTLP exporter reads standard OTLP env.
+//   - Each SpanRequest node is mapped to gen_ai.* attributes per the authoritative
+//     Datadog LLM Obs OTel schema. The backend mapping of those attributes is NOT
+//     asserted here; the hermetic pytest only asserts the emitted OTLP payload's
+//     gen_ai.* attributes + headers.
+//
+// The /llm_observability/trace input contract (the SpanRequest tree) is
+// unchanged, so the harness can still drive it via test_library.llmobs_trace().
+//
+// TODO(draft): whether dd-trace-go's OTLP trace export preserves arbitrary
+// gen_ai.* string attributes verbatim (vs. remapping/dropping them) is the key
+// unverified assumption; the pytest is what proves or disproves it.
+
 import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
-	"os"
-	"sync"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"github.com/DataDog/dd-trace-go/v2/llmobs"
-	"github.com/DataDog/dd-trace-go/v2/llmobs/dataset"
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-// llmObsStartOnce guards a single tracer.Start so LLM Obs is initialized on the
-// first /llm_observability/* request. LLM Obs piggybacks on the tracer: it is
-// enabled by starting the tracer with DD_LLMOBS_ENABLED / DD_LLMOBS_ML_APP (set
-// by the system-tests scenario) or tracer.WithLLMObsEnabled(true).
-var llmObsStartOnce sync.Once
-
-// ensureLLMObs starts the tracer (and therefore LLM Obs) exactly once, honoring
-// the DD_LLMOBS_* environment variables provided by the scenario.
-//
-// TODO(draft): the parametric app never calls tracer.Start() in main(), so we
-// lazily start it here. If a scenario expects LLM Obs to be enabled purely
-// programmatically (no env), force tracer.WithLLMObsEnabled(true) here instead.
-func ensureLLMObs() {
-	llmObsStartOnce.Do(func() {
-		if err := tracer.Start(); err != nil {
-			log.Printf("llmobs: failed to start tracer: %v", err)
-		}
-	})
-}
-
 // ---------------------------------------------------------------------------
-// Request / response types
-//
-// These mirror the harness-side dataclasses (utils/docker_fixtures/spec/
-// llm_observability.py). The three node shapes (ApmSpanRequest,
-// LlmObsSpanRequest, LlmObsAnnotationContextRequest) are folded into a single
-// recursive struct discriminated by "type"/"sdk"; JSON field names never
-// collide across the shapes so one struct decodes all of them.
+// Request types — unchanged from the native draft; they mirror the harness-side
+// dataclasses in utils/docker_fixtures/spec/llm_observability.py. The three node
+// shapes (ApmSpanRequest, LlmObsSpanRequest, LlmObsAnnotationContextRequest) fold
+// into one recursive struct discriminated by "type"/"sdk".
 // ---------------------------------------------------------------------------
 
 type llmObsTraceRequest struct {
@@ -82,47 +85,19 @@ type llmObsAnnotationRequest struct {
 	ExplicitSpan bool               `json:"explicit_span"`
 }
 
-type datasetRecordRequest struct {
-	InputData      map[string]any `json:"input_data"`
-	ExpectedOutput any            `json:"expected_output"`
-	Metadata       map[string]any `json:"metadata"`
-}
-
-type datasetCreateRequest struct {
-	DatasetName string                 `json:"dataset_name"`
-	Description string                 `json:"description"`
-	Records     []datasetRecordRequest `json:"records"`
-	ProjectName string                 `json:"project_name"`
-}
-
-type datasetResponse struct {
-	DatasetID     string           `json:"dataset_id"`
-	Name          string           `json:"name"`
-	Description   string           `json:"description"`
-	ProjectName   *string          `json:"project_name"`
-	ProjectID     *string          `json:"project_id"`
-	Version       int              `json:"version"`
-	LatestVersion int              `json:"latest_version"`
-	Records       []map[string]any `json:"records"`
-}
-
-type datasetDeleteRequest struct {
-	DatasetID string `json:"dataset_id"`
-}
-
 // ---------------------------------------------------------------------------
 // POST /llm_observability/trace
 // ---------------------------------------------------------------------------
 
 func (s *apmClientServer) llmObsTraceHandler(w http.ResponseWriter, r *http.Request) {
-	ensureLLMObs()
-
-	// The Python app force-flushes the telemetry writer in a finally block.
-	// tracer.Flush() (which internally flushes LLM Obs) is the closest idiom
-	// available from the public API and guarantees the span reaches the
-	// test-agent before the handler returns.
-	// TODO(draft): confirm span flush (not just telemetry) is what the harness
-	// waits on via test_agent.wait_for_llmobs_requests.
+	// dd-trace-go's OTLP trace exporter (scenario: OTEL_TRACES_EXPORTER=otlp +
+	// OTEL_EXPORTER_OTLP_TRACES_*) is what ships these spans to the test-agent OTLP
+	// receiver. tracer.Flush() pushes the trace writer; the hermetic test also
+	// polls the OTLP receiver with a deadline as a backstop.
+	//
+	// TODO(draft): confirm tracer.Flush() drains the OTLP trace exporter and not
+	// only the native trace writer. If it does not, an explicit OTLP exporter
+	// flush hook (or a short poll on the receiver) is required.
 	defer tracer.Flush()
 
 	var req llmObsTraceRequest
@@ -132,9 +107,10 @@ func (s *apmClientServer) llmObsTraceHandler(w http.ResponseWriter, r *http.Requ
 	}
 	defer r.Body.Close()
 
-	exported := s.createLLMObsTrace(context.Background(), req.TraceStructureRequest)
+	tr := s.tp.Tracer("system-tests-llmobs")
+	exported := s.buildGenAISpan(context.Background(), tr, req.TraceStructureRequest)
 	if exported == nil {
-		// Success with no export requested -> {} (see llmobs.py llmobs_trace).
+		// Success with no export requested -> {} (mirrors llmobs.py llmobs_trace).
 		exported = map[string]any{}
 	}
 
@@ -144,367 +120,224 @@ func (s *apmClientServer) llmObsTraceHandler(w http.ResponseWriter, r *http.Requ
 	}
 }
 
-// createLLMObsTrace builds the (recursive) span tree and returns the first
-// non-nil exported span context bubbled up from the tree, mirroring
-// llmobs.py create_trace.
-func (s *apmClientServer) createLLMObsTrace(ctx context.Context, node *llmObsSpanNode) map[string]any {
+// buildGenAISpan walks the recursive SpanRequest tree, emitting one OTel span per
+// node with gen_ai.* attributes, and bubbles up the first exported span context.
+func (s *apmClientServer) buildGenAISpan(ctx context.Context, tr oteltrace.Tracer, node *llmObsSpanNode) map[string]any {
 	if node == nil {
 		return nil
 	}
 
+	// annotation_context has no gen_ai equivalent (it is a dd-trace-py scope that
+	// applies prompt/name/tags to spans opened within the block). Recurse so the
+	// tree/parentage is preserved; the contextual annotations are dropped.
+	// TODO(draft): if the contract needs those tags on descendant spans, apply
+	// node.Tags/node.Prompt to each child span here.
 	if node.Type == "annotation_context" {
-		// TODO(draft): the public dd-trace-go v2 llmobs package exposes no
-		// annotation_context equivalent (dd-trace-py's LLMObs.annotation_context
-		// applies prompt/name/tags/cost_tags to all spans opened within the
-		// block). For the draft we simply recurse into the children so the tree
-		// is still built; the contextual annotations are dropped. This needs an
-		// upstream SDK addition or a per-child annotation workaround.
 		var exported map[string]any
 		for _, child := range node.Children {
-			if e := s.createLLMObsTrace(ctx, child); e != nil && exported == nil {
+			if e := s.buildGenAISpan(ctx, tr, child); e != nil && exported == nil {
 				exported = e
 			}
 		}
 		return exported
 	}
 
-	// APM (plain tracer) span branch.
-	if node.SDK == "tracer" {
-		// Start from the incoming ctx so a tracer span nested under an LLMObs span
-		// keeps the intended parentage (e.g. llmobs -> tracer -> llmobs) from the
-		// shared request model; StartSpanFromContext also returns the child-bearing
-		// context to place descendants under this span.
-		span, childCtx := tracer.StartSpanFromContext(ctx, node.Name)
+	name := node.Name
+	if name == "" {
+		name = node.Kind
+	}
+	spanCtx, span := tr.Start(ctx, name)
 
-		// TODO(draft): dd-trace-py applies annotations to tracer-sdk spans via
-		// LLMObs.annotate(span=...). The public Go llmobs annotation API only
-		// operates on llmobs span types, so annotations on tracer-sdk spans are
-		// not applied here.
-		var exported map[string]any
-		for _, child := range node.Children {
-			if e := s.createLLMObsTrace(childCtx, child); e != nil && exported == nil {
-				exported = e
-			}
-		}
-		span.Finish()
-		return exported
+	attrs := genAIBaseAttributes(node)
+	for _, a := range node.Annotations {
+		attrs = append(attrs, genAIAnnotationAttributes(node.Kind, a)...)
 	}
-
-	// LLM Obs span branch.
-	var opts []llmobs.StartSpanOption
-	if node.SessionID != "" {
-		opts = append(opts, llmobs.WithSessionID(node.SessionID))
-	}
-	if node.MLApp != "" {
-		opts = append(opts, llmobs.WithMLApp(node.MLApp))
-	}
-	if node.ModelName != "" {
-		opts = append(opts, llmobs.WithModelName(node.ModelName))
-	}
-	if node.ModelProvider != "" {
-		opts = append(opts, llmobs.WithModelProvider(node.ModelProvider))
-	}
-
-	span, childCtx := startLLMObsSpan(ctx, node.Kind, node.Name, opts...)
-	if span == nil {
-		// Unknown kind: recurse without a span so the rest of the tree still
-		// builds, still bubbling up any exported child context.
-		var exported map[string]any
-		for _, child := range node.Children {
-			if e := s.createLLMObsTrace(ctx, child); e != nil && exported == nil {
-				exported = e
-			}
-		}
-		return exported
-	}
-
-	// Apply annotations before export/children (unless annotate_after).
-	if len(node.Annotations) > 0 && !node.AnnotateAfter {
-		for _, a := range node.Annotations {
-			applyLLMObsAnnotation(span, a)
-		}
+	if len(attrs) > 0 {
+		span.SetAttributes(attrs...)
 	}
 
 	var exported map[string]any
 	if node.ExportSpan != "" {
-		// Both "explicit" (LLMObs.export_span(span)) and "implicit"
-		// (LLMObs.export_span()) resolve to the same span here.
-		exported = exportedSpanContext(span, node.MLApp)
+		// The hermetic test does not read the export dict back from a backend, so
+		// the OTel span/trace ids (hex) are a best-effort echo. Both "explicit" and
+		// "implicit" resolve to the same span here.
+		exported = map[string]any{
+			"span_id":  span.SpanContext().SpanID().String(),
+			"trace_id": span.SpanContext().TraceID().String(),
+		}
+		if node.MLApp != "" {
+			exported["ml_app"] = node.MLApp
+		}
 	}
 
-	// Recurse into children, bubbling up the first exported context found. This
-	// span's own export (if any) takes precedence; otherwise the first child's,
-	// matching the shared Python/Node handlers.
 	for _, child := range node.Children {
-		if e := s.createLLMObsTrace(childCtx, child); e != nil && exported == nil {
+		if e := s.buildGenAISpan(spanCtx, tr, child); e != nil && exported == nil {
 			exported = e
 		}
 	}
 
-	span.Finish()
-
-	if node.AnnotateAfter && len(node.Annotations) > 0 {
-		// TODO(draft): dd-trace-py expects annotating an already-finished span to
-		// raise (the harness calls this path with raise_on_error=False and
-		// expects a non-2xx). The Go SDK annotation methods are safe no-ops on a
-		// finished span and will not error, so this contract case is not yet
-		// satisfied.
-		for _, a := range node.Annotations {
-			applyLLMObsAnnotation(span, a)
-		}
-	}
-
+	span.End()
 	return exported
 }
 
-// startLLMObsSpan dispatches on the span kind and returns the created span as
-// the generic llmobs.Span handle plus the derived context for children.
-func startLLMObsSpan(ctx context.Context, kind, name string, opts ...llmobs.StartSpanOption) (llmobs.Span, context.Context) {
+// genAIBaseAttributes maps the node's kind/model/session onto gen_ai.* attributes.
+func genAIBaseAttributes(node *llmObsSpanNode) []attribute.KeyValue {
+	if node.SDK == "tracer" {
+		// Plain APM-style span: no gen_ai.* attributes, kept only for tree shape.
+		// TODO(draft): gen_ai has no APM-span concept; such a node defaults to a
+		// workflow span on the backend (operation.name omitted).
+		return nil
+	}
+
+	var attrs []attribute.KeyValue
+	if op, ok := genAIOperation(node.Kind); ok {
+		attrs = append(attrs, attribute.String("gen_ai.operation.name", op))
+	}
+	if node.ModelName != "" {
+		attrs = append(attrs, attribute.String("gen_ai.request.model", node.ModelName))
+	}
+	if node.ModelProvider != "" {
+		attrs = append(attrs, attribute.String("gen_ai.provider.name", node.ModelProvider))
+	}
+	if node.SessionID != "" {
+		attrs = append(attrs, attribute.String("gen_ai.conversation.id", node.SessionID))
+	}
+	return attrs
+}
+
+// genAIOperation maps a SpanRequest kind to gen_ai.operation.name per the schema:
+// chat->llm, embeddings->embedding, execute_tool->tool, invoke_agent->agent;
+// anything else (including workflow) defaults to a workflow span when the
+// attribute is omitted.
+func genAIOperation(kind string) (string, bool) {
 	switch kind {
 	case "llm":
-		sp, c := llmobs.StartLLMSpan(ctx, name, opts...)
-		return sp, c
-	case "agent":
-		sp, c := llmobs.StartAgentSpan(ctx, name, opts...)
-		return sp, c
-	case "workflow":
-		sp, c := llmobs.StartWorkflowSpan(ctx, name, opts...)
-		return sp, c
-	case "task":
-		sp, c := llmobs.StartTaskSpan(ctx, name, opts...)
-		return sp, c
-	case "tool":
-		sp, c := llmobs.StartToolSpan(ctx, name, opts...)
-		return sp, c
+		return "chat", true
 	case "embedding":
-		sp, c := llmobs.StartEmbeddingSpan(ctx, name, opts...)
-		return sp, c
-	case "retrieval":
-		sp, c := llmobs.StartRetrievalSpan(ctx, name, opts...)
-		return sp, c
+		return "embeddings", true
+	case "tool":
+		return "execute_tool", true
+	case "agent":
+		return "invoke_agent", true
+	case "workflow", "task", "retrieval", "":
+		// default -> workflow. task/retrieval have no authoritative gen_ai operation.
+		// TODO(draft): confirm task/retrieval are acceptable as workflow spans.
+		return "", false
 	default:
-		return nil, ctx
+		return "", false
 	}
 }
 
-// applyLLMObsAnnotation maps a single annotation request onto the kind-specific
-// IO annotation method plus the generic (tags/metadata/metrics/prompt/cost)
-// options, mirroring llmobs.py apply_annotations (which drops explicit_span and
-// drops cost_tags when nil).
-func applyLLMObsAnnotation(span llmobs.Span, a llmObsAnnotationRequest) {
-	var annOpts []llmobs.AnnotateOption
-	if len(a.Tags) > 0 {
-		annOpts = append(annOpts, llmobs.WithAnnotatedTags(toStringMap(a.Tags)))
+// genAIAnnotationAttributes maps a single annotation onto gen_ai I/O + usage +
+// metadata attributes. The same gen_ai.input.messages / gen_ai.output.messages
+// attributes are used for every kind; the backend routes them to
+// meta.input.messages (llm) or meta.input.value (others).
+func genAIAnnotationAttributes(kind string, a llmObsAnnotationRequest) []attribute.KeyValue {
+	var attrs []attribute.KeyValue
+	if a.InputData != nil {
+		attrs = append(attrs, attribute.String("gen_ai.input.messages", genAIMessagesJSON(a.InputData)))
+	}
+	if a.OutputData != nil {
+		attrs = append(attrs, attribute.String("gen_ai.output.messages", genAIMessagesJSON(a.OutputData)))
 	}
 	if len(a.Metadata) > 0 {
-		annOpts = append(annOpts, llmobs.WithAnnotatedMetadata(a.Metadata))
+		if b, err := json.Marshal(a.Metadata); err == nil {
+			// Custom metadata is carried as a JSON string; the backend merges
+			// _dd.ml_obs.metadata into meta.metadata.
+			attrs = append(attrs, attribute.String("_dd.ml_obs.metadata", string(b)))
+		}
 	}
-	if len(a.Metrics) > 0 {
-		annOpts = append(annOpts, llmobs.WithAnnotatedMetrics(a.Metrics))
-	}
-	// TODO(draft): prompt annotation (Test_Prompts) and cost_tags require llmobs
-	// options that are not in a released dd-trace-go yet: WithAnnotatedPrompt and
-	// WithAnnotatedCostTagKeys (plus the richer Prompt{Label,ChatTemplate,Tags}
-	// shape) land on main after the v2.7.x line. Once a release ships them, bump
-	// parametric/go.mod and attach them here — prompt only on llm-kind spans,
-	// since the contract asserts meta.input.prompt is absent for other kinds.
-	// Until then Test_Prompts / cost-tag tests should be gated missing_feature.
-	// a.Prompt / a.CostTags are decoded above but intentionally unused for now.
+	attrs = append(attrs, genAIUsageAttributes(a.Metrics)...)
+
+	// TODO(draft): tags, prompt, and cost_tags have no authoritative gen_ai.*
+	// attribute in this schema and are dropped. If needed, tags could be folded
+	// into _dd.ml_obs.metadata and prompt into gen_ai.request.* / a prompt attr.
+	_ = a.Tags
 	_ = a.Prompt
 	_ = a.CostTags
-
-	switch sp := span.(type) {
-	case *llmobs.LLMSpan:
-		sp.AnnotateLLMIO(toLLMMessages(a.InputData), toLLMMessages(a.OutputData), annOpts...)
-	case *llmobs.WorkflowSpan:
-		sp.AnnotateTextIO(toText(a.InputData), toText(a.OutputData), annOpts...)
-	case *llmobs.AgentSpan:
-		sp.AnnotateTextIO(toText(a.InputData), toText(a.OutputData), annOpts...)
-	case *llmobs.ToolSpan:
-		sp.AnnotateTextIO(toText(a.InputData), toText(a.OutputData), annOpts...)
-	case *llmobs.TaskSpan:
-		sp.AnnotateTextIO(toText(a.InputData), toText(a.OutputData), annOpts...)
-	case *llmobs.EmbeddingSpan:
-		sp.AnnotateEmbeddingIO(toEmbeddedDocuments(a.InputData), toText(a.OutputData), annOpts...)
-	case *llmobs.RetrievalSpan:
-		sp.AnnotateRetrievalIO(toText(a.InputData), toRetrievedDocuments(a.OutputData), annOpts...)
-	default:
-		span.Annotate(annOpts...)
-	}
+	_ = kind
+	return attrs
 }
 
-// exportedSpanContext approximates dd-trace-py's LLMObs.export_span() return
-// dict from the fields the Go SDK exposes.
-//
-// TODO(draft): dd-trace-go v2 has no public LLMObs.export_span; the exact key
-// set (and whether ml_app is included) is unverified. The harness treats the
-// value as an opaque dict, so span_id/trace_id are the load-bearing fields.
-func exportedSpanContext(span llmobs.Span, mlApp string) map[string]any {
-	ctx := map[string]any{
-		"span_id":  span.SpanID(),
-		"trace_id": span.TraceID(),
+// genAIUsageAttributes maps recognized token metrics to gen_ai.usage.* integers.
+func genAIUsageAttributes(metrics map[string]float64) []attribute.KeyValue {
+	if len(metrics) == 0 {
+		return nil
 	}
-	if mlApp != "" {
-		ctx["ml_app"] = mlApp
+	usageKeys := map[string]string{
+		"input_tokens":      "gen_ai.usage.input_tokens",
+		"output_tokens":     "gen_ai.usage.output_tokens",
+		"prompt_tokens":     "gen_ai.usage.prompt_tokens",
+		"completion_tokens": "gen_ai.usage.completion_tokens",
+		"total_tokens":      "gen_ai.usage.total_tokens",
 	}
-	return ctx
-}
-
-// ---------------------------------------------------------------------------
-// POST /llm_observability/dataset/create
-// ---------------------------------------------------------------------------
-
-func (s *apmClientServer) llmObsDatasetCreateHandler(w http.ResponseWriter, r *http.Request) {
-	ensureLLMObs()
-
-	var req datasetCreateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, fmt.Sprintf("Error decoding JSON: %v", err), http.StatusBadRequest)
-		return
-	}
-	defer r.Body.Close()
-
-	var records []dataset.Record
-	for _, rec := range req.Records {
-		md := rec.Metadata
-		if md == nil {
-			md = map[string]any{}
+	var attrs []attribute.KeyValue
+	for k, v := range metrics {
+		if attrKey, ok := usageKeys[k]; ok {
+			attrs = append(attrs, attribute.Int64(attrKey, int64(v)))
 		}
-		records = append(records, dataset.Record{
-			Input:          rec.InputData,
-			ExpectedOutput: rec.ExpectedOutput,
-			Metadata:       md,
-		})
+		// TODO(draft): non-token custom metrics have no gen_ai.usage.* mapping
+		// and are dropped.
 	}
+	return attrs
+}
 
-	// The dataset tests configure DD_LLMOBS_PROJECT_NAME (via the
-	// llmobs_project_name fixture) and assert the response project name matches,
-	// even when the request omits project_name. Fall back to that env so the
-	// create-response reflects the configured project rather than null.
-	projectName := req.ProjectName
-	if projectName == "" {
-		projectName = os.Getenv("DD_LLMOBS_PROJECT_NAME")
-	}
-
-	var opts []dataset.CreateOption
-	if req.Description != "" {
-		opts = append(opts, dataset.WithDescription(req.Description))
-	}
-	if projectName != "" {
-		opts = append(opts, dataset.WithProjectName(projectName))
-	}
-
-	// dataset.Create creates and (when records are present) pushes the dataset.
-	ds, err := dataset.Create(r.Context(), req.DatasetName, records, opts...)
+// genAIMessagesJSON renders an input/output value as the JSON string expected by
+// gen_ai.input.messages / gen_ai.output.messages.
+func genAIMessagesJSON(v any) string {
+	msgs := toGenAIMessages(v)
+	b, err := json.Marshal(msgs)
 	if err != nil {
-		http.Error(w, "Failed to create dataset: "+err.Error(), http.StatusInternalServerError)
-		return
+		return "[]"
 	}
-
-	// TODO(draft): the public *dataset.Dataset exposes ID/Name/Version/Len/URL
-	// but NOT Description/ProjectName/ProjectID/latest_version. We echo the
-	// request/configured values for description/project_name and reuse Version()
-	// for latest_version. ProjectID is unavailable and returned as null.
-	resp := datasetResponse{
-		DatasetID:     ds.ID(),
-		Name:          ds.Name(),
-		Description:   req.Description,
-		ProjectName:   optStr(projectName),
-		ProjectID:     nil,
-		Version:       ds.Version(),
-		LatestVersion: ds.Version(),
-		Records:       datasetRecordsToMaps(ds),
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+	return string(b)
 }
 
-func datasetRecordsToMaps(ds *dataset.Dataset) []map[string]any {
-	records := make([]map[string]any, 0, ds.Len())
-	for _, rec := range ds.Records() {
-		// TODO(draft): exact record dict shape expected by the harness is
-		// unverified; we expose the round-trippable fields plus id/version.
-		records = append(records, map[string]any{
-			"id":              rec.ID(),
-			"version":         rec.Version(),
-			"input_data":      rec.Input,
-			"expected_output": rec.ExpectedOutput,
-			"metadata":        rec.Metadata,
-		})
-	}
-	return records
-}
-
-// ---------------------------------------------------------------------------
-// POST /llm_observability/dataset/delete
-// ---------------------------------------------------------------------------
-
-func (s *apmClientServer) llmObsDatasetDeleteHandler(w http.ResponseWriter, r *http.Request) {
-	ensureLLMObs()
-
-	var req datasetDeleteRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, fmt.Sprintf("Error decoding JSON: %v", err), http.StatusBadRequest)
-		return
-	}
-	defer r.Body.Close()
-
-	// TODO(draft): dd-trace-go v2's public llmobs/dataset package exposes no
-	// delete-dataset-by-id API (only Dataset.Delete(index) for individual
-	// records). dd-trace-py uses the private LLMObs._delete_dataset. Until an
-	// upstream API exists we cannot actually delete; report success so the
-	// contract's response shape ({"success": true}) is honored.
-	_ = req.DatasetID
-
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]bool{"success": true}); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Conversion helpers
-// ---------------------------------------------------------------------------
-
-func toLLMMessages(v any) []llmobs.LLMMessage {
+func toGenAIMessages(v any) []map[string]any {
 	switch t := v.(type) {
 	case nil:
 		return nil
 	case string:
-		return []llmobs.LLMMessage{{Content: t}}
+		return []map[string]any{{"content": t}}
 	case map[string]any:
-		return []llmobs.LLMMessage{toLLMMessage(t)}
+		return []map[string]any{normalizeMessage(t)}
 	case []any:
-		out := make([]llmobs.LLMMessage, 0, len(t))
+		out := make([]map[string]any, 0, len(t))
 		for _, e := range t {
 			switch el := e.(type) {
 			case string:
-				out = append(out, llmobs.LLMMessage{Content: el})
+				out = append(out, map[string]any{"content": el})
 			case map[string]any:
-				out = append(out, toLLMMessage(el))
+				out = append(out, normalizeMessage(el))
+			default:
+				out = append(out, map[string]any{"content": toText(el)})
 			}
 		}
 		return out
+	default:
+		return []map[string]any{{"content": toText(t)}}
 	}
-	return nil
 }
 
-func toLLMMessage(m map[string]any) llmobs.LLMMessage {
-	msg := llmobs.LLMMessage{}
-	if r, ok := m["role"].(string); ok {
-		msg.Role = r
+// normalizeMessage keeps role/content when present (the common gen_ai message
+// shape); everything else is stringified into content.
+// TODO(draft): the full gen_ai message schema (role enum, structured parts) is
+// not modeled; role/content passthrough is the minimal faithful subset.
+func normalizeMessage(m map[string]any) map[string]any {
+	msg := map[string]any{}
+	if role, ok := m["role"]; ok {
+		msg["role"] = role
 	}
-	if c, ok := m["content"].(string); ok {
-		msg.Content = c
+	if content, ok := m["content"]; ok {
+		msg["content"] = content
+	} else {
+		msg["content"] = toText(m)
 	}
 	return msg
 }
 
-// toText renders an input/output value as a string: strings pass through,
-// everything else is JSON-encoded.
+// toText renders a value as a string: strings pass through, everything else is
+// JSON-encoded.
 func toText(v any) string {
 	if v == nil {
 		return ""
@@ -517,69 +350,4 @@ func toText(v any) string {
 		return fmt.Sprintf("%v", v)
 	}
 	return string(b)
-}
-
-func toEmbeddedDocuments(v any) []llmobs.EmbeddedDocument {
-	// TODO(draft): richer mapping of dict fields (name/score/id) to
-	// EmbeddedDocument is unverified against the contract.
-	switch t := v.(type) {
-	case string:
-		return []llmobs.EmbeddedDocument{{Text: t}}
-	case map[string]any:
-		return []llmobs.EmbeddedDocument{{Text: toText(t["text"])}}
-	case []any:
-		out := make([]llmobs.EmbeddedDocument, 0, len(t))
-		for _, e := range t {
-			switch el := e.(type) {
-			case string:
-				out = append(out, llmobs.EmbeddedDocument{Text: el})
-			case map[string]any:
-				out = append(out, llmobs.EmbeddedDocument{Text: toText(el["text"])})
-			}
-		}
-		return out
-	}
-	return nil
-}
-
-func toRetrievedDocuments(v any) []llmobs.RetrievedDocument {
-	// TODO(draft): richer mapping of dict fields (name/score/id) to
-	// RetrievedDocument is unverified against the contract.
-	switch t := v.(type) {
-	case string:
-		return []llmobs.RetrievedDocument{{Text: t}}
-	case map[string]any:
-		return []llmobs.RetrievedDocument{{Text: toText(t["text"])}}
-	case []any:
-		out := make([]llmobs.RetrievedDocument, 0, len(t))
-		for _, e := range t {
-			switch el := e.(type) {
-			case string:
-				out = append(out, llmobs.RetrievedDocument{Text: el})
-			case map[string]any:
-				out = append(out, llmobs.RetrievedDocument{Text: toText(el["text"])})
-			}
-		}
-		return out
-	}
-	return nil
-}
-
-func toStringMap(m map[string]any) map[string]string {
-	out := make(map[string]string, len(m))
-	for k, v := range m {
-		if s, ok := v.(string); ok {
-			out[k] = s
-		} else {
-			out[k] = fmt.Sprintf("%v", v)
-		}
-	}
-	return out
-}
-
-func optStr(s string) *string {
-	if s == "" {
-		return nil
-	}
-	return &s
 }

--- a/utils/build/docker/golang/parametric/llmobs.go
+++ b/utils/build/docker/golang/parametric/llmobs.go
@@ -1,0 +1,563 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/llmobs"
+	"github.com/DataDog/dd-trace-go/v2/llmobs/dataset"
+)
+
+// llmObsStartOnce guards a single tracer.Start so LLM Obs is initialized on the
+// first /llm_observability/* request. LLM Obs piggybacks on the tracer: it is
+// enabled by starting the tracer with DD_LLMOBS_ENABLED / DD_LLMOBS_ML_APP (set
+// by the system-tests scenario) or tracer.WithLLMObsEnabled(true).
+var llmObsStartOnce sync.Once
+
+// ensureLLMObs starts the tracer (and therefore LLM Obs) exactly once, honoring
+// the DD_LLMOBS_* environment variables provided by the scenario.
+//
+// TODO(draft): the parametric app never calls tracer.Start() in main(), so we
+// lazily start it here. If a scenario expects LLM Obs to be enabled purely
+// programmatically (no env), force tracer.WithLLMObsEnabled(true) here instead.
+func ensureLLMObs() {
+	llmObsStartOnce.Do(func() {
+		if err := tracer.Start(); err != nil {
+			log.Printf("llmobs: failed to start tracer: %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Request / response types
+//
+// These mirror the harness-side dataclasses (utils/docker_fixtures/spec/
+// llm_observability.py). The three node shapes (ApmSpanRequest,
+// LlmObsSpanRequest, LlmObsAnnotationContextRequest) are folded into a single
+// recursive struct discriminated by "type"/"sdk"; JSON field names never
+// collide across the shapes so one struct decodes all of them.
+// ---------------------------------------------------------------------------
+
+type llmObsTraceRequest struct {
+	TraceStructureRequest *llmObsSpanNode `json:"trace_structure_request"`
+}
+
+type llmObsSpanNode struct {
+	Type string `json:"type"` // "span" (default) | "annotation_context"
+	SDK  string `json:"sdk"`  // "tracer" | "llmobs"
+	Name string `json:"name"`
+
+	// LlmObsSpanRequest-only fields.
+	Kind          string `json:"kind"`
+	SessionID     string `json:"session_id"`
+	MLApp         string `json:"ml_app"`
+	ModelName     string `json:"model_name"`
+	ModelProvider string `json:"model_provider"`
+
+	Children      []*llmObsSpanNode         `json:"children"`
+	Annotations   []llmObsAnnotationRequest `json:"annotations"`
+	AnnotateAfter bool                      `json:"annotate_after"`
+	ExportSpan    string                    `json:"export_span"` // "explicit" | "implicit"
+
+	// LlmObsAnnotationContextRequest-only fields (also reuses Name/Children).
+	Prompt   map[string]any `json:"prompt"`
+	Tags     map[string]any `json:"tags"`
+	CostTags []any          `json:"cost_tags"`
+}
+
+type llmObsAnnotationRequest struct {
+	InputData    any                `json:"input_data"`
+	OutputData   any                `json:"output_data"`
+	Metadata     map[string]any     `json:"metadata"`
+	Metrics      map[string]float64 `json:"metrics"`
+	Tags         map[string]any     `json:"tags"`
+	CostTags     []any              `json:"cost_tags"`
+	Prompt       map[string]any     `json:"prompt"`
+	ExplicitSpan bool               `json:"explicit_span"`
+}
+
+type datasetRecordRequest struct {
+	InputData      map[string]any `json:"input_data"`
+	ExpectedOutput any            `json:"expected_output"`
+	Metadata       map[string]any `json:"metadata"`
+}
+
+type datasetCreateRequest struct {
+	DatasetName string                 `json:"dataset_name"`
+	Description string                 `json:"description"`
+	Records     []datasetRecordRequest `json:"records"`
+	ProjectName string                 `json:"project_name"`
+}
+
+type datasetResponse struct {
+	DatasetID     string           `json:"dataset_id"`
+	Name          string           `json:"name"`
+	Description   string           `json:"description"`
+	ProjectName   *string          `json:"project_name"`
+	ProjectID     *string          `json:"project_id"`
+	Version       int              `json:"version"`
+	LatestVersion int              `json:"latest_version"`
+	Records       []map[string]any `json:"records"`
+}
+
+type datasetDeleteRequest struct {
+	DatasetID string `json:"dataset_id"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /llm_observability/trace
+// ---------------------------------------------------------------------------
+
+func (s *apmClientServer) llmObsTraceHandler(w http.ResponseWriter, r *http.Request) {
+	ensureLLMObs()
+
+	// The Python app force-flushes the telemetry writer in a finally block.
+	// tracer.Flush() (which internally flushes LLM Obs) is the closest idiom
+	// available from the public API and guarantees the span reaches the
+	// test-agent before the handler returns.
+	// TODO(draft): confirm span flush (not just telemetry) is what the harness
+	// waits on via test_agent.wait_for_llmobs_requests.
+	defer tracer.Flush()
+
+	var req llmObsTraceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("Error decoding JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	exported := s.createLLMObsTrace(context.Background(), req.TraceStructureRequest)
+	if exported == nil {
+		// Success with no export requested -> {} (see llmobs.py llmobs_trace).
+		exported = map[string]any{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(exported); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// createLLMObsTrace builds the (recursive) span tree and returns the first
+// non-nil exported span context bubbled up from the tree, mirroring
+// llmobs.py create_trace.
+func (s *apmClientServer) createLLMObsTrace(ctx context.Context, node *llmObsSpanNode) map[string]any {
+	if node == nil {
+		return nil
+	}
+
+	if node.Type == "annotation_context" {
+		// TODO(draft): the public dd-trace-go v2 llmobs package exposes no
+		// annotation_context equivalent (dd-trace-py's LLMObs.annotation_context
+		// applies prompt/name/tags/cost_tags to all spans opened within the
+		// block). For the draft we simply recurse into the children so the tree
+		// is still built; the contextual annotations are dropped. This needs an
+		// upstream SDK addition or a per-child annotation workaround.
+		var exported map[string]any
+		for _, child := range node.Children {
+			if e := s.createLLMObsTrace(ctx, child); e != nil && exported == nil {
+				exported = e
+			}
+		}
+		return exported
+	}
+
+	// APM (plain tracer) span branch.
+	if node.SDK == "tracer" {
+		span := tracer.StartSpan(node.Name)
+		// Bridge the APM span into the context so nested LLM Obs children parent
+		// off it.
+		ctx = tracer.ContextWithSpan(ctx, span)
+
+		// TODO(draft): dd-trace-py applies annotations to tracer-sdk spans via
+		// LLMObs.annotate(span=...). The public Go llmobs annotation API only
+		// operates on llmobs span types, so annotations on tracer-sdk spans are
+		// not applied here.
+		for _, child := range node.Children {
+			s.createLLMObsTrace(ctx, child)
+		}
+		span.Finish()
+		return nil
+	}
+
+	// LLM Obs span branch.
+	var opts []llmobs.StartSpanOption
+	if node.SessionID != "" {
+		opts = append(opts, llmobs.WithSessionID(node.SessionID))
+	}
+	if node.MLApp != "" {
+		opts = append(opts, llmobs.WithMLApp(node.MLApp))
+	}
+	if node.ModelName != "" {
+		opts = append(opts, llmobs.WithModelName(node.ModelName))
+	}
+	if node.ModelProvider != "" {
+		opts = append(opts, llmobs.WithModelProvider(node.ModelProvider))
+	}
+
+	span, childCtx := startLLMObsSpan(ctx, node.Kind, node.Name, opts...)
+	if span == nil {
+		// Unknown kind: recurse without a span so the rest of the tree still
+		// builds.
+		for _, child := range node.Children {
+			s.createLLMObsTrace(ctx, child)
+		}
+		return nil
+	}
+
+	// Apply annotations before export/children (unless annotate_after).
+	if len(node.Annotations) > 0 && !node.AnnotateAfter {
+		for _, a := range node.Annotations {
+			applyLLMObsAnnotation(span, a)
+		}
+	}
+
+	var exported map[string]any
+	if node.ExportSpan != "" {
+		// Both "explicit" (LLMObs.export_span(span)) and "implicit"
+		// (LLMObs.export_span()) resolve to the same span here.
+		exported = exportedSpanContext(span, node.MLApp)
+	}
+
+	for _, child := range node.Children {
+		s.createLLMObsTrace(childCtx, child)
+	}
+
+	span.Finish()
+
+	if node.AnnotateAfter && len(node.Annotations) > 0 {
+		// TODO(draft): dd-trace-py expects annotating an already-finished span to
+		// raise (the harness calls this path with raise_on_error=False and
+		// expects a non-2xx). The Go SDK annotation methods are safe no-ops on a
+		// finished span and will not error, so this contract case is not yet
+		// satisfied.
+		for _, a := range node.Annotations {
+			applyLLMObsAnnotation(span, a)
+		}
+	}
+
+	return exported
+}
+
+// startLLMObsSpan dispatches on the span kind and returns the created span as
+// the generic llmobs.Span handle plus the derived context for children.
+func startLLMObsSpan(ctx context.Context, kind, name string, opts ...llmobs.StartSpanOption) (llmobs.Span, context.Context) {
+	switch kind {
+	case "llm":
+		sp, c := llmobs.StartLLMSpan(ctx, name, opts...)
+		return sp, c
+	case "agent":
+		sp, c := llmobs.StartAgentSpan(ctx, name, opts...)
+		return sp, c
+	case "workflow":
+		sp, c := llmobs.StartWorkflowSpan(ctx, name, opts...)
+		return sp, c
+	case "task":
+		sp, c := llmobs.StartTaskSpan(ctx, name, opts...)
+		return sp, c
+	case "tool":
+		sp, c := llmobs.StartToolSpan(ctx, name, opts...)
+		return sp, c
+	case "embedding":
+		sp, c := llmobs.StartEmbeddingSpan(ctx, name, opts...)
+		return sp, c
+	case "retrieval":
+		sp, c := llmobs.StartRetrievalSpan(ctx, name, opts...)
+		return sp, c
+	default:
+		return nil, ctx
+	}
+}
+
+// applyLLMObsAnnotation maps a single annotation request onto the kind-specific
+// IO annotation method plus the generic (tags/metadata/metrics/prompt/cost)
+// options, mirroring llmobs.py apply_annotations (which drops explicit_span and
+// drops cost_tags when nil).
+func applyLLMObsAnnotation(span llmobs.Span, a llmObsAnnotationRequest) {
+	var annOpts []llmobs.AnnotateOption
+	if len(a.Tags) > 0 {
+		annOpts = append(annOpts, llmobs.WithAnnotatedTags(toStringMap(a.Tags)))
+	}
+	if len(a.Metadata) > 0 {
+		annOpts = append(annOpts, llmobs.WithAnnotatedMetadata(a.Metadata))
+	}
+	if len(a.Metrics) > 0 {
+		annOpts = append(annOpts, llmobs.WithAnnotatedMetrics(a.Metrics))
+	}
+	// TODO(draft): prompt annotation (Test_Prompts) and cost_tags require llmobs
+	// options that are not in a released dd-trace-go yet: WithAnnotatedPrompt and
+	// WithAnnotatedCostTagKeys (plus the richer Prompt{Label,ChatTemplate,Tags}
+	// shape) land on main after the v2.7.x line. Once a release ships them, bump
+	// parametric/go.mod and attach them here — prompt only on llm-kind spans,
+	// since the contract asserts meta.input.prompt is absent for other kinds.
+	// Until then Test_Prompts / cost-tag tests should be gated missing_feature.
+	// a.Prompt / a.CostTags are decoded above but intentionally unused for now.
+	_ = a.Prompt
+	_ = a.CostTags
+
+	switch sp := span.(type) {
+	case *llmobs.LLMSpan:
+		sp.AnnotateLLMIO(toLLMMessages(a.InputData), toLLMMessages(a.OutputData), annOpts...)
+	case *llmobs.WorkflowSpan:
+		sp.AnnotateTextIO(toText(a.InputData), toText(a.OutputData), annOpts...)
+	case *llmobs.AgentSpan:
+		sp.AnnotateTextIO(toText(a.InputData), toText(a.OutputData), annOpts...)
+	case *llmobs.ToolSpan:
+		sp.AnnotateTextIO(toText(a.InputData), toText(a.OutputData), annOpts...)
+	case *llmobs.TaskSpan:
+		sp.AnnotateTextIO(toText(a.InputData), toText(a.OutputData), annOpts...)
+	case *llmobs.EmbeddingSpan:
+		sp.AnnotateEmbeddingIO(toEmbeddedDocuments(a.InputData), toText(a.OutputData), annOpts...)
+	case *llmobs.RetrievalSpan:
+		sp.AnnotateRetrievalIO(toText(a.InputData), toRetrievedDocuments(a.OutputData), annOpts...)
+	default:
+		span.Annotate(annOpts...)
+	}
+}
+
+// exportedSpanContext approximates dd-trace-py's LLMObs.export_span() return
+// dict from the fields the Go SDK exposes.
+//
+// TODO(draft): dd-trace-go v2 has no public LLMObs.export_span; the exact key
+// set (and whether ml_app is included) is unverified. The harness treats the
+// value as an opaque dict, so span_id/trace_id are the load-bearing fields.
+func exportedSpanContext(span llmobs.Span, mlApp string) map[string]any {
+	ctx := map[string]any{
+		"span_id":  span.SpanID(),
+		"trace_id": span.TraceID(),
+	}
+	if mlApp != "" {
+		ctx["ml_app"] = mlApp
+	}
+	return ctx
+}
+
+// ---------------------------------------------------------------------------
+// POST /llm_observability/dataset/create
+// ---------------------------------------------------------------------------
+
+func (s *apmClientServer) llmObsDatasetCreateHandler(w http.ResponseWriter, r *http.Request) {
+	ensureLLMObs()
+
+	var req datasetCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("Error decoding JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var records []dataset.Record
+	for _, rec := range req.Records {
+		md := rec.Metadata
+		if md == nil {
+			md = map[string]any{}
+		}
+		records = append(records, dataset.Record{
+			Input:          rec.InputData,
+			ExpectedOutput: rec.ExpectedOutput,
+			Metadata:       md,
+		})
+	}
+
+	var opts []dataset.CreateOption
+	if req.Description != "" {
+		opts = append(opts, dataset.WithDescription(req.Description))
+	}
+	if req.ProjectName != "" {
+		opts = append(opts, dataset.WithProjectName(req.ProjectName))
+	}
+
+	// dataset.Create creates and (when records are present) pushes the dataset.
+	ds, err := dataset.Create(r.Context(), req.DatasetName, records, opts...)
+	if err != nil {
+		http.Error(w, "Failed to create dataset: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// TODO(draft): the public *dataset.Dataset exposes ID/Name/Version/Len/URL
+	// but NOT Description/ProjectName/ProjectID/latest_version. We echo the
+	// request values for description/project_name and reuse Version() for
+	// latest_version. ProjectID is unavailable and returned as null.
+	resp := datasetResponse{
+		DatasetID:     ds.ID(),
+		Name:          ds.Name(),
+		Description:   req.Description,
+		ProjectName:   optStr(req.ProjectName),
+		ProjectID:     nil,
+		Version:       ds.Version(),
+		LatestVersion: ds.Version(),
+		Records:       datasetRecordsToMaps(ds),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func datasetRecordsToMaps(ds *dataset.Dataset) []map[string]any {
+	records := make([]map[string]any, 0, ds.Len())
+	for _, rec := range ds.Records() {
+		// TODO(draft): exact record dict shape expected by the harness is
+		// unverified; we expose the round-trippable fields plus id/version.
+		records = append(records, map[string]any{
+			"id":              rec.ID(),
+			"version":         rec.Version(),
+			"input_data":      rec.Input,
+			"expected_output": rec.ExpectedOutput,
+			"metadata":        rec.Metadata,
+		})
+	}
+	return records
+}
+
+// ---------------------------------------------------------------------------
+// POST /llm_observability/dataset/delete
+// ---------------------------------------------------------------------------
+
+func (s *apmClientServer) llmObsDatasetDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	ensureLLMObs()
+
+	var req datasetDeleteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("Error decoding JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	// TODO(draft): dd-trace-go v2's public llmobs/dataset package exposes no
+	// delete-dataset-by-id API (only Dataset.Delete(index) for individual
+	// records). dd-trace-py uses the private LLMObs._delete_dataset. Until an
+	// upstream API exists we cannot actually delete; report success so the
+	// contract's response shape ({"success": true}) is honored.
+	_ = req.DatasetID
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]bool{"success": true}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+func toLLMMessages(v any) []llmobs.LLMMessage {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case string:
+		return []llmobs.LLMMessage{{Content: t}}
+	case map[string]any:
+		return []llmobs.LLMMessage{toLLMMessage(t)}
+	case []any:
+		out := make([]llmobs.LLMMessage, 0, len(t))
+		for _, e := range t {
+			switch el := e.(type) {
+			case string:
+				out = append(out, llmobs.LLMMessage{Content: el})
+			case map[string]any:
+				out = append(out, toLLMMessage(el))
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func toLLMMessage(m map[string]any) llmobs.LLMMessage {
+	msg := llmobs.LLMMessage{}
+	if r, ok := m["role"].(string); ok {
+		msg.Role = r
+	}
+	if c, ok := m["content"].(string); ok {
+		msg.Content = c
+	}
+	return msg
+}
+
+// toText renders an input/output value as a string: strings pass through,
+// everything else is JSON-encoded.
+func toText(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+func toEmbeddedDocuments(v any) []llmobs.EmbeddedDocument {
+	// TODO(draft): richer mapping of dict fields (name/score/id) to
+	// EmbeddedDocument is unverified against the contract.
+	switch t := v.(type) {
+	case string:
+		return []llmobs.EmbeddedDocument{{Text: t}}
+	case map[string]any:
+		return []llmobs.EmbeddedDocument{{Text: toText(t["text"])}}
+	case []any:
+		out := make([]llmobs.EmbeddedDocument, 0, len(t))
+		for _, e := range t {
+			switch el := e.(type) {
+			case string:
+				out = append(out, llmobs.EmbeddedDocument{Text: el})
+			case map[string]any:
+				out = append(out, llmobs.EmbeddedDocument{Text: toText(el["text"])})
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func toRetrievedDocuments(v any) []llmobs.RetrievedDocument {
+	// TODO(draft): richer mapping of dict fields (name/score/id) to
+	// RetrievedDocument is unverified against the contract.
+	switch t := v.(type) {
+	case string:
+		return []llmobs.RetrievedDocument{{Text: t}}
+	case map[string]any:
+		return []llmobs.RetrievedDocument{{Text: toText(t["text"])}}
+	case []any:
+		out := make([]llmobs.RetrievedDocument, 0, len(t))
+		for _, e := range t {
+			switch el := e.(type) {
+			case string:
+				out = append(out, llmobs.RetrievedDocument{Text: el})
+			case map[string]any:
+				out = append(out, llmobs.RetrievedDocument{Text: toText(el["text"])})
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func toStringMap(m map[string]any) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		} else {
+			out[k] = fmt.Sprintf("%v", v)
+		}
+	}
+	return out
+}
+
+func optStr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/utils/build/docker/golang/parametric/llmobs.go
+++ b/utils/build/docker/golang/parametric/llmobs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"sync"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
@@ -169,20 +170,24 @@ func (s *apmClientServer) createLLMObsTrace(ctx context.Context, node *llmObsSpa
 
 	// APM (plain tracer) span branch.
 	if node.SDK == "tracer" {
-		span := tracer.StartSpan(node.Name)
-		// Bridge the APM span into the context so nested LLM Obs children parent
-		// off it.
-		ctx = tracer.ContextWithSpan(ctx, span)
+		// Start from the incoming ctx so a tracer span nested under an LLMObs span
+		// keeps the intended parentage (e.g. llmobs -> tracer -> llmobs) from the
+		// shared request model; StartSpanFromContext also returns the child-bearing
+		// context to place descendants under this span.
+		span, childCtx := tracer.StartSpanFromContext(ctx, node.Name)
 
 		// TODO(draft): dd-trace-py applies annotations to tracer-sdk spans via
 		// LLMObs.annotate(span=...). The public Go llmobs annotation API only
 		// operates on llmobs span types, so annotations on tracer-sdk spans are
 		// not applied here.
+		var exported map[string]any
 		for _, child := range node.Children {
-			s.createLLMObsTrace(ctx, child)
+			if e := s.createLLMObsTrace(childCtx, child); e != nil && exported == nil {
+				exported = e
+			}
 		}
 		span.Finish()
-		return nil
+		return exported
 	}
 
 	// LLM Obs span branch.
@@ -203,11 +208,14 @@ func (s *apmClientServer) createLLMObsTrace(ctx context.Context, node *llmObsSpa
 	span, childCtx := startLLMObsSpan(ctx, node.Kind, node.Name, opts...)
 	if span == nil {
 		// Unknown kind: recurse without a span so the rest of the tree still
-		// builds.
+		// builds, still bubbling up any exported child context.
+		var exported map[string]any
 		for _, child := range node.Children {
-			s.createLLMObsTrace(ctx, child)
+			if e := s.createLLMObsTrace(ctx, child); e != nil && exported == nil {
+				exported = e
+			}
 		}
-		return nil
+		return exported
 	}
 
 	// Apply annotations before export/children (unless annotate_after).
@@ -224,8 +232,13 @@ func (s *apmClientServer) createLLMObsTrace(ctx context.Context, node *llmObsSpa
 		exported = exportedSpanContext(span, node.MLApp)
 	}
 
+	// Recurse into children, bubbling up the first exported context found. This
+	// span's own export (if any) takes precedence; otherwise the first child's,
+	// matching the shared Python/Node handlers.
 	for _, child := range node.Children {
-		s.createLLMObsTrace(childCtx, child)
+		if e := s.createLLMObsTrace(childCtx, child); e != nil && exported == nil {
+			exported = e
+		}
 	}
 
 	span.Finish()
@@ -364,12 +377,21 @@ func (s *apmClientServer) llmObsDatasetCreateHandler(w http.ResponseWriter, r *h
 		})
 	}
 
+	// The dataset tests configure DD_LLMOBS_PROJECT_NAME (via the
+	// llmobs_project_name fixture) and assert the response project name matches,
+	// even when the request omits project_name. Fall back to that env so the
+	// create-response reflects the configured project rather than null.
+	projectName := req.ProjectName
+	if projectName == "" {
+		projectName = os.Getenv("DD_LLMOBS_PROJECT_NAME")
+	}
+
 	var opts []dataset.CreateOption
 	if req.Description != "" {
 		opts = append(opts, dataset.WithDescription(req.Description))
 	}
-	if req.ProjectName != "" {
-		opts = append(opts, dataset.WithProjectName(req.ProjectName))
+	if projectName != "" {
+		opts = append(opts, dataset.WithProjectName(projectName))
 	}
 
 	// dataset.Create creates and (when records are present) pushes the dataset.
@@ -381,13 +403,13 @@ func (s *apmClientServer) llmObsDatasetCreateHandler(w http.ResponseWriter, r *h
 
 	// TODO(draft): the public *dataset.Dataset exposes ID/Name/Version/Len/URL
 	// but NOT Description/ProjectName/ProjectID/latest_version. We echo the
-	// request values for description/project_name and reuse Version() for
-	// latest_version. ProjectID is unavailable and returned as null.
+	// request/configured values for description/project_name and reuse Version()
+	// for latest_version. ProjectID is unavailable and returned as null.
 	resp := datasetResponse{
 		DatasetID:     ds.ID(),
 		Name:          ds.Name(),
 		Description:   req.Description,
-		ProjectName:   optStr(req.ProjectName),
+		ProjectName:   optStr(projectName),
 		ProjectID:     nil,
 		Version:       ds.Version(),
 		LatestVersion: ds.Version(),

--- a/utils/build/docker/golang/parametric/llmobs.go
+++ b/utils/build/docker/golang/parametric/llmobs.go
@@ -1,0 +1,11 @@
+package main
+
+import "net/http"
+
+var llmObsExportHandlerImpl = func(_ *apmClientServer, w http.ResponseWriter, _ *http.Request) {
+	http.Error(w, "offline LLM Obs export is unavailable in this tracer version", http.StatusNotImplemented)
+}
+
+func (s *apmClientServer) llmObsExportHandler(w http.ResponseWriter, r *http.Request) {
+	llmObsExportHandlerImpl(s, w, r)
+}

--- a/utils/build/docker/golang/parametric/llmobs.go
+++ b/utils/build/docker/golang/parametric/llmobs.go
@@ -1,34 +1,5 @@
 package main
 
-// This file reorients the /llm_observability/trace endpoint from the native
-// dd-trace-go llmobs SDK path to an OTel gen_ai OTLP path.
-//
-// Design (verified against the parametric app + OTLP capture research):
-//   - We DO NOT add any new module. Spans are created through the app's EXISTING
-//     ddotel bridge provider (s.tp, a *ddotel.TracerProvider created in
-//     newServer()). dd-trace-go's own OTLP trace exporter — enabled by the
-//     scenario via OTEL_TRACES_EXPORTER=otlp + OTEL_EXPORTER_OTLP_TRACES_* — ships
-//     these spans as OTLP/JSON to the ddapm-test-agent OTLP receiver, exactly the
-//     transport the hermetic test_otlp_trace_metrics.py tests already rely on
-//     (see test_fr15_3, which reads /v1/traces off the OTLP receiver for spans
-//     produced by dd-trace-go's OTLP export). No upstream otlptrace exporter and
-//     no sdktrace provider is introduced, so this compiles against the deps
-//     already in parametric/go.mod.
-//   - The intake headers (dd-otlp-source=llmobs, dd-ml-app, dd-api-key) are set on
-//     the exporter via OTEL_EXPORTER_OTLP_TRACES_HEADERS (scenario env), not in
-//     code, because dd-trace-go's OTLP exporter reads standard OTLP env.
-//   - Each SpanRequest node is mapped to gen_ai.* attributes per the authoritative
-//     Datadog LLM Obs OTel schema. The backend mapping of those attributes is NOT
-//     asserted here; the hermetic pytest only asserts the emitted OTLP payload's
-//     gen_ai.* attributes + headers.
-//
-// The /llm_observability/trace input contract (the SpanRequest tree) is
-// unchanged, so the harness can still drive it via test_library.llmobs_trace().
-//
-// TODO(draft): whether dd-trace-go's OTLP trace export preserves arbitrary
-// gen_ai.* string attributes verbatim (vs. remapping/dropping them) is the key
-// unverified assumption; the pytest is what proves or disproves it.
-
 import (
 	"context"
 	"encoding/json"
@@ -40,13 +11,6 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-// ---------------------------------------------------------------------------
-// Request types — unchanged from the native draft; they mirror the harness-side
-// dataclasses in utils/docker_fixtures/spec/llm_observability.py. The three node
-// shapes (ApmSpanRequest, LlmObsSpanRequest, LlmObsAnnotationContextRequest) fold
-// into one recursive struct discriminated by "type"/"sdk".
-// ---------------------------------------------------------------------------
-
 type llmObsTraceRequest struct {
 	TraceStructureRequest *llmObsSpanNode `json:"trace_structure_request"`
 }
@@ -56,7 +20,6 @@ type llmObsSpanNode struct {
 	SDK  string `json:"sdk"`  // "tracer" | "llmobs"
 	Name string `json:"name"`
 
-	// LlmObsSpanRequest-only fields.
 	Kind          string `json:"kind"`
 	SessionID     string `json:"session_id"`
 	MLApp         string `json:"ml_app"`
@@ -68,7 +31,6 @@ type llmObsSpanNode struct {
 	AnnotateAfter bool                      `json:"annotate_after"`
 	ExportSpan    string                    `json:"export_span"` // "explicit" | "implicit"
 
-	// LlmObsAnnotationContextRequest-only fields (also reuses Name/Children).
 	Prompt   map[string]any `json:"prompt"`
 	Tags     map[string]any `json:"tags"`
 	CostTags []any          `json:"cost_tags"`
@@ -85,19 +47,7 @@ type llmObsAnnotationRequest struct {
 	ExplicitSpan bool               `json:"explicit_span"`
 }
 
-// ---------------------------------------------------------------------------
-// POST /llm_observability/trace
-// ---------------------------------------------------------------------------
-
 func (s *apmClientServer) llmObsTraceHandler(w http.ResponseWriter, r *http.Request) {
-	// dd-trace-go's OTLP trace exporter (scenario: OTEL_TRACES_EXPORTER=otlp +
-	// OTEL_EXPORTER_OTLP_TRACES_*) is what ships these spans to the test-agent OTLP
-	// receiver. tracer.Flush() pushes the trace writer; the hermetic test also
-	// polls the OTLP receiver with a deadline as a backstop.
-	//
-	// TODO(draft): confirm tracer.Flush() drains the OTLP trace exporter and not
-	// only the native trace writer. If it does not, an explicit OTLP exporter
-	// flush hook (or a short poll on the receiver) is required.
 	defer tracer.Flush()
 
 	var req llmObsTraceRequest
@@ -110,7 +60,6 @@ func (s *apmClientServer) llmObsTraceHandler(w http.ResponseWriter, r *http.Requ
 	tr := s.tp.Tracer("system-tests-llmobs")
 	exported := s.buildGenAISpan(context.Background(), tr, req.TraceStructureRequest)
 	if exported == nil {
-		// Success with no export requested -> {} (mirrors llmobs.py llmobs_trace).
 		exported = map[string]any{}
 	}
 
@@ -120,18 +69,12 @@ func (s *apmClientServer) llmObsTraceHandler(w http.ResponseWriter, r *http.Requ
 	}
 }
 
-// buildGenAISpan walks the recursive SpanRequest tree, emitting one OTel span per
-// node with gen_ai.* attributes, and bubbles up the first exported span context.
 func (s *apmClientServer) buildGenAISpan(ctx context.Context, tr oteltrace.Tracer, node *llmObsSpanNode) map[string]any {
 	if node == nil {
 		return nil
 	}
 
-	// annotation_context has no gen_ai equivalent (it is a dd-trace-py scope that
-	// applies prompt/name/tags to spans opened within the block). Recurse so the
-	// tree/parentage is preserved; the contextual annotations are dropped.
-	// TODO(draft): if the contract needs those tags on descendant spans, apply
-	// node.Tags/node.Prompt to each child span here.
+	// gen_ai has no annotation-context equivalent, so preserve nesting while dropping its annotations.
 	if node.Type == "annotation_context" {
 		var exported map[string]any
 		for _, child := range node.Children {
@@ -158,9 +101,7 @@ func (s *apmClientServer) buildGenAISpan(ctx context.Context, tr oteltrace.Trace
 
 	var exported map[string]any
 	if node.ExportSpan != "" {
-		// The hermetic test does not read the export dict back from a backend, so
-		// the OTel span/trace ids (hex) are a best-effort echo. Both "explicit" and
-		// "implicit" resolve to the same span here.
+		// Both export modes return the current OTel span context.
 		exported = map[string]any{
 			"span_id":  span.SpanContext().SpanID().String(),
 			"trace_id": span.SpanContext().TraceID().String(),
@@ -180,12 +121,9 @@ func (s *apmClientServer) buildGenAISpan(ctx context.Context, tr oteltrace.Trace
 	return exported
 }
 
-// genAIBaseAttributes maps the node's kind/model/session onto gen_ai.* attributes.
 func genAIBaseAttributes(node *llmObsSpanNode) []attribute.KeyValue {
 	if node.SDK == "tracer" {
-		// Plain APM-style span: no gen_ai.* attributes, kept only for tree shape.
-		// TODO(draft): gen_ai has no APM-span concept; such a node defaults to a
-		// workflow span on the backend (operation.name omitted).
+		// Tracer nodes preserve tree shape but carry no gen_ai attributes.
 		return nil
 	}
 
@@ -205,10 +143,6 @@ func genAIBaseAttributes(node *llmObsSpanNode) []attribute.KeyValue {
 	return attrs
 }
 
-// genAIOperation maps a SpanRequest kind to gen_ai.operation.name per the schema:
-// chat->llm, embeddings->embedding, execute_tool->tool, invoke_agent->agent;
-// anything else (including workflow) defaults to a workflow span when the
-// attribute is omitted.
 func genAIOperation(kind string) (string, bool) {
 	switch kind {
 	case "llm":
@@ -220,18 +154,13 @@ func genAIOperation(kind string) (string, bool) {
 	case "agent":
 		return "invoke_agent", true
 	case "workflow", "task", "retrieval", "":
-		// default -> workflow. task/retrieval have no authoritative gen_ai operation.
-		// TODO(draft): confirm task/retrieval are acceptable as workflow spans.
+		// These kinds have no authoritative gen_ai operation mapping.
 		return "", false
 	default:
 		return "", false
 	}
 }
 
-// genAIAnnotationAttributes maps a single annotation onto gen_ai I/O + usage +
-// metadata attributes. The same gen_ai.input.messages / gen_ai.output.messages
-// attributes are used for every kind; the backend routes them to
-// meta.input.messages (llm) or meta.input.value (others).
 func genAIAnnotationAttributes(kind string, a llmObsAnnotationRequest) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
 	if a.InputData != nil {
@@ -242,16 +171,13 @@ func genAIAnnotationAttributes(kind string, a llmObsAnnotationRequest) []attribu
 	}
 	if len(a.Metadata) > 0 {
 		if b, err := json.Marshal(a.Metadata); err == nil {
-			// Custom metadata is carried as a JSON string; the backend merges
-			// _dd.ml_obs.metadata into meta.metadata.
+			// The backend merges this JSON string into meta.metadata.
 			attrs = append(attrs, attribute.String("_dd.ml_obs.metadata", string(b)))
 		}
 	}
 	attrs = append(attrs, genAIUsageAttributes(a.Metrics)...)
 
-	// TODO(draft): tags, prompt, and cost_tags have no authoritative gen_ai.*
-	// attribute in this schema and are dropped. If needed, tags could be folded
-	// into _dd.ml_obs.metadata and prompt into gen_ai.request.* / a prompt attr.
+	// These fields have no authoritative gen_ai attribute mapping.
 	_ = a.Tags
 	_ = a.Prompt
 	_ = a.CostTags
@@ -259,7 +185,6 @@ func genAIAnnotationAttributes(kind string, a llmObsAnnotationRequest) []attribu
 	return attrs
 }
 
-// genAIUsageAttributes maps recognized token metrics to gen_ai.usage.* integers.
 func genAIUsageAttributes(metrics map[string]float64) []attribute.KeyValue {
 	if len(metrics) == 0 {
 		return nil
@@ -272,18 +197,15 @@ func genAIUsageAttributes(metrics map[string]float64) []attribute.KeyValue {
 		"total_tokens":      "gen_ai.usage.total_tokens",
 	}
 	var attrs []attribute.KeyValue
+	// Non-token metrics have no gen_ai usage mapping.
 	for k, v := range metrics {
 		if attrKey, ok := usageKeys[k]; ok {
 			attrs = append(attrs, attribute.Int64(attrKey, int64(v)))
 		}
-		// TODO(draft): non-token custom metrics have no gen_ai.usage.* mapping
-		// and are dropped.
 	}
 	return attrs
 }
 
-// genAIMessagesJSON renders an input/output value as the JSON string expected by
-// gen_ai.input.messages / gen_ai.output.messages.
 func genAIMessagesJSON(v any) string {
 	msgs := toGenAIMessages(v)
 	b, err := json.Marshal(msgs)
@@ -319,10 +241,7 @@ func toGenAIMessages(v any) []map[string]any {
 	}
 }
 
-// normalizeMessage keeps role/content when present (the common gen_ai message
-// shape); everything else is stringified into content.
-// TODO(draft): the full gen_ai message schema (role enum, structured parts) is
-// not modeled; role/content passthrough is the minimal faithful subset.
+// Preserve the common role/content subset and encode other shapes as content.
 func normalizeMessage(m map[string]any) map[string]any {
 	msg := map[string]any{}
 	if role, ok := m["role"]; ok {
@@ -336,8 +255,6 @@ func normalizeMessage(m map[string]any) map[string]any {
 	return msg
 }
 
-// toText renders a value as a string: strings pass through, everything else is
-// JSON-encoded.
 func toText(v any) string {
 	if v == nil {
 		return ""

--- a/utils/build/docker/golang/parametric/llmobs.go
+++ b/utils/build/docker/golang/parametric/llmobs.go
@@ -16,8 +16,8 @@ type llmObsTraceRequest struct {
 }
 
 type llmObsSpanNode struct {
-	Type string `json:"type"` // "span" (default) | "annotation_context"
-	SDK  string `json:"sdk"`  // "tracer" | "llmobs"
+	Type string `json:"type"`
+	SDK  string `json:"sdk"`
 	Name string `json:"name"`
 
 	Kind          string `json:"kind"`
@@ -29,7 +29,7 @@ type llmObsSpanNode struct {
 	Children      []*llmObsSpanNode         `json:"children"`
 	Annotations   []llmObsAnnotationRequest `json:"annotations"`
 	AnnotateAfter bool                      `json:"annotate_after"`
-	ExportSpan    string                    `json:"export_span"` // "explicit" | "implicit"
+	ExportSpan    string                    `json:"export_span"`
 
 	Prompt   map[string]any `json:"prompt"`
 	Tags     map[string]any `json:"tags"`

--- a/utils/build/docker/golang/parametric/main.go
+++ b/utils/build/docker/golang/parametric/main.go
@@ -130,10 +130,8 @@ func main() {
 	http.HandleFunc("/metrics/otel/create_asynchronous_gauge", s.otelCreateAsynchronousGaugeHandler)
 	http.HandleFunc("/metrics/otel/force_flush", s.otelMetricsForceFlushHandler)
 
-	// llm-observability endpoints:
+	// llm-observability (gen_ai OTLP) endpoint:
 	http.HandleFunc("/llm_observability/trace", s.llmObsTraceHandler)
-	http.HandleFunc("/llm_observability/dataset/create", s.llmObsDatasetCreateHandler)
-	http.HandleFunc("/llm_observability/dataset/delete", s.llmObsDatasetDeleteHandler)
 
 	err = http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 	if err != nil {

--- a/utils/build/docker/golang/parametric/main.go
+++ b/utils/build/docker/golang/parametric/main.go
@@ -130,6 +130,11 @@ func main() {
 	http.HandleFunc("/metrics/otel/create_asynchronous_gauge", s.otelCreateAsynchronousGaugeHandler)
 	http.HandleFunc("/metrics/otel/force_flush", s.otelMetricsForceFlushHandler)
 
+	// llm-observability endpoints:
+	http.HandleFunc("/llm_observability/trace", s.llmObsTraceHandler)
+	http.HandleFunc("/llm_observability/dataset/create", s.llmObsDatasetCreateHandler)
+	http.HandleFunc("/llm_observability/dataset/delete", s.llmObsDatasetDeleteHandler)
+
 	err = http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)

--- a/utils/build/docker/golang/parametric/main.go
+++ b/utils/build/docker/golang/parametric/main.go
@@ -130,7 +130,6 @@ func main() {
 	http.HandleFunc("/metrics/otel/create_asynchronous_gauge", s.otelCreateAsynchronousGaugeHandler)
 	http.HandleFunc("/metrics/otel/force_flush", s.otelMetricsForceFlushHandler)
 
-	// llm-observability (gen_ai OTLP) endpoint:
 	http.HandleFunc("/llm_observability/trace", s.llmObsTraceHandler)
 
 	err = http.ListenAndServe(fmt.Sprintf(":%d", port), nil)

--- a/utils/build/docker/golang/parametric/main.go
+++ b/utils/build/docker/golang/parametric/main.go
@@ -130,6 +130,8 @@ func main() {
 	http.HandleFunc("/metrics/otel/create_asynchronous_gauge", s.otelCreateAsynchronousGaugeHandler)
 	http.HandleFunc("/metrics/otel/force_flush", s.otelMetricsForceFlushHandler)
 
+	http.HandleFunc("/llm_observability/export", s.llmObsExportHandler)
+
 	err = http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)

--- a/utils/docker_fixtures/_test_clients/_test_client_parametric.py
+++ b/utils/docker_fixtures/_test_clients/_test_client_parametric.py
@@ -18,6 +18,8 @@ from utils.docker_fixtures.spec.llm_observability import (
     DatasetCreateRequest,
     DatasetResponse,
     LlmObsAnnotationContextRequest,
+    LlmObsExportRequest,
+    LlmObsExportResponse,
     SpanRequest,
 )
 from utils.docker_fixtures.spec.otel_trace import OtelSpanContext
@@ -993,6 +995,14 @@ class ParametricTestClientApi(TestClientApi):
 
         return cast("dict", resp.json()) if resp.ok else resp.text
 
+    def llmobs_export(self, export_request: LlmObsExportRequest) -> LlmObsExportResponse:
+        resp = self._session.post(
+            self._url("/llm_observability/export"),
+            json=asdict(export_request),
+        )
+        resp.raise_for_status()
+        return cast("LlmObsExportResponse", resp.json())
+
     def llmobs_dataset_create(self, dataset_create_request: DatasetCreateRequest) -> DatasetResponse:
         resp = self._session.post(
             self._url("/llm_observability/dataset/create"),
@@ -1257,6 +1267,9 @@ class APMLibrary:
         self, trace_structure_request: SpanRequest | LlmObsAnnotationContextRequest, *, raise_on_error: bool = True
     ) -> dict | str | None:
         return self._client.llmobs_trace(trace_structure_request, raise_on_error=raise_on_error)
+
+    def llmobs_export(self, export_request: LlmObsExportRequest) -> LlmObsExportResponse:
+        return self._client.llmobs_export(export_request)
 
     def llmobs_dataset_create(self, dataset_create_request: DatasetCreateRequest) -> DatasetResponse:
         return self._client.llmobs_dataset_create(dataset_create_request)

--- a/utils/docker_fixtures/spec/llm_observability.py
+++ b/utils/docker_fixtures/spec/llm_observability.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal, TypedDict
+
+
+LlmObsExportKind = Literal["llm", "agent", "workflow", "task", "step", "tool", "embedding", "retrieval"]
+LlmObsExportMetricType = Literal["categorical", "score", "boolean", "json"]
 
 
 @dataclass
@@ -55,6 +59,89 @@ class LlmObsAnnotationContextRequest:
 
     children: list[LlmObsAnnotationContextRequest | LlmObsSpanRequest] | None = None
     type: Literal["annotation_context"] = "annotation_context"
+
+
+@dataclass
+class LlmObsExportSpanLinkRequest:
+    trace_id: str
+    span_id: str
+    trace_id_high: int = 0
+    attributes: dict[str, str] | None = None
+    tracestate: str = ""
+    flags: int = 0
+
+
+@dataclass
+class LlmObsExportErrorRequest:
+    type: str
+    message: str
+    stack: str
+
+
+@dataclass
+class LlmObsExportSpanRequest:
+    trace_id: str
+    span_id: str
+    kind: LlmObsExportKind
+    start_ns: int
+    duration_ns: int
+    parent_id: str = ""
+    session_id: str = ""
+    name: str = ""
+    service: str = ""
+    model_name: str = ""
+    model_provider: str = ""
+    input: str = ""
+    output: str = ""
+    metadata: dict[str, Any] | None = None
+    metrics: dict[str, float] | None = None
+    tags: list[str] | None = None
+    span_links: list[LlmObsExportSpanLinkRequest] | None = None
+    apm_trace_id: str = ""
+    error: LlmObsExportErrorRequest | None = None
+
+
+@dataclass
+class LlmObsExportEvaluationRequest:
+    label: str
+    span_id: str = ""
+    trace_id: str = ""
+    tag_key: str = ""
+    tag_value: str = ""
+    metric_type: LlmObsExportMetricType | None = None
+    categorical_value: str | None = None
+    score_value: float | None = None
+    boolean_value: bool | None = None
+    json_value: dict[str, Any] | None = None
+    tags: list[str] | None = None
+    ml_app: str = ""
+    timestamp_ms: int = 0
+    assessment: str = ""
+    reasoning: str = ""
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass
+class LlmObsExportRequest:
+    ml_app: str
+    service: str = ""
+    env: str = ""
+    version: str = ""
+    call_service: str = ""
+    call_ml_app: str = ""
+    spans: list[LlmObsExportSpanRequest] = field(default_factory=list)
+    evaluations: list[LlmObsExportEvaluationRequest] = field(default_factory=list)
+
+
+class LlmObsExportSubmissionResult(TypedDict):
+    sent: int
+    dropped: int
+    failed: int
+
+
+class LlmObsExportResponse(TypedDict):
+    spans: LlmObsExportSubmissionResult
+    evaluations: LlmObsExportSubmissionResult
 
 
 class DatasetRecordRequest(TypedDict, total=False):

--- a/utils/docker_fixtures/spec/llm_observability.py
+++ b/utils/docker_fixtures/spec/llm_observability.py
@@ -1,3 +1,32 @@
+"""Shared LLM Observability parametric contracts.
+
+The request types in this module define the cross-SDK HTTP interface. Intake
+payload assertions must follow the canonical consumers pinned below rather than
+any tracer's producer-side types.
+
+Pinned intake source roots:
+
+https://github.com/ddoghq/dd-go/tree/0293d577fbc211484fda1815eafbbbaa7a111f17
+https://github.com/ddoghq/dd-source/tree/7b1e4d9f79cf6ef25fb288a691775d24be59c789
+
+Canonical intake sources:
+
+- Span and evaluation decoder:
+  https://github.com/ddoghq/dd-go/blob/0293d577fbc211484fda1815eafbbbaa7a111f17/domains/ml-observability/apps/llm-obs-events-processor/decoder/decoder.go
+- Event envelope and internal attributes:
+  https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/shared/libs/llmobs-internal/types.go
+- Span payload, span link, and error fields:
+  https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/shared/libs/llmobs-internal/types_span.go
+- Raw span metadata and error placement:
+  https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/shared/libs/llmobs-internal/types_span_deprecated.go
+- V2 evaluation intake request and handler:
+  https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/internal/adapters/handlersv1/http/eval_metric.go
+- V2 evaluation metric fields:
+  https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/internal/core/domain/eval_metric.go
+- Intake route registration:
+  https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/bootstrap.go
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/utils/docker_fixtures/spec/llm_observability.py
+++ b/utils/docker_fixtures/spec/llm_observability.py
@@ -23,6 +23,10 @@ Canonical intake sources:
   https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/internal/adapters/handlersv1/http/eval_metric.go
 - V2 evaluation metric fields:
   https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/internal/core/domain/eval_metric.go
+- V2 evaluation metric structural validation:
+  https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/internal/validation/eval_metric.go
+- V2 evaluation metric timestamp validation:
+  https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/internal/validation/validator.go
 - Intake route registration:
   https://github.com/ddoghq/dd-source/blob/7b1e4d9f79cf6ef25fb288a691775d24be59c789/domains/ml-observability/apps/apis/llm-obs/bootstrap.go
 """


### PR DESCRIPTION
## Summary

- exercise the public `llmobs/export` API added by DataDog/dd-trace-go#4936 through the Go parametric app and Agent EVP proxy
- assert the production span envelope for all eight public kinds, including opaque caller IDs, timing, model, I/O, metadata, metrics, errors, tags, APM correlation, span links, and service precedence
- assert score and JSON evaluation payloads, join identifiers, ML app precedence, timestamps, assessment, reasoning, metadata, and structured submission results
- activate the contract for Go tracer `>=2.11.0-dev.1` while keeping the older Go LLM Obs test files marked as an incomplete test app
- mark the Go-only export endpoint unsupported in non-Go parametric apps
- keep older Go tracer images buildable by installing the exporter handler only when the selected tracer contains `llmobs/export`
- pin the contract provenance to the canonical intake consumer and backend types in `dd-go` and `dd-source`; dd-trace-go types are treated as producer-side inputs
- centralize those intake sources in the shared LLM Observability parametric spec so future SDK implementations use the same contract references; language adapters own only their transport DTOs
- require the v2 evaluation intake field `metadata` rather than the producer-only `eval_metric_metadata` spelling

## Intake contract audit

Validated against the exact pinned objects:

- `dd-go@0293d577fbc211484fda1815eafbbbaa7a111f17`
- `dd-source@7b1e4d9f79cf6ef25fb288a691775d24be59c789`

The span envelope, kinds, IDs, timing, status, nested metadata/error shape after EVP processing, metrics, and span links align with the pinned decoder and `llmobs-internal` types. Go-specific `service` and `_dd.span_id`/`_dd.trace_id` assertions remain intentionally covered as producer behavior.

The V2 evaluation contract requires `join_on`, `ml_app`, a type-matched value, and `timestamp_ms` no older than 24 hours. It names arbitrary metric metadata `metadata`. The test now generates a current timestamp and pins both the structural and timestamp validators alongside the handler and domain types.

## Validation

Current head: `ea35c25bede1f875992cbfc8f92faaffce3c8563`

- `./format.sh`: mypy passed for 540 source files; Ruff, whitespace, YAML formatting/linting, manifest parsing, AI Guard fixtures, shellcheck, and Node.js lint passed
- manifest semver boundary check: `2.11.0-dev` and `2.11.0-dev.0` are excluded; `2.11.0-dev.1`, later prereleases, `2.11.0`, and later releases are included
- focused local evaluation test: 1 failed only at the canonical `metadata` assertion; the captured request contains `eval_metric_metadata`
- current-head CI lint and `Test the test` passed
- current-head Go parametric shard 2: 1 failed, 255 passed, 21 skipped, 122 xfailed, and 24 xpassed; the sole failure is `test_evaluation_contract` raising `KeyError: 'metadata'`
- current-head Go parametric shard 1: 284 passed, 13 skipped, 99 xfailed, and 27 xpassed
- a fresh local image rebuild did not reach the test because the local Go override references unavailable revision `45d9d7db9bf62b353e402d64a89c4e463a3e8631`; the focused result reused the previously built image with `--skip-parametric-build`
- unrelated current-head matrix checks are still running

## Upstream dependency

DataDog/dd-trace-go#4936 must serialize `EvaluationMetric.Metadata` as `metadata` for `/api/intake/llm-obs/v2/eval-metric`, then update its matching wire assertions. Once a new Go development image contains that correction, rerun both offline-export tests and the full required CI rollup.

## Related

Validates DataDog/dd-trace-go#4936.

[TRA-148](https://linear.app/datadoghq/issue/TRA-148)
