### PR TITLE
refactor(rust_weblog): drop opentelemetry-instrumentation-tower git dep

### DIFF
--- a/utils/build/docker/rust/axum/Cargo.lock
+++ b/utils/build/docker/rust/axum/Cargo.lock
@@ -85,7 +85,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -129,17 +128,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1462,22 +1450,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-instrumentation-tower"
-version = "0.17.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust-contrib?rev=66bfea4#66bfea4e84253996965c708c23a6eb38b0d848aa"
-dependencies = [
- "axum",
- "http",
- "http-body",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-semantic-conventions",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,7 +2734,6 @@ dependencies = [
  "http",
  "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-instrumentation-tower",
  "opentelemetry_sdk",
  "reqwest",
  "reqwest-middleware",

--- a/utils/build/docker/rust/axum/Cargo.toml
+++ b/utils/build/docker/rust/axum/Cargo.toml
@@ -39,26 +39,15 @@ uuid = "1.23.4"
 # OpenTelemetry version alignment (see install_ddtrace.sh):
 #
 # The whole opentelemetry crate family must resolve to a single minor version;
-# a duplicate silently turns HTTPLayer's server spans (and context extraction)
-# into no-ops. install_ddtrace.sh installs datadog-opentelemetry as the source
-# of truth (unbounded latest from crates.io, or a local /binaries checkout) and
-# then align_opentelemetry() repins the published family — opentelemetry*,
-# reqwest-tracing, tracing-opentelemetry, and this crate — to the minor it
-# resolves to.
-#
-# opentelemetry-instrumentation-tower is on crates.io, but no released version
-# yet ships the HTTPLayer we need, so we depend on git instead. That means it
-# cannot be repinned by version/feature like the crates above: its OpenTelemetry
-# minor is whatever the git rev below depends on. The rev pinned here (and
-# re-pinned to the same value by align_opentelemetry, as a plain `cargo build`
-# outside install_ddtrace.sh needs it too) is only known-good for OpenTelemetry
-# 0.32; align_opentelemetry has a TODO to pick a compatible rev automatically
-# once datadog-opentelemetry moves past that minor — until then it fails the
-# build with an actionable message. Once a crates.io release ships HTTPLayer,
-# switch this back to a version dependency and hand its pinning fully to
-# install_ddtrace.sh's align_opentelemetry(), like the other opentelemetry*
-# crates.
-opentelemetry-instrumentation-tower = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib", rev = "66bfea4", package = "opentelemetry-instrumentation-tower", features = ["axum"] }
+# a duplicate silently turns the weblog's server-span middleware (and its trace
+# context extraction) into no-ops. install_ddtrace.sh installs
+# datadog-opentelemetry as the source of truth (unbounded latest from crates.io,
+# or a local /binaries checkout) and then align_opentelemetry() repins the
+# published family — opentelemetry*, reqwest-tracing, tracing-opentelemetry — to
+# the minor it resolves to. The weblog instruments axum with its own middleware
+# (src/integration/axum_layer.rs) built entirely on those published crates, so
+# there is no longer a git-only OpenTelemetry dependency to bump by hand on a
+# minor change.
 
 # datadog-opentelemetry: git rev only matters for a plain `cargo build` outside
 # the Docker build; install_ddtrace.sh always overrides it (unbounded latest

--- a/utils/build/docker/rust/axum/src/integration/axum_layer.rs
+++ b/utils/build/docker/rust/axum/src/integration/axum_layer.rs
@@ -1,33 +1,48 @@
 //! Axum server-side span enrichment.
 
 use axum::{
-    extract::Request,
+    extract::{MatchedPath, Request},
     middleware::{self, Next},
     response::Response,
     Router,
 };
-use opentelemetry::{trace::TraceContextExt, Context, KeyValue};
+use opentelemetry::{
+    global,
+    trace::{FutureExt, SpanKind, Status, TraceContextExt, Tracer},
+    KeyValue,
+};
+use opentelemetry_http::HeaderExtractor;
 
 use super::dd_tags;
 
-/// Installs the Datadog-specific span-enrichment layer and the OTel HTTP
-/// instrumentation layer onto the given router.
+/// Installs the single middleware that creates the inbound HTTP server span and
+/// enriches it with the Datadog attributes `validate_all_spans` expects.
 pub fn install_middleware(router: Router) -> Router {
-    router
-        .layer(middleware::from_fn(datadog_specific_axum_layer))
-        .layer(opentelemetry_instrumentation_tower::HTTPLayer::default())
+    router.layer(middleware::from_fn(datadog_specific_axum_layer))
 }
 
-/// Adds Datadog-specific attributes on top of the OTel HTTP server span that
-/// `opentelemetry_instrumentation_tower::HTTPLayer` created for this request.
-///
-/// `HTTPLayer` builds its span via `opentelemetry::Context`, not `tracing`,
-/// so we use `Context::current().span()` instead of `tracing::Span::current()`.
-/// Only attributes not already set by `HTTPLayer` are added here.
+/// Creates the inbound server span on the OpenTelemetry `Context` (extracting any
+/// upstream trace context from the request headers), makes it current for the
+/// downstream handler, and records both the OTel HTTP semantic-convention
+/// attributes and the Datadog-specific attributes needed by `validate_all_spans`.
 async fn datadog_specific_axum_layer(request: Request, next: Next) -> Response {
-    let cx = Context::current();
-    let span = cx.span();
+    // Extract any upstream trace context propagated in the inbound headers.
+    let parent_cx = global::get_text_map_propagator(|propagator| {
+        propagator.extract(&HeaderExtractor(request.headers()))
+    });
 
+    // Low-cardinality route from axum's matched path (e.g. "/params/{value}"),
+    // falling back to a method-only span name when no route matched.
+    let method = request.method().as_str().to_owned();
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|p| p.as_str().to_owned());
+    let span_name = route
+        .as_ref()
+        .map_or_else(|| method.clone(), |r| format!("{method} {r}"));
+
+    // server.address and http.url are built from the request URI + Host header.
     let host = request
         .headers()
         .get(axum::http::header::HOST)
@@ -36,8 +51,7 @@ async fn datadog_specific_axum_layer(request: Request, next: Next) -> Response {
         .to_owned();
     let server_address = host.split(':').next().unwrap_or(&host).to_owned();
     let path = request.uri().path().to_owned();
-    // http.url from the request URI + host header. Query-string obfuscation is
-    // a tracer responsibility, so the weblog reports the URL verbatim.
+    // Query-string obfuscation is a tracer responsibility, so report verbatim.
     let query_suffix = request
         .uri()
         .query()
@@ -45,14 +59,50 @@ async fn datadog_specific_axum_layer(request: Request, next: Next) -> Response {
         .unwrap_or_default();
     let url = format!("http://{host}{path}{query_suffix}");
 
-    for attr in dd_tags() {
-        span.set_attribute(attr);
+    // OTel HTTP server-span attributes (semantic conventions) ...
+    let mut attributes = vec![
+        KeyValue::new("http.request.method", method.clone()),
+        KeyValue::new("url.path", path),
+        KeyValue::new("url.full", request.uri().to_string()),
+    ];
+    if let Some(user_agent) = request
+        .headers()
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+    {
+        attributes.push(KeyValue::new("user_agent.original", user_agent.to_owned()));
     }
-    span.set_attribute(KeyValue::new("http.url", url));
-    span.set_attribute(KeyValue::new("server.address", server_address));
-    // _dd.top_level marks this as a root span so the library interface can
-    // match traces to requests via the user-agent header.
-    span.set_attribute(KeyValue::new("_dd.top_level", 1i64));
+    if let Some(route) = &route {
+        attributes.push(KeyValue::new("http.route", route.clone()));
+    }
+    // ... plus the Datadog-specific attributes.
+    attributes.extend(dd_tags());
+    attributes.push(KeyValue::new("http.url", url));
+    attributes.push(KeyValue::new("server.address", server_address));
+    // _dd.top_level marks this as a root span so the library interface can match
+    // traces to requests via the user-agent header.
+    attributes.push(KeyValue::new("_dd.top_level", 1i64));
 
-    next.run(request).await
+    let tracer = global::tracer("weblog");
+    let span = tracer
+        .span_builder(span_name)
+        .with_kind(SpanKind::Server)
+        .with_attributes(attributes)
+        .start_with_context(&tracer, &parent_cx);
+    let cx = parent_cx.with_span(span);
+
+    // Run the downstream handler with the server span as the current context.
+    let response = next.run(request).with_context(cx.clone()).await;
+
+    // Record the response status on the span before it ends (on drop of `cx`).
+    let span = cx.span();
+    let status = response.status().as_u16();
+    span.set_attribute(KeyValue::new("http.response.status_code", i64::from(status)));
+    if status >= 500 {
+        span.set_status(Status::Error {
+            description: format!("HTTP {status}").into(),
+        });
+    }
+
+    response
 }

--- a/utils/build/docker/rust/install_ddtrace.sh
+++ b/utils/build/docker/rust/install_ddtrace.sh
@@ -5,20 +5,17 @@
 # OpenTelemetry dependency graph to match.
 #
 # Why: datadog-opentelemetry, the plain opentelemetry* crates, and the
-# OTel-consuming contrib crates (reqwest-tracing, tracing-opentelemetry,
-# opentelemetry-instrumentation-tower) must all resolve to the same
-# `opentelemetry` minor version, or cargo links two copies side by side and
-# half the app silently gets a no-op tracer/propagator. Since
-# datadog-opentelemetry's required OTel minor moves with dd-trace-rs (and can
-# differ between a released version and a local/git checkout), we can't just
-# pin it statically in Cargo.toml: we install it first, inspect what OTel
-# minor `cargo metadata` says it actually resolved to, then re-pin every
-# other OTel-related crate to that minor (align_opentelemetry) — including
-# opentelemetry-instrumentation-tower, which is git-only and currently
-# hardcoded to the rev known to match OTel 0.32 (see TODO in
-# align_opentelemetry) — and finally fail the build if `cargo metadata`
-# still reports more than one `opentelemetry` version
-# (check_single_opentelemetry_version).
+# OTel-consuming contrib crates (reqwest-tracing, tracing-opentelemetry) must
+# all resolve to the same `opentelemetry` minor version, or cargo links two
+# copies side by side and half the app silently gets a no-op tracer/propagator.
+# Since datadog-opentelemetry's required OTel minor moves with dd-trace-rs (and
+# can differ between a released version and a local/git checkout), we can't just
+# pin it statically in Cargo.toml: we install it first, inspect what OTel minor
+# `cargo metadata` says it actually resolved to, then re-pin every other
+# OTel-related crate to that minor (align_opentelemetry), and finally fail the
+# build if `cargo metadata` still reports more than one `opentelemetry` version
+# (check_single_opentelemetry_version). Every crate involved is published on
+# crates.io, so there is no git-only dependency to select a rev for by hand.
 
 set -eu
 
@@ -154,23 +151,6 @@ align_opentelemetry() {
     if ! cargo add "tracing-opentelemetry@~${tracing_otel_minor}" >/dev/null 2>&1; then
         fail "no tracing-opentelemetry ~${tracing_otel_minor} on crates.io (needed for OpenTelemetry ${otel_minor}). Wait for that release or pin datadog-opentelemetry to a compatible OTel minor."
     fi
-
-    # opentelemetry-instrumentation-tower: git-only (no crates.io release ships
-    # HTTPLayer yet), so it can't be repinned by version/feature like the deps
-    # above. rev 66bfea4 is known-good for opentelemetry 0.32.
-    # TODO: once datadog-opentelemetry moves past OTel 0.32, we need a real
-    # strategy for picking a compatible rev (e.g. walk opentelemetry-rust-contrib
-    # commits/tags until one resolves to the target minor) instead of this
-    # hardcoded pin.
-    if [[ "$otel_minor_num" -gt 32 ]]; then
-        fail "opentelemetry-instrumentation-tower has no known rev for OpenTelemetry ${otel_minor} (only 0.32 is hardcoded). Update install_ddtrace.sh with a rev-selection strategy for this minor."
-    fi
-
-    cargo remove opentelemetry-instrumentation-tower >/dev/null 2>&1 || true
-    if ! cargo add --git https://github.com/open-telemetry/opentelemetry-rust-contrib --rev 66bfea4 \
-        --package opentelemetry-instrumentation-tower --features axum >/dev/null 2>&1; then
-        fail "could not install opentelemetry-instrumentation-tower from opentelemetry-rust-contrib@66bfea4."
-    fi
 }
 align_opentelemetry
 
@@ -185,7 +165,7 @@ check_single_opentelemetry_version() {
     fi
 
     if [[ $(echo "$versions" | grep -c .) -gt 1 ]]; then
-        fail "incompatible OpenTelemetry versions resolved: ${versions//$'\n'/, }. align_opentelemetry() already re-pins the published crates (opentelemetry*, reqwest-tracing, tracing-opentelemetry) and opentelemetry-instrumentation-tower to whatever datadog-opentelemetry resolves, so the usual culprit is that opentelemetry-instrumentation-tower's hardcoded rev (66bfea4, pinned for OTel 0.32) no longer matches — see the TODO in align_opentelemetry for picking a compatible rev, or use a dd-trace-rs revision that resolves back to OTel 0.32."
+        fail "incompatible OpenTelemetry versions resolved: ${versions//$'\n'/, }. align_opentelemetry() re-pins every published peer crate (opentelemetry*, reqwest-tracing, tracing-opentelemetry) to whatever datadog-opentelemetry resolves, so a mismatch here means one of them has no release on that opentelemetry minor yet — usually reqwest-tracing's opentelemetry_0_* feature or the tracing-opentelemetry version. Use a dd-trace-rs revision on a supported opentelemetry minor."
     fi
 }
 check_single_opentelemetry_version


### PR DESCRIPTION
> Stacked on top of #7288 (base: `milan.garnier/axum-weblog`). Review/merge that first.

## What

The axum weblog used the git-only `opentelemetry-instrumentation-tower` crate (`HTTPLayer`) purely to create the inbound server span and extract upstream trace context, with a second `from_fn` layer adding the Datadog attributes. This replaces both with a **single `from_fn` middleware** (`integration/axum_layer.rs`) and drops the crate entirely.

## Why

Because the crate is git-only, its OpenTelemetry minor was fixed by a hardcoded rev (`66bfea4`, OTel 0.32). `align_opentelemetry` therefore needed a special-cased re-pin plus a `fail`/TODO for any newer minor — the **one non-derivable pin** in the whole alignment, and the thing that would break system-tests the moment `datadog-opentelemetry` moved to a new OTel minor.

Every remaining OTel peer crate (`opentelemetry*`, `reqwest-tracing`, `tracing-opentelemetry`) is on crates.io, so after this change `align_opentelemetry` pins **no git rev** and there is nothing to bump by hand on a minor change.
