### PR TITLE
[appsec] system tests for agentic onboarding runtime detection

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -11,6 +11,7 @@
 manifest:
   tests/appsec/api_security/test_endpoints.py: irrelevant (language not implementing this feature)
   tests/appsec/iast/source/test_parameter_value.py::TestParameterValue::test_source_reported: irrelevant
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: irrelevant (ASM is not implemented in C++)
   tests/appsec/test_only_python.py::Test_ImportError: irrelevant (specific tests for python tracer)
   tests/appsec/test_traces.py::Test_AppSecEventSpanTags::test_header_collection: irrelevant (test)
   tests/appsec/waf/test_reports.py::Test_Monitoring::test_waf_monitoring_optional: irrelevant (optional tags)

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -11,7 +11,7 @@
 manifest:
   tests/appsec/api_security/test_endpoints.py: irrelevant (language not implementing this feature)
   tests/appsec/iast/source/test_parameter_value.py::TestParameterValue::test_source_reported: irrelevant
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: irrelevant (ASM is not implemented in C++)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature
   tests/appsec/test_only_python.py::Test_ImportError: irrelevant (specific tests for python tracer)
   tests/appsec/test_traces.py::Test_AppSecEventSpanTags::test_header_collection: irrelevant (test)
   tests/appsec/waf/test_reports.py::Test_Monitoring::test_waf_monitoring_optional: irrelevant (optional tags)

--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -29,6 +29,7 @@ manifest:
   tests/appsec/: irrelevant (ASM is not implemented in C++)
   tests/appsec/api_security/test_endpoints.py: irrelevant (language not implementing this feature)
   tests/appsec/iast/source/test_parameter_value.py::TestParameterValue::test_source_reported: irrelevant
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: irrelevant (ASM is not implemented in C++)
   tests/appsec/test_only_python.py::Test_ImportError: irrelevant (specific tests for python tracer)
   tests/appsec/test_traces.py::Test_AppSecEventSpanTags::test_header_collection: irrelevant (test)
   tests/appsec/waf/test_reports.py::Test_Monitoring::test_waf_monitoring_optional: irrelevant (optional tags)

