### PR TITLE
Raw response body

### DIFF
--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -216,7 +216,6 @@ manifest:
   tests/appsec/waf/test_addresses.py::Test_UrlQueryKey: v1.2.0
   tests/appsec/waf/test_addresses.py::Test_UrlRaw: v1.2.0
   tests/appsec/waf/test_addresses.py::Test_gRPC: irrelevant
-  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking: v1.2.0
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_full_html:  # Modified by easy win activation script
     - declaration: bug (APPSEC-61196)
@@ -239,6 +238,7 @@ manifest:
   tests/appsec/waf/test_miscs.py::Test_CorrectOptionProcessing: v1.2.0
   tests/appsec/waf/test_miscs.py::Test_MultipleAttacks: v1.2.0
   tests/appsec/waf/test_miscs.py::Test_MultipleHighlight: v1.2.0
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_reports.py::Test_Monitoring:  # Modified by easy win activation script
     - declaration: missing_feature (WAF monitoring tags not implemented)
       component_version: <1.12.0

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -216,6 +216,7 @@ manifest:
   tests/appsec/waf/test_addresses.py::Test_UrlQueryKey: v1.2.0
   tests/appsec/waf/test_addresses.py::Test_UrlRaw: v1.2.0
   tests/appsec/waf/test_addresses.py::Test_gRPC: irrelevant
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking: v1.2.0
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_full_html:  # Modified by easy win activation script
     - declaration: bug (APPSEC-61196)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -553,6 +553,7 @@ manifest:
   tests/appsec/waf/test_addresses.py::Test_UrlQueryKey: v2.7.0
   tests/appsec/waf/test_addresses.py::Test_UrlRaw: v1.28.6
   tests/appsec/waf/test_addresses.py::Test_gRPC: missing_feature
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking: v2.27.0
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_full_html: missing_feature (Support for quality not implemented)
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_partial_html: missing_feature (Support for partial html not implemented)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -553,7 +553,6 @@ manifest:
   tests/appsec/waf/test_addresses.py::Test_UrlQueryKey: v2.7.0
   tests/appsec/waf/test_addresses.py::Test_UrlRaw: v1.28.6
   tests/appsec/waf/test_addresses.py::Test_gRPC: missing_feature
-  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking: v2.27.0
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_full_html: missing_feature (Support for quality not implemented)
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_partial_html: missing_feature (Support for partial html not implemented)
@@ -575,6 +574,7 @@ manifest:
   tests/appsec/waf/test_miscs.py::Test_CorrectOptionProcessing: v1.28.6
   tests/appsec/waf/test_miscs.py::Test_MultipleAttacks: v2.1.0
   tests/appsec/waf/test_miscs.py::Test_MultipleHighlight: v2.3.0
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_reports.py::Test_Monitoring: v2.9.0
   tests/appsec/waf/test_rules.py::Test_CommandInjection: v1.28.6
   tests/appsec/waf/test_rules.py::Test_DiscoveryScan: v2.3.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -946,7 +946,6 @@ manifest:
     - weblog_declaration:
         envoy: missing_feature
         haproxy: missing_feature
-  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking: v1.50.0-rc.1
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_full_html:
     - declaration: bug (APPSEC-61196)
@@ -992,6 +991,7 @@ manifest:
     - weblog_declaration:
         "*": v1.36.0
         gin: v1.37.0
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_reports.py::Test_Monitoring: v1.38.0
   tests/appsec/waf/test_reports.py::Test_Monitoring::test_waf_monitoring_errors: irrelevant (expected tags were deprecated by rfc1025)
   tests/appsec/waf/test_reports.py::Test_Monitoring::test_waf_monitoring_once:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -946,6 +946,7 @@ manifest:
     - weblog_declaration:
         envoy: missing_feature
         haproxy: missing_feature
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking: v1.50.0-rc.1
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_full_html:
     - declaration: bug (APPSEC-61196)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2718,7 +2718,6 @@ manifest:
         spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         vertx3: irrelevant
         vertx4: irrelevant
-  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking:
     - weblog_declaration:
         "*": v0.112.0
@@ -2811,6 +2810,7 @@ manifest:
         "*": v0.95.0
         akka-http: v1.22.0
         spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_reports.py::Test_Monitoring:
     - weblog_declaration:
         "*": v0.100.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2718,6 +2718,7 @@ manifest:
         spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
         vertx3: irrelevant
         vertx4: irrelevant
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking:
     - weblog_declaration:
         "*": v0.112.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1454,7 +1454,6 @@ manifest:
         nextjs: *ref_4_17_0
   tests/appsec/waf/test_addresses.py::Test_UrlRaw: v2.0.0
   tests/appsec/waf/test_addresses.py::Test_gRPC: missing_feature
