### PR TITLE
Fix nodejs startup-logs version gate to v6.0.0

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -100,7 +100,7 @@ refs:
   - &ref_5_109_0 '>=5.109.0'
   - &ref_5_110_0 '>=5.110.0'
   - &ref_5_111_0 '>=5.111.0'
-  - &ref_6_0_0 '>=6.0.0-pre'
+  - &ref_6_0_0 '>=6.0.0'
   - &ref_6_5_0 '>=6.5.0 || ^5.116.0'
 manifest:
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardEvent_Tag:


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
PR #6513 gated `tests/parametric/test_startup_logs.py::Test_Startup_Logs::test_startup_logs_default` on `>=6.0.0-pre`, which is dd-trace-js's `package.json` placeholder version for `main`, not the actual release where the feature ([DataDog/dd-trace-js#7474](https://github.com/DataDog/dd-trace-js/pull/7474): startup logs enabled by default in v6) shipped.

## Changes

<!-- A brief description of the change being made with this pull request. -->
- Changes `&ref_6_0_0` in `manifests/nodejs.yml` from `'>=6.0.0-pre'` to `'>=6.0.0'`.
- Verified against dd-trace-js: the earliest release tag containing the enabling commit (`46aa1f0`) is `v6.0.0`, and `supported-configurations.json` at that tag already reports the default as `true`, so `v6.0.0` is the precise boundary (not a later 6.x release).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
      _(N/A — only `manifests/nodejs.yml` is touched)_
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)