### PR TITLE
Activate Test_Trace_Filters for golang

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1531,7 +1531,7 @@ manifest:
   tests/parametric/test_telemetry.py::Test_TelemetryInstallSignature::test_telemetry_event_not_propagated: missing_feature  # Created by easy win activation script
   tests/parametric/test_telemetry.py::Test_TelemetrySCAEnvVar: v1.63.0-rc.1
   tests/parametric/test_telemetry.py::Test_TelemetrySSIConfigs: missing_feature
-  tests/parametric/test_trace_filters.py::Test_Trace_Filters: missing_feature
+  tests/parametric/test_trace_filters.py::Test_Trace_Filters: v2.11.0-dev
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_Basic: v1.37.0  # TODO what is the earliest version?
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_Globs: v1.60.0
   tests/parametric/test_trace_sampling.py::Test_Trace_Sampling_Globs_Feb2024_Revision: v1.64.0


### PR DESCRIPTION
dd-trace-go now applies agent-advertised trace filters client-side ([dd-trace-go#5035](https://github.com/DataDog/dd-trace-go/pull/5035)), so `Test_Trace_Filters` moves from `missing_feature` to `v2.11.0-dev`. Validated locally against dd-trace-go main: all 17 tests pass.