-  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking: *ref_3_19_0
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_full_html: missing_feature (Support for quality not implemented)
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_partial_html: missing_feature (Support for partial html not implemented)
@@ -1499,6 +1498,7 @@ manifest:
     - weblog_declaration:
         "*": v2.0.0
         fastify: *ref_5_57_0
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_reports.py::Test_Monitoring:
     - weblog_declaration:
         "*": v2.8.0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1454,6 +1454,7 @@ manifest:
         nextjs: *ref_4_17_0
   tests/appsec/waf/test_addresses.py::Test_UrlRaw: v2.0.0
   tests/appsec/waf/test_addresses.py::Test_gRPC: missing_feature
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking: *ref_3_19_0
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_full_html: missing_feature (Support for quality not implemented)
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_partial_html: missing_feature (Support for partial html not implemented)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -596,6 +596,7 @@ manifest:
   tests/appsec/waf/test_miscs.py::Test_CorrectOptionProcessing: v0.1.0
   tests/appsec/waf/test_miscs.py::Test_MultipleAttacks: v0.1.0
   tests/appsec/waf/test_miscs.py::Test_MultipleHighlight: v0.2.0
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: v1.24.0
   tests/appsec/waf/test_reports.py::Test_Monitoring: v0.73.0
   tests/appsec/waf/test_reports.py::Test_Monitoring::test_waf_monitoring_optional: irrelevant (optional tags)
   tests/appsec/waf/test_rules.py::Test_CommandInjection: v0.68.3

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1080,7 +1080,6 @@ manifest:
         "*": v0.58.5
         fastapi: v2.4.0
   tests/appsec/waf/test_addresses.py::Test_gRPC: missing_feature
-  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking:
     - weblog_declaration:
         "*": v1.16.1
@@ -1126,6 +1125,7 @@ manifest:
     - weblog_declaration:
         "*": v1.2.1
         fastapi: v2.4.0
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_reports.py::Test_Monitoring:
     - weblog_declaration:
         "*": v1.5.0-rc1

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1080,6 +1080,7 @@ manifest:
         "*": v0.58.5
         fastapi: v2.4.0
   tests/appsec/waf/test_addresses.py::Test_gRPC: missing_feature
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking:
     - weblog_declaration:
         "*": v1.16.1

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1646,7 +1646,6 @@ manifest:
   tests/appsec/waf/test_addresses.py::Test_UrlQuery: v0.54.2
   tests/appsec/waf/test_addresses.py::Test_UrlQueryKey: v1.0.0
   tests/appsec/waf/test_addresses.py::Test_gRPC: missing_feature
-  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking: v1.11.0
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_all:
     - declaration: bug (APMRP-360)
@@ -1701,6 +1700,7 @@ manifest:
       component_version: <=1.12.1
   tests/appsec/waf/test_miscs.py::Test_MultipleAttacks: v0.54.2
   tests/appsec/waf/test_miscs.py::Test_MultipleHighlight: v1.0.0.beta1
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_reports.py::Test_Monitoring: v1.8.0
   tests/appsec/waf/test_reports.py::Test_Monitoring::test_waf_monitoring_errors: irrelevant (replaced by test_waf_monitoring_once_rfc1025)
   tests/appsec/waf/test_reports.py::Test_Monitoring::test_waf_monitoring_once: irrelevant (replaced by test_waf_monitoring_once_rfc1025)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1646,6 +1646,7 @@ manifest:
   tests/appsec/waf/test_addresses.py::Test_UrlQuery: v0.54.2
   tests/appsec/waf/test_addresses.py::Test_UrlQueryKey: v1.0.0
   tests/appsec/waf/test_addresses.py::Test_gRPC: missing_feature
+  tests/appsec/waf/test_raw_response_body.py::Test_RawResponseBody: missing_feature
   tests/appsec/waf/test_blocking.py::Test_Blocking: v1.11.0
   tests/appsec/waf/test_blocking.py::Test_Blocking::test_accept_all:
     - declaration: bug (APMRP-360)

--- a/tests/appsec/custom_rules.json
+++ b/tests/appsec/custom_rules.json
@@ -3100,6 +3100,27 @@
           }
         }
       ]
+    },
+    {
+      "id": "raw-response-body-test",
+      "name": "Test rule for server.response.body.raw",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "operator": "match_regex",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.body.raw"
+              }
+            ],
+            "regex": "(?i)server_response_body_raw_poison"
+          }
+        }
+      ]
     }
   ]
 }

