### PR TITLE
test(trace-source): assert _dd.p.ts bitmask for ASM and AI Guard

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -16,7 +16,7 @@ manifest:
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardStandalone:
     - weblog_declaration:
         "*": irrelevant (just one weblog is enough to test the SDK)
-        "flask-poc": v3.13.0.dev
+        "flask-poc": v4.13.0-dev
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardTelemetryRequests: missing_feature
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardTelemetryTruncated: missing_feature
   tests/ai_guard/test_ai_guard_sdk.py::Test_AnomalyDetectionTags:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -16,7 +16,7 @@ manifest:
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardStandalone:
     - weblog_declaration:
         "*": irrelevant (just one weblog is enough to test the SDK)
-        "flask-poc": v4.10.0
+        "flask-poc": v3.13.0.dev
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardTelemetryRequests: missing_feature
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardTelemetryTruncated: missing_feature
   tests/ai_guard/test_ai_guard_sdk.py::Test_AnomalyDetectionTags:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -15,7 +15,16 @@ manifest:
         rails80: '>=2.36.0'
         rails61: '>=2.36.0'
         rails52: '>=2.36.0'
-  tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardStandalone::test_standalone_keeps_ai_guard_trace: bug (APPSEC-68488)  # Ruby does not yet set the _dd.p.ts trace source tag
+  tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardStandalone::test_standalone_keeps_ai_guard_trace:
+    - weblog_declaration: 
+        "*": v2.40.0-dev
+        rails42: irrelevant
+        rack: irrelevant
+        sinatra14: irrelevant
+        sinatra22: irrelevant
+        sinatra32: irrelevant
+        sinatra41: irrelevant
+        uds-sinatra: irrelevant
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardTelemetryRequests: missing_feature
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardTelemetryTruncated: missing_feature
   tests/ai_guard/test_ai_guard_sdk.py::Test_AnomalyDetectionTags:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -15,6 +15,7 @@ manifest:
         rails80: '>=2.36.0'
         rails61: '>=2.36.0'
         rails52: '>=2.36.0'
+  tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardStandalone::test_standalone_keeps_ai_guard_trace: bug (APPSEC-68488)  # Ruby does not yet set the _dd.p.ts trace source tag
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardTelemetryRequests: missing_feature
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardTelemetryTruncated: missing_feature
   tests/ai_guard/test_ai_guard_sdk.py::Test_AnomalyDetectionTags:

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -16,7 +16,7 @@ manifest:
         rails61: '>=2.36.0'
         rails52: '>=2.36.0'
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardStandalone::test_standalone_keeps_ai_guard_trace:
-    - weblog_declaration: 
+    - weblog_declaration:
         "*": v2.40.0-dev
         rails42: irrelevant
         rack: irrelevant

--- a/tests/ai_guard/test_ai_guard_sdk.py
+++ b/tests/ai_guard/test_ai_guard_sdk.py
@@ -2,7 +2,7 @@ import json
 import math
 
 from utils import context, interfaces, scenarios, weblog, features, rfc
-from utils.dd_constants import SamplingMechanism, SamplingPriority
+from utils.dd_constants import TRACE_SOURCE_PROPAGATION_KEY, SamplingMechanism, SamplingPriority, TraceSource
 from utils.dd_types import DataDogLibrarySpan, DataDogLibraryTrace, is_same_boolean
 
 BLOCKING_HEADER: str = "X-AI-Guard-Block"
@@ -651,6 +651,10 @@ class Test_AIGuardStandalone:
             )
             assert root_span.get("meta", {}).get("_dd.p.dm") == "-" + str(SamplingMechanism.AI_GUARD), (
                 "Decision maker (_dd.p.dm) must match AI_GUARD sampling mechanism in standalone mode"
+            )
+            assert root_span.get("meta", {}).get(TRACE_SOURCE_PROPAGATION_KEY) == TraceSource.AI_GUARD.as_tag_value(), (
+                f"Trace source tag ({TRACE_SOURCE_PROPAGATION_KEY}) must be "
+                f"'{TraceSource.AI_GUARD.as_tag_value()}' (AI Guard) when AI Guard originates the trace"
             )
 
 

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -5,7 +5,7 @@ import time
 
 from requests.structures import CaseInsensitiveDict
 
-from utils.dd_constants import SAMPLING_PRIORITY_KEY, SamplingPriority
+from utils.dd_constants import TRACE_SOURCE_PROPAGATION_KEY, SAMPLING_PRIORITY_KEY, SamplingPriority, TraceSource
 from utils.telemetry_utils import TelemetryUtils
 from utils._weblog import HttpResponse, _Weblog
 from utils import context, weblog, interfaces, scenarios, features, rfc, logger
