### PR TITLE
Verify standalone billing scenarios run infra-less

### DIFF
--- a/manifests/agent.yml
+++ b/manifests/agent.yml
@@ -98,6 +98,9 @@ manifest:
     - component_version: ">=7.75.0-0"
       declaration: irrelevant (has been replaced by test_error_exception_event)
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: v7.48.0
+  tests/test_infra_disabled.py:
+    - component_version: "<7.77.0-0"
+      declaration: irrelevant (APM Standalone option was added in 7.77.0)
   tests/test_sampling_rates.py::Test_SamplingRates: v7.33.0
   tests/test_telemetry.py::Test_APMOnboardingInstallID: v7.50.0
   tests/test_telemetry.py::Test_Telemetry::test_proxy_forwarding:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -318,10 +318,10 @@ manifest:
   tests/appsec/smoke_tests/test_apm_standalone.py: v1.18.0
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_shi_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_sqli_smoke: missing_feature
-  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Telemetry::test_telemetry_smoke: bug (APPSEC-69425 & APPSEC-69429)
+  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Telemetry::test_telemetry_smoke: bug (APPSEC-69429)
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_shi_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_sqli_smoke: missing_feature
-  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Telemetry::test_telemetry_smoke: bug (APPSEC-69425 & APPSEC-69429)
+  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Telemetry::test_telemetry_smoke: bug (APPSEC-69429)
   tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v1.24.0+dev
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone: v1.11.0
   ? tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone::test_no_appsec_upstream__no_asm_event__is_kept_with_priority_1__from_2

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -318,8 +318,10 @@ manifest:
   tests/appsec/smoke_tests/test_apm_standalone.py: v1.18.0
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_shi_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp::test_sqli_smoke: missing_feature
+  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Telemetry::test_telemetry_smoke: bug (APPSEC-69425)
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_shi_smoke: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp::test_sqli_smoke: missing_feature
+  tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Telemetry::test_telemetry_smoke: bug (APPSEC-69425)
   tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v1.24.0+dev
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone: v1.11.0
   ? tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone::test_no_appsec_upstream__no_asm_event__is_kept_with_priority_1__from_2