--- a/tests/appsec/waf/test_raw_response_body.py
+++ b/tests/appsec/waf/test_raw_response_body.py
@@ -1,0 +1,20 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+from utils import weblog, interfaces, scenarios, features, rfc
+
+
+@rfc("https://docs.google.com/document/d/1gvYRWNQ28GyRIAepx59di-KxIqZsqY1a9XwFYaXmGG4")
+@scenarios.appsec_custom_rules
+@features.appsec_raw_response_body
+class Test_RawResponseBody:
+    """WAF detects attacks in raw HTTP response body (server.response.body.raw address)"""
+
+    def setup_waf_detects_response_body(self):
+        self.r = weblog.get("/tag_value/server_response_body_raw_poison/200")
+
+    def test_waf_detects_response_body(self):
+        """WAF fires when the response body contains a known attack pattern"""
+        assert self.r.status_code == 200
+        interfaces.library.assert_waf_attack(self.r, address="server.response.body.raw")

--- a/tests/appsec/waf/test_raw_response_body.py
+++ b/tests/appsec/waf/test_raw_response_body.py
@@ -12,7 +12,10 @@ class Test_RawResponseBody:
     """WAF detects attacks in raw HTTP response body (server.response.body.raw address)"""
 
     def setup_waf_detects_response_body(self):
-        self.r = weblog.get("/tag_value/server_response_body_raw_poison/200")
+        self.r = weblog.post(
+            "/tag_value/payload_in_response_body_raw_attack/200",
+            data="attack=server_response_body_raw_poison",
+        )
 
     def test_waf_detects_response_body(self):
         """WAF fires when the response body contains a known attack pattern"""

--- a/tests/appsec/waf/test_raw_response_body.py
+++ b/tests/appsec/waf/test_raw_response_body.py
@@ -14,7 +14,7 @@ class Test_RawResponseBody:
     def setup_waf_detects_response_body(self):
         self.r = weblog.post(
             "/tag_value/payload_in_response_body_raw_attack/200",
-            data="attack=server_response_body_raw_poison",
+            data={"attack": "server_response_body_raw_poison"},
         )
 
     def test_waf_detects_response_body(self):

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -324,7 +324,10 @@ class _Scenarios:
     )
     appsec_custom_rules = DdTraceEndToEndScenario(
         "APPSEC_CUSTOM_RULES",
-        weblog_env={"DD_APPSEC_RULES": "/appsec_custom_rules.json"},
+        weblog_env={
+            "DD_APPSEC_RULES": "/appsec_custom_rules.json",
+            "DD_APPSEC_RAW_RESPONSE_BODY_ENABLED": "1",
+        },
         weblog_volumes={"./tests/appsec/custom_rules.json": {"bind": "/appsec_custom_rules.json", "mode": "ro"}},
         doc="Test custom appsec rules file",
         scenario_groups=[scenario_groups.appsec],

--- a/utils/_features.py
+++ b/utils/_features.py
@@ -3028,5 +3028,14 @@ class _Features:
         """
         return _mark_test_object(test_object, feature_id=560, owner=_Owner.asm)
 
+    @staticmethod
+    def appsec_raw_response_body(test_object):
+        """AppSec sends the raw HTTP response body to the WAF for inspection
+        (server.response.body.raw address), enabled via DD_APPSEC_RAW_RESPONSE_BODY_ENABLED.
+
+        https://feature-parity.us1.prod.dog/#/?feature=565
+        """
+        return _mark_test_object(test_object, feature_id=565, owner=_Owner.asm)
+
 
 features = _Features()


### PR DESCRIPTION
## Motivation

Adds support for sending the raw HTTP response body to the WAF for inspection via a new WAF address server.response.body.raw.

  When DD_APPSEC_RAW_RESPONSE_BODY_ENABLED=1 is set, the extension captures the raw response body and passes it to the WAF before the response is sent to the client. This allows WAF rules to detect sensitive data or attack patterns in HTTP
  responses.

  Changes:
  - Capture the raw response body and send it to the WAF as server.response.body.raw
  - Register the new AsmRawResponseBody (bit 49) remote config capability so the Agent knows the tracer supports this feature
  - Add DD_APPSEC_RAW_RESPONSE_BODY_ENABLED to the configuration registry
  - Add integration tests verifying WAF fires on server.response.body.raw
  - Add capability test verifying ASM_RAW_RESPONSE_BODY is advertised
  - Add system test in APPSEC_CUSTOM_RULES scenario (PHP only, missing_feature for all other tracers)

  RFC: https://docs.google.com/document/d/1gvYRWNQ28GyRIAepx59di-KxIqZsqY1a9XwFYaXmGG4
## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
