### PR TITLE
Expect propagation tags in the first span of each trace chunk

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -242,6 +242,7 @@ manifest:
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing: '>=2.0.0'  # Modified by easy win activation script
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span: missing_feature  # Created by easy win activation script
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span_default: missing_feature  # Created by easy win activation script
+  tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_propagation_tags: missing_feature  # Created by easy win activation script
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery: ">1.0.0"
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery::test_metadata_content_with_process_tags:  # Modified by easy win activation script
     - declaration: bug (APMAPI-1744)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3962,6 +3962,7 @@ manifest:
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_write_log: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span: 'missing_feature (java uses ''>'' so it needs one more span to force a partial flush)'
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span_default: 'missing_feature (java uses ''>'' so it needs one more span to force a partial flush)'
+  tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_propagation_tags: v1.65.0-SNAPSHOT+7071ae2ed6
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery: v1.55.0-SNAPSHOT
   tests/parametric/test_sampling_manual.py::Test_Manual_Sampling: v1.59.0-SNAPSHOT+419da213f7
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: v1.61.0-SNAPSHOT  # https://github.com/DataDog/dd-trace-java/pull/10802

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2417,6 +2417,7 @@ manifest:
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing: '>=2.27.0'  # Modified by easy win activation script
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span: missing_feature  # Created by easy win activation script
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span_default: missing_feature  # Created by easy win activation script
+  tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_propagation_tags: missing_feature  # Created by easy win activation script
   tests/parametric/test_process_discovery.py::Test_ProcessDiscovery: v2.18.0
   tests/parametric/test_sampling_delegation.py::Test_Decisionless_Extraction: v2.4.0
   tests/parametric/test_sampling_span_tags.py::Test_Knuth_Sample_Rate: v2.31.0-dev

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -296,6 +296,7 @@ manifest:
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing: '>=0.2.1'  # Modified by easy win activation script
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span: missing_feature  # Created by easy win activation script
   tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span_default: missing_feature  # Created by easy win activation script
+  tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_propagation_tags: missing_feature  # Created by easy win activation script
   tests/parametric/test_process_discovery.py: missing_feature
   tests/parametric/test_sampling_manual.py::Test_Manual_Sampling: missing_feature
   tests/parametric/test_sampling_span_tags.py: '>=0.2.1'  # Modified by easy win activation script

--- a/tests/parametric/test_partial_flushing.py
+++ b/tests/parametric/test_partial_flushing.py
@@ -1,5 +1,5 @@
 import pytest
-from utils.docker_fixtures.spec.trace import find_span, find_trace
+from utils.docker_fixtures.spec.trace import find_first_span_in_trace_payload, find_span, find_trace
 from utils import features, scenarios
 from utils.docker_fixtures import TestAgentAPI
 from .conftest import APMLibrary
