### PR TITLE
chore: enforce lint rules on utils/onboarding and remove stale ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,21 +226,8 @@ ignore = [
 ]
 "utils/build/*"  = ["ALL"]  # mostly python weblog code. it may be a good idea to enable rules here
 
-"utils/onboarding/*" = [
-    "ANN201",  # missing-return-type-undocumented-public-function: TODO
-    "DTZ005",  # call-datetime-now-without-tzinfo: TODO
-    "DTZ006",  # call-datetime-fromtimestamp: TODO
-    "E501",    # line-too-long: TODO
-    "FBT001",  # boolean-type-hint-positional-argument: TODO
-    "FBT002",  # boolean-default-value-positional-argument: TODO
-    "N803",    # invalid-argument-name: TODO
-    "N806",    # non-lowercase-variable-in-function: TODO
-    "PLR2004", # magic-value-comparison: TODO
-    "PLR2044", # empty-comment: TODO
-    "PTH102",  # os-mkdir: TODO
-    "RET505",  # superfluous-else-return: TODO
-    "S507",    # ssh-no-host-key-verification: TODO
-    "UP017",   # datetime-timezone-utc: TODO
+"utils/onboarding/weblog_interface.py" = [
+    "E501",    # line-too-long: the curl command is embedded in an inline bash script and cannot be safely wrapped
 ]
 "utils/scripts/ssi_wizards/aws_onboarding_wizard_utils.py" = [
     "PLR2004",  # magic-value-comparison: TODO

--- a/utils/onboarding/backend_interface.py
+++ b/utils/onboarding/backend_interface.py
@@ -1,8 +1,9 @@
 from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
 import json
 import os
 import time
-from datetime import datetime, timedelta, timezone
 import requests
 import random
 from utils._logger import logger
@@ -12,7 +13,7 @@ API_HOST = "https://dd.datadoghq.com"
 _json_meta_values = frozenset(["_dd.appsec.json", "_dd.iast.json"])
 
 
-def wait_backend_trace_id(trace_id: str, profile: bool = False, validator: Callable | None = None):
+def wait_backend_trace_id(trace_id: str, *, profile: bool = False, validator: Callable | None = None) -> None:
     logger.info(f"Waiting for backend trace with trace_id: {trace_id}")
     results = _query_for_trace_id(trace_id, validator=validator)
     runtime_id = results["runtime_id"]
@@ -76,8 +77,8 @@ def _query_for_trace_id(trace_id: str, validator: Callable | None = None):
     root_id = trace_data["trace"]["root_id"]
     root_span = trace_data["trace"]["spans"][root_id]
     start_time = root_span["start"]
-    start_date = datetime.fromtimestamp(start_time)
-    if (datetime.now() - start_date).days > 1:
+    start_date = datetime.fromtimestamp(start_time, tz=UTC)
+    if (datetime.now(tz=UTC) - start_date).days > 1:
         logger.info("Backend trace is too old")
         results["runtime_id"] = None
     else:
@@ -109,18 +110,21 @@ def _make_request(
     max_retries: int = 30,
     validator: Callable | None = None,
 ):
-    """Make a request to the backend with retries and backoff. With the defaults, this will retry for approximately 5 minutes."""
+    """Make a request to the backend with retries and backoff.
+
+    With the defaults, this will retry for approximately 5 minutes.
+    """
     start_time = time.perf_counter()
     for _attempt in range(max_retries):
         try:
             r = requests.request(method=method, url=url, headers=headers, json=json, timeout=request_timeout)
             logger.debug(f" Backend response status for url [{url}]: [{r.status_code}]")
-            if r.status_code == 200:
+            if r.status_code == HTTPStatus.OK:
                 response_json = r.json()
                 if not validator or validator(response_json):
                     return response_json
                 logger.debug(f" Backend response does not meet expectation for url [{url}]: [{r.text}]")
-            if r.status_code == 429:
+            if r.status_code == HTTPStatus.TOO_MANY_REQUESTS:
                 retry_after = _parse_retry_after(r.headers)
                 logger.debug(f" Received 429 for url [{url}], rate limit reset in: [{retry_after}]")
                 if retry_after > 0:
@@ -152,7 +156,8 @@ def _parse_retry_after(headers: dict[str, str]):
     name = headers.get("X-RateLimit-Name")
 
     logger.info(
-        f" Rate limit information: X-RateLimit-Name={name} X-RateLimit-Limit={limit} X-RateLimit-period={period} X-RateLimit-Ramaining={remaining} X-RateLimit-Reset={reset}"
+        f" Rate limit information: X-RateLimit-Name={name} X-RateLimit-Limit={limit} "
+        f"X-RateLimit-period={period} X-RateLimit-Ramaining={remaining} X-RateLimit-Reset={reset}"
     )
 
     try:
@@ -171,10 +176,10 @@ def _query_for_profile(runtime_id: str):
     headers = _headers()
     headers["Content-Type"] = "application/json"
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(tz=UTC)
     time_to = now + timedelta(minutes=6)
     time_from = now - timedelta(minutes=6)
-    queryJson = {
+    query_json = {
         "track": "profile",
         "filter": {
             "query": f"-_dd.hotdog:* runtime-id:{runtime_id}",
@@ -183,8 +188,8 @@ def _query_for_profile(runtime_id: str):
         },
     }
 
-    logger.debug(f"Posting to {url} with query: {queryJson}")
-    profileId = _make_request(
-        url, headers=headers, method="post", json=queryJson, validator=_validate_profiler_response
+    logger.debug(f"Posting to {url} with query: {query_json}")
+    profile_id = _make_request(
+        url, headers=headers, method="post", json=query_json, validator=_validate_profiler_response
     )["data"][0]["id"]
-    logger.debug(f"Found profile in the backend with ID: {profileId}")
+    logger.debug(f"Found profile in the backend with ID: {profile_id}")

--- a/utils/onboarding/debug_vm.py
+++ b/utils/onboarding/debug_vm.py
@@ -24,11 +24,17 @@ _LOG_COLLECTION_COMMANDS = [
     "bash -lc 'cd ~ && sudo docker-compose ps > /var/log/datadog_weblog/docker_proccess.log 2>&1 || true'",
     "bash -lc 'cd ~ && sudo docker-compose logs > /var/log/datadog_weblog/docker_logs.log 2>&1 || true'",
     "sudo journalctl -xeu docker > /var/log/datadog_weblog/journalctl_docker.log 2>&1 || true",
-    "sudo cp /etc/datadog-agent/application_monitoring.yaml /var/log/datadog_weblog/application_monitoring.yaml 2>&1 || true",
+    (
+        "sudo cp /etc/datadog-agent/application_monitoring.yaml "
+        "/var/log/datadog_weblog/application_monitoring.yaml 2>&1 || true"
+    ),
     "sudo cat /var/log/cloud-init.log > /var/log/datadog_weblog/cloud-init.log 2>&1 || true",
     "sudo cat /var/log/syslog > /var/log/datadog_weblog/syslog.log 2>&1 || true",
     "sudo dmesg > /var/log/datadog_weblog/dmesg.log 2>&1 || true",
-    "sudo systemctl list-dependencies docker.service > /var/log/datadog_weblog/docker_list_dependencies.log 2>&1 || true",
+    (
+        "sudo systemctl list-dependencies docker.service > "
+        "/var/log/datadog_weblog/docker_list_dependencies.log 2>&1 || true"
+    ),
     "sudo systemctl list-timers --all > /var/log/datadog_weblog/system.timers.log 2>&1 || true",
     "sudo crontab -l > /var/log/datadog_weblog/crontab.log 2>&1 || true",
     "sudo cat /var/log/apt/history.log > /var/log/datadog_weblog/apt.log 2>&1 || true",

--- a/utils/onboarding/injection_log_parser.py
+++ b/utils/onboarding/injection_log_parser.py
@@ -9,11 +9,11 @@ WLS_ALLOWED_INJECTION = "Workload selection allowed injection: continuing"
 NO_KNOWN_RUNTIME = "No known runtime was detected - not injecting!"
 
 
-def exclude_telemetry_logs_filter(line: str):
+def exclude_telemetry_logs_filter(line: str) -> bool:
     return '"command":"telemetry"' not in line and '"caller":"telemetry/' not in line
 
 
-def command_injection_skipped(command_line: str, log_local_path: str):
+def command_injection_skipped(command_line: str, log_local_path: str) -> bool:
     """Determine if the given command was skipped from auto injection
     (e.g. by workload selection policies or no language matched).
     """
@@ -69,8 +69,8 @@ def _parse_command(command: str):
 def _get_process_logs_from_log_file(log_local_path: str, line_filter: Callable):
     r"""From instrumentation log file, extract all log lines per process.
 
-    A process chunk starts at the line containing \"process_exe:\" and runs until the next \"process_exe:\". This includes WLS decision
-    lines and post-WLS lines like \"No known runtime was detected - not injecting!\".
+    A process chunk starts at the line containing \"process_exe:\" and runs until the next \"process_exe:\".
+    This includes WLS decision lines and post-WLS lines like \"No known runtime was detected - not injecting!\".
     """
     process_logs: list[str] = []
     with open(log_local_path, encoding="utf-8") as f:
@@ -88,7 +88,7 @@ def _get_process_logs_from_log_file(log_local_path: str, line_filter: Callable):
         yield process_logs.copy()
 
 
-def main():
+def main() -> None:
     log_file = "logs_onboarding_host_block_list/host_injection_21711f84-86b3-4125-9a5f-cd129195d99a.log"
     command = "java -Dversion=-version -jar myapp.jar"
     skipped = command_injection_skipped(command, log_file)

--- a/utils/onboarding/wait_for_tcp_port.py
+++ b/utils/onboarding/wait_for_tcp_port.py
@@ -22,7 +22,7 @@ import time
 from utils._logger import logger
 
 
-def wait_for_port(port: int, host: str = "localhost", timeout: float = 5.0):
+def wait_for_port(port: int, host: str = "localhost", timeout: float = 5.0) -> bool:
     """Wait until a port starts accepting TCP connections.
 
     Args:

--- a/utils/onboarding/weblog_interface.py
+++ b/utils/onboarding/weblog_interface.py
@@ -6,7 +6,7 @@ import requests
 from utils.virtual_machine.virtual_machines import _VirtualMachine
 
 
-def make_get_request(app_url: str, appsec: bool = False):
+def make_get_request(app_url: str, *, appsec: bool = False) -> str:
     generated_uuid = str(randint(1, 100000000000000000))
     headers = {
         "x-datadog-trace-id": generated_uuid,
@@ -25,7 +25,7 @@ def make_get_request(app_url: str, appsec: bool = False):
     return generated_uuid
 
 
-def warmup_weblog(app_url: str):
+def warmup_weblog(app_url: str) -> None:
     for _ in range(15):
         try:
             requests.get(app_url, timeout=10)
@@ -34,7 +34,7 @@ def warmup_weblog(app_url: str):
             time.sleep(5)
 
 
-def make_internal_get_request(stdin_file: str, vm_port: int, appsec: bool = False):
+def make_internal_get_request(stdin_file: str, vm_port: int, *, appsec: bool = False) -> str:
     """Exclusively for testing through KrunVm microVM.
     It is used to make a request to the weblog application inside the VM, using stdin file
     """


### PR DESCRIPTION
## Summary
Removes most of the `utils/onboarding/*` per-file lint ignores in `pyproject.toml` and fixes the underlying code so the rules pass cleanly.
## Changes
- **Dropped stale ignores** that were no longer triggered by any code: `PLR2044`, `PTH102`, `RET505`, `S507`, `N803`.
- **ANN201** – added missing return type annotations (`-> None`, `-> str`, `-> bool`) across `backend_interface.py`, `weblog_interface.py`, `injection_log_parser.py`, and `wait_for_tcp_port.py`.
- **FBT001/FBT002** – made the `appsec`/`profile` boolean parameters keyword-only. All existing callers already pass them by keyword, so this is non-breaking.
- **DTZ005/DTZ006/UP017** – made `datetime` calls timezone-aware using `datetime.UTC` (`now(tz=UTC)`, `fromtimestamp(..., tz=UTC)`). The age comparison keeps the same behavior since both operands are absolute.
- **N806** – renamed `queryJson` → `query_json` and `profileId` → `profile_id`.
- **PLR2004** – replaced magic HTTP status codes `200`/`429` with `HTTPStatus.OK`/`HTTPStatus.TOO_MANY_REQUESTS`.
- **E501** – wrapped long docstrings, a log f-string, and shell commands (via implicit string concatenation, no content change).
## Left as a marked exception
The `E501` ignore is kept, but narrowed from the whole folder down to `utils/onboarding/weblog_interface.py` only. That file contains a long `curl` command embedded inside an inline bash script (a triple-quoted f-string) that cannot be safely wrapped without risking the script's behavior. The ignore comment now explains the real reason instead of a generic `TODO`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