@@ -813,10 +813,10 @@ class Test_AppSecStandalone_UpstreamPropagation_V2(BaseAppSecStandaloneUpstreamP
     """APPSEC correctly propagates AppSec events in distributing tracing with DD_APM_TRACING_ENABLED=false."""
 
     def propagated_tag(self) -> str:
-        return "_dd.p.ts"
+        return TRACE_SOURCE_PROPAGATION_KEY
 
     def propagated_tag_value(self) -> str:
-        return "02"
+        return TraceSource.ASM.as_tag_value()
 
 
 @rfc("https://docs.google.com/document/d/12NBx-nD-IoQEMiCRnJXneq4Be7cbtSc6pJLOFUWTpNE/edit")
@@ -826,10 +826,10 @@ class Test_IastStandalone_UpstreamPropagation_V2(BaseIastStandaloneUpstreamPropa
     """IAST correctly propagates AppSec events in distributing tracing with DD_APM_TRACING_ENABLED=false."""
 
     def propagated_tag(self) -> str:
-        return "_dd.p.ts"
+        return TRACE_SOURCE_PROPAGATION_KEY
 
     def propagated_tag_value(self) -> str:
-        return "02"
+        return TraceSource.ASM.as_tag_value()
 
 
 @rfc("https://docs.google.com/document/d/12NBx-nD-IoQEMiCRnJXneq4Be7cbtSc6pJLOFUWTpNE/edit")
@@ -839,10 +839,10 @@ class Test_SCAStandalone_Telemetry_V2(BaseSCAStandaloneTelemetry):
     """Tracer correctly propagates SCA telemetry in distributing tracing with DD_APM_TRACING_ENABLED=false."""
 
     def propagated_tag(self) -> str:
-        return "_dd.p.ts"
+        return TRACE_SOURCE_PROPAGATION_KEY
 
     def propagated_tag_value(self) -> str:
-        return "02"
+        return TraceSource.ASM.as_tag_value()
 
 
 @rfc("https://docs.google.com/document/d/18JZdOS5fmnYomRn6OGer0ViS1I6zzT6xl5HMtjDtFn4/edit")
@@ -852,10 +852,10 @@ class Test_APISecurityStandalone(BaseAppSecStandaloneUpstreamPropagation):
     """Test API Security schemas are retained in ASM Standalone mode regardless of sampling"""
 
     def propagated_tag(self) -> str:
-        return "_dd.p.ts"
+        return TRACE_SOURCE_PROPAGATION_KEY
 
     def propagated_tag_value(self) -> str:
-        return "02"
+        return TraceSource.ASM.as_tag_value()
 
     @staticmethod
     def get_schema(request: HttpResponse, address: str) -> list | None:
@@ -1031,7 +1031,7 @@ class Test_UserEventsStandalone_Automated:
 
     def _get_standalone_span_meta(self, trace_id: int):
         tested_meta: dict[str, str | Callable | None] = {
-            "_dd.p.ts": "02",
+            TRACE_SOURCE_PROPAGATION_KEY: TraceSource.ASM.as_tag_value(),
         }
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -1104,7 +1104,7 @@ class Test_UserEventsStandalone_SDK_V1:
 
     def _get_standalone_span_meta(self, trace_id: int):
         tested_meta: dict[str, str | Callable | None] = {
-            "_dd.p.ts": "02",
+            TRACE_SOURCE_PROPAGATION_KEY: TraceSource.ASM.as_tag_value(),
         }
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)
@@ -1168,7 +1168,7 @@ class Test_UserEventsStandalone_SDK_V2:
 
     def _get_standalone_span_meta(self, trace_id: int):
         tested_meta: dict[str, str | Callable | None] = {
-            "_dd.p.ts": "02",
+            TRACE_SOURCE_PROPAGATION_KEY: TraceSource.ASM.as_tag_value(),
         }
         for data, trace, span in interfaces.library.get_spans(request=self.r):
             assert assert_tags(trace[0], span, "meta", tested_meta)

--- a/utils/dd_constants.py
+++ b/utils/dd_constants.py
@@ -111,6 +111,32 @@ class SamplingMechanism(IntEnum):
     AI_GUARD = 13
 
 
+# Key of the Trace Source Propagated Tag (an 8-bit mask consolidating the products
+# responsible for originating a trace). Propagated via `x-datadog-tags`.
+TRACE_SOURCE_PROPAGATION_KEY = "_dd.p.ts"
+
+
+class TraceSource(IntEnum):
+    """Trace Source Propagated Tag (`_dd.p.ts`) bitmask.
+
+    Each bit maps to the product responsible for originating a trace. The tag is a
+    two-character, case-insensitive hexadecimal string (e.g. ``02`` for ASM, ``20`` for
+    AI Guard). APM is reserved by specification but omitted by default since all traces
+    are APM-produced. Use ``format(TraceSource.ASM, "02x")`` to get the propagated value.
+    """
+
+    APM = 0x01
+    ASM = 0x02
+    DSM = 0x04
+    DJM = 0x08
+    DBM = 0x10
+    AI_GUARD = 0x20
+
+    def as_tag_value(self) -> str:
+        """Return the two-character hexadecimal string used in `_dd.p.ts`."""
+        return format(self.value, "02x")
+
+
 # See https://github.com/open-telemetry/opentelemetry-proto/blob/v1.9.0/opentelemetry/proto/trace/v1/trace.proto#L153
 class SpanKind(IntEnum):
     UNSPECIFIED = 0


### PR DESCRIPTION
## What

Adds coverage for the **Trace Source Propagated Tag** (`_dd.p.ts`) — an 8-bit mask consolidating the products responsible for originating a trace — for **ASM** and **AI Guard**.

- New shared `TraceSource` bitmask in `utils/dd_constants.py` (`APM=01`, `ASM=02`, `DSM=04`, `DJM=08`, `DBM=10`, `AI Guard=20`) plus `TRACE_SOURCE_PROPAGATION_KEY = "_dd.p.ts"`, so values aren't magic strings.
- **AI Guard** (`Test_AIGuardStandalone`): now asserts the root span carries `_dd.p.ts=20` when AI Guard originates the trace in standalone mode. Previously only `_dd.p.dm=-13` and `USER_KEEP` were checked — this was a gap.
- **ASM** (`test_asm_standalone.py`): the existing `_dd.p.ts=02` assertions now source their value from the shared constant instead of hardcoded `"02"`. Behavior unchanged.

## Why

Confirms tracers emit the correct `_dd.p.ts` bitmask for ASM (`02`) and AI Guard (`20`) per the Trace Source Propagated Tag spec.

Jira Task: https://datadoghq.atlassian.net/browse/APPSEC-69305
Python PR: https://github.com/DataDog/dd-trace-py/pull/19195/