--- a/tests/test_infra_disabled.py
+++ b/tests/test_infra_disabled.py
@@ -1,0 +1,99 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+"""Verify that the agent does not report infrastructure data on standalone billing scenarios.
+
+Standalone billing products (AppSec, IAST, SCA, AI Guard) opt out of APM billing with
+DD_APM_TRACING_ENABLED=false on the tracer side. That alone does not prevent the host from being
+billed as an infra host: the agent must also run with DD_INFRASTRUCTURE_MODE=none, which disables
+every check (cpu, memory, disk, io, load, uptime, file handles, container and process collection).
+These tests assert the outcome of that mode: no infrastructure metric ever reaches the backend.
+"""
+
+from utils import features, interfaces, rfc, scenarios
+
+# Paths used by the agent to submit metric series to the backend
+AGENT_SERIES_PATHS = ("/api/v2/series", "/api/intake/metrics/v3/series")
+
+# Metric prefixes that only the infrastructure checks produce. The agent keeps reporting its own
+# internal metrics (datadog.agent.*, datadog.dogstatsd.*, datadog.trace_agent.*) and forwards custom
+# metrics in this mode, so only the check-produced namespaces are relevant to infra billing.
+INFRA_METRIC_PREFIXES = ("system.", "container.", "docker.", "kubernetes.", "process.", "ntp.")
+
+# The agent flushes metrics every 15 seconds
+AGENT_METRICS_FLUSH_TIMEOUT = 60
+
+
+def _is_metrics_payload(data: dict) -> bool:
+    if data["path"] not in AGENT_SERIES_PATHS:
+        return False
+
+    content = data["request"]["content"]
+    return isinstance(content, dict) and len(content.get("series", [])) != 0
+
+
+@rfc("https://datadoghq.atlassian.net/wiki/spaces/agent/pages/6319080743/APM+Standalone+Mode+Mode+Spec")
+class BaseInfraDisabled:
+    """The agent must not report any infrastructure metric when the infra product is disabled."""
+
+    def setup_no_infra_metrics(self):
+        # Metrics are flushed on an interval, so wait for the first payload instead of relying on
+        # the fixed collection window: an empty interface would make the assertion vacuous.
+        self.agent_has_flushed_metrics = interfaces.agent.wait_for(
+            _is_metrics_payload, timeout=AGENT_METRICS_FLUSH_TIMEOUT
+        )
+
+    def test_no_infra_metrics(self):
+        assert self.agent_has_flushed_metrics, (
+            f"The agent did not submit any metric within {AGENT_METRICS_FLUSH_TIMEOUT}s, "
+            "absence of infrastructure metrics can't be asserted"
+        )
+
+        infra_metrics = sorted(
+            {
+                metric["metric"]
+                for _, metric in interfaces.agent.get_metrics()
+                if metric.get("metric", "").startswith(INFRA_METRIC_PREFIXES)
+            }
+        )
+
+        assert not infra_metrics, (
+            f"The agent reported infrastructure metrics, the host will be billed as an infra host: {infra_metrics}"
+        )
+
+
+@features.appsec_apm_standalone
+@scenarios.appsec_standalone
+class Test_AppSecStandalone_InfraDisabled(BaseInfraDisabled):
+    """AppSec standalone billing does not report infrastructure data."""
+
+
+@features.appsec_apm_standalone
+@scenarios.iast_standalone
+class Test_IastStandalone_InfraDisabled(BaseInfraDisabled):
+    """IAST standalone billing does not report infrastructure data."""
+
+
+@features.appsec_apm_standalone
+@scenarios.sca_standalone
+class Test_SCAStandalone_InfraDisabled(BaseInfraDisabled):
+    """SCA standalone billing does not report infrastructure data."""
+
+
+@features.ai_guard_standalone
+@scenarios.ai_guard_standalone
+class Test_AIGuardStandalone_InfraDisabled(BaseInfraDisabled):
+    """AI Guard standalone billing does not report infrastructure data."""
+
+
+@features.appsec_apm_standalone
+@scenarios.appsec_apm_standalone
+class Test_AppSecAPMStandalone_InfraDisabled(BaseInfraDisabled):
+    """AppSec with APM Standalone mode does not report infrastructure data."""
+
+
+@features.appsec_apm_standalone
+@scenarios.appsec_standalone_apm_standalone
+class Test_AppSecStandaloneAPMStandalone_InfraDisabled(BaseInfraDisabled):
+    """AppSec standalone billing with APM Standalone mode does not report infrastructure data."""

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -553,7 +553,10 @@ class _Scenarios:
             "DD_APPSEC_HEADER_COLLECTION_REDACTION_ENABLED": "false",
             "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
         },
-        doc="Appsec standalone mode (APM opt out)",
+        agent_env={
+            "DD_INFRASTRUCTURE_MODE": "none",
+        },
+        doc="Appsec standalone mode (APM opt out), with the infra product disabled on the agent",
         scenario_groups=[scenario_groups.appsec],
     )
 
@@ -619,7 +622,10 @@ class _Scenarios:
             "DD_IAST_VULNERABILITIES_PER_REQUEST": "10",
             "DD_IAST_MAX_CONTEXT_OPERATIONS": "10",
         },
-        doc="Source code vulnerability standalone mode (APM opt out)",
+        agent_env={
+            "DD_INFRASTRUCTURE_MODE": "none",
+        },
+        doc="Source code vulnerability standalone mode (APM opt out), with the infra product disabled on the agent",
         scenario_groups=[scenario_groups.appsec],
     )
 
@@ -633,7 +639,10 @@ class _Scenarios:
             "DD_TELEMETRY_DEPENDENCY_RESOLUTION_PERIOD_MILLIS": "1",
             "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
         },
-        doc="SCA standalone mode (APM opt out)",
+        agent_env={
+            "DD_INFRASTRUCTURE_MODE": "none",
+        },
+        doc="SCA standalone mode (APM opt out), with the infra product disabled on the agent",
         scenario_groups=[scenario_groups.appsec],
     )
 
