### PR TITLE
feat: add /trace/manual_keep_drop endpoint to all weblogs

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -151,7 +151,7 @@ jobs:
       if: inputs._build_weblog_base_image
       run: |
         source venv/bin/activate
-        ./utils/script/build_base_image.py ${{ inputs.library }} ${{ inputs.weblog }}
+        ./utils/scripts/build-base-image.py ${{ inputs.library }} ${{ inputs.weblog }}
 
     - name: Pull images
       uses: ./.github/actions/pull_images

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -219,7 +219,7 @@ jobs:
         if: matrix.weblog.build_base_image
         run: |
           source venv/bin/activate
-          ./utils/script/build_base_image.py ${{ inputs.library }} ${{ matrix.weblog.name }}
+          ./utils/scripts/build-base-image.py ${{ inputs.library }} ${{ matrix.weblog.name }}
       - name: Build weblog
         id: build
         run: SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh ${{ inputs.library }} -i weblog -w ${{ matrix.weblog.name }} -s --github-token-file "$RUNNER_TEMP/github_token.txt"

--- a/docs/understand/weblogs/end-to-end_weblog.md
+++ b/docs/understand/weblogs/end-to-end_weblog.md
@@ -575,8 +575,21 @@ Examples:
 - `GET /trace/manual_keep_drop?decision=keep`
 - `GET /trace/manual_keep_drop?decision=drop`
 
-The endpoint returns a `200` status code with a plain text body once the decision has been applied.
-Any other value for `decision`, or a missing `decision` parameter, returns a `400` status code.
+Once the decision has been applied, the endpoint makes an outgoing HTTP call to `http://localhost:7777/`,
+so that tests can assert on the sampling decision propagated downstream. Unlike `/make_distant_call`
+the target is not configurable. The response mirrors `/make_distant_call`, with a `200` status code:
+
+```js
+{
+    "url": "http://localhost:7777/",  // the hardcoded downstream url
+    "status_code": 200, // status code of the downstream response
+    "request_headers": {}, // headers sent downstream, including the propagated sampling decision
+    "response_headers": {} // headers of the downstream response
+}
+```
+
+Any other value for `decision`, or a missing `decision` parameter, returns a `400` status code and
+makes no downstream call.
 
 ### GET /dbm
 

