### PR TITLE
Test Java agentless Feature Flags without the Java agent

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3766,7 +3766,7 @@ manifest:
   tests/parametric/test_extract_behavior.py::Test_ExtractBehavior_Restart::test_baggage: incomplete_test_app (The parametric test app does not preserve baggage after extraction)
   tests/parametric/test_extract_behavior.py::Test_ExtractBehavior_Restart_With_Extract_First: v1.48.0
   tests/parametric/test_extract_behavior.py::Test_ExtractBehavior_Restart_With_Extract_First::test_baggage: incomplete_test_app (The parametric test app does not preserve baggage after extraction)
-  tests/parametric/test_ffe/test_configuration_sources.py: missing_feature (FFL-2693 tracks Java agentless configuration-source implementation; FFL-2731 tracks system-tests configuration-source contract)
+  tests/parametric/test_ffe/test_configuration_sources.py: v1.65.0-SNAPSHOT
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation: v1.56.0
   tests/parametric/test_ffe/test_span_enrichment.py: missing_feature
   tests/parametric/test_headers_b3.py::Test_Headers_B3::test_headers_b3_migrated_extract_invalid:  # Modified by easy win activation script

--- a/tests/parametric/test_ffe/test_configuration_sources.py
+++ b/tests/parametric/test_ffe/test_configuration_sources.py
@@ -96,6 +96,8 @@ def library_env(
         env["DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS"] = str(
             params["provider_initialization_timeout_ms"]
         )
+    if "java_agent_enabled" in params:
+        env["SYSTEM_TESTS_JAVA_AGENT_ENABLED"] = str(params["java_agent_enabled"]).lower()
 
     if responses is not None:
         mock_ffe_agentless_backend.set_responses(responses)
@@ -798,3 +800,91 @@ class Test_Feature_Flag_Configuration_Source_Poller_Concurrency:
         assert status["requests_total"] >= requests_before + 2
         assert status["max_in_flight"] == 1
         assert status["last_path"] == CONFIG_PATH
+
+
+@scenarios.parametric
+@features.feature_flags_agentless
+class Test_Feature_Flag_Agentless_Without_Java_Agent:
+    """Validate Java agentless delivery without attaching dd-java-agent.jar."""
+
+    @parametrize(
+        "library_env",
+        [
+            pytest.param(
+                {"configuration_source": None, "java_agent_enabled": False, "response": "valid"},
+                id="default-agentless",
+            ),
+            pytest.param(
+                {
+                    "configuration_source": "agentless",
+                    "java_agent_enabled": False,
+                    "legacy_provider_enabled": True,
+                    "response": "valid",
+                },
+                id="explicit-agentless-over-legacy",
+            ),
+        ],
+        indirect=True,
+    )
+    def test_agentless_evaluation_without_java_agent(
+        self,
+        test_library: APMLibrary,
+        mock_ffe_agentless_backend: MockFFEAgentlessBackendServer,
+    ) -> None:
+        _assert_no_mock_requests(mock_ffe_agentless_backend)
+
+        assert test_library.ffe_start(), "failed to start the no-agent FFE provider"
+        _assert_expected_value(_evaluate(test_library))
+
+        status = _wait_for_status(
+            mock_ffe_agentless_backend,
+            lambda current: current["requests_total"] > 0 and current["last_status_code"] == 200,
+            "no-agent valid response request",
+        )
+        assert status["last_auth_present"] is False
+        assert status["last_path"] == CONFIG_PATH
+
+    @parametrize(
+        "library_env",
+        [
+            {
+                "configuration_source": "agentless",
+                "java_agent_enabled": False,
+                "responses": ["valid", "server_error"],
+            }
+        ],
+        indirect=True,
+    )
+    def test_no_agent_preserves_last_known_good_configuration(
+        self,
+        test_library: APMLibrary,
+        mock_ffe_agentless_backend: MockFFEAgentlessBackendServer,
+    ) -> None:
+        assert test_library.ffe_start(), "failed to start the no-agent FFE provider"
+
+        status = _wait_for_status(
+            mock_ffe_agentless_backend,
+            lambda current: _has_status_sequence(current["status_codes"], [200, 500]),
+            "no-agent valid-to-server-error sequence",
+        )
+        _assert_expected_value(_evaluate(test_library))
+        assert status["last_path"] == CONFIG_PATH
+
+    @parametrize(
+        "library_env",
+        [
+            {
+                "configuration_source": "remote_config",
+                "java_agent_enabled": False,
+                "response": "valid",
+            }
+        ],
+        indirect=True,
+    )
+    def test_remote_config_requires_java_agent(
+        self,
+        test_library: APMLibrary,
+        mock_ffe_agentless_backend: MockFFEAgentlessBackendServer,
+    ) -> None:
+        assert not test_library.ffe_start(), "remote_config started without dd-java-agent.jar"
+        _assert_no_mock_requests(mock_ffe_agentless_backend)

--- a/utils/build/docker/java/parametric/pom.xml
+++ b/utils/build/docker/java/parametric/pom.xml
@@ -149,6 +149,11 @@
                     <scope>system</scope>
                     <systemPath>${customDdOpenfeature}</systemPath>
                 </dependency>
+                <dependency>
+                    <groupId>com.squareup.moshi</groupId>
+                    <artifactId>moshi</artifactId>
+                    <version>1.11.0</version>
+                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/utils/build/docker/java/parametric/run.sh
+++ b/utils/build/docker/java/parametric/run.sh
@@ -41,9 +41,16 @@ DISABLE_INTEGRATIONS=(-Ddd.integration.servlet-request-body.enabled=false \
 # Limit JIT to tier one as the client application is a short-lived process that frequently killed / restarted
 OPTIMIZATION_OPTIONS=(-XX:TieredStopAtLevel=1)
 
+# The no-agent FFE tests run the OpenFeature provider without attaching dd-java-agent.jar.
+JAVA_AGENT_OPTIONS=()
+case $(echo "${SYSTEM_TESTS_JAVA_AGENT_ENABLED:-true}" | tr '[:upper:]' '[:lower:]') in
+  "false" | "0") ;;
+  *) JAVA_AGENT_OPTIONS=(-javaagent:"${DD_JAVA_AGENT}");;
+esac
+
 # Start client application
 # shellcheck disable=SC2086
-java -Xmx128M -javaagent:"${DD_JAVA_AGENT}" \
+java -Xmx128M "${JAVA_AGENT_OPTIONS[@]}" \
   $ENABLE_OTEL_TRACING_API \
   "${ENABLE_CRASH_TRACKING[@]}" \
   "${DISABLED_FEATURES[@]}" \


### PR DESCRIPTION
## Motivation

Java agentless Feature Flags must work without `dd-java-agent.jar`. Legacy Remote Configuration must remain agent-backed.

## Changes and Decisions

- Add a Java launcher switch that omits `-javaagent` only for explicit no-agent cases.
- Add default CDN, explicit source precedence, last-known-good, and Remote Configuration rejection coverage.
- Keep existing Java agent-present coverage enabled.
- Add Moshi to custom provider artifact builds.
- Validate the behavior introduced by [DataDog/dd-trace-java#12109](https://github.com/DataDog/dd-trace-java/pull/12109).

## Validation

- Local no-agent coverage: four cases passed.
- Local agent-present source and lifecycle coverage: 29 cases passed.
- The built Java process omitted `-javaagent` for no-agent cases and retained it otherwise.