### PR TITLE
[FFE] Test custom endpoints without Datadog authentication

### DIFF
--- a/tests/parametric/test_ffe/test_configuration_sources.py
+++ b/tests/parametric/test_ffe/test_configuration_sources.py
@@ -44,6 +44,7 @@ AGENTLESS_BASE_URL = "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL"
 SEMANTICALLY_UNSET_CONFIGURATION_SOURCES: tuple[str | None, ...] = (None, "", "   ")
 
 BASE_ENVVARS = {
+    "DD_API_KEY": TEST_API_KEY,
     "DD_INSTRUMENTATION_TELEMETRY_ENABLED": "false",
     "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.2",
 }
@@ -86,7 +87,6 @@ def library_env(
     configuration_source = params.get("configuration_source", "agentless")
     response = params.get("response", "valid")
     responses = params.get("responses")
-    api_key = params.get("api_key", TEST_API_KEY)
 
     if "provider_enabled" in params:
         env["DD_FEATURE_FLAGS_ENABLED"] = str(params["provider_enabled"]).lower()
@@ -117,9 +117,6 @@ def library_env(
             )
         env |= agentless_env
         env[AGENTLESS_BASE_URL] = mock_ffe_agentless_backend.library_config_url
-
-    if api_key is not None:
-        env["DD_API_KEY"] = str(api_key)
 
     return env
 
@@ -300,7 +297,7 @@ class Test_Feature_Flag_Configuration_Source_Selection:
         # An absent, empty, or whitespace-only source with no legacy/stable enablement variable
         # models a new customer whose source is semantically unset; the usable CDN inputs ensure
         # default source selection can complete. Zero startup traffic proves agentless is lazy;
-        # evaluation, authenticated CONFIG_PATH traffic, and no RC capability prove CDN activation.
+        # evaluation, unauthenticated CONFIG_PATH traffic, and no RC capability prove CDN activation.
         _assert_no_mock_requests(mock_ffe_agentless_backend)
         _assert_no_ffe_remote_config_activation(test_agent)
 
@@ -312,7 +309,7 @@ class Test_Feature_Flag_Configuration_Source_Selection:
             lambda current: current["requests_total"] > 0 and current["last_status_code"] == 200,
             "valid response request",
         )
-        assert status["last_auth_present"] is True
+        assert status["last_auth_present"] is False
         assert status["last_path"] == CONFIG_PATH
         _assert_no_ffe_remote_config_activation(test_agent)
 
@@ -342,7 +339,7 @@ class Test_Feature_Flag_Configuration_Source_Selection:
             lambda current: current["requests_total"] > 0 and current["last_status_code"] == 200,
             "stable-enabled default agentless response request",
         )
-        assert status["last_auth_present"] is True
+        assert status["last_auth_present"] is False
         assert status["last_path"] == CONFIG_PATH
         _assert_no_ffe_remote_config_activation(test_agent)
 
@@ -531,22 +528,20 @@ class Test_Feature_Flag_Configuration_Source_Cold_Failure_And_Recovery:
 
     @parametrize(
         "library_env",
-        [{"configuration_source": "agentless", "response": "valid", "api_key": None}],
+        [{"configuration_source": "agentless", "response": "unauthorized"}],
         indirect=True,
     )
