### PR TITLE
Activate test_fr04_2_unmeasured_child_excluded

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1021,6 +1021,7 @@ manifest:
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer: v2.8.0
   tests/parametric/test_otlp_trace_metrics.py: v3.50.0
   tests/parametric/test_otlp_trace_metrics.py::Test_FR02_Mutual_Exclusion::test_fr02_3_otlp_suppresses_native_stats: irrelevant (OTLP trace metrics alongside native (non-OTLP) trace export was removed and will not be supported; OTLP trace metrics now require OTEL_TRACES_EXPORTER=otlp)
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR04_Span_Selection::test_fr04_2_unmeasured_child_excluded: v3.51.0
   tests/parametric/test_otlp_trace_metrics.py::Test_FR06_Otel_Resource_Attributes::test_fr06_10_hostname: missing_feature (host.name is not yet reported on the OTLP trace metrics resource)
   tests/parametric/test_otlp_trace_metrics.py::Test_FR08_AdditionalTags::test_fr08_10_dd_tags_resource_attributes: missing_feature (DD_TAGS is not yet reported as tracer_dd_tags on the OTLP trace metrics resource)
   tests/parametric/test_otlp_trace_metrics.py::Test_FR08_AdditionalTags::test_fr08_11_otel_resource_attributes_env: missing_feature (OTEL_RESOURCE_ATTRIBUTES is not yet reported as tracer_dd_tags on the OTLP trace metrics resource)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1021,7 +1021,6 @@ manifest:
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer: v2.8.0
   tests/parametric/test_otlp_trace_metrics.py: v3.50.0
   tests/parametric/test_otlp_trace_metrics.py::Test_FR02_Mutual_Exclusion::test_fr02_3_otlp_suppresses_native_stats: irrelevant (OTLP trace metrics alongside native (non-OTLP) trace export was removed and will not be supported; OTLP trace metrics now require OTEL_TRACES_EXPORTER=otlp)
-  tests/parametric/test_otlp_trace_metrics.py::Test_FR04_Span_Selection::test_fr04_2_unmeasured_child_excluded: bug (APMAPI-2193)
   tests/parametric/test_otlp_trace_metrics.py::Test_FR06_Otel_Resource_Attributes::test_fr06_10_hostname: missing_feature (host.name is not yet reported on the OTLP trace metrics resource)
   tests/parametric/test_otlp_trace_metrics.py::Test_FR08_AdditionalTags::test_fr08_10_dd_tags_resource_attributes: missing_feature (DD_TAGS is not yet reported as tracer_dd_tags on the OTLP trace metrics resource)
   tests/parametric/test_otlp_trace_metrics.py::Test_FR08_AdditionalTags::test_fr08_11_otel_resource_attributes_env: missing_feature (OTEL_RESOURCE_ATTRIBUTES is not yet reported as tracer_dd_tags on the OTLP trace metrics resource)


### PR DESCRIPTION
## Motivation

Activates `test_fr04_2_unmeasured_child_excluded` for dotnet, which was skipped with `bug (APMAPI-2193)` in #7361 because the fix wasn't in yet.

The fix is now in dd-trace-dotnet branch `anna/fix-otlp-stats-child-spans`:
https://github.com/DataDog/dd-trace-dotnet/pull/8947

## Changes

- Remove the `bug (APMAPI-2193)` skip for `tests/parametric/test_otlp_trace_metrics.py::Test_FR04_Span_Selection::test_fr04_2_unmeasured_child_excluded` in `manifests/dotnet.yml`
- PR title includes `[dotnet@anna/fix-otlp-stats-child-spans]` to run CI against that dd-trace-dotnet branch

This PR is based on #7361 (includes all changes from that PR).

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from R&P team
* [ ] A docker base image is modified?
* [ ] A scenario is added, removed or renamed?

🤖 Generated with [Claude Code](https://claude.com/claude-code)