### PR TITLE
fix(ssi): Validate flattened `v1` AppSec attributes.

### DIFF
--- a/tests/auto_inject/utils.py
+++ b/tests/auto_inject/utils.py
@@ -126,8 +126,63 @@ class AutoInjectBaseTest:
 
     def _appsec_validator(self, _: str, trace_data: dict):
         """Validator for Appsec traces that checks if the trace contains an Appsec event."""
-        root_id = trace_data["trace"]["root_id"]
-        root_span = trace_data["trace"]["spans"][root_id]
+        trace = trace_data["trace"]
+        root_id = trace["root_id"]
+        spans = trace["spans"]
+        root_span = spans[root_id]
+
+        trace_appsec_fields = {}
+        for section_name in ("meta", "metrics", "meta_struct", "attributes"):
+            section = trace.get(section_name)
+            if isinstance(section, dict):
+                trace_appsec_fields[section_name] = {
+                    str(key): {
+                        "type": type(value).__name__,
+                        "has_triggers": isinstance(value, dict) and bool(value.get("triggers")),
+                    }
+                    for key, value in section.items()
+                    if "appsec" in str(key)
+                }
+
+        logger.info(
+            "AppSec trace diagnostics: root_id=%r, span_ids=%r, trace_keys=%r, trace_appsec_fields=%r",
+            root_id,
+            list(spans),
+            sorted(trace),
+            trace_appsec_fields,
+        )
+
+        for span_id, span in spans.items():
+            span_meta = span.get("meta", {})
+            span_metrics = span.get("metrics", {})
+            span_meta_struct = span.get("meta_struct", {})
+            meta_payload = span_meta.get("_dd.appsec.json")
+            meta_struct_payload = span_meta_struct.get("appsec")
+
+            logger.info(
+                "AppSec span diagnostics: span_id=%r, selected_root=%r, parent_id=%r, name=%r, resource=%r, "
+                "span_keys=%r, meta_event=%r, metrics_event=%r, meta_enabled=%r, metrics_enabled=%r, "
+                "meta_appsec_keys=%r, metrics_appsec_keys=%r, meta_struct_appsec_keys=%r, "
+                "meta_payload_type=%s, meta_payload_has_triggers=%r, meta_struct_payload_type=%s, "
+                "meta_struct_payload_has_triggers=%r",
+                span_id,
+                span_id == root_id,
+                span.get("parent_id"),
+                span.get("name"),
+                span.get("resource"),
+                sorted(span),
+                span_meta.get("appsec.event"),
+                span_metrics.get("appsec.event"),
+                span_meta.get("_dd.appsec.enabled"),
+                span_metrics.get("_dd.appsec.enabled"),
+                sorted(str(key) for key in span_meta if "appsec" in str(key)),
+                sorted(str(key) for key in span_metrics if "appsec" in str(key)),
+                sorted(str(key) for key in span_meta_struct if "appsec" in str(key)),
+                type(meta_payload).__name__,
+                isinstance(meta_payload, dict) and bool(meta_payload.get("triggers")),
+                type(meta_struct_payload).__name__,
+                isinstance(meta_struct_payload, dict) and bool(meta_struct_payload.get("triggers")),
+            )
 
         meta = root_span.get("meta", {})
         metrics = root_span.get("metrics", {})
@@ -141,11 +196,6 @@ class AutoInjectBaseTest:
 
         # Accept both layouts because v1 typed booleans may be normalized into metrics.
         meta_or_metrics = {**meta, **metrics}
-        logger.info(
-            "AppSec event values: meta=%r, metrics=%r",
-            meta.get("appsec.event"),
-            metrics.get("appsec.event"),
-        )
         if is_same_boolean(actual=meta_or_metrics.get("appsec.event"), expected="true"):
             return True
 

--- a/tests/auto_inject/utils.py
+++ b/tests/auto_inject/utils.py
@@ -5,7 +5,6 @@ from utils.onboarding.backend_interface import wait_backend_trace_id
 from utils.onboarding.wait_for_tcp_port import wait_for_port
 from utils.virtual_machine.virtual_machines import _VirtualMachine
 from utils.virtual_machine.vm_logger import vm_logger
-from utils.dd_types import is_same_boolean
 from utils import context, logger
 from threading import Timer
 
@@ -126,63 +125,8 @@ class AutoInjectBaseTest:
 
     def _appsec_validator(self, _: str, trace_data: dict):
         """Validator for Appsec traces that checks if the trace contains an Appsec event."""
