### PR TITLE
fix(stats): Check v1 trace requests for client drop P0s.

### DIFF
--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -606,6 +606,8 @@ class Test_Client_Drop_P0s:
             trace_requests = list(interfaces.library.get_data("/v0.5/traces"))
         if len(trace_requests) == 0:
             trace_requests = list(interfaces.library.get_data("/v0.7/traces"))
+        if len(trace_requests) == 0:
+            trace_requests = list(interfaces.library.get_data("/v1.0/traces"))
 
         assert len(trace_requests) > 0, "Should have at least one trace request"
 


### PR DESCRIPTION
## Motivation

The `client-drop-P0s` test only checks legacy trace endpoints, so it fails when `dd-trace-java` uses `/v1.0/traces` by default.

## Changes

Check `/v1.0/traces` when validating the `Datadog-Client-Computed-Stats` header.


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
