### PR TITLE
Remove e2e gitlab from schedules

### DIFF
--- a/tests/test_the_test/test_compute_libraries_and_scenarios.py
+++ b/tests/test_the_test/test_compute_libraries_and_scenarios.py
@@ -567,9 +567,9 @@ class Test_GitLabMode:
 
     @pytest.mark.parametrize(
         ("source", "ref"),
-        [("push", "main"), ("schedule", "main")],
+        [("push", "some_branch"), ("schedule", "main"), ("schedule", "some_branch")],
     )
-    def test_main_and_scheduled_pipelines_select_python(
+    def test_non_main_and_scheduled_pipelines_do_not_select_python(
         self,
         monkeypatch: pytest.MonkeyPatch,
         source: str,
@@ -578,6 +578,17 @@ class Test_GitLabMode:
         monkeypatch.setenv("GITLAB_CI", "true")
         monkeypatch.setenv("CI_PIPELINE_SOURCE", source)
         monkeypatch.setenv("CI_COMMIT_REF_NAME", ref)
+        inputs = build_inputs()
+
+        assert 'libraries="python"' not in process(inputs)
+
+    def test_main_pipelines_select_python(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GITLAB_CI", "true")
+        monkeypatch.setenv("CI_PIPELINE_SOURCE", "push")
+        monkeypatch.setenv("CI_COMMIT_REF_NAME", "main")
         inputs = build_inputs()
 
         assert 'libraries="python"' in process(inputs)

--- a/utils/scripts/compute_libraries_and_scenarios.py
+++ b/utils/scripts/compute_libraries_and_scenarios.py
@@ -31,7 +31,7 @@ OTEL_LIBRARIES = COMPONENT_GROUPS.otel - {"nodejs_otel"}  # nodejs_otel intentio
 ALL_LIBRARIES = LIBRARIES | OTEL_LIBRARIES
 GITHUB_EXCLUDED_LIBRARIES = {"c"}
 GITLAB_PR_LIBRARIES = {"c"}
-GITLAB_MAIN_AND_SCHEDULE_LIBRARIES = {"python"}
+GITLAB_MAIN = {"python"}
 
 
 def check_scenarios(scenarios: set[str]) -> bool:
@@ -174,8 +174,8 @@ class LibraryProcessor:
 
 def filter_gitlab_libraries(inputs: Inputs, libraries: set[str]) -> set[str]:
     """Limit the GitLab end-to-end rollout by pipeline context."""
-    if inputs.ref == "refs/heads/main" or inputs.event_name == "schedule":
-        return libraries & GITLAB_MAIN_AND_SCHEDULE_LIBRARIES
+    if inputs.ref == "refs/heads/main" and inputs.event_name != "schedule":
+        return libraries & GITLAB_MAIN
 
     if inputs.event_name in ("pull_request", "push"):
         return libraries & GITLAB_PR_LIBRARIES


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
