### PR TITLE
Use maven proxy for spring boot native build

### DIFF
--- a/utils/build/docker/java/spring-boot-3-native/pom.xml
+++ b/utils/build/docker/java/spring-boot-3-native/pom.xml
@@ -159,5 +159,25 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>maven-proxy-profile</id>
+            <activation>
+              <property>
+                <name>env.MAVEN_REPOSITORY_PROXY</name>
+              </property>
+            </activation>
+            <repositories>
+              <repository>
+                <id>maven-proxy-repo</id>
+                <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+              </repository>
+            </repositories>
+            <pluginRepositories>
+              <pluginRepository>
+                <id>maven-plugin-proxy</id>
+                <url>${env.MAVEN_REPOSITORY_PROXY}</url>
+              </pluginRepository>
+           </pluginRepositories>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
## Motivation

Rate limits from Maven Central when deploying to CuSim

## Changes

Configures the maven proxy if the environment variable is set. Copies from [dd-trace-java](https://github.com/DataDog/dd-trace-java/blob/master/dd-smoke-tests/springboot-openliberty-23/application/pom.xml#L110)'s smoketest

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
