### PR TITLE
[appsec] assert effective agentic-onboarding config entry (RFC-1113)

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -386,7 +386,7 @@ manifest:
         "*": irrelevant (LFi detection requires orchestrion)
         net-http-orchestrion: v2.7.0
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_UserEvents: missing_feature
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v2.11.0-dev
   tests/appsec/test_alpha.py:
     - weblog_declaration:
         envoy: v1.72.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -386,7 +386,11 @@ manifest:
         "*": irrelevant (LFi detection requires orchestrion)
         net-http-orchestrion: v2.7.0
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_UserEvents: missing_feature
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v2.11.0-dev
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding:
+    - weblog_declaration:
+        "*": v2.11.0-dev
+        envoy: irrelevant (not applicable to proxies)
+        haproxy: irrelevant (not applicable to proxies)
   tests/appsec/test_alpha.py:
     - weblog_declaration:
         envoy: v1.72.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1579,7 +1579,7 @@ manifest:
         resteasy-netty3: missing_feature (login endpoints not implemented)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v1.65.0-SNAPSHOT
   tests/appsec/test_alpha.py::Test_Basic:
     - weblog_declaration:
         "*": v0.87.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1579,7 +1579,10 @@ manifest:
         resteasy-netty3: missing_feature (login endpoints not implemented)
         vertx3: missing_feature (login endpoints not implemented)
         vertx4: missing_feature (login endpoints not implemented)
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v1.65.0-SNAPSHOT
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding:
+    - weblog_declaration:
+        "*": v1.65.0-SNAPSHOT
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
   tests/appsec/test_alpha.py::Test_Basic:
     - weblog_declaration:
         "*": v0.87.0

--- a/tests/appsec/test_agentic_onboarding.py
+++ b/tests/appsec/test_agentic_onboarding.py
@@ -5,9 +5,19 @@ from utils import rfc, features, scenarios, interfaces
 CONFIG_NAMES = ("appsec.agentic_onboarding", "DD_APPSEC_AGENTIC_ONBOARDING")
 
 
-def _find_config() -> list[dict[str, object]]:
-    """Return telemetry configuration entries for the agentic-onboarding signal."""
-    return [conf for conf in interfaces.library.get_telemetry_configurations() if conf.get("name") in CONFIG_NAMES]
+def _effective_config() -> dict[str, object] | None:
+    """Return the effective agentic-onboarding config entry, or None if absent.
+
+    A tracer may report the same configuration key at more than one precedence
+    (e.g. a seeded ``default`` entry alongside the ``env_var`` value). The telemetry
+    ``seq_id`` orders those entries and the highest one is the value actually in
+    effect. Selecting the max-``seq_id`` entry works both for tracers that emit a
+    single entry and for those that emit one entry per precedence.
+    """
+    entries = [conf for conf in interfaces.library.get_telemetry_configurations() if conf.get("name") in CONFIG_NAMES]
+    if not entries:
+        return None
+    return max(entries, key=lambda conf: conf.get("seq_id", 0))
 
 
 @rfc("https://docs.google.com/document/d/1q1ZnDLFiKlLhGKljOCE8xTUOqdz325Rc3BcKjVan0VY/edit")
@@ -22,27 +32,23 @@ class Test_AppsecAgenticOnboarding:
     @scenarios.telemetry_enhanced_config_reporting
     def test_reported_verbatim(self):
         """AppSec enabled + arbitrary value -> reported verbatim, origin=env_var."""
-        entries = _find_config()
-        assert entries, f"{CONFIG_NAMES} missing from telemetry"
-        # Check every entry: prefork weblogs / config-change carrier can emit more than one.
-        for entry in entries:
-            assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
-            assert entry["value"] == "MiXeD-Value_42", f"Expected verbatim value, got: {entry}"
+        entry = _effective_config()
+        assert entry is not None, f"{CONFIG_NAMES} missing from telemetry"
+        assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
+        assert entry["value"] == "MiXeD-Value_42", f"Expected verbatim value, got: {entry}"
 
     @scenarios.telemetry_app_started_products_disabled
     def test_reported_verbatim_appsec_disabled(self):
         """AppSec disabled + "true" -> still reported verbatim as "true", origin=env_var."""
-        entries = _find_config()
-        assert entries, f"{CONFIG_NAMES} missing from telemetry"
-        for entry in entries:
-            assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
-            assert entry["value"] == "true", f"Expected verbatim value 'true', got: {entry}"
+        entry = _effective_config()
+        assert entry is not None, f"{CONFIG_NAMES} missing from telemetry"
+        assert entry.get("origin") == "env_var", f"Expected origin env_var, got: {entry}"
+        assert entry["value"] == "true", f"Expected verbatim value 'true', got: {entry}"
 
     @scenarios.default
     def test_reported_when_unset(self):
         """Flag absent -> still reported with empty value and origin=default."""
-        entries = _find_config()
-        assert entries, f"{CONFIG_NAMES} missing from telemetry"
-        for entry in entries:
-            assert entry.get("origin") == "default", f"Expected origin default, got: {entry}"
-            assert entry["value"] == "", f"Expected empty string value, got: {entry}"
+        entry = _effective_config()
+        assert entry is not None, f"{CONFIG_NAMES} missing from telemetry"
+        assert entry.get("origin") == "default", f"Expected origin default, got: {entry}"
+        assert entry["value"] == "", f"Expected empty string value, got: {entry}"


### PR DESCRIPTION
APPSEC-69171

## Motivation

The RFC-1113 agentic-onboarding tests required *every* reported config entry for `DD_APPSEC_AGENTIC_ONBOARDING` to have `origin=env_var`. That breaks for tracers reporting one entry per precedence (e.g. dd-trace-rb emits a seeded `default` entry alongside the `env_var` value), which fail on the stray `default` entry.

## Changes

- `tests/appsec/test_agentic_onboarding.py`: assert on the effective entry (highest `seq_id`) instead of all entries — correct for single-entry and per-precedence tracers.
- `manifests/golang.yml`, `manifests/java.yml`: enable the tests (dev builds already pass), declaring golang `v2.11.0-dev` and java `v1.65.0-SNAPSHOT`.