### PR TITLE
Update Nginx version to latest, 1.31.3

### DIFF
--- a/utils/build/docker/cpp_nginx/nginx.Dockerfile
+++ b/utils/build/docker/cpp_nginx/nginx.Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim
 
-ARG NGINX_VERSION="1.29.8"
+ARG NGINX_VERSION="1.31.3"
 ENV NGINX_VERSION=${NGINX_VERSION}
 
 RUN groupadd --system --gid 101 nginx \


### PR DESCRIPTION
## Motivation

Following [delivery of Datadog Nginx module v1.21.0](https://github.com/DataDog/nginx-datadog/releases/tag/v1.21.0), which notably adds support to Nginx 1.31.3, update the Nginx version in System Tests to this latest Nginx version.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
