### PR TITLE
[appsec] update agentic onboarding tests for RFC-1113

### DIFF
--- a/tests/appsec/test_agentic_onboarding.py
+++ b/tests/appsec/test_agentic_onboarding.py
@@ -1,71 +1,48 @@
 from utils import rfc, features, scenarios, interfaces
 
 
-# Tracers report configuration entries under different naming conventions: some emit
-# the raw dotted name (`appsec.agentic_onboarding`), others (e.g. Java) normalize it to
-# the env-var form (`DD_APPSEC_AGENTIC_ONBOARDING`, uppercased with dots -> underscores).
-# Both are the same configuration; accept either, just like other telemetry tests do for
-# e.g. ["DD_APPSEC_ENABLED", "appsec.enabled"].
+# Some tracers emit the raw name, others normalize it to the env-var form. Accept either.
 CONFIG_NAMES = ("appsec.agentic_onboarding", "DD_APPSEC_AGENTIC_ONBOARDING")
 
 
 def _find_config() -> list[dict[str, object]]:
-    """Return configuration entries for the agentic-onboarding signal.
-
-    Matches either the raw name or the normalized env-var name (see `CONFIG_NAMES`).
-    The match is case-sensitive on purpose: intake normalization and retention
-    mappings rely on the exact configuration name, so a tracer emitting the wrong
-    wire casing must fail rather than pass.
-
-    Per RFC-1110 the signal normally rides `app-started`, but when AppSec finishes
-    starting after the first `app-started` it is delivered in the subsequent
-    `app-client-configuration-change` event instead. `get_telemetry_configurations()`
-    reads both carriers, so we intentionally accept either.
-    """
+    """Return telemetry configuration entries for the agentic-onboarding signal."""
     return [conf for conf in interfaces.library.get_telemetry_configurations() if conf.get("name") in CONFIG_NAMES]
 
 
-@rfc("https://docs.google.com/document/d/1l09G9w-VQGUy1RPZ41n2uwPDxHDGZNZ9pWWAvHg4f34/edit")
+@rfc("https://docs.google.com/document/d/1q1ZnDLFiKlLhGKljOCE8xTUOqdz325Rc3BcKjVan0VY/edit")
 @features.appsec_agentic_onboarding
 class Test_AppsecAgenticOnboarding:
-    """RFC-1110: agentic-onboarding runtime signal.
+    """RFC-1113: agentic-onboarding runtime signal (supersedes RFC-1110).
 
-    When `DD_APPSEC_AGENTIC_ONBOARDING` is set, the tracer reports a single boolean
-    configuration entry (`appsec.agentic_onboarding`, or the normalized `DD_APPSEC_AGENTIC_ONBOARDING`
-    name for tracers that normalize config keys) in its telemetry (on `app-started`, or the
-    subsequent `app-client-configuration-change`), with `origin=env_var` when the flag is
-    injected as an environment variable. The reported value reflects whether AppSec is
-    active at startup; the flag is presence-only, i.e. the tracer never reads the env-var's
-    literal value, it only derives the boolean from AppSec state.
+    `DD_APPSEC_AGENTIC_ONBOARDING` is an ordinary string config, reported verbatim with
+    `origin` reflecting the source. No derived boolean, no AppSec-state gating.
     """
 
     @scenarios.telemetry_enhanced_config_reporting
-    def test_reported_true(self):
-        """Flag set + AppSec enabled -> agentic-onboarding config = true, origin=env_var."""
+    def test_reported_verbatim(self):
+        """AppSec enabled + arbitrary value -> reported verbatim, origin=env_var."""
         entries = _find_config()
         assert entries, f"{CONFIG_NAMES} missing from telemetry"
-        # Assert every reported entry is consistent rather than counting them: prefork /
-        # multiprocess weblogs (uwsgi, php-fpm) and the app-client-configuration-change
-        # carrier can legitimately emit more than one, so a count check would be flaky;
-        # this still catches a contradictory or wrongly-sourced report.
+        # Check every entry: prefork weblogs / config-change carrier can emit more than one.
         for entry in entries:
             assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
-            # native bool preferred; string fallback for cross-tracer compat. `is True`
-            # rejects numeric 1 (1 == True in Python).
-            assert entry["value"] is True or entry["value"] == "true", f"Expected boolean true, got: {entry}"
+            assert entry["value"] == "MiXeD-Value_42", f"Expected verbatim value, got: {entry}"
 
     @scenarios.telemetry_app_started_products_disabled
-    def test_reported_false(self):
-        """Flag set + AppSec disabled -> appsec.agentic_onboarding=false, origin=env_var.
-
-        The flag value in this scenario is "true" while AppSec is off, proving the
-        reported boolean follows AppSec state, not the flag's literal value. The
-        `origin=env_var` assertion ensures the entry is driven by the flag itself, not
-        a default/product-state configuration that happens to be false.
-        """
+    def test_reported_verbatim_appsec_disabled(self):
+        """AppSec disabled + "true" -> still reported verbatim as "true", origin=env_var."""
         entries = _find_config()
         assert entries, f"{CONFIG_NAMES} missing from telemetry"
-        entry = entries[-1]
-        assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
-        # `is False` rejects numeric 0 (0 == False in Python).
-        assert entry["value"] is False or entry["value"] == "false", f"Expected boolean false, got: {entry}"
+        for entry in entries:
+            assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
+            assert entry["value"] == "true", f"Expected verbatim value 'true', got: {entry}"
+
+    @scenarios.default
+    def test_reported_when_unset(self):
+        """Flag absent -> still reported with empty value and origin=default."""
+        entries = _find_config()
+        assert entries, f"{CONFIG_NAMES} missing from telemetry"
+        for entry in entries:
+            assert entry.get("origin") == "default", f"Expected origin default, got: {entry}"
+            assert entry["value"] == "", f"Expected empty string value, got: {entry}"

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -258,7 +258,8 @@ class _Scenarios:
             "DD_APPSEC_ENABLED": "false",
             "DD_PROFILING_ENABLED": "false",
             "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "false",
-            # RFC-1110: agentic-onboarding flag set while AppSec is disabled -> appsec.agentic_onboarding=false
+            # RFC-1113: agentic-onboarding flag set while AppSec is disabled. The value is
+            # reported verbatim ("true"), decoupled from AppSec state (no derived boolean).
             "DD_APPSEC_AGENTIC_ONBOARDING": "true",
         },
         appsec_enabled=False,
@@ -272,9 +273,11 @@ class _Scenarios:
             "DD_LOGS_INJECTION": "false",
             "CONFIG_CHAINING_TEST": "true",
             "DD_TRACE_CONFIG": "/app/ConfigChaining.properties",
-            # RFC-1110: agentic-onboarding flag set while AppSec is enabled -> appsec.agentic_onboarding=true
-            # value "0" is intentional: the flag is presence-only, its value is never read
-            "DD_APPSEC_AGENTIC_ONBOARDING": "0",
+            # RFC-1113: agentic-onboarding flag set while AppSec is enabled. The value is
+            # reported verbatim; a mixed-case arbitrary value is intentional to prove it is a
+            # pass-through of the configured value (not a boolean derived from AppSec being
+            # active, and not lowercased/normalized by the tracer).
+            "DD_APPSEC_AGENTIC_ONBOARDING": "MiXeD-Value_42",
         },
         doc="Test telemetry for environment variable configurations",
         scenario_groups=[scenario_groups.telemetry],


### PR DESCRIPTION
APPSEC-69171

Follow-up to #7320. RFC-1110 was superseded by RFC-1113 (simplified): `DD_APPSEC_AGENTIC_ONBOARDING` is now an ordinary string config reported verbatim (no derived boolean, no AppSec-state logic), origin reflecting the source; the "did AppSec start" join moves to Metabase.

- Assert the verbatim string value + origin instead of a derived boolean.
- Mixed-case arbitrary value proves pass-through (no normalization).
- Add an unset case: config still reported with empty value and `origin=default`.
- Update the RFC link and scenario comments/values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)