### PR TITLE
fix(tests/library_conf): fix payload normalization issue

### DIFF
--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -865,8 +865,10 @@ class Test_ExtractBehavior_Restart_Otel:
 def _get_span_link_trace_id(link: dict, span_format: AgentTraceFormat) -> tuple[int, int]:
     """Returns the trace ID of a span link according to its format split into high and low 64 bits"""
     if span_format == AgentTraceFormat.efficient_trace_payload_format:
-        trace_id_low = int(link["traceID"], 16) & 0xFFFFFFFFFFFFFFFF
-        trace_id_high = (int(link["traceID"], 16) >> 64) & 0xFFFFFFFFFFFFFFFF
+        raw_trace_id = link["traceID"]
+        trace_id = raw_trace_id if isinstance(raw_trace_id, int) else int(raw_trace_id, 16)
+        trace_id_low = trace_id & 0xFFFFFFFFFFFFFFFF
+        trace_id_high = (trace_id >> 64) & 0xFFFFFFFFFFFFFFFF
     else:
         trace_id_low = int(link["traceID"])
         trace_id_high = int(link["traceIDHigh"])

--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -446,7 +446,8 @@ def retrieve_span_links(span: DataDogAgentSpan) -> list[dict] | None:
         return None
 
     # Convert span_links tags into msgpack v0.4 format
-    json_links = json.loads(span_meta["_dd.span_links"])
+    raw_links = span_meta["_dd.span_links"]
+    json_links = raw_links if isinstance(raw_links, list) else json.loads(raw_links)
     links = []
     for json_link in json_links:
         link = {}


### PR DESCRIPTION
## Motivation

Node.js dev extraction-behavior end-to-end tests already emit the expected span link, but the test helper fails while normalizing `_dd.span_links`. The v1 payload parser has already decoded that metadata into a list, and the helper attempts to decode it a second time.

## Changes

- Accept both serialized and already-decoded `_dd.span_links` metadata in extraction-behavior assertions.
- Preserve the legacy JSON decoding path.
- Validation: mypy and ruff passed through `./format.sh`; the untouched YAML checks could not start because this fresh macOS worktree lacks `sha256sum` for the `yamlfmt` bootstrap. Focused pytest collection passed: `venv/bin/pytest --collect-only -q tests/test_library_conf.py::Test_ExtractBehavior_Default::test_multiple_tracecontexts`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)