### PR TITLE
fix(parametric): handle empty v1 span links

### DIFF
--- a/tests/parametric/test_extract_behavior.py
+++ b/tests/parametric/test_extract_behavior.py
@@ -53,9 +53,12 @@ NONDEFAULT_EXTRACT_STYLE = "datadog,tracecontext,b3multi,baggage"
 
 
 def assert_no_span_links(span: dict) -> None:
-    """retrieve_span_links raises ValueError when a span carries no span links."""
-    with pytest.raises(ValueError):
-        retrieve_span_links(span)
+    if "span_links" in span:  # v1 traces always contain a structured span-links array
+        assert retrieve_span_links(span) == []
+    else:
+        # v0.4 traces without span links omit the span-links tag entirely
+        with pytest.raises(ValueError):
+            retrieve_span_links(span)
 
 
 def injected_headers(test_library: APMLibrary, span_id: int) -> dict[str, str]:


### PR DESCRIPTION
## Motivation

`v1` emits `span_links: []` for spans without links, which caused the extract-behavior tests to fail when `v1` became the default trace protocol.

## Changes

Updates `assert_no_span_links` to handle protocol-specific empty span-link representations:

- `v1` asserts that the structured `span_links` array is empty.
- `v0.4` keeps the existing expectation that `retrieve_span_links` raises `ValueError` when the tag is absent.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