@@ -23,6 +23,23 @@ class Test_Partial_Flushing:
         partial flushing triggers. This test assumes partial flushing is enabled by default.
         """
         self.do_partial_flush_test(test_agent, test_library)
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+                "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": "true",
+                "DD_TRACE_PARTIAL_FLUSH_MIN_SPANS": "2",
+                "DD_TRACE_PARTIAL_FLUSH_ENABLED": "true",
+                "DD_TRACE_SAMPLE_RATE": "1",
+            }
+        ],
+    )
+    def test_partial_flushing_propagation_tags(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """Create a trace with a root span and two children. Finish the children, and ensure
+        partial flushing places propagation tags on the first span in the chunk.
+        """
+        self.do_propagation_tags_test(test_agent, test_library)
 
     @pytest.mark.parametrize(
         "library_env", [{"DD_TRACE_PARTIAL_FLUSH_MIN_SPANS": "5", "DD_TRACE_PARTIAL_FLUSH_ENABLED": "true"}]
@@ -64,6 +81,36 @@ class Test_Partial_Flushing:
         root_span = find_span(full_trace, parent_span.span_id)
         assert len(traces) == 1
         assert root_span["name"] == "root"
+
+    def do_propagation_tags_test(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        """Create a trace with a root span and two children. Finish the children, and ensure
+        partial flushing emits them in a chunk before the root.
+        """
+        with test_library, test_library.dd_start_span(name="root") as parent_span:
+            child_span_ids: dict[str, int | str] = {}
+            for child_name in ("child1", "child2"):
+                with test_library.dd_start_span(name=child_name, parent_id=parent_span.span_id) as child_span:
+                    child_span_ids[child_name] = child_span.span_id
+
+            partial_traces = test_agent.wait_for_num_traces(1, clear=True, wait_loops=30, sort_by_start=False)
+            partial_trace = find_trace(partial_traces, parent_span.trace_id)
+            assert len(partial_trace) == 2
+            for child_name, child_span_id in child_span_ids.items():
+                assert find_span(partial_trace, child_span_id)["name"] == child_name
+
+            first_span = find_first_span_in_trace_payload(partial_trace)
+            assert first_span["metrics"]["_sampling_priority_v1"] == 2.0
+            assert first_span["meta"]["_dd.p.tid"]
+            assert first_span["meta"]["_dd.p.dm"] == "-3"
+
+        traces = test_agent.wait_for_num_traces(1, clear=True, sort_by_start=False)
+        full_trace = find_trace(traces, parent_span.trace_id)
+        root_span = find_span(full_trace, parent_span.span_id)
+        assert len(traces) == 1
+        assert root_span["name"] == "root"
+        assert root_span == find_first_span_in_trace_payload(full_trace)
+        assert root_span["meta"]["_dd.p.tid"]
+        assert root_span["meta"]["_dd.p.dm"] == "-3"
 
     def no_partial_flush_test(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         """Create a trace with a root span and one child. Finish the child, and ensure

--- a/tests/parametric/test_partial_flushing.py
+++ b/tests/parametric/test_partial_flushing.py
@@ -103,7 +103,6 @@ class Test_Partial_Flushing:
             assert first_span["meta"]["_dd.p.tid"]
             assert first_span["meta"]["_dd.p.dm"] == "-3"
             for later_span in partial_trace[1:]:
-                assert "_dd.p.tid" not in later_span.get("meta", {})
                 assert "_dd.p.dm" not in later_span.get("meta", {})
 
         traces = test_agent.wait_for_num_traces(1, clear=True, sort_by_start=False)

--- a/tests/parametric/test_partial_flushing.py
+++ b/tests/parametric/test_partial_flushing.py
@@ -102,6 +102,9 @@ class Test_Partial_Flushing:
             assert first_span["metrics"]["_sampling_priority_v1"] == 2.0
             assert first_span["meta"]["_dd.p.tid"]
             assert first_span["meta"]["_dd.p.dm"] == "-3"
+            for later_span in partial_trace[1:]:
+                assert "_dd.p.tid" not in later_span.get("meta", {})
+                assert "_dd.p.dm" not in later_span.get("meta", {})
 
         traces = test_agent.wait_for_num_traces(1, clear=True, sort_by_start=False)
         full_trace = find_trace(traces, parent_span.trace_id)

--- a/tests/test_the_test/scenarios.json
+++ b/tests/test_the_test/scenarios.json
@@ -5079,6 +5079,9 @@
   "tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_one_span_default[library_env0]": [
     "PARAMETRIC"
   ],
+  "tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_propagation_tags[library_env0]": [
+    "PARAMETRIC"
+  ],
   "tests/parametric/test_partial_flushing.py::Test_Partial_Flushing::test_partial_flushing_under_limit_one_payload[library_env0]": [
     "PARAMETRIC"
   ],


### PR DESCRIPTION
## Motivation

Ensure that propagation tags are passed correctly to the first span of each trace chunk, not including the root span. This is expected behavior as noted in [[RFC] Supporting 128-Bit TraceIds - Integrations](https://docs.google.com/document/d/1h69s_dPWCJ2shqrnqPFGOw_cvpav9ZnWzfn8OiYrKBs/edit?tab=t.0#bookmark=id.c42om2p3835).

## Changes

Add a parametric test asserting `_dd.p.tid` and `_dd.p.dm` appear in the `Meta` map of the first span in each partial-flush chunk.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