-        trace = trace_data["trace"]
-        root_id = trace["root_id"]
-        spans = trace["spans"]
-        root_span = spans[root_id]
-
-        trace_appsec_fields = {}
-        for section_name in ("meta", "metrics", "meta_struct", "attributes"):
-            section = trace.get(section_name)
-            if isinstance(section, dict):
-                trace_appsec_fields[section_name] = {
-                    str(key): {
-                        "type": type(value).__name__,
-                        "has_triggers": isinstance(value, dict) and bool(value.get("triggers")),
-                    }
-                    for key, value in section.items()
-                    if "appsec" in str(key)
-                }
-
-        logger.info(
-            "AppSec trace diagnostics: root_id=%r, span_ids=%r, trace_keys=%r, trace_appsec_fields=%r",
-            root_id,
-            list(spans),
-            sorted(trace),
-            trace_appsec_fields,
-        )
-
-        for span_id, span in spans.items():
-            span_meta = span.get("meta", {})
-            span_metrics = span.get("metrics", {})
-            span_meta_struct = span.get("meta_struct", {})
-            meta_payload = span_meta.get("_dd.appsec.json")
-            meta_struct_payload = span_meta_struct.get("appsec")
-
-            logger.info(
-                "AppSec span diagnostics: span_id=%r, selected_root=%r, parent_id=%r, name=%r, resource=%r, "
-                "span_keys=%r, meta_event=%r, metrics_event=%r, meta_enabled=%r, metrics_enabled=%r, "
-                "meta_appsec_keys=%r, metrics_appsec_keys=%r, meta_struct_appsec_keys=%r, "
-                "meta_payload_type=%s, meta_payload_has_triggers=%r, meta_struct_payload_type=%s, "
-                "meta_struct_payload_has_triggers=%r",
-                span_id,
-                span_id == root_id,
-                span.get("parent_id"),
-                span.get("name"),
-                span.get("resource"),
-                sorted(span),
-                span_meta.get("appsec.event"),
-                span_metrics.get("appsec.event"),
-                span_meta.get("_dd.appsec.enabled"),
-                span_metrics.get("_dd.appsec.enabled"),
-                sorted(str(key) for key in span_meta if "appsec" in str(key)),
-                sorted(str(key) for key in span_metrics if "appsec" in str(key)),
-                sorted(str(key) for key in span_meta_struct if "appsec" in str(key)),
-                type(meta_payload).__name__,
-                isinstance(meta_payload, dict) and bool(meta_payload.get("triggers")),
-                type(meta_struct_payload).__name__,
-                isinstance(meta_struct_payload, dict) and bool(meta_struct_payload.get("triggers")),
-            )
+        root_id = trace_data["trace"]["root_id"]
+        root_span = trace_data["trace"]["spans"][root_id]
 
         meta = root_span.get("meta", {})
         metrics = root_span.get("metrics", {})
@@ -194,14 +138,13 @@ class AutoInjectBaseTest:
             )
             return False
 
-        # Accept both layouts because v1 typed booleans may be normalized into metrics.
-        meta_or_metrics = {**meta, **metrics}
-        if is_same_boolean(actual=meta_or_metrics.get("appsec.event"), expected="true"):
+        # Check for v0.4 protocol, which exposes the AppSec event marker directly in span metadata.
+        if meta.get("appsec.event") == "true":
             return True
 
-        # Check for AppSec event payload
+        # Check for v1 protocol, which exposes either the event payload or flattened trigger fields.
         appsec_payload = meta.get("_dd.appsec.json")
-        if appsec_payload and appsec_payload.get("triggers"):
+        if (appsec_payload and appsec_payload.get("triggers")) or meta.get("appsec.triggers.rule.id"):
             return True
 
         logger.error("expected 'appsec.event' to be true in trace meta or at least one rule triggered")

--- a/tests/auto_inject/utils.py
+++ b/tests/auto_inject/utils.py
@@ -139,7 +139,14 @@ class AutoInjectBaseTest:
             )
             return False
 
-        if is_same_boolean(actual=meta.get("appsec.event"), expected="true"):
+        # Accept both layouts because v1 typed booleans may be normalized into metrics.
+        meta_or_metrics = {**meta, **metrics}
+        logger.info(
+            "AppSec event values: meta=%r, metrics=%r",
+            meta.get("appsec.event"),
+            metrics.get("appsec.event"),
+        )
+        if is_same_boolean(actual=meta_or_metrics.get("appsec.event"), expected="true"):
             return True
 
         # Check for AppSec event payload


### PR DESCRIPTION
## Motivation

The SSI AppSec validator rejected valid `v1` traces because the backend response exposes AppSec events as flattened `appsec.triggers.*` metadata instead of the legacy `appsec.event` marker.

## Changes

- Keep validation of `appsec.event` for v0.4 traces.
- Accept `_dd.appsec.json` trigger payloads and normalized `appsec.triggers.rule.id` metadata for v1 traces.
- Remove the unnecessary boolean normalization introduced in #7418, since the `v1` failure was caused by the event marker being absent rather than encoded differently.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
