### PR TITLE
Add rule and checks to validate no test cross-imports are performed

### DIFF
--- a/.cursor/rules/pr-review.mdc
+++ b/.cursor/rules/pr-review.mdc
@@ -58,7 +58,13 @@ When adding a new weblog, verify the name is unique across all languages. Search
 
 - Ref: [build.md](mdc:docs/execute/build.md)
 
-## 10. Manifest YAML Syntax
+## 10. No Cross-Test-File Imports
+
+A `test_*.py` file must never import from another `test_*.py` file (absolute like `from tests.xxx.test_yyy import ...` or relative like `from .test_yyy import ...`). If logic is shared between test files, it must be moved to a local `utils.py` file in the same folder instead. Flag any PR that adds such an import.
+
+- Ref: [repository-structure.mdc](mdc:.cursor/rules/repository-structure.mdc), enforced by `tests/test_the_test/test_conventions.py::test_no_cross_test_file_imports`
+
+## 11. Manifest YAML Syntax
 
 - `bug` and `flaky` markers must include a JIRA ticket (e.g., `bug (JIRA-123)`)
 - Values with special YAML characters (`>`, `<`, `:`, `#`) must be quoted

--- a/.cursor/rules/repository-structure.mdc
+++ b/.cursor/rules/repository-structure.mdc
@@ -120,3 +120,8 @@ system-tests/
       ...
   ```
 - Never define a setup method without a matching test method.
+
+## 6. No Cross-Test-File Imports
+- A test file (`test_*.py`) must never import anything from another test file, whether via an absolute (`from tests.xxx.test_yyy import ...`) or relative (`from .test_yyy import ...`) import.
+- If logic needs to be shared between test files, move it into a local `utils.py` file in the same folder and have both test files import from there.
+- This is enforced by `tests/test_the_test/test_conventions.py::test_no_cross_test_file_imports`.

--- a/tests/test_the_test/test_conventions.py
+++ b/tests/test_the_test/test_conventions.py
@@ -1,5 +1,7 @@
+import ast
 import os
-from utils import scenarios
+from pathlib import Path
+from utils import scenarios, logger
 
 
 @scenarios.test_the_test
@@ -26,5 +28,71 @@ def test_utils():
             raise ValueError(f"File {os.path.join(folder, file)} is not a test file or a utils file {folder}")
 
 
+def _is_test_file(path: Path) -> bool:
+    return path.suffix == ".py" and path.name.startswith("test_")
+
+
+def _resolve_import_target(current_file: Path, module: str | None, level: int) -> Path | None:
+    """Resolve an import (relative or absolute) to the .py file path it points at, if any."""
+    if not module:
+        # `from . import something` / `from .. import something`: imports a package, not a specific file
+        return None
+
+    if level > 0:
+        directory = current_file.parent
+        for _ in range(level - 1):
+            directory = directory.parent
+        return directory.joinpath(*module.split(".")).with_suffix(".py")
+
+    if not module.startswith("tests."):
+        # not an import of another test module, nothing to resolve
+        return None
+
+    return Path(*module.split(".")).with_suffix(".py")
+
+
+@scenarios.test_the_test
+def test_no_cross_test_file_imports():
+    """A test file must never import from another test file. If logic is shared, it must live in a local utils.py."""
+
+    has_error = False
+
+    for folder, _, files in os.walk("tests"):
+        if folder.startswith("tests/fuzzer"):
+            # do not check these folders, they are particular use cases
+            continue
+
+        for file in files:
+            if not file.startswith("test_") or not file.endswith(".py"):
+                continue
+
+            path = Path(folder, file)
+
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom):
+                    targets = [_resolve_import_target(path, node.module, node.level)]
+                elif isinstance(node, ast.Import):
+                    targets = [_resolve_import_target(path, alias.name, 0) for alias in node.names]
+                else:
+                    continue
+
+                for target in targets:
+                    if target is None or target == path:
+                        continue
+
+                    if _is_test_file(target):
+                        logger.error(f"{path} imports from another test file: {target}")
+                        has_error = True
+
+    if has_error:
+        raise ValueError(
+            "Some test file imports from another test file. "
+            "Shared logic must be moved to a local utils.py file instead."
+        )
+
+
 if __name__ == "__main__":
     test_utils()
+    test_no_cross_test_file_imports()


### PR DESCRIPTION
## Motivation

A test file should not import anything from another test file, as it'll defeat the CI orchestrator mechanism. This rule is easy to miss (8 occurences so far in the test base)

## Changes

* add PR rule for AI
* Add generic rule for AI
* Add a test in test_the_test

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
