### PR TITLE
Activate Test_AIGuardStandalone for Java

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -5,7 +5,10 @@ manifest:
     - weblog_declaration:
         "*": irrelevant (just one weblog is enough to test the SDK)
         "spring-boot": v1.62.0
-  tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardStandalone: missing_feature
+  tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardStandalone:
+    - weblog_declaration:
+        "*": irrelevant (just one weblog is enough to test the SDK)
+        "spring-boot": v1.65.0-SNAPSHOT
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardTelemetryRequests: missing_feature
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardTelemetryTruncated: missing_feature
   tests/ai_guard/test_ai_guard_sdk.py::Test_AnomalyDetectionTags:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The Java tracer now supports AI Guard traces under `DD_APM_TRACING_ENABLED=false` (standalone billing-free mode), landing in [DataDog/dd-trace-java#11885](https://github.com/DataDog/dd-trace-java/pull/11885). `Test_AIGuardStandalone` was still blanket-marked `missing_feature` for Java in the manifest.

## Changes

<!-- A brief description of the change being made with this pull request. -->
`manifests/java.yml`: replace the `missing_feature` entry for `tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardStandalone` with a `weblog_declaration` gated on `spring-boot: v1.65.0-SNAPSHOT`, mirroring how nodejs/python already activate this test.


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)