### PR TITLE
fix(weblog): surface request errors instead of a silent None

### DIFF
--- a/tests/test_the_test/test_weblog_request.py
+++ b/tests/test_the_test/test_weblog_request.py
@@ -1,0 +1,90 @@
+import http.server
+import socket
+import struct
+import threading
+
+from utils import scenarios
+from utils._weblog import _Weblog
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port: int = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _weblog_on(port: int) -> _Weblog:
+    weblog = _Weblog()
+    weblog.domain = "127.0.0.1"
+    weblog.port = port
+    return weblog
+
+
+@scenarios.test_the_test
+def test_connection_refused_is_reported() -> None:
+    """Connection refused surfaces the error on response.error, not a silent status_code=None."""
+    port = _free_port()  # bound then released -> connection is deterministically refused
+    response = _weblog_on(port).get("/")
+
+    assert response.status_code is None
+    assert response.error is not None
+    assert "127.0.0.1" in response.error
+    assert response.error in repr(response)
+
+
+@scenarios.test_the_test
+def test_connection_reset_is_reported() -> None:
+    """Connection reset also surfaces the error rather than a silent None."""
+    port = _free_port()
+    ready = threading.Event()
+
+    def serve() -> None:
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", port))
+        srv.listen(1)
+        ready.set()
+        conn, _ = srv.accept()
+        # hard reset: close immediately with SO_LINGER(0) so the client sees a connection reset
+        conn.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+        conn.close()
+        srv.close()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    assert ready.wait(5), "test server did not start"
+
+    response = _weblog_on(port).get("/")
+    thread.join(5)
+
+    assert response.status_code is None
+    assert response.error is not None
+
+
+@scenarios.test_the_test
+def test_successful_request_has_no_error() -> None:
+    """Control: a healthy response reports status_code and no error."""
+    port = _free_port()
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def log_message(self, *args: object) -> None:  # silence per-request logging
+            pass
+
+    srv = http.server.HTTPServer(("127.0.0.1", port), Handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        response = _weblog_on(port).get("/")
+    finally:
+        srv.shutdown()
+        thread.join(5)
+
+    assert response.status_code == 200
+    assert response.error is None

--- a/utils/_weblog.py
+++ b/utils/_weblog.py
@@ -80,6 +80,8 @@ class HttpResponse:
         self.headers: CaseInsensitiveDict = CaseInsensitiveDict(data.get("headers", {}))
         self.text = data["text"]
         self.cookies = data["cookies"]
+        # set when the request failed (connection refused/reset/timeout); status_code is None in that case
+        self.error: str | None = data.get("error")
 
     def to_json(self) -> dict:
         return self._data
@@ -89,7 +91,8 @@ class HttpResponse:
         return HttpResponse(data)
 
     def __repr__(self) -> str:
-        return f"HttpResponse(status_code:{self.status_code}, headers:{self.headers}, text:{self.text})"
+        error = f", error:{self.error}" if self.error else ""
+        return f"HttpResponse(status_code:{self.status_code}, headers:{self.headers}, text:{self.text}{error})"
 
     def get_rid(self) -> str:
         user_agent = next(v for k, v in self.request.headers.items() if k.lower() == "user-agent")
@@ -228,6 +231,7 @@ class _Weblog:
         status_code = None
         response_headers: CaseInsensitiveDict = CaseInsensitiveDict()
         text = None
+        error: str | None = None
 
         for retry in range(self._default_retries):
             try:
@@ -250,7 +254,9 @@ class _Weblog:
                 status_code = response.status_code
                 response_headers = response.headers
                 text = response.text
+                error = None
             except requests.exceptions.ConnectionError as e:
+                error = f"{type(e).__name__}: {e}"
                 logger.error(f"Request {rid} raise an error: {e}")
                 if (
                     isinstance(e.args[0], urllib3.exceptions.ProtocolError)
@@ -261,6 +267,7 @@ class _Weblog:
                     time.sleep(0.25)  # wait before retrying
                     continue
             except Exception as e:
+                error = f"{type(e).__name__}: {e}"
                 logger.error(f"Request {rid} raise an error: {e}")
             else:
                 logger.debug(f"Request {rid}: {response.status_code}")
@@ -278,6 +285,7 @@ class _Weblog:
                 "headers": response_headers,
                 "text": text,
                 "cookies": requests.utils.dict_from_cookiejar(s.cookies),
+                "error": error,
             }
         )
 


### PR DESCRIPTION
## Motivation

Weblog-backed tests can fail with an uninformative `assert None == 200`. When `_Weblog.request()` hits a connection error (refused, reset, timeout), it logs the exception, then returns `HttpResponse(status_code=None)`. The assertion the test makes only sees the `None`, so the real cause never reaches the failure output. You have to dig through container logs to find out what happened.

This showed up while investigating a flaky `Test_RemoteConfigurationExtraServices.test_tracer_extra_services` (parametric-python, django-poc/python3.12/django-py3.13). The weblog was being torn down while the test's setup request was in flight; the request was refused, but all CI showed was `assert None == 200`.

## Changes

- `HttpResponse` now carries the underlying error on a new `error` field, and `__repr__` includes it when set. A failed request now reports e.g. `HttpResponse(status_code:None, ..., error:ConnectionError: ...)` instead of a bare `None`.
- `_Weblog.request()` records the caught exception into that field.
- Regression tests in `tests/test_the_test/` drive `_Weblog` against a refused port, a reset connection, and a healthy server.

This is purely additive: successful responses are unchanged, and previously-serialized logs without the key deserialize as `error=None`.

This does not fix the underlying teardown race that makes the test flaky (tracked separately). It makes the next occurrence diagnosable instead of silent. Note: while here I found that the `set_request_default_retry` retry mechanism (added for uwsgi-poc in #4896) is dead code: the setter writes an attribute the request loop never reads. I left it alone; fixing it properly needs an idempotency policy for retried POSTs and propagation through `get_session()`, which is a separate change.

## Workflow

1. Create your PR as draft
2. Work on your PR until the CI passes
3. Mark it as ready for review

## Reviewer checklist

* [ ] `utils/_weblog.py` (framework) is modified — needs approval from R&P team
