### PR TITLE
Temporarily disable PHP telemetry heartbeat delay test

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1726,6 +1726,8 @@ manifest:
   tests/test_telemetry.py::Test_Telemetry::test_app_heartbeats_delays:
     - declaration: bug (APMAPI-971)
       component_version: '>1.5.1 <1.17.0'
+    - declaration: bug (APMAPI-971)
+      component_version: '>=1.24.0'
     - declaration: flaky (APMRP-360)
       component_version: <=0.90
   tests/test_telemetry.py::Test_Telemetry::test_app_product_change: missing_feature (Weblog GET/enable_product and app-product-change event is not implemented yet.)


### PR DESCRIPTION
## Motivation

Unrelated system-tests pull requests are blocked by repeated PHP failures in `Test_Telemetry.test_app_heartbeats_delays`. The PHP tracer now starts an additional background-sender application that shares a runtime ID with the weblog. Both applications emit heartbeats at the expected cadence, but the test combines their interleaved streams and calculates an artificially low average delay.

This temporary suppression restores reliable signal for contributors while the test grouping is corrected under [APMAPI-971](https://datadoghq.atlassian.net/browse/APMAPI-971).

## Changes and Decisions

### Changes

The PHP manifest now declares `tests/test_telemetry.py::Test_Telemetry::test_app_heartbeats_delays` as affected by APMAPI-971 for component versions `>=1.24.0`. Existing historical version gates remain unchanged.

### Decisions

The suppression is implemented in the PHP manifest instead of the test body so other tracer implementations continue exercising the heartbeat cadence assertion. The lower bound is PHP 1.24.0 because that includes the tracer change introducing the second application stream, while older PHP releases remain covered. This is intentionally temporary and can be removed when the test groups heartbeats by application identity as well as runtime ID.

## Validation

`./format.sh` completed successfully, including mypy, Ruff, whitespace, YAML formatting and linting, manifest parser checks, ShellCheck, and Node.js linters.

[APMAPI-971]: https://datadoghq.atlassian.net/browse/APMAPI-971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