### PR TITLE
Fix Java parametric protocol selection

### DIFF
--- a/utils/build/docker/java/parametric/run.sh
+++ b/utils/build/docker/java/parametric/run.sh
@@ -2,6 +2,15 @@
 
 DD_JAVA_AGENT=/client/tracer/dd-java-agent.jar
 
+# Translate the shared parametric trace API setting to the Java tracer configuration.
+if [[ -z "${DD_TRACE_AGENT_PROTOCOL_VERSION:-}" ]]; then
+  case "${DD_TRACE_API_VERSION:-}" in
+    v0.4 | v0.5 | v1.0)
+      export DD_TRACE_AGENT_PROTOCOL_VERSION="${DD_TRACE_API_VERSION#v}"
+      ;;
+  esac
+fi
+
 # Enable application debug level if tracer debug flag is enabled
 case $(echo "${DD_TRACE_DEBUG:-false}" | tr '[:upper:]' '[:lower:]') in
   "true" | "1") export APM_TEST_CLIENT_LOG_LEVEL=debug;;


### PR DESCRIPTION
## Motivation

Java parametric scenarios requesting `v0.5`, but actually ignored by `dd-trace-java` tracer.
As specified in [RFC: Efficient Trace Payload Protocol](https://docs.google.com/document/d/1hNS6anKYutOYW-nmR759UlKXUdT6H0mRwVt7_L70ESc/edit?tab=t.0). Protocol can be specified via: `DD_TRACE_AGENT_PROTOCOL_VERSION` variable. And default value is `v0.4` for now.
```
Configuration: When this feature is off by default it can be enabled in the Client Library using the environment variable DD_TRACE_AGENT_PROTOCOL_VERSION with a value of “1.0”
```

## Changes

Maps shared `DD_TRACE_API_VERSION` values (`v0.4`, `v0.5`, and `v1.0`) to the Java tracer setting `DD_TRACE_AGENT_PROTOCOL_VERSION` in the parametric launcher while preserving explicit Java configuration.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
