### PR TITLE
[python]: enable Test_AppSecStandalone_APMDisabledMarker test for python

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -710,7 +710,7 @@ manifest:
   : - component_version: "<3.11.0"
       declaration: missing_feature (APPSEC-57830 python tracer was using MANUAL_KEEP for 1 trace in 60 seconds to keep instead of AUTO_KEEP)
       weblog: *django
-  tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_APMDisabledMarker: missing_feature
+  tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_APMDisabledMarker: v4.13.0rc1
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_NotEnabled: v2.12.3
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_UpstreamPropagation_V2: v3.2.0.dev
   tests/appsec/test_asm_standalone.py::Test_IastStandalone_UpstreamPropagation_V2:  # Easy win for flask-poc and version 4.6.4


### PR DESCRIPTION
## Motivation

Enable the `Test_AppSecStandalone_APMDisabledMarker` test for the Python tracer, mirroring what was done for Node.js in #7395.

Jira: [APPSEC-68486](https://datadoghq.atlassian.net/browse/APPSEC-68486)

## Changes

Change the manifest file: `tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_APMDisabledMarker` goes from `missing_feature` to `v4.13.0rc1` in `manifests/python.yml`.

The test asserts every span sent in standalone mode carries the numeric `_dd.apm.enabled:0` billing marker. `dd-trace-py` tags *all* spans (not only service-entry spans) since ["fix(tracing): tag all spans as APM-disabled when APM tracing is disabled"](https://github.com/DataDog/dd-trace-py/pull/19242), which is first contained in tag `v4.13.0rc1` (no backport to 4.12).

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APPSEC-68486]: https://datadoghq.atlassian.net/browse/APPSEC-68486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