### PR TITLE
Activate Test_AppSecStandalone_APMDisabledMarker for Java

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1670,7 +1670,7 @@ manifest:
         akka-http: bug (APPSEC-55001)
         jersey-grizzly2: bug (APPSEC-55001)
         play: bug (APPSEC-55001)
-  tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_APMDisabledMarker: missing_feature
+  tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_APMDisabledMarker: v1.64.2
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_NotEnabled: missing_feature
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_UpstreamPropagation_V2:
     - weblog_declaration:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -1670,7 +1670,10 @@ manifest:
         akka-http: bug (APPSEC-55001)
         jersey-grizzly2: bug (APPSEC-55001)
         play: bug (APPSEC-55001)
-  tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_APMDisabledMarker: v1.64.2
+  tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_APMDisabledMarker:
+    - weblog_declaration:
+        "*": v1.64.2
+        spring-boot-3-native: irrelevant (GraalVM. Tracing support only)
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_NotEnabled: missing_feature
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_UpstreamPropagation_V2:
     - weblog_declaration:


### PR DESCRIPTION
## Motivation

Activate Test_AppSecStandalone_APMDisabledMarker for Java after patch 1.64.2

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
