### PR TITLE
test(agentic-onboarding): enable python tests for v4.13.0rc1

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -698,7 +698,7 @@ manifest:
         *django: v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: v2.15.0
   tests/appsec/smoke_tests/test_apm_standalone.py: v4.6.0
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v4.13.0rc1
   tests/appsec/test_alpha.py::Test_Basic:
     - weblog_declaration:
         "*": v1.1.0-rc2


### PR DESCRIPTION
APPSEC-69157

## Motivation

Enable the agentic onboarding system tests for dd-trace-py now that RFC-1113 support ships in `v4.13.0rc1`.

## Changes

- `manifests/python.yml`: pin `tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding` to `v4.13.0rc1`, replacing the `missing_feature (APPSEC-68904)` skip.

Only Python is enabled; all other languages remain `missing_feature (APPSEC-68904)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)