### PR TITLE
fix(ssi): Normalize AppSec event validation.

### DIFF
--- a/tests/auto_inject/utils.py
+++ b/tests/auto_inject/utils.py
@@ -5,6 +5,7 @@ from utils.onboarding.backend_interface import wait_backend_trace_id
 from utils.onboarding.wait_for_tcp_port import wait_for_port
 from utils.virtual_machine.virtual_machines import _VirtualMachine
 from utils.virtual_machine.vm_logger import vm_logger
+from utils.dd_types import is_same_boolean
 from utils import context, logger
 from threading import Timer
 
@@ -138,11 +139,10 @@ class AutoInjectBaseTest:
             )
             return False
 
-        # Check for v0.4 protocol
-        if meta.get("appsec.event") == "true":
+        if is_same_boolean(actual=meta.get("appsec.event"), expected="true"):
             return True
 
-        # Check for v1.4 protocol
+        # Check for AppSec event payload
         appsec_payload = meta.get("_dd.appsec.json")
         if appsec_payload and appsec_payload.get("triggers"):
             return True


### PR DESCRIPTION
## Motivation

SSI AppSec validation expected `appsec.event` to always be the string `"true"`. Trace protocol `v1` can expose the same value as a typed boolean, causing valid AppSec traces to fail validation.

## Changes

Use `is_same_boolean()` when validating `appsec.event` so both legacy string and typed boolean representations are accepted.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