--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -29,7 +29,6 @@ manifest:
   tests/appsec/: irrelevant (ASM is not implemented in C++)
   tests/appsec/api_security/test_endpoints.py: irrelevant (language not implementing this feature)
   tests/appsec/iast/source/test_parameter_value.py::TestParameterValue::test_source_reported: irrelevant
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: irrelevant (ASM is not implemented in C++)
   tests/appsec/test_only_python.py::Test_ImportError: irrelevant (specific tests for python tracer)
   tests/appsec/test_traces.py::Test_AppSecEventSpanTags::test_header_collection: irrelevant (test)
   tests/appsec/waf/test_reports.py::Test_Monitoring::test_waf_monitoring_optional: irrelevant (optional tags)

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -76,6 +76,7 @@ manifest:
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Telemetry: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Threats: '>=1.19.1'  # TODO: a lower version might be supported
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_UserEvents: missing_feature
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: irrelevant (ASM is not implemented in C++)
   tests/appsec/test_alpha.py: irrelevant (ASM is not implemented in C++)
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone: '>=1.12.0'  # Modified by easy win activation script
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone::test_appsec_propagation_does_not_force_schema_collection: missing_feature  # Created by easy win activation script

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -76,7 +76,7 @@ manifest:
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Telemetry: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Threats: '>=1.19.1'  # TODO: a lower version might be supported
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_UserEvents: missing_feature
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: irrelevant (ASM is not implemented in C++)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature
   tests/appsec/test_alpha.py: irrelevant (ASM is not implemented in C++)
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone: '>=1.12.0'  # Modified by easy win activation script
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone::test_appsec_propagation_does_not_force_schema_collection: missing_feature  # Created by easy win activation script

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -311,6 +311,7 @@ manifest:
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_UrlQuery: v2.51.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: v3.4.1
   tests/appsec/smoke_tests/test_apm_standalone.py: v3.41.0
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
   tests/appsec/test_alpha.py::Test_Basic: v1.28.6
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone: v3.17.0
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_UpstreamPropagation_V2: v3.12.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -386,6 +386,7 @@ manifest:
         "*": irrelevant (LFi detection requires orchestrion)
         net-http-orchestrion: v2.7.0
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_UserEvents: missing_feature
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
   tests/appsec/test_alpha.py:
     - weblog_declaration:
         envoy: v1.72.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1579,6 +1579,7 @@ manifest:
         resteasy-netty3: missing_feature (login endpoints not implemented)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
   tests/appsec/test_alpha.py::Test_Basic:
     - weblog_declaration:
         "*": v0.87.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -986,6 +986,7 @@ manifest:
     - weblog_declaration:
         fastify: missing_feature
         nextjs: missing_feature
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
   tests/appsec/test_alpha.py::Test_Basic: v2.0.0
   tests/appsec/test_asm_standalone.py::BaseSCAStandaloneTelemetry::test_app_dependencies_loaded:
     - weblog_declaration:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -320,6 +320,7 @@ manifest:
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_sqli_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_shi_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_sqli_smoke: missing_feature
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone: v1.11.0
   ? tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone::test_no_appsec_upstream__no_asm_event__is_kept_with_priority_1__from_2
   : - weblog_declaration:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -698,6 +698,7 @@ manifest:
         *django: v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: v2.15.0
   tests/appsec/smoke_tests/test_apm_standalone.py: v4.6.0
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
   tests/appsec/test_alpha.py::Test_Basic:
     - weblog_declaration:
         "*": v1.1.0-rc2

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -698,7 +698,7 @@ manifest:
         *django: v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: v2.15.0
   tests/appsec/smoke_tests/test_apm_standalone.py: v4.6.0
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v4.12.0
   tests/appsec/test_alpha.py::Test_Basic:
     - weblog_declaration:
         "*": v1.1.0-rc2

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -698,7 +698,7 @@ manifest:
         *django: v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: v2.15.0
   tests/appsec/smoke_tests/test_apm_standalone.py: v4.6.0
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v4.12.0
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v4.13.0-rc1
   tests/appsec/test_alpha.py::Test_Basic:
     - weblog_declaration:
         "*": v1.1.0-rc2

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1145,6 +1145,7 @@ manifest:
         sinatra32: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
         sinatra41: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
         uds-sinatra: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone: v2.18.0
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_NotEnabled: v2.13.0
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_UpstreamPropagation_V2: v2.13.0

--- a/tests/appsec/test_agentic_onboarding.py
+++ b/tests/appsec/test_agentic_onboarding.py
@@ -38,11 +38,15 @@ class Test_AppsecAgenticOnboarding:
         """Flag set + AppSec enabled -> appsec.agentic_onboarding=true, origin=env_var."""
         entries = _find_config(CONFIG_KEY)
         assert entries, f"{CONFIG_KEY} missing from telemetry"
-        entry = entries[-1]
-        assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
-        # native bool preferred; string fallback for cross-tracer compat. `is True`
-        # rejects numeric 1 (1 == True in Python).
-        assert entry["value"] is True or entry["value"] == "true", f"Expected boolean true, got: {entry}"
+        # Assert every reported entry is consistent rather than counting them: prefork /
+        # multiprocess weblogs (uwsgi, php-fpm) and the app-client-configuration-change
+        # carrier can legitimately emit more than one, so a count check would be flaky;
+        # this still catches a contradictory or wrongly-sourced report.
+        for entry in entries:
+            assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
+            # native bool preferred; string fallback for cross-tracer compat. `is True`
+            # rejects numeric 1 (1 == True in Python).
+            assert entry["value"] is True or entry["value"] == "true", f"Expected boolean true, got: {entry}"
         # presence-only: only the derived boolean is sent, never the raw flag
         assert not _find_config(RAW_ENV_VAR), f"{RAW_ENV_VAR} must not be reported in telemetry"
 

