### PR TITLE
test(agentic-onboarding): enable tests for dotnet, nodejs, php

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -311,7 +311,7 @@ manifest:
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_UrlQuery: v2.51.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: v3.4.1
   tests/appsec/smoke_tests/test_apm_standalone.py: v3.41.0
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v3.5.0
   tests/appsec/test_alpha.py::Test_Basic: v1.28.6
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone: v3.17.0
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_UpstreamPropagation_V2: v3.12.0

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -311,7 +311,7 @@ manifest:
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_UrlQuery: v2.51.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: v3.4.1
   tests/appsec/smoke_tests/test_apm_standalone.py: v3.41.0
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v3.5.0
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v3.50.0
   tests/appsec/test_alpha.py::Test_Basic: v1.28.6
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone: v3.17.0
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_UpstreamPropagation_V2: v3.12.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -986,7 +986,7 @@ manifest:
     - weblog_declaration:
         fastify: missing_feature
         nextjs: missing_feature
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v7.83.0-devel
   tests/appsec/test_alpha.py::Test_Basic: v2.0.0
   tests/appsec/test_asm_standalone.py::BaseSCAStandaloneTelemetry::test_app_dependencies_loaded:
     - weblog_declaration:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -986,7 +986,7 @@ manifest:
     - weblog_declaration:
         fastify: missing_feature
         nextjs: missing_feature
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v7.83.0-devel
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v7.0.0-pre
   tests/appsec/test_alpha.py::Test_Basic: v2.0.0
   tests/appsec/test_asm_standalone.py::BaseSCAStandaloneTelemetry::test_app_dependencies_loaded:
     - weblog_declaration:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -101,6 +101,7 @@ refs:
   - &ref_5_110_0 '>=5.110.0'
   - &ref_5_111_0 '>=5.111.0'
   - &ref_6_0_0 '>=6.0.0-pre'
+  - &ref_6_5_0 '>=6.5.0 || ^5.116.0'
 manifest:
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardEvent_Tag:
     - weblog_declaration:
@@ -986,7 +987,7 @@ manifest:
     - weblog_declaration:
         fastify: missing_feature
         nextjs: missing_feature
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v7.0.0-pre
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: *ref_6_5_0
   tests/appsec/test_alpha.py::Test_Basic: v2.0.0
   tests/appsec/test_asm_standalone.py::BaseSCAStandaloneTelemetry::test_app_dependencies_loaded:
     - weblog_declaration:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -320,7 +320,7 @@ manifest:
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_sqli_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_shi_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_sqli_smoke: missing_feature
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v1.24.0+dev
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone: v1.11.0
   ? tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone::test_no_appsec_upstream__no_asm_event__is_kept_with_priority_1__from_2
   : - weblog_declaration:


### PR DESCRIPTION
Enable `tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding`:

- dotnet: v3.50.0
- nodejs: ref_6_5_0 (>=6.5.0 || ^5.116.0)
- php: v1.24.0+dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)