@@ -1397,7 +1406,10 @@ class _Scenarios:
             "DD_APM_TRACING_ENABLED": "false",
             "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
         },
-        doc="AI Guard standalone mode",
+        agent_env={
+            "DD_INFRASTRUCTURE_MODE": "none",
+        },
+        doc="AI Guard standalone mode, with the infra product disabled on the agent",
         scenario_groups=[scenario_groups.ai_guard],
     )
 


### PR DESCRIPTION
## Motivation

Jira: [APPSEC-69411](https://datadoghq.atlassian.net/browse/APPSEC-69411) (epic [APPSEC-61460](https://datadoghq.atlassian.net/browse/APPSEC-61460))

The AI Guard / AppSec / IAST / SCA standalone scenarios assert that APM billing is opted out (`DD_APM_TRACING_ENABLED=false`, `_dd.apm.enabled=0`, no client-computed stats). That is only half of the bill: the host can still be billed as an **infra host** if the agent keeps shipping infrastructure data.

The agent side of that is APM Standalone Mode, `infrastructure_mode: "none"` ([spec](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/6319080743/APM+Standalone+Mode+Mode+Spec) — *"This host should not be billed as an Infra Host"*). Today it is set on `APPSEC_APM_STANDALONE` and `APPSEC_STANDALONE_APM_STANDALONE` only, and **nothing asserts the outcome**: `tests/appsec/smoke_tests/` only checks that WAF / RASP / telemetry / RC / API security / user events still reach the backend with the flag on.

## Measured behaviour (`datadog/agent` 7.77.3)

| | checks running | series intake |
| --- | --- | --- |
| default | 12 | `system.cpu.*`, `system.mem.*`, `system.disk.*`, `system.io.*`, `system.load.*`, `system.swap.*`, `system.fs.*`, `system.uptime` |
| `DD_INFRASTRUCTURE_MODE=none` | 0 | no `system.*`; only `datadog.agent.*`, `datadog.dogstatsd.*`, `datadog.trace_agent.*` |

Host metadata on `/intake/` (including the process `resources` snapshot) is still sent in this mode, so the metric series are the right signal to assert on.

## Changes

- `utils/_context/_scenarios/__init__.py`: `agent_env={"DD_INFRASTRUCTURE_MODE": "none"}` on `APPSEC_STANDALONE`, `IAST_STANDALONE`, `SCA_STANDALONE`, `AI_GUARD_STANDALONE`. No new scenarios, so no extra CI cost.
- `tests/test_infra_disabled.py` (new): `BaseInfraDisabled` waits for a real agent metrics flush (`interfaces.agent.wait_for`, so the check cannot pass vacuously) and asserts no series matches `system.` / `container.` / `docker.` / `kubernetes.` / `process.` / `ntp.`. Bound to the four scenarios above plus the two existing `*_APM_STANDALONE` ones.
- `manifests/agent.yml`: gated `<7.77.0-0` as irrelevant, matching the existing APM standalone smoke tests.

## Tests

- All six scenarios pass locally (`./run.sh <SCENARIO> -k InfraDisabled`), python/flask-poc.
- Negative control: with `DD_INFRASTRUCTURE_MODE=none` temporarily removed from `AI_GUARD_STANDALONE`, the test fails with `['ntp.offset', 'system.load.1', 'system.load.15', ...]`.
- Full `IAST_STANDALONE`, `SCA_STANDALONE`, `AI_GUARD_STANDALONE` suites pass. `APPSEC_STANDALONE` has 18 failures locally that are pre-existing — a baseline run without this change produces the identical 18 (local `dd-trace-py` 4.12.0-rc1 weblog).
- `./run.sh TEST_THE_TEST`: 354 passed. `./format.sh`: mypy and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APPSEC-69411]: https://datadoghq.atlassian.net/browse/APPSEC-69411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-61460]: https://datadoghq.atlassian.net/browse/APPSEC-61460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