--- a/docs/understand/weblogs/end-to-end_weblog.md
+++ b/docs/understand/weblogs/end-to-end_weblog.md
@@ -559,6 +559,25 @@ This endpoint accept a mandatory parameter `url`. It'll make a call to these url
 }
 ```
 
+### GET /trace/manual_keep_drop
+
+This endpoint forces the sampling decision of the current trace, using the tracer's manual keep/drop
+API (the `manual.keep` / `manual.drop` tags, or the equivalent idiomatic call in the library) applied
+to the currently active span.
+
+It accepts a mandatory query parameter `decision`, whose value must be either:
+
+- `keep`: force the trace to be kept (`manual.keep`)
+- `drop`: force the trace to be dropped (`manual.drop`)
+
+Examples:
+
+- `GET /trace/manual_keep_drop?decision=keep`
+- `GET /trace/manual_keep_drop?decision=drop`
+
+The endpoint returns a `200` status code with a plain text body once the decision has been applied.
+Any other value for `decision`, or a missing `decision` parameter, returns a `400` status code.
+
 ### GET /dbm
 
 This endpoint executes database queries for [DBM supported libraries](https://docs.datadoghq.com/database_monitoring/guide/connect_dbm_and_apm/?tab=go#before-you-begin). A 200 response is returned if the query

--- a/manifests/c.yml
+++ b/manifests/c.yml
@@ -14,7 +14,7 @@ manifest:
   tests/test_library_conf.py: missing_feature (dd-trace-c does not support header-tag configuration or configurable extraction behavior)
   tests/test_library_logs.py: irrelevant (These assertions target Java and .NET logs)
   tests/test_rum_injection.py: irrelevant (dd-trace-c does not implement RUM injection)
-  tests/test_sampling_manual.py: incomplete_test_app (Manual keep/drop requires an SDK endpoint the Perl Mojolicious workload does not provide)
+  tests/test_sampling_manual.py: missing_feature (dd-trace-c does not implement manual keep/drop)
   tests/test_sampling_rates.py::Test_SampleRateFunction: missing_feature (dd-trace-c does not implement static trace sampling rules)
   tests/test_sampling_rates.py::Test_SamplingDecisions: missing_feature (dd-trace-c does not implement static trace sampling rules)
   tests/test_sampling_rates.py::Test_SamplingRates: missing_feature (dd-trace-c does not implement static trace sampling rules)

--- a/manifests/c.yml
+++ b/manifests/c.yml
@@ -14,6 +14,7 @@ manifest:
   tests/test_library_conf.py: missing_feature (dd-trace-c does not support header-tag configuration or configurable extraction behavior)
   tests/test_library_logs.py: irrelevant (These assertions target Java and .NET logs)
   tests/test_rum_injection.py: irrelevant (dd-trace-c does not implement RUM injection)
+  tests/test_sampling_manual.py: incomplete_test_app (Manual keep/drop requires an SDK endpoint the Perl Mojolicious workload does not provide)
   tests/test_sampling_rates.py::Test_SampleRateFunction: missing_feature (dd-trace-c does not implement static trace sampling rules)
   tests/test_sampling_rates.py::Test_SamplingDecisions: missing_feature (dd-trace-c does not implement static trace sampling rules)
   tests/test_sampling_rates.py::Test_SamplingRates: missing_feature (dd-trace-c does not implement static trace sampling rules)

--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -184,6 +184,7 @@ manifest:
   tests/test_profiling.py: missing_feature (missing profiling module in weblog)
   tests/test_resource_renaming.py: missing_feature
   tests/test_rum_injection.py: irrelevant (RUM injection only supported for Java)
+  tests/test_sampling_manual.py: incomplete_test_app (/trace/manual_keep_drop endpoint is not implemented)
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction: v1.0.0  # real version unknown
   tests/test_sampling_rates.py::Test_SampleRateFunction::test_sample_rate_function: missing_feature (/sample_rate_route is not implemented)

--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -184,7 +184,7 @@ manifest:
   tests/test_profiling.py: missing_feature (missing profiling module in weblog)
   tests/test_resource_renaming.py: missing_feature
   tests/test_rum_injection.py: irrelevant (RUM injection only supported for Java)
-  tests/test_sampling_manual.py: incomplete_test_app (/trace/manual_keep_drop endpoint is not implemented)
+  tests/test_sampling_manual.py: missing_feature (/trace/manual_keep_drop is not implemented)
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction: v1.0.0  # real version unknown
   tests/test_sampling_rates.py::Test_SampleRateFunction::test_sample_rate_function: missing_feature (/sample_rate_route is not implemented)

--- a/manifests/cpp_kong.yml
+++ b/manifests/cpp_kong.yml
@@ -28,6 +28,7 @@ manifest:
   tests/test_profiling.py: irrelevant (Kong is a proxy, not a profiling target)
   tests/test_resource_renaming.py: missing_feature
   tests/test_rum_injection.py: irrelevant
+  tests/test_sampling_manual.py: irrelevant (Kong is a proxy, not an application)
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature
   tests/test_sampling_rates.py: missing_feature
   tests/test_scrubbing.py: irrelevant

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -446,6 +446,7 @@ manifest:
   tests/test_resource_renaming.py::Test_Resource_Renaming_HTTP_Endpoint_Tag::test_http_endpoint_edge_cases: missing_feature
   tests/test_resource_renaming.py::Test_Resource_Renaming_Stats_Aggregation_Keys: missing_feature
   tests/test_rum_injection.py: irrelevant (RUM injection only supported for Java)
+  tests/test_sampling_manual.py: incomplete_test_app (/trace/manual_keep_drop endpoint is not implemented)
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction: v1.0.0  # real version unknown
   tests/test_sampling_rates.py::Test_SamplingDecisionAdded: v1.0.0  # real version unknown

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -446,7 +446,7 @@ manifest:
   tests/test_resource_renaming.py::Test_Resource_Renaming_HTTP_Endpoint_Tag::test_http_endpoint_edge_cases: missing_feature
   tests/test_resource_renaming.py::Test_Resource_Renaming_Stats_Aggregation_Keys: missing_feature
   tests/test_rum_injection.py: irrelevant (RUM injection only supported for Java)
-  tests/test_sampling_manual.py: incomplete_test_app (/trace/manual_keep_drop endpoint is not implemented)
+  tests/test_sampling_manual.py: irrelevant (nginx is a proxy, not an application)
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction: v1.0.0  # real version unknown
   tests/test_sampling_rates.py::Test_SamplingDecisionAdded: v1.0.0  # real version unknown

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1255,6 +1255,7 @@ manifest:
   tests/test_profiling.py::Test_Profile::test_process_tags_svc: missing_feature
   tests/test_resource_renaming.py: missing_feature
   tests/test_rum_injection.py: irrelevant (RUM injection only supported for Java)
+  tests/test_sampling_manual.py::Test_Manual_Sampling: v3.0.0  # before 3.0, ActiveScope can be null on ASP.NET Core requests
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction: v3.11.1  # real version unknown
   tests/test_sampling_rates.py::Test_SamplingDecisionAdded: v3.11.1  # real version unknown

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1825,6 +1825,7 @@ manifest:
         net-http-orchestrion: v2.4.0
         net-http-span-pool: v2.4.0
   tests/test_rum_injection.py: irrelevant (RUM injection only supported for Java)
+  tests/test_sampling_manual.py::Test_Manual_Sampling: v2.4.0  # before 2.4, the manual tags could not override an extracted decision
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: v2.7.0-dev
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease::test_sampling_rate_capped_increase: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction: v1.72.1  # real version unknown

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4439,6 +4439,13 @@ manifest:
         "*": irrelevant (RUM injection only supported for spring-boot)
         spring-boot: v1.49.0
   tests/test_sampling_manual.py::Test_Manual_Sampling::test_manual_drop_overrides_upstream_keep: bug (APMAPI-2194)
+  tests/test_sampling_manual.py::Test_Manual_Sampling::test_manual_keep_overrides_upstream_drop:
+    - weblog_declaration:
+        akka-http: incomplete_test_app (endpoint does not support fetching headers injected to downstream call)
+        jersey-grizzly2: incomplete_test_app (endpoint does not support fetching headers injected to downstream call)
+        ratpack: incomplete_test_app (endpoint does not support fetching headers injected to downstream call)
+        resteasy-netty3: incomplete_test_app (endpoint does not support fetching headers injected to downstream call)
+        spring-boot-3-native: incomplete_test_app (endpoint does not support fetching headers injected to downstream call)
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: v1.60.0-SNAPSHOT+c95286e6a5
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease::test_sampling_rate_capped_increase: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4438,6 +4438,7 @@ manifest:
     - weblog_declaration:
         "*": irrelevant (RUM injection only supported for spring-boot)
         spring-boot: v1.49.0
+  tests/test_sampling_manual.py::Test_Manual_Sampling::test_manual_drop_overrides_upstream_keep: missing_feature (dd-trace-java refuses to lower an already propagated sampling priority, only manual keep bypasses the lock)
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: v1.60.0-SNAPSHOT+c95286e6a5
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease::test_sampling_rate_capped_increase: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4438,7 +4438,7 @@ manifest:
     - weblog_declaration:
         "*": irrelevant (RUM injection only supported for spring-boot)
         spring-boot: v1.49.0
-  tests/test_sampling_manual.py::Test_Manual_Sampling::test_manual_drop_overrides_upstream_keep: missing_feature (dd-trace-java refuses to lower an already propagated sampling priority, only manual keep bypasses the lock)
+  tests/test_sampling_manual.py::Test_Manual_Sampling::test_manual_drop_overrides_upstream_keep: bug (APMAPI-2194)
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: v1.60.0-SNAPSHOT+c95286e6a5
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease::test_sampling_rate_capped_increase: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction:

--- a/manifests/java_otel.yml
+++ b/manifests/java_otel.yml
@@ -70,4 +70,5 @@ manifest:
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)
   tests/test_library_logs.py::Test_NoExceptions::test_java_logs: irrelevant (only for Java)
   tests/test_library_logs.py::Test_NoExceptions::test_java_telemetry_logs: irrelevant (only for Java)
+  tests/test_sampling_manual.py: irrelevant (OpenTelemetry test library does not implement Datadog manual keep/drop)
   tests/test_telemetry.py::Test_Telemetry::test_telemetry_message_has_datadog_container_id: "irrelevant (cgroup in weblog is 0::/, so this test can't work)"

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2488,6 +2488,7 @@ manifest:
     - weblog_declaration:
         nextjs: missing_feature
   tests/test_rum_injection.py: irrelevant (RUM injection only supported for Java)
+  tests/test_sampling_manual.py: bug (APMAPI-1720)
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction: *ref_5_54_0
   tests/test_sampling_rates.py::Test_SamplingDecisionAdded: *ref_5_17_0

--- a/manifests/nodejs_otel.yml
+++ b/manifests/nodejs_otel.yml
@@ -87,4 +87,5 @@ manifest:
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)
   tests/test_library_logs.py::Test_NoExceptions::test_java_logs: irrelevant (only for Java)
   tests/test_library_logs.py::Test_NoExceptions::test_java_telemetry_logs: irrelevant (only for Java)
+  tests/test_sampling_manual.py: irrelevant (OpenTelemetry test library does not implement Datadog manual keep/drop)
   tests/test_telemetry.py::Test_Telemetry::test_telemetry_message_has_datadog_container_id: "irrelevant (cgroup in weblog is 0::/, so this test can't work)"

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1308,6 +1308,7 @@ manifest:
   tests/test_resource_renaming.py: v1.14.0
   tests/test_resource_renaming.py::Test_Resource_Renaming_Stats_Aggregation_Keys: missing_feature
   tests/test_rum_injection.py: irrelevant (RUM injection only supported for Java)
+  tests/test_sampling_manual.py::Test_Manual_Sampling: v0.68.0  # \DDTrace\set_priority_sampling was introduced in 0.68.0
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction: v1.13.0+4663b2fa7c20c6920f347d059b57dc2a419cb7f7
   tests/test_sampling_rates.py::Test_SamplingDecisionAdded: v1.7.2  # real version unknown

--- a/manifests/python_otel.yml
+++ b/manifests/python_otel.yml
@@ -79,4 +79,5 @@ manifest:
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)
   tests/test_library_logs.py::Test_NoExceptions::test_java_logs: irrelevant (only for Java)
   tests/test_library_logs.py::Test_NoExceptions::test_java_telemetry_logs: irrelevant (only for Java)
+  tests/test_sampling_manual.py: irrelevant (OpenTelemetry test library does not implement Datadog manual keep/drop)
   tests/test_telemetry.py::Test_Telemetry::test_telemetry_message_has_datadog_container_id: "irrelevant (cgroup in weblog is 0::/, so this test can't work)"

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2883,6 +2883,7 @@ manifest:
         uds-sinatra: irrelevant
   tests/test_resource_renaming.py::Test_Resource_Renaming_Stats_Aggregation_Keys: missing_feature
   tests/test_rum_injection.py: irrelevant (RUM injection only supported for Java)
+  tests/test_sampling_manual.py::Test_Manual_Sampling: v1.0.0  # trace-level keep!/reject! are not available before 1.0
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature
   tests/test_sampling_rates.py::Test_SampleRateFunction: v2.15.0  # real version unknown
   tests/test_sampling_rates.py::Test_SamplingDecisionAdded: v2.12.1  # real version unknown

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -447,6 +447,7 @@ manifest:
   tests/test_profiling.py::Test_Profile: missing_feature (profiling is not implemented)
   tests/test_resource_renaming.py: incomplete_test_app (resource-renaming endpoints are not implemented)
   tests/test_rum_injection.py::Test_RUM_Injection::test_rum_enabled: missing_feature (/html endpoint not implemented)
+  tests/test_sampling_manual.py::Test_Manual_Sampling: missing_feature (dd-trace-rs does not honor the manual.keep/manual.drop attributes)
   tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature (sampling-rate capping is not implemented)
   tests/test_scrubbing.py::Test_UrlQuery: missing_feature (Rust does not implement query string obfuscation)
   tests/test_span_events.py: missing_feature (Span Events are not implemented)

--- a/tests/test_sampling_manual.py
+++ b/tests/test_sampling_manual.py
@@ -33,6 +33,32 @@ def _assert_upstream_trace_continued(request: HttpResponse) -> None:
     assert UPSTREAM_PARENT_ID in parent_ids, f"No span is a child of the upstream span: {parent_ids}"
 
 
+def _assert_decision_propagated_downstream(request: HttpResponse, expected: SamplingPriority) -> None:
+    """The endpoint calls downstream once the decision has been applied, and reports the headers it
+    sent. The propagated priority must be the manual decision, not the upstream one.
+    """
+    request_headers = request.json()["request_headers"]
+
+    # Case-insensitive lookup, as the header casing depends on the weblog app implementation, and some
+    # weblogs report the headers as a list of objects instead of a dict
+    if isinstance(request_headers, dict):
+        propagated = next(
+            (value for key, value in request_headers.items() if key.lower() == "x-datadog-sampling-priority"), None
+        )
+    else:
+        propagated = next(
+            (
+                header.get("value")
+                for header in request_headers
+                if header.get("key", "").lower() == "x-datadog-sampling-priority"
+            ),
+            None,
+        )
+
+    assert propagated is not None, f"No sampling priority propagated downstream: {request_headers}"
+    assert int(propagated) == expected, f"Propagated sampling priority is {propagated}, expected {int(expected)}"
+
+
 def _get_sampling_priority(request: HttpResponse) -> int:
     """Sampling priority is reported on the local root span of the trace chunk, which is the
     weblog span here, as the trace is continued from an upstream service.
@@ -65,6 +91,7 @@ class Test_Manual_Sampling:
         assert self.r_keep.status_code == 200
         _assert_upstream_trace_continued(self.r_keep)
         assert _get_sampling_priority(self.r_keep) == SamplingPriority.USER_KEEP
+        _assert_decision_propagated_downstream(self.r_keep, SamplingPriority.USER_KEEP)
 
     def setup_manual_drop_overrides_upstream_keep(self):
         self.r_drop = weblog.get(
@@ -77,3 +104,4 @@ class Test_Manual_Sampling:
         assert self.r_drop.status_code == 200
         _assert_upstream_trace_continued(self.r_drop)
         assert _get_sampling_priority(self.r_drop) == SamplingPriority.USER_REJECT
+        _assert_decision_propagated_downstream(self.r_drop, SamplingPriority.USER_REJECT)

--- a/tests/test_sampling_manual.py
+++ b/tests/test_sampling_manual.py
@@ -2,6 +2,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
+import json
+
 from utils import weblog, interfaces, scenarios, features
 from utils._weblog import HttpResponse
 from utils.dd_constants import SamplingPriority
@@ -37,7 +39,7 @@ def _assert_decision_propagated_downstream(request: HttpResponse, expected: Samp
     """The endpoint calls downstream once the decision has been applied, and reports the headers it
     sent. The propagated priority must be the manual decision, not the upstream one.
     """
-    request_headers = request.json()["request_headers"]
+    request_headers = json.loads(request.text)["request_headers"]
 
     # Case-insensitive lookup, as the header casing depends on the weblog app implementation, and some
     # weblogs report the headers as a list of objects instead of a dict

--- a/tests/test_sampling_manual.py
+++ b/tests/test_sampling_manual.py
@@ -1,0 +1,63 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+from utils import weblog, interfaces, scenarios, features
+from utils._weblog import HttpResponse
+from utils.dd_constants import SamplingPriority
+
+# Arbitrary upstream trace context, the ids only have to be stable and non-zero
+UPSTREAM_TRACE_ID = 1212121212121212121
+UPSTREAM_PARENT_ID = 34343434
+
+
+def _upstream_headers(sampling_priority: SamplingPriority) -> dict[str, str]:
+    return {
+        "x-datadog-trace-id": str(UPSTREAM_TRACE_ID),
+        "x-datadog-parent-id": str(UPSTREAM_PARENT_ID),
+        "x-datadog-sampling-priority": str(int(sampling_priority)),
+    }
+
+
+def _get_sampling_priority(request: HttpResponse) -> int:
+    """Sampling priority is reported on the local root span of the trace chunk, which is the
+    weblog span here, as the trace is continued from an upstream service.
+    """
+    priorities = {
+        span["metrics"]["_sampling_priority_v1"]
+        for _, _, span in interfaces.library.get_spans(request=request)
+        if "_sampling_priority_v1" in span.get("metrics", {})
+    }
+
+    assert priorities, "No span reported a _sampling_priority_v1 metric for that request"
+    assert len(priorities) == 1, f"Spans of the same trace disagree on the sampling priority: {priorities}"
+
+    return priorities.pop()
+
+
+@scenarios.sampling
+@features.ensure_that_sampling_is_consistent_across_languages
+class Test_Manual_Sampling:
+    """The manual keep/drop API overrides the sampling decision transmitted by an upstream service"""
+
+    def setup_manual_keep_overrides_upstream_drop(self):
+        self.r_keep = weblog.get(
+            "/trace/manual_keep_drop",
+            params={"decision": "keep"},
+            headers=_upstream_headers(SamplingPriority.AUTO_REJECT),
+        )
+
+    def test_manual_keep_overrides_upstream_drop(self):
+        assert self.r_keep.status_code == 200
+        assert _get_sampling_priority(self.r_keep) == SamplingPriority.USER_KEEP
+
+    def setup_manual_drop_overrides_upstream_keep(self):
+        self.r_drop = weblog.get(
+            "/trace/manual_keep_drop",
+            params={"decision": "drop"},
+            headers=_upstream_headers(SamplingPriority.USER_KEEP),
+        )
+
+    def test_manual_drop_overrides_upstream_keep(self):
+        assert self.r_drop.status_code == 200
+        assert _get_sampling_priority(self.r_drop) == SamplingPriority.USER_REJECT

--- a/tests/test_sampling_manual.py
+++ b/tests/test_sampling_manual.py
@@ -19,6 +19,20 @@ def _upstream_headers(sampling_priority: SamplingPriority) -> dict[str, str]:
     }
 
 
+def _assert_upstream_trace_continued(request: HttpResponse) -> None:
+    """Without this check, a weblog that does not extract the upstream context at all would start a
+    fresh trace, and the manual decision alone would still yield the expected priority.
+    """
+    spans = [span for _, _, span in interfaces.library.get_spans(request=request)]
+    assert spans, "No span reported for that request"
+
+    trace_ids = {span["trace_id"] for span in spans}
+    assert trace_ids == {UPSTREAM_TRACE_ID}, f"Spans do not belong to the upstream trace: {trace_ids}"
+
+    parent_ids = {span.get("parent_id") for span in spans}
+    assert UPSTREAM_PARENT_ID in parent_ids, f"No span is a child of the upstream span: {parent_ids}"
+
+
 def _get_sampling_priority(request: HttpResponse) -> int:
     """Sampling priority is reported on the local root span of the trace chunk, which is the
     weblog span here, as the trace is continued from an upstream service.
@@ -49,6 +63,7 @@ class Test_Manual_Sampling:
 
     def test_manual_keep_overrides_upstream_drop(self):
         assert self.r_keep.status_code == 200
+        _assert_upstream_trace_continued(self.r_keep)
         assert _get_sampling_priority(self.r_keep) == SamplingPriority.USER_KEEP
 
     def setup_manual_drop_overrides_upstream_keep(self):
@@ -60,4 +75,5 @@ class Test_Manual_Sampling:
 
     def test_manual_drop_overrides_upstream_keep(self):
         assert self.r_drop.status_code == 200
+        _assert_upstream_trace_continued(self.r_drop)
         assert _get_sampling_priority(self.r_drop) == SamplingPriority.USER_REJECT

--- a/utils/build/docker/dotnet/weblog/Endpoints/ManualKeepDropEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/ManualKeepDropEndpoint.cs
@@ -1,11 +1,28 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
 using Datadog.Trace;
 
 namespace weblog
 {
     public class ManualKeepDropEndpoint : ISystemTestEndpoint
     {
+        private const string DownstreamUrl = "http://localhost:7777/";
+
+        private class EndpointResponse
+        {
+            [JsonPropertyName("url")]
+            public string? Url { get; set; }
+            [JsonPropertyName("status_code")]
+            public int StatusCode { get; set; }
+            [JsonPropertyName("request_headers")]
+            public Dictionary<string, string>? RequestHeaders { get; set; }
+            [JsonPropertyName("response_headers")]
+            public Dictionary<string, string>? ResponseHeaders { get; set; }
+        }
+
         public void Register(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder routeBuilder)
         {
             routeBuilder.MapGet("/trace/manual_keep_drop", async context =>
@@ -21,7 +38,17 @@ namespace weblog
                 var span = Tracer.Instance.ActiveScope?.Span;
                 span?.SetTag(decision == "keep" ? Tags.ManualKeep : Tags.ManualDrop, "true");
 
-                await context.Response.WriteAsync("OK\\n");
+                // Call downstream so that tests can assert on the sampling decision that gets propagated
+                var response = await HttpClientWrapper.LocalGetRequest(DownstreamUrl);
+                var endpointResponse = new EndpointResponse()
+                {
+                    Url = DownstreamUrl,
+                    StatusCode = (int)response.StatusCode,
+                    RequestHeaders = response.RequestMessage?.Headers.Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value.First())).ToDictionary(),
+                    ResponseHeaders = response.Headers.Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value.First())).ToDictionary(),
+                };
+
+                await context.Response.WriteAsJsonAsync(endpointResponse);
             });
         }
     }

--- a/utils/build/docker/dotnet/weblog/Endpoints/ManualKeepDropEndpoint.cs
+++ b/utils/build/docker/dotnet/weblog/Endpoints/ManualKeepDropEndpoint.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Datadog.Trace;
+
+namespace weblog
+{
+    public class ManualKeepDropEndpoint : ISystemTestEndpoint
+    {
+        public void Register(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder routeBuilder)
+        {
+            routeBuilder.MapGet("/trace/manual_keep_drop", async context =>
+            {
+                string? decision = context.Request.Query["decision"];
+                if (decision != "keep" && decision != "drop")
+                {
+                    context.Response.StatusCode = 400;
+                    await context.Response.WriteAsync("decision must be keep or drop\\n");
+                    return;
+                }
+
+                var span = Tracer.Instance.ActiveScope?.Span;
+                span?.SetTag(decision == "keep" ? Tags.ManualKeep : Tags.ManualDrop, "true");
+
+                await context.Response.WriteAsync("OK\\n");
+            });
+        }
+    }
+}

--- a/utils/build/docker/golang/app/_shared/common/common.go
+++ b/utils/build/docker/golang/app/_shared/common/common.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 )
 
@@ -26,6 +27,30 @@ func InitDatadog() {
 	span := tracer.StartSpan("init.service")
 	defer span.Finish()
 	span.SetTag("whip", "done")
+}
+
+// ManualKeepDrop forces the sampling decision of the trace the request belongs to,
+// based on the mandatory `decision` query parameter (either "keep" or "drop").
+func ManualKeepDrop(w http.ResponseWriter, r *http.Request) {
+	span, ok := tracer.SpanFromContext(r.Context())
+	if !ok {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("no active span"))
+		return
+	}
+
+	switch r.URL.Query().Get("decision") {
+	case "keep":
+		span.SetTag(ext.ManualKeep, true)
+	case "drop":
+		span.SetTag(ext.ManualDrop, true)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("decision must be keep or drop"))
+		return
+	}
+
+	w.Write([]byte("OK"))
 }
 
 func ParseBody(r *http.Request) (interface{}, error) {

--- a/utils/build/docker/golang/app/_shared/common/common.go
+++ b/utils/build/docker/golang/app/_shared/common/common.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
@@ -30,7 +31,8 @@ func InitDatadog() {
 }
 
 // ManualKeepDrop forces the sampling decision of the trace the request belongs to,
-// based on the mandatory `decision` query parameter (either "keep" or "drop").
+// based on the mandatory `decision` query parameter (either "keep" or "drop"), then calls
+// downstream so that tests can assert on the sampling decision that gets propagated.
 func ManualKeepDrop(w http.ResponseWriter, r *http.Request) {
 	span, ok := tracer.SpanFromContext(r.Context())
 	if !ok {
@@ -50,7 +52,44 @@ func ManualKeepDrop(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write([]byte("OK"))
+	const url = "http://localhost:7777/"
+	req, _ := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
+	// Inject the current span's context into req.Header so the headers are visible after
+	// client.Do, which injects into a cloned request.
+	tracer.Inject(span.Context(), tracer.HTTPHeadersCarrier(req.Header))
+
+	res, err := httpClient().Do(req)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	defer res.Body.Close()
+
+	requestHeaders := make(map[string]string, len(req.Header))
+	for key, values := range req.Header {
+		requestHeaders[strings.ToLower(key)] = strings.Join(values, ",")
+	}
+
+	responseHeaders := make(map[string]string, len(res.Header))
+	for key, values := range res.Header {
+		responseHeaders[key] = strings.Join(values, ",")
+	}
+
+	jsonResponse, err := json.Marshal(struct {
+		URL             string            `json:"url"`
+		StatusCode      int               `json:"status_code"`
+		RequestHeaders  map[string]string `json:"request_headers"`
+		ResponseHeaders map[string]string `json:"response_headers"`
+	}{URL: url, StatusCode: res.StatusCode, RequestHeaders: requestHeaders, ResponseHeaders: responseHeaders})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonResponse)
 }
 
 func ParseBody(r *http.Request) (interface{}, error) {

--- a/utils/build/docker/golang/app/chi/main.go
+++ b/utils/build/docker/golang/app/chi/main.go
@@ -151,6 +151,8 @@ func main() {
 		w.Write([]byte("OK"))
 	})
 
+	mux.HandleFunc("/trace/manual_keep_drop", common.ManualKeepDrop)
+
 	mux.HandleFunc("/make_distant_call", func(w http.ResponseWriter, r *http.Request) {
 		url := r.URL.Query().Get("url")
 		if url == "" {

--- a/utils/build/docker/golang/app/echo/main.go
+++ b/utils/build/docker/golang/app/echo/main.go
@@ -167,6 +167,8 @@ func main() {
 		return c.String(rCode, "OK")
 	})
 
+	r.Any("/trace/manual_keep_drop", echoHandleFunc(common.ManualKeepDrop))
+
 	r.Any("/make_distant_call", func(c echo.Context) error {
 		url := c.Request().URL.Query().Get("url")
 		if url == "" {

--- a/utils/build/docker/golang/app/gin/main.go
+++ b/utils/build/docker/golang/app/gin/main.go
@@ -157,6 +157,8 @@ func main() {
 		ctx.Writer.Write([]byte("OK"))
 	})
 
+	r.Any("/trace/manual_keep_drop", ginHandleFunc(common.ManualKeepDrop))
+
 	r.Any("/make_distant_call", func(ctx *gin.Context) {
 		url := ctx.Request.URL.Query().Get("url")
 		if url == "" {

--- a/utils/build/docker/golang/app/gqlgen/server.go
+++ b/utils/build/docker/golang/app/gqlgen/server.go
@@ -48,6 +48,8 @@ func main() {
 		w.Write([]byte("Hello world!\n"))
 	})
 
+	mux.HandleFunc("/trace/manual_keep_drop", common.ManualKeepDrop)
+
 	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
 
 		healthCheck, err := common.GetHealtchCheck()

--- a/utils/build/docker/golang/app/graph-gophers/main.go
+++ b/utils/build/docker/golang/app/graph-gophers/main.go
@@ -61,6 +61,8 @@ func main() {
 		w.Write([]byte("Hello world!\n"))
 	})
 
+	mux.HandleFunc("/trace/manual_keep_drop", common.ManualKeepDrop)
+
 	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
 
 		healthCheck, err := common.GetHealtchCheck()

--- a/utils/build/docker/golang/app/graphql-go/main.go
+++ b/utils/build/docker/golang/app/graphql-go/main.go
@@ -89,6 +89,8 @@ func main() {
 		w.Write([]byte("Hello world!\n"))
 	})
 
+	mux.HandleFunc("/trace/manual_keep_drop", common.ManualKeepDrop)
+
 	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
 
 		healthCheck, err := common.GetHealtchCheck()

--- a/utils/build/docker/golang/app/net-http-orchestrion/main.go
+++ b/utils/build/docker/golang/app/net-http-orchestrion/main.go
@@ -145,6 +145,8 @@ func main() {
 		w.Write([]byte("OK"))
 	})
 
+	mux.HandleFunc("/trace/manual_keep_drop", common.ManualKeepDrop)
+
 	mux.HandleFunc("/make_distant_call", func(w http.ResponseWriter, r *http.Request) {
 		url := r.URL.Query().Get("url")
 		if url == "" {

--- a/utils/build/docker/golang/app/net-http-span-pool/main.go
+++ b/utils/build/docker/golang/app/net-http-span-pool/main.go
@@ -188,6 +188,8 @@ func main() {
 		w.Write([]byte("OK"))
 	})
 
+	mux.HandleFunc("/trace/manual_keep_drop", common.ManualKeepDrop)
+
 	mux.HandleFunc("/make_distant_call", func(w http.ResponseWriter, r *http.Request) {
 		url := r.URL.Query().Get("url")
 		if url == "" {

--- a/utils/build/docker/golang/app/net-http/main.go
+++ b/utils/build/docker/golang/app/net-http/main.go
@@ -193,6 +193,8 @@ func main() {
 
 	mux.HandleFunc("/spawn_child", common.SpawnChild)
 
+	mux.HandleFunc("/trace/manual_keep_drop", common.ManualKeepDrop)
+
 	mux.HandleFunc("/make_distant_call", func(w http.ResponseWriter, r *http.Request) {
 		url := r.URL.Query().Get("url")
 		if url == "" {

--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
@@ -204,7 +204,8 @@ object AppSecRoutes {
               if (span != null) {
                 span.setTag(if (decision == "keep") DDTags.MANUAL_KEEP else DDTags.MANUAL_DROP, true)
               }
-              complete(StatusCodes.OK, "OK")
+              // Call downstream so that tests can assert on the sampling decision that gets propagated
+              complete(StatusCodes.OK, makeDistantCall("http://localhost:7777/"))(Marshaller.futureMarshaller(jsonMarshaller))
             }
           }
         }

--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import datadog.appsec.api.blocking.Blocking
+import datadog.trace.api.DDTags
 import datadog.trace.api.interceptor.MutableSpan
 import io.opentracing.util.GlobalTracer
 import com.datadoghq.system_tests.iast.utils.Utils
@@ -191,6 +192,21 @@ object AppSecRoutes {
       path("waf" / RemainingPath) { remaining: Path =>
         get {
           complete(remaining.toString())
+        }
+      } ~
+      path("trace" / "manual_keep_drop") {
+        get {
+          parameter("decision") { decision =>
+            if (decision != "keep" && decision != "drop") {
+              complete(StatusCodes.BadRequest, "decision must be keep or drop")
+            } else {
+              val span = GlobalTracer.get().activeSpan()
+              if (span != null) {
+                span.setTag(if (decision == "keep") DDTags.MANUAL_KEEP else DDTags.MANUAL_DROP, true)
+              }
+              complete(StatusCodes.OK, "OK")
+            }
+          }
         }
       } ~
       path("make_distant_call") {

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
@@ -402,7 +402,7 @@ public class MyResource {
 
     @GET
     @Path("/trace/manual_keep_drop")
-    public Response traceManualKeepDrop(@QueryParam("decision") String decision) {
+    public Response traceManualKeepDrop(@QueryParam("decision") String decision) throws Exception {
         if (!"keep".equals(decision) && !"drop".equals(decision)) {
             return Response.status(400).entity("decision must be keep or drop").build();
         }
@@ -412,7 +412,10 @@ public class MyResource {
             span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
         }
 
-        return Response.ok("OK").build();
+        // Call downstream so that tests can assert on the sampling decision that gets propagated
+        String result = new ObjectMapper().writeValueAsString(make_distant_call("http://localhost:7777/"));
+
+        return Response.ok(result).type(MediaType.APPLICATION_JSON).build();
     }
 
     @GET

--- a/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
+++ b/utils/build/docker/java/jersey-grizzly2/src/main/java/com/datadoghq/jersey/MyResource.java
@@ -6,6 +6,7 @@ import static java.util.Collections.emptyMap;
 import com.datadoghq.system_tests.iast.utils.*;
 import datadog.appsec.api.blocking.Blocking;
 import datadog.appsec.api.login.EventTrackerV2;
+import datadog.trace.api.DDTags;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
@@ -397,6 +398,21 @@ public class MyResource {
         headers.getRequestHeaders().forEach((name, values) ->
             values.forEach(value -> System.out.println(name + ": " + value)));
         return Response.status(statusCode).entity("ok").build();
+    }
+
+    @GET
+    @Path("/trace/manual_keep_drop")
+    public Response traceManualKeepDrop(@QueryParam("decision") String decision) {
+        if (!"keep".equals(decision) && !"drop".equals(decision)) {
+            return Response.status(400).entity("decision must be keep or drop").build();
+        }
+
+        final Span span = GlobalTracer.get().activeSpan();
+        if (span != null) {
+            span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
+        }
+
+        return Response.ok("OK").build();
     }
 
     @GET

--- a/utils/build/docker/java/play/app/controllers/AppSecController.scala
+++ b/utils/build/docker/java/play/app/controllers/AppSecController.scala
@@ -184,19 +184,24 @@ class AppSecController @Inject()(cc: MessagesControllerComponents, ws: WSClient,
     }
   }
 
-  def traceManualKeepDrop(decision: String) = Action {
+  def traceManualKeepDrop(decision: String) = Action.async {
     if (decision != "keep" && decision != "drop") {
-      Results.BadRequest("decision must be keep or drop")
+      Future.successful(Results.BadRequest("decision must be keep or drop"))
     } else {
       val span = GlobalTracer.get().activeSpan()
       if (span != null) {
         span.setTag(if (decision == "keep") DDTags.MANUAL_KEEP else DDTags.MANUAL_DROP, true)
       }
-      Results.Ok("OK")
+      // Call downstream so that tests can assert on the sampling decision that gets propagated
+      makeDistantCall("http://localhost:7777/")
     }
   }
 
   def distantCall(url: String) = Action.async {
+    makeDistantCall(url)
+  }
+
+  private def makeDistantCall(url: String): Future[Result] = {
     val remoteReq: WSRequest = ws.url(url).withMethod("GET")
 
     // we need to break the abstraction to be able to get to the request headers

--- a/utils/build/docker/java/play/app/controllers/AppSecController.scala
+++ b/utils/build/docker/java/play/app/controllers/AppSecController.scala
@@ -4,6 +4,7 @@ import akka.stream.Materializer
 import akka.stream.javadsl.Sink
 import akka.util.ByteString
 import datadog.appsec.api.blocking.Blocking
+import datadog.trace.api.DDTags
 import datadog.trace.api.interceptor.MutableSpan
 import io.opentracing.util.GlobalTracer
 import play.api.libs.json.{JsValue, Json, Writes}
@@ -180,6 +181,18 @@ class AppSecController @Inject()(cc: MessagesControllerComponents, ws: WSClient,
         Results.Ok(data)
       case anything =>
         Results.Ok(anything.toString)
+    }
+  }
+
+  def traceManualKeepDrop(decision: String) = Action {
+    if (decision != "keep" && decision != "drop") {
+      Results.BadRequest("decision must be keep or drop")
+    } else {
+      val span = GlobalTracer.get().activeSpan()
+      if (span != null) {
+        span.setTag(if (decision == "keep") DDTags.MANUAL_KEEP else DDTags.MANUAL_DROP, true)
+      }
+      Results.Ok("OK")
     }
   }
 

--- a/utils/build/docker/java/play/conf/routes
+++ b/utils/build/docker/java/play/conf/routes
@@ -12,6 +12,7 @@ GET  /waf                      controllers.AppSecController.waf
 GET  /waf/                      controllers.AppSecController.waf
 GET  /waf/*segments            controllers.AppSecController.params(segments: Seq[String])
 POST /waf                      controllers.AppSecController.wafPost
+GET  /trace/manual_keep_drop   controllers.AppSecController.traceManualKeepDrop(decision: String)
 GET  /make_distant_call        controllers.AppSecController.distantCall(url: String)
 GET  /status                   controllers.AppSecController.status(code: Int)
 GET  /stats-unique             controllers.AppSecController.statsUnique(code: Option[Int])

--- a/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
+++ b/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
@@ -7,6 +7,7 @@ import static ratpack.jackson.Jackson.json;
 import com.datadoghq.system_tests.iast.infra.SqlServer;
 import com.datadoghq.system_tests.iast.utils.CryptoExamples;
 import datadog.appsec.api.login.EventTrackerV2;
+import datadog.trace.api.DDTags;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.internal.InternalTracer;
 import io.opentracing.Span;
@@ -172,6 +173,20 @@ public class Main {
                                 }
                                 response.getHeaders().add("content-language", "en-US");
                                 response.send("text/plain", "Response with more than 50 headers");
+                            })
+                            .get("trace/manual_keep_drop", ctx -> {
+                                String decision = ctx.getRequest().getQueryParams().get("decision");
+                                if (!"keep".equals(decision) && !"drop".equals(decision)) {
+                                    ctx.getResponse().status(400).send("decision must be keep or drop");
+                                    return;
+                                }
+
+                                final Span span = GlobalTracer.get().activeSpan();
+                                if (span != null) {
+                                    span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
+                                }
+
+                                ctx.getResponse().status(200).send("OK");
                             })
                             .get("make_distant_call", ctx -> {
                                 final Promise<String> res = Blocking.get(() -> {

--- a/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
+++ b/utils/build/docker/java/ratpack/src/main/java/com/datadoghq/ratpack/Main.java
@@ -186,7 +186,47 @@ public class Main {
                                     span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
                                 }
 
-                                ctx.getResponse().status(200).send("OK");
+                                // Call downstream so that tests can assert on the sampling decision that gets propagated
+                                final Promise<String> downstream = Blocking.get(() -> {
+                                    String url = "http://localhost:7777/";
+
+                                    URL urlObject = new URL(url);
+
+                                    HttpURLConnection con = (HttpURLConnection) urlObject.openConnection();
+                                    con.setRequestMethod("GET");
+
+                                    // Save request headers
+                                    HashMap<String, String> request_headers = new HashMap<String, String>();
+                                    for (Map.Entry<String, List<String>> header : con.getRequestProperties().entrySet()) {
+                                        if (header.getKey() == null) {
+                                            continue;
+                                        }
+
+                                        request_headers.put(header.getKey(), header.getValue().get(0));
+                                    }
+
+                                    // Save response headers and status code
+                                    int status_code = con.getResponseCode();
+                                    HashMap<String, String> response_headers = new HashMap<String, String>();
+                                    for (Map.Entry<String, List<String>> header : con.getHeaderFields().entrySet()) {
+                                        if (header.getKey() == null) {
+                                            continue;
+                                        }
+
+                                        response_headers.put(header.getKey(), header.getValue().get(0));
+                                    }
+
+                                    DistantCallResponse result = new DistantCallResponse();
+                                    result.url = url;
+                                    result.status_code = status_code;
+                                    result.request_headers = request_headers;
+                                    result.response_headers = response_headers;
+
+                                    return (new ObjectMapper()).writeValueAsString(result);
+                                });
+                                downstream.then((r) -> {
+                                    ctx.getResponse().send("application/json", r);
+                                });
                             })
                             .get("make_distant_call", ctx -> {
                                 final Promise<String> res = Blocking.get(() -> {

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import datadog.appsec.api.blocking.Blocking;
 import datadog.appsec.api.login.EventTrackerV2;
+import datadog.trace.api.DDTags;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
@@ -466,6 +467,21 @@ public class MyResource {
         headers.getRequestHeaders().forEach((name, values) ->
             values.forEach(value -> System.out.println(name + ": " + value)));
         return Response.status(statusCode).entity("ok").build();
+    }
+
+    @GET
+    @Path("/trace/manual_keep_drop")
+    public Response traceManualKeepDrop(@QueryParam("decision") String decision) {
+        if (!"keep".equals(decision) && !"drop".equals(decision)) {
+            return Response.status(400).entity("decision must be keep or drop").build();
+        }
+
+        final Span span = GlobalTracer.get().activeSpan();
+        if (span != null) {
+            span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
+        }
+
+        return Response.ok("OK").build();
     }
 
     @GET

--- a/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
+++ b/utils/build/docker/java/resteasy-netty3/src/main/java/com/datadoghq/resteasy/MyResource.java
@@ -471,7 +471,7 @@ public class MyResource {
 
     @GET
     @Path("/trace/manual_keep_drop")
-    public Response traceManualKeepDrop(@QueryParam("decision") String decision) {
+    public Response traceManualKeepDrop(@QueryParam("decision") String decision) throws Exception {
         if (!"keep".equals(decision) && !"drop".equals(decision)) {
             return Response.status(400).entity("decision must be keep or drop").build();
         }
@@ -481,7 +481,10 @@ public class MyResource {
             span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
         }
 
-        return Response.ok("OK").build();
+        // Call downstream so that tests can assert on the sampling decision that gets propagated
+        String result = new ObjectMapper().writeValueAsString(make_distant_call("http://localhost:7777/"));
+
+        return Response.ok(result).type(MediaType.APPLICATION_JSON).build();
     }
 
     @GET

--- a/utils/build/docker/java/spring-boot-3-native/src/main/java/com/datadoghq/springbootnative/WebController.java
+++ b/utils/build/docker/java/spring-boot-3-native/src/main/java/com/datadoghq/springbootnative/WebController.java
@@ -178,7 +178,7 @@ public class WebController {
   }
 
   @RequestMapping("/trace/manual_keep_drop")
-  ResponseEntity<String> traceManualKeepDrop(@RequestParam String decision) {
+  ResponseEntity<?> traceManualKeepDrop(@RequestParam String decision) throws Exception {
     if (!"keep".equals(decision) && !"drop".equals(decision)) {
       return ResponseEntity.badRequest().body("decision must be keep or drop");
     }
@@ -188,7 +188,8 @@ public class WebController {
       span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
     }
 
-    return ResponseEntity.ok("OK");
+    // Call downstream so that tests can assert on the sampling decision that gets propagated
+    return ResponseEntity.ok(make_distant_call("http://localhost:7777/"));
   }
 
   @RequestMapping("/make_distant_call")

--- a/utils/build/docker/java/spring-boot-3-native/src/main/java/com/datadoghq/springbootnative/WebController.java
+++ b/utils/build/docker/java/spring-boot-3-native/src/main/java/com/datadoghq/springbootnative/WebController.java
@@ -3,6 +3,9 @@ package com.datadoghq.springbootnative;
 import static datadog.appsec.api.user.User.setUser;
 
 import datadog.appsec.api.login.EventTrackerV2;
+import datadog.trace.api.DDTags;
+import io.opentracing.Span;
+import io.opentracing.util.GlobalTracer;
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -172,6 +175,20 @@ public class WebController {
     metadata.put("scope", "usr.scope");
     setUser("usr.id", metadata);
     return "OK";
+  }
+
+  @RequestMapping("/trace/manual_keep_drop")
+  ResponseEntity<String> traceManualKeepDrop(@RequestParam String decision) {
+    if (!"keep".equals(decision) && !"drop".equals(decision)) {
+      return ResponseEntity.badRequest().body("decision must be keep or drop");
+    }
+
+    final Span span = GlobalTracer.get().activeSpan();
+    if (span != null) {
+      span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
+    }
+
+    return ResponseEntity.ok("OK");
   }
 
   @RequestMapping("/make_distant_call")

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -1059,7 +1059,7 @@ public class App {
     }
 
     @RequestMapping("/trace/manual_keep_drop")
-    ResponseEntity<String> traceManualKeepDrop(@RequestParam String decision) {
+    ResponseEntity<?> traceManualKeepDrop(@RequestParam String decision) throws Exception {
         if (!"keep".equals(decision) && !"drop".equals(decision)) {
             return ResponseEntity.badRequest().body("decision must be keep or drop");
         }
@@ -1069,7 +1069,8 @@ public class App {
             span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
         }
 
-        return ResponseEntity.ok("OK");
+        // Call downstream so that tests can assert on the sampling decision that gets propagated
+        return ResponseEntity.ok(make_distant_call("http://localhost:7777/"));
     }
 
     @RequestMapping("/make_distant_call")

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -126,6 +126,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import datadog.trace.api.DDTags;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
 
@@ -1055,6 +1056,20 @@ public class App {
         }
 
         return "hi OGNL";
+    }
+
+    @RequestMapping("/trace/manual_keep_drop")
+    ResponseEntity<String> traceManualKeepDrop(@RequestParam String decision) {
+        if (!"keep".equals(decision) && !"drop".equals(decision)) {
+            return ResponseEntity.badRequest().body("decision must be keep or drop");
+        }
+
+        final Span span = GlobalTracer.get().activeSpan();
+        if (span != null) {
+            span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
+        }
+
+        return ResponseEntity.ok("OK");
     }
 
     @RequestMapping("/make_distant_call")

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
@@ -13,6 +13,7 @@ import com.datadoghq.vertx3.rasp.Api10RouteProvider;
 import com.datadoghq.vertx3.rasp.RaspRouteProvider;
 import datadog.appsec.api.blocking.Blocking;
 import datadog.appsec.api.login.EventTrackerV2;
+import datadog.trace.api.DDTags;
 import datadog.trace.api.EventTracker;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
@@ -404,6 +405,20 @@ public class Main {
                     setRootSpanTag("service", serviceName);
                     ctx.response().end("ok");
                 });
+        router.get("/trace/manual_keep_drop").handler(ctx -> {
+            String decision = ctx.request().getParam("decision");
+            if (!"keep".equals(decision) && !"drop".equals(decision)) {
+                ctx.response().setStatusCode(400).end("decision must be keep or drop");
+                return;
+            }
+
+            final Span span = GlobalTracer.get().activeSpan();
+            if (span != null) {
+                span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
+            }
+
+            ctx.response().end("OK");
+        });
         router.get("/make_distant_call").handler(ctx -> {
             String url = ctx.request().getParam("url");
             JsonObject requestHeaders = new JsonObject();

--- a/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
+++ b/utils/build/docker/java/vertx3/src/main/java/com/datadoghq/vertx3/Main.java
@@ -417,7 +417,51 @@ public class Main {
                 span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
             }
 
-            ctx.response().end("OK");
+            // Call downstream so that tests can assert on the sampling decision that gets propagated
+            String url = "http://localhost:7777/";
+            JsonObject requestHeaders = new JsonObject();
+
+            OkHttpClient client = new OkHttpClient.Builder()
+            .addNetworkInterceptor(chain -> { // Save request headers
+                Request request = chain.request();
+                Response response = chain.proceed(request);
+                Headers finalHeaders = request.headers();
+                for (String name : finalHeaders.names()) {
+                    requestHeaders.put(name, finalHeaders.get(name));
+                }
+
+                return response;
+            })
+            .build();
+
+            Request request = new Request.Builder()
+                    .url(url)
+                    .get()
+                    .build();
+
+            client.newCall(request).enqueue(new Callback() {
+                @Override
+                public void onFailure(Call call, IOException e) {
+                    ctx.response().setStatusCode(500).end(e.getMessage());
+                }
+
+                @Override
+                public void onResponse(Call call, Response response) throws IOException {
+                    JsonObject responseHeaders = new JsonObject();
+                    Headers headers = response.headers();
+                    for (String name : headers.names()) {
+                        responseHeaders.put(name, headers.get(name));
+                    }
+
+                    JsonObject result = new JsonObject();
+                    result.put("url", url);
+                    result.put("status_code", response.code());
+                    result.put("request_headers", requestHeaders);
+                    result.put("response_headers", responseHeaders);
+
+                    ctx.response().end(result.encodePrettily());
+                }
+            });
         });
         router.get("/make_distant_call").handler(ctx -> {
             String url = ctx.request().getParam("url");

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
@@ -12,6 +12,7 @@ import com.datadoghq.vertx4.iast.routes.IastSamplingRouteProvider;
 import com.datadoghq.vertx4.rasp.RaspRouteProvider;
 import datadog.appsec.api.blocking.Blocking;
 import datadog.appsec.api.login.EventTrackerV2;
+import datadog.trace.api.DDTags;
 import datadog.trace.api.EventTracker;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
@@ -402,6 +403,21 @@ public class Main {
                     setRootSpanTag("service", serviceName);
                     ctx.response().end("ok");
                 });
+
+        router.get("/trace/manual_keep_drop").handler(ctx -> {
+            String decision = ctx.request().getParam("decision");
+            if (!"keep".equals(decision) && !"drop".equals(decision)) {
+                ctx.response().setStatusCode(400).end("decision must be keep or drop");
+                return;
+            }
+
+            final Span span = GlobalTracer.get().activeSpan();
+            if (span != null) {
+                span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
+            }
+
+            ctx.response().end("OK");
+        });
 
         router.get("/make_distant_call").handler(ctx -> {
             String url = ctx.request().getParam("url");

--- a/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
+++ b/utils/build/docker/java/vertx4/src/main/java/com/datadoghq/vertx4/Main.java
@@ -416,7 +416,51 @@ public class Main {
                 span.setTag("keep".equals(decision) ? DDTags.MANUAL_KEEP : DDTags.MANUAL_DROP, true);
             }
 
-            ctx.response().end("OK");
+            // Call downstream so that tests can assert on the sampling decision that gets propagated
+            String url = "http://localhost:7777/";
+            JsonObject requestHeaders = new JsonObject();
+
+            OkHttpClient client = new OkHttpClient.Builder()
+            .addNetworkInterceptor(chain -> { // Save request headers
+                Request request = chain.request();
+                Response response = chain.proceed(request);
+                Headers finalHeaders = request.headers();
+                for (String name : finalHeaders.names()) {
+                    requestHeaders.put(name, finalHeaders.get(name));
+                }
+
+                return response;
+            })
+            .build();
+
+            Request request = new Request.Builder()
+                    .url(url)
+                    .get()
+                    .build();
+
+            client.newCall(request).enqueue(new Callback() {
+                @Override
+                public void onFailure(Call call, IOException e) {
+                    ctx.response().setStatusCode(500).end(e.getMessage());
+                }
+
+                @Override
+                public void onResponse(Call call, Response response) throws IOException {
+                    JsonObject responseHeaders = new JsonObject();
+                    Headers headers = response.headers();
+                    for (String name : headers.names()) {
+                        responseHeaders.put(name, headers.get(name));
+                    }
+
+                    JsonObject result = new JsonObject();
+                    result.put("url", url);
+                    result.put("status_code", response.code());
+                    result.put("request_headers", requestHeaders);
+                    result.put("response_headers", responseHeaders);
+
+                    ctx.response().end(result.encodePrettily());
+                }
+            });
         });
 
         router.get("/make_distant_call").handler(ctx -> {

--- a/utils/build/docker/nodejs/express/app.js
+++ b/utils/build/docker/nodejs/express/app.js
@@ -9,7 +9,7 @@ if (process.env.CONFIG_CHAINING_TEST) {
 }
 
 const tracer = require('dd-trace').init(opts)
-const { MANUAL_KEEP, MANUAL_DROP } = require('dd-trace/ext')
+const { tags: { MANUAL_KEEP, MANUAL_DROP } } = require('dd-trace/ext')
 
 const { promisify } = require('util')
 const app = require('express')()

--- a/utils/build/docker/nodejs/express/app.js
+++ b/utils/build/docker/nodejs/express/app.js
@@ -9,6 +9,7 @@ if (process.env.CONFIG_CHAINING_TEST) {
 }
 
 const tracer = require('dd-trace').init(opts)
+const { MANUAL_KEEP, MANUAL_DROP } = require('dd-trace/ext')
 
 const { promisify } = require('util')
 const app = require('express')()
@@ -212,6 +213,18 @@ app.get('/session/new', (req, res) => {
 
 app.get('/status', (req, res) => {
   res.status(parseInt(req.query.code) || 400).send('OK')
+})
+
+app.get('/trace/manual_keep_drop', (req, res) => {
+  const decision = req.query.decision
+
+  if (decision !== 'keep' && decision !== 'drop') {
+    return res.status(400).send('decision must be keep or drop')
+  }
+
+  tracer.scope().active().setTag(decision === 'keep' ? MANUAL_KEEP : MANUAL_DROP, true)
+
+  res.send('OK')
 })
 
 app.get('/make_distant_call', (req, res) => {

--- a/utils/build/docker/nodejs/express/app.js
+++ b/utils/build/docker/nodejs/express/app.js
@@ -224,7 +224,27 @@ app.get('/trace/manual_keep_drop', (req, res) => {
 
   tracer.scope().active().setTag(decision === 'keep' ? MANUAL_KEEP : MANUAL_DROP, true)
 
-  res.send('OK')
+  // Call downstream so that tests can assert on the sampling decision that gets propagated
+  const url = 'http://localhost:7777/'
+  const request = http.request({ hostname: 'localhost', port: 7777, path: '/', method: 'GET' }, (response) => {
+    response.on('data', () => {})
+
+    response.on('end', () => {
+      res.json({
+        url,
+        status_code: response.statusCode,
+        request_headers: response.req.getHeaders(),
+        response_headers: response.headers
+      })
+    })
+  })
+
+  request.on('error', (error) => {
+    console.log(error)
+    res.status(500).send(error.message)
+  })
+
+  request.end()
 })
 
 app.get('/make_distant_call', (req, res) => {

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -156,7 +156,27 @@ app.get("/trace/manual_keep_drop", (req: Request, res: Response) => {
 
   tracer.scope().active().setTag(decision === 'keep' ? MANUAL_KEEP : MANUAL_DROP, true);
 
-  res.send('OK');
+  // Call downstream so that tests can assert on the sampling decision that gets propagated
+  const url = 'http://localhost:7777/'
+  const request = http.request({ hostname: 'localhost', port: 7777, path: '/', method: 'GET' }, (response: http.IncomingMessage) => {
+    response.on('data', () => {})
+
+    response.on('end', () => {
+      res.json({
+        url,
+        status_code: response.statusCode,
+        request_headers: response.req.getHeaders(),
+        response_headers: response.headers
+      })
+    })
+  })
+
+  request.on('error', (error: Error) => {
+    console.log(error)
+    res.status(500).send(error.message)
+  })
+
+  request.end()
 });
 
 app.get("/make_distant_call", (req: Request, res: Response) => {

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -4,6 +4,7 @@ import { Request, Response } from "express";
 import http from 'http';
 
 const tracer = require('dd-trace').init();
+const { MANUAL_KEEP, MANUAL_DROP } = require('dd-trace/ext');
 
 const { promisify } = require('util')
 const app = require('express')()
@@ -144,6 +145,18 @@ app.get('/session/new', (req: Request, res: Response) => {
 
 app.get('/status', (req: Request, res: Response) => {
   res.status(parseInt('' + req.query.code)).send('OK');
+});
+
+app.get("/trace/manual_keep_drop", (req: Request, res: Response) => {
+  const decision = req.query.decision
+
+  if (decision !== 'keep' && decision !== 'drop') {
+    return res.status(400).send('decision must be keep or drop');
+  }
+
+  tracer.scope().active().setTag(decision === 'keep' ? MANUAL_KEEP : MANUAL_DROP, true);
+
+  res.send('OK');
 });
 
 app.get("/make_distant_call", (req: Request, res: Response) => {

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -4,7 +4,7 @@ import { Request, Response } from "express";
 import http from 'http';
 
 const tracer = require('dd-trace').init();
-const { MANUAL_KEEP, MANUAL_DROP } = require('dd-trace/ext');
+const { tags: { MANUAL_KEEP, MANUAL_DROP } } = require('dd-trace/ext');
 
 const { promisify } = require('util')
 const app = require('express')()

--- a/utils/build/docker/nodejs/express4-typescript/app.ts
+++ b/utils/build/docker/nodejs/express4-typescript/app.ts
@@ -165,7 +165,7 @@ app.get("/trace/manual_keep_drop", (req: Request, res: Response) => {
       res.json({
         url,
         status_code: response.statusCode,
-        request_headers: response.req.getHeaders(),
+        request_headers: request.getHeaders(),
         response_headers: response.headers
       })
     })

--- a/utils/build/docker/nodejs/fastify/app.js
+++ b/utils/build/docker/nodejs/fastify/app.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const tracer = require('dd-trace').init()
+const { MANUAL_KEEP, MANUAL_DROP } = require('dd-trace/ext')
 
 const { promisify } = require('util')
 const axios = require('axios')
@@ -195,6 +196,19 @@ fastify.get('/session/new', async (request, reply) => {
 
 fastify.get('/status', async (request, reply) => {
   reply.status(parseInt(request.query.code))
+  return 'OK'
+})
+
+fastify.get('/trace/manual_keep_drop', async (request, reply) => {
+  const decision = request.query.decision
+
+  if (decision !== 'keep' && decision !== 'drop') {
+    reply.status(400)
+    return 'decision must be keep or drop'
+  }
+
+  tracer.scope().active().setTag(decision === 'keep' ? MANUAL_KEEP : MANUAL_DROP, true)
+
   return 'OK'
 })
 

--- a/utils/build/docker/nodejs/fastify/app.js
+++ b/utils/build/docker/nodejs/fastify/app.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const tracer = require('dd-trace').init()
-const { MANUAL_KEEP, MANUAL_DROP } = require('dd-trace/ext')
+const { tags: { MANUAL_KEEP, MANUAL_DROP } } = require('dd-trace/ext')
 
 const { promisify } = require('util')
 const axios = require('axios')

--- a/utils/build/docker/nodejs/fastify/app.js
+++ b/utils/build/docker/nodejs/fastify/app.js
@@ -209,7 +209,26 @@ fastify.get('/trace/manual_keep_drop', async (request, reply) => {
 
   tracer.scope().active().setTag(decision === 'keep' ? MANUAL_KEEP : MANUAL_DROP, true)
 
-  return 'OK'
+  // Call downstream so that tests can assert on the sampling decision that gets propagated
+  const url = 'http://localhost:7777/'
+  return new Promise((resolve, reject) => {
+    const httpRequest = http.request({ hostname: 'localhost', port: 7777, path: '/', method: 'GET' }, (response) => {
+      response.on('data', () => {})
+
+      response.on('end', () => {
+        resolve({
+          url,
+          status_code: response.statusCode,
+          request_headers: response.req.getHeaders(),
+          response_headers: response.headers
+        })
+      })
+    })
+
+    httpRequest.on('error', reject)
+
+    httpRequest.end()
+  })
 })
 
 fastify.get('/make_distant_call', async (request, reply) => {

--- a/utils/build/docker/nodejs/nextjs/src/app/trace/manual_keep_drop/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/trace/manual_keep_drop/route.js
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET (request) {
+  const decision = request.nextUrl.searchParams.get('decision')
+
+  if (decision !== 'keep' && decision !== 'drop') {
+    return new NextResponse('decision must be keep or drop', { status: 400 })
+  }
+
+  const tracer = global._ddtrace
+  tracer?.scope().active()?.setTag(decision === 'keep' ? 'manual.keep' : 'manual.drop', true)
+
+  return new NextResponse('OK')
+}

--- a/utils/build/docker/nodejs/nextjs/src/app/trace/manual_keep_drop/route.js
+++ b/utils/build/docker/nodejs/nextjs/src/app/trace/manual_keep_drop/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import http from 'http'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,5 +13,27 @@ export async function GET (request) {
   const tracer = global._ddtrace
   tracer?.scope().active()?.setTag(decision === 'keep' ? 'manual.keep' : 'manual.drop', true)
 
-  return new NextResponse('OK')
+  // Call downstream so that tests can assert on the sampling decision that gets propagated
+  const url = 'http://localhost:7777/'
+  return new Promise((resolve) => {
+    const downstream = http.request({ hostname: 'localhost', port: 7777, path: '/', method: 'GET' }, (response) => {
+      response.on('data', () => {})
+
+      response.on('end', () => {
+        resolve(NextResponse.json({
+          url,
+          status_code: response.statusCode,
+          request_headers: response.req.getHeaders(),
+          response_headers: response.headers
+        }))
+      })
+    })
+
+    downstream.on('error', (error) => {
+      console.log(error)
+      resolve(new NextResponse(error.message, { status: 500 }))
+    })
+
+    downstream.end()
+  })
 }

--- a/utils/build/docker/nodejs/parametric/server.js
+++ b/utils/build/docker/nodejs/parametric/server.js
@@ -6,7 +6,7 @@ tracer.use('express', false)
 tracer.use('http', false)
 tracer.use('dns', false)
 
-const { MANUAL_KEEP, MANUAL_DROP } = require('dd-trace/ext')
+const { tags: { MANUAL_KEEP, MANUAL_DROP } } = require('dd-trace/ext')
 const SpanContext = require('dd-trace/packages/dd-trace/src/opentracing/span_context')
 const OtelSpanContext = require('dd-trace/packages/dd-trace/src/opentelemetry/span_context')
 

--- a/utils/build/docker/php/common/rewrite-rules.conf
+++ b/utils/build/docker/php/common/rewrite-rules.conf
@@ -31,6 +31,7 @@ RewriteRule "^/otel_drop_in_baggage_api_datadog$" "/otel_drop_in_baggage_api_dat
 RewriteRule "^/otel_drop_in_extract_and_make_distant_call$" "/otel_drop_in_extract_and_make_distant_call/" [QSA]
 RewriteRule "^/otel_drop_in$" "/otel_drop_in/"
 RewriteRule "^/db$" "/db/"
+RewriteRule "^/trace/manual_keep_drop$" "/trace_manual_keep_drop/"
 RewriteRule "^/trace/sql$" "/trace_sql/"
 RewriteRule "^/trace/mongo$" "/trace_mongo/"
 RewriteRule "^/e2e_otel_span$" "/e2e_otel_span/"

--- a/utils/build/docker/php/weblogs/laravel11x/routes/web.php
+++ b/utils/build/docker/php/weblogs/laravel11x/routes/web.php
@@ -55,7 +55,27 @@ Route::get('/trace/manual_keep_drop', function (Request $request) {
         $decision === 'keep' ? DD_TRACE_PRIORITY_SAMPLING_USER_KEEP : DD_TRACE_PRIORITY_SAMPLING_USER_REJECT
     );
 
-    return response('OK');
+    // Call downstream so that tests can assert on the sampling decision that gets propagated
+    $url = 'http://localhost:7777/';
+    $requestHeaders = [];
+    $response = Http::beforeSending(function ($outgoingRequest) use (&$requestHeaders) {
+            foreach ($outgoingRequest->headers() as $name => $values) {
+                $requestHeaders[strtolower($name)] = implode(', ', $values);
+            }
+        })
+        ->get($url);
+
+    $responseHeaders = [];
+    foreach ($response->headers() as $name => $values) {
+        $responseHeaders[strtolower($name)] = implode(', ', $values);
+    }
+
+    return response()->json([
+        'url'              => $url,
+        'status_code'      => $response->status(),
+        'request_headers'  => $requestHeaders,
+        'response_headers' => $responseHeaders,
+    ]);
 });
 
 Route::get('/make_distant_call', function (Request $request) {

--- a/utils/build/docker/php/weblogs/laravel11x/routes/web.php
+++ b/utils/build/docker/php/weblogs/laravel11x/routes/web.php
@@ -43,6 +43,18 @@ Route::get('/status', function (Request $request) {
     return response('', $code);
 });
 
+Route::get('/trace/manual_keep_drop', function (Request $request) {
+    $decision = $request->query('decision', '');
+    if ($decision !== 'keep' && $decision !== 'drop') {
+        return response('decision must be keep or drop', 400);
+    }
+
+    $span = \DDTrace\active_span();
+    $span->meta[$decision === 'keep' ? \DDTrace\Tag::MANUAL_KEEP : \DDTrace\Tag::MANUAL_DROP] = true;
+
+    return response('OK');
+});
+
 Route::get('/make_distant_call', function (Request $request) {
     $url = $request->query('url', '');
     if ($url === '') {

--- a/utils/build/docker/php/weblogs/laravel11x/routes/web.php
+++ b/utils/build/docker/php/weblogs/laravel11x/routes/web.php
@@ -49,8 +49,11 @@ Route::get('/trace/manual_keep_drop', function (Request $request) {
         return response('decision must be keep or drop', 400);
     }
 
-    $span = \DDTrace\active_span();
-    $span->meta[$decision === 'keep' ? \DDTrace\Tag::MANUAL_KEEP : \DDTrace\Tag::MANUAL_DROP] = true;
+    // set_priority_sampling is what \DDTrace\Span::setTag does for the manual.keep / manual.drop tags,
+    // and unlike writing the tag into the root span's meta it also overrides a decision propagated upstream.
+    \DDTrace\set_priority_sampling(
+        $decision === 'keep' ? DD_TRACE_PRIORITY_SAMPLING_USER_KEEP : DD_TRACE_PRIORITY_SAMPLING_USER_REJECT
+    );
 
     return response('OK');
 });

--- a/utils/build/docker/php/weblogs/plain/trace_manual_keep_drop.php
+++ b/utils/build/docker/php/weblogs/plain/trace_manual_keep_drop.php
@@ -8,8 +8,11 @@ if ($decision !== 'keep' && $decision !== 'drop') {
     exit;
 }
 
-$span = \DDTrace\active_span();
-$span->meta[$decision === 'keep' ? \DDTrace\Tag::MANUAL_KEEP : \DDTrace\Tag::MANUAL_DROP] = true;
+// set_priority_sampling is what \DDTrace\Span::setTag does for the manual.keep / manual.drop tags,
+// and unlike writing the tag into the root span's meta it also overrides a decision propagated upstream.
+\DDTrace\set_priority_sampling(
+    $decision === 'keep' ? DD_TRACE_PRIORITY_SAMPLING_USER_KEEP : DD_TRACE_PRIORITY_SAMPLING_USER_REJECT
+);
 
 header('Content-Type: text/plain');
 echo 'OK';

--- a/utils/build/docker/php/weblogs/plain/trace_manual_keep_drop.php
+++ b/utils/build/docker/php/weblogs/plain/trace_manual_keep_drop.php
@@ -14,5 +14,43 @@ if ($decision !== 'keep' && $decision !== 'drop') {
     $decision === 'keep' ? DD_TRACE_PRIORITY_SAMPLING_USER_KEEP : DD_TRACE_PRIORITY_SAMPLING_USER_REJECT
 );
 
-header('Content-Type: text/plain');
-echo 'OK';
+// Call downstream so that tests can assert on the sampling decision that gets propagated
+$url = 'http://localhost:7777/';
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_HEADER, false);
+curl_setopt($ch, CURLINFO_HEADER_OUT, true);
+
+$responseHeaders = [];
+curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($curl, $header) use (&$responseHeaders) {
+    $len = strlen($header);
+    $parts = explode(':', $header, 2);
+    if (count($parts) === 2) {
+        $responseHeaders[strtolower(trim($parts[0]))] = trim($parts[1]);
+    }
+    return $len;
+});
+
+curl_exec($ch);
+$statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+$requestHeaders = [];
+$rawRequestHeaders = curl_getinfo($ch, CURLINFO_HEADER_OUT);
+if ($rawRequestHeaders) {
+    foreach (explode("\r\n", $rawRequestHeaders) as $line) {
+        if (strpos($line, ':') !== false) {
+            list($key, $value) = explode(':', $line, 2);
+            $requestHeaders[strtolower(trim($key))] = trim($value);
+        }
+    }
+}
+
+curl_close($ch);
+
+header('Content-Type: application/json');
+echo json_encode([
+    'url' => $url,
+    'status_code' => $statusCode,
+    'request_headers' => $requestHeaders,
+    'response_headers' => $responseHeaders,
+]);

--- a/utils/build/docker/php/weblogs/plain/trace_manual_keep_drop.php
+++ b/utils/build/docker/php/weblogs/plain/trace_manual_keep_drop.php
@@ -1,0 +1,15 @@
+<?php
+
+$decision = $_GET["decision"] ?? '';
+if ($decision !== 'keep' && $decision !== 'drop') {
+    http_response_code(400);
+    header('Content-Type: text/plain');
+    echo 'decision must be keep or drop';
+    exit;
+}
+
+$span = \DDTrace\active_span();
+$span->meta[$decision === 'keep' ? \DDTrace\Tag::MANUAL_KEEP : \DDTrace\Tag::MANUAL_DROP] = true;
+
+header('Content-Type: text/plain');
+echo 'OK';

--- a/utils/build/docker/php/weblogs/symfony7x/src/Controller/AppController.php
+++ b/utils/build/docker/php/weblogs/symfony7x/src/Controller/AppController.php
@@ -83,8 +83,11 @@ class AppController extends AbstractController
             return new Response('decision must be keep or drop', 400);
         }
 
-        $span = \DDTrace\active_span();
-        $span->meta[$decision === 'keep' ? \DDTrace\Tag::MANUAL_KEEP : \DDTrace\Tag::MANUAL_DROP] = true;
+        // set_priority_sampling is what \DDTrace\Span::setTag does for the manual.keep / manual.drop tags,
+        // and unlike writing the tag into the root span's meta it also overrides a decision propagated upstream.
+        \DDTrace\set_priority_sampling(
+            $decision === 'keep' ? DD_TRACE_PRIORITY_SAMPLING_USER_KEEP : DD_TRACE_PRIORITY_SAMPLING_USER_REJECT
+        );
 
         return new Response('OK');
     }

--- a/utils/build/docker/php/weblogs/symfony7x/src/Controller/AppController.php
+++ b/utils/build/docker/php/weblogs/symfony7x/src/Controller/AppController.php
@@ -75,6 +75,20 @@ class AppController extends AbstractController
         return new Response('', $code);
     }
 
+    #[Route('/trace/manual_keep_drop', name: 'trace_manual_keep_drop', methods: ['GET'])]
+    public function traceManualKeepDrop(Request $request): Response
+    {
+        $decision = $request->query->get('decision', '');
+        if ($decision !== 'keep' && $decision !== 'drop') {
+            return new Response('decision must be keep or drop', 400);
+        }
+
+        $span = \DDTrace\active_span();
+        $span->meta[$decision === 'keep' ? \DDTrace\Tag::MANUAL_KEEP : \DDTrace\Tag::MANUAL_DROP] = true;
+
+        return new Response('OK');
+    }
+
     #[Route('/make_distant_call', name: 'make_distant_call', methods: ['GET'])]
     public function makeDistantCall(Request $request): JsonResponse
     {

--- a/utils/build/docker/php/weblogs/symfony7x/src/Controller/AppController.php
+++ b/utils/build/docker/php/weblogs/symfony7x/src/Controller/AppController.php
@@ -89,7 +89,23 @@ class AppController extends AbstractController
             $decision === 'keep' ? DD_TRACE_PRIORITY_SAMPLING_USER_KEEP : DD_TRACE_PRIORITY_SAMPLING_USER_REJECT
         );
 
-        return new Response('OK');
+        // Call downstream so that tests can assert on the sampling decision that gets propagated
+        $url             = 'http://localhost:7777/';
+        $client          = HttpClient::create();
+        $response        = $client->request('GET', $url);
+        $statusCode      = $response->getStatusCode();
+        $responseHeaders = [];
+        foreach ($response->getHeaders(false) as $name => $values) {
+            $responseHeaders[$name] = implode(', ', $values);
+        }
+        $requestHeaders = $this->parseRequestHeadersFromDebug($response->getInfo('debug') ?? '');
+
+        return new JsonResponse([
+            'url'              => $url,
+            'status_code'      => $statusCode,
+            'request_headers'  => $requestHeaders,
+            'response_headers' => $responseHeaders,
+        ]);
     }
 
     #[Route('/make_distant_call', name: 'make_distant_call', methods: ['GET'])]

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -857,7 +857,18 @@ def trace_manual_keep_drop(request):
     span = tracer.current_span()
     span.set_tag(MANUAL_KEEP_KEY if decision == "keep" else MANUAL_DROP_KEY)
 
-    return HttpResponse("OK", status=200)
+    # Call downstream so that tests can assert on the sampling decision that gets propagated
+    url = "http://localhost:7777/"
+    response = requests.get(url)
+
+    return JsonResponse(
+        {
+            "url": url,
+            "status_code": response.status_code,
+            "request_headers": dict(response.request.headers),
+            "response_headers": dict(response.headers),
+        }
+    )
 
 
 def make_distant_call(request):

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -34,6 +34,8 @@ from iast import (
 import ddtrace
 
 from ddtrace.appsec import trace_utils as ato_user_sdk_v1
+from ddtrace.constants import MANUAL_DROP_KEY
+from ddtrace.constants import MANUAL_KEEP_KEY
 
 try:
     from ddtrace.appsec import track_user_sdk
@@ -847,6 +849,17 @@ def view_iast_code_injection_secure(request):
     return HttpResponse("OK", status=200)
 
 
+def trace_manual_keep_drop(request):
+    decision = request.GET.get("decision")
+    if decision not in ("keep", "drop"):
+        return HttpResponse("decision must be keep or drop", status=400)
+
+    span = tracer.current_span()
+    span.set_tag(MANUAL_KEEP_KEY if decision == "keep" else MANUAL_DROP_KEY)
+
+    return HttpResponse("OK", status=200)
+
+
 def make_distant_call(request):
     # curl localhost:7777/make_distant_call?url=http%3A%2F%2Fweblog%3A7777 | jq
 
@@ -1290,6 +1303,7 @@ urlpatterns = [
     path("iast/unvalidated_redirect/test_secure_redirect", view_iast_unvalidated_redirect_secure),
     path("iast/unvalidated_redirect/test_insecure_header", view_iast_unvalidated_redirect_insecure_header),
     path("iast/unvalidated_redirect/test_secure_header", view_iast_unvalidated_redirect_secure_header),
+    path("trace/manual_keep_drop", trace_manual_keep_drop),
     path("make_distant_call", make_distant_call),
     path("user_login_success_event", track_user_login_success_event),
     path("user_login_failure_event", track_user_login_failure_event),

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -439,7 +439,16 @@ def trace_manual_keep_drop(decision: str = ""):
     span = tracer.current_span()
     span.set_tag(MANUAL_KEEP_KEY if decision == "keep" else MANUAL_DROP_KEY)
 
-    return PlainTextResponse("OK")
+    # Call downstream so that tests can assert on the sampling decision that gets propagated
+    url = "http://localhost:7777/"
+    response = requests.get(url)
+
+    return {
+        "url": url,
+        "status_code": response.status_code,
+        "request_headers": dict(response.request.headers),
+        "response_headers": dict(response.headers),
+    }
 
 
 @app.get("/make_distant_call")

--- a/utils/build/docker/python/fastapi/main.py
+++ b/utils/build/docker/python/fastapi/main.py
@@ -37,6 +37,8 @@ from starlette.middleware.sessions import SessionMiddleware
 
 import ddtrace
 from ddtrace.appsec import trace_utils as appsec_trace_utils
+from ddtrace.constants import MANUAL_DROP_KEY
+from ddtrace.constants import MANUAL_KEEP_KEY
 from openfeature import api
 from ddtrace.openfeature import DataDogProvider
 from openfeature.evaluation_context import EvaluationContext
@@ -427,6 +429,17 @@ async def stats_unique(code: int = 200):
     if code == 204:
         return Response(status_code=code)
     return PlainTextResponse("OK, probably", status_code=code)
+
+
+@app.get("/trace/manual_keep_drop")
+def trace_manual_keep_drop(decision: str = ""):
+    if decision not in ("keep", "drop"):
+        return PlainTextResponse("decision must be keep or drop", status_code=400)
+
+    span = tracer.current_span()
+    span.set_tag(MANUAL_KEEP_KEY if decision == "keep" else MANUAL_DROP_KEY)
+
+    return PlainTextResponse("OK")
 
 
 @app.get("/make_distant_call")

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -620,7 +620,16 @@ def trace_manual_keep_drop():
     span = tracer.current_span()
     span.set_tag(MANUAL_KEEP_KEY if decision == "keep" else MANUAL_DROP_KEY)
 
-    return "OK"
+    # Call downstream so that tests can assert on the sampling decision that gets propagated
+    url = "http://localhost:7777/"
+    response = requests.get(url)
+
+    return {
+        "url": url,
+        "status_code": response.status_code,
+        "request_headers": dict(response.request.headers),
+        "response_headers": dict(response.headers),
+    }
 
 
 @app.route("/make_distant_call")

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -100,6 +100,8 @@ if os.environ.get("CONFIG_CHAINING_TEST", "").lower() == "true":
     config._logs_injection = True
 
 from ddtrace.appsec import trace_utils as appsec_trace_utils
+from ddtrace.constants import MANUAL_DROP_KEY
+from ddtrace.constants import MANUAL_KEEP_KEY
 from ddtrace.internal.datastreams import data_streams_processor
 from ddtrace.internal.datastreams.processor import DsmPathwayCodec
 from ddtrace.data_streams import set_consume_checkpoint
@@ -607,6 +609,18 @@ def status_code():
 def stats_unique():
     code = flask_request.args.get("code", default=200, type=int)
     return Response("OK, probably", status=code)
+
+
+@app.route("/trace/manual_keep_drop")
+def trace_manual_keep_drop():
+    decision = flask_request.args.get("decision")
+    if decision not in ("keep", "drop"):
+        return Response("decision must be keep or drop", status=400)
+
+    span = tracer.current_span()
+    span.set_tag(MANUAL_KEEP_KEY if decision == "keep" else MANUAL_DROP_KEY)
+
+    return "OK"
 
 
 @app.route("/make_distant_call")

--- a/utils/build/docker/python/tornado/main.py
+++ b/utils/build/docker/python/tornado/main.py
@@ -20,6 +20,8 @@ import xmltodict
 from ddtrace._trace.pin import Pin
 from ddtrace.appsec import trace_utils as appsec_trace_utils
 from ddtrace.appsec import track_user_sdk
+from ddtrace.constants import MANUAL_DROP_KEY
+from ddtrace.constants import MANUAL_KEEP_KEY
 from ddtrace.contrib.trace_utils import set_user
 from ddtrace.openfeature import DataDogProvider
 from ddtrace.trace import tracer
@@ -277,6 +279,20 @@ class TagValueHandler(BaseHandler):
 
     def options(self, tag_value: str, status_code: str) -> None:
         self._handle(tag_value, status_code)
+
+
+class TraceManualKeepDropHandler(BaseHandler):
+    def get(self) -> None:
+        decision = self.get_argument("decision", "")
+        if decision not in ("keep", "drop"):
+            self.set_status(HTTPStatus.BAD_REQUEST)
+            self.write("decision must be keep or drop")
+            return
+
+        span = tracer.current_span()
+        span.set_tag(MANUAL_KEEP_KEY if decision == "keep" else MANUAL_DROP_KEY)
+
+        self.write("OK")
 
 
 class MakeDistantCallHandler(BaseHandler):
@@ -1035,6 +1051,7 @@ def make_app() -> Application:
             # Tag value endpoint
             (r"/tag_value/(?P<tag_value>[^/]+)/(?P<status_code>\d+)", TagValueHandler),
             # HTTP client endpoints
+            (r"/trace/manual_keep_drop", TraceManualKeepDropHandler),
             (r"/make_distant_call", MakeDistantCallHandler),
             (r"/external_request", ExternalRequestHandler),
             (r"/external_request/redirect", ExternalRequestRedirectHandler),

--- a/utils/build/docker/python/tornado/main.py
+++ b/utils/build/docker/python/tornado/main.py
@@ -20,8 +20,7 @@ import xmltodict
 from ddtrace._trace.pin import Pin
 from ddtrace.appsec import trace_utils as appsec_trace_utils
 from ddtrace.appsec import track_user_sdk
-from ddtrace.constants import MANUAL_DROP_KEY
-from ddtrace.constants import MANUAL_KEEP_KEY
+from ddtrace.constants import MANUAL_DROP_KEY, MANUAL_KEEP_KEY
 from ddtrace.contrib.trace_utils import set_user
 from ddtrace.openfeature import DataDogProvider
 from ddtrace.trace import tracer

--- a/utils/build/docker/python/tornado/main.py
+++ b/utils/build/docker/python/tornado/main.py
@@ -281,7 +281,7 @@ class TagValueHandler(BaseHandler):
 
 
 class TraceManualKeepDropHandler(BaseHandler):
-    def get(self) -> None:
+    async def get(self) -> None:
         decision = self.get_argument("decision", "")
         if decision not in ("keep", "drop"):
             self.set_status(HTTPStatus.BAD_REQUEST)
@@ -291,7 +291,20 @@ class TraceManualKeepDropHandler(BaseHandler):
         span = tracer.current_span()
         span.set_tag(MANUAL_KEEP_KEY if decision == "keep" else MANUAL_DROP_KEY)
 
-        self.write("OK")
+        # Call downstream so that tests can assert on the sampling decision that gets propagated
+        url = "http://localhost:7777/"
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url)
+
+        result = {
+            "url": url,
+            "status_code": response.status_code,
+            "request_headers": dict(response.request.headers),
+            "response_headers": dict(response.headers),
+        }
+
+        self.set_header("Content-Type", "application/json")
+        self.write(json.dumps(result))
 
 
 class MakeDistantCallHandler(BaseHandler):

--- a/utils/build/docker/ruby/rack/config.ru
+++ b/utils/build/docker/ruby/rack/config.ru
@@ -166,7 +166,26 @@ module TraceManualKeepDrop
     trace = Datadog::Tracing.active_trace
     decision == 'keep' ? trace.keep! : trace.reject!
 
-    [200, { 'Content-Type' => 'text/plain' }, ['OK']]
+    # Call downstream so that tests can assert on the sampling decision that gets propagated
+    url = 'http://localhost:7777/'
+    uri = URI(url)
+    downstream_request = nil
+    response = nil
+
+    Net::HTTP.start(uri.host, uri.port) do |http|
+      downstream_request = Net::HTTP::Get.new(uri)
+
+      response = http.request(downstream_request)
+    end
+
+    result = {
+      url: url,
+      status_code: response.code.to_i,
+      request_headers: downstream_request.each_header.to_h,
+      response_headers: response.each_header.to_h
+    }
+
+    [200, { 'Content-Type' => 'application/json' }, [result.to_json]]
   end
 end
 

--- a/utils/build/docker/ruby/rack/config.ru
+++ b/utils/build/docker/ruby/rack/config.ru
@@ -152,6 +152,24 @@ module Status
   end
 end
 
+# /trace/manual_keep_drop
+module TraceManualKeepDrop
+  module_function
+
+  def run(request)
+    decision = request.params['decision']
+
+    unless %w[keep drop].include?(decision)
+      return [400, { 'Content-Type' => 'text/plain' }, ['decision must be keep or drop']]
+    end
+
+    trace = Datadog::Tracing.active_trace
+    decision == 'keep' ? trace.keep! : trace.reject!
+
+    [200, { 'Content-Type' => 'text/plain' }, ['OK']]
+  end
+end
+
 # /make_distant_call
 module MakeDistantCall
   module_function
@@ -538,6 +556,8 @@ app = proc do |env|
     Identify.run
   elsif request.path.include?('/status')
     Status.run(request)
+  elsif request.path == '/trace/manual_keep_drop'
+    TraceManualKeepDrop.run(request)
   elsif request.path == '/make_distant_call'
     MakeDistantCall.run(request)
   elsif request.path == '/user_login_success_event'

--- a/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
@@ -61,6 +61,16 @@ class SystemTestController < ApplicationController
     render plain: "Ok", status: params[:code]
   end
 
+  def trace_manual_keep_drop
+    decision = params[:decision]
+    return render plain: 'decision must be keep or drop', status: 400 unless %w[keep drop].include?(decision)
+
+    trace = Datadog::Tracing.active_trace
+    decision == 'keep' ? trace.keep! : trace.reject!
+
+    render plain: 'OK'
+  end
+
   def make_distant_call
     url = params[:url]
     uri = URI(url)

--- a/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails42/app/controllers/system_test_controller.rb
@@ -68,7 +68,24 @@ class SystemTestController < ApplicationController
     trace = Datadog::Tracing.active_trace
     decision == 'keep' ? trace.keep! : trace.reject!
 
-    render plain: 'OK'
+    # Call downstream so that tests can assert on the sampling decision that gets propagated
+    url = 'http://localhost:7777/'
+    uri = URI(url)
+    request = nil
+    response = nil
+
+    Net::HTTP.start(uri.host, uri.port) do |http|
+      request = Net::HTTP::Get.new(uri)
+
+      response = http.request(request)
+    end
+
+    render json: {
+      "url": url,
+      "status_code": response.code.to_i,
+      "request_headers": request.each_header.to_h,
+      "response_headers": response.each_header.to_h,
+    }
   end
 
   def make_distant_call

--- a/utils/build/docker/ruby/rails42/config/routes.rb
+++ b/utils/build/docker/ruby/rails42/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get '/params/:value' => 'system_test#handle_path_params'
   get '/spans' => 'system_test#generate_spans'
   get '/status' => 'system_test#status'
+  get '/trace/manual_keep_drop' => 'system_test#trace_manual_keep_drop'
   get '/make_distant_call' => 'system_test#make_distant_call'
 
   get '/headers' => 'system_test#test_headers'

--- a/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
@@ -61,6 +61,16 @@ class SystemTestController < ApplicationController
     render plain: "Ok", status: params[:code]
   end
 
+  def trace_manual_keep_drop
+    decision = params[:decision]
+    return render plain: 'decision must be keep or drop', status: 400 unless %w[keep drop].include?(decision)
+
+    trace = Datadog::Tracing.active_trace
+    decision == 'keep' ? trace.keep! : trace.reject!
+
+    render plain: 'OK'
+  end
+
   def make_distant_call
     url = params[:url]
     uri = URI(url)

--- a/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails52/app/controllers/system_test_controller.rb
@@ -68,7 +68,24 @@ class SystemTestController < ApplicationController
     trace = Datadog::Tracing.active_trace
     decision == 'keep' ? trace.keep! : trace.reject!
 
-    render plain: 'OK'
+    # Call downstream so that tests can assert on the sampling decision that gets propagated
+    url = 'http://localhost:7777/'
+    uri = URI(url)
+    request = nil
+    response = nil
+
+    Net::HTTP.start(uri.host, uri.port) do |http|
+      request = Net::HTTP::Get.new(uri)
+
+      response = http.request(request)
+    end
+
+    render json: {
+      "url": url,
+      "status_code": response.code.to_i,
+      "request_headers": request.each_header.to_h,
+      "response_headers": response.each_header.to_h,
+    }
   end
 
   def make_distant_call

--- a/utils/build/docker/ruby/rails52/config/routes.rb
+++ b/utils/build/docker/ruby/rails52/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   get '/params/:value' => 'system_test#handle_path_params'
   get '/spans' => 'system_test#generate_spans'
   get '/status' => 'system_test#status'
+  get '/trace/manual_keep_drop' => 'system_test#trace_manual_keep_drop'
   get '/make_distant_call' => 'system_test#make_distant_call'
 
   get '/headers' => 'system_test#test_headers'

--- a/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
@@ -61,6 +61,16 @@ class SystemTestController < ApplicationController
     render plain: "Ok", status: params[:code]
   end
 
+  def trace_manual_keep_drop
+    decision = params[:decision]
+    return render plain: 'decision must be keep or drop', status: 400 unless %w[keep drop].include?(decision)
+
+    trace = Datadog::Tracing.active_trace
+    decision == 'keep' ? trace.keep! : trace.reject!
+
+    render plain: 'OK'
+  end
+
   def make_distant_call
     url = params[:url]
     uri = URI(url)

--- a/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails61/app/controllers/system_test_controller.rb
@@ -68,7 +68,24 @@ class SystemTestController < ApplicationController
     trace = Datadog::Tracing.active_trace
     decision == 'keep' ? trace.keep! : trace.reject!
 
-    render plain: 'OK'
+    # Call downstream so that tests can assert on the sampling decision that gets propagated
+    url = 'http://localhost:7777/'
+    uri = URI(url)
+    request = nil
+    response = nil
+
+    Net::HTTP.start(uri.host, uri.port) do |http|
+      request = Net::HTTP::Get.new(uri)
+
+      response = http.request(request)
+    end
+
+    render json: {
+      "url": url,
+      "status_code": response.code.to_i,
+      "request_headers": request.each_header.to_h,
+      "response_headers": response.each_header.to_h,
+    }
   end
 
   def make_distant_call

--- a/utils/build/docker/ruby/rails61/config/routes.rb
+++ b/utils/build/docker/ruby/rails61/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   get '/params/:value' => 'system_test#handle_path_params'
   get '/spans' => 'system_test#generate_spans'
   get '/status' => 'system_test#status'
+  get '/trace/manual_keep_drop' => 'system_test#trace_manual_keep_drop'
   get '/make_distant_call' => 'system_test#make_distant_call'
 
   get '/headers' => 'system_test#test_headers'

--- a/utils/build/docker/ruby/rails72/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/system_test_controller.rb
@@ -104,7 +104,24 @@ class SystemTestController < ApplicationController
     trace = Datadog::Tracing.active_trace
     decision == 'keep' ? trace.keep! : trace.reject!
 
-    render plain: 'OK'
+    # Call downstream so that tests can assert on the sampling decision that gets propagated
+    url = 'http://localhost:7777/'
+    uri = URI(url)
+    request = nil
+    response = nil
+
+    Net::HTTP.start(uri.host, uri.port) do |http|
+      request = Net::HTTP::Get.new(uri)
+
+      response = http.request(request)
+    end
+
+    render json: {
+      "url": url,
+      "status_code": response.code.to_i,
+      "request_headers": request.each_header.to_h,
+      "response_headers": response.each_header.to_h,
+    }
   end
 
   def make_distant_call

--- a/utils/build/docker/ruby/rails72/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/system_test_controller.rb
@@ -97,6 +97,16 @@ class SystemTestController < ApplicationController
     render plain: File.read(params[:file])
   end
 
+  def trace_manual_keep_drop
+    decision = params[:decision]
+    return render plain: 'decision must be keep or drop', status: 400 unless %w[keep drop].include?(decision)
+
+    trace = Datadog::Tracing.active_trace
+    decision == 'keep' ? trace.keep! : trace.reject!
+
+    render plain: 'OK'
+  end
+
   def make_distant_call
     url = params[:url]
     uri = URI(url)

--- a/utils/build/docker/ruby/rails72/config/routes.rb
+++ b/utils/build/docker/ruby/rails72/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
   get '/spans' => 'system_test#generate_spans'
   get '/status' => 'system_test#status'
   get '/read_file' => 'system_test#read_file'
+  get '/trace/manual_keep_drop' => 'system_test#trace_manual_keep_drop'
   get '/make_distant_call' => 'system_test#make_distant_call'
   get '/log/library' => 'system_test#log_library'
 

--- a/utils/build/docker/ruby/rails80/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails80/app/controllers/system_test_controller.rb
@@ -65,6 +65,16 @@ class SystemTestController < ApplicationController
     render plain: File.read(params[:file])
   end
 
+  def trace_manual_keep_drop
+    decision = params[:decision]
+    return render plain: 'decision must be keep or drop', status: 400 unless %w[keep drop].include?(decision)
+
+    trace = Datadog::Tracing.active_trace
+    decision == 'keep' ? trace.keep! : trace.reject!
+
+    render plain: 'OK'
+  end
+
   def make_distant_call
     url = params[:url]
     uri = URI(url)

--- a/utils/build/docker/ruby/rails80/app/controllers/system_test_controller.rb
+++ b/utils/build/docker/ruby/rails80/app/controllers/system_test_controller.rb
@@ -72,7 +72,24 @@ class SystemTestController < ApplicationController
     trace = Datadog::Tracing.active_trace
     decision == 'keep' ? trace.keep! : trace.reject!
 
-    render plain: 'OK'
+    # Call downstream so that tests can assert on the sampling decision that gets propagated
+    url = 'http://localhost:7777/'
+    uri = URI(url)
+    request = nil
+    response = nil
+
+    Net::HTTP.start(uri.host, uri.port) do |http|
+      request = Net::HTTP::Get.new(uri)
+
+      response = http.request(request)
+    end
+
+    render json: {
+      "url": url,
+      "status_code": response.code.to_i,
+      "request_headers": request.each_header.to_h,
+      "response_headers": response.each_header.to_h,
+    }
   end
 
   def make_distant_call

--- a/utils/build/docker/ruby/rails80/config/routes.rb
+++ b/utils/build/docker/ruby/rails80/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   get '/spans' => 'system_test#generate_spans'
   get '/status' => 'system_test#status'
   get '/read_file' => 'system_test#read_file'
+  get '/trace/manual_keep_drop' => 'system_test#trace_manual_keep_drop'
   get '/make_distant_call' => 'system_test#make_distant_call'
 
   get '/headers' => 'system_test#test_headers'

--- a/utils/build/docker/ruby/sinatra14/app.rb
+++ b/utils/build/docker/ruby/sinatra14/app.rb
@@ -137,7 +137,26 @@ get '/trace/manual_keep_drop' do
   trace = Datadog::Tracing.active_trace
   decision == 'keep' ? trace.keep! : trace.reject!
 
-  'OK'
+  content_type :json
+
+  # Call downstream so that tests can assert on the sampling decision that gets propagated
+  url = 'http://localhost:7777/'
+  uri = URI(url)
+  downstream_request = nil
+  response = nil
+
+  Net::HTTP.start(uri.host, uri.port) do |http|
+    downstream_request = Net::HTTP::Get.new(uri)
+
+    response = http.request(downstream_request)
+  end
+
+  {
+    "url": url,
+    "status_code": response.code.to_i,
+    "request_headers": downstream_request.each_header.to_h,
+    "response_headers": response.each_header.to_h
+  }.to_json
 end
 
 get '/make_distant_call' do

--- a/utils/build/docker/ruby/sinatra14/app.rb
+++ b/utils/build/docker/ruby/sinatra14/app.rb
@@ -130,6 +130,16 @@ get '/status' do
   'Ok'
 end
 
+get '/trace/manual_keep_drop' do
+  decision = request.params['decision']
+  halt 400, 'decision must be keep or drop' unless %w[keep drop].include?(decision)
+
+  trace = Datadog::Tracing.active_trace
+  decision == 'keep' ? trace.keep! : trace.reject!
+
+  'OK'
+end
+
 get '/make_distant_call' do
   content_type :json
 

--- a/utils/build/docker/ruby/sinatra22/app.rb
+++ b/utils/build/docker/ruby/sinatra22/app.rb
@@ -125,6 +125,16 @@ get '/status' do
   'Ok'
 end
 
+get '/trace/manual_keep_drop' do
+  decision = request.params['decision']
+  halt 400, 'decision must be keep or drop' unless %w[keep drop].include?(decision)
+
+  trace = Datadog::Tracing.active_trace
+  decision == 'keep' ? trace.keep! : trace.reject!
+
+  'OK'
+end
+
 get '/make_distant_call' do
   content_type :json
 

--- a/utils/build/docker/ruby/sinatra22/app.rb
+++ b/utils/build/docker/ruby/sinatra22/app.rb
@@ -132,7 +132,26 @@ get '/trace/manual_keep_drop' do
   trace = Datadog::Tracing.active_trace
   decision == 'keep' ? trace.keep! : trace.reject!
 
-  'OK'
+  content_type :json
+
+  # Call downstream so that tests can assert on the sampling decision that gets propagated
+  url = 'http://localhost:7777/'
+  uri = URI(url)
+  downstream_request = nil
+  response = nil
+
+  Net::HTTP.start(uri.host, uri.port) do |http|
+    downstream_request = Net::HTTP::Get.new(uri)
+
+    response = http.request(downstream_request)
+  end
+
+  {
+    "url": url,
+    "status_code": response.code.to_i,
+    "request_headers": downstream_request.each_header.to_h,
+    "response_headers": response.each_header.to_h
+  }.to_json
 end
 
 get '/make_distant_call' do

--- a/utils/build/docker/ruby/sinatra32/app.rb
+++ b/utils/build/docker/ruby/sinatra32/app.rb
@@ -125,6 +125,16 @@ get '/status' do
   'Ok'
 end
 
+get '/trace/manual_keep_drop' do
+  decision = request.params['decision']
+  halt 400, 'decision must be keep or drop' unless %w[keep drop].include?(decision)
+
+  trace = Datadog::Tracing.active_trace
+  decision == 'keep' ? trace.keep! : trace.reject!
+
+  'OK'
+end
+
 get '/make_distant_call' do
   content_type :json
 

--- a/utils/build/docker/ruby/sinatra32/app.rb
+++ b/utils/build/docker/ruby/sinatra32/app.rb
@@ -132,7 +132,26 @@ get '/trace/manual_keep_drop' do
   trace = Datadog::Tracing.active_trace
   decision == 'keep' ? trace.keep! : trace.reject!
 
-  'OK'
+  content_type :json
+
+  # Call downstream so that tests can assert on the sampling decision that gets propagated
+  url = 'http://localhost:7777/'
+  uri = URI(url)
+  downstream_request = nil
+  response = nil
+
+  Net::HTTP.start(uri.host, uri.port) do |http|
+    downstream_request = Net::HTTP::Get.new(uri)
+
+    response = http.request(downstream_request)
+  end
+
+  {
+    "url": url,
+    "status_code": response.code.to_i,
+    "request_headers": downstream_request.each_header.to_h,
+    "response_headers": response.each_header.to_h
+  }.to_json
 end
 
 get '/make_distant_call' do

--- a/utils/build/docker/ruby/sinatra41/app.rb
+++ b/utils/build/docker/ruby/sinatra41/app.rb
@@ -135,7 +135,26 @@ get '/trace/manual_keep_drop' do
   trace = Datadog::Tracing.active_trace
   decision == 'keep' ? trace.keep! : trace.reject!
 
-  'OK'
+  content_type :json
+
+  # Call downstream so that tests can assert on the sampling decision that gets propagated
+  url = 'http://localhost:7777/'
+  uri = URI(url)
+  downstream_request = nil
+  response = nil
+
+  Net::HTTP.start(uri.host, uri.port) do |http|
+    downstream_request = Net::HTTP::Get.new(uri)
+
+    response = http.request(downstream_request)
+  end
+
+  {
+    "url": url,
+    "status_code": response.code.to_i,
+    "request_headers": downstream_request.each_header.to_h,
+    "response_headers": response.each_header.to_h
+  }.to_json
 end
 
 get '/make_distant_call' do

--- a/utils/build/docker/ruby/sinatra41/app.rb
+++ b/utils/build/docker/ruby/sinatra41/app.rb
@@ -128,6 +128,16 @@ get '/status' do
   'Ok'
 end
 
+get '/trace/manual_keep_drop' do
+  decision = request.params['decision']
+  halt 400, 'decision must be keep or drop' unless %w[keep drop].include?(decision)
+
+  trace = Datadog::Tracing.active_trace
+  decision == 'keep' ? trace.keep! : trace.reject!
+
+  'OK'
+end
+
 get '/make_distant_call' do
   content_type :json
 

--- a/utils/build/docker/rust/axum/src/main.rs
+++ b/utils/build/docker/rust/axum/src/main.rs
@@ -31,6 +31,7 @@ mod integration;
 
 const VERSION_FILE: &str = "/app/SYSTEM_TESTS_LIBRARY_VERSION";
 const DOWNSTREAM_RETURN_HEADERS_URL: &str = "http://localhost:7777/returnheaders";
+const DOWNSTREAM_ROOT_URL: &str = "http://localhost:7777/";
 
 #[derive(Clone)]
 struct AppState {
@@ -41,6 +42,11 @@ struct AppState {
 #[derive(Deserialize)]
 struct StatusQuery {
     code: u16,
+}
+
+#[derive(Deserialize)]
+struct ManualKeepDropQuery {
+    decision: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -115,6 +121,7 @@ fn app(state: AppState) -> Router {
             get(request_downstream).post(request_downstream),
         )
         .route("/make_distant_call", get(make_distant_call))
+        .route("/trace/manual_keep_drop", get(trace_manual_keep_drop))
         .with_state(state);
     integration::install_middleware(router)
 }
@@ -474,16 +481,37 @@ async fn request_downstream(State(state): State<AppState>, method: Method) -> Re
 
 // ─── External request endpoints ─────────────────────────────────────────────
 
+/// Forces the sampling decision of the trace the request belongs to, then calls downstream so that
+/// tests can assert on the sampling decision that gets propagated.
+async fn trace_manual_keep_drop(Query(query): Query<ManualKeepDropQuery>) -> Response {
+    let tag = match query.decision.as_deref() {
+        Some("keep") => "manual.keep",
+        Some("drop") => "manual.drop",
+        _ => {
+            return (StatusCode::BAD_REQUEST, "decision must be keep or drop").into_response();
+        }
+    };
+
+    Context::current()
+        .span()
+        .set_attribute(KeyValue::new(tag, true));
+
+    distant_call(DOWNSTREAM_ROOT_URL).await
+}
+
 async fn make_distant_call(Query(params): Query<HashMap<String, String>>) -> Response {
     let url = params.get("url").cloned().unwrap_or_default();
+    distant_call(&url).await
+}
 
+async fn distant_call(url: &str) -> Response {
     let capture_request_headers = integration::CaptureRequestHeaders::new();
     let client = ClientBuilder::new(reqwest::Client::new())
         .with(TracingMiddleware::<DatadogClientSpanBackend>::new())
         .with(capture_request_headers.clone())
         .build();
 
-    let resp = client.get(&url).send().await;
+    let resp = client.get(url).send().await;
 
     match resp {
         Ok(r) => {


### PR DESCRIPTION
## Motivation

Nothing in the end-to-end suite can force a trace's sampling decision. The manual keep/drop API was only reachable from the parametric apps, so the "a manual decision overrides everything else" contract had no end-to-end coverage, and no weblog exposed an entry point for it.

## Changes

### New weblog endpoint

`GET /trace/manual_keep_drop?decision=keep|drop` applies the tracer's manual keep/drop API to the current trace and returns `200`. A missing or invalid `decision` returns `400`. Documented in `docs/understand/weblogs/end-to-end_weblog.md`.

Implemented in every end-to-end weblog, one commit per variant, using each library's own manual keep/drop API:

| library | mechanism | weblogs |
|---|---|---|
| java | `GlobalTracer.get().activeSpan()` + `DDTags.MANUAL_KEEP` / `MANUAL_DROP` | spring-boot, spring-boot-3-native, vertx3, vertx4, akka-http, ratpack, play, jersey-grizzly2, resteasy-netty3 |
| python | `tracer.current_span().set_tag(MANUAL_KEEP_KEY / MANUAL_DROP_KEY)` | flask, django, fastapi, tornado |
| nodejs | `tracer.scope().active().setTag(MANUAL_KEEP / MANUAL_DROP, true)`, constants from `ext.tags` | express4, express5, express4-typescript, fastify, nextjs |
| dotnet | `Tracer.Instance.ActiveScope?.Span.SetTag(Tags.ManualKeep / ManualDrop, "true")` | weblog, via `Endpoints/ManualKeepDropEndpoint.cs` |
| ruby | `Datadog::Tracing.active_trace.keep!` / `.reject!` | rails42, rails52, rails61, rails72, rails80, sinatra14, sinatra22, sinatra32, sinatra41, rack |
| golang | shared `common.ManualKeepDrop` handler + `ext.ManualKeep` / `ext.ManualDrop` | net-http, gin, echo, chi, net-http-orchestrion, gqlgen, graphql-go, graph-gophers |
| php | `\DDTrace\set_priority_sampling(...)` | plain, symfony7x, laravel11x |

cpp and rust are skipped: they have no end-to-end weblog, only parametric.

Notes on three of those choices:

* **golang**: the handler lives once in `app/_shared/common/common.go` as an `http.HandlerFunc`, matching how `rasp.LFI`, `common.Requestdownstream` and `dbm.StubDbmHandler` are already shared. gin and echo reuse the existing `ginHandleFunc` / `echoHandleFunc` adapters.
* **php**: `set_priority_sampling` is what `\DDTrace\Span::setTag` itself calls for the `manual.keep` / `manual.drop` tags. Writing the tag into span meta was not viable: in symfony and laravel `\DDTrace\active_span()` is the `symfony.controller` / `laravel.action` child span rather than the root, and the meta path is skipped entirely when a keep decision was propagated from upstream.
* **nodejs**: express4 and express5 share `utils/build/docker/nodejs/express/app.js`, so a single commit covers both. nextjs uses `global._ddtrace` and the literal tag names, matching its neighbouring routes, which avoid direct `dd-trace` imports because of webpack bundling.

### Parametric fix

`utils/build/docker/nodejs/parametric/server.js` destructured `MANUAL_KEEP` / `MANUAL_DROP` off the top level of `dd-trace/ext`, where they do not exist (they live under `ext.tags`). It was therefore calling `span.setTag(undefined, true)`, so the existing nodejs parametric manual-keep coverage was asserting nothing. 

### Tests

`tests/test_sampling_manual.py::Test_Manual_Sampling`, SAMPLING scenario, `@features.ensure_that_sampling_is_consistent_across_languages`. Both directions are driven by an upstream distributed trace context, so each case asserts that the manual decision wins over a propagated one:

| test | upstream `x-datadog-sampling-priority` | `decision` | expected `_sampling_priority_v1` |
|---|---|---|---|
| `test_manual_keep_overrides_upstream_drop` | `0` (auto reject) | `keep` | `2` (user keep) |
| `test_manual_drop_overrides_upstream_keep` | `2` (user keep) | `drop` | `-1` (user reject) |

The SAMPLING scenario is used because it sets `DD_TRACE_STATS_COMPUTATION_ENABLED=false`, so dropped P-1 traces still reach the agent and the drop case is observable. A manual decision takes precedence over that scenario's 0.5 sample rate, so the rate does not affect either assertion.

## Impact

The drop direction is new ground: the parametric suite only ever covered manual keep overriding an upstream drop. Asserting the reverse surfaced two library gaps, both declared in the manifests so they run as xfail and turn into an xpass when fixed.

| library | declaration | reason |
|---|---|---|
| java | `bug (APMAPI-2194)` on `test_manual_drop_overrides_upstream_keep` | [APMAPI-2194](https://datadoghq.atlassian.net/browse/APMAPI-2194): `manual.keep` goes through `DDSpanContext.forceKeep()`, an unconditional update that deliberately wins over an already propagated decision, while `manual.drop` goes through `setSamplingPriority()`, a compare-and-set from `UNSET` that refuses when the priority is locked. Keep can override, drop cannot. |
| nodejs | `bug (APMAPI-1720)` on the whole class | [APMAPI-1720](https://datadoghq.atlassian.net/browse/APMAPI-1720): `PrioritySampler.sample()` returns early whenever a priority already exists, before it reads the manual tags, so neither direction is honoured. |

APMAPI-2194 is filed separately rather than folded into APMAPI-1720 because 1720's analysis only covers the keep direction and lists java as working.

dotnet, golang, php, python and ruby honour both directions.

Weblogs with no SDK to call also get declarations, since they run the SAMPLING scenario:

| manifest | declaration |
|---|---|
| `c.yml` (perl-mojolicious) | `missing_feature`, dd-trace-c does not implement manual keep/drop |
| `cpp_httpd.yml` | `missing_feature`, endpoint not implemented |
| `cpp_kong.yml`, `cpp_nginx.yml` | `irrelevant`, proxy rather than an application |
| `java_otel.yml`, `nodejs_otel.yml`, `python_otel.yml` | `irrelevant`, the OpenTelemetry test library has no Datadog manual keep/drop |

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-2194]: https://datadoghq.atlassian.net/browse/APMAPI-2194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