### PR TITLE
[python] migrate python weblog to ddtrace.aiguard imports

### DIFF
--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -2231,13 +2231,22 @@ def external_request_redirect():
 @app.route("/ai_guard/evaluate", methods=["POST"])
 def ai_guard_evaluate():
     """AI Guard evaluation endpoint."""
-    from ddtrace.internal.settings.asm import ai_guard_config
+    # AI Guard was moved from `ddtrace.appsec.ai_guard` to the top-level `ddtrace.aiguard`
+    # package (dd-trace-py#18754, #19110). Import the new location first and fall back to
+    # the old one to stay compatible with every tracer version under test.
+    try:
+        from ddtrace.internal.settings.aiguard import aiguard_config
+    except ImportError:
+        from ddtrace.internal.settings.asm import ai_guard_config as aiguard_config
 
-    if not ai_guard_config._ai_guard_enabled:
+    if not aiguard_config._ai_guard_enabled:
         return jsonify({"action": "ALLOW", "reason": "AI Guard not enabled"}), 200
 
     try:
-        from ddtrace.appsec.ai_guard import new_ai_guard_client, Options, AIGuardAbortError
+        try:
+            from ddtrace.aiguard import new_ai_guard_client, Options, AIGuardAbortError
+        except ImportError:
+            from ddtrace.appsec.ai_guard import new_ai_guard_client, Options, AIGuardAbortError
         from ddtrace.appsec.track_user_sdk import track_user_id
 
         should_block = flask_request.headers.get("X-AI-Guard-Block", "false").lower() == "true"


### PR DESCRIPTION
## Motivation

AI Guard in `dd-trace-py` was moved out of AppSec into a dedicated top-level package:

- `ddtrace.appsec.ai_guard` → `ddtrace.aiguard` (dd-trace-py#18754, #19110)
- `ddtrace.internal.settings.asm.ai_guard_config` → `ddtrace.internal.settings.aiguard.aiguard_config`

This updates the Python Flask weblog to use the new import locations.

## Changes

- `utils/build/docker/python/flask/app.py`: the `/ai_guard/evaluate` endpoint now imports from the new `ddtrace.aiguard` / `ddtrace.internal.settings.aiguard` locations.

To keep the weblog working against **every tracer version under test** (old and new), the new import paths are attempted first and fall back to the legacy paths on `ImportError`. This retrocompatibility is required because system-tests runs against a matrix of tracer versions.

## Jira

https://datadoghq.atlassian.net/browse/APPSEC-67628

🤖 Generated with [Claude Code](https://claude.com/claude-code)