### PR TITLE
parametric: fail fast when test client container exits during startup wait

### DIFF
--- a/utils/docker_fixtures/_test_clients/_core.py
+++ b/utils/docker_fixtures/_test_clients/_core.py
@@ -169,11 +169,19 @@ class TestClientApi:
             try:
                 if self._is_alive():
                     break
-            except Exception:
-                if self.container.status != "running":
-                    self._print_logs()
-                    message = f"Container {self.container.name} status is {self.container.status}. Please check logs."
-                    _fail(message)
+            except Exception as e:
+                logger.debug(f"Error while checking if {self.container.name} is alive: {e}")
+
+            # _is_alive() swallows a non-running container status and returns False instead of
+            # raising, so the check must be repeated here on every iteration (not only in the
+            # except branch above) or a container that exits early (e.g. crash, port collision)
+            # silently gets retried for the full timeout instead of failing fast with its logs.
+            self.container.reload()
+            if self.container.status not in ("running", "created"):
+                self._print_logs()
+                message = f"Container {self.container.name} status is {self.container.status}. Please check logs."
+                _fail(message)
+
             time.sleep(delay)
         else:
             self._print_logs()


### PR DESCRIPTION
## Problem

Investigated the flaky `Timeout of 60 seconds exceeded waiting for HTTP server to start. Please check logs.` failure that occurs rarely and randomly across parametric tests, e.g. `tests.parametric.test_dynamic_configuration.TestDynamicConfigV2.test_capability_tracing_sampling_rate[library_env0, parametric-python]`.

The root cause of the underlying container flake (SIGKILL mid-shutdown leaving host ports in `TIME_WAIT`, colliding with the next test on the same xdist worker since `docker_run` reuses `4500 + worker_id`) was previously diagnosed and mitigated in #7009 by bumping the parametric client's SIGTERM grace period.

However, the poll loop that produces this error message has a separate bug that masks the true cause whenever a container exits early for *any* reason (crash, port collision, OOM, etc.):

```python
def _is_alive(self) -> bool:
    self.container.reload()
    if self.container.status != "running":
        logger.info(f"Container status is {self.container.status}, waiting...")
        return False
    ...
```

`_is_alive()` returns `False` instead of raising when the container isn't running, so the fail-fast branch in `_wait()`:

```python
except Exception:
    if self.container.status != "running":
        _fail(f"Container {self.container.name} status is {self.container.status}. Please check logs.")
```

is effectively unreachable — no exception is raised for that case. The result: an exited container is silently retried for the full 60s timeout, and the failure always surfaces as the generic timeout message instead of the container's actual status and logs.

## Fix

`_wait()` now reloads and checks the container's live status on every iteration (not only inside the now-mostly-dead except branch), so an early container exit fails fast with the real status and container logs instead of stalling for the full timeout.

## Test plan

- [x] `./format.sh` clean (mypy, ruff, yamllint, shellcheck)
- [x] Manual review of the new control flow: happy path (container running, server not ready yet) still loops normally; container that exits mid-wait now fails immediately with `Container <name> status is exited. Please check logs.` instead of the generic timeout message after 60s.

Made with [Cursor](https://cursor.com)