### PR TITLE
fix(parametric): wait for client-side stats before asserting p0 dropping

### DIFF
--- a/tests/parametric/test_span_sampling.py
+++ b/tests/parametric/test_span_sampling.py
@@ -20,6 +20,24 @@ from utils.docker_fixtures import TestAgentAPI
 from .conftest import APMLibrary
 
 
+def _wait_for_client_side_stats_active(test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+    """Wait until client-side stats are active before asserting p0 dropping.
+
+    p0 dropping only turns on after the tracer's async `/info` handshake; spans flushed before it
+    are forwarded undropped (a startup race). A received `/v0.6/stats` payload proves it is active.
+    """
+    for _ in range(30):
+        with test_library, test_library.dd_start_span(name="css-warmup", service="webserver"):
+            pass
+        try:
+            test_agent.wait_for_num_v06_stats(1, wait_loops=10)
+        except ValueError:
+            continue
+        test_agent.clear()
+        return
+    raise ValueError("client-side stats were not enabled in time; cannot reliably assert p0 dropping")
+
+
 @features.single_span_sampling
 @scenarios.parametric
 class Test_Span_Sampling:
@@ -625,6 +643,7 @@ class Test_Span_Sampling:
         the activate dropping policy.
         """
         assert test_agent.info()["client_drop_p0s"] is True, "Client drop p0s expected to be enabled"
+        _wait_for_client_side_stats_active(test_agent, test_library)
 
         with test_library, test_library.dd_start_span(name="parent", service="webserver"):
             pass
@@ -684,6 +703,7 @@ class Test_Span_Sampling:
         the activate dropping policy.
         """
         assert test_agent.info()["client_drop_p0s"] is True, "Client drop p0s expected to be enabled"
+        _wait_for_client_side_stats_active(test_agent, test_library)
 
         with (
             test_library,
@@ -737,6 +757,7 @@ class Test_Span_Sampling:
         the activate dropping policy.
         """
         assert test_agent.info()["client_drop_p0s"] is True, "Client drop p0s expected to be enabled"
+        _wait_for_client_side_stats_active(test_agent, test_library)
 
         with test_library, test_library.dd_start_span(name="parent", service="webserver"):
             pass


### PR DESCRIPTION
## Motivation

`test_*_when_dropping_policy_is_active016/017/018` in `tests/parametric/test_span_sampling.py` assert client-side p0 dropping right after tracer startup. p0 dropping only turns on once the tracer's async `/info` fetch confirms the agent supports it, so a span flushed before that handshake completes is forwarded to the agent undropped. That is a startup race, not a tracer bug: dd-trace-java and dd-trace-dotnet also send p0 traces until `/info` lands, and the agent recomputes stats and drops them. It surfaced as a flaky `[parametric-rust]` failure because the test is enabled for few tracers and rust's `/info` fetch can lose the race. Approach confirmed with Vianney Ruhlmann in #apm-client-side-stats.

## Changes

Add `_wait_for_client_side_stats_active`: before the assertions, warm up until the test agent receives a `/v0.6/stats` payload (which proves stats and p0 dropping are active), then clear the warm-up traffic. Reuses the existing `TestAgentAPI.wait_for_num_v06_stats` primitive and mirrors the `wait_for_client_side_stats_payload` approach the stats tests already use. Applied to all three dropping-policy tests (016/017/018).

Only `tests/` is modified.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