--- a/tests/appsec/test_agentic_onboarding.py
+++ b/tests/appsec/test_agentic_onboarding.py
@@ -1,12 +1,18 @@
 from utils import rfc, features, scenarios, interfaces
 
 
-# The runtime signal reported in the app-started telemetry configuration list.
+# The runtime signal reported in the telemetry configuration list.
 CONFIG_KEY = "appsec.agentic_onboarding"
 
 
 def _find_config(name: str) -> list[dict]:
-    """Return app-started configuration entries matching `name` (case-insensitive)."""
+    """Return configuration entries matching `name` (case-insensitive).
+
+    Per RFC-1110, the signal normally rides `app-started`, but when AppSec finishes
+    starting after the first `app-started` it is delivered in the subsequent
+    `app-client-configuration-change` event instead. `get_telemetry_configurations()`
+    reads both carriers, so we intentionally accept either.
+    """
     return [
         conf
         for conf in interfaces.library.get_telemetry_configurations()
@@ -20,27 +26,32 @@ class Test_AppsecAgenticOnboarding:
     """RFC-1110: agentic-onboarding runtime signal.
 
     When `DD_APPSEC_AGENTIC_ONBOARDING` is set, the tracer reports a single boolean
-    configuration entry `appsec.agentic_onboarding` in its `app-started` telemetry
-    payload, with `origin=env_var`. The reported value reflects whether AppSec is
-    active at startup; the flag is presence-only (its value is never read).
+    configuration entry `appsec.agentic_onboarding` in its telemetry (on `app-started`,
+    or the subsequent `app-client-configuration-change`), with `origin=env_var` when
+    the flag is injected as an environment variable. The reported value reflects
+    whether AppSec is active at startup; the flag is presence-only (value never read).
     """
 
     @scenarios.telemetry_enhanced_config_reporting
     def test_reported_true(self):
         """Flag set + AppSec enabled -> appsec.agentic_onboarding=true, origin=env_var."""
         entries = _find_config(CONFIG_KEY)
-        assert entries, f"{CONFIG_KEY} missing from app-started telemetry"
+        assert entries, f"{CONFIG_KEY} missing from telemetry"
         entry = entries[-1]
         assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
         assert entry["value"] in (True, "true"), f"Expected truthy value, got: {entry}"
 
     @scenarios.telemetry_app_started_products_disabled
     def test_reported_false(self):
-        """Flag set + AppSec disabled -> appsec.agentic_onboarding=false.
+        """Flag set + AppSec disabled -> appsec.agentic_onboarding=false, origin=env_var.
 
         The flag value in this scenario is "true" while AppSec is off, proving the
-        reported boolean follows AppSec state, not the flag's literal value.
+        reported boolean follows AppSec state, not the flag's literal value. The
+        `origin=env_var` assertion ensures the entry is driven by the flag itself, not
+        a default/product-state configuration that happens to be false.
         """
         entries = _find_config(CONFIG_KEY)
-        assert entries, f"{CONFIG_KEY} missing from app-started telemetry"
-        assert entries[-1]["value"] in (False, "false"), f"Expected falsy value, got: {entries[-1]}"
+        assert entries, f"{CONFIG_KEY} missing from telemetry"
+        entry = entries[-1]
+        assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
+        assert entry["value"] in (False, "false"), f"Expected falsy value, got: {entry}"

--- a/tests/appsec/test_agentic_onboarding.py
+++ b/tests/appsec/test_agentic_onboarding.py
@@ -1,23 +1,23 @@
 from utils import rfc, features, scenarios, interfaces
 
 
-# The runtime signal reported in the telemetry configuration list.
 CONFIG_KEY = "appsec.agentic_onboarding"
+RAW_ENV_VAR = "DD_APPSEC_AGENTIC_ONBOARDING"
 
 
-def _find_config(name: str) -> list[dict]:
-    """Return configuration entries matching `name` (case-insensitive).
+def _find_config(name: str) -> list[dict[str, object]]:
+    """Return configuration entries whose name matches `name` exactly.
 
-    Per RFC-1110, the signal normally rides `app-started`, but when AppSec finishes
+    The match is case-sensitive on purpose: intake normalization and retention
+    mappings rely on the exact configuration name, so a tracer emitting the wrong
+    wire casing must fail rather than pass.
+
+    Per RFC-1110 the signal normally rides `app-started`, but when AppSec finishes
     starting after the first `app-started` it is delivered in the subsequent
     `app-client-configuration-change` event instead. `get_telemetry_configurations()`
     reads both carriers, so we intentionally accept either.
     """
-    return [
-        conf
-        for conf in interfaces.library.get_telemetry_configurations()
-        if conf.get("name", "").lower() == name.lower()
-    ]
+    return [conf for conf in interfaces.library.get_telemetry_configurations() if conf.get("name") == name]
 
 
 @rfc("https://docs.google.com/document/d/1l09G9w-VQGUy1RPZ41n2uwPDxHDGZNZ9pWWAvHg4f34/edit")
@@ -29,7 +29,8 @@ class Test_AppsecAgenticOnboarding:
     configuration entry `appsec.agentic_onboarding` in its telemetry (on `app-started`,
     or the subsequent `app-client-configuration-change`), with `origin=env_var` when
     the flag is injected as an environment variable. The reported value reflects
-    whether AppSec is active at startup; the flag is presence-only (value never read).
+    whether AppSec is active at startup; the flag is presence-only (value never read),
+    so the raw `DD_APPSEC_AGENTIC_ONBOARDING` key is never transmitted.
     """
 
     @scenarios.telemetry_enhanced_config_reporting
@@ -39,7 +40,11 @@ class Test_AppsecAgenticOnboarding:
         assert entries, f"{CONFIG_KEY} missing from telemetry"
         entry = entries[-1]
         assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
-        assert entry["value"] in (True, "true"), f"Expected truthy value, got: {entry}"
+        # native bool preferred; string fallback for cross-tracer compat. `is True`
+        # rejects numeric 1 (1 == True in Python).
+        assert entry["value"] is True or entry["value"] == "true", f"Expected boolean true, got: {entry}"
+        # presence-only: only the derived boolean is sent, never the raw flag
+        assert not _find_config(RAW_ENV_VAR), f"{RAW_ENV_VAR} must not be reported in telemetry"
 
     @scenarios.telemetry_app_started_products_disabled
     def test_reported_false(self):
@@ -54,4 +59,6 @@ class Test_AppsecAgenticOnboarding:
         assert entries, f"{CONFIG_KEY} missing from telemetry"
         entry = entries[-1]
         assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
-        assert entry["value"] in (False, "false"), f"Expected falsy value, got: {entry}"
+        # `is False` rejects numeric 0 (0 == False in Python).
+        assert entry["value"] is False or entry["value"] == "false", f"Expected boolean false, got: {entry}"
+        assert not _find_config(RAW_ENV_VAR), f"{RAW_ENV_VAR} must not be reported in telemetry"

--- a/tests/appsec/test_agentic_onboarding.py
+++ b/tests/appsec/test_agentic_onboarding.py
@@ -1,0 +1,46 @@
+from utils import rfc, features, scenarios, interfaces
+
+
+# The runtime signal reported in the app-started telemetry configuration list.
+CONFIG_KEY = "appsec.agentic_onboarding"
+
+
+def _find_config(name: str) -> list[dict]:
+    """Return app-started configuration entries matching `name` (case-insensitive)."""
+    return [
+        conf
+        for conf in interfaces.library.get_telemetry_configurations()
+        if conf.get("name", "").lower() == name.lower()
+    ]
+
+
+@rfc("https://docs.google.com/document/d/1l09G9w-VQGUy1RPZ41n2uwPDxHDGZNZ9pWWAvHg4f34/edit")
+@features.appsec_agentic_onboarding
+class Test_AppsecAgenticOnboarding:
+    """RFC-1110: agentic-onboarding runtime signal.
+
+    When `DD_APPSEC_AGENTIC_ONBOARDING` is set, the tracer reports a single boolean
+    configuration entry `appsec.agentic_onboarding` in its `app-started` telemetry
+    payload, with `origin=env_var`. The reported value reflects whether AppSec is
+    active at startup; the flag is presence-only (its value is never read).
+    """
+
+    @scenarios.telemetry_enhanced_config_reporting
+    def test_reported_true(self):
+        """Flag set + AppSec enabled -> appsec.agentic_onboarding=true, origin=env_var."""
+        entries = _find_config(CONFIG_KEY)
+        assert entries, f"{CONFIG_KEY} missing from app-started telemetry"
+        entry = entries[-1]
+        assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
+        assert entry["value"] in (True, "true"), f"Expected truthy value, got: {entry}"
+
+    @scenarios.telemetry_app_started_products_disabled
+    def test_reported_false(self):
+        """Flag set + AppSec disabled -> appsec.agentic_onboarding=false.
+
+        The flag value in this scenario is "true" while AppSec is off, proving the
+        reported boolean follows AppSec state, not the flag's literal value.
+        """
+        entries = _find_config(CONFIG_KEY)
+        assert entries, f"{CONFIG_KEY} missing from app-started telemetry"
+        assert entries[-1]["value"] in (False, "false"), f"Expected falsy value, got: {entries[-1]}"

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -258,6 +258,8 @@ class _Scenarios:
             "DD_APPSEC_ENABLED": "false",
             "DD_PROFILING_ENABLED": "false",
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "false",
+            # RFC-1110: agentic-onboarding flag set while AppSec is disabled -> appsec.agentic_onboarding=false
+            "DD_APPSEC_AGENTIC_ONBOARDING": "true",
         },
         appsec_enabled=False,
         doc="Disable all tracers products",
@@ -270,6 +272,9 @@ class _Scenarios:
             "DD_LOGS_INJECTION": "false",
             "CONFIG_CHAINING_TEST": "true",
             "DD_TRACE_CONFIG": "/app/ConfigChaining.properties",
+            # RFC-1110: agentic-onboarding flag set while AppSec is enabled -> appsec.agentic_onboarding=true
+            # value "0" is intentional: the flag is presence-only, its value is never read
+            "DD_APPSEC_AGENTIC_ONBOARDING": "0",
         },
         doc="Test telemetry for environment variable configurations",
         scenario_groups=[scenario_groups.telemetry],

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -1015,6 +1015,14 @@ class _Features:
         return _mark_test_object(test_object, feature_id=154, owner=_Owner.asm)
 
     @staticmethod
+    def appsec_agentic_onboarding(test_object):
+        """Agentic Onboarding Runtime Detection
+
+        https://feature-parity.us1.prod.dog/#/?feature=563
+        """
+        return _mark_test_object(test_object, feature_id=563, owner=_Owner.asm)
+
+    @staticmethod
     def changing_rules_using_rc(test_object):
         """Changing rules using RC
 


### PR DESCRIPTION
APPSEC-69171

System tests for RFC-1110 (Agentic Onboarding Runtime Detection, feature #563): validate the `appsec.agentic_onboarding` boolean in `app-started` telemetry when `DD_APPSEC_AGENTIC_ONBOARDING` is set — `true` when AppSec is active at startup, `false` otherwise (flag is presence-only).

Reuses existing telemetry scenarios; the two tests are `missing_feature` until each tracer implements the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)