### PR TITLE
test(ffe): frame mocked CDN responses for fetch clients

### DIFF
--- a/tests/test_the_test/test_mock_ffe_agentless_backend.py
+++ b/tests/test_the_test/test_mock_ffe_agentless_backend.py
@@ -34,6 +34,7 @@ def test_mock_ffe_agentless_backend_serves_fixture_and_tracks_metadata(worker_id
             timeout=5,
         )
         response.raise_for_status()
+        assert response.headers["Content-Length"] == str(len(response.content))
 
         payload = response.json()
         assert payload["data"]["type"] == UFC_RESPONSE_TYPE

--- a/utils/docker_fixtures/_mock_ffe_agentless_backend.py
+++ b/utils/docker_fixtures/_mock_ffe_agentless_backend.py
@@ -194,6 +194,7 @@ class MockFFEAgentlessBackendRequestHandler(BaseHTTPRequestHandler):
                 self.send_response(status_code)
                 for key, value in headers.items():
                     self.send_header(key, value)
+                self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
                 if body:
                     self.wfile.write(body)
@@ -229,10 +230,12 @@ class MockFFEAgentlessBackendRequestHandler(BaseHTTPRequestHandler):
 
     def _write_json(self, status_code: HTTPStatus, payload: dict[str, Any] | MockFFEAgentlessBackendStatus) -> None:
         with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+            body = json.dumps(payload).encode("utf-8")
             self.send_response(status_code)
             self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
             self.end_headers()
-            self.wfile.write(json.dumps(payload).encode("utf-8"))
+            self.wfile.write(body)
 
 
 def _has_auth(headers: Mapping[str, str]) -> bool:


### PR DESCRIPTION
## Motivation

Node.js built-in `fetch` rejects close-delimited HTTP response bodies when the connection terminates without an explicit framing signal. The agentless UFC mock merged in #7315 returned JSON bodies without `Content-Length`, so otherwise valid Node system tests failed while decoding the response.

## Changes

- Add `Content-Length` to mocked UFC configuration responses.
- Add `Content-Length` to the mock's JSON status and error responses.
- Verify the advertised configuration length in the fixture self-test.

## Decisions

- Keep this follow-up limited to standards-compliant HTTP response framing; the JSON:API payload, `dd_env` query contract, authentication checks, and request tracking remain unchanged.
- Validate framing in the fixture's own `TEST_THE_TEST` scenario so SDK system tests can rely on the controlled CDN surface.

## Validation

```text
uv run --python 3.12 pytest -q -S TEST_THE_TEST tests/test_the_test/test_mock_ffe_agentless_backend.py
3 passed in 2.34s
```

Required by DataDog/dd-trace-js#9397.
