### PR TITLE
test(parametric): fix span_event array decoding for v1

### DIFF
--- a/tests/parametric/test_otel_span_methods.py
+++ b/tests/parametric/test_otel_span_methods.py
@@ -650,9 +650,9 @@ class Test_Otel_Span_Methods:
         assert event3["attributes"].get("int_val") == 1
         assert event3["attributes"].get("string_val") == "2"
 
-        v04_v07_events = "span_events" in root_span
+        arrays_are_flattened = "int_array.0" in event3["attributes"]
 
-        if v04_v07_events:
+        if arrays_are_flattened:
             assert event3["attributes"].get("int_array.0") == 3
             assert event3["attributes"].get("int_array.1") == 4
             assert event3["attributes"].get("string_array.0") == "5"

--- a/utils/docker_fixtures/spec/trace.py
+++ b/utils/docker_fixtures/spec/trace.py
@@ -59,7 +59,9 @@ SAMPLING_AGENT_PRIORITY_RATE = "_dd.agent_psr"
 SAMPLING_RULE_PRIORITY_RATE = "_dd.rule_psr"
 SAMPLING_LIMIT_PRIORITY_RATE = "_dd.limit_psr"
 
-NUM_VALUES_IN_NATIVE_SPAN_ATTRIBUTE = 2
+# The test agent converts protocol v1 span-event attributes to the v0.4 typed representation,
+# whose enum assigns ARRAY the value 4 (STRING=0, BOOLEAN=1, INTEGER=2, DOUBLE=3, ARRAY=4).
+NATIVE_SPAN_ATTRIBUTE_ARRAY_TYPE = 4
 
 
 # Note that class attributes are golang style to match the payload.
@@ -291,18 +293,28 @@ def span_link_trace_ids_equal(a: int | str | None, b: int | str | None) -> bool:
     return _span_link_trace_id_to_low64(a) == _span_link_trace_id_to_low64(b)
 
 
+def _decode_span_event_attribute(value: dict) -> object:
+    """Decode a typed span event attribute into a plain Python value.
+
+    The "type" field may be omitted when it holds the default (zero) enum value,
+    so it is not counted as a value entry.
+    """
+    is_array = value.get("type") == NATIVE_SPAN_ATTRIBUTE_ARRAY_TYPE
+    remaining = {key: inner for key, inner in value.items() if key != "type"}
+    # Excluding the optional "type" discriminator, an attribute has exactly one value field.
+    assert len(remaining) == 1, f"native span event attribute has unexpected number of values: {value}"
+    inner = next(iter(remaining.values()))
+    if is_array:
+        return [_decode_span_event_attribute(item) for item in inner.get("values", [])]
+    return inner
+
+
 def retrieve_span_events(span: Span) -> list | None:
     if span.get("span_events") is not None:
         for event in span["span_events"]:
             for key, value in event.get("attributes", {}).items():
                 if isinstance(value, dict):
-                    # Flatten attributes dict into a single key-value pair
-                    # This is for native span events
-                    assert len(value) == NUM_VALUES_IN_NATIVE_SPAN_ATTRIBUTE, (
-                        f"native span event has unexpected number of values: {event}"
-                    )
-                    value.pop("type")
-                    event["attributes"][key] = next(iter(value.values()))
+                    event["attributes"][key] = _decode_span_event_attribute(value)
                 else:
                     continue
         return span["span_events"]


### PR DESCRIPTION
## Motivation

Java's v1 protocol also uses the top-level `span_events` field but preserves array values. The previous check treated these as flattened and expected keys like `int_array.0`, which don't exist in the native-array case.

## Changes

Decodes typed `span_events` array attributes into plain Python lists, and detects whether arrays are flattened by inspecting attribute keys (`int_array.0`) instead of inferring from the presence of `span_events`.

## Additional Notes

Supports both flattened attributes (`int_array.0`) and native arrays (`int_array: [3, 4]`). Only test decoding and assertions change — tracer behavior is unchanged.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
