### PR TITLE
test(ffe): enable Node.js agentless flag evaluation

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -103,6 +103,7 @@ refs:
   - &ref_6_0_0 '>=6.0.0-pre'
   - &ref_6_5_0 '>=6.5.0 || ^5.116.0'
   - &ref_6_7_0 '>=6.7.0 || ^5.118.0'
+  - &ref_6_8_0 '>=6.8.0 || ^5.119.0'
 manifest:
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardEvent_Tag:
     - weblog_declaration:
@@ -1715,7 +1716,7 @@ manifest:
     - declaration: missing_feature (Not implemented yet)
       component_version: <5.66.0
   tests/docker_ssi/test_docker_ssi_appsec.py::TestDockerSSIAppsecFeatures::test_telemetry_source_ssi: *ref_5_83_0
-  tests/ffe/test_agentless_configuration.py: missing_feature (FFL-2697 tracks Node.js agentless configuration-source implementation; FFL-2731 tracks the system-tests contract)
+  tests/ffe/test_agentless_configuration.py: *ref_6_8_0
   tests/ffe/test_dynamic_evaluation.py:
     - weblog_declaration:
         "*": incomplete_test_app
@@ -2078,7 +2079,7 @@ manifest:
   tests/parametric/test_extract_behavior.py::Test_ExtractBehavior_Restart::test_baggage: incomplete_test_app (The parametric test app does not preserve baggage after extraction)
   tests/parametric/test_extract_behavior.py::Test_ExtractBehavior_Restart_With_Extract_First: *ref_5_47_0
   tests/parametric/test_extract_behavior.py::Test_ExtractBehavior_Restart_With_Extract_First::test_baggage: incomplete_test_app (The parametric test app does not preserve baggage after extraction)
-  tests/parametric/test_ffe/test_configuration_sources.py: missing_feature (FFL-2697 tracks Node.js agentless configuration-source implementation; FFL-2731 tracks system-tests configuration-source contract)
+  tests/parametric/test_ffe/test_configuration_sources.py: *ref_6_8_0
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation: *ref_5_75_0
   tests/parametric/test_ffe/test_span_enrichment.py: "missing_feature (dd-trace-js#8343)"
   tests/parametric/test_headers_b3.py::Test_Headers_B3::test_headers_b3_migrated_extract_invalid: missing_feature (Need to remove b3=b3multi alias)

--- a/tests/ffe/test_agentless_configuration.py
+++ b/tests/ffe/test_agentless_configuration.py
@@ -29,4 +29,3 @@ class Test_FFE_Agentless_Configuration:
         assert backend_status is not None
         assert backend_status["requests_total"] >= 1
         assert backend_status["last_path"] == CONFIG_PATH
-        assert backend_status["last_auth_present"] is True

--- a/tests/parametric/capabilities.yml
+++ b/tests/parametric/capabilities.yml
@@ -72,7 +72,7 @@ capabilities:
       - ASM_ACTIVATION
       - ASM_AUTO_USER_INSTRUM_MODE
 
-    '>=5.72.0 <5.119.0 || >=6.0.0-pre <6.8.0':
+    '>=5.72.0':
       - FFE_FLAG_CONFIGURATION_RULES
 
     '>=5.83.0':

--- a/tests/parametric/capabilities.yml
+++ b/tests/parametric/capabilities.yml
@@ -72,7 +72,7 @@ capabilities:
       - ASM_ACTIVATION
       - ASM_AUTO_USER_INSTRUM_MODE
 
-    '>=5.72.0':
+    '>=5.72.0 <5.119.0 || >=6.0.0-pre <6.8.0':
       - FFE_FLAG_CONFIGURATION_RULES
 
     '>=5.83.0':

--- a/tests/test_the_test/test_docker_scenario.py
+++ b/tests/test_the_test/test_docker_scenario.py
@@ -107,14 +107,17 @@ def test_recursive_2():
 
 
 @scenarios.test_the_test
-@pytest.mark.parametrize(("is_empty_test_run", "flush"), [(True, False), (False, True)])
-def test_end_to_end_scenario_only_flushes_non_empty_test_runs(
-    monkeypatch: pytest.MonkeyPatch, *, is_empty_test_run: bool, flush: bool
+@pytest.mark.parametrize(
+    ("include_agent", "is_empty_test_run", "flush"),
+    [(True, True, False), (True, False, True), (False, True, False), (False, False, False)],
+)
+def test_end_to_end_scenario_only_flushes_agent_backed_non_empty_test_runs(
+    monkeypatch: pytest.MonkeyPatch, *, include_agent: bool, is_empty_test_run: bool, flush: bool
 ) -> None:
     scenario = DdTraceEndToEndScenario(
         "FAKE_END_TO_END",
         doc="",
-        include_agent=False,
+        include_agent=include_agent,
         use_proxy_for_agent=False,
         use_proxy_for_weblog=False,
     )

--- a/tests/test_the_test/test_mock_ffe_agentless_backend.py
+++ b/tests/test_the_test/test_mock_ffe_agentless_backend.py
@@ -1,5 +1,6 @@
 """Unit coverage for the mock FFE agentless backend test fixture."""
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import requests
@@ -155,3 +156,41 @@ def test_agentless_end_to_end_scenario_closes_backend_when_status_fails() -> Non
 
     backend.close.assert_called_once_with()
     assert scenario._mock_backend is None  # noqa: SLF001 - focused lifecycle test
+
+
+@scenarios.test_the_test
+def test_agentless_end_to_end_scenario_persists_backend_status_for_replay(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    recording_scenario = FeatureFlaggingAgentlessEndToEndScenario("MOCK_FFE_AGENTLESS_REPLAY", doc="test")
+    recording_scenario._mock_backend_status_path.parent.mkdir()  # noqa: SLF001 - focused lifecycle test
+
+    expected_status = {
+        "requests_total": 1,
+        "in_flight": 0,
+        "max_in_flight": 1,
+        "last_path": CONFIG_PATH,
+        "last_if_none_match": None,
+        "last_auth_present": True,
+        "last_status_code": 200,
+        "status_codes": [200],
+    }
+    backend = MagicMock(spec=MockFFEAgentlessBackendServer)
+    backend.status.return_value = expected_status
+    recording_scenario._mock_backend = backend  # noqa: SLF001 - focused lifecycle test
+
+    recording_scenario._stop_mock_backend()  # noqa: SLF001 - focused lifecycle test
+
+    replay_scenario = FeatureFlaggingAgentlessEndToEndScenario("MOCK_FFE_AGENTLESS_REPLAY", doc="test")
+    replay_scenario.replay = True
+    base_configure = MagicMock()
+    monkeypatch.setattr(endtoend_scenarios.DdTraceEndToEndScenario, "configure", base_configure)
+    config = MagicMock(spec=pytest.Config)
+    replay_scenario.configure(config)
+
+    backend.close.assert_called_once_with()
+    base_configure.assert_called_once_with(config)
+    assert replay_scenario.mock_backend_status() == expected_status

--- a/tests/test_the_test/test_mock_ffe_agentless_backend.py
+++ b/tests/test_the_test/test_mock_ffe_agentless_backend.py
@@ -15,7 +15,7 @@ from utils.mocked_backend.ffe import (
     MockFFEAgentlessBackendServer,
     UFC_RESPONSE_TYPE,
 )
-from utils._context._scenarios.endtoend import FeatureFlaggingAgentlessEndToEndScenario, NODE_EXTRA_CA_CERTS_PATH
+from utils._context._scenarios.endtoend import FeatureFlaggingAgentlessEndToEndScenario
 
 
 @scenarios.test_the_test
@@ -79,24 +79,6 @@ def test_mock_ffe_agentless_backend_host_gateway_mapping(monkeypatch: pytest.Mon
 
 
 @scenarios.test_the_test
-def test_mock_ffe_agentless_backend_tls(worker_id: str) -> None:
-    server = MockFFEAgentlessBackendServer(worker_id, port=0, use_tls=True)
-    try:
-        assert server.ca_cert_path is not None
-        assert server.base_url.startswith("https://127.0.0.1:")
-        assert server.library_config_url.startswith("https://host.docker.internal:")
-
-        response = requests.get(
-            f"{server.base_url}{CONFIG_PATH}?{CONFIG_QUERY}",
-            timeout=5,
-            verify=str(server.ca_cert_path),
-        )
-        response.raise_for_status()
-    finally:
-        server.close()
-
-
-@scenarios.test_the_test
 def test_mock_ffe_agentless_backend_status_is_metadata_only(worker_id: str) -> None:
     server = MockFFEAgentlessBackendServer(worker_id, port=0)
     try:
@@ -142,29 +124,6 @@ def test_agentless_end_to_end_scenario_starts_backend_before_weblog() -> None:
 
 
 @scenarios.test_the_test
-def test_agentless_end_to_end_scenario_trusts_tls_backend() -> None:
-    scenario = FeatureFlaggingAgentlessEndToEndScenario("MOCK_FFE_AGENTLESS_TLS_E2E", doc="test")
-
-    try:
-        scenario._start_mock_backend(use_tls=True)  # noqa: SLF001 - focused lifecycle test
-
-        environment = scenario.weblog_infra.library_container.environment
-        assert environment["NODE_EXTRA_CA_CERTS"] == NODE_EXTRA_CA_CERTS_PATH
-        base_url = environment["DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL"]
-        assert isinstance(base_url, str)
-        assert base_url.startswith("https://")
-
-        assert scenario._mock_backend is not None  # noqa: SLF001 - focused lifecycle test
-        assert scenario._mock_backend.ca_cert_path is not None  # noqa: SLF001 - focused lifecycle test
-        assert scenario.weblog_infra.library_container.volumes[str(scenario._mock_backend.ca_cert_path)] == {  # noqa: SLF001
-            "bind": NODE_EXTRA_CA_CERTS_PATH,
-            "mode": "ro",
-        }
-    finally:
-        scenario._stop_mock_backend()  # noqa: SLF001 - focused lifecycle test
-
-
-@scenarios.test_the_test
 def test_agentless_end_to_end_scenario_closes_backend_when_startup_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -172,16 +131,13 @@ def test_agentless_end_to_end_scenario_closes_backend_when_startup_fails(
     backend = MagicMock(spec=MockFFEAgentlessBackendServer)
     backend.reset.side_effect = RuntimeError("reset failed")
 
-    def create_backend(*, use_tls: bool = False) -> MagicMock:
-        assert use_tls is True
+    def create_backend() -> MagicMock:
         return backend
 
     monkeypatch.setattr(endtoend_scenarios, "MockFFEAgentlessBackendServer", create_backend)
 
-    config = MagicMock(spec=pytest.Config)
-    config.option = MagicMock(library="nodejs")
     with pytest.raises(RuntimeError, match="reset failed"):
-        scenario.configure(config)
+        scenario.configure(MagicMock(spec=pytest.Config))
 
     backend.close.assert_called_once_with()
     assert scenario._mock_backend is None  # noqa: SLF001 - focused lifecycle test

--- a/tests/test_the_test/test_mock_ffe_agentless_backend.py
+++ b/tests/test_the_test/test_mock_ffe_agentless_backend.py
@@ -15,7 +15,7 @@ from utils.mocked_backend.ffe import (
     MockFFEAgentlessBackendServer,
     UFC_RESPONSE_TYPE,
 )
-from utils._context._scenarios.endtoend import FeatureFlaggingAgentlessEndToEndScenario
+from utils._context._scenarios.endtoend import FeatureFlaggingAgentlessEndToEndScenario, NODE_EXTRA_CA_CERTS_PATH
 
 
 @scenarios.test_the_test
@@ -79,6 +79,24 @@ def test_mock_ffe_agentless_backend_host_gateway_mapping(monkeypatch: pytest.Mon
 
 
 @scenarios.test_the_test
+def test_mock_ffe_agentless_backend_tls(worker_id: str) -> None:
+    server = MockFFEAgentlessBackendServer(worker_id, port=0, use_tls=True)
+    try:
+        assert server.ca_cert_path is not None
+        assert server.base_url.startswith("https://127.0.0.1:")
+        assert server.library_config_url.startswith("https://host.docker.internal:")
+
+        response = requests.get(
+            f"{server.base_url}{CONFIG_PATH}?{CONFIG_QUERY}",
+            timeout=5,
+            verify=str(server.ca_cert_path),
+        )
+        response.raise_for_status()
+    finally:
+        server.close()
+
+
+@scenarios.test_the_test
 def test_mock_ffe_agentless_backend_status_is_metadata_only(worker_id: str) -> None:
     server = MockFFEAgentlessBackendServer(worker_id, port=0)
     try:
@@ -124,6 +142,29 @@ def test_agentless_end_to_end_scenario_starts_backend_before_weblog() -> None:
 
 
 @scenarios.test_the_test
+def test_agentless_end_to_end_scenario_trusts_tls_backend() -> None:
+    scenario = FeatureFlaggingAgentlessEndToEndScenario("MOCK_FFE_AGENTLESS_TLS_E2E", doc="test")
+
+    try:
+        scenario._start_mock_backend(use_tls=True)  # noqa: SLF001 - focused lifecycle test
+
+        environment = scenario.weblog_infra.library_container.environment
+        assert environment["NODE_EXTRA_CA_CERTS"] == NODE_EXTRA_CA_CERTS_PATH
+        base_url = environment["DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL"]
+        assert isinstance(base_url, str)
+        assert base_url.startswith("https://")
+
+        assert scenario._mock_backend is not None  # noqa: SLF001 - focused lifecycle test
+        assert scenario._mock_backend.ca_cert_path is not None  # noqa: SLF001 - focused lifecycle test
+        assert scenario.weblog_infra.library_container.volumes[str(scenario._mock_backend.ca_cert_path)] == {  # noqa: SLF001
+            "bind": NODE_EXTRA_CA_CERTS_PATH,
+            "mode": "ro",
+        }
+    finally:
+        scenario._stop_mock_backend()  # noqa: SLF001 - focused lifecycle test
+
+
+@scenarios.test_the_test
 def test_agentless_end_to_end_scenario_closes_backend_when_startup_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -131,13 +172,16 @@ def test_agentless_end_to_end_scenario_closes_backend_when_startup_fails(
     backend = MagicMock(spec=MockFFEAgentlessBackendServer)
     backend.reset.side_effect = RuntimeError("reset failed")
 
-    def create_backend() -> MagicMock:
+    def create_backend(*, use_tls: bool = False) -> MagicMock:
+        assert use_tls is True
         return backend
 
     monkeypatch.setattr(endtoend_scenarios, "MockFFEAgentlessBackendServer", create_backend)
 
+    config = MagicMock(spec=pytest.Config)
+    config.option = MagicMock(library="nodejs")
     with pytest.raises(RuntimeError, match="reset failed"):
-        scenario.configure(MagicMock(spec=pytest.Config))
+        scenario.configure(config)
 
     backend.close.assert_called_once_with()
     assert scenario._mock_backend is None  # noqa: SLF001 - focused lifecycle test

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -33,6 +33,8 @@ from utils._logger import logger
 
 from .core import Scenario, ScenarioGroup, scenario_groups as all_scenario_groups
 
+NODE_EXTRA_CA_CERTS_PATH = "/usr/local/share/ca-certificates/system-tests-ffe-agentless.pem"
+
 
 class DockerScenario(Scenario):
     """Scenario that tests docker containers"""
@@ -647,17 +649,17 @@ class FeatureFlaggingAgentlessEndToEndScenario(DdTraceEndToEndScenario):
     def configure(self, config: pytest.Config) -> None:
         try:
             if not self.replay:
-                self._start_mock_backend()
+                self._start_mock_backend(use_tls=config.option.library == "nodejs")
 
             super().configure(config)
         except BaseException:
             self._stop_mock_backend()
             raise
 
-    def _start_mock_backend(self) -> None:
+    def _start_mock_backend(self, *, use_tls: bool = False) -> None:
         assert self._mock_backend is None, "mock FFE agentless backend is already running"
 
-        self._mock_backend = MockFFEAgentlessBackendServer()
+        self._mock_backend = MockFFEAgentlessBackendServer(use_tls=use_tls)
         self._mock_backend.reset()
 
         environment = self.weblog_infra.library_container.environment
@@ -665,6 +667,13 @@ class FeatureFlaggingAgentlessEndToEndScenario(DdTraceEndToEndScenario):
             "DD_API_KEY": EXPECTED_API_KEY,
             "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL": self._mock_backend.library_config_url,
         }
+        if use_tls:
+            assert self._mock_backend.ca_cert_path is not None
+            environment["NODE_EXTRA_CA_CERTS"] = NODE_EXTRA_CA_CERTS_PATH
+            self.weblog_infra.library_container.volumes[str(self._mock_backend.ca_cert_path)] = {
+                "bind": NODE_EXTRA_CA_CERTS_PATH,
+                "mode": "ro",
+            }
         self.weblog_infra.library_container.extra_hosts = extra_hosts_for_environment(environment)
 
     def mock_backend_status(self) -> MockFFEAgentlessBackendStatus | None:

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -1,5 +1,8 @@
-from typing import Literal
+import json
 import os
+from pathlib import Path
+from typing import Literal, cast
+
 import pytest
 
 from docker.models.networks import Network
@@ -615,6 +618,7 @@ class FeatureFlaggingAgentlessEndToEndScenario(DdTraceEndToEndScenario):
     """FFE end-to-end scenario with UFC available before the weblog starts."""
 
     _default_scenario_groups: tuple[ScenarioGroup, ...] = ()
+    _mock_backend_status_filename = "mock_ffe_agentless_backend_status.json"
 
     _mock_backend: MockFFEAgentlessBackendServer | None = None
     _last_mock_backend_status: MockFFEAgentlessBackendStatus | None = None
@@ -646,12 +650,15 @@ class FeatureFlaggingAgentlessEndToEndScenario(DdTraceEndToEndScenario):
 
     def configure(self, config: pytest.Config) -> None:
         try:
-            if not self.replay:
+            if self.replay:
+                self._load_mock_backend_status()
+            else:
+                self._last_mock_backend_status = None
                 self._start_mock_backend()
 
             super().configure(config)
         except BaseException:
-            self._stop_mock_backend()
+            self._stop_mock_backend(persist_status=False)
             raise
 
     def _start_mock_backend(self) -> None:
@@ -672,14 +679,30 @@ class FeatureFlaggingAgentlessEndToEndScenario(DdTraceEndToEndScenario):
             return self._mock_backend.status()
         return self._last_mock_backend_status
 
-    def _stop_mock_backend(self) -> None:
+    @property
+    def _mock_backend_status_path(self) -> Path:
+        return Path(self.host_log_folder) / self._mock_backend_status_filename
+
+    def _load_mock_backend_status(self) -> None:
+        self._last_mock_backend_status = cast(
+            "MockFFEAgentlessBackendStatus",
+            json.loads(self._mock_backend_status_path.read_text(encoding="utf-8")),
+        )
+
+    def _stop_mock_backend(self, *, persist_status: bool = True) -> None:
         backend = self._mock_backend
         if backend is None:
             return
 
         self._mock_backend = None
         try:
-            self._last_mock_backend_status = backend.status()
+            if persist_status:
+                self._last_mock_backend_status = backend.status()
+                self._mock_backend_status_path.parent.mkdir(parents=True, exist_ok=True)
+                self._mock_backend_status_path.write_text(
+                    json.dumps(self._last_mock_backend_status, indent=2) + "\n",
+                    encoding="utf-8",
+                )
         finally:
             backend.close()
 

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -466,9 +466,9 @@ class EndToEndScenario(DockerScenario):
         else:
             self._wait_interface(interfaces.library, 0 if is_empty_test_run else self.library_interface_timeout)
 
-            # An empty selection has no test-generated data to flush. This also avoids waiting on
-            # Agent-backed writers in scenarios that intentionally do not start an Agent.
-            self.weblog_infra.stop(flush=not is_empty_test_run)
+            # An empty selection has no test-generated data to flush. An Agentless scenario also
+            # has no Agent-backed writer target, so its flush endpoint can only time out.
+            self.weblog_infra.stop(flush=not is_empty_test_run and self.include_agent)
             interfaces.library.check_deserialization_errors()
 
             for container in self.buddies:

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -627,7 +627,6 @@ class FeatureFlaggingAgentlessEndToEndScenario(DdTraceEndToEndScenario):
         weblog_env: dict[str, str | None] | None = None,
     ) -> None:
         environment: dict[str, str | None] = {
-            "DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED": "true",
             "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS": "0.2",
             "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS": "2",
             "DD_REMOTE_CONFIGURATION_ENABLED": "false",

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -33,8 +33,6 @@ from utils._logger import logger
 
 from .core import Scenario, ScenarioGroup, scenario_groups as all_scenario_groups
 
-NODE_EXTRA_CA_CERTS_PATH = "/usr/local/share/ca-certificates/system-tests-ffe-agentless.pem"
-
 
 class DockerScenario(Scenario):
     """Scenario that tests docker containers"""
@@ -649,17 +647,17 @@ class FeatureFlaggingAgentlessEndToEndScenario(DdTraceEndToEndScenario):
     def configure(self, config: pytest.Config) -> None:
         try:
             if not self.replay:
-                self._start_mock_backend(use_tls=config.option.library == "nodejs")
+                self._start_mock_backend()
 
             super().configure(config)
         except BaseException:
             self._stop_mock_backend()
             raise
 
-    def _start_mock_backend(self, *, use_tls: bool = False) -> None:
+    def _start_mock_backend(self) -> None:
         assert self._mock_backend is None, "mock FFE agentless backend is already running"
 
-        self._mock_backend = MockFFEAgentlessBackendServer(use_tls=use_tls)
+        self._mock_backend = MockFFEAgentlessBackendServer()
         self._mock_backend.reset()
 
         environment = self.weblog_infra.library_container.environment
@@ -667,13 +665,6 @@ class FeatureFlaggingAgentlessEndToEndScenario(DdTraceEndToEndScenario):
             "DD_API_KEY": EXPECTED_API_KEY,
             "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL": self._mock_backend.library_config_url,
         }
-        if use_tls:
-            assert self._mock_backend.ca_cert_path is not None
-            environment["NODE_EXTRA_CA_CERTS"] = NODE_EXTRA_CA_CERTS_PATH
-            self.weblog_infra.library_container.volumes[str(self._mock_backend.ca_cert_path)] = {
-                "bind": NODE_EXTRA_CA_CERTS_PATH,
-                "mode": "ro",
-            }
         self.weblog_infra.library_container.extra_hosts = extra_hosts_for_environment(environment)
 
     def mock_backend_status(self) -> MockFFEAgentlessBackendStatus | None:

--- a/utils/build/docker/nodejs/express/app.js
+++ b/utils/build/docker/nodejs/express/app.js
@@ -834,21 +834,40 @@ app.post('/ai_guard/evaluate', async (req, res) => {
 })
 
 let openFeatureClient = null
-let openFeatureProviderReady = Promise.resolve()
+let openFeatureClientPromise = null
 
-// Initialize OpenFeature provider if FFE is enabled
-if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED === 'true') {
-  const { openfeature } = tracer
-  openFeatureProviderReady = OpenFeature.setProviderAndWait(openfeature)
-  openFeatureClient = OpenFeature.getClient()
+async function getOpenFeatureClient () {
+  if (openFeatureClient) {
+    return openFeatureClient
+  }
+
+  if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED !== 'true') {
+    return null
+  }
+
+  if (!openFeatureClientPromise) {
+    const { openfeature } = tracer
+    openFeatureClientPromise = OpenFeature.setProviderAndWait(openfeature)
+      .then(() => {
+        openFeatureClient = OpenFeature.getClient()
+        return openFeatureClient
+      })
+      .catch(error => {
+        openFeatureClientPromise = null
+        throw error
+      })
+  }
+
+  return openFeatureClientPromise
 }
 
 // Single FFE endpoint that evaluates feature flags
 app.post('/ffe', async (req, res) => {
   try {
     const { flag, variationType, defaultValue, targetingKey, targetingKeys, attributes } = req.body
+    const client = await getOpenFeatureClient()
 
-    if (!openFeatureClient) {
+    if (!client) {
       return res.status(500).json({ error: 'FFE provider not initialized' })
     }
 
@@ -860,17 +879,17 @@ app.post('/ffe', async (req, res) => {
 
       switch (variationType) {
         case 'BOOLEAN':
-          value = await openFeatureClient.getBooleanValue(flag, defaultValue, context)
+          value = await client.getBooleanValue(flag, defaultValue, context)
           break
         case 'STRING':
-          value = await openFeatureClient.getStringValue(flag, defaultValue, context)
+          value = await client.getStringValue(flag, defaultValue, context)
           break
         case 'INTEGER':
         case 'NUMERIC':
-          value = await openFeatureClient.getNumberValue(flag, defaultValue, context)
+          value = await client.getNumberValue(flag, defaultValue, context)
           break
         case 'JSON':
-          value = await openFeatureClient.getObjectValue(flag, defaultValue, context)
+          value = await client.getObjectValue(flag, defaultValue, context)
           break
         default:
           return res.status(400).json({ error: `Unknown variation type: ${variationType}` })
@@ -891,9 +910,7 @@ const initGraphQL = () => {
     : Promise.resolve()
 }
 
-const startServer = async () => {
-  await openFeatureProviderReady
-
+const startServer = () => {
   return new Promise((resolve) => {
     const server = http.createServer((req, res) => {
       if (req.url.startsWith('/resource_renaming')) {

--- a/utils/build/docker/nodejs/express/app.js
+++ b/utils/build/docker/nodejs/express/app.js
@@ -834,11 +834,12 @@ app.post('/ai_guard/evaluate', async (req, res) => {
 })
 
 let openFeatureClient = null
+let openFeatureProviderReady = Promise.resolve()
 
 // Initialize OpenFeature provider if FFE is enabled
 if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED === 'true') {
   const { openfeature } = tracer
-  OpenFeature.setProvider(openfeature)
+  openFeatureProviderReady = OpenFeature.setProviderAndWait(openfeature)
   openFeatureClient = OpenFeature.getClient()
 }
 
@@ -890,7 +891,9 @@ const initGraphQL = () => {
     : Promise.resolve()
 }
 
-const startServer = () => {
+const startServer = async () => {
+  await openFeatureProviderReady
+
   return new Promise((resolve) => {
     const server = http.createServer((req, res) => {
       if (req.url.startsWith('/resource_renaming')) {

--- a/utils/build/docker/nodejs/express/app.js
+++ b/utils/build/docker/nodejs/express/app.js
@@ -841,7 +841,7 @@ async function getOpenFeatureClient () {
     return openFeatureClient
   }
 
-  if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED !== 'true') {
+  if (process.env.DD_FEATURE_FLAGS_ENABLED === 'false') {
     return null
   }
 

--- a/utils/build/docker/nodejs/express4-typescript.Dockerfile
+++ b/utils/build/docker/nodejs/express4-typescript.Dockerfile
@@ -10,6 +10,11 @@ ENV PGPORT=5433
 
 ENV DD_DATA_STREAMS_ENABLED=true
 
+# Refresh the application code and dependencies baked into the base image.
+COPY utils/build/docker/nodejs/express4-typescript/package.json utils/build/docker/nodejs/express4-typescript/bun.lock ./
+COPY utils/build/docker/nodejs/express4-typescript/app.ts app.ts
+RUN bun install --frozen-lockfile --network-concurrency 8 --linker=hoisted
+
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh && rm -rf /root/.bun
 RUN bun run build

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -525,18 +525,38 @@ app.get('/external_request/redirect', (req: Request, res: Response) => {
 require('./rasp')(app)
 
 let openFeatureClient: Client | null = null
-let openFeatureProviderReady = Promise.resolve()
+let openFeatureClientPromise: Promise<Client> | null = null
 
-if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED === 'true') {
-  openFeatureProviderReady = OpenFeature.setProviderAndWait(tracer.openfeature)
-  openFeatureClient = OpenFeature.getClient()
+async function getOpenFeatureClient (): Promise<Client | null> {
+  if (openFeatureClient) {
+    return openFeatureClient
+  }
+
+  if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED !== 'true') {
+    return null
+  }
+
+  if (!openFeatureClientPromise) {
+    openFeatureClientPromise = OpenFeature.setProviderAndWait(tracer.openfeature)
+      .then(() => {
+        openFeatureClient = OpenFeature.getClient()
+        return openFeatureClient
+      })
+      .catch((error: unknown) => {
+        openFeatureClientPromise = null
+        throw error
+      })
+  }
+
+  return openFeatureClientPromise
 }
 
 app.post('/ffe', async (req: Request, res: Response) => {
   try {
     const { flag, variationType, defaultValue, targetingKey, targetingKeys, attributes } = req.body
+    const client = await getOpenFeatureClient()
 
-    if (!openFeatureClient) {
+    if (!client) {
       return res.status(500).json({ error: 'FFE provider not initialized' })
     }
 
@@ -548,17 +568,17 @@ app.post('/ffe', async (req: Request, res: Response) => {
 
       switch (variationType) {
         case 'BOOLEAN':
-          value = await openFeatureClient.getBooleanValue(flag, defaultValue, context)
+          value = await client.getBooleanValue(flag, defaultValue, context)
           break
         case 'STRING':
-          value = await openFeatureClient.getStringValue(flag, defaultValue, context)
+          value = await client.getStringValue(flag, defaultValue, context)
           break
         case 'INTEGER':
         case 'NUMERIC':
-          value = await openFeatureClient.getNumberValue(flag, defaultValue, context)
+          value = await client.getNumberValue(flag, defaultValue, context)
           break
         case 'JSON':
-          value = await openFeatureClient.getObjectValue(flag, defaultValue, context)
+          value = await client.getObjectValue(flag, defaultValue, context)
           break
         default:
           return res.status(400).json({ error: `Unknown variation type: ${variationType}` })
@@ -572,9 +592,7 @@ app.post('/ffe', async (req: Request, res: Response) => {
   }
 })
 
-const startServer = async () => {
-  await openFeatureProviderReady
-
+const startServer = () => {
   return new Promise((resolve) => {
     const server = http.createServer((req: http.IncomingMessage, res: http.ServerResponse) => {
       if (req.url?.startsWith('/resource_renaming')) {

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -1,10 +1,12 @@
 'use strict'
 
 import { Request, Response } from "express";
+import type { Client } from '@openfeature/server-sdk'
 import http from 'http';
 
 const tracer = require('dd-trace').init();
 
+const { OpenFeature } = require('@openfeature/server-sdk')
 const { promisify } = require('util')
 const app = require('express')()
 const axios = require('axios')
@@ -521,6 +523,53 @@ app.get('/external_request/redirect', (req: Request, res: Response) => {
 })
 
 require('./rasp')(app)
+
+let openFeatureClient: Client | null = null
+
+if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED === 'true') {
+  OpenFeature.setProvider(tracer.openfeature)
+  openFeatureClient = OpenFeature.getClient()
+}
+
+app.post('/ffe', async (req: Request, res: Response) => {
+  try {
+    const { flag, variationType, defaultValue, targetingKey, targetingKeys, attributes } = req.body
+
+    if (!openFeatureClient) {
+      return res.status(500).json({ error: 'FFE provider not initialized' })
+    }
+
+    let value
+    const keys = Array.isArray(targetingKeys) && targetingKeys.length > 0 ? targetingKeys : [targetingKey]
+
+    for (const key of keys) {
+      const context = { targetingKey: key, ...attributes }
+
+      switch (variationType) {
+        case 'BOOLEAN':
+          value = await openFeatureClient.getBooleanValue(flag, defaultValue, context)
+          break
+        case 'STRING':
+          value = await openFeatureClient.getStringValue(flag, defaultValue, context)
+          break
+        case 'INTEGER':
+        case 'NUMERIC':
+          value = await openFeatureClient.getNumberValue(flag, defaultValue, context)
+          break
+        case 'JSON':
+          value = await openFeatureClient.getObjectValue(flag, defaultValue, context)
+          break
+        default:
+          return res.status(400).json({ error: `Unknown variation type: ${variationType}` })
+      }
+    }
+
+    return res.status(200).json({ value, count: keys.length })
+  } catch (error: any) {
+    console.error('[FFE] Error:', error)
+    return res.status(500).json({ error: error.message })
+  }
+})
 
 const startServer = () => {
   return new Promise((resolve) => {

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -532,7 +532,7 @@ async function getOpenFeatureClient (): Promise<Client | null> {
     return openFeatureClient
   }
 
-  if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED !== 'true') {
+  if (process.env.DD_FEATURE_FLAGS_ENABLED === 'false') {
     return null
   }
 

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -525,9 +525,10 @@ app.get('/external_request/redirect', (req: Request, res: Response) => {
 require('./rasp')(app)
 
 let openFeatureClient: Client | null = null
+let openFeatureProviderReady = Promise.resolve()
 
 if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED === 'true') {
-  OpenFeature.setProvider(tracer.openfeature)
+  openFeatureProviderReady = OpenFeature.setProviderAndWait(tracer.openfeature)
   openFeatureClient = OpenFeature.getClient()
 }
 
@@ -571,7 +572,9 @@ app.post('/ffe', async (req: Request, res: Response) => {
   }
 })
 
-const startServer = () => {
+const startServer = async () => {
+  await openFeatureProviderReady
+
   return new Promise((resolve) => {
     const server = http.createServer((req: http.IncomingMessage, res: http.ServerResponse) => {
       if (req.url?.startsWith('/resource_renaming')) {

--- a/utils/build/docker/nodejs/express4-typescript/bun.lock
+++ b/utils/build/docker/nodejs/express4-typescript/bun.lock
@@ -6,7 +6,7 @@
       "name": "express4-typescript",
       "dependencies": {
         "@openfeature/core": "^1.9.0",
-        "@openfeature/server-sdk": "~1.19.0",
+        "@openfeature/server-sdk": "~1.18.0",
         "@opentelemetry/api": "^1.9.0",
         "@types/express-session": "^1.18.1",
         "@types/ldapjs": "^3.0.6",
@@ -95,7 +95,7 @@
 
     "@openfeature/core": ["@openfeature/core@1.12.0", "", {}, "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA=="],
 
-    "@openfeature/server-sdk": ["@openfeature/server-sdk@1.19.0", "", { "peerDependencies": { "@openfeature/core": "^1.9.0" } }, "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg=="],
+    "@openfeature/server-sdk": ["@openfeature/server-sdk@1.18.0", "", { "peerDependencies": { "@openfeature/core": "^1.7.0" } }, "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/utils/build/docker/nodejs/express4-typescript/bun.lock
+++ b/utils/build/docker/nodejs/express4-typescript/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "express4-typescript",
       "dependencies": {
+        "@openfeature/core": "^1.9.0",
+        "@openfeature/server-sdk": "~1.19.0",
         "@opentelemetry/api": "^1.9.0",
         "@types/express-session": "^1.18.1",
         "@types/ldapjs": "^3.0.6",
@@ -90,6 +92,10 @@
     "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.3", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg=="],
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.1.4", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw=="],
+
+    "@openfeature/core": ["@openfeature/core@1.12.0", "", {}, "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA=="],
+
+    "@openfeature/server-sdk": ["@openfeature/server-sdk@1.19.0", "", { "peerDependencies": { "@openfeature/core": "^1.9.0" } }, "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/utils/build/docker/nodejs/express4-typescript/package-lock.json
+++ b/utils/build/docker/nodejs/express4-typescript/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@openfeature/core": "^1.9.0",
-        "@openfeature/server-sdk": "~1.19.0",
+        "@openfeature/server-sdk": "~1.18.0",
         "@opentelemetry/api": "^1.9.0",
         "@types/express-session": "^1.18.1",
         "@types/ldapjs": "^3.0.6",
@@ -331,15 +331,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@openfeature/server-sdk": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.19.0.tgz",
-      "integrity": "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.18.0.tgz",
+      "integrity": "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@openfeature/core": "^1.9.0"
+        "@openfeature/core": "^1.7.0"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/utils/build/docker/nodejs/express4-typescript/package-lock.json
+++ b/utils/build/docker/nodejs/express4-typescript/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@openfeature/core": "^1.9.0",
+        "@openfeature/server-sdk": "~1.19.0",
         "@opentelemetry/api": "^1.9.0",
         "@types/express-session": "^1.18.1",
         "@types/ldapjs": "^3.0.6",
@@ -320,6 +322,24 @@
       "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@openfeature/core": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@openfeature/server-sdk": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.19.0.tgz",
+      "integrity": "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@openfeature/core": "^1.9.0"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/utils/build/docker/nodejs/express4-typescript/package.json
+++ b/utils/build/docker/nodejs/express4-typescript/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@openfeature/core": "^1.9.0",
-    "@openfeature/server-sdk": "~1.19.0",
+    "@openfeature/server-sdk": "~1.18.0",
     "@opentelemetry/api": "^1.9.0",
     "@types/express-session": "^1.18.1",
     "@types/ldapjs": "^3.0.6",

--- a/utils/build/docker/nodejs/express4-typescript/package.json
+++ b/utils/build/docker/nodejs/express4-typescript/package.json
@@ -11,6 +11,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@openfeature/core": "^1.9.0",
+    "@openfeature/server-sdk": "~1.19.0",
     "@opentelemetry/api": "^1.9.0",
     "@types/express-session": "^1.18.1",
     "@types/ldapjs": "^3.0.6",

--- a/utils/build/docker/nodejs/express4.Dockerfile
+++ b/utils/build/docker/nodejs/express4.Dockerfile
@@ -5,6 +5,10 @@ FROM datadog/system-tests:express4.base-v3
 COPY utils/build/docker/nodejs/express/app.js app.js
 COPY utils/build/docker/nodejs/express/fork_child.js fork_child.js
 
+# Refresh the dependencies baked into the base image.
+COPY utils/build/docker/nodejs/express4/package.json utils/build/docker/nodejs/express4/bun.lock ./
+RUN bun install --frozen-lockfile --network-concurrency 8 --linker=hoisted
+
 EXPOSE 7777
 
 ENV PGUSER=system_tests_user

--- a/utils/build/docker/nodejs/express4/bun.lock
+++ b/utils/build/docker/nodejs/express4/bun.lock
@@ -6,7 +6,7 @@
       "name": "express4",
       "dependencies": {
         "@openfeature/core": "^1.9.0",
-        "@openfeature/server-sdk": "~1.19.0",
+        "@openfeature/server-sdk": "~1.18.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.30.1",
         "amqplib": "^0.10.3",
@@ -50,7 +50,7 @@
     },
   },
   "overrides": {
-    "@openfeature/server-sdk": "~1.19.0",
+    "@openfeature/server-sdk": "~1.18.0",
   },
   "packages": {
     "@aashutoshrathi/word-wrap": ["@aashutoshrathi/word-wrap@1.2.6", "", {}, "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA=="],
@@ -165,7 +165,7 @@
 
     "@openfeature/core": ["@openfeature/core@1.10.0", "", {}, "sha512-C3ynxtPYhe5qVJgQIqCNxZXeRXo4t1Eo86uiROr8+sD6F2OjEJGIp6VOGxz+r6jkad2s8Br9BnUJOvskhai/3A=="],
 
-    "@openfeature/server-sdk": ["@openfeature/server-sdk@1.19.0", "", { "peerDependencies": { "@openfeature/core": "^1.9.0" } }, "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg=="],
+    "@openfeature/server-sdk": ["@openfeature/server-sdk@1.18.0", "", { "peerDependencies": { "@openfeature/core": "^1.7.0" } }, "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/utils/build/docker/nodejs/express4/package-lock.json
+++ b/utils/build/docker/nodejs/express4/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@openfeature/core": "^1.9.0",
-        "@openfeature/server-sdk": "~1.19.0",
+        "@openfeature/server-sdk": "~1.18.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.30.1",
         "amqplib": "^0.10.3",
@@ -903,15 +903,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@openfeature/server-sdk": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.19.0.tgz",
-      "integrity": "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.18.0.tgz",
+      "integrity": "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@openfeature/core": "^1.9.0"
+        "@openfeature/core": "^1.7.0"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/utils/build/docker/nodejs/express4/package.json
+++ b/utils/build/docker/nodejs/express4/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@openfeature/core": "^1.9.0",
-    "@openfeature/server-sdk": "~1.19.0",
+    "@openfeature/server-sdk": "~1.18.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.30.1",
     "amqplib": "^0.10.3",

--- a/utils/build/docker/nodejs/express5.Dockerfile
+++ b/utils/build/docker/nodejs/express5.Dockerfile
@@ -1,7 +1,9 @@
 FROM datadog/system-tests:express5.base-v3
 
-# Refresh the application code baked into the base image.
+# Refresh the application code and dependencies baked into the base image.
 COPY utils/build/docker/nodejs/express/app.js app.js
+COPY utils/build/docker/nodejs/express5/package.json utils/build/docker/nodejs/express5/bun.lock ./
+RUN bun install --frozen-lockfile --network-concurrency 8 --linker=hoisted
 
 EXPOSE 7777
 

--- a/utils/build/docker/nodejs/express5.Dockerfile
+++ b/utils/build/docker/nodejs/express5.Dockerfile
@@ -1,5 +1,8 @@
 FROM datadog/system-tests:express5.base-v3
 
+# Refresh the application code baked into the base image.
+COPY utils/build/docker/nodejs/express/app.js app.js
+
 EXPOSE 7777
 
 ENV PGUSER=system_tests_user

--- a/utils/build/docker/nodejs/express5/bun.lock
+++ b/utils/build/docker/nodejs/express5/bun.lock
@@ -6,7 +6,7 @@
       "name": "express5",
       "dependencies": {
         "@openfeature/core": "^1.9.0",
-        "@openfeature/server-sdk": "~1.19.0",
+        "@openfeature/server-sdk": "~1.18.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.30.1",
         "amqplib": "^0.10.3",
@@ -48,7 +48,7 @@
     },
   },
   "overrides": {
-    "@openfeature/server-sdk": "~1.19.0",
+    "@openfeature/server-sdk": "~1.18.0",
   },
   "packages": {
     "@azure-rest/core-client": ["@azure-rest/core-client@2.6.0", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.10.0", "@azure/core-rest-pipeline": "^1.22.0", "@azure/core-tracing": "^1.3.0", "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ=="],
@@ -127,7 +127,7 @@
 
     "@openfeature/core": ["@openfeature/core@1.10.0", "", {}, "sha512-C3ynxtPYhe5qVJgQIqCNxZXeRXo4t1Eo86uiROr8+sD6F2OjEJGIp6VOGxz+r6jkad2s8Br9BnUJOvskhai/3A=="],
 
-    "@openfeature/server-sdk": ["@openfeature/server-sdk@1.19.0", "", { "peerDependencies": { "@openfeature/core": "^1.9.0" } }, "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg=="],
+    "@openfeature/server-sdk": ["@openfeature/server-sdk@1.18.0", "", { "peerDependencies": { "@openfeature/core": "^1.7.0" } }, "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/utils/build/docker/nodejs/express5/package-lock.json
+++ b/utils/build/docker/nodejs/express5/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@openfeature/core": "^1.9.0",
-        "@openfeature/server-sdk": "~1.19.0",
+        "@openfeature/server-sdk": "~1.18.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.30.1",
         "amqplib": "^0.10.3",
@@ -745,15 +745,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@openfeature/server-sdk": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.19.0.tgz",
-      "integrity": "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.18.0.tgz",
+      "integrity": "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@openfeature/core": "^1.9.0"
+        "@openfeature/core": "^1.7.0"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/utils/build/docker/nodejs/express5/package.json
+++ b/utils/build/docker/nodejs/express5/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@openfeature/core": "^1.9.0",
-    "@openfeature/server-sdk": "~1.19.0",
+    "@openfeature/server-sdk": "~1.18.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.30.1",
     "amqplib": "^0.10.3",

--- a/utils/build/docker/nodejs/fastify.Dockerfile
+++ b/utils/build/docker/nodejs/fastify.Dockerfile
@@ -10,6 +10,11 @@ ENV PGPORT=5433
 
 ENV DD_DATA_STREAMS_ENABLED=true
 
+# Refresh the application code and dependencies baked into the base image.
+COPY utils/build/docker/nodejs/fastify/package.json utils/build/docker/nodejs/fastify/bun.lock ./
+COPY utils/build/docker/nodejs/fastify/app.js app.js
+RUN bun install --frozen-lockfile --network-concurrency 8 --linker=hoisted
+
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN chmod +x app.sh

--- a/utils/build/docker/nodejs/fastify/app.js
+++ b/utils/build/docker/nodejs/fastify/app.js
@@ -961,18 +961,38 @@ fastify.get('/external_request/redirect', async (request, reply) => {
 require('./rasp')(fastify)
 
 let openFeatureClient = null
-let openFeatureProviderReady = Promise.resolve()
+let openFeatureClientPromise = null
 
-if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED === 'true') {
-  openFeatureProviderReady = OpenFeature.setProviderAndWait(tracer.openfeature)
-  openFeatureClient = OpenFeature.getClient()
+async function getOpenFeatureClient () {
+  if (openFeatureClient) {
+    return openFeatureClient
+  }
+
+  if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED !== 'true') {
+    return null
+  }
+
+  if (!openFeatureClientPromise) {
+    openFeatureClientPromise = OpenFeature.setProviderAndWait(tracer.openfeature)
+      .then(() => {
+        openFeatureClient = OpenFeature.getClient()
+        return openFeatureClient
+      })
+      .catch(error => {
+        openFeatureClientPromise = null
+        throw error
+      })
+  }
+
+  return openFeatureClientPromise
 }
 
 fastify.post('/ffe', async (request, reply) => {
   try {
     const { flag, variationType, defaultValue, targetingKey, targetingKeys, attributes } = request.body
+    const client = await getOpenFeatureClient()
 
-    if (!openFeatureClient) {
+    if (!client) {
       reply.status(500)
       return { error: 'FFE provider not initialized' }
     }
@@ -985,17 +1005,17 @@ fastify.post('/ffe', async (request, reply) => {
 
       switch (variationType) {
         case 'BOOLEAN':
-          value = await openFeatureClient.getBooleanValue(flag, defaultValue, context)
+          value = await client.getBooleanValue(flag, defaultValue, context)
           break
         case 'STRING':
-          value = await openFeatureClient.getStringValue(flag, defaultValue, context)
+          value = await client.getStringValue(flag, defaultValue, context)
           break
         case 'INTEGER':
         case 'NUMERIC':
-          value = await openFeatureClient.getNumberValue(flag, defaultValue, context)
+          value = await client.getNumberValue(flag, defaultValue, context)
           break
         case 'JSON':
-          value = await openFeatureClient.getObjectValue(flag, defaultValue, context)
+          value = await client.getObjectValue(flag, defaultValue, context)
           break
         default:
           reply.status(400)
@@ -1014,7 +1034,6 @@ fastify.post('/ffe', async (request, reply) => {
 
 const startServer = async () => {
   try {
-    await openFeatureProviderReady
     await fastify.listen({ port: 7777, host: '0.0.0.0' })
     tracer.trace('init.service', () => {})
     console.log('listening')

--- a/utils/build/docker/nodejs/fastify/app.js
+++ b/utils/build/docker/nodejs/fastify/app.js
@@ -968,7 +968,7 @@ async function getOpenFeatureClient () {
     return openFeatureClient
   }
 
-  if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED !== 'true') {
+  if (process.env.DD_FEATURE_FLAGS_ENABLED === 'false') {
     return null
   }
 

--- a/utils/build/docker/nodejs/fastify/app.js
+++ b/utils/build/docker/nodejs/fastify/app.js
@@ -2,6 +2,7 @@
 
 const tracer = require('dd-trace').init()
 
+const { OpenFeature } = require('@openfeature/server-sdk')
 const { promisify } = require('util')
 const axios = require('axios')
 const crypto = require('crypto')
@@ -958,6 +959,57 @@ fastify.get('/external_request/redirect', async (request, reply) => {
 })
 
 require('./rasp')(fastify)
+
+let openFeatureClient = null
+
+if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED === 'true') {
+  OpenFeature.setProvider(tracer.openfeature)
+  openFeatureClient = OpenFeature.getClient()
+}
+
+fastify.post('/ffe', async (request, reply) => {
+  try {
+    const { flag, variationType, defaultValue, targetingKey, targetingKeys, attributes } = request.body
+
+    if (!openFeatureClient) {
+      reply.status(500)
+      return { error: 'FFE provider not initialized' }
+    }
+
+    let value
+    const keys = Array.isArray(targetingKeys) && targetingKeys.length > 0 ? targetingKeys : [targetingKey]
+
+    for (const key of keys) {
+      const context = { targetingKey: key, ...attributes }
+
+      switch (variationType) {
+        case 'BOOLEAN':
+          value = await openFeatureClient.getBooleanValue(flag, defaultValue, context)
+          break
+        case 'STRING':
+          value = await openFeatureClient.getStringValue(flag, defaultValue, context)
+          break
+        case 'INTEGER':
+        case 'NUMERIC':
+          value = await openFeatureClient.getNumberValue(flag, defaultValue, context)
+          break
+        case 'JSON':
+          value = await openFeatureClient.getObjectValue(flag, defaultValue, context)
+          break
+        default:
+          reply.status(400)
+          return { error: `Unknown variation type: ${variationType}` }
+      }
+    }
+
+    reply.status(200)
+    return { value, count: keys.length }
+  } catch (error) {
+    console.error('[FFE] Error:', error)
+    reply.status(500)
+    return { error: error.message }
+  }
+})
 
 const startServer = async () => {
   try {

--- a/utils/build/docker/nodejs/fastify/app.js
+++ b/utils/build/docker/nodejs/fastify/app.js
@@ -961,9 +961,10 @@ fastify.get('/external_request/redirect', async (request, reply) => {
 require('./rasp')(fastify)
 
 let openFeatureClient = null
+let openFeatureProviderReady = Promise.resolve()
 
 if (process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED === 'true') {
-  OpenFeature.setProvider(tracer.openfeature)
+  openFeatureProviderReady = OpenFeature.setProviderAndWait(tracer.openfeature)
   openFeatureClient = OpenFeature.getClient()
 }
 
@@ -1013,6 +1014,7 @@ fastify.post('/ffe', async (request, reply) => {
 
 const startServer = async () => {
   try {
+    await openFeatureProviderReady
     await fastify.listen({ port: 7777, host: '0.0.0.0' })
     tracer.trace('init.service', () => {})
     console.log('listening')

--- a/utils/build/docker/nodejs/fastify/bun.lock
+++ b/utils/build/docker/nodejs/fastify/bun.lock
@@ -8,6 +8,8 @@
         "@fastify/cookie": "^11.0.2",
         "@fastify/formbody": "^8.0.0",
         "@fastify/multipart": "^9.0.3",
+        "@openfeature/core": "^1.9.0",
+        "@openfeature/server-sdk": "~1.19.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.30.1",
         "amqplib": "^0.10.3",
@@ -133,6 +135,10 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@openfeature/core": ["@openfeature/core@1.12.0", "", {}, "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA=="],
+
+    "@openfeature/server-sdk": ["@openfeature/server-sdk@1.19.0", "", { "peerDependencies": { "@openfeature/core": "^1.9.0" } }, "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/utils/build/docker/nodejs/fastify/package-lock.json
+++ b/utils/build/docker/nodejs/fastify/package-lock.json
@@ -12,6 +12,8 @@
         "@fastify/cookie": "^11.0.2",
         "@fastify/formbody": "^8.0.0",
         "@fastify/multipart": "^9.0.3",
+        "@openfeature/core": "^1.9.0",
+        "@openfeature/server-sdk": "~1.19.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.30.1",
         "amqplib": "^0.10.3",
@@ -787,6 +789,24 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@openfeature/core": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@openfeature/server-sdk": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.19.0.tgz",
+      "integrity": "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@openfeature/core": "^1.9.0"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/utils/build/docker/nodejs/fastify/package.json
+++ b/utils/build/docker/nodejs/fastify/package.json
@@ -12,6 +12,8 @@
   "license": "ISC",
   "dependencies": {
     "@fastify/formbody": "^8.0.0",
+    "@openfeature/core": "^1.9.0",
+    "@openfeature/server-sdk": "~1.19.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.30.1",
     "aws-sdk": "^2.1530.0",

--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -2,8 +2,14 @@ FROM datadog/system-tests:nextjs.base-v3
 
 EXPOSE 7777
 
+# Refresh the application route and dependencies baked into the base image.
+COPY utils/build/docker/nodejs/nextjs/package.json utils/build/docker/nodejs/nextjs/bun.lock ./
+COPY utils/build/docker/nodejs/nextjs/src/app/ffe ./src/app/ffe
+RUN bun install --frozen-lockfile --network-concurrency 8 --linker=hoisted
+
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh && rm -rf /root/.bun
+RUN bun run build && rm -rf .next/cache
 ENV DD_TRACE_HEADER_TAGS=user-agent
 
 # docker startup

--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -5,7 +5,7 @@ EXPOSE 7777
 # Refresh the application route and dependencies baked into the base image.
 COPY utils/build/docker/nodejs/nextjs/package.json utils/build/docker/nodejs/nextjs/bun.lock ./
 COPY utils/build/docker/nodejs/nextjs/src/app/ffe ./src/app/ffe
-RUN rm -rf node_modules/next \
+RUN rm -rf node_modules \
  && bun install --frozen-lockfile --network-concurrency 8 --linker=hoisted
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/

--- a/utils/build/docker/nodejs/nextjs.Dockerfile
+++ b/utils/build/docker/nodejs/nextjs.Dockerfile
@@ -5,7 +5,8 @@ EXPOSE 7777
 # Refresh the application route and dependencies baked into the base image.
 COPY utils/build/docker/nodejs/nextjs/package.json utils/build/docker/nodejs/nextjs/bun.lock ./
 COPY utils/build/docker/nodejs/nextjs/src/app/ffe ./src/app/ffe
-RUN bun install --frozen-lockfile --network-concurrency 8 --linker=hoisted
+RUN rm -rf node_modules/next \
+ && bun install --frozen-lockfile --network-concurrency 8 --linker=hoisted
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh && rm -rf /root/.bun

--- a/utils/build/docker/nodejs/nextjs/bun.lock
+++ b/utils/build/docker/nodejs/nextjs/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "nextjs",
       "dependencies": {
+        "@openfeature/core": "^1.9.0",
+        "@openfeature/server-sdk": "~1.19.0",
         "@opentelemetry/api": "^1.9.0",
         "axios": "^1.5.1",
         "next": "^14.0.4",
@@ -71,6 +73,10 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, ""],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, ""],
+
+    "@openfeature/core": ["@openfeature/core@1.12.0", "", {}, "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA=="],
+
+    "@openfeature/server-sdk": ["@openfeature/server-sdk@1.19.0", "", { "peerDependencies": { "@openfeature/core": "^1.9.0" } }, "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/utils/build/docker/nodejs/nextjs/package-lock.json
+++ b/utils/build/docker/nodejs/nextjs/package-lock.json
@@ -8,6 +8,8 @@
       "name": "nextjs",
       "version": "0.1.0",
       "dependencies": {
+        "@openfeature/core": "^1.9.0",
+        "@openfeature/server-sdk": "~1.19.0",
         "@opentelemetry/api": "^1.9.0",
         "axios": "^1.5.1",
         "next": "^14.0.4",
@@ -153,6 +155,24 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@openfeature/core": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@openfeature/server-sdk": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.19.0.tgz",
+      "integrity": "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@openfeature/core": "^1.9.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -3819,6 +3839,17 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@openfeature/core": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA=="
+    },
+    "@openfeature/server-sdk": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.19.0.tgz",
+      "integrity": "sha512-sxmYKkBCpWWkKX2xJt6bFK15dorfR2lH27lkeKduTFPXRMV+pO7eORUelI9gctXhxvfXbDGK94ybq5fiso3/vg==",
+      "requires": {}
     },
     "@opentelemetry/api": {
       "version": "1.9.1",

--- a/utils/build/docker/nodejs/nextjs/package.json
+++ b/utils/build/docker/nodejs/nextjs/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@openfeature/core": "^1.9.0",
+    "@openfeature/server-sdk": "~1.19.0",
     "@opentelemetry/api": "^1.9.0",
     "axios": "^1.5.1",
     "next": "^14.0.4",

--- a/utils/build/docker/nodejs/nextjs/src/app/ffe/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/ffe/route.js
@@ -12,7 +12,7 @@ async function getOpenFeatureClient () {
   }
 
   const tracer = global._ddtrace
-  if (!tracer?.openfeature || process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED !== 'true') {
+  if (!tracer?.openfeature || process.env.DD_FEATURE_FLAGS_ENABLED === 'false') {
     return null
   }
 

--- a/utils/build/docker/nodejs/nextjs/src/app/ffe/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/ffe/route.js
@@ -4,8 +4,9 @@ import { NextResponse } from 'next/server'
 export const dynamic = 'force-dynamic'
 
 let openFeatureClient = null
+let openFeatureClientPromise = null
 
-function getOpenFeatureClient () {
+async function getOpenFeatureClient () {
   if (openFeatureClient) {
     return openFeatureClient
   }
@@ -15,14 +16,24 @@ function getOpenFeatureClient () {
     return null
   }
 
-  OpenFeature.setProvider(tracer.openfeature)
-  openFeatureClient = OpenFeature.getClient()
-  return openFeatureClient
+  if (!openFeatureClientPromise) {
+    openFeatureClientPromise = OpenFeature.setProviderAndWait(tracer.openfeature)
+      .then(() => {
+        openFeatureClient = OpenFeature.getClient()
+        return openFeatureClient
+      })
+      .catch(error => {
+        openFeatureClientPromise = null
+        throw error
+      })
+  }
+
+  return openFeatureClientPromise
 }
 
 export async function POST (request) {
   try {
-    const client = getOpenFeatureClient()
+    const client = await getOpenFeatureClient()
     if (!client) {
       return NextResponse.json({ error: 'FFE provider not initialized' }, { status: 500 })
     }

--- a/utils/build/docker/nodejs/nextjs/src/app/ffe/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/ffe/route.js
@@ -1,0 +1,61 @@
+import { OpenFeature } from '@openfeature/server-sdk'
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+let openFeatureClient = null
+
+function getOpenFeatureClient () {
+  if (openFeatureClient) {
+    return openFeatureClient
+  }
+
+  const tracer = global._ddtrace
+  if (!tracer?.openfeature || process.env.DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED !== 'true') {
+    return null
+  }
+
+  OpenFeature.setProvider(tracer.openfeature)
+  openFeatureClient = OpenFeature.getClient()
+  return openFeatureClient
+}
+
+export async function POST (request) {
+  try {
+    const client = getOpenFeatureClient()
+    if (!client) {
+      return NextResponse.json({ error: 'FFE provider not initialized' }, { status: 500 })
+    }
+
+    const { flag, variationType, defaultValue, targetingKey, targetingKeys, attributes } = await request.json()
+    const keys = Array.isArray(targetingKeys) && targetingKeys.length > 0 ? targetingKeys : [targetingKey]
+    let value
+
+    for (const key of keys) {
+      const context = { targetingKey: key, ...attributes }
+
+      switch (variationType) {
+        case 'BOOLEAN':
+          value = await client.getBooleanValue(flag, defaultValue, context)
+          break
+        case 'STRING':
+          value = await client.getStringValue(flag, defaultValue, context)
+          break
+        case 'INTEGER':
+        case 'NUMERIC':
+          value = await client.getNumberValue(flag, defaultValue, context)
+          break
+        case 'JSON':
+          value = await client.getObjectValue(flag, defaultValue, context)
+          break
+        default:
+          return NextResponse.json({ error: `Unknown variation type: ${variationType}` }, { status: 400 })
+      }
+    }
+
+    return NextResponse.json({ value, count: keys.length })
+  } catch (error) {
+    console.error('[FFE] Error:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -517,8 +517,8 @@ app.post('/ffe/start', async (req, res) => {
   ].some(name => process.env[name] !== undefined)
 
   if (hasFeatureFlaggingConfiguration) {
-    const { openfeature } = tracer
     try {
+      const { openfeature } = tracer
       await OpenFeature.setProviderAndWait(openfeature)
     } catch {
       openFeatureClient = OpenFeature.getClient()

--- a/utils/mocked_backend/ffe.py
+++ b/utils/mocked_backend/ffe.py
@@ -14,9 +14,6 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import os
 from pathlib import Path
-import ssl
-import subprocess
-import tempfile
 import threading
 import time
 from typing import TYPE_CHECKING, Any, TypedDict, cast
@@ -292,43 +289,18 @@ def _strip_config_path(url: str) -> str:
 
 
 class MockFFEAgentlessBackendServer:
-    def __init__(self, worker_id: str = "master", *, port: int | None = None, use_tls: bool = False) -> None:
-        self._use_tls = use_tls
-        self._tls_directory: tempfile.TemporaryDirectory[str] | None = None
-        self.ca_cert_path: Path | None = None
-
-        try:
-            cert_path: Path | None = None
-            key_path: Path | None = None
-            if use_tls:
-                cert_path, key_path = self._create_tls_certificate()
-
-            self.port = get_host_port(worker_id, 4900) if port is None else port
-            self._server = MockFFEAgentlessBackendHTTPServer(
-                ("0.0.0.0", self.port)  # noqa: S104 - test fixture must be container-reachable.
-            )
-            self.port = self._server.server_port
-
-            if cert_path is not None and key_path is not None:
-                tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-                tls_context.load_cert_chain(certfile=cert_path, keyfile=key_path)
-                self._server.socket = tls_context.wrap_socket(self._server.socket, server_side=True)
-
-            self._thread = threading.Thread(
-                target=self._server.serve_forever, name="mock-ffe-agentless-backend", daemon=True
-            )
-            self._thread.start()
-        except BaseException:
-            server = getattr(self, "_server", None)
-            if server is not None:
-                server.server_close()
-            self._close_tls_directory()
-            raise
+    def __init__(self, worker_id: str = "master", *, port: int | None = None) -> None:
+        self.port = get_host_port(worker_id, 4900) if port is None else port
+        self._server = MockFFEAgentlessBackendHTTPServer(("0.0.0.0", self.port))  # noqa: S104 - test fixture must be container-reachable.
+        self.port = self._server.server_port
+        self._thread = threading.Thread(
+            target=self._server.serve_forever, name="mock-ffe-agentless-backend", daemon=True
+        )
+        self._thread.start()
 
     @property
     def base_url(self) -> str:
-        scheme = "https" if self._use_tls else "http"
-        return f"{scheme}://127.0.0.1:{self.port}"
+        return f"http://127.0.0.1:{self.port}"
 
     @property
     def library_base_url(self) -> str:
@@ -341,15 +313,14 @@ class MockFFEAgentlessBackendServer:
         host = os.environ.get("SYSTEM_TESTS_MOCK_FFE_AGENTLESS_BACKEND_HOST") or os.environ.get(
             "SYSTEM_TESTS_MOCK_AGENTLESS_BACKEND_HOST", "host.docker.internal"
         )
-        scheme = "https" if self._use_tls else "http"
-        return f"{scheme}://{host}:{self.port}"
+        return f"http://{host}:{self.port}"
 
     @property
     def library_config_url(self) -> str:
         return f"{self.library_base_url}{CONFIG_PATH}?{CONFIG_QUERY}"
 
     def reset(self) -> None:
-        response = requests.post(f"{self.base_url}/control/reset", timeout=5, verify=self._requests_verify)
+        response = requests.post(f"{self.base_url}/control/reset", timeout=5)
         response.raise_for_status()
 
     def set_response(self, response_id: str) -> None:
@@ -358,15 +329,12 @@ class MockFFEAgentlessBackendServer:
     def set_responses(self, responses: object) -> None:
         validated_responses = validate_responses(responses)
         response = requests.post(
-            f"{self.base_url}/control/responses",
-            json={"responses": validated_responses},
-            timeout=5,
-            verify=self._requests_verify,
+            f"{self.base_url}/control/responses", json={"responses": validated_responses}, timeout=5
         )
         response.raise_for_status()
 
     def status(self) -> MockFFEAgentlessBackendStatus:
-        response = requests.get(f"{self.base_url}/status", timeout=5, verify=self._requests_verify)
+        response = requests.get(f"{self.base_url}/status", timeout=5)
         response.raise_for_status()
         return cast("MockFFEAgentlessBackendStatus", response.json())
 
@@ -374,55 +342,6 @@ class MockFFEAgentlessBackendServer:
         self._server.shutdown()
         self._server.server_close()
         self._thread.join(timeout=5)
-        self._close_tls_directory()
-
-    @property
-    def _requests_verify(self) -> bool | str:
-        return str(self.ca_cert_path) if self.ca_cert_path is not None else True
-
-    def _create_tls_certificate(self) -> tuple[Path, Path]:
-        self._tls_directory = tempfile.TemporaryDirectory(prefix="system-tests-ffe-agentless-")
-        directory = Path(self._tls_directory.name)
-        cert_path = directory / "certificate.pem"
-        key_path = directory / "private-key.pem"
-        subprocess.run(
-            [
-                "openssl",
-                "req",
-                "-x509",
-                "-newkey",
-                "rsa:2048",
-                "-sha256",
-                "-nodes",
-                "-days",
-                "1",
-                "-subj",
-                "/CN=host.docker.internal",
-                "-addext",
-                "subjectAltName=DNS:host.docker.internal,IP:127.0.0.1",
-                "-addext",
-                "basicConstraints=critical,CA:TRUE",
-                "-addext",
-                "keyUsage=critical,digitalSignature,keyEncipherment,keyCertSign",
-                "-addext",
-                "extendedKeyUsage=serverAuth",
-                "-keyout",
-                str(key_path),
-                "-out",
-                str(cert_path),
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        self.ca_cert_path = cert_path
-        return cert_path, key_path
-
-    def _close_tls_directory(self) -> None:
-        if self._tls_directory is not None:
-            self._tls_directory.cleanup()
-            self._tls_directory = None
-            self.ca_cert_path = None
 
 
 @pytest.fixture

--- a/utils/mocked_backend/ffe.py
+++ b/utils/mocked_backend/ffe.py
@@ -14,6 +14,9 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import os
 from pathlib import Path
+import ssl
+import subprocess
+import tempfile
 import threading
 import time
 from typing import TYPE_CHECKING, Any, TypedDict, cast
@@ -289,18 +292,43 @@ def _strip_config_path(url: str) -> str:
 
 
 class MockFFEAgentlessBackendServer:
-    def __init__(self, worker_id: str = "master", *, port: int | None = None) -> None:
-        self.port = get_host_port(worker_id, 4900) if port is None else port
-        self._server = MockFFEAgentlessBackendHTTPServer(("0.0.0.0", self.port))  # noqa: S104 - test fixture must be container-reachable.
-        self.port = self._server.server_port
-        self._thread = threading.Thread(
-            target=self._server.serve_forever, name="mock-ffe-agentless-backend", daemon=True
-        )
-        self._thread.start()
+    def __init__(self, worker_id: str = "master", *, port: int | None = None, use_tls: bool = False) -> None:
+        self._use_tls = use_tls
+        self._tls_directory: tempfile.TemporaryDirectory[str] | None = None
+        self.ca_cert_path: Path | None = None
+
+        try:
+            cert_path: Path | None = None
+            key_path: Path | None = None
+            if use_tls:
+                cert_path, key_path = self._create_tls_certificate()
+
+            self.port = get_host_port(worker_id, 4900) if port is None else port
+            self._server = MockFFEAgentlessBackendHTTPServer(
+                ("0.0.0.0", self.port)  # noqa: S104 - test fixture must be container-reachable.
+            )
+            self.port = self._server.server_port
+
+            if cert_path is not None and key_path is not None:
+                tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+                tls_context.load_cert_chain(certfile=cert_path, keyfile=key_path)
+                self._server.socket = tls_context.wrap_socket(self._server.socket, server_side=True)
+
+            self._thread = threading.Thread(
+                target=self._server.serve_forever, name="mock-ffe-agentless-backend", daemon=True
+            )
+            self._thread.start()
+        except BaseException:
+            server = getattr(self, "_server", None)
+            if server is not None:
+                server.server_close()
+            self._close_tls_directory()
+            raise
 
     @property
     def base_url(self) -> str:
-        return f"http://127.0.0.1:{self.port}"
+        scheme = "https" if self._use_tls else "http"
+        return f"{scheme}://127.0.0.1:{self.port}"
 
     @property
     def library_base_url(self) -> str:
@@ -313,14 +341,15 @@ class MockFFEAgentlessBackendServer:
         host = os.environ.get("SYSTEM_TESTS_MOCK_FFE_AGENTLESS_BACKEND_HOST") or os.environ.get(
             "SYSTEM_TESTS_MOCK_AGENTLESS_BACKEND_HOST", "host.docker.internal"
         )
-        return f"http://{host}:{self.port}"
+        scheme = "https" if self._use_tls else "http"
+        return f"{scheme}://{host}:{self.port}"
 
     @property
     def library_config_url(self) -> str:
         return f"{self.library_base_url}{CONFIG_PATH}?{CONFIG_QUERY}"
 
     def reset(self) -> None:
-        response = requests.post(f"{self.base_url}/control/reset", timeout=5)
+        response = requests.post(f"{self.base_url}/control/reset", timeout=5, verify=self._requests_verify)
         response.raise_for_status()
 
     def set_response(self, response_id: str) -> None:
@@ -329,12 +358,15 @@ class MockFFEAgentlessBackendServer:
     def set_responses(self, responses: object) -> None:
         validated_responses = validate_responses(responses)
         response = requests.post(
-            f"{self.base_url}/control/responses", json={"responses": validated_responses}, timeout=5
+            f"{self.base_url}/control/responses",
+            json={"responses": validated_responses},
+            timeout=5,
+            verify=self._requests_verify,
         )
         response.raise_for_status()
 
     def status(self) -> MockFFEAgentlessBackendStatus:
-        response = requests.get(f"{self.base_url}/status", timeout=5)
+        response = requests.get(f"{self.base_url}/status", timeout=5, verify=self._requests_verify)
         response.raise_for_status()
         return cast("MockFFEAgentlessBackendStatus", response.json())
 
@@ -342,6 +374,55 @@ class MockFFEAgentlessBackendServer:
         self._server.shutdown()
         self._server.server_close()
         self._thread.join(timeout=5)
+        self._close_tls_directory()
+
+    @property
+    def _requests_verify(self) -> bool | str:
+        return str(self.ca_cert_path) if self.ca_cert_path is not None else True
+
+    def _create_tls_certificate(self) -> tuple[Path, Path]:
+        self._tls_directory = tempfile.TemporaryDirectory(prefix="system-tests-ffe-agentless-")
+        directory = Path(self._tls_directory.name)
+        cert_path = directory / "certificate.pem"
+        key_path = directory / "private-key.pem"
+        subprocess.run(
+            [
+                "openssl",
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-sha256",
+                "-nodes",
+                "-days",
+                "1",
+                "-subj",
+                "/CN=host.docker.internal",
+                "-addext",
+                "subjectAltName=DNS:host.docker.internal,IP:127.0.0.1",
+                "-addext",
+                "basicConstraints=critical,CA:TRUE",
+                "-addext",
+                "keyUsage=critical,digitalSignature,keyEncipherment,keyCertSign",
+                "-addext",
+                "extendedKeyUsage=serverAuth",
+                "-keyout",
+                str(key_path),
+                "-out",
+                str(cert_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.ca_cert_path = cert_path
+        return cert_path, key_path
+
+    def _close_tls_directory(self) -> None:
+        if self._tls_directory is not None:
+            self._tls_directory.cleanup()
+            self._tls_directory = None
+            self.ca_cert_path = None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Motivation

Node.js now supports the complete agentless configuration-source behavior. The system-test manifest still disables this contract before its 6.8.0 and 5.119.0 releases.

## Changes and Decisions

- Enable agentless configuration and flag evaluation for `>=6.8.0 || ^5.119.0`.
- Exercise the default agentless source without the legacy Remote Configuration opt-in.
- Run all configuration-source cases without per-test or weblog exclusions.
- Expose the evaluation endpoint in the TypeScript, Fastify, and Next.js weblogs.
- Call OpenFeature `setProviderAndWait()` on the first evaluation request, after weblog startup.
- Keep custom-endpoint authentication in the parametric configuration-source contract.
- Refresh changed application code and Node 18-compatible OpenFeature dependencies that existing base images otherwise hide.
- Skip the Agent-backed weblog flush when the scenario does not start an Agent.
- Persist the mocked CDN request status so replay mode can verify the agentless contract.
- Keep exposure events, evaluation events, and evaluation metrics disabled.