### PR TITLE
test(parametric): recognize v1 trace requests

### DIFF
--- a/tests/parametric/test_otlp_trace_metrics.py
+++ b/tests/parametric/test_otlp_trace_metrics.py
@@ -260,8 +260,9 @@ def _data_point_services(metrics: list[Any]) -> set[Any]:
 
 
 def _trace_requests(test_agent: TestAgentAPI) -> list[AgentRequest]:
-    """Native Datadog trace export requests (v0.4/v0.5/v0.7), regardless of the wire version used."""
-    return [r for r in test_agent.requests() if r["url"].endswith(("/v0.4/traces", "/v0.5/traces", "/v0.7/traces"))]
+    """Native Datadog trace export requests, regardless of the wire version used."""
+    trace_endpoints = ("/v0.4/traces", "/v0.5/traces", "/v0.7/traces", "/v1.0/traces")
+    return [r for r in test_agent.requests() if r["url"].endswith(trace_endpoints)]
 
 
 def _trace_count(request: AgentRequest) -> int:


### PR DESCRIPTION
## Motivation
Java can use trace protocol `v1.0`, but the helper only recognized `/v0.4/traces`, `/v0.5/traces`, and `/v0.7/traces`. Valid requests were filtered out, causing three client-computed-stats tests to report that no trace export request was received.

## Changes
Includes native `/v1.0/traces` requests when locating span-carrying trace exports in the OTLP trace-metrics tests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