-    def test_missing_auth_cold(
+    def test_unauthorized_cold(
         self, test_library: APMLibrary, mock_ffe_agentless_backend: MockFFEAgentlessBackendServer
     ) -> None:
-        # Explicit agentless plus api_key=None removes authentication without changing the valid base
-        # URL or polling inputs, isolating authentication as the initial-load failure.
-        # A 401/403 on CONFIG_PATH with no auth header proves the intended request was rejected, and
-        # the default/not-ready evaluation proves unauthenticated bytes never initialize the provider.
+        # The custom endpoint explicitly returns 401 without relying on a Datadog API key. This
+        # isolates endpoint authentication failure while proving the tracer did not disclose its key.
         started = test_library.ffe_start()
 
         status = _wait_for_status(
             mock_ffe_agentless_backend,
             lambda current: current["last_status_code"] in {401, 403},
-            "missing_auth_cold auth failure",
+            "unauthorized_cold auth failure",
         )
         _assert_cold_not_ready(test_library, started=started)
         assert status["last_auth_present"] is False
@@ -560,9 +555,9 @@ class Test_Feature_Flag_Configuration_Source_Cold_Failure_And_Recovery:
     def test_malformed_cold(
         self, test_library: APMLibrary, mock_ffe_agentless_backend: MockFFEAgentlessBackendServer
     ) -> None:
-        # Explicit agentless with response=malformed keeps transport, authentication, and HTTP status
-        # successful while making the first UFC payload invalid, isolating payload validation.
-        # The authenticated 200 request to CONFIG_PATH proves delivery occurred, while the
+        # Explicit agentless with response=malformed keeps transport and HTTP status successful while
+        # making the first UFC payload invalid, isolating payload validation. The unauthenticated 200
+        # request to CONFIG_PATH proves delivery occurred without disclosing the Datadog API key; the
         # default/not-ready evaluation proves malformed data was not installed.
         started = test_library.ffe_start()
 
@@ -572,7 +567,7 @@ class Test_Feature_Flag_Configuration_Source_Cold_Failure_And_Recovery:
             "malformed_cold response",
         )
         _assert_cold_not_ready(test_library, started=started)
-        assert status["last_auth_present"] is True
+        assert status["last_auth_present"] is False
         assert status["last_path"] == CONFIG_PATH
 
     @parametrize(
@@ -595,7 +590,7 @@ class Test_Feature_Flag_Configuration_Source_Cold_Failure_And_Recovery:
             "request_timeout_cold delayed valid response",
         )
         _assert_cold_not_ready(test_library, started=started)
-        assert status["last_auth_present"] is True
+        assert status["last_auth_present"] is False
         assert status["last_path"] == CONFIG_PATH
 
     @parametrize(
@@ -667,24 +662,25 @@ class Test_Feature_Flag_Configuration_Source_Warm_State_Preservation:
     """Validate that later agentless failures do not corrupt last-known-good state."""
 
     @parametrize("library_env", [{"configuration_source": "agentless", "response": "valid"}], indirect=True)
-    def test_missing_auth_warm(
+    def test_unauthorized_warm(
         self, test_library: APMLibrary, mock_ffe_agentless_backend: MockFFEAgentlessBackendServer
     ) -> None:
         # Explicit agentless with an initially valid response establishes last-known-good state before
         # the backend switches to unauthorized, isolating a later authentication failure.
         # The 401/403 and additional CONFIG_PATH request prove the failing poll occurred, while the
         # unchanged expected evaluation proves warm state survives the rejection.
-        assert test_library.ffe_start(), "failed to start FFE provider before missing_auth_warm"
+        assert test_library.ffe_start(), "failed to start FFE provider before unauthorized_warm"
         _assert_expected_value(_evaluate(test_library))
 
         mock_ffe_agentless_backend.set_response("unauthorized")
         status = _wait_for_status(
             mock_ffe_agentless_backend,
             lambda current: current["last_status_code"] in {401, 403},
-            "missing_auth_warm auth failure",
+            "unauthorized_warm auth failure",
         )
         _assert_expected_value(_evaluate(test_library))
         assert status["requests_total"] > 0
+        assert status["last_auth_present"] is False
         assert status["last_path"] == CONFIG_PATH
 
     @parametrize(

--- a/tests/test_the_test/test_mock_ffe_agentless_backend.py
+++ b/tests/test_the_test/test_mock_ffe_agentless_backend.py
@@ -8,7 +8,6 @@ from utils.docker_fixtures._core import HOST_GATEWAY_EXTRA_HOSTS, extra_hosts_fo
 from utils.docker_fixtures._mock_ffe_agentless_backend import (
     CONFIG_PATH,
     CONFIG_QUERY,
-    EXPECTED_API_KEY,
     EXPECTED_DD_ENV,
     MockFFEAgentlessBackendServer,
     UFC_RESPONSE_TYPE,
@@ -23,14 +22,12 @@ def test_mock_ffe_agentless_backend_serves_fixture_and_tracks_metadata(worker_id
         for invalid_query in ("", "?dd_env=", "?dd_env=wrong", f"?dd_env={EXPECTED_DD_ENV}&dd_env=wrong"):
             response = requests.get(
                 server.base_url + CONFIG_PATH + invalid_query,
-                headers={"DD-API-KEY": EXPECTED_API_KEY},
                 timeout=5,
             )
             assert response.status_code == 404
 
         response = requests.get(
             f"{server.base_url}{CONFIG_PATH}?{CONFIG_QUERY}",
-            headers={"DD-API-KEY": EXPECTED_API_KEY},
             timeout=5,
         )
         response.raise_for_status()
@@ -43,9 +40,21 @@ def test_mock_ffe_agentless_backend_serves_fixture_and_tracks_metadata(worker_id
 
         status = server.status()
         assert status["requests_total"] == 1
-        assert status["last_auth_present"] is True
+        assert status["last_auth_present"] is False
         assert status["last_path"] == CONFIG_PATH
         assert status["last_status_code"] == 200
+
+        server.set_response("unauthorized")
+        response = requests.get(
+            f"{server.base_url}{CONFIG_PATH}?{CONFIG_QUERY}",
+            timeout=5,
+        )
+        assert response.status_code == 401
+
+        status = server.status()
+        assert status["requests_total"] == 2
+        assert status["last_auth_present"] is False
+        assert status["last_status_code"] == 401
     finally:
         server.close()
 

--- a/utils/docker_fixtures/_mock_ffe_agentless_backend.py
+++ b/utils/docker_fixtures/_mock_ffe_agentless_backend.py
@@ -185,10 +185,7 @@ class MockFFEAgentlessBackendRequestHandler(BaseHTTPRequestHandler):
             if response in {"delayed_valid", "timeout"}:
                 time.sleep(TIMEOUT_RESPONSE_SECONDS if response == "timeout" else DELAYED_RESPONSE_SECONDS)
 
-            status_code, body, headers = _response_for_response(
-                response=response,
-                has_auth=_has_auth(request_headers),
-            )
+            status_code, body, headers = _response_for_response(response)
             self.server.state.record_response(status_code)
             with contextlib.suppress(BrokenPipeError, ConnectionResetError):
                 self.send_response(status_code)
@@ -270,10 +267,7 @@ def validate_responses(responses: object) -> list[str]:
     return responses
 
 
-def _response_for_response(response: str, *, has_auth: bool) -> tuple[int, bytes, dict[str, str]]:
-    if not has_auth:
-        return HTTPStatus.UNAUTHORIZED, b"", {}
-
+def _response_for_response(response: str) -> tuple[int, bytes, dict[str, str]]:
     if response == "unauthorized":
         return HTTPStatus.UNAUTHORIZED, b"", {}
     if response == "malformed":


### PR DESCRIPTION
## Motivation

A custom Feature Flagging agentless endpoint is a development, proxy, or test endpoint. It is not a first-party Datadog API.

An SDK must not send `DD_API_KEY` to a custom endpoint. Therefore, the system-test mock must return a valid UFC response without Datadog authentication.

Previously, the mock returned `401` if the request did not contain the Datadog API key. This behavior used the wrong trust boundary. It also treated intentional key removal as an authentication failure.

## Changes

- Return valid UFC responses from the custom mock endpoint without `DD_API_KEY`.
- Use the explicit `unauthorized` response mode to test authentication failures.
- Set a sentinel Datadog API key in the Node.js configuration-source tests.
- Verify that the custom endpoint does not receive the sentinel key.
- Rename the cold and warm tests to identify explicit unauthorized responses.
- Test unauthenticated `200` responses and explicit unauthenticated `401` responses in the mock fixture.

## Decisions

- A custom endpoint defines its own authentication.
- A custom endpoint must not implicitly receive Datadog credentials.
- The explicit `unauthorized` response mode produces deterministic `401` test results.
- The absence of `DD_API_KEY` does not produce an authentication failure in the mock.
- This PR changes only the test contract.
- The linked `dd-trace-js` PRs contain the SDK changes.

## Validation

```shell
PYTEST_XDIST_AUTO_NUM_WORKERS=1 TEST_LIBRARY=nodejs pytest -S PARAMETRIC --skip-parametric-build --runxfail -vv -s tests/parametric/test_ffe/test_configuration_sources.py
```

Result: `29 passed in 362.26s`.

Additional checks:

- Ruff passed for all three changed Python files.
- The mock fixture test passed for an unauthenticated `200` response.
- The mock fixture test passed for an explicit `401` response.
- `git diff --check` passed.
