### PR TITLE
Accept empty V1 fields

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -470,13 +470,13 @@ class Test_Otel_Span_Methods:
         assert link.get("trace_id_high") == int(root_tid, 16)
         assert link.get("attributes") is None or len(link.get("attributes")) == 0
         # Tracestate is not required, but if it is present, it must contain the linked span's tracestate
-        assert link.get("tracestate") is None or "dd=" in link.get("tracestate")
+        assert not link.get("tracestate") or "dd=" in link["tracestate"]
 
         link = span_links[1]
         assert link.get("span_id") == first.get("span_id")
         assert link.get("trace_id") == first.get("trace_id")
         assert link.get("trace_id_high") == int(root_tid, 16)
-        assert link.get("tracestate") is None or "dd=" in link.get("tracestate")
+        assert not link.get("tracestate") or "dd=" in link["tracestate"]
 
     @pytest.mark.parametrize(
         ("expected_operation_name", "span_kind", "attributes"),
@@ -637,7 +637,7 @@ class Test_Otel_Span_Methods:
 
         event1 = events[0]
         assert event1.get("name") == "first_event"
-        assert "attributes" not in event1
+        assert not event1.get("attributes")
 
         event2 = events[1]
         assert event2.get("name") == "second_event"


### PR DESCRIPTION
## Motivation
`v1` binary payloads encode empty `attributes` and `tracestate` fields, while legacy JSON payloads omit them. Both representations are equivalent.

## Changes
Updates OpenTelemetry span-event and span-link assertions to accept optional fields that are either omitted or explicitly empty.

# Additional Notes
Validated the span-link test locally.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
